### PR TITLE
Accurately retrieve the mesh dimension

### DIFF
--- a/framework/src/meshgenerators/AdvancedExtruderGenerator.C
+++ b/framework/src/meshgenerators/AdvancedExtruderGenerator.C
@@ -330,7 +330,7 @@ AdvancedExtruderGenerator::generate()
       mesh->add_elem_integer(id_names[i]);
   }
 
-  // retreive subdomain/sideset/nodeset name maps
+  // retrieve subdomain/sideset/nodeset name maps
   const auto & input_subdomain_map = _input->get_subdomain_name_map();
   const auto & input_sideset_map = _input->get_boundary_info().get_sideset_name_map();
   const auto & input_nodeset_map = _input->get_boundary_info().get_nodeset_name_map();

--- a/framework/src/meshgenerators/SideSetsGeneratorBase.C
+++ b/framework/src/meshgenerators/SideSetsGeneratorBase.C
@@ -54,7 +54,10 @@ SideSetsGeneratorBase::setup(MeshBase & mesh)
 {
   mooseAssert(_fe_face == nullptr, "FE Face has already been initialized");
 
-  unsigned int dim = mesh.mesh_dimension();
+  // To know the dimension of the mesh
+  if (!mesh.is_prepared())
+    mesh.prepare_for_use();
+  const auto dim = mesh.mesh_dimension();
 
   // Setup the FE Object so we can calculate normals
   FEType fe_type(Utility::string_to_enum<Order>("CONSTANT"),

--- a/test/tests/meshgenerators/ordering_of_execution/modifier_depend_order.i
+++ b/test/tests/meshgenerators/ordering_of_execution/modifier_depend_order.i
@@ -4,7 +4,7 @@
     file = square.e
   []
 
-  # Mesh Modifiers
+  # Mesh Generators
   # If no dependencies are defined, the order of execution is not defined (based on pointer locations) so
   # this test case has several dependencies to minimize the chance of getting lucky when things aren't defined properly.
   # Rotations along different axes must occur in a defined order to end up at the right orientation at the end.


### PR DESCRIPTION
 before creating a face quadrature to get normals when generating sidesets

@roystgnr this could also wait if you are reworking that call, splitting out (or offering a separate call) for this dimension-getting part from prepare_for_use

@cpgr this should fix your issue

refs #15945

