### PR TITLE
Stage 1 of active material property refactor

### DIFF
--- a/framework/include/loops/ComputeFVFluxThread.h
+++ b/framework/include/loops/ComputeFVFluxThread.h
@@ -596,7 +596,7 @@ ComputeFVFluxThread<RangeType, AttributeTagType>::checkPropDeps(
 #ifndef NDEBUG
   std::set<unsigned int> props_diff;
   std::set<unsigned int> supplied_props;
-  std::set<unsigned int> fv_kernel_requested_props;
+  std::unordered_set<unsigned int> fv_kernel_requested_props;
 
   for (auto * kernel : _fv_flux_kernels)
   {
@@ -615,7 +615,8 @@ ComputeFVFluxThread<RangeType, AttributeTagType>::checkPropDeps(
     }
 
     const auto & mp_deps = mat->getMatPropDependencies();
-    emptyDifferenceTest(mp_deps, supplied_props, props_diff);
+    emptyDifferenceTest(
+        std::set<unsigned int>(mp_deps.begin(), mp_deps.end()), supplied_props, props_diff);
   }
 
   // Print a warning if block restricted materials are used
@@ -631,7 +632,10 @@ ComputeFVFluxThread<RangeType, AttributeTagType>::checkPropDeps(
                      "property name? \nUnfortunately that is not supported in FV because we have "
                      "to allow ghosting \nof material properties for block-restricted physics."));
 
-  emptyDifferenceTest(fv_kernel_requested_props, supplied_props, props_diff);
+  emptyDifferenceTest(
+      std::set<unsigned int>(fv_kernel_requested_props.begin(), fv_kernel_requested_props.end()),
+      supplied_props,
+      props_diff);
 #endif
 }
 

--- a/framework/include/materials/InterfaceMaterial.h
+++ b/framework/include/materials/InterfaceMaterial.h
@@ -168,7 +168,7 @@ public:
 
   virtual bool isBoundaryMaterial() const override { return true; }
 
-  virtual const std::set<unsigned int> & getMatPropDependencies() const override
+  virtual const std::unordered_set<unsigned int> & getMatPropDependencies() const override
   {
     return TwoMaterialPropertyInterface::getMatPropDependencies();
   }

--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -199,7 +199,7 @@ public:
 
   virtual bool isBoundaryMaterial() const override { return _bnd; }
 
-  virtual const std::set<unsigned int> & getMatPropDependencies() const override
+  virtual const std::unordered_set<unsigned int> & getMatPropDependencies() const override
   {
     return MaterialPropertyInterface::getMatPropDependencies();
   }

--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -215,7 +215,7 @@ public:
    * @return The IDs corresponding to the material properties that
    * MUST be reinited before evaluating this object
    */
-  virtual const std::set<unsigned int> & getMatPropDependencies() const = 0;
+  virtual const std::unordered_set<unsigned int> & getMatPropDependencies() const = 0;
 
   /**
    * @return Whether this material has stateful properties

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -321,7 +321,7 @@ public:
    * @return The IDs corresponding to the material properties that
    * MUST be reinited before evaluating this object
    */
-  const std::set<unsigned int> & getMatPropDependencies() const
+  const std::unordered_set<unsigned int> & getMatPropDependencies() const
   {
     return _material_property_dependencies;
   }
@@ -542,7 +542,7 @@ protected:
   std::vector<std::unique_ptr<PropertyValue>> _default_properties;
 
   /// The set of material properties (as given by their IDs) that _this_ object depends on
-  std::set<unsigned int> _material_property_dependencies;
+  std::unordered_set<unsigned int> _material_property_dependencies;
 
   const MaterialPropertyName _get_suffix;
 

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -782,11 +782,26 @@ public:
                           InputParameters & parameters);
 
   /**
+   * Add the MooseVariables and the material properties that the current materials depend on to the
+   * dependency list.
+   * @param consumer_needed_mat_props The material properties needed by consumer objects (other than
+   * the materials themselves)
+   * @param blk_id The subdomain ID for which we are preparing our list of needed vars and props
+   * @param tid The thread ID we are preparing the requirements for
+   *
+   * This MUST be done after the moose variable dependency list has been set for all the other
+   * objects using the \p setActiveElementalMooseVariables API!
+   */
+  void prepareMaterials(const std::unordered_set<unsigned int> & consumer_needed_mat_props,
+                        const SubdomainID blk_id,
+                        const THREAD_ID tid);
+
+  /**
    * Add the MooseVariables that the current materials depend on to the dependency list.
    *
    * This MUST be done after the dependency list has been set for all the other objects!
    */
-  virtual void prepareMaterials(SubdomainID blk_id, const THREAD_ID tid);
+  void prepareMaterials(const SubdomainID blk_id, const THREAD_ID tid);
 
   void reinitMaterials(SubdomainID blk_id, const THREAD_ID tid, bool swap_stateful = true);
 

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -851,7 +851,7 @@ public:
    *
    * @param tid The thread id
    */
-  void setActiveMaterialProperties(const std::set<unsigned int> & mat_prop_ids,
+  void setActiveMaterialProperties(const std::unordered_set<unsigned int> & mat_prop_ids,
                                    const THREAD_ID tid);
 
   /**
@@ -859,7 +859,7 @@ public:
    *
    * @param tid The thread id
    */
-  const std::set<unsigned int> & getActiveMaterialProperties(const THREAD_ID tid) const;
+  const std::unordered_set<unsigned int> & getActiveMaterialProperties(const THREAD_ID tid) const;
 
   /**
    * Method to check whether or not a list of active material roperties has been set. This method
@@ -2405,6 +2405,9 @@ protected:
   bool _calculate_jacobian_in_uo;
 
   std::vector<std::vector<const MooseVariableFEBase *>> _uo_jacobian_moose_vars;
+
+  /// Set of material property ids that determine whether materials get reinited
+  std::vector<std::unordered_set<unsigned int>> _active_material_property_ids;
 
   SolverParams _solver_params;
 

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -1000,9 +1000,6 @@ protected:
   /* This needs to remain <unsigned int> for threading purposes */
   std::vector<unsigned int> _has_active_elemental_moose_variables;
 
-  /// Set of material property ids that determine whether materials get reinited
-  std::vector<std::set<unsigned int>> _active_material_property_ids;
-
   std::vector<std::set<TagID>> _active_fe_var_coupleable_matrix_tags;
 
   std::vector<std::set<TagID>> _active_fe_var_coupleable_vector_tags;

--- a/framework/include/utils/MortarUtils.h
+++ b/framework/include/utils/MortarUtils.h
@@ -102,7 +102,7 @@ loopOverMortarSegments(
   const auto & JxW_msm = assembly.jxWMortar();
 
   // Set required material properties
-  std::set<unsigned int> needed_mat_props;
+  std::unordered_set<unsigned int> needed_mat_props;
   for (const auto & consumer : consumers)
   {
     const auto & mp_deps = consumer->getMatPropDependencies();

--- a/framework/include/vectorpostprocessors/LineMaterialSamplerBase.h
+++ b/framework/include/vectorpostprocessors/LineMaterialSamplerBase.h
@@ -157,8 +157,8 @@ LineMaterialSamplerBase<T>::execute()
   const RealVectorValue line_unit_vec = line_vec / line_length;
   std::vector<Real> values(_material_properties.size());
 
-  std::set<unsigned int> needed_mat_props;
-  const std::set<unsigned int> & mp_deps = getMatPropDependencies();
+  std::unordered_set<unsigned int> needed_mat_props;
+  const auto & mp_deps = getMatPropDependencies();
   needed_mat_props.insert(mp_deps.begin(), mp_deps.end());
   _fe_problem.setActiveMaterialProperties(needed_mat_props, _tid);
 

--- a/framework/include/warehouses/MooseObjectWarehouseBase.h
+++ b/framework/include/warehouses/MooseObjectWarehouseBase.h
@@ -152,14 +152,15 @@ public:
   /**
    * Update material property dependency vector.
    */
-  void updateMatPropDependency(std::set<unsigned int> & needed_mat_props, THREAD_ID tid = 0) const;
+  void updateMatPropDependency(std::unordered_set<unsigned int> & needed_mat_props,
+                               THREAD_ID tid = 0) const;
   void updateBlockMatPropDependency(SubdomainID id,
-                                    std::set<unsigned int> & needed_mat_props,
+                                    std::unordered_set<unsigned int> & needed_mat_props,
                                     THREAD_ID tid = 0) const;
-  void updateBoundaryMatPropDependency(std::set<unsigned int> & needed_mat_props,
+  void updateBoundaryMatPropDependency(std::unordered_set<unsigned int> & needed_mat_props,
                                        THREAD_ID tid = 0) const;
   void updateBoundaryMatPropDependency(BoundaryID id,
-                                       std::set<unsigned int> & needed_mat_props,
+                                       std::unordered_set<unsigned int> & needed_mat_props,
                                        THREAD_ID tid = 0) const;
   ///@}
 
@@ -232,7 +233,7 @@ protected:
   /**
    * Helper method for updating material property dependency vector
    */
-  static void updateMatPropDependencyHelper(std::set<unsigned int> & needed_mat_props,
+  static void updateMatPropDependencyHelper(std::unordered_set<unsigned int> & needed_mat_props,
                                             const std::vector<std::shared_ptr<T>> & objects);
 
   /**
@@ -686,8 +687,8 @@ MooseObjectWarehouseBase<T>::updateFEVariableCoupledVectorTagDependencyHelper(
 
 template <typename T>
 void
-MooseObjectWarehouseBase<T>::updateMatPropDependency(std::set<unsigned int> & needed_mat_props,
-                                                     THREAD_ID tid /* = 0*/) const
+MooseObjectWarehouseBase<T>::updateMatPropDependency(
+    std::unordered_set<unsigned int> & needed_mat_props, THREAD_ID tid /* = 0*/) const
 {
   if (hasActiveObjects(tid))
     updateMatPropDependencyHelper(needed_mat_props, _all_objects[tid]);
@@ -695,9 +696,10 @@ MooseObjectWarehouseBase<T>::updateMatPropDependency(std::set<unsigned int> & ne
 
 template <typename T>
 void
-MooseObjectWarehouseBase<T>::updateBlockMatPropDependency(SubdomainID id,
-                                                          std::set<unsigned int> & needed_mat_props,
-                                                          THREAD_ID tid /* = 0*/) const
+MooseObjectWarehouseBase<T>::updateBlockMatPropDependency(
+    SubdomainID id,
+    std::unordered_set<unsigned int> & needed_mat_props,
+    THREAD_ID tid /* = 0*/) const
 {
   if (hasActiveBlockObjects(id, tid))
     updateMatPropDependencyHelper(needed_mat_props, getActiveBlockObjects(id, tid));
@@ -706,7 +708,7 @@ MooseObjectWarehouseBase<T>::updateBlockMatPropDependency(SubdomainID id,
 template <typename T>
 void
 MooseObjectWarehouseBase<T>::updateBoundaryMatPropDependency(
-    std::set<unsigned int> & needed_mat_props, THREAD_ID tid /* = 0*/) const
+    std::unordered_set<unsigned int> & needed_mat_props, THREAD_ID tid /* = 0*/) const
 {
   if (hasActiveBoundaryObjects(tid))
     for (auto & active_bnd_object : _active_boundary_objects[tid])
@@ -716,7 +718,9 @@ MooseObjectWarehouseBase<T>::updateBoundaryMatPropDependency(
 template <typename T>
 void
 MooseObjectWarehouseBase<T>::updateBoundaryMatPropDependency(
-    BoundaryID id, std::set<unsigned int> & needed_mat_props, THREAD_ID tid /* = 0*/) const
+    BoundaryID id,
+    std::unordered_set<unsigned int> & needed_mat_props,
+    THREAD_ID tid /* = 0*/) const
 {
   if (hasActiveBoundaryObjects(id, tid))
     updateMatPropDependencyHelper(needed_mat_props, getActiveBoundaryObjects(id, tid));
@@ -725,7 +729,8 @@ MooseObjectWarehouseBase<T>::updateBoundaryMatPropDependency(
 template <typename T>
 void
 MooseObjectWarehouseBase<T>::updateMatPropDependencyHelper(
-    std::set<unsigned int> & needed_mat_props, const std::vector<std::shared_ptr<T>> & objects)
+    std::unordered_set<unsigned int> & needed_mat_props,
+    const std::vector<std::shared_ptr<T>> & objects)
 {
   for (auto & object : objects)
   {

--- a/framework/src/auxkernels/NodalPatchRecovery.C
+++ b/framework/src/auxkernels/NodalPatchRecovery.C
@@ -147,8 +147,8 @@ NodalPatchRecovery::reinitPatch()
   _coef.resize(_multi_index.size());
 
   // activate dependent material properties
-  std::set<unsigned int> needed_mat_props;
-  const std::set<unsigned int> & mp_deps = getMatPropDependencies();
+  std::unordered_set<unsigned int> needed_mat_props;
+  const auto & mp_deps = getMatPropDependencies();
   needed_mat_props.insert(mp_deps.begin(), mp_deps.end());
   _fe_problem.setActiveMaterialProperties(needed_mat_props, _tid);
 }

--- a/framework/src/loops/ComputeDiracThread.C
+++ b/framework/src/loops/ComputeDiracThread.C
@@ -60,7 +60,7 @@ ComputeDiracThread::subdomainChanged()
   _dirac_kernels.updateVariableDependency(needed_moose_vars, _tid);
 
   // Update material dependencies
-  std::set<unsigned int> needed_mat_props;
+  std::unordered_set<unsigned int> needed_mat_props;
   _dirac_kernels.updateMatPropDependency(needed_mat_props, _tid);
 
   _fe_problem.setActiveElementalMooseVariables(needed_moose_vars, _tid);

--- a/framework/src/loops/ComputeElemAuxBcsThread.C
+++ b/framework/src/loops/ComputeElemAuxBcsThread.C
@@ -103,10 +103,10 @@ ComputeElemAuxBcsThread<AuxKernelType>::operator()(const ConstBndElemRange & ran
 
         if (_need_materials)
         {
-          std::set<unsigned int> needed_mat_props;
+          std::unordered_set<unsigned int> needed_mat_props;
           for (const auto & aux : iter->second)
           {
-            const std::set<unsigned int> & mp_deps = aux->getMatPropDependencies();
+            const auto & mp_deps = aux->getMatPropDependencies();
             needed_mat_props.insert(mp_deps.begin(), mp_deps.end());
           }
           _fe_problem.setActiveMaterialProperties(needed_mat_props, _tid);

--- a/framework/src/loops/ComputeElemAuxVarsThread.C
+++ b/framework/src/loops/ComputeElemAuxVarsThread.C
@@ -54,7 +54,7 @@ ComputeElemAuxVarsThread<AuxKernelType>::subdomainChanged()
   _fe_problem.subdomainSetup(_subdomain, _tid);
 
   std::set<MooseVariableFEBase *> needed_moose_vars;
-  std::set<unsigned int> needed_mat_props;
+  std::unordered_set<unsigned int> needed_mat_props;
   std::set<TagID> needed_fe_var_matrix_tags;
   std::set<TagID> needed_fe_var_vector_tags;
 
@@ -67,8 +67,8 @@ ComputeElemAuxVarsThread<AuxKernelType>::subdomainChanged()
     for (const auto & aux : kernels)
     {
       aux->subdomainSetup();
-      const std::set<MooseVariableFEBase *> & mv_deps = aux->getMooseVariableDependencies();
-      const std::set<unsigned int> & mp_deps = aux->getMatPropDependencies();
+      const auto & mv_deps = aux->getMooseVariableDependencies();
+      const auto & mp_deps = aux->getMatPropDependencies();
       needed_moose_vars.insert(mv_deps.begin(), mv_deps.end());
       needed_mat_props.insert(mp_deps.begin(), mp_deps.end());
 

--- a/framework/src/loops/ComputeIndicatorThread.C
+++ b/framework/src/loops/ComputeIndicatorThread.C
@@ -69,7 +69,7 @@ ComputeIndicatorThread::subdomainChanged()
       _subdomain, needed_var_vector_tags, _tid);
   _fe_problem.setActiveFEVariableCoupleableVectorTags(needed_var_vector_tags, _tid);
 
-  std::set<unsigned int> needed_mat_props;
+  std::unordered_set<unsigned int> needed_mat_props;
   _indicator_whs.updateMatPropDependency(needed_mat_props, _tid);
   _internal_side_indicators.updateMatPropDependency(needed_mat_props, _tid);
   _fe_problem.setActiveMaterialProperties(needed_mat_props, _tid);

--- a/framework/src/loops/ComputeUserObjectsThread.C
+++ b/framework/src/loops/ComputeUserObjectsThread.C
@@ -74,7 +74,7 @@ ComputeUserObjectsThread::subdomainChanged()
   _fe_problem.subdomainSetup(_subdomain, _tid);
 
   std::set<MooseVariableFEBase *> needed_moose_vars;
-  std::set<unsigned int> needed_mat_props;
+  std::unordered_set<unsigned int> needed_mat_props;
   std::set<TagID> needed_fe_var_vector_tags;
   for (const auto obj : objs)
   {

--- a/framework/src/loops/NonlinearThread.C
+++ b/framework/src/loops/NonlinearThread.C
@@ -86,7 +86,7 @@ NonlinearThread::subdomainChanged()
       _subdomain, needed_fe_var_vector_tags, _tid);
 
   // Update material dependencies
-  std::set<unsigned int> needed_mat_props;
+  std::unordered_set<unsigned int> needed_mat_props;
   _tag_kernels->updateBlockMatPropDependency(_subdomain, needed_mat_props, _tid);
   _ibc_warehouse->updateBoundaryMatPropDependency(needed_mat_props, _tid);
   _dg_warehouse->updateBlockMatPropDependency(_subdomain, needed_mat_props, _tid);

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3476,7 +3476,9 @@ FEProblemBase::addMaterialHelper(std::vector<MaterialWarehouse *> warehouses,
 }
 
 void
-FEProblemBase::prepareMaterials(SubdomainID blk_id, const THREAD_ID tid)
+FEProblemBase::prepareMaterials(const std::unordered_set<unsigned int> & consumer_needed_mat_props,
+                                const SubdomainID blk_id,
+                                const THREAD_ID tid)
 {
   std::set<MooseVariableFEBase *> needed_moose_vars;
   std::unordered_set<unsigned int> needed_mat_props;
@@ -3498,12 +3500,16 @@ FEProblemBase::prepareMaterials(SubdomainID blk_id, const THREAD_ID tid)
   needed_moose_vars.insert(current_active_elemental_moose_variables.begin(),
                            current_active_elemental_moose_variables.end());
 
-  const auto & current_active_material_properties = getActiveMaterialProperties(tid);
-  needed_mat_props.insert(current_active_material_properties.begin(),
-                          current_active_material_properties.end());
+  needed_mat_props.insert(consumer_needed_mat_props.begin(), consumer_needed_mat_props.end());
 
   setActiveElementalMooseVariables(needed_moose_vars, tid);
   setActiveMaterialProperties(needed_mat_props, tid);
+}
+
+void
+FEProblemBase::prepareMaterials(const SubdomainID blk_id, const THREAD_ID tid)
+{
+  prepareMaterials(getActiveMaterialProperties(tid), blk_id, tid);
 }
 
 void

--- a/framework/src/problems/SubProblem.C
+++ b/framework/src/problems/SubProblem.C
@@ -64,7 +64,6 @@ SubProblem::SubProblem(const InputParameters & parameters)
   unsigned int n_threads = libMesh::n_threads();
   _active_elemental_moose_variables.resize(n_threads);
   _has_active_elemental_moose_variables.resize(n_threads);
-  _active_material_property_ids.resize(n_threads);
 
   _active_fe_var_coupleable_matrix_tags.resize(n_threads);
   _active_fe_var_coupleable_vector_tags.resize(n_threads);

--- a/modules/ray_tracing/src/userobjects/RayTracingStudy.C
+++ b/modules/ray_tracing/src/userobjects/RayTracingStudy.C
@@ -631,7 +631,7 @@ RayTracingStudy::segmentSubdomainSetup(const SubdomainID subdomain,
   _fe_problem.subdomainSetup(subdomain, tid);
 
   std::set<MooseVariableFEBase *> needed_moose_vars;
-  std::set<unsigned int> needed_mat_props;
+  std::unordered_set<unsigned int> needed_mat_props;
 
   // Get RayKernels and their dependencies and call subdomain setup
   getRayKernels(_threaded_current_ray_kernels[tid], subdomain, tid, ray_id);

--- a/modules/thermal_hydraulics/include/vectorpostprocessors/Sampler1DBase.h
+++ b/modules/thermal_hydraulics/include/vectorpostprocessors/Sampler1DBase.h
@@ -120,7 +120,7 @@ Sampler1DBase<T>::execute()
 {
   std::vector<Real> values(_material_properties.size());
 
-  std::set<unsigned int> needed_mat_props;
+  std::unordered_set<unsigned int> needed_mat_props;
   const std::set<unsigned int> & mp_deps = getMatPropDependencies();
   needed_mat_props.insert(mp_deps.begin(), mp_deps.end());
   _fe_problem.setActiveMaterialProperties(needed_mat_props, _tid);

--- a/modules/thermal_hydraulics/include/vectorpostprocessors/Sampler1DBase.h
+++ b/modules/thermal_hydraulics/include/vectorpostprocessors/Sampler1DBase.h
@@ -121,7 +121,7 @@ Sampler1DBase<T>::execute()
   std::vector<Real> values(_material_properties.size());
 
   std::unordered_set<unsigned int> needed_mat_props;
-  const std::set<unsigned int> & mp_deps = getMatPropDependencies();
+  const auto & mp_deps = getMatPropDependencies();
   needed_mat_props.insert(mp_deps.begin(), mp_deps.end());
   _fe_problem.setActiveMaterialProperties(needed_mat_props, _tid);
 

--- a/modules/thermal_hydraulics/src/vectorpostprocessors/Sampler1DReal.C
+++ b/modules/thermal_hydraulics/src/vectorpostprocessors/Sampler1DReal.C
@@ -68,8 +68,8 @@ Sampler1DRealTempl<is_ad>::execute()
 {
   std::vector<Real> values(_material_properties.size());
 
-  std::set<unsigned int> needed_mat_props;
-  const std::set<unsigned int> & mp_deps = getMatPropDependencies();
+  std::unordered_set<unsigned int> needed_mat_props;
+  const auto & mp_deps = getMatPropDependencies();
   needed_mat_props.insert(mp_deps.begin(), mp_deps.end());
   _fe_problem.setActiveMaterialProperties(needed_mat_props, _tid);
 


### PR DESCRIPTION
This is stage 1 of an active material property refactor with #26696 representing the sum of stages 1 and 2. This stage:

- changes the set of required properties from a `std::set` to a `std::unordered_set`
- introduces a new `prepareMaterials` API. This is the API that users should use because it does not have a prerequisite that `setActiveMaterialProperties` be called. This will allow follow-on elimination of `FEProblemBase::getActiveMaterialProperties` and the change to store active material properties on the materials themselves instead of on the problem