### PR TITLE
Add instructions for local documentation

### DIFF
--- a/modules/doc/content/ncrc/applications/ncrc_conda.md.template
+++ b/modules/doc/content/ncrc/applications/ncrc_conda.md.template
@@ -55,3 +55,15 @@ cd ./{{binary}}/tests
 ```
 
 One or two failures may indicate those tests have their tolerances set too tight. You likely can ignore a few failures.
+
+## Offline {{ApplicationName}} Documentation
+
+Documentation is included in the package and is available to peruse without the use of a network.
+The local location can be discovered by loading the environment and echoing the following variable:
+
+```bash
+conda activate {{ApplicationLower}}
+echo ${{ApplicationLower}}_DOCS
+```
+
+Copy and paste the results into your favorite web browser to view the documentation.


### PR DESCRIPTION
Update markdown to demonstrate how to learn the location of the pre-built documentation contained in the Conda packages.

Closes #26634
