### PR TITLE
Use CoupledName as an alias for std::vector<VariableName>

### DIFF
--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -1057,6 +1057,10 @@ DerivativeStringClass(NonlinearSystemName);
 /// Command line argument, specialized to handle quotes in vector arguments
 DerivativeStringClass(CLIArgString);
 
+/**
+ * additional MOOSE typedefs
+ */
+typedef std::vector<VariableName> CoupledName;
 namespace Moose
 {
 extern const TagName SOLUTION_TAG;

--- a/modules/contact/include/actions/ContactAction.h
+++ b/modules/contact/include/actions/ContactAction.h
@@ -111,9 +111,6 @@ protected:
   /// Whether mortar dynamic contact constraints are to be used
   const bool _mortar_dynamics;
 
-  /// Type that we use in Actions for declaring coupling
-  typedef std::vector<VariableName> CoupledName;
-
 private:
   /**
    * Generate mesh and other Moose objects for Mortar contact

--- a/modules/navier_stokes/include/actions/CNSAction.h
+++ b/modules/navier_stokes/include/actions/CNSAction.h
@@ -113,7 +113,4 @@ protected:
   std::set<SubdomainID> _block_ids;
   /// pressure variable name
   const std::string _pressure_variable_name;
-
-  /// Type that we use in Actions for declaring coupling
-  typedef std::vector<VariableName> CoupledName;
 };

--- a/modules/navier_stokes/include/actions/INSAction.h
+++ b/modules/navier_stokes/include/actions/INSAction.h
@@ -84,7 +84,4 @@ protected:
   std::set<SubdomainID> _block_ids;
   /// pressure variable name
   const std::string _pressure_variable_name;
-
-  /// Type that we use in Actions for declaring coupling
-  typedef std::vector<VariableName> CoupledName;
 };

--- a/modules/navier_stokes/include/base/NSFVBase.h
+++ b/modules/navier_stokes/include/base/NSFVBase.h
@@ -55,10 +55,6 @@ public:
   ///@}
 
 protected:
-  /// Type that we use in Actions for declaring coupling between the solutions
-  /// of different physics components
-  typedef std::vector<VariableName> CoupledName;
-
   /// Adds NS variables
   void addNSVariables();
   /// Adds NS initial conditions

--- a/modules/tensor_mechanics/include/actions/DomainIntegralAction.h
+++ b/modules/tensor_mechanics/include/actions/DomainIntegralAction.h
@@ -160,7 +160,4 @@ protected:
    * is greater than 1
    */
   const bool _used_by_xfem_to_grow_crack;
-
-  /// Type that we use in Actions for declaring coupling
-  typedef std::vector<VariableName> CoupledName;
 };


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->
closes #26639

## Reason
<!--Why do you need this feature or what is the enhancement?-->
Please refer to #26639.
Add an alias for convenience.

## Design
<!--A concise description (design) of the enhancement.-->
Please refer to #26639.
Use an alias `CoupledName` for `std::vector<VariableName>`, which already been implemented in a couple of moose modules.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
None.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
