### PR TITLE
Update MooseServer formatting to not pull in included file contents

### DIFF
--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -319,18 +319,6 @@ Node::children(NodeType t)
   return nodes;
 }
 
-std::string
-Node::render(int indent, const std::string & indent_text, int maxlen)
-{
-  if (root() != this)
-    indent = -1;
-
-  std::string s;
-  for (auto child : _children)
-    s += child->render(indent + 1, indent_text, maxlen) + "\n";
-  return s;
-}
-
 Node *
 Node::parent()
 {
@@ -490,7 +478,10 @@ Section::render(int indent, const std::string & indent_text, int maxlen)
 {
   std::string s;
 
-  if (!path().empty() && path() != "-")
+  // check if this is document root level in order to skip syntax rendering
+  bool at_root_level = path().empty() || path() == "-";
+
+  if (!at_root_level)
   {
     std::string opening_marks;
     if (_hnv.child_count() > 3 && _hnv.child_at(2).type() == wasp::DECL &&
@@ -501,14 +492,9 @@ Section::render(int indent, const std::string & indent_text, int maxlen)
   }
 
   for (auto child : children())
-  {
-    if (!path().empty() && path() != "-")
-      s += child->render(indent + 1, indent_text, maxlen);
-    else
-      s += child->render(indent, indent_text, maxlen);
-  }
+    s += child->render(indent + (at_root_level ? 0 : 1), indent_text, maxlen);
 
-  if (!path().empty() && path() != "-")
+  if (!at_root_level)
   {
     wasp::HITNodeView term_node = _hnv.first_child_by_name("term");
     std::string term_data = !term_node.is_null() ? term_node.data() : "[]";
@@ -553,18 +539,32 @@ Field::path()
 std::string
 Field::render(int indent, const std::string & indent_text, int maxlen)
 {
-  auto render_field = path();
-  auto render_val = val();
-  auto render_kind = kind();
+  std::string s = "\n" + strRepeat(indent_text, indent) + path() + " = ";
 
-  std::string s = "\n" + strRepeat(indent_text, indent) + render_field + " = ";
-
+  const std::string render_val = val();
+  std::size_t val_column = _hnv.child_count() > 2 ? _hnv.child_at(2).column() : 0;
   size_t prefix_len = s.size() - 1;
+
+  s += formatValue(render_val, val_column, prefix_len, maxlen);
+
+  for (auto child : children())
+    s += child->render(indent + 1, indent_text, maxlen);
+
+  return s;
+}
+
+std::string
+formatValue(const std::string & render_val,
+            std::size_t val_column,
+            std::size_t prefix_len,
+            std::size_t max_length)
+{
+  std::string s;
   auto quote = quoteChar(render_val);
-  int max = maxlen - prefix_len - 1;
+  int max = max_length - prefix_len - 1;
 
   // special rendering logic for double quoted strings that go over maxlen:
-  if (render_kind == Kind::String && quote == "\"" && max > 0)
+  if (quote == "\"" && max > 0)
   {
     if (render_val.find('\n') == std::string::npos)
     {
@@ -612,7 +612,7 @@ Field::render(int indent, const std::string & indent_text, int maxlen)
     }
     else
     {
-      const int delta_indent = _hnv.child_count() > 2 ? prefix_len - _hnv.child_at(2).column() : 0;
+      const int delta_indent = prefix_len - val_column;
 
       // first line is always added as is
       std::size_t start = 0;
@@ -654,9 +654,6 @@ Field::render(int indent, const std::string & indent_text, int maxlen)
     s += "'" + render_val + "'";
   else
     s += render_val;
-
-  for (auto child : children())
-    s += child->render(indent + 1, indent_text, maxlen);
 
   return s;
 }
@@ -745,7 +742,13 @@ Field::setVal(const std::string & value, Kind kind)
 std::string
 Field::val()
 {
-  std::string value = _hnv.data();
+  return extractValue(_hnv.data());
+}
+
+std::string
+extractValue(const std::string & field_data)
+{
+  std::string value = field_data;
 
   size_t equal_index = value.find("=");
   if (equal_index != std::string::npos)
@@ -1208,7 +1211,8 @@ buildHITTree(std::shared_ptr<wasp::DefaultHITInterpreter> interpreter,
         hit_parent->addChild(new Blank());
 
       auto hit_child = new Comment(interpreter, hnv_child);
-      if (hnv_child.line() == previous_line && hit_parent->children().size() > 0)
+      if (hnv_child.node_pool()->stream_name() == previous_file &&
+          hnv_child.line() == previous_line && hit_parent->children().size() > 0)
       {
         hit_child->setInline(true);
         hit_parent->children().back()->addChild(hit_child);

--- a/framework/contrib/hit/parse.h
+++ b/framework/contrib/hit/parse.h
@@ -137,6 +137,15 @@ std::string pathNorm(const std::string & path);
 /// pathJoin a joined version of the given hit (relative) paths as single hit path.
 std::string pathJoin(const std::vector<std::string> & paths);
 
+/// formatValue reflows double-quoted strings and reindents multi-line data
+std::string formatValue(const std::string & render_val,
+                        std::size_t val_column,
+                        std::size_t prefix_len,
+                        std::size_t max_length = 100);
+
+/// extractValue returns after equal with quoted value merged and unescaped
+std::string extractValue(const std::string & field_data);
+
 /// Node represents an object in a parsed hit tree.  Each node manages the memory for its child
 /// nodes.  It is safe to delete any node in the tree; doing so will also delete that node's
 /// children recursively.  It is not safe to place a single node in multiple trees.  Instead, use
@@ -230,7 +239,7 @@ public:
   /// indent string (repeated once for each level).  maxlen is the maximum line length before
   /// breaking string values.
   virtual std::string
-  render(int indent = 0, const std::string & indent_text = default_indent, int maxlen = 0);
+  render(int indent = 0, const std::string & indent_text = default_indent, int maxlen = 0) = 0;
 
   /// walk does a depth-first traversal of the hit tree starting at this node (it
   /// doesn't visit any nodes that require traversing this node's parent) calling the passed

--- a/framework/include/base/MooseServer.h
+++ b/framework/include/base/MooseServer.h
@@ -239,6 +239,15 @@ private:
                                          bool insert_spaces);
 
   /**
+   * Recursively walk down whole nodeview tree while formatting document.
+   * @param parent - nodeview for recursive tree traversal starting point
+   * @param prev_line - line of last print for blanks and inline comments
+   * @param level - current level in document tree to use for indentation
+   * @return - formatted string that gets appended to each recursive call
+   */
+  std::string formatDocument(wasp::HITNodeView parent, std::size_t & prev_line, std::size_t level);
+
+  /**
    * Gather document symbols - specific to this server implemention.
    * @param documentSymbols - data array of symbols data objects to fill
    * @return - true if the gathering of symbols completed successfully
@@ -324,4 +333,9 @@ private:
    * @brief _type_to_input_paths - map of parameter types to lookup paths
    */
   std::map<std::string, std::set<std::string>> _type_to_input_paths;
+
+  /**
+   * @brief _formatting_tab_size - number of indent spaces for formatting
+   */
+  std::size_t _formatting_tab_size;
 };

--- a/framework/src/base/MooseServer.C
+++ b/framework/src/base/MooseServer.C
@@ -190,7 +190,8 @@ MooseServer::gatherDocumentCompletionItems(wasp::DataArray & completionItems,
     object_context = object_context.parent();
   const std::string & object_path = object_context.path();
   wasp::HITNodeView type_node = object_context.first_child_by_name("type");
-  const std::string & object_type = type_node.is_null() ? "" : type_node.last_as_string();
+  const std::string & object_type =
+      type_node.is_null() ? "" : wasp::strip_quotes(hit::extractValue(type_node.data()));
 
   // get set of all parameter and subblock names already specified in input
   std::set<std::string> existing_params, existing_subblocks;
@@ -796,7 +797,8 @@ MooseServer::gatherDocumentDefinitionLocations(wasp::DataArray & definitionLocat
     object_context = object_context.parent();
   const std::string & object_path = object_context.path();
   wasp::HITNodeView type_node = object_context.first_child_by_name("type");
-  const std::string & object_type = type_node.is_null() ? "" : type_node.last_as_string();
+  const std::string & object_type =
+      type_node.is_null() ? "" : wasp::strip_quotes(hit::extractValue(type_node.data()));
 
   // set used to gather all parameters valid from object context of request
   InputParameters valid_params = emptyInputParameters();
@@ -1045,9 +1047,10 @@ MooseServer::gatherDocumentSymbols(wasp::DataArray & documentSymbols)
     int last_line = view_child.last_line() - 1;
     int last_column = view_child.last_column();
     int symbol_kind = getDocumentSymbolKind(view_child);
-    std::string detail = !view_child.first_child_by_name("type").is_null()
-                             ? view_child.first_child_by_name("type").last_as_string()
-                             : "";
+    std::string detail =
+        !view_child.first_child_by_name("type").is_null()
+            ? wasp::strip_quotes(hit::extractValue(view_child.first_child_by_name("type").data()))
+            : "";
 
     // build document symbol object from node child info and push to array
     documentSymbols.push_back(wasp::DataObject());
@@ -1097,9 +1100,10 @@ MooseServer::traverseParseTreeAndFillSymbols(wasp::HITNodeView view_parent,
     int last_line = view_child.last_line() - 1;
     int last_column = view_child.last_column();
     int symbol_kind = getDocumentSymbolKind(view_child);
-    std::string detail = !view_child.first_child_by_name("type").is_null()
-                             ? view_child.first_child_by_name("type").last_as_string()
-                             : "";
+    std::string detail =
+        !view_child.first_child_by_name("type").is_null()
+            ? wasp::strip_quotes(hit::extractValue(view_child.first_child_by_name("type").data()))
+            : "";
 
     // build document symbol object from node child info and push to array
     wasp::DataObject & data_child = wasp::lsp::addDocumentSymbolChild(data_parent);


### PR DESCRIPTION
Update MooseServer document formatting so it shows `!include` directives and not the contents of external files

  - factor out `extractValue()` and `formatValue()` from `hit::Node` to be reused by language server formatting
  - walk over the WASP tree instead of the HIT tree to see `!include` directives rather than included file contents

refs #22766
