### PR TITLE
Patched multiple procs writing to same file

### DIFF
--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -222,6 +222,9 @@ protected:
   /// Time format
   TimeFormatEnum _time_format;
 
+  /// Whether to write all processors to files
+  const bool _write_all_procs_to_files;
+
 private:
   /**
    * Add a message to the output streams

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -61,8 +61,6 @@
     check_files = 'console_file_system_information_out.txt'
     check_not_exists = 'console_file_system_information_out_0.txt console_file_system_information_out_1.txt'
     recover = false
-    min_parallel = 2
-    max_parallel = 2
 
     requirement = 'The system shall support outputting head processor console information to a file when run in parallel.'
     issues = '#26174'
@@ -75,9 +73,8 @@
     check_files = 'console_file_system_information_out_0.txt console_file_system_information_out_1.txt'
     recover = false
     min_parallel = 2
-    max_parallel = 2
 
-    requirement = "The system shall support outputting all processors' console information to separate files when run in parallel with --keep-cout."
+    requirement = "The system shall support outputting all processors' console information to separate files when run in parallel with the --keep-cout command line option."
     issues = '#26174'
   [../]
   [./file_postprocessor]

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -53,6 +53,33 @@
     requirement = 'The system shall support outputting console information to a file.'
     issues = '#1927'
   [../]
+  [./file_system_information_2procs_head]
+    # Test that file contains regex
+    type = CheckFiles
+    input = 'console.i'
+    cli_args = 'Outputs/screen/output_file=true Outputs/screen/file_base=console_file_system_information_out'
+    check_files = 'console_file_system_information_out.txt'
+    file_expect_out = 'Num\s*Local\s*DOFs:\s*134'
+    recover = false
+    min_parallel = 2
+    max_parallel = 2
+
+    requirement = 'The system shall support outputting head processor console information to a file when run in parallel.'
+    issues = '#1927'
+  [../]
+  [./file_system_information_2procs_all]
+    # Test that file contains regex
+    type = CheckFiles
+    input = 'console.i'
+    cli_args = 'Outputs/screen/output_file=true Outputs/screen/file_base=console_file_system_information_out --keep-cout'
+    check_files = 'console_file_system_information_out_0.txt console_file_system_information_out_1.txt'
+    recover = false
+    min_parallel = 2
+    max_parallel = 2
+
+    requirement = "The system shall support outputting all processors' console information to separate files when run in parallel with --keep-cout."
+    issues = '#1927'
+  [../]
   [./file_postprocessor]
     # Test that file contains regex
     type = CheckFiles

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -59,7 +59,7 @@
     input = 'console.i'
     cli_args = 'Outputs/screen/output_file=true Outputs/screen/file_base=console_file_system_information_out'
     check_files = 'console_file_system_information_out.txt'
-    check_not_exist = 'console_file_system_information_out_0.txt console_file_system_information_out_1.txt'
+    check_not_exists = 'console_file_system_information_out_0.txt console_file_system_information_out_1.txt'
     recover = false
     min_parallel = 2
     max_parallel = 2

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -59,13 +59,13 @@
     input = 'console.i'
     cli_args = 'Outputs/screen/output_file=true Outputs/screen/file_base=console_file_system_information_out'
     check_files = 'console_file_system_information_out.txt'
-    file_expect_out = 'Num\s*Local\s*DOFs:\s*134'
+    check_not_exist = 'console_file_system_information_out_0.txt console_file_system_information_out_1.txt'
     recover = false
     min_parallel = 2
     max_parallel = 2
 
     requirement = 'The system shall support outputting head processor console information to a file when run in parallel.'
-    issues = '#1927'
+    issues = '#26174'
   [../]
   [./file_system_information_2procs_all]
     # Test that file contains regex
@@ -78,7 +78,7 @@
     max_parallel = 2
 
     requirement = "The system shall support outputting all processors' console information to separate files when run in parallel with --keep-cout."
-    issues = '#1927'
+    issues = '#26174'
   [../]
   [./file_postprocessor]
     # Test that file contains regex


### PR DESCRIPTION
Console objects have a parameter 'output_file', that when true, writes console output to a file. Parallel simulations would write information from all processors to the same file, which can lead to bad behavior. This commit introduces a patch that only writes console content from the head proc to the file. In the case that --keep-cout is passed to the executable, each proc writes its console content to a separate file. The same bahavior can be achieved without setting output_file to true by instead passing '--keep-cout --redirect-stdout' to the executable.

Closes Ref #26174.
