### PR TITLE
Update libMesh submodule

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2024.01.23" %}
+{% set version = "2024.02.28" %}
 {% set vtk_friendly_version = "9.2" %}
 
 # permanent

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
-  - moose-libmesh 2024.01.23 build_0
+  - moose-libmesh 2024.02.28 build_0
 
 moose_wasp:
   - moose-wasp 2024.03.01

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -6,7 +6,7 @@
 #   framework/doc/packages_config.yml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.03.01" %}
+{% set version = "2024.03.05" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_dev:
-  - moose-dev 2024.03.01
+  - moose-dev 2024.03.05
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=7c03afd53c9c7fd7fcb6e3e20bae37cf1b124986
+ARG LIBMESH_REV=4e661a5ff0a35eaf798a2817c818d10c5fe6c59c
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -6,7 +6,7 @@ minimum_python: 3.7
 mpich: 4.0.2
 petsc_alt: 3.11.4
 petsc: 3.20.3
-moose_dev: 2024.03.01
+moose_dev: 2024.03.05
 moose_tools: 2023.12.20
 apptainer_rockylinux: 8.8.20230518
 apptainer_mpich: 3.4.3

--- a/modules/doc/content/newsletter/2024/2024_03.md
+++ b/modules/doc/content/newsletter/2024/2024_03.md
@@ -9,6 +9,28 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2024.02.28` Update
+
+- Added capability to read and write sparse matrices in the
+  ASCII/Matlab format used by PETSc. 
+- Added capability to read mesh constraint rows from an arbitrary
+  sparse matrix.  This will enable IGA solves on more flexible meshes
+  without perfect body fit domains.
+- Added vector-valued parameter support in Reduced-Basis code.
+- Added normalization to Empirical Interpolation Method in
+  Reduced-Basis code.
+- Removed redundant mapping code for FEXYZ.  Instead use the common
+  mapping code, which has additional optimizations, and which avoids a
+  bug triggered by MOOSE use of those optimizations.
+- Fixed bugs in Tet14 element refinement with non-default diagonal
+  selection.
+- Always number assembly element nodes contiguously when reading
+  IsoGeometric Analysis meshes.  This avoids a bug in transient IGA
+  solves on distributed meshes with discontinuous assembly elements.
+- Minor bug fixes to example applications' common shell functions,
+  test execution in configurations without numeric solver libraries,
+  and an unused variable warning on newer compilers.
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -207,3 +207,9 @@ e104da697ce080c846b1c25cc6a7999a8803af9d: #26797
   libmesh: 7cd53c3
   moose-dev: deb8bf9
   wasp: c153aa5
+c3887b923cf95aaad424203cfc15e92bbc911318: #26919
+  mpich: 702900f
+  petsc: b32e40b
+  libmesh: 4262509
+  moose-dev: 253024f
+  wasp: c153aa5


### PR DESCRIPTION
- Added capability to read and write sparse matrices in the
  ASCII/Matlab format used by PETSc.
- Added capability to read mesh constraint rows from an arbitrary
  sparse matrix.  This will enable IGA solves on more flexible meshes
  without perfect body fit domains.
- Added vector-valued parameter support in Reduced-Basis code.
- Added normalization to Empirical Interpolation Method in
  Reduced-Basis code.
- Removed redundant mapping code for FEXYZ.  Instead use the common
  mapping code, which has additional optimizations, and which avoids a
  bug triggered by MOOSE use of those optimizations.
- Fixed bugs in Tet14 element refinement with non-default diagonal
  selection.
- Always number assembly element nodes contiguously when reading
  IsoGeometric Analysis meshes.  This avoids a bug in transient IGA
  solves on distributed meshes with discontinuous assembly elements.
- Minor bug fixes to example applications' common shell functions,
  test execution in configurations without numeric solver libraries,
  and an unused variable warning on newer compilers.
  
I cherry-picked the March newsletter template from @cticenhour in #26911 and put the update details in there; I figured we'll almost surely want to merge that PR before this.

We haven't been doing many libMesh-only updates lately.  I don't see a new PETSc ready to go, though.  Is there anything else we need to update while we're tweaking the conda configs?