### PR TITLE
Need to be able to set the moose mesh for mesh generators 

### DIFF
--- a/framework/include/meshgenerators/MeshGenerator.h
+++ b/framework/include/meshgenerators/MeshGenerator.h
@@ -376,8 +376,8 @@ protected:
    */
   void declareNullMeshName(const MeshGeneratorName & name);
 
-  /// References to the mesh and displaced mesh (currently in the ActionWarehouse)
-  const std::shared_ptr<MooseMesh> & _mesh;
+  /// Pointer to the owning mesh
+  MooseMesh * const _mesh;
 
 private:
   /**

--- a/framework/include/utils/MooseMeshUtils.h
+++ b/framework/include/utils/MooseMeshUtils.h
@@ -268,14 +268,14 @@ bool hasSubdomainName(MeshBase & input_mesh, const SubdomainName & name);
  * @param input mesh over which to determine boundary IDs
  * @param boundary ID
  */
-bool hasBoundaryID(MeshBase & input_mesh, const BoundaryID & id);
+bool hasBoundaryID(const MeshBase & input_mesh, const BoundaryID id);
 
 /**
  * Whether a particular boundary name exists in the mesh
  * @param input mesh over which to determine boundary names
  * @param boundary name
  */
-bool hasBoundaryName(MeshBase & input_mesh, const BoundaryName & name);
+bool hasBoundaryName(const MeshBase & input_mesh, const BoundaryName & name);
 
 /**
  * Convert a list of sides in the form of a vector of pairs of node ids into a list of ordered nodes

--- a/framework/src/meshgenerators/MeshGenerator.C
+++ b/framework/src/meshgenerators/MeshGenerator.C
@@ -43,6 +43,7 @@ MeshGenerator::validParams()
   params.registerBase("MeshGenerator");
 
   params.addPrivateParam<bool>("_has_generate_data", false);
+  params.addPrivateParam<MooseMesh *>("_moose_mesh", nullptr);
 
   return params;
 }
@@ -50,7 +51,8 @@ MeshGenerator::validParams()
 MeshGenerator::MeshGenerator(const InputParameters & parameters)
   : MooseObject(parameters),
     MeshMetaDataInterface(this),
-    _mesh(_app.actionWarehouse().mesh()),
+    _mesh(getParam<MooseMesh *>("_moose_mesh") ? getParam<MooseMesh *>("_moose_mesh")
+                                               : _app.actionWarehouse().mesh().get()),
     _save_with_name(getParam<std::string>("save_with_name"))
 {
   if (_save_with_name == _app.getMeshGeneratorSystem().mainMeshGeneratorName())

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -416,7 +416,7 @@ hasSubdomainName(MeshBase & input_mesh, const SubdomainName & name)
 }
 
 bool
-hasBoundaryID(MeshBase & input_mesh, const BoundaryID & id)
+hasBoundaryID(const MeshBase & input_mesh, const BoundaryID id)
 {
   const BoundaryInfo & boundary_info = input_mesh.get_boundary_info();
   std::set<boundary_id_type> boundary_ids = boundary_info.get_boundary_ids();
@@ -430,7 +430,7 @@ hasBoundaryID(MeshBase & input_mesh, const BoundaryID & id)
 }
 
 bool
-hasBoundaryName(MeshBase & input_mesh, const BoundaryName & name)
+hasBoundaryName(const MeshBase & input_mesh, const BoundaryName & name)
 {
   const auto id = getBoundaryID(name, input_mesh);
   return hasBoundaryID(input_mesh, id);


### PR DESCRIPTION
Griffin creates a mesh generator and new mesh for its pebble bed streamline calculations. When attaching relationship managers to this new mesh we need to be able to wrap a moose mesh around it that is not the moose mesh wrapping the simulation mesh. In a follow-on PR this will allow initializing relationship managers with consistent and corresponding `MooseMesh` and `MeshBase` objects

Refs failures spurred by https://github.com/idaholab/moose/pull/26593 and its follow-on https://github.com/idaholab/moose/pull/26625