### PR TITLE
Diagnostic script to be more useful

### DIFF
--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -11,3 +11,6 @@ moose_tools: 2024.03.07
 apptainer_rockylinux: 8.8.20230518
 apptainer_mpich: 3.4.3
 apptainer_gcc: 12.2.1
+conda_version: 23.11.0-0
+conda_mpi: moose-mpich
+mpi: mpich

--- a/scripts/diagnostics.sh
+++ b/scripts/diagnostics.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function get_value()
@@ -179,11 +188,7 @@ MOOSE_PACKAGES="${MPI_PACKAGES} ${SUPPORT_PACKAGES}"
 
 INSTANCE_EXE='conda'
 INSTANCE_SUP='Miniforge3'
-print_sep
 install_conda
-print_sep
 create_env
-print_sep
 build_application
-print_sep
 test_application

--- a/scripts/diagnostics.sh
+++ b/scripts/diagnostics.sh
@@ -1,145 +1,189 @@
-#!/usr/bin/env bash
-#* This file is part of the MOOSE framework
-#* https://www.mooseframework.org
-#*
-#* All rights reserved, see COPYRIGHT for full restrictions
-#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-#*
-#* Licensed under LGPL 2.1, please see LICENSE for details
-#* https://www.gnu.org/licenses/lgpl-2.1.html
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-## Script which contains the diagnostics we wish to generate.
-## This script will output all diagnostics to stdout.
-
-write_to_stdout() {
-  echo -e "$@"
+function get_value()
+{
+    echo $(cat ${SCRIPT_DIR}/../framework/doc/packages_config.yml | grep "^$1: " | awk '{print $2}')
 }
 
-file_born_date() {
-  if [ -f $1 ]; then
+function print_failure_and_exit()
+{
+    print_environment
+    printf "\nThere was an error while $(print_red "$@")\033[0m.
+
+Please report the entirety of the output of diagnostics on
+this terminal to either YOUR existing post OR a new post on
+https://github.com/idaholab/moose/discussions\n"
+    exit 1
+}
+
+function print_sep()
+{
+    printf '\n'
+    printf '#%.0s' {1..75}
+    printf '\n'
+}
+
+function print_red()
+{
+    printf "\033[1;31m$@\033[0m"
+}
+
+function print_orange()
+{
+    printf "\033[38;5;202m$@\033[0m"
+}
+
+function print_green()
+{
+    printf "\033[1;32m$@\033[0m"
+}
+
+function create_tmp()
+{
+    if [ -n "$CTMP_DIR" ]; then echo $CTMP_DIR; return; fi
     if [ `uname` == "Darwin" ]; then
-      echo `stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$1"`
+        local TMP_DIR=${TMP_DIR:-`mktemp -d -t MOOSE`}
     else
-      echo `date -d @$(stat -c %Y "$1") +%Y-%m-%d\ %H:%M`
+        local TMP_DIR=${TMP_DIR:-`mktemp -d -t MOOSE.XXXXXXXX`}
     fi
-  fi
+    echo $TMP_DIR
 }
 
-diagnose_compilers() {
-    # Variable
-    which $CC &> /dev/null
-    if [ "$?" -eq 0 ]; then
-        write_to_stdout "\nVariable \`which \$CC\` check:\n`which $CC`\n\n\$CC --version:\n`$CC --version`"
+function print_help()
+{
+    args=("-h|--help"\
+          "-f|--full-build"\
+          "-r|--run-checks"\
+          "-a|--active-environment"\
+          "-c|--conda-channel")
+
+    args_about=("Print this message and exit."\
+                "Build everything: PETSc, libMesh, WASP, MOOSE."\
+                "Run Checks."\
+                "Do not use a pristine Conda environment, use current environment instead."\
+                "Prioritize MOOSE packages with this channel (default is public).")
+
+    printf "\nSyntax:\n\t./`basename $0`\n\nOptions:\n\n"
+    print_args args args_about
+    printf "\nInfluencial Environment Variables:\n
+\tMETHODS
+\tMETHOD
+\tMOOSE_JOBS
+\tREQUESTS_CA_BUNDLE
+\tSSL_CERT_FILE
+\tCURL_CA_BUNDLE\n
+Supplying no arguments prints useful environment information.\n"
+}
+
+# Check Arguments. If PRISTINE is already set, break out of argument checking
+if [ -z "$PRISTINE_ENVIRONMENT" ]; then
+    source ${SCRIPT_DIR}/functions/help_system
+    while [[ "$#" -gt 0 ]]; do
+        case $1 in
+            -h|--help)
+                print_help; exit 0;;
+            -f|--full-build)
+                export FULL_BUILD=1; shift ;;
+            -r|--run-checks)
+                export RUN_CHECKS=1; shift ;;
+            -a|--active-environment)
+                export PRISTINE_ENVIRONMENT=0; shift ;;
+            -c|--conda-channel)
+                export CONDA_CHANNEL=$2; shift 2;;
+            *)
+                printf "Unknown argument: $1\n"; exit 1;;
+        esac
+    done
+    # default to printing active environment, otherwise do not print active environment
+    # (basically I want the default behavior to behave like the previous diagnostic.sh script)
+    if [ -n "${FULL_BUILD}" ] || [ -n "${RUN_CHECKS}" ]; then
+        NO_ENVIRONMENT=1
+    fi
+    # FULL_BUILD or RUN_CHECKS is set, but not PRISTINE_ENVIRONMENT
+    if [ "${PRISTINE_ENVIRONMENT}" != 0 ] && [ "${NO_ENVIRONMENT}" == 1 ]; then
+        printf "Beginning in a pristine environment\n"
+        env -i bash --rcfile <(echo "CLEAN_ENV='True' \
+                                PRISTINE_ENVIRONMENT=1 \
+                                METHODS=${METHODS:-opt} \
+                                METHOD=${METHOD:-opt} \
+                                MOOSE_JOBS=${MOOSE_JOBS:-6} \
+                                FULL_BUILD=${FULL_BUILD:-0} \
+                                RUN_CHECKS=${RUN_CHECKS:-0} \
+                                CONDA_CHANNEL=${CONDA_CHANNEL:-'https://conda.software.inl.gov/public'} \
+                                REQUESTS_CA_BUNDLE=${REQUESTS_CA_BUNDLE:-''} \
+                                SSL_CERT_FILE=${SSL_CERT_FILE:-''} \
+                                CURL_CA_BUNDLE=${CURL_CA_BUNDLE:-''} \
+                                NO_ENVIRONMENT=1 \
+                                ${SCRIPT_DIR}/${BASH_SOURCE[0]}; exit")
+        exit $?
     else
-        write_to_stdout "\n\$CC not set"
+        # Set defaults
+        export PRISTINE_ENVIRONMENT=${PRISTINE_ENVIRONMENT:-0}
+        export FULL_BUILD=${FULL_BUILD:-0}
+        export METHOD=${METHOD:-opt}
+        export METHODS=${METHODS:-opt}
+        export MOOSE_JOBS=${MOOSE_JOBS:-6}
+        export RUN_CHECKS=${RUN_CHECKS:-0}
+        export CONDA_CHANNEL=${CONDA_CHANNEL:-'https://conda.software.inl.gov/public'}
+        export REQUESTS_CA_BUNDLE=${REQUESTS_CA_BUNDLE:-''}
+        export SSL_CERT_FILE=${SSL_CERT_FILE:-''}
+        export CURL_CA_BUNDLE=${CURL_CA_BUNDLE:-''}
+        export NO_ENVIRONMENT=${NO_ENVIRONMENT:-0}
     fi
+fi
 
-    # Static
-    which mpicc &> /dev/null
-    if [ "$?" -eq 0 ]; then
-        write_to_stdout "\nMPICC:\nwhich mpicc:\n\t`which mpicc`\nmpicc -show:\n\t`mpicc -show`\n\nCOMPILER `echo $(mpicc -show | cut -d\  -f1)`:\n`$(mpicc -show | cut -d\  -f1) --version`"
-    else
-        write_to_stdout "\nMPICC WRAPPER NOT FOUND"
-    fi
-}
+# Augment additional pristine environment variables
+if [ "${PRISTINE_ENVIRONMENT}" == "1" ]; then
+    # Make our environment more sane
+    export PATH=/bin:/usr/bin:/sbin
+    export TERM=xterm-256color
+    # Make our environment safe
+    umask 027
+    # Obtain our temp directory
+    export CTMP_DIR=$(create_tmp)
+    # It's not enough to set these with --rcfile. They must be exported to be inherited by child processes
+    export REQUESTS_CA_BUNDLE SSL_CERT_FILE CURL_CA_BUNDLE
+    # Delete temporary directory at any time this script exits
+    trap 'rm -rf "$CTMP_DIR"' EXIT
+    print_sep
+    printf "Temporary Directory:\n${CTMP_DIR}\n\n"
+fi
 
-diagnose_modules() {
-    type module &> /dev/null
-    if [ "$?" -eq 0 ]; then
-        write_to_stdout "\nMODULES:\n`module list 2>&1`"
-    else
-        write_to_stdout "\nMODULES NOT AVAILABLE"
-    fi
-}
+# Make print_environment available in any step
+source ${SCRIPT_DIR}/functions/diagnostic_environment.sh
 
-diagnose_root() {
-    if [ $(id -u) = 0 ]; then write_to_stdout "RUNNING AS ROOT"; fi
-}
+# Do only the one thing if default behavior
+if [ "${NO_ENVIRONMENT}" == 0 ]; then print_environment; exit; fi
+# Do all the things
+printf "Note: The following steps are being performed in a temporary directory, and
+will be deleted when finished or upon encountering an error. This tool
+should only be used as a troubleshooting step to verify that your system is
+capable of running MOOSE.
 
-diagnose_environment() {
-    write_to_stdout "\nENVIRONMENT:\n`env | sort`"
-}
+Errors encountered here will likely be key reasons why you might be
+experiencing issues.
 
-diagnose_cpus() {
-    if [ `uname` == "Darwin" ]; then
-        CPUS=`/usr/sbin/sysctl -n hw.ncpu`
-    else
-        CPUS=`cat /proc/cpuinfo | grep processor | wc -l`
-    fi
-    write_to_stdout "\nCPU Count: `echo $CPUS`"
-}
+If no errors are encountered then likely the issue will be something in
+your environment as the cause.\n"
+source ${SCRIPT_DIR}/functions/diagnostic_conda.sh
+source ${SCRIPT_DIR}/functions/diagnostic_application.sh
+source ${SCRIPT_DIR}/functions/diagnostic_tests.sh
+CONDA_VERSION=$(get_value 'conda_version')
 
-diagnose_memory() {
-    if [ `uname` == "Darwin" ]; then
-        PAGE_SIZE=`vm_stat | grep "page size of" | sed 's/[^0-9]*//g'`
-        MEMORY_FREE=`vm_stat | grep free | awk -v page_size=$PAGE_SIZE '{ print (page_size * $3) / 1048576}'`
-    else
-        MEMORY_FREE=`awk '/MemFree/ { printf "%.3f \n", $2/1024 }' /proc/meminfo`
-    fi
-    write_to_stdout "\nMemory Free: `echo $MEMORY_FREE` MB"
-}
+# Get individual packages for now, until moose-mpi becomes available
+MPI_PACKAGES="$(get_value 'mpi')=$(get_value $(get_value 'mpi')) $(get_value 'mpi')-mpicc $(get_value 'mpi')-mpicxx $(get_value 'mpi')-mpifort"
+SUPPORT_PACKAGES="hdf5=*=mpi_* gfortran cmake make libtool autoconf automake=1.16.5 m4 zfp=0.5.5 bison=3.4 packaging pyaml jinja2 python=3.10"
+if [[ `uname` == 'Linux' ]]; then SUPPORT_PACKAGES="libxt-devel-cos7-x86_64=1.1.5 zlib ${SUPPORT_PACKAGES}"; fi
+MOOSE_PACKAGES="${MPI_PACKAGES} ${SUPPORT_PACKAGES}"
 
-diagnose_arch() {
-    if [ `uname` == "Darwin" ]; then
-        SYSTEM=`uname -v`
-    else
-        which lsb_release &> /dev/null
-        if [ "$?" -eq 0 ]; then
-            SYSTEM="`lsb_release -a`"
-        else
-            if [ -f /etc/system-release ]; then
-                SYSTEM="`cat /etc/system-release`"
-            else
-                SYSTEM="Not Available"
-            fi
-        fi
-    fi
-    write_to_stdout "\nSystem Arch: `echo $SYSTEM`"
-}
-
-diagnose_package_version() {
-    if [ -f /opt/moose/build ]; then
-        write_to_stdout "\nMOOSE Package Version: `cat /opt/moose/build | sed 's/[^0-9]*//g'`"
-    else
-        write_to_stdout "\nMOOSE Package Version: Custom Build"
-    fi
-}
-
-diagnose_python() {
-    which python &> /dev/null
-    if [ "$?" -eq 0 ]; then
-        write_to_stdout "\nPython:\n\t`which python`\n\t`python --version 2>&1`"
-    else
-        write_to_stdout "\nPython: NO PYTHON DETECTED"
-    fi
-}
-
-diagnose_petsc() {
-    if [ -f "$PETSC_DIR/include/petscconfiginfo.h" ]; then
-        formatted=`cat $PETSC_DIR/include/petscconfiginfo.h | sed -e 's|\\\||g'`
-        write_to_stdout "\nPETSc configure:\n$formatted"
-        write_to_stdout "\nPETSc linked libraries:"
-
-        if [ `uname` = "Linux" ]; then
-            ldd $PETSC_DIR/lib/libpetsc.so
-        else
-            otool -L $PETSC_DIR/lib/libpetsc.dylib
-        fi
-
-    elif [ -z "$PETSC_DIR" ]; then
-        write_to_stdout "\nPETSC_DIR not set"
-    fi
-}
-
-# Execute the diagnostics
-date
-diagnose_root
-diagnose_arch
-diagnose_package_version
-diagnose_cpus
-diagnose_memory
-diagnose_compilers
-diagnose_python
-diagnose_modules
-diagnose_petsc
-diagnose_environment
+INSTANCE_EXE='conda'
+INSTANCE_SUP='Miniforge3'
+print_sep
+install_conda
+print_sep
+create_env
+print_sep
+build_application
+print_sep
+test_application

--- a/scripts/diagnostics.sh
+++ b/scripts/diagnostics.sh
@@ -117,8 +117,10 @@ Supplying no arguments prints useful environment information.\n\n"
 
 function ctl_c()
 {
-    printf "\033[0m\nYou canceled diagnostics\n"
+    printf "\033[0m\n\nYou canceled diagnostics. Running clean-up routines.
+Please do not ctl-c again, and allow the temp directory to be deleted.\n"
     export CANCELED=true
+    exit 1
 }
 
 # Check Arguments. If PRISTINE is already set, break out of argument checking
@@ -196,6 +198,8 @@ fi
 # Augment additional pristine environment variables
 if [ "${PRISTINE_ENVIRONMENT}" == "1" ]; then
     trap 'ctl_c' INT
+    # Further sandbox our environment
+    export HOME=${CTMP_DIR}
     # Make our environment more sane
     export PATH=/bin:/usr/bin:/sbin
     export TERM=xterm-256color
@@ -204,7 +208,7 @@ if [ "${PRISTINE_ENVIRONMENT}" == "1" ]; then
     # It's not enough to set these with --rcfile. They must be exported to be inherited by child processes
     export CTMP_DIR REQUESTS_CA_BUNDLE SSL_CERT_FILE CURL_CA_BUNDLE
     print_sep
-    printf "Temporary Directory:\n${CTMP_DIR}\n\n"
+    printf "Temporary Directory:\n${CTMP_DIR}\n"
 fi
 
 # Make print_environment available in any step

--- a/scripts/diagnostics.sh
+++ b/scripts/diagnostics.sh
@@ -218,18 +218,18 @@ source ${SCRIPT_DIR}/functions/diagnostic_environment.sh
 if [ "${NO_ENVIRONMENT}" == 0 ]; then print_environment; exit; fi
 # Do all the things
 printf "
-Note: The following steps are being performed in a temporary directory, and will be deleted when
+Note: The following steps will be performed in a temporary directory, and will be deleted when
       finished or upon encountering an error.
 
-      The purpose of this tool is to determine if there are external factors preventing you from
+      The purpose of this tool is to determine if external factors are preventing you from
       building or running MOOSE.
 
-      Errors encountered will usually mean network related or hardware related causes (VPN,
-      Network Proxies, Corporate SSL Certificates, etc).
+      Errors encountered will usually mean network or hardware related causes (VPN, Network
+      Proxies, Corporate SSL Certificates, etc).
 
-      If no errors are encountered then likely the issue will be something in your environment as
-      to the cause. If this is case, run `basename $0` again without any arguments, and carefully
-      scrutinize the output.\n"
+      If diagnostics runs to completion without errors then likely the issue will be something in
+      your environment as to the cause. If this is case, run `basename $0` again without any
+      arguments, and carefully scrutinize the output.\n"
 print_sep
 source ${SCRIPT_DIR}/functions/diagnostic_conda.sh
 source ${SCRIPT_DIR}/functions/diagnostic_application.sh

--- a/scripts/functions/diagnostic_application.sh
+++ b/scripts/functions/diagnostic_application.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
 
 function enter_moose()
 {
@@ -33,6 +41,7 @@ download properly.\n\n"
 function build_library()
 {
     if [ "${FULL_BUILD}" == 0 ]; then return; fi
+    print_sep
     local error_cnt=${error_cnt:-0}
     if [ ${error_cnt} -le 0 ]; then printf "Build Step: $1\n"; fi
     enter_moose
@@ -88,6 +97,7 @@ function build_moose()
 
 function build_application()
 {
+    print_sep
     clone_moose
     # Do the dumb necessary things we do in 'moose-mpich' package
     # TODO: remove this when 'moose-mpi' becomes available
@@ -97,7 +107,6 @@ function build_application()
 
     local LIBS=(petsc libmesh wasp)
     for lib in ${LIBS[@]}; do
-        print_sep
         build_library ${lib}
     done
     print_sep

--- a/scripts/functions/diagnostic_application.sh
+++ b/scripts/functions/diagnostic_application.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+function enter_moose()
+{
+    # TODO: allow a --use-moose-dir argument
+    cd $CTMP_DIR/moose || exit 1
+}
+
+function clone_moose()
+{
+    # TODO: allow a --use-moose-dir argument
+    printf "Creating a clean clone of MOOSE repository\n"
+    git clone --depth 1 https://github.com/idaholab/moose ${CTMP_DIR}/moose -b master &> ${CTMP_DIR}/moose_clone_stdouterr.log
+    local exit_code=$?
+    if [ ${exit_code} -ge 1 ] && [ $(cat ${CTMP_DIR}/moose_clone_stdouterr.log | grep -c -i 'SSL certificate problem') -ge 1 ]; then
+        print_orange "WARNING: "
+        printf "SSL issues detected, attempting again with SSL protections off
+
+This may indicate the cause of other issues. PETSc contribs may fail to
+download properly.\n\n"
+        print_orange "export GIT_SSL_NO_VERIFY=true\n\n"
+        export GIT_SSL_NO_VERIFY=true
+        clone_moose
+        unset GIT_SSL_NO_VERIFY
+        return
+    fi
+    # Print relevant repo data
+    git -C ${CTMP_DIR}/moose rev-parse HEAD
+    git -C ${CTMP_DIR}/moose branch
+    git -C ${CTMP_DIR}/moose status
+}
+
+function build_library()
+{
+    if [ "${FULL_BUILD}" == 0 ]; then return; fi
+    local error_cnt=${error_cnt:-0}
+    if [ ${error_cnt} -le 0 ]; then printf "Build Step: $1\n"; fi
+    enter_moose
+    if [ "$1" == 'petsc' ]; then
+        # PETSc is special due to all the contribs.
+        mkdir -p $CTMP_DIR/downloads
+        local petsc_urls=(`scripts/update_and_rebuild_petsc.sh --with-packages-download-dir=$CTMP_DIR/downloads 2>/dev/null | grep "\[" | cut -d, -f 2 | sed -e "s/\]//g"`)
+        cd $CTMP_DIR/downloads
+        printf "Downloading PETSc contribs...\n"
+        for petsc_url in "${petsc_urls[@]}"; do
+            clean_url=$(echo ${petsc_url} | sed -e "s/'//g")
+            curl --insecure -L -O $clean_url 2>/dev/null
+        done
+        enter_moose
+        printf "Running scripts/update_and_rebuild_${1}.sh using ${MOOSE_JOBS:-6} jobs\n"
+        scripts/update_and_rebuild_${1}.sh --skip-submodule-update --with-packages-download-dir=$CTMP_DIR/downloads &> ./${1}_stdouterr.log
+    else
+        printf "Running scripts/update_and_rebuild_${1}.sh using ${MOOSE_JOBS:-6} jobs, METHODS: ${METHODS}\n"
+        scripts/update_and_rebuild_${1}.sh &> ./${1}_stdouterr.log
+    fi
+
+    exit_code=$?
+    if [ "$exit_code" != '0' ] && [ ${error_cnt} -ge 1 ]; then
+        print_failure_and_exit $(tail -20 ./${1}_stdouterr.log)
+    elif [ "$exit_code" != '0' ] && [ $(cat ./${1}_stdouterr.log | grep -c -i 'SSL certificate problem') -ge 1 ]; then
+        let error_cnt+=1
+        print_orange "SSL issues detected, attempting again with SSL protections off\n"
+        export GIT_SSL_NO_VERIFY=true
+        build_library $1
+        # unset so we see it error in each step
+        unset GIT_SSL_NO_VERIFY
+        return
+    elif [ "$exit_code" != '0' ]; then
+        tail -20 ${1}_stdouterr.log
+        print_failure_and_exit "building $1"
+    fi
+    printf "Successfully built ${1} ...\n"
+}
+
+function build_moose()
+{
+    printf "Build Step: MOOSE\n"
+    enter_moose
+    cd test
+    METHOD=${METHOD} make -j ${MOOSE_JOBS:-6} &> ./stdouterr.log
+    if [ "$?" != '0' ]; then
+        tail -20 ./stdouterr.log
+        print_failure_and_exit "building MOOSE"
+        exit 1
+    fi
+    printf "Successfully built MOOSE\n"
+}
+
+function build_application()
+{
+    clone_moose
+    # Do the dumb necessary things we do in 'moose-mpich' package
+    # TODO: remove this when 'moose-mpi' becomes available
+    TEMP_CXXFLAGS=${CXXFLAGS//-std=c++[0-9][0-9]}
+    ACTIVATION_CXXFLAGS=${TEMP_CXXFLAGS%%-fdebug-prefix-map*}-std=c++17
+    export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77 C_INCLUDE_PATH=${CONDA_PREFIX}/include MOOSE_NO_CODESIGN=true MPIHOME=${CONDA_PREFIX} CXXFLAGS="$ACTIVATION_CXXFLAGS" HDF5_DIR=${CONDA_PREFIX} FI_PROVIDER=tcp
+
+    local LIBS=(petsc libmesh wasp)
+    for lib in ${LIBS[@]}; do
+        print_sep
+        build_library ${lib}
+    done
+    print_sep
+    build_moose
+}

--- a/scripts/functions/diagnostic_application.sh
+++ b/scripts/functions/diagnostic_application.sh
@@ -11,31 +11,60 @@
 function enter_moose()
 {
     # TODO: allow a --use-moose-dir argument
-    cd $CTMP_DIR/moose || exit 1
+    cd $CTMP_DIR/moose || exit_on_failure 1
 }
 
 function clone_moose()
 {
     # TODO: allow a --use-moose-dir argument
     printf "Creating a clean clone of MOOSE repository\n"
-    git clone --depth 1 https://github.com/idaholab/moose ${CTMP_DIR}/moose -b master &> ${CTMP_DIR}/moose_clone_stdouterr.log
+    if [ -z "${retry_cnt}" ]; then
+        export retry_cnt=0
+    else
+        let retry_cnt+=1
+    fi
+    set -o pipefail
+    git clone --depth 1 https://github.com/idaholab/moose ${CTMP_DIR}/moose -b master 2>&1 | tee ${CTMP_DIR}/moose_clone_stdouterr.log
     local exit_code=$?
-    if [ ${exit_code} -ge 1 ] && [ $(cat ${CTMP_DIR}/moose_clone_stdouterr.log | grep -c -i 'SSL certificate problem') -ge 1 ]; then
-        print_orange "WARNING: "
-        printf "SSL issues detected, attempting again with SSL protections off
+    set +o pipefail
+    if [ ${exit_code} -ge 1 ] && [ $(cat ${CTMP_DIR}/moose_clone_stdouterr.log | grep -c -i 'SSL') -ge 1 ]; then
+        if [ -n "${retry_cnt}" ] && [ ${retry_cnt} -ge 2 ]; then
+            print_red "\n${retry_cnt} attempt failure.\n"
+            exit_on_failure 1
+            clone_moose
+            return
+        elif [ "${GIT_SSL_NO_VERIFY}" == 'true' ]; then
+            print_orange "\n${retry_cnt} attempt failure.\n"
+            clone_moose
+            return
+        fi
+        print_orange "\nWARNING: "
+        printf "SSL issues detected.
 
-This may indicate the cause of other issues. PETSc contribs may fail to
-download properly.\n\n"
+This may indicate the root cause of other issues. e.g PETSc contribs may
+fail to download properly in later steps, etc
+
+Trying again with protections turned off...\n"
         print_orange "export GIT_SSL_NO_VERIFY=true\n\n"
         export GIT_SSL_NO_VERIFY=true
         clone_moose
         unset GIT_SSL_NO_VERIFY
         return
+    elif [ $(cat ${CTMP_DIR}/moose_clone_stdouterr.log | grep -c -i 'SSL') -ge 1 ]; then
+        print_orange "\nWARNING: "
+        printf "Additional SSL issues detected even after turning GIT SSL
+verification off. This indicates a networking issue.
+
+We will continue, but it is very likely we will fail if we attempt to build
+PETSc (a full build: -f).\n\n"
+        export ALREADY_TRIED_SSL=true
+    elif [ ${exit_code} -ge 1 ]; then
+        exit_on_failure 1
     fi
     # Print relevant repo data
-    git -C ${CTMP_DIR}/moose rev-parse HEAD
-    git -C ${CTMP_DIR}/moose branch
-    git -C ${CTMP_DIR}/moose status
+    git -C ${CTMP_DIR}/moose rev-parse HEAD || exit_on_failure 1
+    git -C ${CTMP_DIR}/moose branch || exit_on_failure 1
+    git -C ${CTMP_DIR}/moose status || exit_on_failure 1
 }
 
 function build_library()
@@ -90,7 +119,6 @@ function build_moose()
     if [ "$?" != '0' ]; then
         tail -20 ./stdouterr.log
         print_failure_and_exit "building MOOSE"
-        exit 1
     fi
     printf "Successfully built MOOSE\n"
 }

--- a/scripts/functions/diagnostic_application.sh
+++ b/scripts/functions/diagnostic_application.sh
@@ -17,16 +17,22 @@ function enter_moose()
 function clone_moose()
 {
     # TODO: allow a --use-moose-dir argument
-    printf "Creating a clean clone of MOOSE repository\n"
+    printf "Cloning MOOSE repository\n\n"
     if [ -z "${retry_cnt}" ]; then
         export retry_cnt=0
     else
         let retry_cnt+=1
     fi
-    set -o pipefail
-    git clone --depth 1 https://github.com/idaholab/moose ${CTMP_DIR}/moose -b master 2>&1 | tee ${CTMP_DIR}/moose_clone_stdouterr.log
-    local exit_code=$?
-    set +o pipefail
+    local COMMAND="git clone --depth 1 https://github.com/idaholab/moose ${CTMP_DIR}/moose -b master"
+    if [ "${VERBOSITY}" == '1' ]; then
+        set -o pipefail
+        run_command "${COMMAND}" 2>&1 | tee ${CTMP_DIR}/moose_clone_stdouterr.log
+        local exit_code=$?
+        set +o pipefail
+    else
+        ${COMMAND} &> ${CTMP_DIR}/moose_clone_stdouterr.log
+        local exit_code=$?
+    fi
     if [ ${exit_code} -ge 1 ] && [ $(cat ${CTMP_DIR}/moose_clone_stdouterr.log | grep -c -i 'SSL') -ge 1 ]; then
         if [ -n "${retry_cnt}" ] && [ ${retry_cnt} -ge 2 ]; then
             print_red "\n${retry_cnt} attempt failure.\n"
@@ -38,73 +44,120 @@ function clone_moose()
             clone_moose
             return
         fi
+        if [ "${VERBOSITY}" == '0' ]; then
+            run_command "tail -15 ${CTMP_DIR}/moose_clone_stdouterr.log"
+        fi
         print_orange "\nWARNING: "
         printf "SSL issues detected.
 
-This may indicate the root cause of other issues. e.g PETSc contribs may
-fail to download properly in later steps, etc
+This may indicate the root cause of other issues. e.g MOOSE dependencies may fail to download
+properly in later steps.
 
-Trying again with protections turned off...\n"
-        print_orange "export GIT_SSL_NO_VERIFY=true\n\n"
+Possible solutions: You should contact your network support team and inform them of this issue.
+                    In the meantime, you can attempt to disable GIT SSL Verification (not
+                    recommended):
+
+                    \texport GIT_SSL_NO_VERIFY=true
+
+Trying again with SSL protections turned off...\n\n"
         export GIT_SSL_NO_VERIFY=true
         clone_moose
         unset GIT_SSL_NO_VERIFY
         return
     elif [ $(cat ${CTMP_DIR}/moose_clone_stdouterr.log | grep -c -i 'SSL') -ge 1 ]; then
+        if [ "${VERBOSITY}" == '0' ]; then
+            run_command "tail -15 ${CTMP_DIR}/moose_clone_stdouterr.log"
+        fi
         print_orange "\nWARNING: "
-        printf "Additional SSL issues detected even after turning GIT SSL
-verification off. This indicates a networking issue.
+        printf "Additional SSL issues remain after disabling SSL verification.
 
-We will continue, but it is very likely we will fail if we attempt to build
-PETSc (a full build: -f).\n\n"
+This indicates a more serious networking issue which may indicate your inability to build MOOSE
+dependencies.
+
+Possible solutions: You should contact your network support team and inform them of this issue.
+                    Disable any VPN software for the time being, if available.
+                    You can attempt to disable SSL Verification in several ways:
+
+                    \texport GIT_SSL_NO_VERIFY=true
+                    \tconda config --set ssl_verify false
+
+                    Your network support team should inform you how to properly set the following
+                    variables:
+
+                    \tREQUESTS_CA_BUNDLE
+                    \tSSL_CERT_FILE
+                    \tCURL_CA_BUNDLE
+\n"
         export ALREADY_TRIED_SSL=true
     elif [ ${exit_code} -ge 1 ]; then
         exit_on_failure 1
     fi
     # Print relevant repo data
-    git -C ${CTMP_DIR}/moose rev-parse HEAD || exit_on_failure 1
-    git -C ${CTMP_DIR}/moose branch || exit_on_failure 1
-    git -C ${CTMP_DIR}/moose status || exit_on_failure 1
+    #run_command "git -C ${CTMP_DIR}/moose log -1"
+    run_command "git -C ${CTMP_DIR}/moose branch"
+    run_command "git -C ${CTMP_DIR}/moose status"
 }
 
 function build_library()
 {
-    if [ "${FULL_BUILD}" == 0 ]; then return; fi
-    print_sep
+    if [ "${FULL_BUILD}" == '0' ]; then return; fi
     local error_cnt=${error_cnt:-0}
-    if [ ${error_cnt} -le 0 ]; then printf "Build Step: $1\n"; fi
+    if [ ${error_cnt} -le 0 ]; then print_sep; printf "Build Step: $1\n\n"; fi
     enter_moose
+    printf "Running scripts/update_and_rebuild_${1}.sh using ${MOOSE_JOBS:-6} jobs, METHODS: ${METHODS}\n"
     if [ "$1" == 'petsc' ]; then
-        # PETSc is special due to all the contribs.
+        # PETSc is special due to all the contribs. We need to download each, manualy
         mkdir -p $CTMP_DIR/downloads
         local petsc_urls=(`scripts/update_and_rebuild_petsc.sh --with-packages-download-dir=$CTMP_DIR/downloads 2>/dev/null | grep "\[" | cut -d, -f 2 | sed -e "s/\]//g"`)
         cd $CTMP_DIR/downloads
         printf "Downloading PETSc contribs...\n"
         for petsc_url in "${petsc_urls[@]}"; do
             clean_url=$(echo ${petsc_url} | sed -e "s/'//g")
-            curl --insecure -L -O $clean_url 2>/dev/null
+            if [ "${VERBOSITY}" == '1' ]; then
+                run_command "curl -L -O $clean_url"
+            else
+                curl -L -O $clean_url 2>/dev/null
+            fi
         done
         enter_moose
-        printf "Running scripts/update_and_rebuild_${1}.sh using ${MOOSE_JOBS:-6} jobs\n"
-        scripts/update_and_rebuild_${1}.sh --skip-submodule-update --with-packages-download-dir=$CTMP_DIR/downloads &> ./${1}_stdouterr.log
+        if [ "${VERBOSITY}" == '1' ]; then
+            set -o pipefail
+            run_command "scripts/update_and_rebuild_${1}.sh --skip-submodule-update --with-packages-download-dir=$CTMP_DIR/downloads" 2>&1 | tee ./${1}_stdouterr.log
+            exit_code=$?
+            set +o pipefail
+        else
+            scripts/update_and_rebuild_${1}.sh --skip-submodule-update --with-packages-download-dir=$CTMP_DIR/downloads &> ./${1}_stdouterr.log
+            exit_code=$?
+        fi
     else
-        printf "Running scripts/update_and_rebuild_${1}.sh using ${MOOSE_JOBS:-6} jobs, METHODS: ${METHODS}\n"
-        scripts/update_and_rebuild_${1}.sh &> ./${1}_stdouterr.log
+        if [ "${VERBOSITY}" == '1' ]; then
+            set -o pipefail
+            run_command "scripts/update_and_rebuild_${1}.sh" 2>&1 | tee ./${1}_stdouterr.log
+            exit_code=$?
+            set +o pipefail
+        else
+            scripts/update_and_rebuild_${1}.sh &> ./${1}_stdouterr.log
+            exit_code=$?
+        fi
     fi
 
-    exit_code=$?
     if [ "$exit_code" != '0' ] && [ ${error_cnt} -ge 1 ]; then
         print_failure_and_exit $(tail -20 ./${1}_stdouterr.log)
     elif [ "$exit_code" != '0' ] && [ $(cat ./${1}_stdouterr.log | grep -c -i 'SSL certificate problem') -ge 1 ]; then
         let error_cnt+=1
-        print_orange "SSL issues detected, attempting again with SSL protections off\n"
+        if [ "${VERBOSITY}" == '0' ]; then
+            run_command "tail -15 ./${1}_stdouterr.log"
+        fi
+        print_orange "\nWARNING: "
+        printf "SSL issues detected, attempting again with SSL protections off\n\n"
         export GIT_SSL_NO_VERIFY=true
         build_library $1
-        # unset so we see it error in each step
         unset GIT_SSL_NO_VERIFY
         return
     elif [ "$exit_code" != '0' ]; then
-        tail -20 ${1}_stdouterr.log
+        if [ "${VERBOSITY}" == '0' ]; then
+            run_command "tail -15 ${1}_stdouterr.log"
+        fi
         print_failure_and_exit "building $1"
     fi
     printf "Successfully built ${1} ...\n"
@@ -112,12 +165,22 @@ function build_library()
 
 function build_moose()
 {
-    printf "Build Step: MOOSE\n"
+    printf "Build Step: MOOSE. Using ${MOOSE_JOBS:-6} cores\n\n"
     enter_moose
     cd test
-    METHOD=${METHOD} make -j ${MOOSE_JOBS:-6} &> ./stdouterr.log
-    if [ "$?" != '0' ]; then
-        tail -20 ./stdouterr.log
+    if [ "${VERBOSITY}" == '1' ]; then
+        set -o pipefail
+        run_command "METHOD=${METHOD} make -j ${MOOSE_JOBS:-6}" 2>&1 | tee ./stdouterr.log
+        exit_code=$?
+        set +o pipefail
+    else
+        METHOD=${METHOD} make -j ${MOOSE_JOBS:-6} &> ./stdouterr.log
+        exit_code=$?
+    fi
+    if [ "$exit_code" != '0' ]; then
+        if [ "${VERBOSITY}" == '0' ]; then
+            tail -20 ./stdouterr.log
+        fi
         print_failure_and_exit "building MOOSE"
     fi
     printf "Successfully built MOOSE\n"

--- a/scripts/functions/diagnostic_application.sh
+++ b/scripts/functions/diagnostic_application.sh
@@ -113,17 +113,20 @@ function build_library()
         mkdir -p $CTMP_DIR/downloads
         local petsc_urls=(`scripts/update_and_rebuild_petsc.sh --with-packages-download-dir=$CTMP_DIR/downloads 2>/dev/null | grep "\[" | cut -d, -f 2 | sed -e "s/\]//g"`)
         cd $CTMP_DIR/downloads
-        printf "Downloading PETSc contribs...\n\n"
+        printf "Downloading PETSc contribs...\n"
         for petsc_url in "${petsc_urls[@]}"; do
             clean_url=$(echo ${petsc_url} | sed -e "s/'//g")
             if [ "${VERBOSITY}" == '1' ]; then
+                printf "\n"
                 run_command "curl -L -O $clean_url"
             else
                 curl -L -O $clean_url 2>/dev/null
             fi
         done
         enter_moose
+        printf "Building PETSc...\n"
         if [ "${VERBOSITY}" == '1' ]; then
+            printf "\n"
             set -o pipefail
             run_command "scripts/update_and_rebuild_${1}.sh --skip-submodule-update --with-packages-download-dir=$CTMP_DIR/downloads" 2>&1 | tee ./${1}_stdouterr.log
             exit_code=$?
@@ -169,7 +172,7 @@ SSL issues). Attempting again with SSL protections off.\n\n"
         fi
         print_failure_and_exit "building $1"
     fi
-    printf "Successfully built ${1} ...\n"
+    printf "Successfully built ${1}\n"
 }
 
 function build_moose()

--- a/scripts/functions/diagnostic_application.sh
+++ b/scripts/functions/diagnostic_application.sh
@@ -171,11 +171,12 @@ function build_moose()
     cd test
     if [ "${VERBOSITY}" == '1' ]; then
         set -o pipefail
-        run_command "METHOD=${METHOD} make -j ${MOOSE_JOBS:-6}" 2>&1 | tee ./stdouterr.log
+        export METHOD=${METHOD:-opt}
+        run_command "make -j ${MOOSE_JOBS:-6}" 2>&1 | tee ./stdouterr.log
         exit_code=$?
         set +o pipefail
     else
-        METHOD=${METHOD} make -j ${MOOSE_JOBS:-6} &> ./stdouterr.log
+        METHOD=${METHOD:-opt} make -j ${MOOSE_JOBS:-6} &> ./stdouterr.log
         exit_code=$?
     fi
     if [ "$exit_code" != '0' ]; then

--- a/scripts/functions/diagnostic_application.sh
+++ b/scripts/functions/diagnostic_application.sh
@@ -53,11 +53,13 @@ function clone_moose()
 This may indicate the root cause of other issues. e.g MOOSE dependencies may fail to download
 properly in later steps.
 
-Possible solutions: You should contact your network support team and inform them of this issue.
-                    In the meantime, you can attempt to disable GIT SSL Verification (not
-                    recommended):
+Possible solutions:
 
-                    \texport GIT_SSL_NO_VERIFY=true
+\tYou should contact your network support team and inform them of this issue. In the
+\tmeantime you can attempt to disable GIT SSL Verification (not a long-term
+\trecommended solution):
+
+\t\texport GIT_SSL_NO_VERIFY=true
 
 Trying again with SSL protections turned off...\n\n"
         export GIT_SSL_NO_VERIFY=true
@@ -69,24 +71,23 @@ Trying again with SSL protections turned off...\n\n"
             run_command "tail -15 ${CTMP_DIR}/moose_clone_stdouterr.log"
         fi
         print_orange "\nWARNING: "
-        printf "Additional SSL issues remain after disabling SSL verification.
+        printf "Additional SSL issues remain after disabling SSL verification. This indicates
+a more serious networking issue which may indicate your inability to build MOOSE dependencies.
 
-This indicates a more serious networking issue which may indicate your inability to build MOOSE
-dependencies.
+Possible solutions:
 
-Possible solutions: You should contact your network support team and inform them of this issue.
-                    Disable any VPN software for the time being, if available.
-                    You can attempt to disable SSL Verification in several ways:
+\tYou should contact your network support team and inform them of this issue.
+\tDisable any VPN software for the time being, if available.
+\tYou can attempt to disable SSL Verification in several ways:
 
-                    \texport GIT_SSL_NO_VERIFY=true
-                    \tconda config --set ssl_verify false
+\t\texport GIT_SSL_NO_VERIFY=true
+\t\tconda config --set ssl_verify false
 
-                    Your network support team should inform you how to properly set the following
-                    variables:
+\tYour network support team should inform you how to properly set the following variables:
 
-                    \tREQUESTS_CA_BUNDLE
-                    \tSSL_CERT_FILE
-                    \tCURL_CA_BUNDLE
+\t\tREQUESTS_CA_BUNDLE
+\t\tSSL_CERT_FILE
+\t\tCURL_CA_BUNDLE
 \n"
         export ALREADY_TRIED_SSL=true
     elif [ ${exit_code} -ge 1 ]; then
@@ -143,7 +144,7 @@ function build_library()
 
     if [ "$exit_code" != '0' ] && [ ${error_cnt} -ge 1 ]; then
         print_failure_and_exit $(tail -20 ./${1}_stdouterr.log)
-    elif [ "$exit_code" != '0' ] && [ $(cat ./${1}_stdouterr.log | grep -c -i 'SSL certificate problem') -ge 1 ]; then
+    elif [ "$exit_code" != '0' ] && [ $(cat ./${1}_stdouterr.log | grep -c -i 'SSL certificate problem\|No such file or directory') -ge 1 ]; then
         let error_cnt+=1
         if [ "${VERBOSITY}" == '0' ]; then
             run_command "tail -15 ./${1}_stdouterr.log"

--- a/scripts/functions/diagnostic_conda.sh
+++ b/scripts/functions/diagnostic_conda.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
 
 function conda_url()
 {

--- a/scripts/functions/diagnostic_conda.sh
+++ b/scripts/functions/diagnostic_conda.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+function conda_url()
+{
+    local CONDA_URL='https://github.com/conda-forge/miniforge/releases/download'
+    echo ${CONDA_URL}/${CONDA_VERSION}/${INSTANCE_SUP}-${CONDA_VERSION}
+}
+
+function create_env()
+{
+    if [ "${PRISTINE_ENVIRONMENT}" == 0 ]; then return; fi
+    printf "Creating MOOSE Conda Environment...\n"
+    if [ ${FULL_BUILD} == 0 ]; then MOOSE_PACKAGES='moose-dev'; fi
+    export CONDARC=$CTMP_DIR/.condarc
+    export CONDA_ENVS_PATH=$CTMP_DIR/_env/.envs
+    ${INSTANCE_EXE} config --env --set ssl_verify false
+    ${INSTANCE_EXE} config --env --set channel_priority strict
+    ${INSTANCE_EXE} config --env --add envs_dirs $CTMP_DIR/_env/.envs
+    ${INSTANCE_EXE} config --env --add pkgs_dirs $CTMP_DIR/_env/.pkgs
+    ${INSTANCE_EXE} config --env --set changeps1 false
+    ${INSTANCE_EXE} config --env --set always_yes true
+    ${INSTANCE_EXE} config --env --add channels ${CONDA_CHANNEL} &>/dev/null
+    ${INSTANCE_EXE} create -p $CTMP_DIR/_env -q -y ${MOOSE_PACKAGES} git git-lfs 1>/dev/null \
+    || print_failure_and_exit 'installing Conda environment'
+    source activate $CTMP_DIR/_env || print_failure_and_exit 'activating environment'
+    printf "The following MOOSE packages were installed:\n\n"
+    ${INSTANCE_EXE} list | grep moose
+}
+
+function install_conda()
+{
+    if [ "${PRISTINE_ENVIRONMENT}" == 0 ]; then return; fi
+    printf "Installing ${INSTANCE_SUP} @ v${CONDA_VERSION}...\n"
+    # Double protect that we will not interfere with existing Conda implementation
+    export HOME=${CTMP_DIR}
+    if ! `type conda &>/dev/null`; then
+        local URL=`conda_url`
+        if [ `uname -p` == 'arm' ]; then
+            local ARCHFILE="MacOSX-arm64.sh"
+        elif [ `uname -p` == 'i386' ]; then
+            local ARCHFILE="MacOSX-x86_64.sh"
+        else
+            local ARCHFILE="Linux-x86_64.sh"
+        fi
+        local DOWNLOAD_URL="${URL}-${ARCHFILE}"
+        curl --insecure -L ${DOWNLOAD_URL} --output \
+        ${CTMP_DIR}/install_conda.sh &>/dev/null || exit 1
+        bash ${CTMP_DIR}/install_conda.sh \
+        -b -p ${CTMP_DIR}/${INSTANCE_EXE} &>/dev/null || print_failure_and_exit 'installing conda'
+        export PATH=${CTMP_DIR}/${INSTANCE_EXE}/bin:$PATH
+    else
+        printf "An existing Conda implementation cannot be avoided (system install perhaps?),
+and thus we must exit now.\n\nThis *may* be your reason for not being able to run MOOSE.\n"
+        exit 1
+    fi
+}

--- a/scripts/functions/diagnostic_conda.sh
+++ b/scripts/functions/diagnostic_conda.sh
@@ -31,7 +31,9 @@ function create_env()
     ${INSTANCE_EXE} create -p $CTMP_DIR/_env -q -y ${MOOSE_PACKAGES} git git-lfs 1>/dev/null \
     || print_failure_and_exit 'installing Conda environment'
     source activate $CTMP_DIR/_env || print_failure_and_exit 'activating environment'
-    printf "The following MOOSE packages were installed:\n\n"
+    if [ ${FULL_BUILD} == 0 ]; then
+        printf "The following MOOSE packages were installed:\n\n"
+    fi
     ${INSTANCE_EXE} list | grep moose
 }
 
@@ -52,7 +54,7 @@ function install_conda()
         fi
         local DOWNLOAD_URL="${URL}-${ARCHFILE}"
         curl --insecure -L ${DOWNLOAD_URL} --output \
-        ${CTMP_DIR}/install_conda.sh &>/dev/null || exit 1
+        ${CTMP_DIR}/install_conda.sh &>/dev/null || exit_on_failure 1
         bash ${CTMP_DIR}/install_conda.sh \
         -b -p ${CTMP_DIR}/${INSTANCE_EXE} &>/dev/null || print_failure_and_exit 'installing conda'
         export PATH=${CTMP_DIR}/${INSTANCE_EXE}/bin:$PATH

--- a/scripts/functions/diagnostic_conda.sh
+++ b/scripts/functions/diagnostic_conda.sh
@@ -17,8 +17,13 @@ function conda_url()
 function create_env()
 {
     if [ "${PRISTINE_ENVIRONMENT}" == 0 ]; then return; fi
-    printf "Creating MOOSE Conda Environment...\n"
-    if [ ${FULL_BUILD} == 0 ]; then MOOSE_PACKAGES='moose-dev'; fi
+    printf "Creating Conda Environment..."
+    if [ ${FULL_BUILD} == 0 ]; then
+        MOOSE_PACKAGES='moose-dev'
+        printf " using moose-dev associated packages\n"
+    else
+        printf " using conda-forge only packages\n"
+    fi
     export CONDARC=$CTMP_DIR/.condarc
     export CONDA_ENVS_PATH=$CTMP_DIR/_env/.envs
     ${INSTANCE_EXE} config --env --set channel_priority strict

--- a/scripts/functions/diagnostic_conda.sh
+++ b/scripts/functions/diagnostic_conda.sh
@@ -50,8 +50,6 @@ function install_conda()
 {
     if [ "${PRISTINE_ENVIRONMENT}" == 0 ]; then return; fi
     printf "Installing ${INSTANCE_SUP} @ v${CONDA_VERSION}...\n"
-    # Double protect that we will not interfere with existing Conda implementation
-    export HOME=${CTMP_DIR}
     if ! `type conda &>/dev/null`; then
         local URL=`conda_url`
         if [ `uname -p` == 'arm' ]; then

--- a/scripts/functions/diagnostic_environment.sh
+++ b/scripts/functions/diagnostic_environment.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
 
 function compiler_test()
 {

--- a/scripts/functions/diagnostic_environment.sh
+++ b/scripts/functions/diagnostic_environment.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+function compiler_test()
+{
+    print_sep
+    printf "Compiler(s) (CC CXX FC F77 F90 F95):\n\n"
+    local compiler_array=(CC CXX FC F77 F90 F95)
+    local error_cnt=0
+    for compiler in ${compiler_array[@]}; do
+        if ! [[ "x${!compiler}" == "x" ]]; then
+            printf "${compiler}=$(which ${!compiler} 2>/dev/null \
+            || printf "${compiler}=${!compiler}\tnot found")\n"
+            if [[ $(basename ${!compiler} | grep -c '^mpi') -ge 1 ]]; then
+                printf "${compiler} -show:\n$(${!compiler} -show)\n"
+            fi
+            printf "${compiler} version:\t$(which ${!compiler} &>/dev/null \
+            && ${!compiler} --version | head -1)\n\n"
+        else
+            printf "${compiler}\t\tnot set\n"
+            let error_cnt+=1
+        fi
+    done
+    if [[ $error_cnt -ge 1 ]]; then
+        print_red "\nFAIL: "
+        printf "One or more compiler variables not set\n"
+        return 1
+    else
+        print_green "OK\n"
+    fi
+    return 0
+}
+
+function env_test()
+{
+    print_sep
+    printf "Influential Environment Variables\n\n"
+    reg_exp='^LD\|^DYLD\|^PATH\|^CFLAGS\|^CPP\|^CC\|^CXX\|^FFLAGS\|^FC\|^F90\|^F95\|^F77\|^CONDA'
+    reg_exp+='\|^HDF5\|^MOOSE\|^PETSC\|^LIBMESH\|^WASP\|^APPTAINER\|^MODULES'
+    reg_not='CONDA_BACKUP'
+    env | sort | grep "${reg_exp}" | grep -v "${reg_not}"
+}
+
+function python_test()
+{
+    print_sep
+    printf "Python Sanity Checks\n\n"
+    my_version="$(/usr/bin/env python3 --version || printf 'NONE')"
+    if [[ "${my_version}" != 'NONE' ]]; then
+        printf "Verify \`/usr/bin/env python3 --version\` (reporting as: ${my_version}),
+matches versions for: \`which python3 && which python\`\n\n"
+        which_pythons=('python3' 'python')
+        local error_cnt=0
+        for which_python in "${which_pythons[@]}"; do
+            local my_python=$(which ${which_python})
+            if [[ -n ${my_python} ]] && [[ "$(${my_python} --version)" != "${my_version}" ]]; then
+                print_red "FAIL: "
+                printf "${my_python} --version (reporting as $(${my_python} --version)) != ${my_version}\n"
+                let error_cnt+=1
+            elif [[ -z "${my_python}" ]]; then
+                print_orange "\nWARNING: "
+                printf "\`${which_python}\` does not exist\n"
+                printf "This does not mean there will be a failure, but some shebangs in some python
+files may still be relying on calling: \`/usr/bin/env ${which_python}\` (Python 2.x era)\n"
+            fi
+        done
+    else
+        printf "\`python3\` not found\n\n"
+        let error_cnt+=1
+    fi
+    if [[ $error_cnt -ge 1 ]]; then
+        printf "\nThis will likely result in the TestHarness failing. Or WASP/HIT parsing errors.\n"
+        return 1
+    else
+        print_green "OK\n"
+    fi
+    return 0
+}
+
+function _python_modules()
+{
+    print_sep
+    printf "Python Modules (TestHarness, runnability)\n\n"
+    check_modules=(packaging yaml pyaml jinja2)
+    local error_cnt=0
+    for check_module in "${check_modules[@]}"; do
+        /usr/bin/env python3 -c "import ${check_module}" 2>/dev/null
+        if [[ $? -ge 1 ]]; then
+            print_red "FAIL: "
+            printf "python module: \`${check_module}\` not available\n"
+            let error_cnt+=1
+        fi
+    done
+    if [[ $error_cnt -ge 1 ]]; then
+        printf "\nSome Python modules are not available. Numerous miscellaneous issues may
+persist without these packages present. Either install these packages, or
+perhaps you have yet to \`conda activate moose\`.\n"
+        return 1
+    else
+        print_green "OK\n"
+    fi
+    return 0
+}
+
+function conda_test()
+{
+    # First run our python_modules test. We need yaml in order to run conda_test.
+    _python_modules
+    modules_test=$?
+    print_sep
+    printf "CONDA MOOSE Packages\n\n"
+    if [[ $modules_test -ge 1 ]]; then
+        print_orange "WARNING: "
+        printf "Unable to run Conda tests due to missing Python modules\n\n"
+        return 1
+    fi
+    if [[ -n "${CONDA_PREFIX}" ]] && [[ -n "${MOOSE_NO_CODESIGN}" ]]; then
+        # right to left dependency
+        moose_packages=(dev wasp libmesh petsc)
+        conda_list=`conda list | grep 'moose-'`
+
+        # iterate over and break on the top-most level we find installed
+        for package in ${moose_packages[@]}; do
+            my_version=$(echo -e "${conda_list}" | grep "^moose-${package} " | awk '{print $2}')
+            if [ -n "$my_version" ]; then
+                # hack naming conventions
+                if [[ ${package} == 'dev' ]]; then prefix='moose-'; fi
+                local needs_version=(`./versioner.py "${prefix}${package}" --yaml 2>/dev/null| \
+                                      grep 'install:' | \
+                                      awk 'BEGIN { FS = "=" }; {print $2" "$3}'`)
+                if [[ ${package} != 'dev' ]]; then
+                    reminder='moose-dev\t\t  Not present. Careful attention needed\n\t\t\t  when keep everything in sync.'
+                fi
+                break
+            fi
+        done
+        echo -e "${conda_list}"
+        if [ -n "${reminder}" ]; then print_orange "${reminder}\n"; fi
+        if [[ -n "${my_version}" ]] && [[ "${my_version}" != "${needs_version}" ]]; then
+            print_red "\nFAIL: "
+            printf "${prefix}${package}/repository version mismatch\n"
+            printf "\nYour MOOSE repository requires moose-${package}:\t$(print_green ${needs_version})
+while your Conda environment has moose-${package}:\t$(print_red ${my_version})
+
+There are two ways to fix this:
+
+1.  To install the required Conda package version:
+
+\tconda install moose-${package}=${needs_version}
+
+2.  Or adjust your repository to be in sync with moose-${package} Conda package.\n\n"
+            return 1
+        elif [[ -n "${my_version}" ]]; then
+            print_green "\nOK:"
+            printf " Conda packages and MOOSE repo/submodule versions match\n\n"
+        else
+            printf "\nConda MOOSE packages not applicative.
+User is required to manually build PETSc, libMesh, and/or WASP\n\n"
+        fi
+    else
+        print_orange "\nWARNING: "
+        printf "Not using Conda MOOSE packages, or \`conda activate moose\` not
+performed\n\n"
+    fi
+    return 0
+}
+
+function print_environment()
+{
+    if [ "${NO_ENVIRONMENT}" == 1 ]; then return; fi
+    local ERR_CNT=0
+    env_test
+    compiler_test || let ERR_CNT+=1
+    python_test || let ERR_CNT+=1
+    conda_test || let ERR_CNT+=1
+    exit $ERR_CNT
+}

--- a/scripts/functions/diagnostic_environment.sh
+++ b/scripts/functions/diagnostic_environment.sh
@@ -30,7 +30,7 @@ function compiler_test()
     done
     if [[ $error_cnt -ge 1 ]]; then
         print_red "\nFAIL: "
-        printf "One or more compiler variables not set\n"
+        printf "One or more compiler environment variables not set\n"
         return 1
     else
         print_green "OK\n"
@@ -43,7 +43,7 @@ function env_test()
     print_sep
     printf "Influential Environment Variables\n\n"
     reg_exp='^LD\|^DYLD\|^PATH\|^CFLAGS\|^CPP\|^CC\|^CXX\|^FFLAGS\|^FC\|^F90\|^F95\|^F77\|^CONDA'
-    reg_exp+='\|^HDF5\|^MOOSE\|^PETSC\|^LIBMESH\|^WASP\|^APPTAINER\|^MODULES'
+    reg_exp+='\|^HDF5\|^MOOSE\|^PETSC\|^LIBMESH\|^WASP\|^APPTAINER\|^MODULES\|^PBS\|^SLURM'
     reg_not='CONDA_BACKUP'
     env | sort | grep "${reg_exp}" | grep -v "${reg_not}"
 }
@@ -156,7 +156,7 @@ function conda_test()
                                       grep 'install:' | \
                                       awk 'BEGIN { FS = "=" }; {print $2" "$3}'`)
                 if [[ ${package} != 'dev' ]]; then
-                    reminder='moose-dev\t\t  Not present. Careful attention needed\n\t\t\t  when keep everything in sync.'
+                    reminder='moose-dev\t\t  is not present. All the packages must\n\t\t\t  kept in sync manually.'
                 fi
                 break
             fi
@@ -178,7 +178,7 @@ There are two ways to fix this:
 2.  Or adjust your repository to be in sync with moose-${package} Conda package.\n\n"
             return 1
         elif [[ -n "${my_version}" ]]; then
-            print_green "\nOK:"
+            print_green "\nOK"
             printf " Conda packages and MOOSE repo/submodule versions match\n\n"
         else
             printf "\nConda MOOSE packages not applicative.
@@ -200,5 +200,5 @@ function print_environment()
     compiler_test || let ERR_CNT+=1
     python_test || let ERR_CNT+=1
     conda_test || let ERR_CNT+=1
-    exit $ERR_CNT
+    exit_on_failure $ERR_CNT
 }

--- a/scripts/functions/diagnostic_environment.sh
+++ b/scripts/functions/diagnostic_environment.sh
@@ -43,7 +43,8 @@ function env_test()
     print_sep
     printf "Influential Environment Variables\n\n"
     reg_exp='^LD\|^DYLD\|^PATH\|^CFLAGS\|^CPP\|^CC\|^CXX\|^FFLAGS\|^FC\|^F90\|^F95\|^F77\|^CONDA'
-    reg_exp+='\|^HDF5\|^MOOSE\|^PETSC\|^LIBMESH\|^WASP\|^APPTAINER\|^MODULES\|^PBS\|^SLURM'
+    reg_exp+='\|^HDF5\|^MOOSE\|^PETSC\|^LIBMESH\|^WASP\|^APPTAINER\|^MODULES\|^PBS\|^SLURM\|^http'
+    reg_exp+='\|^HTTPS\|^REQUESTS_CA_BUNDLE\|^SSL_CERT_FILE\|^CURL_CA_BUNDLE'
     reg_not='CONDA_BACKUP'
     env | sort | grep "${reg_exp}" | grep -v "${reg_not}"
 }
@@ -89,7 +90,7 @@ function _python_modules()
     print_sep
     printf "Python Modules (TestHarness, run-ability)\n\n"
     fail_modules=(packaging)
-    warn_modules=(yaml pyaml jinja2)
+    warn_modules=(yaml jinja2)
     local error_cnt=0
     local warn_cnt=0
     for fail_module in "${fail_modules}"; do

--- a/scripts/functions/diagnostic_tests.sh
+++ b/scripts/functions/diagnostic_tests.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+function check_failure()
+{
+    # TODO, we will implement some sort of regexp check on the output
+    # for the things we see most common (gethostbyname, etc!)
+    printf "Checking error for known solutions...
+TODO: this function is not yet complete. Basically the idea will be to take your error
+and attempt to match it with issues commonly found. You will have to do this yourself
+for now... Go to the following address, and see if the error you are receiving matches
+anything found there:
+
+https://mooseframework.inl.gov/help/troubleshooting.html
+"
+}
+
+function test_always_ok()
+{
+    ./run_tests --${METHOD} -i always_ok -x  | tee fail.log &>/dev/null
+    if [ "$?" != "0" ]; then
+        if [ -f tests/test_harness/test_harness.always_ok.FAIL.txt ]; then
+            cat tests/test_harness/test_harness.always_ok.FAIL.txt
+        else
+            cat fail.log
+        fi
+        print_failure_and_exit 'running always_ok'
+    fi
+    print_green 'OK: Serial Tests\n'
+}
+
+function test_parallel()
+{
+    ./run_tests --${METHOD} -i always_ok -p 2 &>/dev/null
+    if [ "$?" != "0" ]; then
+        cat tests/test_harness/test_harness.always_ok.FAIL.txt
+        print_failure_and_exit 'running parallel test'
+    fi
+    print_green 'OK: Parallel Tests\n'
+}
+
+function test_application()
+{
+    if [ "${FULL_BUILD}" == 0 ]; then
+        printf "Running aggregated tests\n\n"
+        enter_moose
+        cd test
+        set -o pipefail
+        test_always_ok
+        test_parallel
+        print_green '\n\nAll tests passed.\n\n'
+        set +o pipefail
+    else
+        printf "Running all tests...\n\n"
+        enter_moose
+        cd test
+        if [[ ${MOOSE_JOBS:-6} -gt 12 ]]; then
+            MOOSE_JOBS=12
+        fi
+        ./run_tests -j ${MOOSE_JOBS:-6} --${METHOD}
+    fi
+}

--- a/scripts/functions/diagnostic_tests.sh
+++ b/scripts/functions/diagnostic_tests.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
 
 function check_failure()
 {
@@ -40,6 +48,7 @@ function test_parallel()
 
 function test_application()
 {
+    print_sep
     if [ "${FULL_BUILD}" == 0 ]; then
         printf "Running aggregated tests\n\n"
         enter_moose

--- a/scripts/functions/help_system
+++ b/scripts/functions/help_system
@@ -1,4 +1,13 @@
 #!/bin/bash
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
 function print_args()
 {
     #### This function uses indirect expansion (pass variable name, not the value)

--- a/scripts/functions/help_system
+++ b/scripts/functions/help_system
@@ -1,0 +1,107 @@
+#!/bin/bash
+function print_args()
+{
+    #### This function uses indirect expansion (pass variable name, not the value)
+    ##
+    ## Syntax:  print_args args args_about
+    ##
+    ## Where args and args_about are arrays containing double quoted content:
+    ##
+    ##   args=("-h|--help"\
+    ##         "-a|--absolute [INT]"\
+    ##         "-b|--bool-option")
+    ##
+    ##   args_about=("Pring this message and exit"\
+    ##               "-a does this"\
+    ##               "-b does that")
+    ##
+    ## Note: Line Skips/Continuations "\" are _required_ for multiple arguments, such
+    ##       as the above example.
+    ####
+
+    ## The desired maximium about text length, before justification occurs
+    local max_length=132
+
+    ## The desired 'tab' length which separates the argument from argument description
+    local tab="   "
+
+    #### End user customizations
+    local _args_array=$1
+    local _msgs_array=$2
+    local _tmp=$_args_array[@]
+    local _args_array=( "${!_tmp}" )
+    local _tmp=$_msgs_array[@]
+    local _msgs_array=( "${!_tmp}" )
+    local _longest_found=""
+    local _indent=$(printf "%.s " {1..100})
+
+    # Discover longest argument
+    for argument in "${_args_array[@]}"; do
+        if [ ${#argument} -gt ${#_longest_found} ]; then
+            _longest_found="${argument}${tab}"
+        fi
+    done
+
+    # Create indent for about strings based on longest found argument length
+    index=0
+    for argument in "${_args_array[@]}"; do
+        _args_array[$index]="${argument}${_indent::${#_longest_found}-${#argument}}"
+        let index=$index+1
+    done
+
+    index=0
+    for message in "${_msgs_array[@]}"; do
+        message_length=${#_msgs_array[$index]}
+
+        # About string longer than max_length
+        if [ $message_length -gt $max_length ]; then
+            justified_message=""
+
+            # Format the message string while it is longer than max_length (this method continues to widdle down message_length)
+            while [ $message_length -gt $max_length ]; do
+                tmp_char_index=$max_length
+                # Move backwards to detect a space separated word. If we hit the floor, move forwards instead
+                while [ "${_msgs_array[$index]:$tmp_char_index:1}" != " " ] && [ -z "$move_forwards_instead" ]; do
+                    let tmp_char_index=$tmp_char_index-1
+                    # We hit the floor
+                    if [ $tmp_char_index -le 0 ]; then
+                        move_forwards_instead=true
+                        let tmp_char_index=$max_length+1
+                        while [ "${_msgs_array[$index]:$tmp_char_index:1}" != " " ]; do
+                            # Catch end of string condition
+                            if [ $tmp_char_index -ge ${#_msgs_array[$index]} ]; then break; fi
+                            let tmp_char_index=$tmp_char_index+1
+                        done
+                    fi
+                done
+                unset move_forwards_instead
+                let index_max_length=$tmp_char_index
+
+                # Where the magic happens. Append the new line with the proper lengthed spaces to justify the about text
+                justified_message="${justified_message}${_msgs_array[$index]::$index_max_length}\n${tab}${_indent::${#_longest_found}}"
+
+                # Move forwards until we don't hit a space
+                while [ "${_msgs_array[$index]:$index_max_length:1}" = " " ]; do
+                    # Catch end of string condition
+                    if [ $index_max_length -ge ${#_msgs_array[$index]} ]; then break; fi
+                    let index_max_length=$index_max_length+1
+                done
+
+                # Consume/advance our position within the message, so we eventually exit this while loop
+                _msgs_array[$index]="${_msgs_array[$index]:$index_max_length}"
+                message_length=${#_msgs_array[$index]}
+
+            done
+            # Consume last part of message as we exit the while loop
+            remainder_message="${_msgs_array[$index]}"
+
+            # Print beautified message string
+            echo -e "${tab}${_args_array[$index]}${justified_message}${remainder_message}\n"
+        else
+            # Print as-is, no formatting was required
+            echo -e "${tab}${_args_array[$index]}${_msgs_array[$index]}"
+        fi
+        let index=$index+1
+    done
+}
+

--- a/scripts/functions/help_system
+++ b/scripts/functions/help_system
@@ -29,7 +29,7 @@ function print_args()
     ####
 
     ## The desired maximum about text length, before justification occurs
-    local max_length=132
+    local max_length=70
 
     ## The desired 'tab' length which separates the argument from argument description
     local tab="    "

--- a/scripts/functions/help_system
+++ b/scripts/functions/help_system
@@ -28,11 +28,11 @@ function print_args()
     ##       as the above example.
     ####
 
-    ## The desired maximium about text length, before justification occurs
+    ## The desired maximum about text length, before justification occurs
     local max_length=132
 
     ## The desired 'tab' length which separates the argument from argument description
-    local tab="   "
+    local tab="    "
 
     #### End user customizations
     local _args_array=$1


### PR DESCRIPTION
Repurpose the aging diagnostic script to allow the script to build and run tests to in an effort to isolate issues building/running MOOSE.

More work to be done: Add regexp that searches the test output to make comparisons found on our FAQ Troubleshooting sections. Things like:

  ./run_tests -i always_ok -p 2

might contain pesky output about 'gethostbyname failed'.

Errors like this can be caught, and direct the user to a proper fix.

Closes #26843