### PR TITLE
FSI acoustic structure interface document fix

### DIFF
--- a/modules/fsi/doc/content/source/interfacekernels/StructureAcousticInterface.md
+++ b/modules/fsi/doc/content/source/interfacekernels/StructureAcousticInterface.md
@@ -8,10 +8,10 @@ This interface kernel enforces displacement and pressure/stress continuity acros
 the fluid and structural domains. This interface kernel is part of the fluid-structure interaction codes. Please refer to [fluid-structure interaction using acoustics](/fsi_acoustics.md) for the theoretical details.
 
 !alert note title=Element and neighbor definitions and normal vector
-In this interface kernel, element is always the structure and neighbor is always
- the fluid. Furthermore, the normal vector always points from the structure to
- the fluid. This means, when defining the sideset using the `SideSetsBetweenSubdomainsGenerator` option in MOOSE meshing, `primary_block` should
-  be the structure and `paired_block` should be the fluid. If sideset is defined
+In this interface kernel, element is always the fluid and neighbor is always
+ the structure. Furthermore, the normal vector always points from the fluid to
+ the structure. This means, when defining the sideset using the `SideSetsBetweenSubdomainsGenerator` option in MOOSE meshing, `primary_block` should
+  be the fluid and `paired_block` should be the structure. If sideset is defined
   using Paraview, use the `with respect to` option.
 
 !syntax parameters /InterfaceKernels/StructureAcousticInterface


### PR DESCRIPTION
## Bug Description
The definitions of the primary and secondary blocks in the `StructureAcousticInterface.md` documentation file are fixed.

## Steps to Reproduce
N/A

## Impact
No impact to existing objects.

Closes #26635 
