### PR TITLE
Fix makefile for downstream apps with additional dependencies

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -455,7 +455,7 @@ endif
 $(app_EXEC): $(app_LIBS) $(mesh_library) $(main_object) $(app_test_LIB) $(depend_test_libs) $(app_resource)
 	@echo "Linking Executable "$@"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-	  $(libmesh_CXX) $(CXXFLAGS) $(libmesh_CXXFLAGS) -o $@ $(main_object) $(depend_test_libs_flags) $(applibs) $(libmesh_LDFLAGS) $(libmesh_LIBS) $(EXTERNAL_FLAGS)
+	  $(libmesh_CXX) $(CXXFLAGS) $(libmesh_CXXFLAGS) -o $@ $(main_object) $(depend_test_libs_flags) $(applibs) $(ADDITIONAL_LIBS) $(libmesh_LDFLAGS) $(libmesh_LIBS) $(EXTERNAL_FLAGS)
 	@$(codesign)
 
 ###### install stuff #############


### PR DESCRIPTION
undoes a change for #26450

This fixes the cardinal  moose submodule update failure (tested locally)
I would like to have this in ASAP to test it on the bluecrab build failures with TRACE which I cannot debug on my own, not having access to trace.