### PR TITLE
Restrict tests that cant compile their AD parsed function currently

### DIFF
--- a/modules/phase_field/test/tests/GrandPotentialPFM/tests
+++ b/modules/phase_field/test/tests/GrandPotentialPFM/tests
@@ -99,6 +99,7 @@
     issues = '#15573'
     design = '/ACSwitching.md /CoupledSwitchingTimeDerivative.md'
     requirement = 'MOOSE shall provide a Grand Potential based multiphase model with AD option'
+    installation_type = 'in_tree' # refs #26129
   []
 
   [ADGrandPotentialMultiphase_jac]
@@ -111,5 +112,6 @@
     issues = '#15573'
     design = '/ACSwitching.md /CoupledSwitchingTimeDerivative.md'
     requirement = 'The jacobian for the AD Allen-Cahn problem with a variable dependent coeffecients shall be perfect'
+    installation_type = 'in_tree' # refs #26129
   []
 []

--- a/modules/phase_field/test/tests/phase_field_kernels/tests
+++ b/modules/phase_field/test/tests/phase_field_kernels/tests
@@ -208,6 +208,7 @@
     issues = '#15573'
     design = '/ACBarrierFunction.md /ACKappaFunction.md'
     requirement = 'MOOSE shall have AD examples where the barrier height and gradient energy parameter depend on non-linear variables'
+    installation_type = 'in_tree' # refs #26129
   [../]
 
   [./ADnonuniform_barrier_coefficient-jac]
@@ -220,5 +221,6 @@
     issues = '#15573'
     design = '/ACBarrierFunction.md /ACKappaFunction.md'
     requirement = 'The Jacobian for the AD Allen-Cahn problem with a variable dependent coeffecients shall be perfect'
+    installation_type = 'in_tree' # refs #26129
   [../]
 []


### PR DESCRIPTION
to in-tree runs
refs #26129