### PR TITLE
Revert more makefile change

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -209,6 +209,7 @@ app_LINK := $(foreach i, $(include_files), $(all_header_dir)/$(notdir $(i)))
 $(eval $(call all_header_dir_rule, $(all_header_dir)))
 $(call symlink_rules, $(all_header_dir), $(include_files))
 
+$(APPLICATION_NAME)_header_symlinks: $(all_header_dir) $(app_LINK)
 app_INCLUDE = -I$(all_header_dir)
 
 else # No Header Symlinks
@@ -257,6 +258,7 @@ else
 endif
 
 app_LIBS       += $(app_LIB)
+app_LIBS_other := $(filter-out $(app_LIB),$(app_LIBS))
 app_HEADERS    := $(app_HEADER) $(app_HEADERS)
 app_INCLUDES   += $(app_INCLUDE) $(ADDITIONAL_INCLUDES)
 app_DIRS       += $(APPLICATION_DIR)
@@ -289,7 +291,7 @@ ifeq ($(MOOSE_HEADER_SYMLINKS),true)
 # object files until all symlinking is completed. The first dependency in the
 # list below ensures this.
 
-$(all_app_objects) : | $(app_LINKS) $(moose_config_symlink)
+$(all_app_objects) : | $(APPLICATION_NAME)_header_symlinks $(moose_config_symlink)
 
 else
 

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -168,7 +168,7 @@ moose_all_header_dir := $(all_header_dir)
 define all_header_dir_rule
 $(1):
 	@echo Rebuilding symlinks in $$@
-	@mkdir -p $$@
+	@$$(shell mkdir -p $$@)
 endef
 
 include_files	:= $(shell find $(FRAMEWORK_DIR)/include \( -regex "[^\#~]*\.h" ! -name "*MooseConfig.h" \))
@@ -181,7 +181,7 @@ link_names := $(foreach i, $(include_files), $(all_header_dir)/$(notdir $(i)))
 # 1: the header file
 # 2: the symlink to create
 define symlink_rule
-$(2): $(1) | $(abspath $(dir $(2)))
+$(2): $(1)
 	@ln -sf $$< $$@
 endef
 


### PR DESCRIPTION
I'm seeing local tutorial builds fail post #26725

and they seem related to these two files. 
First errors points to app.mk rule (line 212) on the header symlinks
```
Not compiling MOOSE with NEML2 because NEML2_DIR is not a valid NEML2 checkout and/or libtorch is not enabled.
make: *** No rule to make target '/Users/giudgl/projects/moose_v3/framework/build/header_symlinks', needed by '/Users/giudgl/projects/moose_v3/tutorials/darcy_thermo_mech/../..//framework/build/header_symlinks/LineSearch.h'.  Stop.
make: *** Waiting for unfinished jobs....
Rebuilding symlinks in /Users/giudgl/projects/moose_v3/tutorials/darcy_thermo_mech/../..//framework/build/header_symlinks
Creating Unity Directory /Users/giudgl/projects/moose_v3/tutorials/darcy_thermo_mech/../..//framework/build/unity_src
Copying default MOOSE configuration to: /Users/giudgl/projects/moose_v3/tutorials/darcy_thermo_mech/../..//framework/include/base/MooseConfig.h...
make: Leaving directory '/Users/giudgl/projects/moose_v3/tutorials/darcy_thermo_mech/step09_mechanics'
```

Second error points to moose.mk with a missing symlink folder (not just the file, folder is not being built).
Maybe `@mkdir` and `@shell mkdir` behave differently smh

```
Compiling C++ (in devel mode) /Users/giudgl/projects/moose_v3/tutorials/darcy_thermo_mech/../..//framework/contrib/exodiff/STRINGLIB_tokenize.C...
Creating Unity Directory /Users/giudgl/projects/moose_v3/tutorials/darcy_thermo_mech/../..//modules/ray_tracing/build/unity_src
ln: /Users/giudgl/projects/moose_v3/tutorials/darcy_thermo_mech/../..//modules/ray_tracing/build/header_symlinks/NullRayBC.h: No such file or directory
make: *** [/Users/giudgl/projects/moose_v3/tutorials/darcy_thermo_mech/../..//framework/app.mk:210: /Users/giudgl/projects/moose_v3/tutorials/darcy_thermo_mech/../..//modules/ray_tracing/build/header_symlinks/NullRayBC.h] Error 1
make: *** Waiting for unfinished jobs....
make[1]: Entering directory '/Users/giudgl/projects/moose_v3/framework/contrib/hit'
Building hit for python with python3-config
mpicxx -std=c++17 -I/Users/giudgl/mambaforge3/envs/moose/wasp/include -g -ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0 -isystem /Users/giudgl/mambaforge3/envs/moose/include -std=c++17 main.cc parse.cc lex.cc braceexpr.cc -o hit -Wl,-rpath,/Users/giudgl/mambaforge3/envs/moose/wasp/lib -L/Users/giudgl/mambaforge3/envs/moose/wasp/lib -lwasplsp -lwasphalite -lwaspson -lwaspcore -lwaspexpr -lwaspjson -lwaspddi -lwasphive -lwasphit -lwaspsiren
make[1]: Leaving directory '/Users/giudgl/projects/moose_v3/framework/contrib/hit'
make: Leaving directory '/Users/giudgl/projects/moose_v3/tutorials/darcy_thermo_mech/step09_mechanics'

```