### PR TITLE
Make January 2024 news public

### DIFF
--- a/modules/doc/content/newsletter/2024/2024_01.md
+++ b/modules/doc/content/newsletter/2024/2024_01.md
@@ -1,10 +1,5 @@
 # MOOSE Newsletter (January 2024)
 
-!alert! construction title=In Progress
-This MOOSE Newsletter edition is in progress. Please check back in February 2024
-for a complete description of all MOOSE changes.
-!alert-end!
-
 ## MOOSE Improvements
 
 ## libMesh-level Changes

--- a/modules/doc/content/newsletter/2024/2024_01.md
+++ b/modules/doc/content/newsletter/2024/2024_01.md
@@ -2,6 +2,13 @@
 
 ## MOOSE Improvements
 
+### New Physics action syntax
+
+The [Physics](syntax/Physics/index.md) syntax has been added to MOOSE. The `Physics` system is meant
+to streamline the input of an equation in MOOSE, by selecting good default parameters and preconditioners
+for example. `Physics` are derived from [Actions](syntax/Actions/index.md) but define additional APIs
+to facilitate the implementation of a new `Physics` action. As appropriate, some of the modules' actions that defined equations will be transitioned to the `Physics` system over the coming months.
+
 ### Separation of the Materials and FunctorMaterials block
 
 [Functor materials](syntax/FunctorMaterials/index.md) were added to MOOSE to

--- a/modules/doc/content/newsletter/2024/2024_01.md
+++ b/modules/doc/content/newsletter/2024/2024_01.md
@@ -5,24 +5,26 @@
 ### New Physics action syntax
 
 The [Physics](syntax/Physics/index.md) syntax has been added to MOOSE. The `Physics` system is meant
-to streamline the input of an equation in MOOSE, by selecting good default parameters and preconditioners
-for example. `Physics` are derived from [Actions](source/actions/Action.md) but define additional APIs
-to facilitate the implementation of a new `Physics` action. As appropriate, some of the modules' actions that defined equations will be transitioned to the `Physics` system over the coming months.
+to streamline the input of an set of physical equations in MOOSE. For example, this might allow the
+definition of the required equations automatically but also the selection of good default parameters
+and preconditioners. `Physics` are derived from [Actions](source/actions/Action.md) but define additional
+APIs to facilitate the implementation of a new `Physics` action. As appropriate, some of the modules'
+actions that defined equations will be transitioned to the `Physics` system over the coming months.
 
 ### Separation of the Materials and FunctorMaterials block
 
 [Functor materials](syntax/FunctorMaterials/index.md) were added to MOOSE to
 allow evaluation of material properties at arbitrary locations, such as element
-faces or nodes. These materials do not define material properties in the traditional
-[Material](syntax/Materials/index.md) material system, but instead they define
-[Functors](syntax/Functors/index.md). To mark the difference between the two system,
-the two types of objects should no longer be created in the same `[Materials]` block,
+faces or nodes. These materials do not define traditional material properties as in the
+[Material](syntax/Materials/index.md) system, but instead they define
+[Functors](syntax/Functors/index.md). To mark the difference between the two systems,
+the two types of objects should no longer be created in the same `[Materials]` block;
 FunctorMaterials should be created inside a `[FunctorMaterials]` block.
 
 ### Improvements in the Navier Stokes Module
 
-- k-$\epsilon$ turbulence model was added. This method enables more accurate turbulence modeling compared to the current mixing-length model.
-- A drift-flux mixture model was added which enables solutions of two-phase flows where the phases move at different velocities, but assume local equilibrium over short spatial length scales.
+- The k-$\epsilon$ turbulence model was added. This method enables more accurate turbulence modeling compared to the current mixing-length model.
+- A drift-flux mixture model was added which enables solutions of two-phase flows where the phases move at different velocities but assume local equilibrium over short spatial length scales.
 
 ### Field Split Additions
 

--- a/modules/doc/content/newsletter/2024/2024_01.md
+++ b/modules/doc/content/newsletter/2024/2024_01.md
@@ -12,6 +12,11 @@ faces or nodes. These materials do not define material properties in the traditi
 the two types of objects should no longer be created in the same `[Materials]` block,
 FunctorMaterials should be created inside a `[FunctorMaterials]` block.
 
+### Improvements in the Navier Stokes Module
+
+- k-$\epsilon$ turbulence model was added. This method enables more accurate turbulence modeling compared to the current mixing-length model.
+- A drift-flux mixture model was added which enables solutions of two-phase flows where the phases move at different velocities, but assume local equilibrium over short spatial length scales.
+
 ## libMesh-level Changes
 
 ### `2024.01.23` Update

--- a/modules/doc/content/newsletter/2024/2024_01.md
+++ b/modules/doc/content/newsletter/2024/2024_01.md
@@ -75,6 +75,40 @@ problem sizes up to 70 million degrees of freedom.
 
 ## PETSc-level Changes
 
+### PETSc updated to 3.20.3
+
+The `moose-petsc` package has been updated alongside the repository submodule to version 3.20.3.
+Consequently, the `moose-dev` conda environment has been updated. To update your MOOSE
+package to this release, please activate your MOOSE conda environment and perform the command:
+
+```
+mamba install moose-dev=2024.01.23
+```
+
+or remove and re-create your moose environment by performing the following:
+
+```
+conda deactivate
+conda env remove -n moose
+conda create -n moose moose-dev=2024.01.23
+```
+
+The following MOOSE package versions and builds corresponding to `moose-dev=2024.01.23` should be
+seen in the new conda environment.
+
+```
+Package                  Version           Build
+===================================================
+moose-dev                2024.01.23        build_0
+moose-libmesh            2024.01.23        build_0
+moose-libmesh-vtk        9.2.6             build_8
+moose-mpich              4.0.2             build_15
+moose-peacock            2023.11.29        hb4c3223_0
+moose-petsc              3.20.3            build_0
+moose-tools              2023.12.20        he4b30e4_0
+moose-wasp               2023.11.29        build_0
+```
+
 ## Bug Fixes and Minor Enhancements
 
 - Shorthand functor material property output was added using the [!param](/FunctorMaterials/GenericFunctorMaterial/output_properties) parameter. This automatically creates a [FunctorAux.md] and a constant monomial variable for output, which had to be done manually before.

--- a/modules/doc/content/newsletter/2024/2024_01.md
+++ b/modules/doc/content/newsletter/2024/2024_01.md
@@ -5,9 +5,9 @@
 ### New Physics action syntax
 
 The [Physics](syntax/Physics/index.md) syntax has been added to MOOSE. The `Physics` system is meant
-to streamline the input of an set of physical equations in MOOSE. For example, this might allow the
+to streamline the input of a set of physical equations in MOOSE. For example, this might allow the
 definition of the required equations automatically but also the selection of good default parameters
-and preconditioners. `Physics` are derived from [Actions](source/actions/Action.md) but define additional
+and preconditioners. `Physics` are derived from [Actions](source/actions/Action.md) but define
 APIs to facilitate the implementation of a new `Physics` action. As appropriate, some of the modules'
 actions that defined equations will be transitioned to the `Physics` system over the coming months.
 
@@ -15,7 +15,7 @@ actions that defined equations will be transitioned to the `Physics` system over
 
 [Functor materials](syntax/FunctorMaterials/index.md) were added to MOOSE to
 allow evaluation of material properties at arbitrary locations, such as element
-faces or nodes. These materials do not define traditional material properties as in the
+faces or nodes, usually on-the-fly (although some caching is supported). These materials do not define traditional material properties as in the
 [Material](syntax/Materials/index.md) system, but instead they define
 [Functors](syntax/Functors/index.md). To mark the difference between the two systems,
 the two types of objects should no longer be created in the same `[Materials]` block;

--- a/modules/doc/content/newsletter/2024/2024_01.md
+++ b/modules/doc/content/newsletter/2024/2024_01.md
@@ -6,7 +6,7 @@
 
 The [Physics](syntax/Physics/index.md) syntax has been added to MOOSE. The `Physics` system is meant
 to streamline the input of an equation in MOOSE, by selecting good default parameters and preconditioners
-for example. `Physics` are derived from [Actions](syntax/Actions/index.md) but define additional APIs
+for example. `Physics` are derived from [Actions](source/actions/Action.md) but define additional APIs
 to facilitate the implementation of a new `Physics` action. As appropriate, some of the modules' actions that defined equations will be transitioned to the `Physics` system over the coming months.
 
 ### Separation of the Materials and FunctorMaterials block
@@ -75,6 +75,6 @@ problem sizes up to 70 million degrees of freedom.
 
 ## Bug Fixes and Minor Enhancements
 
-- Shorthand functor material property output was added using the [!param](/FunctorMaterials/GenericFunctorMaterial/property_output) parameter. This automatically creates a [FunctorAux.md] and a constant monomial variable for output, which had to be done manually before.
-- Extra element IDs can now be used to assign elements to subdomains in the [ParsedSubdomainGenerator.md].
+- Shorthand functor material property output was added using the [!param](/FunctorMaterials/GenericFunctorMaterial/output_properties) parameter. This automatically creates a [FunctorAux.md] and a constant monomial variable for output, which had to be done manually before.
+- Extra element IDs can now be used to assign elements to subdomains in the [ParsedSubdomainMeshGenerator.md].
 - The [PropertyReadFile.md] user object can now read multiple files, once every time it is executed. The execution is controlled with the [!param](/UserObjects/PropertyReadFile/execute_on) parameter.

--- a/modules/doc/content/newsletter/2024/2024_01.md
+++ b/modules/doc/content/newsletter/2024/2024_01.md
@@ -2,6 +2,16 @@
 
 ## MOOSE Improvements
 
+### Separation of the Materials and FunctorMaterials block
+
+[Functor materials](syntax/FunctorMaterials/index.md) were added to MOOSE to
+allow evaluation of material properties at arbitrary locations, such as element
+faces or nodes. These materials do not define material properties in the traditional
+[Material](syntax/Materials/index.md) material system, but instead they define
+[Functors](syntax/Functors/index.md). To mark the difference between the two system,
+the two types of objects should no longer be created in the same `[Materials]` block,
+FunctorMaterials should be created inside a `[FunctorMaterials]` block.
+
 ## libMesh-level Changes
 
 ### `2024.01.23` Update
@@ -45,3 +55,7 @@
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements
+
+- Shorthand functor material property output was added using the [!param](/FunctorMaterials/GenericFunctorMaterial/property_output) parameter. This automatically creates a [FunctorAux.md] and a constant monomial variable for output, which had to be done manually before.
+- Extra element IDs can now be used to assign elements to subdomains in the [ParsedSubdomainGenerator.md].
+- The [PropertyReadFile.md] user object can now read multiple files, once every time it is executed. The execution is controlled with the [!param](/UserObjects/PropertyReadFile/execute_on) parameter.

--- a/modules/doc/content/newsletter/2024/2024_01.md
+++ b/modules/doc/content/newsletter/2024/2024_01.md
@@ -80,3 +80,4 @@ problem sizes up to 70 million degrees of freedom.
 - Shorthand functor material property output was added using the [!param](/FunctorMaterials/GenericFunctorMaterial/output_properties) parameter. This automatically creates a [FunctorAux.md] and a constant monomial variable for output, which had to be done manually before.
 - Extra element IDs can now be used to assign elements to subdomains in the [ParsedSubdomainMeshGenerator.md].
 - The [PropertyReadFile.md] user object can now read multiple files, once every time it is executed. The execution is controlled with the [!param](/UserObjects/PropertyReadFile/execute_on) parameter.
+- The [NEML2](syntax/NEML2/index.md) constitutive model library was added to the tensor mechanics module as an optional dependency. NEML2 is built on top of libTorch and supports teh implementation of devide independent material models (with GPU support).

--- a/modules/doc/content/newsletter/2024/2024_01.md
+++ b/modules/doc/content/newsletter/2024/2024_01.md
@@ -80,4 +80,4 @@ problem sizes up to 70 million degrees of freedom.
 - Shorthand functor material property output was added using the [!param](/FunctorMaterials/GenericFunctorMaterial/output_properties) parameter. This automatically creates a [FunctorAux.md] and a constant monomial variable for output, which had to be done manually before.
 - Extra element IDs can now be used to assign elements to subdomains in the [ParsedSubdomainMeshGenerator.md].
 - The [PropertyReadFile.md] user object can now read multiple files, once every time it is executed. The execution is controlled with the [!param](/UserObjects/PropertyReadFile/execute_on) parameter.
-- The [NEML2](syntax/NEML2/index.md) constitutive model library was added to the tensor mechanics module as an optional dependency. NEML2 is built on top of libTorch and supports teh implementation of devide independent material models (with GPU support).
+- The [NEML2](syntax/NEML2/index.md) constitutive model library was added to the tensor mechanics module as an optional dependency. NEML2 is built on top of libTorch and supports the implementation of device-independent material models (with GPU support).

--- a/modules/doc/content/newsletter/2024/2024_01.md
+++ b/modules/doc/content/newsletter/2024/2024_01.md
@@ -24,6 +24,13 @@ FunctorMaterials should be created inside a `[FunctorMaterials]` block.
 - k-$\epsilon$ turbulence model was added. This method enables more accurate turbulence modeling compared to the current mixing-length model.
 - A drift-flux mixture model was added which enables solutions of two-phase flows where the phases move at different velocities, but assume local equilibrium over short spatial length scales.
 
+### Field Split Additions
+
+Field splits can now be nested within each other. Moreover a [NavierStokesProblem.md] was introduced
+that allows for scalable preconditioning of the Navier-Stokes equations for low to moderate Reynolds
+numbers. The Least Squared Commutator preconditioning techniques employed have been demonstrated on
+problem sizes up to 70 million degrees of freedom.
+
 ## libMesh-level Changes
 
 ### `2024.01.23` Update

--- a/modules/doc/content/newsletter/2024/2024_02.md
+++ b/modules/doc/content/newsletter/2024/2024_02.md
@@ -1,0 +1,14 @@
+# MOOSE Newsletter (February 2024)
+
+!alert! construction title=In Progress
+This MOOSE Newsletter edition is in progress. Please check back in March 2024
+for a complete description of all MOOSE changes.
+!alert-end!
+
+## MOOSE Improvements
+
+## libMesh-level Changes
+
+## PETSc-level Changes
+
+## Bug Fixes and Minor Enhancements

--- a/modules/doc/content/newsletter/index.md
+++ b/modules/doc/content/newsletter/index.md
@@ -4,6 +4,10 @@ MOOSE is a dynamic project with changes occurring daily. In order to help users 
 major changes to the project monthly highlights will be produced. These highlights will be posted
 monthly to the [MOOSE discussion forum](contact_us.md) as well as provided below.
 
+## 2024
+
+- [January, 2024](2024_01.md)
+
 ## 2023
 
 - [December, 2023](2023_12.md)


### PR DESCRIPTION
Create February 2024 template

Refs #11447

@idaholab/moose-ccb Please add the missing contributions from your work and that of our collaborators that are missing from the January news! 
