### PR TITLE
Improve the AD docs

### DIFF
--- a/framework/doc/content/automatic_differentiation/index.md
+++ b/framework/doc/content/automatic_differentiation/index.md
@@ -157,16 +157,16 @@ MetaPhysicL overloads binary arithmetic operators (`+,-,*,/`), unary functions
 involving a `DualNumber` propagates both the function value and its
 derivatives.
 
-MOOSE leverages one of two MetaPhysicL container class templates depending
-on user configuration. The default MOOSE configuration uses the
+MOOSE used to leverage one of two MetaPhysicL container class templates depending
+on user configuration. The default MOOSE configuration used to be the
 `NumberArray` class template which accepts `std::size_t N` and
 `typename T` template arguments where `N` denotes the length of
 an underlying C-array that holds the `NumberArray` data and `T` is
 the floating-point type held by the C-array. `NumberArray` is an ideal derivative
 container choice when there is dense coupling between physics variables; this is because
 operator and function overloads for `NumberArray` operate on the entire
-underlying C-array. The second MetaPhysicL container class leveraged by
-MOOSE is `SemiDynamicSparseNumberArray`, which is a more ideal
+underlying C-array. The second MetaPhysicL container class, and the only one that
+is currently leveraged by MOOSE, is `SemiDynamicSparseNumberArray`, which is a more ideal
 choice for problems in which variable coupling is sparse or when a user wishes
 to solve a variety of problems with a single library configuration. In contrast to
 `NumberArray` which only holds a single C-array of floating-type data,
@@ -179,20 +179,17 @@ user who may configure MOOSE with an underlying derivative storage container
 size of 81 for solid mechanics simulations on 3D second-order hexahedral finite elements
 (3 displacement variables $\times$ 27 degrees of freedom per variable per finite
 element = 81 local dofs). When running 3D, second-order cases,
-the non-sparse `NumberArray` container would be 100% efficient. However,
-if the user wishes to run a 2D, second-order case
+the non-sparse `NumberArray` container would have been 100% efficient. However,
+if the user later wished to run a 2D, second-order case
 (2 displacement variables $\times$ 9 degrees of freedom per variable per finite
 element = 18 local dofs) with the same MOOSE
-configuration, they would be performing $81 / 18 = 4.5$ times more work
+configuration, they would have been performing $81 / 18 = 4.5$ times more work
 than is necessary if using `NumberArray`. Because
 `SemiDynamicSparseNumberArray` tracks the sparsity pattern, it will only
 initialize and operate on the floating-point array elements that are required,
 i.e. the "sparse size" (stored as a `_dynamic_N` data member) of its
 data containers will never exceed what is required for the run-time problem,
-e.g. 18 for the 2D second-order solid mechanics example. Of course tracking the
-sparsity pattern has non-zero cost, so if the user knows they will always be
-running a certain kind of problem, they may be best served by configuring with
-non-sparse `NumberArray` container.
+e.g. 18 for the 2D second-order solid mechanics example.
 
 ## AD in MOOSE
 

--- a/framework/doc/content/automatic_differentiation/index.md
+++ b/framework/doc/content/automatic_differentiation/index.md
@@ -307,7 +307,7 @@ modules, all of which heavily leverage MOOSE's [!ac](AD) capabilities.
 
 For performance reasons, AD values in MOOSE have a maximum container size, i.e.,
 they have a maximum number of degrees of freedom that each AD quantity may
-depend upon. Currently, MOOSE's default maximum AD container size is 53. If the
+depend upon. Currently, MOOSE's default maximum AD container size is 64. If the
 maximum AD container size is exceeded, then an error will result.
 If a quantity needs to depend on more degrees of freedom than the maximum AD
 container size, then MOOSE needs to be reconfigured: go to the

--- a/framework/doc/content/automatic_differentiation/index.md
+++ b/framework/doc/content/automatic_differentiation/index.md
@@ -133,7 +133,7 @@ used for generating manufactured solution tests for increasingly
 complicated physics simulations, when it was discovered that multiple
 symbolic differentiation packages were suffering software failures on
 sufficiently large problems.  Symbolically differentiating
-manufactured solution fields through e.g.\ 3-D Navier-Stokes physics
+manufactured solution fields through e.g. 3-D Navier-Stokes physics
 caused a combinatorial explosion, leading to corresponding forcing
 functions that were hundreds of kilobytes in length, or required many
 man-hours of manual simplification, or failed altogether on some
@@ -150,8 +150,8 @@ correspond to $f(\vec{x})$ and $\nabla f(\vec{x})$ respectively. `value`
 and `derivatives` types are determined by `T` and `D`
 template parameters, where `T` is some floating point type, and
 `D` is equivalent to `T` for single-argument functions or equal to
-some container type for a generic vector of arguments. MetaPhysicL
-overloads binary arithmetic operators (`+,-,*,/`), unary functions
+some container type for a generic vector of arguments (see the next paragraph).
+MetaPhysicL overloads binary arithmetic operators (`+,-,*,/`), unary functions
 (`std::sin, std::cos, std::exp` etc.), and binary functions
 (`std::pow, std::max, std::min` etc.), ensuring that any calculation
 involving a `DualNumber` propagates both the function value and its
@@ -162,9 +162,7 @@ on user configuration. The default MOOSE configuration uses the
 `NumberArray` class template which accepts `std::size_t N` and
 `typename T` template arguments where `N` denotes the length of
 an underlying C-array that holds the `NumberArray` data and `T` is
-the floating-point type held by the C-array. As for `DualNumber`,
-MetaPhysicL provides arithmetic, unary, and binary function overloads for
-manipulation of its container types. `NumberArray` is an ideal derivative
+the floating-point type held by the C-array. `NumberArray` is an ideal derivative
 container choice when there is dense coupling between physics variables; this is because
 operator and function overloads for `NumberArray` operate on the entire
 underlying C-array. The second MetaPhysicL container class leveraged by
@@ -178,16 +176,18 @@ additional data member enables sparse operations that may involve only a subset
 of the elements in the underlying floating-point data. As an explicit example of
 when these sparse operations are useful, consider a
 user who may configure MOOSE with an underlying derivative storage container
-size of 81 for solid mechanics simulations on 3D second-order hexagonal finite elements
-(3 displacement variables * 27 degrees of freedom per variable per finite
+size of 81 for solid mechanics simulations on 3D second-order hexahedral finite elements
+(3 displacement variables $\times$ 27 degrees of freedom per variable per finite
 element = 81 local dofs). When running 3D, second-order cases,
-the non-sparse `NumberArray` container would be 100\% efficient. However,
-if the user wishes to run a 2D, second-order case with the same MOOSE
+the non-sparse `NumberArray` container would be 100% efficient. However,
+if the user wishes to run a 2D, second-order case
+(2 displacement variables $\times$ 9 degrees of freedom per variable per finite
+element = 18 local dofs) with the same MOOSE
 configuration, they would be performing $81 / 18 = 4.5$ times more work
 than is necessary if using `NumberArray`. Because
 `SemiDynamicSparseNumberArray` tracks the sparsity pattern, it will only
 initialize and operate on the floating-point array elements that are required,
-e.g. the ``sparse size'' (stored as a `_dynamic_N` data member) of its
+i.e. the "sparse size" (stored as a `_dynamic_N` data member) of its
 data containers will never exceed what is required for the run-time problem,
 e.g. 18 for the 2D second-order solid mechanics example. Of course tracking the
 sparsity pattern has non-zero cost, so if the user knows they will always be

--- a/framework/doc/content/source/systems/NonlinearSystem.md
+++ b/framework/doc/content/source/systems/NonlinearSystem.md
@@ -76,7 +76,7 @@ One can elect to sacrifice some computing speed and calculate Jacobians
 automatically using
 [automatic differentiation (AD)](https://en.wikipedia.org/wiki/Automatic_differentiation). MOOSE
 employs the `DualNumber` class from the
-[MetaPhysicL](https://github.com/roystgnr/MetaPhysicL) package in order to
+[MetaPhysicL](https://github.com/libMesh/MetaPhysicL) package in order to
 enable AD. If the application developer wants to make use of AD, they should
 inherit from `ADKernel` as opposed to `Kernel`. Additionally, when coupling in
 variables, the `adCoupled*` methods should be used. For example, to retrieve a

--- a/framework/doc/content/source/utils/DualReal.md
+++ b/framework/doc/content/source/utils/DualReal.md
@@ -9,11 +9,11 @@ capabilities.
 ## Overview id=overview
 
 `DualReal` is a MOOSE typedef defined from the
-[`MetaPhysicL`](https://github.com/roystgnr/metaphysicl) template class
+[MetaPhysicL](https://github.com/libMesh/MetaPhysicL) template class
 `DualNumber`. `DualNumber` takes two template arguments `T` and `D`; `T`
 represents the "value" type of the `DualNumber`, e.g. the type of $f(\vec{x})$,
 while `D` represents the derivative type of the `DualNumber`, e.g. the type of
-$\nabla f = \frac{\partial f}{\partial\vec{x}}$. `MetaPhysicL` offers several
+$\nabla f = \frac{\partial f}{\partial\vec{x}}$. MetaPhysicL offers several
 options for `D` types, including:
 
 1. `NumberArray`

--- a/framework/doc/content/source/utils/DualReal.md
+++ b/framework/doc/content/source/utils/DualReal.md
@@ -33,14 +33,13 @@ options for `D` types, including:
     - Avoid looping over the whole size of the std::array by
       maintaining a dynamic size data member
 
-The default configuration in MOOSE uses `NumberArray` for derivative storage
-because it is generally the fastest container (albeit
-inflexible). `SemiDynamicSparseNumberArray` can be selected as the derivative
-storage type by running `./configure --with-derivative-type=sparse` in MOOSE's
-framework directory. The underlying derivative storage array size for both
-`NumberArray` and `SemiDynamicSparseNumberArray` can be modified by running
-`configure` with the option `--with-derivative-size=<n>` where `<n>` is the
-desired size of the container. By default, MOOSE is configured `--with-derivative-size=64`.
+Currently, MOOSE uses `SemiDynamicSparseNumberArray` for derivative storage
+because it is much more flexible than `NumberArray` and more performant than
+`DynamicSparseNumberArray`.
+The underlying derivative storage array size for `SemiDynamicSparseNumberArray`
+can be modified by running `configure` with the option
+`--with-derivative-size=<n>` where `<n>` is the desired size of the container.
+By default, MOOSE is configured `--with-derivative-size=64`.
 
 ## AD-Related Timings id=timings
 
@@ -60,5 +59,5 @@ desired size of the container. By default, MOOSE is configured `--with-derivativ
 
 #### SNESComputeJacobian timing
 
-- MOOSE non-sparse config: 9.61 seconds
-- MOOSE sparse config: 9.22 seconds
+- MOOSE non-sparse config: 9.61 seconds (MOOSE's old config, no longer available)
+- MOOSE sparse config: 9.22 seconds (MOOSE's current config)

--- a/framework/doc/content/source/utils/DualReal.md
+++ b/framework/doc/content/source/utils/DualReal.md
@@ -40,7 +40,7 @@ storage type by running `./configure --with-derivative-type=sparse` in MOOSE's
 framework directory. The underlying derivative storage array size for both
 `NumberArray` and `SemiDynamicSparseNumberArray` can be modified by running
 `configure` with the option `--with-derivative-size=<n>` where `<n>` is the
-desired size of the container. By default, MOOSE is configured `--with-derivative-size=53`.
+desired size of the container. By default, MOOSE is configured `--with-derivative-size=64`.
 
 ## AD-Related Timings id=timings
 

--- a/modules/doc/content/getting_started/examples_and_tutorials/tutorial01_app_development/step10_auxkernels.md
+++ b/modules/doc/content/getting_started/examples_and_tutorials/tutorial01_app_development/step10_auxkernels.md
@@ -93,7 +93,7 @@ In `include/auxkernels`, create a file name `DarcyVelocity.h` and add the code g
          id=dv-header
          caption=Header file for the `DarcyVelocity` class.
 
-In `src/auxkernels`, create a file name `DarcyVelocity.C` and add the code given in [dv-source]. For the dependencies, the header file for the [`MetaPhysicL` namespace](https://github.com/roystgnr/MetaPhysicL/blob/master/src/numerics/include/metaphysicl/raw_type.h) was included in addition to `DarcyVelocity.h`, because it provides a simple method for accessing the raw values of [!ac](AD) types, which are usually a complex set of containers storing a variable and all of its derivatives. The method will be used to handle the `ADMaterialProperty` data.
+In `src/auxkernels`, create a file name `DarcyVelocity.C` and add the code given in [dv-source]. For the dependencies, the header file for the [MetaPhysicL namespace](https://github.com/libMesh/MetaPhysicL/blob/master/src/numerics/include/metaphysicl/raw_type.h) was included in addition to `DarcyVelocity.h`, because it provides a simple method for accessing the raw values of [!ac](AD) types, which are usually a complex set of containers storing a variable and all of its derivatives. The method will be used to handle the `ADMaterialProperty` data.
 
 The only input that needs to be appended to those defined by `VectorAuxKernel::validParams()` is the name of the nonlinear variable containing the values for $p$. Thus, the `addRequiredCoupledVar()` method was used to define a parameter `"pressure"`. This `InputParameters` member is like `addRequiredParam()`, but the only type of data it accepts is a string identifying the variable object, for which, if not found, will cause an error.
 

--- a/modules/doc/content/getting_started/new_users.md.template
+++ b/modules/doc/content/getting_started/new_users.md.template
@@ -120,7 +120,7 @@ MOOSE can be customized by running a `configure` script in
   the derivative storage type; `nonsparse` selects `NumberArray`. A more detailed overview of these
   storage types can be found in the [`DualReal` documentation](/DualReal.md).
 - `--with-derivative-size=<n>`: Specify the length of the underlying derivative storage array. The
-  default is 50. A smaller number may be chosen for increased speed; a larger number may be required
+  default is 64. A smaller number may be chosen for increased speed; a larger number may be required
   for 3D problems or problems with coupling between many variables.
 - `--prefix`: Specify a target installation path. Useful if you plan on running `make install`.
 

--- a/modules/doc/content/getting_started/new_users.md.template
+++ b/modules/doc/content/getting_started/new_users.md.template
@@ -113,16 +113,13 @@ MOOSE can be customized by running a `configure` script in
 {{PATH}}/moose. Below we summarize the configuration options available:
 !style-end!
 
+- `--prefix`: Specify a target installation path. Useful if you plan on running `make install`.
+
 ### Automatic Differentiation
 
-- `--with-derivative-type`: Specify the derivative storage type to use for MOOSE's `DualReal`
-  object. Options are `sparse` and `nonsparse`. `sparse` selects `SemiDynamicSparseNumberArray` as
-  the derivative storage type; `nonsparse` selects `NumberArray`. A more detailed overview of these
-  storage types can be found in the [`DualReal` documentation](/DualReal.md).
 - `--with-derivative-size=<n>`: Specify the length of the underlying derivative storage array. The
   default is 64. A smaller number may be chosen for increased speed; a larger number may be required
   for 3D problems or problems with coupling between many variables.
-- `--prefix`: Specify a target installation path. Useful if you plan on running `make install`.
 
 !include installation/installation_troubleshooting.md
 

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -20,7 +20,7 @@ TERM_FORMAT = os.getenv('MOOSE_TERM_FORMAT', 'njcst')
 
 MOOSE_OPTIONS = {
     'ad_size' : { 're_option' : r'#define\s+MOOSE_AD_MAX_DOFS_PER_ELEM\s+(\d+)',
-                           'default'   : '50'
+                           'default'   : '64'
     },
 
     'libpng' :    { 're_option' : r'#define\s+MOOSE_HAVE_LIBPNG\s+(\d+)',


### PR DESCRIPTION
## Feature request
AD documentation does not give enough details about global vs local indexing, and is not up to date with the mostly removal of local indexing

## Design
Add more text to doco files

## Impact
Facilitate development


Hi Alex (@lindsayad),

I thought it'd be a good idea to read a bit on AD, since it's been such a stone in my shoe recently. 😅

So, why do we skip the local assembly to `_local_re` and `_local_ke`?
Is it just older code or is it a conscious design decision for a particular reason? It sounded like the latter.

EDIT: It seems like you removed the option to switch between `NumberArray` and `SemiDynamicSparseNumberArray` almost a year ago now, ~so maybe the docs require bigger changes~ so I tried to reword the docs to accommodate for that.

Cheers,
-N