### PR TITLE
Allow the use of the non-AD version of rho_from_p_T for the density time derivative

### DIFF
--- a/modules/navier_stokes/doc/content/source/functormaterials/GeneralFunctorFluidProps.md
+++ b/modules/navier_stokes/doc/content/source/functormaterials/GeneralFunctorFluidProps.md
@@ -31,6 +31,13 @@ and the pressure and temperature derivatives of the:
 - Prandtl number, $\text{Pr}$
 - pore Reynolds number $\text{Re}$
 
+!alert note
+In order to use this with some fluid properties that do not compute the AD version of the density
+derivatives, such as the Spline Base Table Lookup fluid properties, you can use the
+[!param](/FunctorMaterials/GeneralFunctorFluidProps/neglect_derivatives_of_density_time_derivative)
+to neglect the derivatives with regards to the nonlinear variables (usually pressure, temperature)
+of the time derivative of the density.
+
 !syntax parameters /FunctorMaterials/GeneralFunctorFluidProps
 
 !syntax inputs /FunctorMaterials/GeneralFunctorFluidProps

--- a/modules/navier_stokes/include/functormaterials/GeneralFunctorFluidProps.h
+++ b/modules/navier_stokes/include/functormaterials/GeneralFunctorFluidProps.h
@@ -51,6 +51,9 @@ protected:
   /// Function to ramp down the viscosity, useful for relaxation transient
   const Function & _mu_rampdown;
 
+  /// Whether to neglect the contributions to the Jacobian of the density time derivative
+  const bool _neglect_derivatives_of_density_time_derivative;
+
   using DerivativeMaterialPropertyNameInterface::derivativePropertyNameFirst;
   using UserObjectInterface::getUserObject;
 };

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/materials/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/materials/tests
@@ -17,7 +17,16 @@
     type = 'Exodiff'
     input = functorfluidprops.i
     exodiff = functorfluidprops_out.e
-    requirement = 'The system shall be able to output gradeurs, derivatives and adimensional quantities from realistic functor fluid properties'
+    requirement = 'The system shall be able to output grandeurs, derivatives and non-dimensional quantities from realistic functor fluid properties'
     recover = false
+  []
+  [neglect_drho_dt_derivatives]
+    type = 'Exodiff'
+    input = functorfluidprops.i
+    exodiff = functorfluidprops_out.e
+    cli_args = 'FunctorMaterials/fluid_props_to_mat_props/neglect_derivatives_of_density_time_derivative=true'
+    requirement = 'The system shall be able to neglect the derivatives with regards to nonlinear variables of the density first order time derivative.'
+    recover = false
+    prereq = 'fluidprops'
   []
 []


### PR DESCRIPTION
closes #26704
