### PR TITLE
Improve `MooseObject::mooseError()` with more context, correct file paths with many inputs

### DIFF
--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -218,19 +218,29 @@ Node::getNodeView()
 }
 
 const std::string &
-Node::filename()
+Node::filename() const
 {
   return _hnv.node_pool()->stream_name();
 }
 
+std::string
+Node::fileLocation(const bool with_column /* = true */) const
+{
+  std::stringstream ss;
+  ss << filename() << ":" << line();
+  if (with_column)
+    ss << "." << column();
+  return ss.str();
+}
+
 int
-Node::line()
+Node::line() const
 {
   return _hnv.line();
 }
 
 int
-Node::column()
+Node::column() const
 {
   return _hnv.column();
 }
@@ -253,7 +263,7 @@ Node::floatVal()
   valthrow();
 }
 std::string
-Node::strVal()
+Node::strVal() const
 {
   valthrow();
 }
@@ -280,7 +290,7 @@ Node::vecStrVal()
 #undef valthrow
 
 NodeType
-Node::type()
+Node::type() const
 {
   if (_hnv.type() == wasp::BLANK_LINE)
     return NodeType::Blank;
@@ -334,7 +344,7 @@ Node::root()
 }
 
 std::string
-Node::path()
+Node::path() const
 {
   if (!_override_path.empty())
     return _override_path;
@@ -343,7 +353,7 @@ Node::path()
 }
 
 std::string
-Node::fullpath()
+Node::fullpath() const
 {
   if (_parent == nullptr)
     return "";
@@ -425,9 +435,7 @@ Comment::render(int indent, const std::string & indent_text, int /*maxlen*/)
 }
 
 Node *
-Comment::clone(bool
-                   absolute_path
-)
+Comment::clone(bool absolute_path)
 {
   auto n = new Comment(_dhi, _hnv);
   n->setInline(_isinline);
@@ -468,7 +476,7 @@ Section::clearLegacyMarkers()
 }
 
 std::string
-Section::path()
+Section::path() const
 {
   return Node::path();
 }
@@ -531,7 +539,7 @@ Field::Field(std::shared_ptr<wasp::DefaultHITInterpreter> dhi, wasp::HITNodeView
 }
 
 std::string
-Field::path()
+Field::path() const
 {
   return Node::path();
 }
@@ -740,7 +748,7 @@ Field::setVal(const std::string & value, Kind kind)
 }
 
 std::string
-Field::val()
+Field::val() const
 {
   return extractValue(_hnv.data());
 }
@@ -887,7 +895,7 @@ Field::floatVal()
 }
 
 std::string
-Field::strVal()
+Field::strVal() const
 {
   const auto value = val();
   std::string s = value;

--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -330,15 +330,9 @@ Node::children(NodeType t)
 }
 
 Node *
-Node::parent()
-{
-  return _parent;
-}
-
-Node *
 Node::root()
 {
-  if (_parent == nullptr)
+  if (isRoot())
     return this;
   return _parent->root();
 }

--- a/framework/contrib/hit/parse.h
+++ b/framework/contrib/hit/parse.h
@@ -76,7 +76,7 @@ enum class NodeType
   Comment, /// Represents comments that are not directly part of the actual hit document.
   Field,   /// Represents field-value pairs (i.e. paramname=val).
   Blank,   /// Represents a blank line
-  Other, /// Represents any other type of node
+  Other,   /// Represents any other type of node
 };
 
 /// Traversal order for walkers. Determines if the walker on a node is executed before or
@@ -225,9 +225,14 @@ public:
   /// children returns a list of this node's children of the given type t.
   std::vector<Node *> children(NodeType t = NodeType::All);
   /// parent returns a pointer to this node's parent node or nullptr if this node has no parent.
-  Node * parent();
+  ///@{
+  Node * parent() { return _parent; }
+  const Node * parent() const { return _parent; }
+  ///@}
   /// root returns the root node for the gepot tree this node resides in.
   Node * root();
+  /// Whether or not this is the root
+  bool isRoot() const { return parent() == nullptr; }
   /// clone returns a complete (deep) copy of this node.  The caller will be responsible for
   /// managing the memory/deallocation of the returned clone node.
   virtual Node * clone(bool absolute_path = false) = 0;
@@ -288,7 +293,6 @@ protected:
   wasp::HITNodeView _hnv;
 
 private:
-
   template <typename T>
   T paramInner(Node *)
   {

--- a/framework/contrib/hit/parse.h
+++ b/framework/contrib/hit/parse.h
@@ -176,23 +176,26 @@ public:
   wasp::HITNodeView getNodeView();
 
   /// type returns the type of the node (e.g. one of Field, Section, Comment, etc.)
-  NodeType type();
+  NodeType type() const;
   /// path returns this node's local/direct contribution its full hit path.  For section nodes, this
   /// is the section name, for field nodes, this is the field/parameter name, for other nodes this
   /// is empty. if setOverridePath (wasp) has been called for this Node, then that set path is
   /// returned.
-  virtual std::string path();
+  virtual std::string path() const;
   /// fullpath returns the full hit path to this node (including all parent sections
   /// recursively) starting from the tree's root node.
-  std::string fullpath();
+  std::string fullpath() const;
   /// line returns the line number of the original parsed input (file) that contained the start of
   /// the content that this node was built from.
-  int line();
+  int line() const;
   /// column returns the starting column number of this node in the original parsed input
-  int column();
+  int column() const;
   /// name returns the file name of the original parsed input (file) that contained the start of
   /// the content that this node was built from.
-  const std::string & filename();
+  const std::string & filename() const;
+  /// returns the file location in the form <filename()>:<line()>.<column()> where
+  /// the column is optional defined by \p with_column
+  std::string fileLocation(const bool with_column = true) const;
 
   /// the following functions return the stored value of the node (if any exists) of the type
   /// indicated in the function name. If the node holds a value of a different type or doesn't hold
@@ -203,7 +206,7 @@ public:
   /// strVal is special in that it only throws an exception if the node doesn't hold a value at
   /// all.  All nodes with a value hold data that was originally represented as a string in the
   /// parsed input - so this returns that raw string.
-  virtual std::string strVal();
+  virtual std::string strVal() const;
   /// the vec-prefixed value retrieval functions assume the node holds a string-typed value holding
   /// whitespace delimited entries of the element type indicated in the function name.
   virtual std::vector<double> vecFloatVal();
@@ -442,7 +445,7 @@ public:
   void clearLegacyMarkers();
 
   /// path returns the hit path located in the section's header i.e. the section's name.
-  virtual std::string path() override;
+  virtual std::string path() const override;
 
   virtual std::string
   render(int indent = 0, const std::string & indent_text = default_indent, int maxlen = 0) override;
@@ -472,7 +475,7 @@ public:
   Field(std::shared_ptr<wasp::DefaultHITInterpreter> dhi, wasp::HITNodeView hnv);
 
   /// path returns the hit Field name (i.e. content before the "=")
-  virtual std::string path() override;
+  virtual std::string path() const override;
 
   virtual std::string
   render(int indent = 0, const std::string & indent_text = default_indent, int maxlen = 0) override;
@@ -490,7 +493,7 @@ public:
   void setVal(const std::string & value, Kind kind = Kind::None);
   /// val returns the raw text of the field's value as it was read from the hit input.  This is
   /// the value set by setVal.
-  std::string val();
+  std::string val() const;
 
   virtual std::vector<double> vecFloatVal() override;
   virtual std::vector<bool> vecBoolVal() override;
@@ -499,7 +502,7 @@ public:
   virtual bool boolVal() override;
   virtual int64_t intVal() override;
   virtual double floatVal() override;
-  virtual std::string strVal() override;
+  virtual std::string strVal() const override;
 
 private:
   Kind _kind;

--- a/framework/doc/content/source/interfaces/DataFileInterface.md
+++ b/framework/doc/content/source/interfaces/DataFileInterface.md
@@ -13,9 +13,10 @@ getDataFileNameByName | Finds a data file given a relative path
 Files located in `moose/framework/data`, the `moose/modules/*/data`, or
 `<your_app>/data` directories can be retrieved using the `getDataFileName(const
 std::string & param)` function, where `param` is an input parameter of type
-`FileName`
+`DataFileName`
 
-`getDataFileName` will search (in this order)
+If the provided path is absolute, no searching will take place and the absolute
+path will be used. Otherwise, `getDataFileName` will search (in this order)
 
 - relative to the input file
 - relative to the running binary in the shared directory (assuming the application is installed)

--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -120,6 +120,34 @@ protected:
    */
   virtual void act() = 0;
 
+  /**
+   * Associates the object's parameters \p params with the input location from this
+   * Action's parameter with the name \p param_name, if one exists.
+   *
+   * For example, you have a parameter in this action of type bool with name "add_mesh".
+   * You then add an action within this action that creates a mesh if this param is
+   * true. If you call associateWithParameter("add_mesh", action_params) where
+   * action_params are the parameters for the action, we then associate that action
+   * with the "add_mesh" parameter. Therefore, the resulting created mesh will also
+   * be associated with the "add_mesh" param and any errors that are non-parameter errors
+   * (i.e., mooseError/mooseWarning) will have the line context of the "add_mesh"
+   * parameter in this action. The same goes for any errors that are produce within
+   * the created action.
+   */
+  void associateWithParameter(const std::string & param_name, InputParameters & params) const;
+
+  /**
+   * The same as associateWithParameter() without \p from_params, but instead
+   * allows you to associate this with another object's parameters instead of the
+   * parameters from this action.
+   *
+   * An example here is when you want to associate the creation of an action with
+   * an arugment from the aplication.
+   */
+  void associateWithParameter(const InputParameters & from_params,
+                              const std::string & param_name,
+                              InputParameters & params) const;
+
   // The registered syntax for this block if any
   std::string _registered_identifier;
 

--- a/framework/include/actions/ActionFactory.h
+++ b/framework/include/actions/ActionFactory.h
@@ -100,6 +100,13 @@ public:
    */
   bool isRegisteredTask(const std::string & task) const { return _tasks.count(task); }
 
+  /**
+   * @return Whether or not this is currently creating an object
+   *
+   * Can be used to ensure that all Actions are created using the ActionFactory
+   */
+  bool currentlyConstructing() const { return _currently_constructing; }
+
 private:
   template <class T>
   static std::shared_ptr<Action> buildAction(const InputParameters & parameters)
@@ -119,4 +126,8 @@ private:
 
   /// The registered tasks
   std::set<std::string> _tasks;
+
+  /// Whether or not the factory is currently constructing an object; used to make sure
+  /// that all objects are created by the factory
+  bool _currently_constructing;
 };

--- a/framework/include/actions/ActionFactory.h
+++ b/framework/include/actions/ActionFactory.h
@@ -101,11 +101,12 @@ public:
   bool isRegisteredTask(const std::string & task) const { return _tasks.count(task); }
 
   /**
-   * @return Whether or not this is currently creating an object
+   * @return The InputParameters for the object that is currently being constructed,
+   * if any.
    *
    * Can be used to ensure that all Actions are created using the ActionFactory
    */
-  bool currentlyConstructing() const { return _currently_constructing; }
+  const InputParameters * currentlyConstructing() const;
 
 private:
   template <class T>
@@ -127,7 +128,8 @@ private:
   /// The registered tasks
   std::set<std::string> _tasks;
 
-  /// Whether or not the factory is currently constructing an object; used to make sure
-  /// that all objects are created by the factory
-  bool _currently_constructing;
+  /// The object's parameters that are currently being constructed (if any).
+  /// This is a vector because we create within create, thus the last entry is the
+  /// one that is being constructed at the moment
+  std::vector<const InputParameters *> _currently_constructing;
 };

--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -249,6 +249,13 @@ public:
   const std::string & getMooseAppName();
   const std::string & getCurrentTaskName() const { return _current_task; }
 
+  /**
+   * @return The current action that is running, if any
+   */
+  const Action * getCurrentAction() const { return _current_action; }
+  /**
+   * @return The name of the current action that is running
+   */
   std::string getCurrentActionName() const;
 
   /**
@@ -304,6 +311,8 @@ protected:
   // When executing the actions in the warehouse, this string will always contain
   // the current task name
   std::string _current_task;
+  // The current action that is running
+  Action * _current_action;
 
   //
   // data created by actions
@@ -321,8 +330,6 @@ protected:
 private:
   /// Last task to run before (optional) early termination - blank means no early termination.
   std::string _final_task;
-
-  ActionIterator _act_iter;
 
   const std::list<Action *> _empty_action_list;
 };

--- a/framework/include/actions/CommonOutputAction.h
+++ b/framework/include/actions/CommonOutputAction.h
@@ -12,6 +12,8 @@
 // MOOSE includes
 #include "Action.h"
 
+#include <optional>
+
 /**
  * Meta-action for creating common output object parameters
  * This action serves two purpose, first it adds common output object
@@ -35,8 +37,11 @@ private:
   /**
    * Helper method for creating the short-cut actions
    * @param object_type String of the object type, i.e., the value of 'type=' in the input file
+   * @param param_name The name of the input parameter that is responsible for creating, if any
    */
-  void create(std::string object_type);
+  void create(std::string object_type,
+              const std::optional<std::string> & param_name,
+              const InputParameters * const from_params = nullptr);
 
   /**
    * Check if a Console object that outputs to the screen has been defined

--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -133,6 +133,13 @@ public:
 
   MooseApp & app() { return _app; }
 
+  /**
+   * @return Whether or not this is currently creating an object
+   *
+   * Can be used to ensure that all MooseObjects are created using the Factory
+   */
+  bool currentlyConstructing() const { return _currently_constructing; }
+
 private:
   /**
    * Parse time string (mm/dd/yyyy HH:MM)
@@ -183,4 +190,8 @@ private:
   /// again - which is okay/allowed, while still allowing us to detect/reject cases of duplicate
   /// object name registration where the label/appname is not identical.
   std::set<std::pair<std::string, std::string>> _objects_by_label;
+
+  /// Whether or not the factory is currently constructing an object; used to make sure
+  /// that all objects are created by the factory
+  bool _currently_constructing;
 };

--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -70,11 +70,18 @@ public:
    * @param print_deprecated controls the deprecated message
    * @return The created object
    */
+  ///@{
+  std::unique_ptr<MooseObject> createUnique(const std::string & obj_name,
+                                            const std::string & name,
+                                            const InputParameters & parameters,
+                                            THREAD_ID tid = 0,
+                                            bool print_deprecated = true);
   std::shared_ptr<MooseObject> create(const std::string & obj_name,
                                       const std::string & name,
                                       const InputParameters & parameters,
                                       THREAD_ID tid = 0,
                                       bool print_deprecated = true);
+  ///@}
 
   /**
    * Build an object (must be registered)
@@ -84,21 +91,39 @@ public:
    * @param tid The thread id that this copy will be created for
    * @return The created object
    */
+  ///@{
+  template <typename T>
+  std::unique_ptr<T> createUnique(const std::string & obj_name,
+                                  const std::string & name,
+                                  const InputParameters & parameters,
+                                  const THREAD_ID tid = 0);
   template <typename T>
   std::shared_ptr<T> create(const std::string & obj_name,
                             const std::string & name,
                             const InputParameters & parameters,
-                            THREAD_ID tid = 0)
-  {
-    std::shared_ptr<T> new_object =
-        std::dynamic_pointer_cast<T>(create(obj_name, name, parameters, tid, false));
-    if (!new_object)
-      mooseError("We expected to create an object of type '" + demangle(typeid(T).name()) +
-                 "'.\nInstead we received a parameters object for type '" + obj_name +
-                 "'.\nDid you call the wrong \"add\" method in your Action?");
+                            const THREAD_ID tid = 0);
+  ///@}
 
-    return new_object;
-  }
+  /**
+   * Clones the object \p object.
+   *
+   * Under the hood, this creates a copy of the InputParameters from \p object
+   * and constructs a new object with the copied parameters. The suffix _clone<i>
+   * will be added to the object's name, where <i> is incremented each time
+   * the object is cloned.
+   */
+  template <typename T>
+  std::unique_ptr<T> clone(const T & object);
+
+  /**
+   * Copy constructs the object \p object.
+   *
+   * Under the hood, the new object's parameters will point to the same address
+   * as the parameters in \p object. This can be dangerous and thus this is only
+   * allowed for a subset of objects.
+   */
+  template <typename T>
+  std::unique_ptr<T> copyConstruct(const T & object);
 
   /**
    * Releases any shared resources created as a side effect of creating an object through
@@ -160,6 +185,23 @@ private:
    */
   void reportUnregisteredError(const std::string & obj_name) const;
 
+  /**
+   * Initializes the data structures and the parameters (in the InputParameterWarehouse)
+   * for the object with the given state.
+   */
+  InputParameters & initialize(const std::string & type,
+                               const std::string & name,
+                               const InputParameters & from_params,
+                               const THREAD_ID tid);
+
+  /**
+   * Finalizes the creaction of \p object of type \p type.
+   *
+   * This will do some sanity checking on whether or not the parameters in the
+   * created object match the valid paramters of the associated type.
+   */
+  void finalize(const std::string & type, const MooseObject & object);
+
   /// Reference to the application
   MooseApp & _app;
 
@@ -194,4 +236,89 @@ private:
   /// Whether or not the factory is currently constructing an object; used to make sure
   /// that all objects are created by the factory
   bool _currently_constructing;
+
+  /// Counter for keeping track of the number of times an object with a given name has
+  /// been cloned so that we can continue to create objects with unique names
+  std::map<const MooseObject *, unsigned int> _clone_counter;
 };
+
+template <typename T>
+std::unique_ptr<T>
+Factory::createUnique(const std::string & obj_name,
+                      const std::string & name,
+                      const InputParameters & parameters,
+                      const THREAD_ID tid)
+{
+  auto object = createUnique(obj_name, name, parameters, tid, false);
+  if (!dynamic_cast<T *>(object.get()))
+    mooseError("We expected to create an object of type '" + demangle(typeid(T).name()) +
+               "'.\nInstead we received a parameters object for type '" + obj_name +
+               "'.\nDid you call the wrong \"add\" method in your Action?");
+
+  return std::unique_ptr<T>(static_cast<T *>(object.release()));
+}
+
+template <typename T>
+std::shared_ptr<T>
+Factory::create(const std::string & obj_name,
+                const std::string & name,
+                const InputParameters & parameters,
+                const THREAD_ID tid)
+{
+  return std::move(createUnique<T>(obj_name, name, parameters, tid));
+}
+
+template <typename T>
+std::unique_ptr<T>
+Factory::clone(const T & object)
+{
+  static_assert(std::is_base_of_v<MooseObject, T>, "Not a MooseObject");
+
+  const auto tid = object.template getParam<THREAD_ID>("_tid");
+  if (tid != 0)
+    mooseError("Factory::clone(): The object ",
+               object.typeAndName(),
+               " is threaded but cloning does not work with threaded objects");
+
+  // Clone the parameters; we can't copy construct InputParameters
+  InputParameters cloned_params = emptyInputParameters();
+  cloned_params += object.parameters();
+  if (const auto hit_node = object.parameters().getHitNode())
+    cloned_params.setHitNode(*hit_node, {});
+
+  // Fill the new parameters in the warehouse
+  const auto type = static_cast<const MooseBase &>(object).type();
+  const auto clone_count = _clone_counter[&object]++;
+  const auto name = object.name() + "_clone" + std::to_string(clone_count);
+  const auto & params = initialize(type, name, cloned_params, 0);
+
+  // Construct the object
+  _currently_constructing = true;
+  auto cloned_object = std::make_unique<T>(params);
+  _currently_constructing = false;
+
+  // Do some sanity checking
+  finalize(type, *cloned_object);
+
+  return cloned_object;
+}
+
+template <typename T>
+std::unique_ptr<T>
+Factory::copyConstruct(const T & object)
+{
+  static_assert(std::is_base_of_v<MooseObject, T>, "Not a MooseObject");
+
+  const auto type = static_cast<const MooseBase &>(object).type();
+  const auto base = object.parameters().getBase();
+  if (!base || (*base != "MooseMesh" && *base != "RelationshipManager"))
+    mooseError("Copy construction of ", type, " objects is not supported.");
+
+  _currently_constructing = true;
+  auto cloned_object = std::make_unique<T>(object);
+  _currently_constructing = false;
+
+  finalize(type, *cloned_object);
+
+  return cloned_object;
+}

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -27,7 +27,7 @@
 #include "MeshGeneratorSystem.h"
 #include "RestartableDataReader.h"
 #include "Backup.h"
-
+#include "MooseBase.h"
 #include "libmesh/parallel_object.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/point.h"
@@ -72,7 +72,8 @@ class Node;
  */
 class MooseApp : public ConsoleStreamInterface,
                  public PerfGraphInterface,
-                 public libMesh::ParallelObject
+                 public libMesh::ParallelObject,
+                 public MooseBase
 {
 public:
   /**
@@ -101,15 +102,6 @@ public:
   TheWarehouse & theWarehouse() { return *_the_warehouse; }
 
   /**
-   * Get the name of the object. In the case of MooseApp, the name of the object is *NOT* the name
-   * of the application. It's the name of the created application which is usually "main". If you
-   * have subapps, then each individual subapp will have a unique name which typically comes from
-   * the input file (e.g. sub0, sub1, etc...).
-   * @return The name of the object
-   */
-  const std::string & name() const { return _name; }
-
-  /**
    * Get printable name of the application.
    */
   virtual std::string getPrintableName() const { return "Application"; }
@@ -128,13 +120,6 @@ public:
    * @return The parameters of the object
    */
   InputParameters & parameters() { return _pars; }
-
-  /**
-   * Get the type of this object as a string. This is a string version of the class name (e.g.
-   * MooseTestApp).
-   * @return The the type of the object
-   */
-  const std::string & type() const;
 
   /**
    * The RankMap is a useful object for determining how the processes
@@ -1496,7 +1481,7 @@ template <typename T>
 const T &
 MooseApp::getParam(const std::string & name) const
 {
-  return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
+  return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0), this);
 }
 
 template <typename T>
@@ -1506,13 +1491,13 @@ MooseApp::getRenamedParam(const std::string & old_name, const std::string & new_
   // this enables having a default on the new parameter but bypassing it with the old one
   // Most important: accept new parameter
   if (isParamSetByUser(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0));
+    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), this);
   // Second most: accept old parameter
   else if (isParamValid(old_name) && !isParamSetByUser(new_name))
-    return InputParameters::getParamHelper(old_name, _pars, static_cast<T *>(0));
+    return InputParameters::getParamHelper(old_name, _pars, static_cast<T *>(0), this);
   // Third most: accept default for new parameter
   else if (isParamValid(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0));
+    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), this);
   // Refuse: no default, no value passed
   else if (!isParamValid(old_name) && !isParamValid(new_name))
     mooseError(_pars.blockFullpath() + ": parameter '" + new_name +

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -234,6 +234,15 @@ public:
   const std::string & getLastInputFileName() const;
 
   /**
+   * @return The file base for reading in files.
+   *
+   * In the case that we have input files, this is the parent path
+   * of the last input file. If we have no input files, this is the current
+   * working directory.
+   */
+  std::filesystem::path getInputFileBase() const;
+
+  /**
    * Override the selection of the output file base name.
    * Note: This method is supposed to be called by MultiApp only.
    */

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -347,10 +347,9 @@ public:
                          const InputParameters & params);
 
   /**
-   * Deprecated helper function to link the new added Builder back to Parser. This function will be
-   *removed after new Parser and builder are merged
+   * @return The Parser
    **/
-  Moose::Builder & parser();
+  Parser & parser();
 
 private:
   /**

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -219,15 +219,6 @@ public:
   const std::string & getLastInputFileName() const;
 
   /**
-   * @return The file base for reading in files.
-   *
-   * In the case that we have input files, this is the parent path
-   * of the last input file. If we have no input files, this is the current
-   * working directory.
-   */
-  std::filesystem::path getInputFileBase() const;
-
-  /**
    * Override the selection of the output file base name.
    * Note: This method is supposed to be called by MultiApp only.
    */

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -55,6 +55,10 @@ namespace libMesh
 {
 class ExodusII_IO;
 }
+namespace hit
+{
+class Node;
+}
 
 /**
  * Base class for MOOSE-based applications
@@ -939,6 +943,15 @@ public:
                                                   const std::string & map_suffix);
   /// The file suffix for restartable data
   std::filesystem::path restartFolderBase(const std::filesystem::path & folder_base) const;
+
+  /**
+   * @return The hit node that is responsible for creating the current action that is running,
+   * if any
+   *
+   * Can be used to link objects that are created by an action to the action that
+   * created them in input
+   */
+  const hit::Node * getCurrentActionHitNode() const;
 
 private:
   /**

--- a/framework/include/base/MooseBase.h
+++ b/framework/include/base/MooseBase.h
@@ -67,7 +67,7 @@ public:
    * file location associated with this object (if any) and the
    * name and type of the object.
    */
-  std::string objectErrorPrefix(const std::string & error_type) const;
+  std::string errorPrefix(const std::string & error_type) const;
 
   /**
    * Calls moose error with the message \p msg.

--- a/framework/include/base/MooseBase.h
+++ b/framework/include/base/MooseBase.h
@@ -11,6 +11,9 @@
 
 #include <string>
 
+class InputParameters;
+class MooseApp;
+
 #define usingMooseBaseMembers                                                                      \
   using MooseBase::getMooseApp;                                                                    \
   using MooseBase::type;                                                                           \
@@ -19,8 +22,6 @@
   using MooseBase::_type;                                                                          \
   using MooseBase::_app;                                                                           \
   using MooseBase::_name
-
-class MooseApp;
 
 /**
  * Base class for everything in MOOSE with a name and a type.
@@ -31,10 +32,10 @@ class MooseApp;
 class MooseBase
 {
 public:
-  MooseBase(const std::string & type, const std::string & name, MooseApp & app)
-    : _app(app), _type(type), _name(name)
-  {
-  }
+  MooseBase(const std::string & type,
+            const std::string & name,
+            MooseApp & app,
+            const InputParameters & params);
 
   virtual ~MooseBase() = default;
 
@@ -59,18 +60,36 @@ public:
    * Get the class's combined type and name; useful in error handling.
    * @return The type and name of this class in the form '<type()> "<name()>"'.
    */
-  std::string typeAndName() const
-  {
-    return type() + std::string(" \"") + name() + std::string("\"");
-  }
+  std::string typeAndName() const;
+
+  /**
+   * @returns A prefix to be used in errors that contains the input
+   * file location associated with this object (if any) and the
+   * name and type of the object.
+   */
+  std::string objectErrorPrefix(const std::string & error_type) const;
+
+  /**
+   * Calls moose error with the message \p msg.
+   *
+   * Will prefix the message with the subapp name if one exists.
+   *
+   * If \p with_prefix, then add the prefix from errorPrefix()
+   * to the error.
+   */
+  [[noreturn]] void callMooseError(std::string msg, const bool with_prefix) const;
 
 protected:
   /// The MOOSE application this is associated with
   MooseApp & _app;
 
   /// The type of this class
-  const std::string & _type;
+  const std::string _type;
 
-  /// The name of this class, reference to value stored in InputParameters
-  const std::string & _name;
+  /// The name of this class
+  const std::string _name;
+
+private:
+  /// The object's parameteres
+  const InputParameters & _params;
 };

--- a/framework/include/base/MooseBaseErrorInterface.h
+++ b/framework/include/base/MooseBaseErrorInterface.h
@@ -51,7 +51,7 @@ public:
   void mooseWarning(Args &&... args) const
   {
     moose::internal::mooseWarningStream(
-        _console, _moose_base.objectErrorPrefix("warning"), std::forward<Args>(args)...);
+        _console, _moose_base.errorPrefix("warning"), std::forward<Args>(args)...);
   }
 
   /**

--- a/framework/include/base/MooseBaseErrorInterface.h
+++ b/framework/include/base/MooseBaseErrorInterface.h
@@ -14,22 +14,13 @@
 #include "MooseError.h"
 #include "MooseBase.h"
 
-/// Needed to break include cycle between MooseApp.h and Action.h
-class MooseApp;
-[[noreturn]] void callMooseErrorRaw(std::string & msg, MooseApp * app);
-
 /**
  * Interface that provides APIs to output errors/warnings/info messages
  */
 class MooseBaseErrorInterface : public ConsoleStreamInterface
 {
 public:
-  MooseBaseErrorInterface(const MooseBase * const base)
-    : ConsoleStreamInterface(base->getMooseApp()), _app(base->getMooseApp()), _moose_base(base)
-  {
-  }
-
-  virtual ~MooseBaseErrorInterface() = default;
+  MooseBaseErrorInterface(const MooseBase & base, const InputParameters & params);
 
   /**
    * Emits an error prefixed with object name and type.
@@ -38,9 +29,8 @@ public:
   [[noreturn]] void mooseError(Args &&... args) const
   {
     std::ostringstream oss;
-    moose::internal::mooseStreamAll(oss, errorPrefix("error"), std::forward<Args>(args)...);
-    std::string msg = oss.str();
-    callMooseErrorRaw(msg, &_app);
+    moose::internal::mooseStreamAll(oss, std::forward<Args>(args)...);
+    _moose_base.callMooseError(oss.str(), /* with_prefix = */ true);
   }
 
   /**
@@ -51,8 +41,7 @@ public:
   {
     std::ostringstream oss;
     moose::internal::mooseStreamAll(oss, std::forward<Args>(args)...);
-    std::string msg = oss.str();
-    callMooseErrorRaw(msg, &_app);
+    _moose_base.callMooseError(oss.str(), /* with_prefix = */ false);
   }
 
   /**
@@ -62,7 +51,7 @@ public:
   void mooseWarning(Args &&... args) const
   {
     moose::internal::mooseWarningStream(
-        _console, errorPrefix("warning"), std::forward<Args>(args)...);
+        _console, _moose_base.objectErrorPrefix("warning"), std::forward<Args>(args)...);
   }
 
   /**
@@ -86,17 +75,13 @@ public:
     moose::internal::mooseInfoStream(_console, std::forward<Args>(args)...);
   }
 
-  /**
-   * A descriptive prefix for errors for this object:
-   *
-   * The following <error_type> occurred in the object "<name>", of type "<type>".
-   */
-  std::string errorPrefix(const std::string & error_type) const;
-
 private:
   /// The MOOSE application this is associated with
   MooseApp & _app;
 
   /// The MooseBase class deriving from this interface
-  const MooseBase * const _moose_base;
+  const MooseBase & _moose_base;
+
+  /// The parameters used to create this object
+  const InputParameters & _params;
 };

--- a/framework/include/base/MooseBaseErrorInterface.h
+++ b/framework/include/base/MooseBaseErrorInterface.h
@@ -20,7 +20,7 @@
 class MooseBaseErrorInterface : public ConsoleStreamInterface
 {
 public:
-  MooseBaseErrorInterface(const MooseBase & base, const InputParameters & params);
+  MooseBaseErrorInterface(const MooseBase & base);
 
   /**
    * Emits an error prefixed with object name and type.
@@ -76,12 +76,6 @@ public:
   }
 
 private:
-  /// The MOOSE application this is associated with
-  MooseApp & _app;
-
   /// The MooseBase class deriving from this interface
   const MooseBase & _moose_base;
-
-  /// The parameters used to create this object
-  const InputParameters & _params;
 };

--- a/framework/include/base/MooseBaseParameterInterface.h
+++ b/framework/include/base/MooseBaseParameterInterface.h
@@ -178,7 +178,7 @@ private:
 
     // With no input location information, append object info (name + type)
     const std::string object_prefix =
-        _pars.inputLocation(param).empty() ? _moose_base.objectErrorPrefix("parameter error") : "";
+        _pars.inputLocation(param).empty() ? _moose_base.errorPrefix("parameter error") : "";
 
     std::ostringstream oss;
     moose::internal::mooseStreamAll(oss, std::forward<Args>(args)...);

--- a/framework/include/base/MooseBaseParameterInterface.h
+++ b/framework/include/base/MooseBaseParameterInterface.h
@@ -13,10 +13,8 @@
 
 #include "MooseBase.h"
 #include "InputParameters.h"
-#include "Registry.h"
 #include "MooseUtils.h"
 #include "MooseObjectParameterName.h"
-#include "MooseBase.h"
 
 #include <string>
 

--- a/framework/include/base/MooseBaseParameterInterface.h
+++ b/framework/include/base/MooseBaseParameterInterface.h
@@ -203,7 +203,7 @@ template <typename T>
 const T &
 MooseBaseParameterInterface::getParam(const std::string & name) const
 {
-  return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
+  return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0), &_moose_base);
 }
 
 template <typename T>
@@ -214,13 +214,13 @@ MooseBaseParameterInterface::getRenamedParam(const std::string & old_name,
   // this enables having a default on the new parameter but bypassing it with the old one
   // Most important: accept new parameter
   if (isParamSetByUser(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0));
+    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), &_moose_base);
   // Second most: accept old parameter
   else if (isParamValid(old_name) && !isParamSetByUser(new_name))
-    return InputParameters::getParamHelper(old_name, _pars, static_cast<T *>(0));
+    return InputParameters::getParamHelper(old_name, _pars, static_cast<T *>(0), &_moose_base);
   // Third most: accept default for new parameter
   else if (isParamValid(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0));
+    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), &_moose_base);
   // Refuse: no default, no value passed
   else if (!isParamValid(old_name) && !isParamValid(new_name))
     mooseError(_pars.blockFullpath() + ": parameter '" + new_name +

--- a/framework/include/base/MooseObjectUnitTest.h
+++ b/framework/include/base/MooseObjectUnitTest.h
@@ -86,14 +86,14 @@ protected:
     mesh_params.set<unsigned int>("nx") = 2;
     mesh_params.set<unsigned int>("ny") = 2;
     mesh_params.set<unsigned int>("nz") = 2;
-    _mesh = _factory.create<MooseMesh>("GeneratedMesh", "name1", mesh_params);
+    _mesh = _factory.createUnique<MooseMesh>("GeneratedMesh", "name1", mesh_params);
     _mesh->setMeshBase(_mesh->buildMeshBaseObject());
     _mesh->buildMesh();
 
     InputParameters problem_params = _factory.getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = _factory.create<FEProblem>("FEProblem", "problem", problem_params);
+    _fe_problem = _factory.createUnique<FEProblem>("FEProblem", "problem", problem_params);
 
     _fe_problem->createQRules(QGAUSS, FIRST, FIRST, FIRST);
   }
@@ -101,10 +101,10 @@ protected:
   template <typename T>
   T & addObject(const std::string & type, const std::string & name, InputParameters & params);
 
-  std::shared_ptr<MooseMesh> _mesh;
+  std::unique_ptr<MooseMesh> _mesh;
   std::shared_ptr<MooseApp> _app;
   Factory & _factory;
-  std::shared_ptr<FEProblem> _fe_problem;
+  std::unique_ptr<FEProblem> _fe_problem;
 };
 
 template <typename T>

--- a/framework/include/base/MooseObjectUnitTest.h
+++ b/framework/include/base/MooseObjectUnitTest.h
@@ -93,9 +93,11 @@ protected:
     InputParameters problem_params = _factory.getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = _factory.createUnique<FEProblem>("FEProblem", "problem", problem_params);
+    _fe_problem = _factory.create<FEProblem>("FEProblem", "problem", problem_params);
 
     _fe_problem->createQRules(QGAUSS, FIRST, FIRST, FIRST);
+
+    _app->actionWarehouse().problemBase() = _fe_problem;
   }
 
   template <typename T>
@@ -104,7 +106,7 @@ protected:
   std::unique_ptr<MooseMesh> _mesh;
   std::shared_ptr<MooseApp> _app;
   Factory & _factory;
-  std::unique_ptr<FEProblem> _fe_problem;
+  std::shared_ptr<FEProblem> _fe_problem;
 };
 
 template <typename T>

--- a/framework/include/interfaces/DataFileInterface.h
+++ b/framework/include/interfaces/DataFileInterface.h
@@ -23,7 +23,7 @@ public:
   /**
    * The parameter type this interface expects for a data file name.
    */
-  using DataFileParameterType = FileName;
+  using DataFileParameterType = DataFileName;
 
   /**
    * Constructing the object

--- a/framework/include/mesh/ConcentricCircleMesh.h
+++ b/framework/include/mesh/ConcentricCircleMesh.h
@@ -25,10 +25,7 @@ public:
   ConcentricCircleMesh(const ConcentricCircleMesh & /* other_mesh */) = default;
 
   ConcentricCircleMesh & operator=(const ConcentricCircleMesh & other_mesh) = delete;
-  virtual std::unique_ptr<MooseMesh> safeClone() const override
-  {
-    return std::make_unique<ConcentricCircleMesh>(*this);
-  }
+  virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;
 

--- a/framework/include/outputs/OversampleOutput.h
+++ b/framework/include/outputs/OversampleOutput.h
@@ -95,7 +95,7 @@ private:
   bool _oversample_mesh_changed;
 
   std::unique_ptr<EquationSystems> _oversample_es;
-  std::shared_ptr<MooseMesh> _cloned_mesh_ptr;
+  std::unique_ptr<MooseMesh> _cloned_mesh_ptr;
 
   /// Oversample solution vector
   /* Each of the MeshFunctions keeps a reference to this vector, the vector is updated for the

--- a/framework/include/outputs/OversampleOutput.h
+++ b/framework/include/outputs/OversampleOutput.h
@@ -95,7 +95,7 @@ private:
   bool _oversample_mesh_changed;
 
   std::unique_ptr<EquationSystems> _oversample_es;
-  std::unique_ptr<MooseMesh> _cloned_mesh_ptr;
+  std::shared_ptr<MooseMesh> _cloned_mesh_ptr;
 
   /// Oversample solution vector
   /* Each of the MeshFunctions keeps a reference to this vector, the vector is updated for the

--- a/framework/include/parser/Builder.h
+++ b/framework/include/parser/Builder.h
@@ -156,27 +156,6 @@ protected:
                        GlobalParamsAction * global_block);
 
   /**
-   * Sets an input parameter representing a file path using input file data.  The file path is
-   * modified to be relative to the directory this application's input file is in.
-   */
-  template <typename T>
-  void setFilePathParam(const std::string & full_name,
-                        const std::string & short_name,
-                        InputParameters::Parameter<T> * param,
-                        bool in_global,
-                        GlobalParamsAction * global_block);
-
-  /**
-   * Sets an input parameter representing a vector of file paths using input file data.  The file
-   * paths are modified to be relative to the directory this application's input file is in.
-   */
-  template <typename T>
-  void setVectorFilePathParam(const std::string & full_name,
-                              const std::string & short_name,
-                              InputParameters::Parameter<std::vector<T>> * param,
-                              bool in_global,
-                              GlobalParamsAction * global_block);
-  /**
    * Template method for setting any double indexed type parameter read from the input file or
    * command line.
    */

--- a/framework/include/parser/Builder.h
+++ b/framework/include/parser/Builder.h
@@ -163,7 +163,6 @@ protected:
   void setFilePathParam(const std::string & full_name,
                         const std::string & short_name,
                         InputParameters::Parameter<T> * param,
-                        InputParameters & params,
                         bool in_global,
                         GlobalParamsAction * global_block);
 
@@ -175,7 +174,6 @@ protected:
   void setVectorFilePathParam(const std::string & full_name,
                               const std::string & short_name,
                               InputParameters::Parameter<std::vector<T>> * param,
-                              InputParameters & params,
                               bool in_global,
                               GlobalParamsAction * global_block);
   /**

--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -113,16 +113,16 @@ class Parser
 {
 public:
   /**
-   * Constructor given a list of input files, given in \p input_filenames
-   */
-  Parser(const std::vector<std::string> & input_filenames);
-  /**
-   * Constructor for a single input file, given in \p input_filename
+   * Constructor given a list of input files, given in \p input_filenames.
    *
-   * Optionally, \p input_text can be provided if you wish to parse contents
-   * from this text instead of reading \p input_filename. This is currently used
-   * within the language server for parsing contents of a file that have not
-   * necessary been saved to disk yet.
+   * Optionally, the file contents can be provided via text in \p input_text.
+   */
+  Parser(const std::vector<std::string> & input_filenames,
+         const std::optional<std::vector<std::string>> & input_text = {});
+  /**
+   * Constructor, given a file in \p input_filename.
+   *
+   * Optionally, the file contents can be provided via text in \p input_text.
    */
   Parser(const std::string & input_filename, const std::optional<std::string> & input_text = {});
 
@@ -177,8 +177,8 @@ private:
   /// The input file names
   const std::vector<std::string> _input_filenames;
 
-  /// The optional input text (to augment reading a single input with the MooseServer)
-  const std::optional<std::string> _input_text;
+  /// The optional input text contents (to support not reading by file)
+  const std::optional<std::vector<std::string>> _input_text;
 
   /// The application types extracted from [Application] block
   std::string _app_type;

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -943,9 +943,8 @@ public:
   ReporterData & getReporterData(ReporterData::WriteKey /*key*/) { return _reporter_data; }
 
   // UserObjects /////
-  virtual void addUserObject(const std::string & user_object_name,
-                             const std::string & name,
-                             InputParameters & parameters);
+  virtual std::vector<std::shared_ptr<UserObject>> addUserObject(
+      const std::string & user_object_name, const std::string & name, InputParameters & parameters);
 
   // TODO: delete this function after apps have been updated to not call it
   const ExecuteMooseObjectWarehouse<UserObject> & getUserObjects() const

--- a/framework/include/relationshipmanagers/AugmentSparsityOnInterface.h
+++ b/framework/include/relationshipmanagers/AugmentSparsityOnInterface.h
@@ -46,10 +46,7 @@ public:
    * A clone() is needed because GhostingFunctor can not be shared between
    * different meshes. The operations in  GhostingFunctor are mesh dependent.
    */
-  virtual std::unique_ptr<GhostingFunctor> clone() const override
-  {
-    return std::make_unique<AugmentSparsityOnInterface>(*this);
-  }
+  virtual std::unique_ptr<GhostingFunctor> clone() const override;
 
   /**
    * Update the cached _lower_to_upper map whenever our Mesh has been

--- a/framework/include/relationshipmanagers/GhostEverything.h
+++ b/framework/include/relationshipmanagers/GhostEverything.h
@@ -25,10 +25,7 @@ public:
                   processor_id_type p,
                   map_type & coupled_elements) override;
 
-  std::unique_ptr<GhostingFunctor> clone() const override
-  {
-    return std::make_unique<GhostEverything>(*this);
-  }
+  std::unique_ptr<GhostingFunctor> clone() const override;
 
   std::string getInfo() const override;
 

--- a/framework/include/relationshipmanagers/GhostHigherDLowerDPointNeighbors.h
+++ b/framework/include/relationshipmanagers/GhostHigherDLowerDPointNeighbors.h
@@ -25,10 +25,7 @@ public:
                   processor_id_type p,
                   map_type & coupled_elements) override;
 
-  std::unique_ptr<GhostingFunctor> clone() const override
-  {
-    return std::make_unique<GhostHigherDLowerDPointNeighbors>(*this);
-  }
+  std::unique_ptr<GhostingFunctor> clone() const override;
 
   std::string getInfo() const override;
 

--- a/framework/include/relationshipmanagers/GhostLowerDElems.h
+++ b/framework/include/relationshipmanagers/GhostLowerDElems.h
@@ -25,10 +25,7 @@ public:
                   processor_id_type p,
                   map_type & coupled_elements) override;
 
-  std::unique_ptr<GhostingFunctor> clone() const override
-  {
-    return std::make_unique<GhostLowerDElems>(*this);
-  }
+  std::unique_ptr<GhostingFunctor> clone() const override;
 
   std::string getInfo() const override;
 

--- a/framework/include/relationshipmanagers/ProxyRelationshipManager.h
+++ b/framework/include/relationshipmanagers/ProxyRelationshipManager.h
@@ -45,10 +45,7 @@ public:
    * A clone() is needed because GhostingFunctor can not be shared between
    * different meshes. The operations in  GhostingFunctor are mesh dependent.
    */
-  virtual std::unique_ptr<GhostingFunctor> clone() const override
-  {
-    return std::make_unique<ProxyRelationshipManager>(*this);
-  }
+  virtual std::unique_ptr<GhostingFunctor> clone() const override;
 
 protected:
   virtual void internalInitWithMesh(const MeshBase &) override{};

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -41,6 +41,7 @@ class Factory;
 class InputParameters;
 class MooseEnum;
 class MooseObject;
+class MooseBase;
 class MultiMooseEnum;
 class Problem;
 namespace hit
@@ -866,7 +867,7 @@ public:
   static const T & getParamHelper(const std::string & name,
                                   const InputParameters & pars,
                                   const T * the_type,
-                                  const MooseObject * moose_object = nullptr);
+                                  const MooseBase * moose_base = nullptr);
   ///@}
 
   using Parameters::get;
@@ -1112,7 +1113,7 @@ private:
                                 const std::string & docstring,
                                 const std::string & removal_date);
 
-  static void callMooseErrorHelper(const MooseObject & object, const std::string & error);
+  static void callMooseErrorHelper(const MooseBase & moose_base, const std::string & error);
 
   struct Metadata
   {
@@ -1890,12 +1891,13 @@ void InputParameters::setParamHelper<MooseFunctorName, int>(const std::string & 
                                                             MooseFunctorName & l_value,
                                                             const int & r_value);
 
+// TODO: pass MooseBase here instead and use it in objects
 template <typename T>
 const T &
 InputParameters::getParamHelper(const std::string & name_in,
                                 const InputParameters & pars,
                                 const T *,
-                                const MooseObject * moose_object /* = nullptr */)
+                                const MooseBase * moose_base /* = nullptr */)
 {
   const auto name = pars.checkForRename(name_in);
 
@@ -1903,8 +1905,8 @@ InputParameters::getParamHelper(const std::string & name_in,
   {
     std::stringstream err;
     err << "The parameter \"" << name << "\" is being retrieved before being set.";
-    if (moose_object)
-      callMooseErrorHelper(*moose_object, err.str());
+    if (moose_base)
+      callMooseErrorHelper(*moose_base, err.str());
     else
       mooseError(err.str());
   }
@@ -1920,14 +1922,14 @@ const MooseEnum &
 InputParameters::getParamHelper<MooseEnum>(const std::string & name,
                                            const InputParameters & pars,
                                            const MooseEnum *,
-                                           const MooseObject * moose_object /* = nullptr */);
+                                           const MooseBase * moose_base /* = nullptr */);
 
 template <>
 const MultiMooseEnum &
 InputParameters::getParamHelper<MultiMooseEnum>(const std::string & name,
                                                 const InputParameters & pars,
                                                 const MultiMooseEnum *,
-                                                const MooseObject * moose_object /* = nullptr */);
+                                                const MooseBase * moose_base /* = nullptr */);
 
 template <typename R1, typename R2, typename V1, typename V2>
 std::vector<std::pair<R1, R2>>

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -681,6 +681,22 @@ public:
                 const std::filesystem::path & default_file_base = std::filesystem::current_path());
 
   /**
+   * @return A file base to associate with the parameter with name \p param_name.
+   *
+   * This may be an empty value depending on if context exists.
+   *
+   * We have the following cases:
+   * - The parameter itself has a hit node set (context for that parameter)
+   * - The InputParameters object has a hit node set (context for all parameters)
+   * - Neither of the above; no context is available
+   *
+   * In the event that the context is from command line arguments, the current
+   * working directory is used. This might not work for MultiApps that do not
+   * exist in the same directory as the main app.
+   */
+  std::optional<std::filesystem::path> getParamFileBase(const std::string & param_name) const;
+
+  /**
    * Methods returning iterators to the coupled variables names stored in this
    * InputParameters object
    */

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -677,8 +677,9 @@ public:
    * This calls checkParams() and sets up the absolute paths for all file name
    * typed parameters.
    */
-  void finalizeParams(const std::string & parsing_syntax,
-                      const std::filesystem::path & default_file_base);
+  void
+  finalizeParams(const std::string & parsing_syntax,
+                 const std::filesystem::path & default_file_base = std::filesystem::current_path());
 
   /**
    * Methods returning iterators to the coupled variables names stored in this

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -38,6 +38,7 @@ class FunctionParserBase
 class Action;
 class ActionFactory;
 class Factory;
+class FEProblemBase;
 class InputParameters;
 class MooseEnum;
 class MooseObject;
@@ -95,6 +96,8 @@ public:
     friend class ActionFactory;
     friend class Moose::Builder;
     friend class Factory;
+    friend class FEProblemBase;
+    friend class InputParameters;
     SetHitNodeKey() {}
     SetHitNodeKey(const SetHitNodeKey &) {}
   };
@@ -674,28 +677,24 @@ public:
   /**
    * Finalizes the parameters, which must be done before constructing any objects
    * with these parameters (to be called in the corresponding factories).
-   *
-   * This calls checkParams() and sets up the absolute paths for all file name
    * typed parameters.
+   *
+   * This calls checkParams() and sets up the absolute paths for all file name.
    */
-  void finalize(const std::string & parsing_syntax,
-                const std::filesystem::path & default_file_base = std::filesystem::current_path());
+  void finalize(const std::string & parsing_syntax);
 
   /**
    * @return A file base to associate with the parameter with name \p param_name.
    *
-   * This may be an empty value depending on if context exists.
-   *
    * We have the following cases:
    * - The parameter itself has a hit node set (context for that parameter)
    * - The InputParameters object has a hit node set (context for all parameters)
-   * - Neither of the above; no context is available
+   * - Neither of the above and we die
    *
-   * In the event that the context is from command line arguments, the current
-   * working directory is used. This might not work for MultiApps that do not
-   * exist in the same directory as the main app.
+   * In the event that a the parameter is set via command line, this will
+   * attempt to look at the parameter's parents to find a suitable context.
    */
-  std::optional<std::filesystem::path> getParamFileBase(const std::string & param_name) const;
+  std::filesystem::path getParamFileBase(const std::string & param_name) const;
 
   /**
    * Methods returning iterators to the coupled variables names stored in this

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -34,6 +34,8 @@ class FunctionParserBase
 #include <optional>
 #include <filesystem>
 
+#include <gtest/gtest.h>
+
 // Forward declarations
 class Action;
 class ActionFactory;
@@ -98,6 +100,7 @@ public:
     friend class Factory;
     friend class FEProblemBase;
     friend class InputParameters;
+    FRIEND_TEST(InputParametersTest, fileNames);
     SetHitNodeKey() {}
     SetHitNodeKey(const SetHitNodeKey &) {}
   };
@@ -109,6 +112,7 @@ public:
   class SetParamHitNodeKey
   {
     friend class Moose::Builder;
+    FRIEND_TEST(InputParametersTest, fileNames);
     SetParamHitNodeKey() {}
     SetParamHitNodeKey(const SetParamHitNodeKey &) {}
   };

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -89,6 +89,7 @@ public:
    */
   class SetHitNodeKey
   {
+    friend class Action;
     friend class ActionFactory;
     friend class Moose::Builder;
     friend class Factory;

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -35,6 +35,8 @@ class FunctionParserBase
 
 // Forward declarations
 class Action;
+class ActionFactory;
+class Factory;
 class InputParameters;
 class MooseEnum;
 class MooseObject;
@@ -43,6 +45,10 @@ class Problem;
 namespace hit
 {
 class Node;
+}
+namespace Moose
+{
+class Builder;
 }
 
 /**
@@ -75,6 +81,30 @@ public:
     std::vector<std::string> syntax;
     /// The type of argument
     ArgumentType argument_type;
+  };
+
+  /**
+   * Class that is used as a parameter to setHitNode() that allows only
+   * relevant classes to set the hit node
+   */
+  class SetHitNodeKey
+  {
+    friend class ActionFactory;
+    friend class Moose::Builder;
+    friend class Factory;
+    SetHitNodeKey() {}
+    SetHitNodeKey(const SetHitNodeKey &) {}
+  };
+
+  /**
+   * Class that is used as a parameter to setHitNode(param) that allows only
+   * relevant classes to set the hit node
+   */
+  class SetParamHitNodeKey
+  {
+    friend class Moose::Builder;
+    SetParamHitNodeKey() {}
+    SetParamHitNodeKey(const SetParamHitNodeKey &) {}
   };
 
   /**
@@ -869,8 +899,10 @@ public:
   const hit::Node * getHitNode(const std::string & param) const;
   /**
    * Sets the hit node associated with the parameter \p param to \p node
+   *
+   * Is protected to be called by only the Builder via the SetParamHitNodeKey.
    */
-  void setHitNode(const std::string & param, const hit::Node & node);
+  void setHitNode(const std::string & param, const hit::Node & node, const SetParamHitNodeKey);
 
   /**
    * @return A string representing the location in the input text the parameter originated from
@@ -1012,8 +1044,11 @@ public:
   /**
    * Sets the hit node that represents the syntax responsible for creating
    * these parameters
+   *
+   * Is protected to be called by only the ActionFactory, Builder, and Factory
+   * via the SetHitNodeKey.
    */
-  void setHitNode(const hit::Node & node) { _hit_node = &node; }
+  void setHitNode(const hit::Node & node, const SetHitNodeKey) { _hit_node = &node; }
 
 private:
   // Private constructor so that InputParameters can only be created in certain places.

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -677,9 +677,8 @@ public:
    * This calls checkParams() and sets up the absolute paths for all file name
    * typed parameters.
    */
-  void
-  finalizeParams(const std::string & parsing_syntax,
-                 const std::filesystem::path & default_file_base = std::filesystem::current_path());
+  void finalize(const std::string & parsing_syntax,
+                const std::filesystem::path & default_file_base = std::filesystem::current_path());
 
   /**
    * Methods returning iterators to the coupled variables names stored in this
@@ -1064,7 +1063,7 @@ public:
   void setHitNode(const hit::Node & node, const SetHitNodeKey) { _hit_node = &node; }
 
   /**
-   * @return Whether or not finalizeParams() has been called
+   * @return Whether or not finalize() has been called
    */
   bool isFinalized() const { return _finalized; }
 
@@ -1250,7 +1249,7 @@ private:
   /// The hit node representing the syntax that created these parameters, if any
   const hit::Node * _hit_node;
 
-  /// Whether or not we've called finalizeParams() on these parameters yet
+  /// Whether or not we've called finalize() on these parameters yet
   bool _finalized;
 
   // These are the only objects allowed to _create_ InputParameters

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -955,17 +955,21 @@ struct enable_bitmask_operators<Moose::RelationshipManagerType>
 
 // Instantiate new Types
 
-/// This type is for expected (i.e. input) file names or paths that your simulation needs.  If
-/// relative paths are assigned to this type, they are treated/modified to be relative to the
-/// location of the simulation's main input file's directory.  It can be used to trigger open file
-/// dialogs in the GUI.
+/// This type is for expected (i.e. input) file names or paths that your simulation needs.
+/// If relative types are assigned to this type, they are replaced with an absolute path
+/// that is relative to the context of the parameter (usually the input file).
 DerivativeStringClass(FileName);
 
-/// This type is for expected filenames where the extension is unwanted, it can be used to trigger open file dialogs in the GUI
+/// Similar to FileName but without an extension
 DerivativeStringClass(FileNameNoExtension);
 
-/// This type is for expected filenames that should be relative (don't set the absolute path under the hood)
+/// This type is for expected filenames that should be relative and will not have their
+/// values set to absolute paths like FileName
 DerivativeStringClass(RelativeFileName);
+
+/// This type is for files used in the DataFileInterface, which enables searching of files
+/// within the registered data directory
+DerivativeStringClass(DataFileName);
 
 /// This type is similar to "FileName", but is used to further filter file dialogs on known file mesh types
 DerivativeStringClass(MeshFileName);

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -964,6 +964,9 @@ DerivativeStringClass(FileName);
 /// This type is for expected filenames where the extension is unwanted, it can be used to trigger open file dialogs in the GUI
 DerivativeStringClass(FileNameNoExtension);
 
+/// This type is for expected filenames that should be relative (don't set the absolute path under the hood)
+DerivativeStringClass(RelativeFileName);
+
 /// This type is similar to "FileName", but is used to further filter file dialogs on known file mesh types
 DerivativeStringClass(MeshFileName);
 

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -75,8 +75,8 @@ Action::Action(const InputParameters & parameters)
     _problem(_awh.problemBase()),
     _act_timer(registerTimedSection("act", 4))
 {
-  mooseAssert(_app.getActionFactory().currentlyConstructing(),
-              "Object was not created using the ActionFactory");
+  if (!_app.getActionFactory().currentlyConstructing())
+    mooseError("This object was not constructed using the ActionFactory, which is not supported.");
 }
 
 void

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -167,7 +167,12 @@ Action::associateWithParameter(const InputParameters & from_params,
                                const std::string & param_name,
                                InputParameters & params) const
 {
-  if (!params.getHitNode())
+  const auto to_hit_node = params.getHitNode();
+  if (!to_hit_node || to_hit_node->isRoot())
+  {
     if (const auto hit_node = from_params.getHitNode(param_name))
       params.setHitNode(*hit_node, {});
+    else if (const auto hit_node = from_params.getHitNode())
+      params.setHitNode(*hit_node, {});
+  }
 }

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -18,6 +18,7 @@
 #include "DisplacedProblem.h"
 #include "RelationshipManager.h"
 #include "InputParameterWarehouse.h"
+#include "ActionFactory.h"
 
 InputParameters
 Action::validParams()
@@ -74,6 +75,8 @@ Action::Action(const InputParameters & parameters)
     _problem(_awh.problemBase()),
     _act_timer(registerTimedSection("act", 4))
 {
+  mooseAssert(_app.getActionFactory().currentlyConstructing(),
+              "Object was not created using the ActionFactory");
 }
 
 void

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -45,7 +45,7 @@ Action::Action(const InputParameters & parameters)
               *parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor"),
               parameters),
     MooseBaseParameterInterface(*this, parameters),
-    MooseBaseErrorInterface(*this, parameters),
+    MooseBaseErrorInterface(static_cast<MooseBase &>(*this)),
     MeshMetaDataInterface(
         *parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
     PerfGraphInterface(

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -75,7 +75,7 @@ Action::Action(const InputParameters & parameters)
     _problem(_awh.problemBase()),
     _act_timer(registerTimedSection("act", 4))
 {
-  if (!_app.getActionFactory().currentlyConstructing())
+  if (_app.getActionFactory().currentlyConstructing() != &parameters)
     mooseError("This object was not constructed using the ActionFactory, which is not supported.");
 }
 

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -152,3 +152,19 @@ Action::addRelationshipManagers(Moose::RelationshipManagerType input_rm_type,
 
   return added;
 }
+
+void
+Action::associateWithParameter(const std::string & param_name, InputParameters & params) const
+{
+  associateWithParameter(parameters(), param_name, params);
+}
+
+void
+Action::associateWithParameter(const InputParameters & from_params,
+                               const std::string & param_name,
+                               InputParameters & params) const
+{
+  if (!params.getHitNode())
+    if (const auto hit_node = from_params.getHitNode(param_name))
+      params.setHitNode(*hit_node, {});
+}

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -40,12 +40,12 @@ Action::validParams()
 }
 
 Action::Action(const InputParameters & parameters)
-  : MooseBase(
-        parameters.get<std::string>("action_type"),
-        parameters.get<std::string>("_action_name"),
-        *parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
-    MooseBaseParameterInterface(parameters, this),
-    MooseBaseErrorInterface(this),
+  : MooseBase(parameters.get<std::string>("action_type"),
+              parameters.get<std::string>("_action_name"),
+              *parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor"),
+              parameters),
+    MooseBaseParameterInterface(*this, parameters),
+    MooseBaseErrorInterface(*this, parameters),
     MeshMetaDataInterface(
         *parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
     PerfGraphInterface(

--- a/framework/src/actions/ActionFactory.C
+++ b/framework/src/actions/ActionFactory.C
@@ -61,6 +61,13 @@ ActionFactory::create(const std::string & action,
         std::string("Unable to find buildable Action from supplied InputParameters Object for ") +
         action_name);
 
+  // If we currently are in an action, that means that we're creating an
+  // action from within an action. Associate the action creating this one
+  // with the new action's parameters so that errors can be associated with it
+  if (!action_params.getHitNode())
+    if (const auto hit_node = _app.getCurrentActionHitNode())
+      action_params.setHitNode(*hit_node);
+
   // Add the name to the parameters and create the object
   action_params.set<std::string>("_action_name") = action_name;
   action_params.set<std::string>("_unique_action_name") = unique_action_name;

--- a/framework/src/actions/ActionFactory.C
+++ b/framework/src/actions/ActionFactory.C
@@ -51,8 +51,8 @@ ActionFactory::create(const std::string & action,
   InputParameters & action_params = _app.getInputParameterWarehouse().addInputParameters(
       unique_action_name, incoming_parser_params);
 
-  // Check to make sure that all required parameters are supplied
-  action_params.checkParams(action_name);
+  // Check and finalize the parameters
+  action_params.finalizeParams(action_name, _app.getInputFileBase());
 
   iters = _name_to_build_info.equal_range(action);
   BuildInfo * build_info = &(iters.first->second);

--- a/framework/src/actions/ActionFactory.C
+++ b/framework/src/actions/ActionFactory.C
@@ -49,7 +49,7 @@ ActionFactory::create(const std::string & action,
       action + incoming_parser_params.get<std::string>("task") + full_action_name;
   // Create the actual parameters object that the object will reference
   InputParameters & action_params = _app.getInputParameterWarehouse().addInputParameters(
-      unique_action_name, incoming_parser_params);
+      unique_action_name, incoming_parser_params, 0, {});
 
   // Check and finalize the parameters
   action_params.finalize(action_name, _app.getInputFileBase());

--- a/framework/src/actions/ActionFactory.C
+++ b/framework/src/actions/ActionFactory.C
@@ -66,7 +66,7 @@ ActionFactory::create(const std::string & action,
   // with the new action's parameters so that errors can be associated with it
   if (!action_params.getHitNode())
     if (const auto hit_node = _app.getCurrentActionHitNode())
-      action_params.setHitNode(*hit_node);
+      action_params.setHitNode(*hit_node, {});
 
   // Add the name to the parameters and create the object
   action_params.set<std::string>("_action_name") = action_name;

--- a/framework/src/actions/ActionFactory.C
+++ b/framework/src/actions/ActionFactory.C
@@ -13,7 +13,7 @@
 #include "InputParameterWarehouse.h"
 #include "MooseObjectAction.h"
 
-ActionFactory::ActionFactory(MooseApp & app) : _app(app), _currently_constructing(false) {}
+ActionFactory::ActionFactory(MooseApp & app) : _app(app) {}
 
 ActionFactory::~ActionFactory() {}
 
@@ -73,9 +73,9 @@ ActionFactory::create(const std::string & action,
   action_params.set<std::string>("_unique_action_name") = unique_action_name;
 
   // Create the object
-  _currently_constructing = true;
+  _currently_constructing.push_back(&action_params);
   std::shared_ptr<Action> action_obj = build_info->_obj_pointer->buildAction(action_params);
-  _currently_constructing = false;
+  _currently_constructing.pop_back();
 
   if (action_params.get<std::string>("task") == "")
     action_obj->appendTask(build_info->_task);
@@ -161,6 +161,13 @@ ActionFactory::getTasksByAction(const std::string & action) const
 
   return tasks;
 }
+
+const InputParameters *
+ActionFactory::currentlyConstructing() const
+{
+  return _currently_constructing.size() ? _currently_constructing.back() : nullptr;
+}
+
 FileLineInfo
 ActionFactory::getLineInfo(const std::string & name, const std::string & task) const
 {

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -175,6 +175,9 @@ AddVariableAction::createInitialConditionAction()
   InputParameters action_params = _action_factory.getValidParams("AddOutputAction");
   action_params.set<ActionWarehouse *>("awh") = &_awh;
 
+  // Associate all action and initial condition errors with "initial_condition"
+  associateWithParameter("initial_condition", action_params);
+
   bool is_vector = (_fe_type.family == LAGRANGE_VEC || _fe_type.family == NEDELEC_ONE ||
                     _fe_type.family == MONOMIAL_VEC || _fe_type.family == RAVIART_THOMAS);
 

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -75,6 +75,9 @@ CreateExecutionerAction::setupAutoPreconditioning()
     InputParameters params = _action_factory.getValidParams("SetupPreconditionerAction");
     params.set<std::string>("type") = "SMP";
 
+    // Associate errors with "solve_type"
+    associateWithParameter(_moose_object_pars, "solve_type", params);
+
     // Create the Action that will build the Preconditioner object
     std::shared_ptr<Action> ptr =
         _action_factory.create("SetupPreconditionerAction", "_moose_auto", params);

--- a/framework/src/actions/ReadExecutorParamsAction.C
+++ b/framework/src/actions/ReadExecutorParamsAction.C
@@ -60,6 +60,9 @@ ReadExecutorParamsAction::setupAutoPreconditioning()
     InputParameters params = _action_factory.getValidParams("SetupPreconditionerAction");
     params.set<std::string>("type") = "SMP";
 
+    // Associate errors with "solve_type"
+    associateWithParameter(_moose_object_pars, "solve_type", params);
+
     // Create the Action that will build the Preconditioner object
     std::shared_ptr<Action> ptr =
         _action_factory.create("SetupPreconditionerAction", "_moose_auto", params);

--- a/framework/src/base/AppFactory.C
+++ b/framework/src/base/AppFactory.C
@@ -136,7 +136,7 @@ AppFactory::createShared(const std::string & app_type,
   parameters.set<std::string>("_type") = app_type;
 
   // Check to make sure that all required parameters are supplied
-  parameters.finalize("", std::filesystem::current_path());
+  parameters.finalize("");
 
   auto comm = std::make_shared<Parallel::Communicator>(comm_world_in);
 

--- a/framework/src/base/AppFactory.C
+++ b/framework/src/base/AppFactory.C
@@ -136,7 +136,7 @@ AppFactory::createShared(const std::string & app_type,
   parameters.set<std::string>("_type") = app_type;
 
   // Check to make sure that all required parameters are supplied
-  parameters.finalizeParams("", std::filesystem::current_path());
+  parameters.finalize("", std::filesystem::current_path());
 
   auto comm = std::make_shared<Parallel::Communicator>(comm_world_in);
 

--- a/framework/src/base/AppFactory.C
+++ b/framework/src/base/AppFactory.C
@@ -136,7 +136,7 @@ AppFactory::createShared(const std::string & app_type,
   parameters.set<std::string>("_type") = app_type;
 
   // Check to make sure that all required parameters are supplied
-  parameters.checkParams("");
+  parameters.finalizeParams("", std::filesystem::current_path());
 
   auto comm = std::make_shared<Parallel::Communicator>(comm_world_in);
 

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -112,7 +112,7 @@ Factory::create(const std::string & obj_name,
                 bool print_deprecated /* =true */)
 {
   std::shared_ptr<MooseObject> object =
-      std::move(createUnique(obj_name, name, parameters, tid, print_deprecated));
+      createUnique(obj_name, name, parameters, tid, print_deprecated);
 
   if (auto fep = std::dynamic_pointer_cast<FEProblemBase>(object))
     _app.actionWarehouse().problemBase() = fep;

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -106,6 +106,14 @@ Factory::create(const std::string & obj_name,
   InputParameters & params =
       _app.getInputParameterWarehouse().addInputParameters(name, parameters, tid);
 
+  // Add the hit node from the action if it isn't set already (it might be set
+  // already because someone had a better option than just the action)
+  // If it isn't set, it typically means that this object was created by a
+  // non-MooseObjectAction Action
+  if (!params.getHitNode())
+    if (const auto hit_node = _app.getCurrentActionHitNode())
+      params.setHitNode(*hit_node);
+
   // Set the _type parameter
   params.set<std::string>("_type") = obj_name;
 

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -112,7 +112,7 @@ Factory::create(const std::string & obj_name,
   // non-MooseObjectAction Action
   if (!params.getHitNode())
     if (const auto hit_node = _app.getCurrentActionHitNode())
-      params.setHitNode(*hit_node);
+      params.setHitNode(*hit_node, {});
 
   // Set the _type parameter
   params.set<std::string>("_type") = obj_name;

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -118,7 +118,7 @@ Factory::create(const std::string & obj_name,
   params.set<std::string>("_type") = obj_name;
 
   // Check to make sure that all required parameters are supplied
-  params.checkParams(name);
+  params.finalizeParams(name, _app.getInputFileBase());
 
   // register type name as constructed
   _constructed_types.insert(obj_name);

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -82,6 +82,28 @@ Factory::getValidParams(const std::string & obj_name) const
   return params;
 }
 
+std::unique_ptr<MooseObject>
+Factory::createUnique(const std::string & obj_name,
+                      const std::string & name,
+                      const InputParameters & parameters,
+                      THREAD_ID tid /* =0 */,
+                      bool print_deprecated /* =true */)
+{
+  if (print_deprecated)
+    mooseDeprecated("Factory::create() is deprecated, please use Factory::create<T>() instead");
+
+  auto & params = initialize(obj_name, name, parameters, tid);
+
+  // call the function pointer to build the object
+  _currently_constructing = true;
+  auto obj = _name_to_object.at(obj_name)->build(params);
+  _currently_constructing = false;
+
+  finalize(obj_name, *obj);
+
+  return obj;
+}
+
 std::shared_ptr<MooseObject>
 Factory::create(const std::string & obj_name,
                 const std::string & name,
@@ -89,91 +111,19 @@ Factory::create(const std::string & obj_name,
                 THREAD_ID tid /* =0 */,
                 bool print_deprecated /* =true */)
 {
-  if (print_deprecated)
-    mooseDeprecated("Factory::create() is deprecated, please use Factory::create<T>() instead");
+  std::shared_ptr<MooseObject> object =
+      std::move(createUnique(obj_name, name, parameters, tid, print_deprecated));
 
-  // Pointer to the object constructor
-  const auto it = _name_to_object.find(obj_name);
-
-  // Check if the object is registered
-  if (it == _name_to_object.end())
-    reportUnregisteredError(obj_name);
-
-  // Print out deprecated message, if it exists
-  deprecatedMessage(obj_name);
-
-  // Create the actual parameters object that the object will reference
-  InputParameters & params =
-      _app.getInputParameterWarehouse().addInputParameters(name, parameters, tid);
-
-  // Add the hit node from the action if it isn't set already (it might be set
-  // already because someone had a better option than just the action)
-  // If it isn't set, it typically means that this object was created by a
-  // non-MooseObjectAction Action
-  if (!params.getHitNode())
-    if (const auto hit_node = _app.getCurrentActionHitNode())
-      params.setHitNode(*hit_node, {});
-
-  // Set the _type parameter
-  params.set<std::string>("_type") = obj_name;
-
-  // Check to make sure that all required parameters are supplied
-  params.finalize(name, _app.getInputFileBase());
-
-  // register type name as constructed
-  _constructed_types.insert(obj_name);
-
-  // add FEProblem pointers to object's params object
-  if (_app.actionWarehouse().problemBase())
-    _app.actionWarehouse().problemBase()->setInputParametersFEProblem(params);
-
-  // call the function pointer to build the object
-  _currently_constructing = true;
-  auto obj = it->second->build(params);
-  _currently_constructing = false;
-
-  auto fep = std::dynamic_pointer_cast<FEProblemBase>(obj);
-  if (fep)
+  if (auto fep = std::dynamic_pointer_cast<FEProblemBase>(object))
     _app.actionWarehouse().problemBase() = fep;
 
-  // Make sure no unexpected parameters were added by the object's constructor or by the action
-  // initiating this create call.  All parameters modified by the constructor must have already
-  // been specified in the object's validParams function.
-  InputParameters orig_params = getValidParams(obj_name);
-  if (orig_params.n_parameters() != parameters.n_parameters())
-  {
-    std::set<std::string> orig, populated;
-    for (const auto & it : orig_params)
-      orig.emplace(it.first);
-    for (const auto & it : parameters)
-      populated.emplace(it.first);
-
-    std::set<std::string> diff;
-    std::set_difference(populated.begin(),
-                        populated.end(),
-                        orig.begin(),
-                        orig.end(),
-                        std::inserter(diff, diff.begin()));
-
-    if (!diff.empty())
-    {
-      std::stringstream ss;
-      for (const auto & name : diff)
-        ss << ", " << name;
-      mooseError("attempted to set unregistered parameter(s) for ",
-                 obj_name,
-                 " object:\n    ",
-                 ss.str().substr(2));
-    }
-  }
-
-  return obj;
+  return object;
 }
 
 void
 Factory::releaseSharedObjects(const MooseObject & moose_object, THREAD_ID tid)
 {
-  _app.getInputParameterWarehouse().removeInputParameters(moose_object, tid);
+  _app.getInputParameterWarehouse().removeInputParameters(moose_object, tid, {});
 }
 
 void
@@ -317,4 +267,81 @@ Factory::associatedClassName(const std::string & name) const
     return "";
   else
     return it->second;
+}
+
+InputParameters &
+Factory::initialize(const std::string & type,
+                    const std::string & name,
+                    const InputParameters & from_params,
+                    const THREAD_ID tid)
+{
+  // Pointer to the object constructor
+  const auto it = _name_to_object.find(type);
+
+  // Check if the object is registered
+  if (it == _name_to_object.end())
+    reportUnregisteredError(type);
+
+  // Print out deprecated message, if it exists
+  deprecatedMessage(type);
+
+  // Create the actual parameters object that the object will reference
+  InputParameters & params =
+      _app.getInputParameterWarehouse().addInputParameters(name, from_params, tid, {});
+
+  // Add the hit node from the action if it isn't set already (it might be set
+  // already because someone had a better option than just the action)
+  // If it isn't set, it typically means that this object was created by a
+  // non-MooseObjectAction Action
+  if (!params.getHitNode())
+    if (const auto hit_node = _app.getCurrentActionHitNode())
+      params.setHitNode(*hit_node, {});
+
+  // Set the _type parameter
+  params.set<std::string>("_type") = type;
+
+  // Check to make sure that all required parameters are supplied
+  params.finalize(name, _app.getInputFileBase());
+
+  // register type name as constructed
+  _constructed_types.insert(type);
+
+  // add FEProblem pointers to object's params object
+  if (_app.actionWarehouse().problemBase())
+    _app.actionWarehouse().problemBase()->setInputParametersFEProblem(params);
+
+  return params;
+}
+
+void
+Factory::finalize(const std::string & type, const MooseObject & object)
+{
+  // Make sure no unexpected parameters were added by the object's constructor or by the action
+  // initiating this create call.  All parameters modified by the constructor must have already
+  // been specified in the object's validParams function.
+  InputParameters orig_params = getValidParams(type);
+  const auto & object_params = object.parameters();
+  if (orig_params.n_parameters() != object_params.n_parameters())
+  {
+    std::set<std::string> orig, populated;
+    for (const auto & it : orig_params)
+      orig.emplace(it.first);
+    for (const auto & it : object_params)
+      populated.emplace(it.first);
+
+    std::set<std::string> diff;
+    std::set_difference(populated.begin(),
+                        populated.end(),
+                        orig.begin(),
+                        orig.end(),
+                        std::inserter(diff, diff.begin()));
+
+    if (!diff.empty())
+    {
+      std::stringstream ss;
+      for (const auto & name : diff)
+        ss << ", " << name;
+      object.mooseError("Attempted to set unregistered parameter(s):\n    ", ss.str().substr(2));
+    }
+  }
 }

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -301,7 +301,7 @@ Factory::initialize(const std::string & type,
   // already because someone had a better option than just the action)
   // If it isn't set, it typically means that this object was created by a
   // non-MooseObjectAction Action
-  if (!params.getHitNode())
+  if (!params.getHitNode() || params.getHitNode()->isRoot())
     if (const auto hit_node = _app.getCurrentActionHitNode())
       params.setHitNode(*hit_node, {});
 
@@ -309,7 +309,7 @@ Factory::initialize(const std::string & type,
   params.set<std::string>("_type") = type;
 
   // Check to make sure that all required parameters are supplied
-  params.finalize(name, _app.getInputFileBase());
+  params.finalize(name);
 
   // register type name as constructed
   _constructed_types.insert(type);

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -14,7 +14,7 @@
 // Just for testing...
 #include "Diffusion.h"
 
-Factory::Factory(MooseApp & app) : _app(app) {}
+Factory::Factory(MooseApp & app) : _app(app), _currently_constructing(false) {}
 
 Factory::~Factory() {}
 
@@ -118,7 +118,7 @@ Factory::create(const std::string & obj_name,
   params.set<std::string>("_type") = obj_name;
 
   // Check to make sure that all required parameters are supplied
-  params.finalizeParams(name, _app.getInputFileBase());
+  params.finalize(name, _app.getInputFileBase());
 
   // register type name as constructed
   _constructed_types.insert(obj_name);
@@ -128,7 +128,9 @@ Factory::create(const std::string & obj_name,
     _app.actionWarehouse().problemBase()->setInputParametersFEProblem(params);
 
   // call the function pointer to build the object
+  _currently_constructing = true;
   auto obj = it->second->build(params);
+  _currently_constructing = false;
 
   auto fep = std::dynamic_pointer_cast<FEProblemBase>(obj);
   if (fep)

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -2415,6 +2415,14 @@ MooseApp::restartFolderBase(const std::filesystem::path & folder_base) const
   return RestartableDataIO::restartableDataFolder(folder);
 }
 
+const hit::Node *
+MooseApp::getCurrentActionHitNode() const
+{
+  if (const auto action = _action_warehouse.getCurrentAction())
+    return action->parameters().getHitNode();
+  return nullptr;
+}
+
 bool
 MooseApp::hasRMClone(const RelationshipManager & template_rm, const MeshBase & mesh) const
 {

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1358,11 +1358,11 @@ MooseApp::addExecutorParams(const std::string & type,
   _executor_params[name] = std::make_pair(type, std::make_unique<InputParameters>(params));
 }
 
-Moose::Builder &
+Parser &
 MooseApp::parser()
 {
-  mooseDeprecated("MooseApp::parser() is deprecated, use MooseApp::builder() instead.");
-  return _builder;
+  mooseAssert(_parser, "Not set");
+  return *_parser;
 }
 
 void

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1062,22 +1062,6 @@ MooseApp::getLastInputFileName() const
   return _parser->getLastInputFileName();
 }
 
-std::filesystem::path
-MooseApp::getInputFileBase() const
-{
-  mooseAssert(_parser, "Parser is not set");
-
-  // If we have input files, the default historically has been the file path
-  // associated with the last input file
-  if (const auto input_filenames = _parser->getInputFileNames(); input_filenames.size())
-  {
-    const auto & last_input = input_filenames.back();
-    mooseAssert(last_input.size(), "Empty input");
-    return std::filesystem::absolute(last_input).parent_path();
-  }
-  return std::filesystem::current_path();
-}
-
 std::string
 MooseApp::getOutputFileBase(bool for_non_moose_build_output) const
 {

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -360,9 +360,11 @@ MooseApp::MooseApp(InputParameters parameters)
     PerfGraphInterface(*this, "MooseApp"),
     ParallelObject(*parameters.get<std::shared_ptr<Parallel::Communicator>>(
         "_comm")), // Can't call getParam() before pars is set
-    _name(parameters.get<std::string>("_app_name")),
+    MooseBase(parameters.get<std::string>("_type"),
+              parameters.get<std::string>("_app_name"),
+              *this,
+              _pars),
     _pars(parameters),
-    _type(getParam<std::string>("_type")),
     _comm(getParam<std::shared_ptr<Parallel::Communicator>>("_comm")),
     _file_base_set_by_user(false),
     _output_position_set(false),
@@ -1044,14 +1046,6 @@ MooseApp::setupOptions()
   }
 
   Moose::out << std::flush;
-}
-
-const std::string &
-MooseApp::type() const
-{
-  if (_parser && _parser->getAppType().size())
-    mooseAssert(_parser->getAppType() == _type, "Should be equivalent");
-  return _type;
 }
 
 const std::vector<std::string> &

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1068,6 +1068,22 @@ MooseApp::getLastInputFileName() const
   return _parser->getLastInputFileName();
 }
 
+std::filesystem::path
+MooseApp::getInputFileBase() const
+{
+  mooseAssert(_parser, "Parser is not set");
+
+  // If we have input files, the default historically has been the file path
+  // associated with the last input file
+  if (const auto input_filenames = _parser->getInputFileNames(); input_filenames.size())
+  {
+    const auto & last_input = input_filenames.back();
+    mooseAssert(last_input.size(), "Empty input");
+    return std::filesystem::absolute(last_input).parent_path();
+  }
+  return std::filesystem::current_path();
+}
+
 std::string
 MooseApp::getOutputFileBase(bool for_non_moose_build_output) const
 {

--- a/framework/src/base/MooseBase.C
+++ b/framework/src/base/MooseBase.C
@@ -1,0 +1,55 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "MooseBase.h"
+
+#include "MooseError.h"
+#include "InputParameters.h"
+#include "MooseApp.h"
+
+#include "parse.h"
+
+MooseBase::MooseBase(const std::string & type,
+                     const std::string & name,
+                     MooseApp & app,
+                     const InputParameters & params)
+  : _app(app), _type(type), _name(name), _params(params)
+{
+}
+
+std::string
+MooseBase::typeAndName() const
+{
+  return type() + std::string(" \"") + name() + std::string("\"");
+}
+
+[[noreturn]] void
+MooseBase::callMooseError(std::string msg, const bool with_prefix) const
+{
+  _app.getOutputWarehouse().mooseConsole();
+  const std::string prefix = _app.isUltimateMaster() ? "" : _app.name();
+  if (with_prefix)
+    msg = objectErrorPrefix("error") + msg;
+  moose::internal::mooseErrorRaw(msg, prefix);
+}
+
+std::string
+MooseBase::objectErrorPrefix(const std::string & error_type) const
+{
+  std::stringstream oss;
+  if (const auto node = _params.getHitNode())
+    oss << node->fileLocation() << ":\n";
+  oss << "The following " << error_type << " occurred in the ";
+  if (const auto base_ptr = _params.getBase())
+    oss << *base_ptr;
+  else
+    oss << "object";
+  oss << " '" << name() << "' of type " << type() << ".\n\n";
+  return oss.str();
+}

--- a/framework/src/base/MooseBase.C
+++ b/framework/src/base/MooseBase.C
@@ -44,7 +44,8 @@ MooseBase::objectErrorPrefix(const std::string & error_type) const
 {
   std::stringstream oss;
   if (const auto node = _params.getHitNode())
-    oss << node->fileLocation() << ":\n";
+    if (!node->isRoot())
+      oss << node->fileLocation() << ":\n";
   oss << "The following " << error_type << " occurred in the ";
   if (const auto base_ptr = _params.getBase())
     oss << *base_ptr;

--- a/framework/src/base/MooseBase.C
+++ b/framework/src/base/MooseBase.C
@@ -35,12 +35,12 @@ MooseBase::callMooseError(std::string msg, const bool with_prefix) const
   _app.getOutputWarehouse().mooseConsole();
   const std::string prefix = _app.isUltimateMaster() ? "" : _app.name();
   if (with_prefix)
-    msg = objectErrorPrefix("error") + msg;
+    msg = errorPrefix("error") + msg;
   moose::internal::mooseErrorRaw(msg, prefix);
 }
 
 std::string
-MooseBase::objectErrorPrefix(const std::string & error_type) const
+MooseBase::errorPrefix(const std::string & error_type) const
 {
   std::stringstream oss;
   if (const auto node = _params.getHitNode())

--- a/framework/src/base/MooseBaseErrorInterface.C
+++ b/framework/src/base/MooseBaseErrorInterface.C
@@ -13,11 +13,7 @@
 
 #include "parse.h"
 
-MooseBaseErrorInterface::MooseBaseErrorInterface(const MooseBase & base,
-                                                 const InputParameters & params)
-  : ConsoleStreamInterface(base.getMooseApp()),
-    _app(base.getMooseApp()),
-    _moose_base(base),
-    _params(params)
+MooseBaseErrorInterface::MooseBaseErrorInterface(const MooseBase & base)
+  : ConsoleStreamInterface(base.getMooseApp()), _moose_base(base)
 {
 }

--- a/framework/src/base/MooseBaseErrorInterface.C
+++ b/framework/src/base/MooseBaseErrorInterface.C
@@ -11,21 +11,13 @@
 #include "MooseBase.h"
 #include "MooseApp.h"
 
-std::string
-MooseBaseErrorInterface::errorPrefix(const std::string & error_type) const
-{
-  std::stringstream oss;
-  oss << "The following " << error_type << " occurred in the object \"" << _moose_base->name()
-      << "\", of type \"" << _moose_base->type() << "\".\n\n";
-  return oss.str();
-}
+#include "parse.h"
 
-[[noreturn]] void
-callMooseErrorRaw(std::string & msg, MooseApp * app)
+MooseBaseErrorInterface::MooseBaseErrorInterface(const MooseBase & base,
+                                                 const InputParameters & params)
+  : ConsoleStreamInterface(base.getMooseApp()),
+    _app(base.getMooseApp()),
+    _moose_base(base),
+    _params(params)
 {
-  app->getOutputWarehouse().mooseConsole();
-  std::string prefix;
-  if (!app->isUltimateMaster())
-    prefix = app->name();
-  moose::internal::mooseErrorRaw(msg, prefix);
 }

--- a/framework/src/base/MooseBaseParameterInterface.C
+++ b/framework/src/base/MooseBaseParameterInterface.C
@@ -7,12 +7,9 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-// MOOSE includes
 #include "MooseBaseParameterInterface.h"
-#include "MooseObjectParameterName.h"
+
 #include "MooseApp.h"
-#include "MooseUtils.h"
-#include "MooseBase.h"
 #include "InputParameterWarehouse.h"
 
 std::string
@@ -21,11 +18,11 @@ paramErrorPrefix(const InputParameters & params, const std::string & param)
   return params.errorPrefix(param);
 }
 
-MooseBaseParameterInterface::MooseBaseParameterInterface(const InputParameters & parameters,
-                                                         const MooseBase * const base)
+MooseBaseParameterInterface::MooseBaseParameterInterface(const MooseBase & base,
+                                                         const InputParameters & parameters)
   : _pars(parameters),
-    _factory(base->getMooseApp().getFactory()),
-    _action_factory(base->getMooseApp().getActionFactory()),
+    _factory(base.getMooseApp().getFactory()),
+    _action_factory(base.getMooseApp().getActionFactory()),
     _moose_base(base)
 {
 }
@@ -39,7 +36,7 @@ MooseBaseParameterInterface::connectControllableParams(const std::string & param
   MooseObjectParameterName primary_name(uniqueName(), parameter);
   const auto base_type = _factory.getValidParams(object_type).get<std::string>("_moose_base");
   MooseObjectParameterName secondary_name(base_type, object_name, object_parameter);
-  _moose_base->getMooseApp().getInputParameterWarehouse().addControllableParameterConnection(
+  _moose_base.getMooseApp().getInputParameterWarehouse().addControllableParameterConnection(
       primary_name, secondary_name);
 
   const auto & tags = _pars.get<std::vector<std::string>>("control_tags");
@@ -47,18 +44,9 @@ MooseBaseParameterInterface::connectControllableParams(const std::string & param
   {
     if (!tag.empty())
     {
-      MooseObjectParameterName tagged_name(tag, _moose_base->name(), parameter);
-      _moose_base->getMooseApp().getInputParameterWarehouse().addControllableParameterConnection(
+      MooseObjectParameterName tagged_name(tag, _moose_base.name(), parameter);
+      _moose_base.getMooseApp().getInputParameterWarehouse().addControllableParameterConnection(
           tagged_name, secondary_name);
     }
   }
-}
-
-std::string
-MooseBaseParameterInterface::objectErrorPrefix(const std::string & error_type) const
-{
-  std::stringstream oss;
-  oss << "The following " << error_type << " occurred in the class \"" << _moose_base->name()
-      << "\", of type \"" << _moose_base->type() << "\".\n\n";
-  return oss.str();
 }

--- a/framework/src/base/MooseBaseParameterInterface.C
+++ b/framework/src/base/MooseBaseParameterInterface.C
@@ -25,6 +25,7 @@ MooseBaseParameterInterface::MooseBaseParameterInterface(const MooseBase & base,
     _action_factory(base.getMooseApp().getActionFactory()),
     _moose_base(base)
 {
+  mooseAssert(_pars.isFinalized(), "Params are not finalized");
 }
 
 void

--- a/framework/src/base/MooseBaseParameterInterface.C
+++ b/framework/src/base/MooseBaseParameterInterface.C
@@ -25,6 +25,7 @@ MooseBaseParameterInterface::MooseBaseParameterInterface(const MooseBase & base,
     _action_factory(base.getMooseApp().getActionFactory()),
     _moose_base(base)
 {
+  // This enforces that we call finalizeParams (checkParams() and setting file paths)
   mooseAssert(_pars.isFinalized(), "Params are not finalized");
 }
 

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -47,9 +47,10 @@ MooseObject::validParams()
 MooseObject::MooseObject(const InputParameters & parameters)
   : MooseBase(parameters.get<std::string>("_type"),
               parameters.get<std::string>("_object_name"),
-              *parameters.getCheckedPointerParam<MooseApp *>("_moose_app")),
-    MooseBaseParameterInterface(parameters, this),
-    MooseBaseErrorInterface(this),
+              *parameters.getCheckedPointerParam<MooseApp *>("_moose_app"),
+              parameters),
+    MooseBaseParameterInterface(*this, parameters),
+    MooseBaseErrorInterface(*this, parameters),
     ParallelObject(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app")),
     DataFileInterface<MooseObject>(*this),
     _enabled(getParam<bool>("enable"))

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -56,6 +56,6 @@ MooseObject::MooseObject(const InputParameters & parameters)
     DataFileInterface<MooseObject>(*this),
     _enabled(getParam<bool>("enable"))
 {
-  mooseAssert(_app.getFactory().currentlyConstructing(),
-              "Object was not created using the Factory");
+  if (!_app.getFactory().currentlyConstructing())
+    mooseError("This object was not constructed using the Factory, which is not supported.");
 }

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -11,6 +11,7 @@
 #include "MooseObject.h"
 #include "MooseApp.h"
 #include "MooseUtils.h"
+#include "Factory.h"
 
 class FEProblem;
 class FEProblemBase;
@@ -55,4 +56,6 @@ MooseObject::MooseObject(const InputParameters & parameters)
     DataFileInterface<MooseObject>(*this),
     _enabled(getParam<bool>("enable"))
 {
+  mooseAssert(_app.getFactory().currentlyConstructing(),
+              "Object was not created using the Factory");
 }

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -56,6 +56,6 @@ MooseObject::MooseObject(const InputParameters & parameters)
     DataFileInterface<MooseObject>(*this),
     _enabled(getParam<bool>("enable"))
 {
-  if (!_app.getFactory().currentlyConstructing())
+  if (_app.getFactory().currentlyConstructing() != &parameters)
     mooseError("This object was not constructed using the Factory, which is not supported.");
 }

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -50,7 +50,7 @@ MooseObject::MooseObject(const InputParameters & parameters)
               *parameters.getCheckedPointerParam<MooseApp *>("_moose_app"),
               parameters),
     MooseBaseParameterInterface(*this, parameters),
-    MooseBaseErrorInterface(*this, parameters),
+    MooseBaseErrorInterface(static_cast<MooseBase &>(*this)),
     ParallelObject(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app")),
     DataFileInterface<MooseObject>(*this),
     _enabled(getParam<bool>("enable"))

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -56,6 +56,7 @@ MooseObject::MooseObject(const InputParameters & parameters)
     DataFileInterface<MooseObject>(*this),
     _enabled(getParam<bool>("enable"))
 {
-  if (_app.getFactory().currentlyConstructing() != &parameters)
-    mooseError("This object was not constructed using the Factory, which is not supported.");
+  if (Registry::isRegisteredObj(type()) && _app.getFactory().currentlyConstructing() != &parameters)
+    mooseError(
+        "This registered object was not constructed using the Factory, which is not supported.");
 }

--- a/framework/src/base/MooseServer.C
+++ b/framework/src/base/MooseServer.C
@@ -57,7 +57,8 @@ MooseServer::parseDocumentForDiagnostics(wasp::DataArray & diagnosticsList)
   pcrecpp::RE("(.*://)(.*)").Replace("\\2", &parse_file_path);
 
   // copy parent application parameters and modify to set up input check
-  InputParameters app_params = _moose_app.parameters();
+  InputParameters app_params = AppFactory::instance().getValidParams(_moose_app.type());
+  app_params.applyParameters(_moose_app.parameters());
   app_params.set<bool>("check_input") = true;
   app_params.set<bool>("error_unused") = true;
   app_params.set<bool>("error") = true;
@@ -65,8 +66,7 @@ MooseServer::parseDocumentForDiagnostics(wasp::DataArray & diagnosticsList)
   app_params.set<bool>("disable_perf_graph_live") = true;
   app_params.set<std::shared_ptr<Parser>>("_parser") =
       std::make_shared<Parser>(parse_file_path, document_text);
-
-  app_params.remove("language_server");
+  app_params.set<std::shared_ptr<CommandLine>>("_command_line") = _moose_app.commandLine();
 
   // turn output off so input check application does not affect messages
   std::streambuf * cached_output_buffer = Moose::out.rdbuf(nullptr);

--- a/framework/src/constraints/AutomaticMortarGeneration.C
+++ b/framework/src/constraints/AutomaticMortarGeneration.C
@@ -258,6 +258,7 @@ AutomaticMortarGeneration::initOutput()
       std::to_string(_primary_secondary_boundary_id_pairs.front().first) +
       std::to_string(_primary_secondary_boundary_id_pairs.front().second) + "_" +
       (_on_displaced ? "displaced" : "undisplaced");
+  _output_params->finalize("MortarNodalGeometryOutput");
   _app.getOutputWarehouse().addOutput(std::make_shared<MortarNodalGeometryOutput>(*_output_params));
 }
 

--- a/framework/src/interfaces/DataFileInterface.C
+++ b/framework/src/interfaces/DataFileInterface.C
@@ -12,6 +12,8 @@
 #include "MooseObject.h"
 #include "Action.h"
 
+#include <filesystem>
+
 template <class T>
 DataFileInterface<T>::DataFileInterface(const T & parent) : _parent(parent)
 {
@@ -21,17 +23,11 @@ template <class T>
 std::string
 DataFileInterface<T>::getDataFileName(const std::string & param) const
 {
-  /// - relative to the input file directory
-  {
-    const auto & absolute_path = _parent.template getParam<DataFileParameterType>(param);
-    if (MooseUtils::checkFileReadable(absolute_path, false, false, false))
-    {
-      _parent.paramInfo(param, "Data file '", absolute_path, "' found relative to the input file.");
-      return absolute_path;
-    }
-  }
+  const auto & relative_path = _parent.template getParam<DataFileParameterType>(param);
+  if (std::filesystem::path(std::string(relative_path)).is_absolute())
+    _parent.paramError(param,
+                       "This file path cannot be absolute because it represents a data file");
 
-  const auto & relative_path = _parent.parameters().rawParamVal(param);
   return getDataFileNameByName(relative_path, &param);
 }
 

--- a/framework/src/mesh/AnnularMesh.C
+++ b/framework/src/mesh/AnnularMesh.C
@@ -9,6 +9,8 @@
 
 #include "AnnularMesh.h"
 
+#include "MooseApp.h"
+
 #include "libmesh/face_quad4.h"
 #include "libmesh/face_tri3.h"
 
@@ -153,7 +155,7 @@ AnnularMesh::getMaxInDimension(unsigned int component) const
 std::unique_ptr<MooseMesh>
 AnnularMesh::safeClone() const
 {
-  return std::make_unique<AnnularMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 void

--- a/framework/src/mesh/ConcentricCircleMesh.C
+++ b/framework/src/mesh/ConcentricCircleMesh.C
@@ -10,6 +10,7 @@
 #include "ConcentricCircleMesh.h"
 #include "libmesh/face_quad4.h"
 #include "MooseMesh.h"
+#include "MooseApp.h"
 #include "libmesh/mesh_modification.h"
 #include "libmesh/serial_mesh.h"
 #include "libmesh/boundary_info.h"
@@ -93,6 +94,12 @@ ConcentricCircleMesh::ConcentricCircleMesh(const InputParameters & parameters)
     for (unsigned i = 0; i < _radii.size(); ++i)
       if (_pitch / 2 < _radii[i])
         mooseError("The pitch / 2 must be larger than any radii.");
+}
+
+std::unique_ptr<MooseMesh>
+ConcentricCircleMesh::safeClone() const
+{
+  return _app.getFactory().copyConstruct(*this);
 }
 
 void

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -52,7 +52,7 @@ FileMesh::~FileMesh() {}
 std::unique_ptr<MooseMesh>
 FileMesh::safeClone() const
 {
-  return std::make_unique<FileMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 void

--- a/framework/src/mesh/GeneratedMesh.C
+++ b/framework/src/mesh/GeneratedMesh.C
@@ -9,6 +9,8 @@
 
 #include "GeneratedMesh.h"
 
+#include "MooseApp.h"
+
 #include "libmesh/mesh_generation.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/periodic_boundaries.h"
@@ -150,7 +152,7 @@ GeneratedMesh::getMaxInDimension(unsigned int component) const
 std::unique_ptr<MooseMesh>
 GeneratedMesh::safeClone() const
 {
-  return std::make_unique<GeneratedMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 void

--- a/framework/src/mesh/ImageMesh.C
+++ b/framework/src/mesh/ImageMesh.C
@@ -58,7 +58,7 @@ ImageMesh::ImageMesh(const ImageMesh & other_mesh)
 std::unique_ptr<MooseMesh>
 ImageMesh::safeClone() const
 {
-  return std::make_unique<ImageMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 void

--- a/framework/src/mesh/MeshGeneratorMesh.C
+++ b/framework/src/mesh/MeshGeneratorMesh.C
@@ -10,6 +10,7 @@
 #include "MeshGeneratorMesh.h"
 
 #include "MeshGeneratorSystem.h"
+#include "MooseApp.h"
 
 #include "libmesh/face_quad4.h"
 #include "libmesh/face_tri3.h"
@@ -37,7 +38,7 @@ MeshGeneratorMesh::MeshGeneratorMesh(const InputParameters & parameters) : Moose
 std::unique_ptr<MooseMesh>
 MeshGeneratorMesh::safeClone() const
 {
-  return std::make_unique<MeshGeneratorMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 void

--- a/framework/src/mesh/PatternedMesh.C
+++ b/framework/src/mesh/PatternedMesh.C
@@ -10,6 +10,7 @@
 #include "PatternedMesh.h"
 #include "Parser.h"
 #include "InputParameters.h"
+#include "MooseApp.h"
 
 #include "libmesh/mesh_modification.h"
 #include "libmesh/serial_mesh.h"
@@ -79,7 +80,7 @@ PatternedMesh::PatternedMesh(const PatternedMesh & other_mesh)
 std::unique_ptr<MooseMesh>
 PatternedMesh::safeClone() const
 {
-  return std::make_unique<PatternedMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 void

--- a/framework/src/mesh/RinglebMesh.C
+++ b/framework/src/mesh/RinglebMesh.C
@@ -9,6 +9,8 @@
 
 #include "RinglebMesh.h"
 
+#include "MooseApp.h"
+
 #include "libmesh/face_quad4.h"
 #include "libmesh/face_tri3.h"
 #include "libmesh/mesh_modification.h"
@@ -64,7 +66,7 @@ RinglebMesh::RinglebMesh(const InputParameters & parameters)
 std::unique_ptr<MooseMesh>
 RinglebMesh::safeClone() const
 {
-  return std::make_unique<RinglebMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 std::vector<Real>

--- a/framework/src/mesh/SpiralAnnularMesh.C
+++ b/framework/src/mesh/SpiralAnnularMesh.C
@@ -9,6 +9,8 @@
 
 #include "SpiralAnnularMesh.h"
 
+#include "MooseApp.h"
+
 #include "libmesh/face_quad4.h"
 #include "libmesh/face_tri3.h"
 
@@ -65,7 +67,7 @@ SpiralAnnularMesh::SpiralAnnularMesh(const InputParameters & parameters)
 std::unique_ptr<MooseMesh>
 SpiralAnnularMesh::safeClone() const
 {
-  return std::make_unique<SpiralAnnularMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 void

--- a/framework/src/mesh/StitchedMesh.C
+++ b/framework/src/mesh/StitchedMesh.C
@@ -11,6 +11,8 @@
 #include "Parser.h"
 #include "InputParameters.h"
 
+#include "MooseApp.h"
+
 #include "libmesh/mesh_modification.h"
 #include "libmesh/serial_mesh.h"
 #include "libmesh/exodusII_io.h"
@@ -74,7 +76,7 @@ StitchedMesh::StitchedMesh(const StitchedMesh & other_mesh)
 std::unique_ptr<MooseMesh>
 StitchedMesh::safeClone() const
 {
-  return std::make_unique<StitchedMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 void

--- a/framework/src/mesh/TiledMesh.C
+++ b/framework/src/mesh/TiledMesh.C
@@ -10,6 +10,7 @@
 #include "TiledMesh.h"
 #include "Parser.h"
 #include "InputParameters.h"
+#include "MooseApp.h"
 
 #include "libmesh/mesh_modification.h"
 #include "libmesh/serial_mesh.h"
@@ -79,7 +80,7 @@ TiledMesh::TiledMesh(const TiledMesh & other_mesh)
 std::unique_ptr<MooseMesh>
 TiledMesh::safeClone() const
 {
-  return std::make_unique<TiledMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 std::string

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -11,7 +11,6 @@
 #include "OversampleOutput.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
-#include "FileMesh.h"
 #include "MooseApp.h"
 
 #include "libmesh/distributed_mesh.h"
@@ -270,14 +269,11 @@ OversampleOutput::cloneMesh()
   // Create the new mesh from a file
   if (isParamValid("file"))
   {
-    InputParameters mesh_params = emptyInputParameters();
-    mesh_params += _mesh_ptr->parameters();
-    mesh_params.applySpecificParameters(parameters(), {"file"});
+    InputParameters mesh_params = _app.getFactory().getValidParams("FileMesh");
+    mesh_params.applyParameters(parameters(), {}, true);
     mesh_params.set<bool>("nemesis") = false;
-    mesh_params.set<bool>("skip_partitioning") = false;
     _cloned_mesh_ptr =
         _app.getFactory().createUnique<MooseMesh>("FileMesh", "output_problem_mesh", mesh_params);
-    _cloned_mesh_ptr = std::make_unique<FileMesh>(mesh_params);
     _cloned_mesh_ptr->allowRecovery(false); // We actually want to reread the initial mesh
     _cloned_mesh_ptr->init();
     _cloned_mesh_ptr->prepare(/*mesh_to_clone=*/nullptr);

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -275,8 +275,8 @@ OversampleOutput::cloneMesh()
     mesh_params.set<MeshFileName>("file") = getParam<MeshFileName>("file");
     mesh_params.set<bool>("nemesis") = false;
     mesh_params.set<bool>("skip_partitioning") = false;
-    mesh_params.set<std::string>("_object_name") = "output_problem_mesh";
-    mesh_params.finalizeParams("Mesh");
+    _cloned_mesh_ptr =
+        _app.getFactory().create<MooseMesh>("FileMesh", "output_problem_mesh", mesh_params);
     _cloned_mesh_ptr = std::make_unique<FileMesh>(mesh_params);
     _cloned_mesh_ptr->allowRecovery(false); // We actually want to reread the initial mesh
     _cloned_mesh_ptr->init();

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -276,6 +276,7 @@ OversampleOutput::cloneMesh()
     mesh_params.set<bool>("nemesis") = false;
     mesh_params.set<bool>("skip_partitioning") = false;
     mesh_params.set<std::string>("_object_name") = "output_problem_mesh";
+    mesh_params.finalizeParams("Mesh");
     _cloned_mesh_ptr = std::make_unique<FileMesh>(mesh_params);
     _cloned_mesh_ptr->allowRecovery(false); // We actually want to reread the initial mesh
     _cloned_mesh_ptr->init();

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -272,11 +272,11 @@ OversampleOutput::cloneMesh()
   {
     InputParameters mesh_params = emptyInputParameters();
     mesh_params += _mesh_ptr->parameters();
-    mesh_params.set<MeshFileName>("file") = getParam<MeshFileName>("file");
+    mesh_params.applySpecificParameters(parameters(), {"file"});
     mesh_params.set<bool>("nemesis") = false;
     mesh_params.set<bool>("skip_partitioning") = false;
     _cloned_mesh_ptr =
-        _app.getFactory().create<MooseMesh>("FileMesh", "output_problem_mesh", mesh_params);
+        _app.getFactory().createUnique<MooseMesh>("FileMesh", "output_problem_mesh", mesh_params);
     _cloned_mesh_ptr = std::make_unique<FileMesh>(mesh_params);
     _cloned_mesh_ptr->allowRecovery(false); // We actually want to reread the initial mesh
     _cloned_mesh_ptr->init();

--- a/framework/src/parser/Builder.C
+++ b/framework/src/parser/Builder.C
@@ -259,7 +259,7 @@ Builder::walkRaw(std::string /*fullpath*/, std::string /*nodepath*/, hit::Node *
 
     params = _action_factory.getValidParams(it->second._action);
     params.set<ActionWarehouse *>("awh") = &_action_wh;
-    params.setHitNode(*n);
+    params.setHitNode(*n, {});
 
     extractParams(curr_identifier, params);
 
@@ -282,7 +282,7 @@ Builder::walkRaw(std::string /*fullpath*/, std::string /*nodepath*/, hit::Node *
       if (object_action)
       {
         auto & object_params = object_action->getObjectParams();
-        object_params.setHitNode(*n);
+        object_params.setHitNode(*n, {});
         extractParams(curr_identifier, object_params);
         object_params.set<std::vector<std::string>>("control_tags")
             .push_back(MooseUtils::baseName(curr_identifier));
@@ -950,7 +950,7 @@ Builder::extractParams(const std::string & prefix, InputParameters & p)
       auto node = root()->find(full_name);
       if (node && node->type() == hit::NodeType::Field)
       {
-        p.setHitNode(param_name, *node);
+        p.setHitNode(param_name, *node, {});
         p.set_attributes(param_name, false);
         // Check if we have already printed the deprecated param message.
         // If we haven't, add it to the tracker, and print it.
@@ -968,7 +968,7 @@ Builder::extractParams(const std::string & prefix, InputParameters & p)
         node = root()->find(full_name);
         if (node)
         {
-          p.setHitNode(param_name, *node);
+          p.setHitNode(param_name, *node, {});
           p.set_attributes(param_name, false);
           _extracted_vars.insert(
               full_name); // Keep track of all variables extracted from the input file

--- a/framework/src/parser/Builder.C
+++ b/framework/src/parser/Builder.C
@@ -1086,6 +1086,7 @@ Builder::extractParams(const std::string & prefix, InputParameters & p)
         setscalar(BoundaryName, string);
         setfpath(FileName);
         setfpath(MeshFileName);
+        setscalar(RelativeFileName, string);
         setfpath(FileNameNoExtension);
         setscalar(PhysicsName, string);
         setscalar(OutFileBase, string);
@@ -1155,6 +1156,7 @@ Builder::extractParams(const std::string & prefix, InputParameters & p)
         setvector(string, string);
         setvectorfpath(FileName);
         setvectorfpath(FileNameNoExtension);
+        setvector(RelativeFileName, string);
         setvectorfpath(MeshFileName);
         setvector(SubdomainName, string);
         setvector(BoundaryName, string);

--- a/framework/src/partitioner/BlockWeightedPartitioner.C
+++ b/framework/src/partitioner/BlockWeightedPartitioner.C
@@ -9,6 +9,7 @@
 
 #include "BlockWeightedPartitioner.h"
 #include "MooseMeshUtils.h"
+#include "MooseApp.h"
 
 #include "libmesh/elem.h"
 
@@ -48,7 +49,7 @@ BlockWeightedPartitioner::BlockWeightedPartitioner(const InputParameters & param
 std::unique_ptr<Partitioner>
 BlockWeightedPartitioner::clone() const
 {
-  return std::make_unique<BlockWeightedPartitioner>(_pars);
+  return _app.getFactory().clone(*this);
 }
 
 void

--- a/framework/src/partitioner/GridPartitioner.C
+++ b/framework/src/partitioner/GridPartitioner.C
@@ -48,7 +48,7 @@ GridPartitioner::~GridPartitioner() {}
 std::unique_ptr<Partitioner>
 GridPartitioner::clone() const
 {
-  return std::make_unique<GridPartitioner>(_pars);
+  return _app.getFactory().clone(*this);
 }
 
 void

--- a/framework/src/partitioner/HierarchicalGridPartitioner.C
+++ b/framework/src/partitioner/HierarchicalGridPartitioner.C
@@ -65,7 +65,7 @@ HierarchicalGridPartitioner::~HierarchicalGridPartitioner() {}
 std::unique_ptr<Partitioner>
 HierarchicalGridPartitioner::clone() const
 {
-  return std::make_unique<HierarchicalGridPartitioner>(_pars);
+  return _app.getFactory().clone(*this);
 }
 
 void

--- a/framework/src/partitioner/LibmeshPartitioner.C
+++ b/framework/src/partitioner/LibmeshPartitioner.C
@@ -9,7 +9,9 @@
 
 #include "LibmeshPartitioner.h"
 
+#include "MooseApp.h"
 #include "MooseMeshUtils.h"
+
 #include "libmesh/linear_partitioner.h"
 #include "libmesh/centroid_partitioner.h"
 #include "libmesh/parmetis_partitioner.h"
@@ -129,7 +131,7 @@ LibmeshPartitioner::clone() const
       return std::make_unique<MortonSFCPartitioner>();
 
     case 4: // subdomain_partitioner
-      return std::make_unique<LibmeshPartitioner>(parameters());
+      return _app.getFactory().clone(*this);
   }
   // this cannot happen but I need to trick the compiler into
   // believing me

--- a/framework/src/partitioner/PetscExternalPartitioner.C
+++ b/framework/src/partitioner/PetscExternalPartitioner.C
@@ -65,7 +65,7 @@ PetscExternalPartitioner::PetscExternalPartitioner(const InputParameters & param
 std::unique_ptr<Partitioner>
 PetscExternalPartitioner::clone() const
 {
-  return std::make_unique<PetscExternalPartitioner>(_pars);
+  return _app.getFactory().clone(*this);
 }
 
 void

--- a/framework/src/partitioner/RandomPartitioner.C
+++ b/framework/src/partitioner/RandomPartitioner.C
@@ -40,7 +40,7 @@ RandomPartitioner::~RandomPartitioner() {}
 std::unique_ptr<Partitioner>
 RandomPartitioner::clone() const
 {
-  return std::make_unique<RandomPartitioner>(_pars);
+  return _app.getFactory().clone(*this);
 }
 
 void

--- a/framework/src/partitioner/SingleRankPartitioner.C
+++ b/framework/src/partitioner/SingleRankPartitioner.C
@@ -9,6 +9,8 @@
 
 #include "SingleRankPartitioner.h"
 
+#include "MooseApp.h"
+
 #include "libmesh/elem.h"
 
 registerMooseObject("MooseApp", SingleRankPartitioner);
@@ -35,7 +37,7 @@ SingleRankPartitioner::SingleRankPartitioner(const InputParameters & params)
 std::unique_ptr<Partitioner>
 SingleRankPartitioner::clone() const
 {
-  return std::make_unique<SingleRankPartitioner>(_pars);
+  return _app.getFactory().clone(*this);
 }
 
 void

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5428,6 +5428,7 @@ FEProblemBase::addAnyRedistributers()
       redistribute_params.set<Moose::RelationshipManagerType>("rm_type") =
           Moose::RelationshipManagerType::GEOMETRIC;
       redistribute_params.set<bool>("use_displaced_mesh") = use_displaced_mesh;
+      redistribute_params.setHitNode(*parameters().getHitNode(), {});
 
       std::shared_ptr<RedistributeProperties> redistributer =
           _factory.create<RedistributeProperties>(

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3805,7 +3805,7 @@ FEProblemBase::addReporter(const std::string & type,
   addUserObject(type, name, parameters);
 }
 
-void
+std::vector<std::shared_ptr<UserObject>>
 FEProblemBase::addUserObject(const std::string & user_object_name,
                              const std::string & name,
                              InputParameters & parameters)
@@ -3875,6 +3875,8 @@ FEProblemBase::addUserObject(const std::string & user_object_name,
       if (_displaced_problem)
         _displaced_problem->addFunctor(name, *functor, tid);
     }
+
+  return uos;
 }
 
 const UserObject &

--- a/framework/src/relationshipmanagers/AugmentSparsityOnInterface.C
+++ b/framework/src/relationshipmanagers/AugmentSparsityOnInterface.C
@@ -398,3 +398,9 @@ AugmentSparsityOnInterface::operator>=(const RelationshipManager & other) const
   }
   return false;
 }
+
+std::unique_ptr<GhostingFunctor>
+AugmentSparsityOnInterface::clone() const
+{
+  return _app.getFactory().copyConstruct(*this);
+}

--- a/framework/src/relationshipmanagers/ElementPointNeighborLayers.C
+++ b/framework/src/relationshipmanagers/ElementPointNeighborLayers.C
@@ -44,7 +44,7 @@ ElementPointNeighborLayers::ElementPointNeighborLayers(const ElementPointNeighbo
 std::unique_ptr<GhostingFunctor>
 ElementPointNeighborLayers::clone() const
 {
-  return std::make_unique<ElementPointNeighborLayers>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 std::string

--- a/framework/src/relationshipmanagers/ElementSideNeighborLayers.C
+++ b/framework/src/relationshipmanagers/ElementSideNeighborLayers.C
@@ -57,7 +57,7 @@ ElementSideNeighborLayers::ElementSideNeighborLayers(const ElementSideNeighborLa
 std::unique_ptr<GhostingFunctor>
 ElementSideNeighborLayers::clone() const
 {
-  return std::make_unique<ElementSideNeighborLayers>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 std::string

--- a/framework/src/relationshipmanagers/GhostEverything.C
+++ b/framework/src/relationshipmanagers/GhostEverything.C
@@ -61,3 +61,9 @@ GhostEverything::operator>=(const RelationshipManager & other) const
 {
   return dynamic_cast<const GhostEverything *>(&other);
 }
+
+std::unique_ptr<GhostingFunctor>
+GhostEverything::clone() const
+{
+  return _app.getFactory().copyConstruct(*this);
+}

--- a/framework/src/relationshipmanagers/GhostHigherDLowerDPointNeighbors.C
+++ b/framework/src/relationshipmanagers/GhostHigherDLowerDPointNeighbors.C
@@ -94,3 +94,9 @@ GhostHigherDLowerDPointNeighbors::operator>=(const RelationshipManager & other) 
   return dynamic_cast<const GhostHigherDLowerDPointNeighbors *>(&other) ||
          dynamic_cast<const GhostLowerDElems *>(&other);
 }
+
+std::unique_ptr<GhostingFunctor>
+GhostHigherDLowerDPointNeighbors::clone() const
+{
+  return _app.getFactory().copyConstruct(*this);
+}

--- a/framework/src/relationshipmanagers/GhostLowerDElems.C
+++ b/framework/src/relationshipmanagers/GhostLowerDElems.C
@@ -76,3 +76,9 @@ GhostLowerDElems::operator>=(const RelationshipManager & other) const
 {
   return dynamic_cast<const GhostLowerDElems *>(&other);
 }
+
+std::unique_ptr<GhostingFunctor>
+GhostLowerDElems::clone() const
+{
+  return _app.getFactory().copyConstruct(*this);
+}

--- a/framework/src/relationshipmanagers/ProxyRelationshipManager.C
+++ b/framework/src/relationshipmanagers/ProxyRelationshipManager.C
@@ -111,3 +111,9 @@ ProxyRelationshipManager::operator>=(const RelationshipManager & /*rhs*/) const
   // There isn't a need to determine these because only the correct ones will be added
   return false;
 }
+
+std::unique_ptr<GhostingFunctor>
+ProxyRelationshipManager::clone() const
+{
+  return _app.getFactory().copyConstruct(*this);
+}

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -39,7 +39,7 @@ RedistributeProperties::operator()(const MeshBase::const_element_iterator &,
 std::unique_ptr<GhostingFunctor>
 RedistributeProperties::clone() const
 {
-  return std::make_unique<RedistributeProperties>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 std::string

--- a/framework/src/utils/InputParameterWarehouse.C
+++ b/framework/src/utils/InputParameterWarehouse.C
@@ -19,7 +19,8 @@ InputParameterWarehouse::InputParameterWarehouse()
 InputParameters &
 InputParameterWarehouse::addInputParameters(const std::string & name,
                                             const InputParameters & parameters,
-                                            THREAD_ID tid /* =0 */)
+                                            THREAD_ID tid,
+                                            const AddRemoveParamsKey)
 {
   // Error if the name contains "::"
   if (name.find("::") != std::string::npos)
@@ -105,7 +106,9 @@ InputParameterWarehouse::addInputParameters(const std::string & name,
 }
 
 void
-InputParameterWarehouse::removeInputParameters(const MooseObject & moose_object, THREAD_ID tid)
+InputParameterWarehouse::removeInputParameters(const MooseObject & moose_object,
+                                               THREAD_ID tid,
+                                               const AddRemoveParamsKey)
 {
   auto moose_object_name_string = moose_object.parameters().get<std::string>("_unique_name");
   MooseObjectName moose_object_name(moose_object_name_string);

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -1314,7 +1314,7 @@ const MooseEnum &
 InputParameters::getParamHelper<MooseEnum>(const std::string & name_in,
                                            const InputParameters & pars,
                                            const MooseEnum *,
-                                           const MooseObject * /* = nullptr */)
+                                           const MooseBase * /* = nullptr */)
 {
   const auto name = pars.checkForRename(name_in);
   return pars.get<MooseEnum>(name);
@@ -1325,7 +1325,7 @@ const MultiMooseEnum &
 InputParameters::getParamHelper<MultiMooseEnum>(const std::string & name_in,
                                                 const InputParameters & pars,
                                                 const MultiMooseEnum *,
-                                                const MooseObject * /* = nullptr */)
+                                                const MooseBase * /* = nullptr */)
 {
   const auto name = pars.checkForRename(name_in);
   return pars.get<MultiMooseEnum>(name);
@@ -1607,7 +1607,7 @@ InputParameters::paramAliases(const std::string & param_name) const
 }
 
 void
-InputParameters::callMooseErrorHelper(const MooseObject & object, const std::string & error)
+InputParameters::callMooseErrorHelper(const MooseBase & moose_base, const std::string & error)
 {
-  object.mooseError(error);
+  moose_base.callMooseError(error, true);
 }

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -692,6 +692,8 @@ InputParameters::finalizeParams(const std::string & parsing_syntax,
     set_if_filename(MeshFileName);
 #undef set_if_filename
   }
+
+  _finalized = true;
 }
 
 bool

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -678,10 +678,9 @@ InputParameters::getParamFileBase(const std::string & param_name) const
   // Context from the parameters
   if (!hit_node)
     hit_node = getHitNode();
-  // No luck :(
+  // No hit node, so use the cwd (no input files)
   if (!hit_node)
-    mooseError(errorPrefix(param_name),
-               " Parameter does not have a hit node to determine a file path context.");
+    return std::filesystem::current_path();
 
   // Find any context that isn't command line arguments
   while (hit_node && hit_node->filename() == "CLI_ARGS")

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -621,8 +621,8 @@ InputParameters::checkParams(const std::string & parsing_syntax)
 }
 
 void
-InputParameters::finalizeParams(const std::string & parsing_syntax,
-                                const std::filesystem::path & default_file_base)
+InputParameters::finalize(const std::string & parsing_syntax,
+                          const std::filesystem::path & default_file_base)
 {
   mooseAssert(!isFinalized(), "Already finalized");
 

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -1287,7 +1287,9 @@ InputParameters::getHitNode(const std::string & param) const
 }
 
 void
-InputParameters::setHitNode(const std::string & param, const hit::Node & node)
+InputParameters::setHitNode(const std::string & param,
+                            const hit::Node & node,
+                            const InputParameters::SetParamHitNodeKey)
 {
   mooseAssert(node.type() == hit::NodeType::Field, "Must be a field");
   at(param)._hit_node = &node;

--- a/framework/src/utils/MooseTypes.C
+++ b/framework/src/utils/MooseTypes.C
@@ -45,6 +45,7 @@ const TagName PREVIOUS_NL_SOLUTION_TAG = "U_PREVIOUS_NL_NEWTON";
   static_assert(true, "")
 DerivativeStringToJSON(FileName);
 DerivativeStringToJSON(FileNameNoExtension);
+DerivativeStringToJSON(RelativeFileName);
 DerivativeStringToJSON(MeshFileName);
 DerivativeStringToJSON(OutFileBase);
 DerivativeStringToJSON(NonlinearVariableName);

--- a/framework/src/utils/MooseTypes.C
+++ b/framework/src/utils/MooseTypes.C
@@ -46,6 +46,7 @@ const TagName PREVIOUS_NL_SOLUTION_TAG = "U_PREVIOUS_NL_NEWTON";
 DerivativeStringToJSON(FileName);
 DerivativeStringToJSON(FileNameNoExtension);
 DerivativeStringToJSON(RelativeFileName);
+DerivativeStringToJSON(DataFileName);
 DerivativeStringToJSON(MeshFileName);
 DerivativeStringToJSON(OutFileBase);
 DerivativeStringToJSON(NonlinearVariableName);

--- a/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
+++ b/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
@@ -57,7 +57,7 @@ PETScDMDAMesh::PETScDMDAMesh(const InputParameters & parameters) : MooseMesh(par
 std::unique_ptr<MooseMesh>
 PETScDMDAMesh::safeClone() const
 {
-  return std::make_unique<PETScDMDAMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 inline dof_id_type

--- a/modules/fluid_properties/unit/src/TabulatedBicubicFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/TabulatedBicubicFluidPropertiesTest.C
@@ -24,10 +24,8 @@ TEST_F(TabulatedBicubicFluidPropertiesTest, unorderedData)
   }
   catch (const std::exception & err)
   {
-    std::size_t pos =
-        std::string(err.what())
-            .find("The column data for temperature is not monotonically increasing in "
-                  "data/csv/unordered_fluid_props.csv");
+    std::size_t pos = std::string(err.what())
+                          .find("The column data for temperature is not monotonically increasing");
     ASSERT_TRUE(pos != std::string::npos);
   }
 }
@@ -60,8 +58,7 @@ TEST_F(TabulatedBicubicFluidPropertiesTest, missingColumn)
   catch (const std::exception & err)
   {
     std::size_t pos = std::string(err.what())
-                          .find("No temperature data read in "
-                                "data/csv/missing_col_fluid_props.csv. A "
+                          .find("data/csv/missing_col_fluid_props.csv. A "
                                 "column named temperature must be present");
     ASSERT_TRUE(pos != std::string::npos);
   }
@@ -78,7 +75,7 @@ TEST_F(TabulatedBicubicFluidPropertiesTest, unknownColumn)
   catch (const std::exception & err)
   {
     std::size_t pos = std::string(err.what())
-                          .find("unknown read in data/csv/unknown_fluid_props.csv is not one of "
+                          .find("data/csv/unknown_fluid_props.csv is not one of "
                                 "the properties that TabulatedFluidProperties understands");
     ASSERT_TRUE(pos != std::string::npos);
   }
@@ -95,7 +92,7 @@ TEST_F(TabulatedBicubicFluidPropertiesTest, missingData)
   catch (const std::exception & err)
   {
     std::size_t pos = std::string(err.what())
-                          .find("The number of rows in data/csv/missing_data_fluid_props.csv "
+                          .find("data/csv/missing_data_fluid_props.csv "
                                 "is not equal to the number of unique pressure values 3 multiplied "
                                 "by the number of unique temperature values 3");
     ASSERT_TRUE(pos != std::string::npos);

--- a/modules/optimization/src/actions/OptimizationAction.C
+++ b/modules/optimization/src/actions/OptimizationAction.C
@@ -47,6 +47,9 @@ OptimizationAction::act()
     InputParameters action_params = _action_factory.getValidParams("SetupMeshAction");
     action_params.set<std::string>("type") = "GeneratedMesh";
 
+    // Associate errors with "solve_type"
+    associateWithParameter("auto_create_mesh", action_params);
+
     // Create The Action
     auto action = std::static_pointer_cast<MooseObjectAction>(
         _action_factory.create("SetupMeshAction", "Mesh", action_params));
@@ -66,6 +69,9 @@ OptimizationAction::act()
   {
     // Build the Action parameters
     InputParameters action_params = _action_factory.getValidParams("CreateProblemAction");
+
+    // Associate errors with "solve_type"
+    associateWithParameter("auto_create_problem", action_params);
 
     // Create the action
     auto action = std::static_pointer_cast<MooseObjectAction>(

--- a/modules/peridynamics/src/mesh/PeridynamicsMesh.C
+++ b/modules/peridynamics/src/mesh/PeridynamicsMesh.C
@@ -104,7 +104,7 @@ PeridynamicsMesh::PeridynamicsMesh(const InputParameters & parameters)
 std::unique_ptr<MooseMesh>
 PeridynamicsMesh::safeClone() const
 {
-  return std::make_unique<PeridynamicsMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 void

--- a/modules/ray_tracing/include/base/RayTracingObject.h
+++ b/modules/ray_tracing/include/base/RayTracingObject.h
@@ -148,4 +148,4 @@ RayTracingObject::getStudy()
   usingFunctionInterfaceMembers;                                                                   \
   usingPostprocessorInterfaceMembers;                                                              \
   usingTransientInterfaceMembers;                                                                  \
-  using RayTracingObject::currentRay;
+  using RayTracingObject::currentRay

--- a/modules/ray_tracing/include/base/RayTracingObject.h
+++ b/modules/ray_tracing/include/base/RayTracingObject.h
@@ -148,5 +148,4 @@ RayTracingObject::getStudy()
   usingFunctionInterfaceMembers;                                                                   \
   usingPostprocessorInterfaceMembers;                                                              \
   usingTransientInterfaceMembers;                                                                  \
-  using RayTracingObject::currentRay;                                                              \
-  using RayTracingObject::errorPrefix
+  using RayTracingObject::currentRay;

--- a/modules/ray_tracing/test/tests/base/ray_tracing_object/tests
+++ b/modules/ray_tracing/test/tests/base/ray_tracing_object/tests
@@ -10,7 +10,7 @@
       input = 'errors.i'
       cli_args = 'RayKernels/test/get_study_bad=true RayKernels/test/study=study'
       allow_test_objects = true
-      expect_err = '\(RayKernels/test/study\):.*Supplied study of type RayTracingStudyTest is not the required study type RepeatableRayStudy'
+      expect_err = 'Supplied study of type RayTracingStudyTest is not the required study type RepeatableRayStudy'
       detail = 'the study is provided via param and is of the wrong type'
     []
     [get_study_bad_default]

--- a/modules/ray_tracing/test/tests/base/ray_tracing_object/tests
+++ b/modules/ray_tracing/test/tests/base/ray_tracing_object/tests
@@ -18,7 +18,7 @@
       input = 'errors.i'
       cli_args = 'RayKernels/test/get_study_bad=true'
       allow_test_objects = true
-      expect_err = 'The following error occurred in the object "test", of type "RayTracingObjectTest"..*Supplied study of type RayTracingStudyTest is not the required study type RepeatableRayStudy'
+      expect_err = 'Supplied study of type RayTracingStudyTest is not the required study type RepeatableRayStudy'
       detail = 'the study is provided by default and is of the wrong type'
     []
   []

--- a/modules/solid_mechanics/src/materials/LAROMANCEStressUpdateBase.C
+++ b/modules/solid_mechanics/src/materials/LAROMANCEStressUpdateBase.C
@@ -151,7 +151,7 @@ LAROMANCEStressUpdateBaseTempl<is_ad>::validParams()
   params.addParam<std::string>("stress_unit", "Pa", "unit of stress");
 
   // use std::string here to avoid automatic absolute path expansion
-  params.addParam<FileName>("model", "LaRomance model JSON datafile");
+  params.addParam<DataFileName>("model", "LaRomance model JSON datafile");
   params.addParam<FileName>("export_model", "Write LaRomance model to JSON datafile");
 
   params.addParamNamesToGroup(
@@ -1396,7 +1396,7 @@ LAROMANCEStressUpdateBaseTempl<is_ad>::checkJSONKey(const std::string & key)
   if (!this->isParamValid("model"))
     this->paramError("model", "Specify a JSON data filename.");
 
-  const auto model_file_name = this->_pars.rawParamVal("model");
+  const auto model_file_name = this->template getParam<DataFileName>("model");
   if (_json.empty())
     this->paramError("model", "The specified JSON data file '", model_file_name, "' is empty.");
   if (!_json.contains(key))

--- a/modules/stochastic_tools/src/actions/StochasticToolsAction.C
+++ b/modules/stochastic_tools/src/actions/StochasticToolsAction.C
@@ -52,6 +52,9 @@ StochasticToolsAction::act()
     InputParameters action_params = _action_factory.getValidParams("SetupMeshAction");
     action_params.set<std::string>("type") = "GeneratedMesh";
 
+    // Associate errors with "auto_create_mesh"
+    associateWithParameter("auto_create_mesh", action_params);
+
     // Create The Action
     auto action = std::static_pointer_cast<MooseObjectAction>(
         _action_factory.create("SetupMeshAction", "Mesh", action_params));
@@ -93,6 +96,9 @@ StochasticToolsAction::act()
       // Build the Action parameters
       InputParameters action_params = _action_factory.getValidParams("CreateProblemAction");
 
+      // Associate errors with "auto_create_problem"
+      associateWithParameter("auto_create_problem", action_params);
+
       // Create the action
       auto action = std::static_pointer_cast<MooseObjectAction>(
           _action_factory.create("CreateProblemAction", "Problem", action_params));
@@ -115,6 +121,9 @@ StochasticToolsAction::act()
     // Build the Action parameters
     InputParameters action_params = _action_factory.getValidParams("CreateExecutionerAction");
     action_params.set<std::string>("type") = "Steady";
+
+    // Associate errors with "auto_create_executioner"
+    associateWithParameter("auto_create_executioner", action_params);
 
     // Create the action
     auto action = std::static_pointer_cast<MooseObjectAction>(

--- a/modules/thermal_hydraulics/src/actions/AddIterationCountPostprocessorsAction.C
+++ b/modules/thermal_hydraulics/src/actions/AddIterationCountPostprocessorsAction.C
@@ -48,6 +48,7 @@ AddIterationCountPostprocessorsAction::act()
       {
         const std::string class_name = "AddPostprocessorAction";
         InputParameters action_params = _action_factory.getValidParams(class_name);
+        associateWithParameter("count_iterations", action_params);
         action_params.set<std::string>("type") = it_per_step_class_names[i];
         auto action = std::static_pointer_cast<MooseObjectAction>(
             _action_factory.create(class_name, it_per_step_names[i], action_params));
@@ -57,6 +58,7 @@ AddIterationCountPostprocessorsAction::act()
       {
         const std::string class_name = "AddPostprocessorAction";
         InputParameters action_params = _action_factory.getValidParams(class_name);
+        associateWithParameter("count_iterations", action_params);
         action_params.set<std::string>("type") = "CumulativeValuePostprocessor";
         auto action = std::static_pointer_cast<MooseObjectAction>(
             _action_factory.create(class_name, total_it_names[i], action_params));

--- a/modules/thermal_hydraulics/src/base/THMMesh.C
+++ b/modules/thermal_hydraulics/src/base/THMMesh.C
@@ -63,7 +63,7 @@ THMMesh::effectiveSpatialDimension() const
 std::unique_ptr<MooseMesh>
 THMMesh::safeClone() const
 {
-  return std::make_unique<THMMesh>(*this);
+  return _app.getFactory().copyConstruct(*this);
 }
 
 void

--- a/modules/thermal_hydraulics/src/relationshipmanagers/AugmentSparsityBetweenElements.C
+++ b/modules/thermal_hydraulics/src/relationshipmanagers/AugmentSparsityBetweenElements.C
@@ -38,7 +38,7 @@ AugmentSparsityBetweenElements::AugmentSparsityBetweenElements(
 std::unique_ptr<GhostingFunctor>
 AugmentSparsityBetweenElements::clone() const
 {
-  return std::make_unique<AugmentSparsityBetweenElements>(*this);
+  return _app.getFactory().clone(*this);
 }
 
 void

--- a/test/src/partitioner/PartitionerWeightTest.C
+++ b/test/src/partitioner/PartitionerWeightTest.C
@@ -9,6 +9,8 @@
 
 #include "PartitionerWeightTest.h"
 
+#include "MooseApp.h"
+
 #include "libmesh/elem.h"
 
 registerMooseObject("MooseTestApp", PartitionerWeightTest);
@@ -31,7 +33,7 @@ PartitionerWeightTest::PartitionerWeightTest(const InputParameters & params)
 std::unique_ptr<Partitioner>
 PartitionerWeightTest::clone() const
 {
-  return std::make_unique<PartitionerWeightTest>(_pars);
+  return _app.getFactory().clone(*this);
 }
 
 dof_id_type

--- a/test/src/userobjects/DataFileNameTest.C
+++ b/test/src/userobjects/DataFileNameTest.C
@@ -15,7 +15,7 @@ InputParameters
 DataFileNameTest::validParams()
 {
   InputParameters params = GeneralUserObject::validParams();
-  params.addRequiredParam<FileName>("data_file", "Data file to look up");
+  params.addRequiredParam<DataFileName>("data_file", "Data file to look up");
   return params;
 }
 

--- a/test/tests/time_steppers/time_stepper_system/tests
+++ b/test/tests/time_steppers/time_stepper_system/tests
@@ -71,7 +71,7 @@
       type = RunException
       input = 'lower_bound.i'
       cli_args = 'Executioner/TimeSteppers/lower_bound=FooDT'
-      expect_err = "lower_bound: Failed to find a timestepper with the name 'FooDT'"
+      expect_err = "Failed to find a timestepper with the name 'FooDT'"
       detail ="time stepper name(s) provided for lower_bound dosen't exist,"
     []
 
@@ -79,7 +79,7 @@
       type = RunException
       input = 'active_timesteppers.i'
       cli_args = "Controls/c1/disable_objects='TimeStepper::ConstDT2 TimeStepper::ConstDT1'"
-      expect_err = "The following error occurred in the object \"CompositionDT\", of type \"CompositionDT\".[.\n]\sNo TimeStepper\(s\) are currently active to compute a timestep"
+      expect_err = "No TimeStepper\(s\) are currently active to compute a timestep"
       detail ='no time steppers are active to compute a timestep,'
     []
 
@@ -94,7 +94,7 @@
       type = RunException
       input = 'testRejectStep.i'
       allow_test_objects = True
-      expect_err = "The following warning occurred in the object \"(.*?)\", of type \"(.*?)\".\n\nrejectStep\(\) calls from TestSourceStepper"
+      expect_err = "rejectStep\(\) calls from TestSourceStepper"
       detail = 'the corresponding rejectStep() function is called when solve fails'
     []
   []

--- a/test/tests/variables/optionally_coupled/tests
+++ b/test/tests/variables/optionally_coupled/tests
@@ -77,7 +77,7 @@
       type = 'RunException'
       input = 'optionally_coupled.i'
       cli_args = 'Kernels/wrong_index/type=CoupledForceWrongIndex Kernels/wrong_index/variable=u'
-      expect_err = 'v: component 2 is out of range for this variable \(max 1\)'
+      expect_err = 'component 2 is out of range for this variable \(max 1\)'
 
       detail = "accessed by name or"
     []
@@ -87,7 +87,7 @@
       input = 'optionally_coupled.i'
       cli_args = 'Kernels/wrong_index/type=CoupledForceWrongIndex Kernels/wrong_index/variable=u '
                  'Kernels/wrong_index/access_value=false'
-      expect_err = 'v: component 2 is out of range for this variable \(max 1\)'
+      expect_err = 'component 2 is out of range for this variable \(max 1\)'
 
       detail = "accessed by index."
     []

--- a/unit/files/InputParametersTest/simple_input.i
+++ b/unit/files/InputParametersTest/simple_input.i
@@ -1,0 +1,3 @@
+[object]
+  file = ../foo
+[]

--- a/unit/include/JSONReaderTest.h
+++ b/unit/include/JSONReaderTest.h
@@ -1,0 +1,18 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseObjectUnitTest.h"
+
+class JSONReaderTest : public MooseObjectUnitTest
+{
+public:
+  JSONReaderTest() : MooseObjectUnitTest("MooseUnitApp") {}
+};

--- a/unit/include/ParsedFunctionTest.h
+++ b/unit/include/ParsedFunctionTest.h
@@ -9,55 +9,21 @@
 
 #pragma once
 
-#include "gtest_include.h"
+#include "MooseObjectUnitTest.h"
 
-#include "InputParameters.h"
-#include "MooseParsedFunction.h"
-#include "FEProblem.h"
-#include "MooseUnitApp.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
 #include "MooseParsedFunctionWrapper.h"
-#include "MooseMain.h"
 
-class ParsedFunctionTest : public ::testing::Test
+class MooseParsedFunction;
+
+class ParsedFunctionTest : public MooseObjectUnitTest
 {
+public:
+  ParsedFunctionTest() : MooseObjectUnitTest("MooseUnitApp") {}
+
 protected:
-  void SetUp()
-  {
-    const char * argv[2] = {"foo", "\0"};
+  ParsedFunction<Real> * fptr(MooseParsedFunction & f);
+  InputParameters getParams();
+  MooseParsedFunction & buildFunction(InputParameters & params);
 
-    _app = Moose::createMooseApp("MooseUnitApp", 1, (char **)argv);
-
-    _factory = &_app->getFactory();
-
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("_object_name") = "mesh";
-    mesh_params.set<std::string>("_type") = "GneratedMesh";
-    mesh_params.set<unsigned int>("nx") = 2;
-    mesh_params.set<unsigned int>("ny") = 2;
-    mesh_params.set<unsigned int>("nz") = 2;
-    mesh_params.set<MooseEnum>("parallel_type") = "REPLICATED";
-
-    _mesh = std::make_unique<GeneratedMesh>(mesh_params);
-    _mesh->setMeshBase(_mesh->buildMeshBaseObject());
-    _mesh->buildMesh();
-
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "FEProblem";
-    problem_params.set<std::string>("_type") = "FEProblem";
-    _fe_problem = std::make_unique<FEProblem>(problem_params);
-  }
-
-  ParsedFunction<Real> * fptr(MooseParsedFunction & f)
-  {
-    return f._function_ptr->_function_ptr.get();
-  }
-
-  std::shared_ptr<MooseApp> _app;
-  std::unique_ptr<MooseMesh> _mesh;
-  std::unique_ptr<FEProblem> _fe_problem;
-  Factory * _factory;
+  unsigned int function_index = 0;
 };

--- a/unit/include/PositionsTest.h
+++ b/unit/include/PositionsTest.h
@@ -1,0 +1,18 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseObjectUnitTest.h"
+
+class PositionsTest : public MooseObjectUnitTest
+{
+public:
+  PositionsTest() : MooseObjectUnitTest("MooseUnitApp") {}
+};

--- a/unit/include/TimesTest.h
+++ b/unit/include/TimesTest.h
@@ -1,0 +1,18 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseObjectUnitTest.h"
+
+class TimesTest : public MooseObjectUnitTest
+{
+public:
+  TimesTest() : MooseObjectUnitTest("MooseUnitApp") {}
+};

--- a/unit/src/InputParameterWarehouseTest.C
+++ b/unit/src/InputParameterWarehouseTest.C
@@ -7,11 +7,11 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#include "gtest/gtest.h"
+#include "InputParameterWarehouseTest.h"
 #include "InputParameterWarehouse.h"
 #include "InputParameters.h"
 
-TEST(InputParameterWarehouse, getControllableItems)
+TEST(InputParameterWarehouseTest, getControllableItems)
 {
   // One item
   {
@@ -21,7 +21,7 @@ TEST(InputParameterWarehouse, getControllableItems)
     in_params.declareControllable("control");
 
     InputParameterWarehouse wh;
-    const InputParameters & params = wh.addInputParameters("Object", in_params);
+    const InputParameters & params = wh.addInputParameters("Object", in_params, 0, {});
 
     MooseObjectParameterName name("Base", "Object", "control");
     auto items = wh.getControllableItems(name);
@@ -47,7 +47,7 @@ TEST(InputParameterWarehouse, getControllableItems)
     in_params.declareControllable("control control2");
 
     InputParameterWarehouse wh;
-    const InputParameters & params = wh.addInputParameters("Object", in_params);
+    const InputParameters & params = wh.addInputParameters("Object", in_params, 0, {});
 
     MooseObjectParameterName name("Base", "Object", "*");
     auto items = wh.getControllableItems(name);
@@ -70,7 +70,7 @@ TEST(InputParameterWarehouse, getControllableItems)
   }
 }
 
-TEST(InputParameterWarehouse, getControllableParameter)
+TEST(InputParameterWarehouseTest, getControllableParameter)
 {
   InputParameters in_params = emptyInputParameters();
   in_params.addPrivateParam<std::string>("_moose_base", "Base");
@@ -80,7 +80,7 @@ TEST(InputParameterWarehouse, getControllableParameter)
   in_params.declareControllable("control control2");
 
   InputParameterWarehouse wh;
-  const InputParameters & params = wh.addInputParameters("Object", in_params);
+  const InputParameters & params = wh.addInputParameters("Object", in_params, 0, {});
 
   MooseObjectParameterName name("Base", "Object", "*");
   auto cp = wh.getControllableParameter(name);
@@ -97,7 +97,7 @@ TEST(InputParameterWarehouse, getControllableParameter)
   EXPECT_EQ(params.get<int>("control2"), 2009);
 }
 
-TEST(InputParameterWarehouse, getControllableParameterValues)
+TEST(InputParameterWarehouseTest, getControllableParameterValues)
 {
   InputParameters in_params = emptyInputParameters();
   in_params.addPrivateParam<std::string>("_moose_base", "Base");
@@ -105,7 +105,7 @@ TEST(InputParameterWarehouse, getControllableParameterValues)
   in_params.declareControllable("control");
 
   InputParameterWarehouse wh;
-  wh.addInputParameters("Object", in_params);
+  wh.addInputParameters("Object", in_params, 0, {});
 
   MooseObjectParameterName name("Base", "Object", "*");
   std::vector<int> values = wh.getControllableParameterValues<int>(name);
@@ -114,7 +114,7 @@ TEST(InputParameterWarehouse, getControllableParameterValues)
   EXPECT_EQ(values, std::vector<int>(1, 2011));
 }
 
-TEST(InputParameterWarehouse, emptyControllableParameterValues)
+TEST(InputParameterWarehouseTest, emptyControllableParameterValues)
 {
   InputParameters in_params = emptyInputParameters();
   in_params.addPrivateParam<std::string>("_moose_base", "Base");
@@ -122,7 +122,7 @@ TEST(InputParameterWarehouse, emptyControllableParameterValues)
   in_params.declareControllable("control");
 
   InputParameterWarehouse wh;
-  wh.addInputParameters("Object", in_params);
+  wh.addInputParameters("Object", in_params, 0, {});
 
   MooseObjectParameterName name("Base", "Object", "asdf");
   std::vector<int> values = wh.getControllableParameterValues<int>(name);
@@ -130,7 +130,7 @@ TEST(InputParameterWarehouse, emptyControllableParameterValues)
   ASSERT_TRUE(values.empty());
 }
 
-TEST(InputParameterWarehouse, addControllableParameterConnection)
+TEST(InputParameterWarehouseTest, addControllableParameterConnection)
 {
   // One-to-one
   {
@@ -140,9 +140,9 @@ TEST(InputParameterWarehouse, addControllableParameterConnection)
     in_params.declareControllable("control");
 
     InputParameterWarehouse wh;
-    const InputParameters & params0 = wh.addInputParameters("Object0", in_params);
+    const InputParameters & params0 = wh.addInputParameters("Object0", in_params, 0, {});
     in_params.set<int>("control") = 1954;
-    const InputParameters & params1 = wh.addInputParameters("Object1", in_params);
+    const InputParameters & params1 = wh.addInputParameters("Object1", in_params, 0, {});
 
     MooseObjectParameterName name0("Base", "Object0", "control");
     MooseObjectParameterName name1("Base", "Object1", "control");
@@ -170,13 +170,13 @@ TEST(InputParameterWarehouse, addControllableParameterConnection)
     in_params.declareControllable("control");
 
     InputParameterWarehouse wh;
-    const InputParameters & params0 = wh.addInputParameters("Object0", in_params);
+    const InputParameters & params0 = wh.addInputParameters("Object0", in_params, 0, {});
 
     in_params.set<int>("control") = 2011;
     in_params.set<std::string>("_moose_base") = "Base2";
-    const InputParameters & params1 = wh.addInputParameters("Object1", in_params);
+    const InputParameters & params1 = wh.addInputParameters("Object1", in_params, 0, {});
     in_params.set<int>("control") = 2013;
-    const InputParameters & params2 = wh.addInputParameters("Object2", in_params);
+    const InputParameters & params2 = wh.addInputParameters("Object2", in_params, 0, {});
 
     MooseObjectParameterName name0("Base", "Object0", "control");
     MooseObjectParameterName name1("Base2", "*", "control");
@@ -209,13 +209,13 @@ TEST(InputParameterWarehouse, addControllableParameterConnection)
     in_params.declareControllable("control");
 
     InputParameterWarehouse wh;
-    const InputParameters & params0 = wh.addInputParameters("Object0", in_params);
+    const InputParameters & params0 = wh.addInputParameters("Object0", in_params, 0, {});
 
     in_params.set<int>("control") = 2011;
     in_params.set<std::string>("_moose_base") = "Base2";
-    const InputParameters & params1 = wh.addInputParameters("Object1", in_params);
+    const InputParameters & params1 = wh.addInputParameters("Object1", in_params, 0, {});
     in_params.set<int>("control") = 2013;
-    const InputParameters & params2 = wh.addInputParameters("Object2", in_params);
+    const InputParameters & params2 = wh.addInputParameters("Object2", in_params, 0, {});
 
     MooseObjectParameterName name0("Base", "Object0", "control");
     MooseObjectParameterName name1("Base2", "Object1", "control");
@@ -275,15 +275,15 @@ TEST(InputParameterWarehouse, addControllableParameterConnection)
     in_params.declareControllable("control");
 
     InputParameterWarehouse wh;
-    const InputParameters & params0 = wh.addInputParameters("Object0", in_params);
+    const InputParameters & params0 = wh.addInputParameters("Object0", in_params, 0, {});
     in_params.addParam<int>("control", 1954, "");
-    const InputParameters & params1 = wh.addInputParameters("Object1", in_params);
+    const InputParameters & params1 = wh.addInputParameters("Object1", in_params, 0, {});
 
     in_params.set<int>("control") = 2011;
     in_params.set<std::string>("_moose_base") = "Base2";
-    const InputParameters & params2 = wh.addInputParameters("Object2", in_params);
+    const InputParameters & params2 = wh.addInputParameters("Object2", in_params, 0, {});
     in_params.set<int>("control") = 2013;
-    const InputParameters & params3 = wh.addInputParameters("Object3", in_params);
+    const InputParameters & params3 = wh.addInputParameters("Object3", in_params, 0, {});
 
     MooseObjectParameterName name0("Base", "Object0", "control");
     MooseObjectParameterName name1("Base", "Object1", "control");
@@ -395,7 +395,7 @@ TEST(InputParameterWarehouse, addControllableParameterConnection)
   }
 }
 
-TEST(InputParameterWarehouse, addControllableParameterAlias)
+TEST(InputParameterWarehouseTest, addControllableParameterAlias)
 {
   InputParameters in_params = emptyInputParameters();
   in_params.addPrivateParam<std::string>("_moose_base", "Base");
@@ -403,7 +403,7 @@ TEST(InputParameterWarehouse, addControllableParameterAlias)
   in_params.declareControllable("control");
 
   InputParameterWarehouse wh;
-  const InputParameters & params = wh.addInputParameters("Object", in_params);
+  const InputParameters & params = wh.addInputParameters("Object", in_params, 0, {});
 
   MooseObjectParameterName alias("not", "a", "param");
   MooseObjectParameterName secondary("Base", "Object", "control");

--- a/unit/src/InputParameterWarehouseTest.C
+++ b/unit/src/InputParameterWarehouseTest.C
@@ -7,7 +7,6 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#include "InputParameterWarehouseTest.h"
 #include "InputParameterWarehouse.h"
 #include "InputParameters.h"
 

--- a/unit/src/InputParametersTest.C
+++ b/unit/src/InputParametersTest.C
@@ -7,14 +7,15 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-// MOOSE includes
+#include "gtest/gtest.h"
+
 #include "InputParameters.h"
 #include "MooseEnum.h"
 #include "MultiMooseEnum.h"
 #include "Conversion.h"
-#include "gtest/gtest.h"
+#include "Parser.h"
 
-TEST(InputParameters, checkControlParamPrivateError)
+TEST(InputParametersTest, checkControlParamPrivateError)
 {
   try
   {
@@ -35,7 +36,7 @@ TEST(InputParameters, checkControlParamPrivateError)
 // This tests for the bug https://github.com/idaholab/moose/issues/8586.
 // It makes sure that range-checked input file parameters comparison functions
 // do absolute floating point comparisons instead of using a default epsilon.
-TEST(InputParameters, checkRangeCheckedParam)
+TEST(InputParametersTest, checkRangeCheckedParam)
 {
   try
   {
@@ -52,7 +53,7 @@ TEST(InputParameters, checkRangeCheckedParam)
   }
 }
 
-TEST(InputParameters, checkControlParamTypeError)
+TEST(InputParametersTest, checkControlParamTypeError)
 {
   try
   {
@@ -70,7 +71,7 @@ TEST(InputParameters, checkControlParamTypeError)
   }
 }
 
-TEST(InputParameters, checkControlParamValidError)
+TEST(InputParametersTest, checkControlParamValidError)
 {
   try
   {
@@ -87,7 +88,7 @@ TEST(InputParameters, checkControlParamValidError)
   }
 }
 
-TEST(InputParameters, checkSuppressedError)
+TEST(InputParametersTest, checkSuppressedError)
 {
   try
   {
@@ -103,7 +104,7 @@ TEST(InputParameters, checkSuppressedError)
   }
 }
 
-TEST(InputParameters, checkSuppressingControllableParam)
+TEST(InputParametersTest, checkSuppressingControllableParam)
 {
   InputParameters params = emptyInputParameters();
   params.addParam<bool>("b", "Controllable boolean");
@@ -115,7 +116,7 @@ TEST(InputParameters, checkSuppressingControllableParam)
   ASSERT_TRUE(params.isControllable("b") == false);
 }
 
-TEST(InputParameters, checkSetDocString)
+TEST(InputParametersTest, checkSetDocString)
 {
   InputParameters params = emptyInputParameters();
   params.addParam<Real>("little_guy", "What about that little guy?");
@@ -126,7 +127,7 @@ TEST(InputParameters, checkSetDocString)
       << "retrieved doc string has unexpected value '" << params.getDocString("little_guy") << "'";
 }
 
-TEST(InputParameters, checkSetDocStringError)
+TEST(InputParametersTest, checkSetDocStringError)
 {
   try
   {
@@ -161,14 +162,14 @@ testBadParamName(const std::string & name)
 }
 
 /// Just make sure we don't allow invalid parameter names
-TEST(InputParameters, checkParamName)
+TEST(InputParametersTest, checkParamName)
 {
   testBadParamName("p 0");
   testBadParamName("p-0");
   testBadParamName("p!0");
 }
 
-TEST(InputParameters, applyParameter)
+TEST(InputParametersTest, applyParameter)
 {
   InputParameters p1 = emptyInputParameters();
   p1.addParam<MultiMooseEnum>("enum", MultiMooseEnum("foo=0 bar=1", "foo"), "testing");
@@ -183,7 +184,7 @@ TEST(InputParameters, applyParameter)
   EXPECT_TRUE(p1.get<MultiMooseEnum>("enum").contains("bar"));
 }
 
-TEST(InputParameters, applyParametersVector)
+TEST(InputParametersTest, applyParametersVector)
 {
   MooseEnum types("foo bar");
 
@@ -204,7 +205,7 @@ TEST(InputParameters, applyParametersVector)
   EXPECT_TRUE(p1.get<std::vector<MooseEnum>>("enum")[0] == "bar");
 }
 
-TEST(InputParameters, applyParameters)
+TEST(InputParametersTest, applyParameters)
 {
   // First enum
   InputParameters p1 = emptyInputParameters();
@@ -241,7 +242,7 @@ TEST(InputParameters, applyParameters)
   EXPECT_TRUE(p1.get<MultiMooseEnum>("enum").contains("foo"));
 }
 
-TEST(InputParameters, applyParametersPrivateOverride)
+TEST(InputParametersTest, applyParametersPrivateOverride)
 {
   InputParameters p1 = emptyInputParameters();
   p1.addPrivateParam<bool>("_flag", true);
@@ -255,7 +256,7 @@ TEST(InputParameters, applyParametersPrivateOverride)
   EXPECT_FALSE(p1.get<bool>("_flag"));
 }
 
-TEST(InputParameters, makeParamRequired)
+TEST(InputParametersTest, makeParamRequired)
 {
   InputParameters params = emptyInputParameters();
   params.addParam<Real>("good_param", "documentation");
@@ -295,7 +296,7 @@ TEST(InputParameters, makeParamRequired)
   }
 }
 
-TEST(InputParameters, setPPandVofPP)
+TEST(InputParametersTest, setPPandVofPP)
 {
   // programmatically set default value of PPName parameter
   InputParameters p1 = emptyInputParameters();
@@ -325,7 +326,7 @@ TEST(InputParameters, setPPandVofPP)
   // EXPECT_EQ(p1.getDefaultPostprocessorValue("pp_name"), 1);
 }
 
-TEST(InputParameters, getPairs)
+TEST(InputParametersTest, getPairs)
 {
   std::vector<std::string> num_words{"zero", "one", "two", "three"};
 
@@ -342,7 +343,7 @@ TEST(InputParameters, getPairs)
   }
 }
 
-TEST(InputParameters, getMultiMooseEnumPairs)
+TEST(InputParametersTest, getMultiMooseEnumPairs)
 {
   std::vector<std::string> v1{"zero", "one", "two", "three"};
   auto s1 = Moose::stringify(v1, " ");
@@ -362,7 +363,7 @@ TEST(InputParameters, getMultiMooseEnumPairs)
   }
 }
 
-TEST(InputParameters, getPairLength)
+TEST(InputParametersTest, getPairLength)
 {
   std::vector<std::string> num_words{"zero", "one", "two"};
 
@@ -386,7 +387,7 @@ TEST(InputParameters, getPairLength)
   }
 }
 
-TEST(InputParameters, getControllablePairs)
+TEST(InputParametersTest, getControllablePairs)
 {
   std::vector<std::string> num_words{"zero", "one", "two", "three"};
 
@@ -412,7 +413,7 @@ TEST(InputParameters, getControllablePairs)
   }
 }
 
-TEST(InputParameters, getParamList)
+TEST(InputParametersTest, getParamList)
 {
   std::vector<std::string> num_words{"zero", "one", "two", "three"};
 
@@ -424,7 +425,7 @@ TEST(InputParameters, getParamList)
   EXPECT_EQ(p.getParametersList(), param_list);
 }
 
-TEST(InputParameters, transferParameters)
+TEST(InputParametersTest, transferParameters)
 {
   // Add parameters of various types to p1
   InputParameters p1 = emptyInputParameters();
@@ -531,7 +532,7 @@ TEST(InputParameters, transferParameters)
   EXPECT_EQ(p1.getDocString("od3b"), p2.getDocString("od3b"));
 }
 
-TEST(InputParameters, noDefaultValueError)
+TEST(InputParametersTest, noDefaultValueError)
 {
   InputParameters params = emptyInputParameters();
   params.addParam<Real>("dummy_real", "a dummy real");
@@ -564,4 +565,183 @@ TEST(InputParameters, noDefaultValueError)
                 std::string::npos)
         << "Failed with unexpected error message: " << msg;
   }
+}
+
+TEST(InputParametersTest, fileNames)
+{
+  // Walker that kind-of does what the Builder does: walks parameters and sets input
+  // parameters. In this case, we only care about the objects that we've declared
+  // and their "file" parameter.
+  //
+  // I chose to do this like this because it means that these tests don't rely
+  // on an application at all, so we're relying on the basic capability
+  class ExtractWalker : public hit::Walker
+  {
+  public:
+    ExtractWalker(std::map<std::string, std::unique_ptr<InputParameters>> & object_params)
+      : _object_params(object_params)
+    {
+    }
+    virtual void walk(const std::string &, const std::string &, hit::Node * n) override
+    {
+      if (auto it = _object_params.find(n->path()); it != _object_params.end())
+      {
+        auto & params = *it->second;
+        params.setHitNode(*n, {});
+        if (const auto node = n->find("file"))
+        {
+          params.setHitNode("file", *node, {});
+          params.set_attributes("file", false);
+          params.set<FileName>("file") = node->strVal();
+        }
+      }
+    }
+
+  private:
+    std::map<std::string, std::unique_ptr<InputParameters>> & _object_params;
+  };
+
+  // Runs a test.
+  // inputs: map of filename -> input text
+  // expected_values: map of object name -> the relative path we expect
+  // cli_args: any cli args to add
+  auto run_test = [](const std::map<std::string, std::string> & inputs,
+                     const std::map<std::string, std::string> & expected_values,
+                     const std::vector<std::string> & cli_args = {})
+  {
+    std::vector<std::string> filenames, input_text;
+    for (const auto & [filename, text] : inputs)
+    {
+      filenames.push_back(filename);
+      input_text.push_back(text);
+    }
+
+    // Parse the inputs
+    Parser parser(filenames, input_text);
+    parser.parse();
+
+    // Merge in the command line arguments, if any
+    std::string cli_hit;
+    for (const auto & value : cli_args)
+      cli_hit += value + "\n";
+    if (cli_hit.size())
+    {
+      auto cli_root = hit::parse("CLI_ARGS", cli_hit);
+      hit::explode(cli_root);
+      hit::merge(cli_root, parser.root());
+      delete cli_root;
+    }
+
+    // Define the parameters that we care about
+    InputParameters base_params = emptyInputParameters();
+    base_params.addParam<FileName>("file", "file name");
+
+    // Initialize the params for each object
+    std::map<std::string, std::unique_ptr<InputParameters>> object_params;
+    for (const auto & object_values_pair : expected_values)
+    {
+      const auto & object_name = object_values_pair.first;
+      auto params = std::make_unique<InputParameters>(base_params);
+      object_params.emplace(object_name, std::move(params));
+    }
+
+    // Fill the object parameters from the input
+    ExtractWalker ew(object_params);
+    parser.root()->walk(&ew, hit::NodeType::Section);
+
+    // Finalize the parameters, which sets the filep aths
+    for (auto & name_params_pair : object_params)
+      name_params_pair.second->finalize("");
+
+    // Check all of the values that we expect
+    for (const auto & [object_name, expected_value] : expected_values)
+    {
+      const auto & params = *object_params.at(object_name);
+      const std::string file = params.get<FileName>("file");
+      const std::filesystem::path file_path(file);
+
+      if (file.size())
+      {
+        EXPECT_TRUE(file_path.is_absolute());
+      }
+      if (expected_value.size())
+      {
+        const auto relative = std::string(std::filesystem::proximate(file));
+        EXPECT_EQ(relative, expected_value);
+      }
+      else
+      {
+        EXPECT_TRUE(file.empty());
+      }
+    }
+  };
+
+  const auto include_files_path = std::filesystem::path(std::string(__FILE__)).parent_path() /
+                                  std::filesystem::path("../files/InputParametersTest");
+  const auto include_file = [&include_files_path](const auto & filename)
+  { return std::string((include_files_path / std::filesystem::path(filename)).c_str()); };
+  const auto relative_include_file = [&include_files_path](const auto & filename)
+  {
+    return std::string(
+        std::filesystem::proximate(include_files_path / std::filesystem::path(filename)).c_str());
+  };
+
+  // const std::filesystem
+  // One input file, same directory
+  // main.i:
+  // [object1]
+  //   file = value
+  // []
+  //
+  // object1:
+  //   file: ./value
+  run_test({{"main.i", "object1/file=value"}}, {{"object1", "value"}});
+
+  // Three input files: cwd, behind a directory, and ahead a directory
+  // main.i:
+  //   main/file=main
+  // ../behind.i:
+  //   behind/file=behind
+  // ahead/ahead.i:
+  //   ahead/file=ahead
+  //
+  // main: ./main
+  // behind: ../behind/behind
+  // ahead: ./ahead/ahead
+  run_test({{"main.i", "main/file=main"},
+            {"../behind.i", "behind/file=behind"},
+            {"ahead/ahead.i", "ahead/file=ahead"}},
+           {{"main", "main"}, {"behind", "../behind"}, {"ahead", "ahead/ahead"}});
+
+  // Two input files in different directories, with no file parameters. But, one
+  // of the input files (in a different directory) has the section only for the object
+  // that takes file parameters. The file is then applied via command line arguments
+  // and the context should be taken from the parent section (defined in the input
+  // in another folder)
+  // main.i:
+  //   unused=unused
+  // ./ahead/ahead.i:
+  //   [object]
+  //   []
+  // CLI args:
+  //   object/file=foo
+  //
+  // object: ./ahead/foo
+  run_test({{"main.i", "unused=unused"}, {"./ahead/ahead.i", "[object][]"}},
+           {{"object", "ahead/foo"}},
+           {"object/file=foo"});
+
+  // Single input in a different directory with no contents, but will store the root
+  // in a different folder and all files should be applied to that folder
+  // ../../main.i:
+  //   unused=unused
+  // CLI args:
+  //   object/file=foo
+  //
+  // object: ../../foo
+  run_test({{"../../main.i", "unused=unused"}}, {{"object", "../../foo"}}, {"object/file=foo"});
+
+  // Input with an include in a different directory
+  run_test({{"../main.i", "!include " + include_file("simple_input.i")}},
+           {{"object", relative_include_file("../foo")}});
 }

--- a/unit/src/MooseServerTest.C
+++ b/unit/src/MooseServerTest.C
@@ -542,7 +542,8 @@ TEST_F(MooseServerTest, DocumentOpenAndDiagnostics)
   wasp::DataObject diagnostics_notification;
 
   EXPECT_TRUE(
-      moose_server->handleDidOpenNotification(didopen_notification, diagnostics_notification));
+      moose_server->handleDidOpenNotification(didopen_notification, diagnostics_notification))
+      << moose_server->getErrors();
 
   EXPECT_TRUE(moose_server->getErrors().empty());
 

--- a/unit/src/ParsedFunctionTest.C
+++ b/unit/src/ParsedFunctionTest.C
@@ -9,21 +9,43 @@
 
 #include "ParsedFunctionTest.h"
 #include "MathFVUtils.h"
+#include "MooseParsedFunction.h"
 
 #include "libmesh/fe_map.h"
 #include "libmesh/quadrature_gauss.h"
 
-TEST_F(ParsedFunctionTest, basicConstructor)
+ParsedFunction<Real> *
+ParsedFunctionTest::fptr(MooseParsedFunction & f)
 {
-  InputParameters params = _factory->getValidParams("ParsedFunction");
+  return f._function_ptr->_function_ptr.get();
+}
+
+InputParameters
+ParsedFunctionTest::getParams()
+{
+  InputParameters params = _factory.getValidParams("ParsedFunction");
   // test constructor with no additional variables
   params.set<FEProblem *>("_fe_problem") = _fe_problem.get();
   params.set<FEProblemBase *>("_fe_problem_base") = _fe_problem.get();
-  params.set<SubProblem *>("_subproblem") = _fe_problem.get();
+  return params;
+}
+
+MooseParsedFunction &
+ParsedFunctionTest::buildFunction(InputParameters & params)
+{
+  const std::string name = "test" + std::to_string(function_index++);
+  _fe_problem->addFunction("ParsedFunction", name, params);
+  auto & f = _fe_problem->getFunction(name);
+  auto parsed_f = dynamic_cast<MooseParsedFunction *>(&f);
+  mooseAssert(parsed_f, "Failed to cast");
+  return *parsed_f;
+}
+
+TEST_F(ParsedFunctionTest, basicConstructor)
+{
+  auto params = getParams();
   params.set<std::string>("value") = std::string("x + 1.5*y + 2 * z + t/4");
-  params.set<std::string>("_object_name") = "test";
-  params.set<std::string>("_type") = "MooseParsedFunction";
-  MooseParsedFunction f(params);
+  auto & f = buildFunction(params);
   Moose::Functor<Real> f_wrapped(f);
   f.initialSetup();
   EXPECT_EQ(f.value(4, Point(1, 2, 3)), 11);
@@ -135,19 +157,13 @@ TEST_F(ParsedFunctionTest, advancedConstructor)
   std::vector<std::string> one_var(1);
   one_var[0] = "q";
 
-  InputParameters params = _factory->getValidParams("ParsedFunction");
-
-  params.set<FEProblem *>("_fe_problem") = _fe_problem.get();
-  params.set<FEProblemBase *>("_fe_problem_base") = _fe_problem.get();
-  params.set<SubProblem *>("_subproblem") = _fe_problem.get();
+  auto params = getParams();
   params.set<std::string>("value") = "x + y + q";
   params.set<std::vector<std::string>>("vars") = one_var;
   params.set<std::vector<std::string>>("vals") =
       std::vector<std::string>(1, "-1"); // Dummy value, will be overwritten in test below
-  params.set<std::string>("_object_name") = "test1";
-  params.set<std::string>("_type") = "MooseParsedFunction";
 
-  MooseParsedFunction f(params);
+  auto & f = buildFunction(params);
   f.initialSetup();
   // Access address via pointer to MooseParsedFunctionWrapper that contains pointer to
   // libMesh::ParsedFunction
@@ -161,18 +177,13 @@ TEST_F(ParsedFunctionTest, advancedConstructor)
   three_vars[1] = "w";
   three_vars[2] = "r";
 
-  InputParameters params2 = _factory->getValidParams("ParsedFunction");
-  params2.set<FEProblem *>("_fe_problem") = _fe_problem.get();
-  params2.set<FEProblemBase *>("_fe_problem_base") = _fe_problem.get();
-  params2.set<SubProblem *>("_subproblem") = _fe_problem.get();
+  auto params2 = getParams();
   params2.set<std::string>("value") = "r*x + y/w + q";
   params2.set<std::vector<std::string>>("vars") = three_vars;
   params2.set<std::vector<std::string>>("vals") =
       std::vector<std::string>(3, "-1"); // Dummy values, will be overwritten in test below
-  params2.set<std::string>("_object_name") = "test2";
-  params2.set<std::string>("_type") = "MooseParsedFunction";
 
-  MooseParsedFunction f2(params2);
+  auto & f2 = buildFunction(params2);
   f2.initialSetup();
   fptr(f2)->getVarAddress("q") = 4;
   fptr(f2)->getVarAddress("w") = 2;
@@ -184,17 +195,12 @@ TEST_F(ParsedFunctionTest, advancedConstructor)
   std::vector<std::string> one_val(1);
   one_val[0] = "2.5";
 
-  InputParameters params3 = _factory->getValidParams("ParsedFunction");
-  params3.set<FEProblem *>("_fe_problem") = _fe_problem.get();
-  params3.set<FEProblemBase *>("_fe_problem_base") = _fe_problem.get();
-  params3.set<SubProblem *>("_subproblem") = _fe_problem.get();
+  auto params3 = getParams();
   params3.set<std::string>("value") = "q*x";
   params3.set<std::vector<std::string>>("vars") = one_var;
   params3.set<std::vector<std::string>>("vals") = one_val;
-  params3.set<std::string>("_object_name") = "test3";
-  params3.set<std::string>("_type") = "MooseParsedFunction";
 
-  MooseParsedFunction f3(params3);
+  auto & f3 = buildFunction(params3);
   f3.initialSetup();
   EXPECT_EQ(f3.value(0, 2), 5);
 
@@ -204,17 +210,12 @@ TEST_F(ParsedFunctionTest, advancedConstructor)
   three_vals[1] = "1";
   three_vals[2] = "0";
 
-  InputParameters params4 = _factory->getValidParams("ParsedFunction");
-  params4.set<FEProblem *>("_fe_problem") = _fe_problem.get();
-  params4.set<FEProblemBase *>("_fe_problem_base") = _fe_problem.get();
-  params4.set<SubProblem *>("_subproblem") = _fe_problem.get();
+  auto params4 = getParams();
   params4.set<std::string>("value") = "q*x + y/r + w";
   params4.set<std::vector<std::string>>("vars") = three_vars;
   params4.set<std::vector<std::string>>("vals") = three_vals;
-  params4.set<std::string>("_object_name") = "test4";
-  params4.set<std::string>("_type") = "MooseParsedFunction";
 
-  MooseParsedFunction f4(params4);
+  auto & f4 = buildFunction(params4);
   f4.initialSetup();
   fptr(f4)->getVarAddress("r") = 2;
   EXPECT_EQ(f4.value(0, Point(2, 4)), 6);
@@ -231,18 +232,13 @@ TEST_F(ParsedFunctionTest, testVariables)
   std::vector<std::string> one_var(1);
   one_var[0] = "q";
 
-  InputParameters params = _factory->getValidParams("ParsedFunction");
-  params.set<FEProblem *>("_fe_problem") = _fe_problem.get();
-  params.set<FEProblemBase *>("_fe_problem_base") = _fe_problem.get();
-  params.set<SubProblem *>("_subproblem") = _fe_problem.get();
+  auto params = getParams();
   params.set<std::string>("value") = "x + y + q";
   params.set<std::vector<std::string>>("vars") = one_var;
   params.set<std::vector<std::string>>("vals") =
       std::vector<std::string>(1, "-1"); // Dummy value, will be overwritten in test below
-  params.set<std::string>("_object_name") = "test1";
-  params.set<std::string>("_type") = "MooseParsedFunction";
 
-  MooseParsedFunction f(params);
+  auto & f = buildFunction(params);
   f.initialSetup();
   Real & q = fptr(f)->getVarAddress("q");
   q = 4;
@@ -261,18 +257,13 @@ TEST_F(ParsedFunctionTest, testVariables)
   three_vars[1] = "w";
   three_vars[2] = "r";
 
-  InputParameters params2 = _factory->getValidParams("ParsedFunction");
-  params2.set<FEProblem *>("_fe_problem") = _fe_problem.get();
-  params2.set<FEProblemBase *>("_fe_problem_base") = _fe_problem.get();
-  params2.set<SubProblem *>("_subproblem") = _fe_problem.get();
+  auto params2 = getParams();
   params2.set<std::string>("value") = "r*x + y/w + q";
   params2.set<std::vector<std::string>>("vars") = three_vars;
   params2.set<std::vector<std::string>>("vals") =
       std::vector<std::string>(3, "-1"); // Dummy values, will be overwritten in test below
-  params2.set<std::string>("_object_name") = "test2";
-  params2.set<std::string>("_type") = "MooseParsedFunction";
 
-  MooseParsedFunction f2(params2);
+  auto & f2 = buildFunction(params2);
   f2.initialSetup();
   Real & q2 = fptr(f2)->getVarAddress("q");
   Real & w2 = fptr(f2)->getVarAddress("w");
@@ -295,27 +286,17 @@ TEST_F(ParsedFunctionTest, testConstants)
 {
   // this functions tests that pi and e get correctly substituted
   // it also tests built in functions of the function parser
-  InputParameters params = _factory->getValidParams("ParsedFunction");
-  params.set<std::string>("_object_name") = "test1";
-  params.set<FEProblem *>("_fe_problem") = _fe_problem.get();
-  params.set<FEProblemBase *>("_fe_problem_base") = _fe_problem.get();
-  params.set<SubProblem *>("_subproblem") = _fe_problem.get();
+  auto params = getParams();
   params.set<std::string>("value") = "log(e) + x";
-  params.set<std::string>("_type") = "MooseParsedFunction";
 
-  MooseParsedFunction f(params);
+  auto & f = buildFunction(params);
   f.initialSetup();
   EXPECT_NEAR(2, f.value(0, 1), 0.0000001);
 
-  InputParameters params2 = _factory->getValidParams("ParsedFunction");
-  params2.set<std::string>("_object_name") = "test2";
-  params2.set<FEProblem *>("_fe_problem") = _fe_problem.get();
-  params2.set<FEProblemBase *>("_fe_problem_base") = _fe_problem.get();
-  params2.set<SubProblem *>("_subproblem") = _fe_problem.get();
+  auto params2 = getParams();
   params2.set<std::string>("value") = "sin(pi*x)";
-  params2.set<std::string>("_type") = "MooseParsedFunction";
 
-  MooseParsedFunction f2(params2);
+  auto & f2 = buildFunction(params2);
   f2.initialSetup();
   EXPECT_NEAR(0, f2.value(0, 1), 0.0000001);
   EXPECT_NEAR(1, f2.value(0, 0.5), 0.0000001);

--- a/unit/src/PositionsTest.C
+++ b/unit/src/PositionsTest.C
@@ -8,33 +8,17 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "gtest/gtest.h"
-#include "MultiAppPositions.h"
-#include "InputPositions.h"
-#include "AppFactory.h"
-#include "Executioner.h"
-#include "MooseMain.h"
 
-TEST(Positions, getUninitialized)
+#include "PositionsTest.h"
+#include "Positions.h"
+
+TEST_F(PositionsTest, getUninitialized)
 {
-  // Create a minimal app that can create objects
-  const char * argv[2] = {"foo", "\0"};
-  const auto & app = Moose::createMooseApp("MooseUnitApp", 1, (char **)argv);
-  const auto & factory = &app->getFactory();
-  app->parameters().set<bool>("minimal") = true;
-  app->run();
-  Executioner * exec = app->getExecutioner();
-  FEProblemBase * fe_problem = &exec->feProblem();
-
   // MultiAppPositions is uninitialized at construction, any other Positions with such
   // behavior would do
-  InputParameters params = factory->getValidParams("MultiAppPositions");
-  params.set<FEProblemBase *>("_fe_problem_base") = fe_problem;
-  params.set<SubProblem *>("_subproblem") = fe_problem;
-  params.set<SystemBase *>("_sys") = &fe_problem->getNonlinearSystemBase(0);
+  InputParameters params = _factory.getValidParams("MultiAppPositions");
   params.set<std::vector<MultiAppName>>("multiapps") = {"m1"};
-  params.set<std::string>("_object_name") = "test";
-  params.set<std::string>("_type") = "MultiAppPositions";
-  MultiAppPositions positions(params);
+  auto & positions = addObject<Positions>("MultiAppPositions", "test", params);
 
   try
   {
@@ -81,26 +65,12 @@ TEST(Positions, getUninitialized)
   }
 }
 
-TEST(Positions, getters)
+TEST_F(PositionsTest, getters)
 {
-  // Create a minimal app that can create objects
-  const char * argv[2] = {"foo", "\0"};
-  const auto & app = Moose::createMooseApp("MooseUnitApp", 1, (char **)argv);
-  const auto & factory = &app->getFactory();
-  app->parameters().set<bool>("minimal") = true;
-  app->run();
-  Executioner * exec = app->getExecutioner();
-  FEProblemBase * fe_problem = &exec->feProblem();
-
-  InputParameters params = factory->getValidParams("InputPositions");
-  params.set<FEProblemBase *>("_fe_problem_base") = fe_problem;
-  params.set<SubProblem *>("_subproblem") = fe_problem;
-  params.set<SystemBase *>("_sys") = &fe_problem->getNonlinearSystemBase(0);
+  InputParameters params = _factory.getValidParams("InputPositions");
   params.set<std::vector<Point>>("positions") = {Point(1, 0, 0), Point(0, 0, 1)};
-  params.set<std::string>("_object_name") = "test";
-  params.set<std::string>("_type") = "InputPositions";
   params.set<bool>("auto_sort") = true;
-  InputPositions positions(params);
+  auto & positions = addObject<Positions>("InputPositions", "test", params);
 
   // Test getters
   EXPECT_EQ(positions.getPositions(false)[0], Point(1, 0, 0));

--- a/unit/src/TimesTest.C
+++ b/unit/src/TimesTest.C
@@ -8,36 +8,20 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "gtest/gtest.h"
-#include "InputTimes.h"
-#include "SimulationTimes.h"
-#include "AppFactory.h"
-#include "Executioner.h"
-#include "MooseMain.h"
 
-TEST(Times, getUninitialized)
+#include "TimesTest.h"
+#include "Times.h"
+
+TEST_F(TimesTest, getUninitialized)
 {
-  // Create a minimal app that can create objects
-  const char * argv[2] = {"foo", "\0"};
-  const auto & app = Moose::createMooseApp("MooseUnitApp", 1, (char **)argv);
-  const auto & factory = &app->getFactory();
-  app->parameters().set<bool>("minimal") = true;
-  app->run();
-  Executioner * exec = app->getExecutioner();
-  FEProblemBase * fe_problem = &exec->feProblem();
-
   // SimulationTimes is uninitialized at construction, any other Times with such
   // behavior would do
-  InputParameters params = factory->getValidParams("SimulationTimes");
-  params.set<FEProblemBase *>("_fe_problem_base") = fe_problem;
-  params.set<SubProblem *>("_subproblem") = fe_problem;
-  params.set<SystemBase *>("_sys") = &fe_problem->getNonlinearSystemBase(0);
-  params.set<std::string>("_object_name") = "test";
-  params.set<std::string>("_type") = "SimulationTimes";
-  SimulationTimes Times(params);
+  InputParameters params = _factory.getValidParams("SimulationTimes");
+  auto & times = addObject<Times>("SimulationTimes", "times", params);
 
   try
   {
-    Times.getTimes();
+    times.getTimes();
     FAIL() << "Missing the expected exception.";
   }
   catch (const std::exception & e)
@@ -47,31 +31,17 @@ TEST(Times, getUninitialized)
   }
 }
 
-TEST(Times, getters)
+TEST_F(TimesTest, getters)
 {
-  // Create a minimal app that can create objects
-  const char * argv[2] = {"foo", "\0"};
-  const auto & app = Moose::createMooseApp("MooseUnitApp", 1, (char **)argv);
-  const auto & factory = &app->getFactory();
-  app->parameters().set<bool>("minimal") = true;
-  app->run();
-  Executioner * exec = app->getExecutioner();
-  FEProblemBase * fe_problem = &exec->feProblem();
-
-  InputParameters params = factory->getValidParams("InputTimes");
-  params.set<FEProblemBase *>("_fe_problem_base") = fe_problem;
-  params.set<SubProblem *>("_subproblem") = fe_problem;
-  params.set<SystemBase *>("_sys") = &fe_problem->getNonlinearSystemBase(0);
+  InputParameters params = _factory.getValidParams("InputTimes");
   params.set<std::vector<Real>>("times") = {0.2, 0.8, 1.2};
-  params.set<std::string>("_object_name") = "test";
-  params.set<std::string>("_type") = "InputTimes";
-  InputTimes Times(params);
+  auto & times = addObject<Times>("InputTimes", "times", params);
 
   // Test getters
-  EXPECT_EQ(Times.getTimes()[0], 0.2);
-  EXPECT_EQ(*Times.getUniqueTimes().begin(), 0.2);
-  EXPECT_EQ(Times.getTimeAtIndex(0), 0.2);
-  EXPECT_EQ(Times.getCurrentTime(), 1);
-  EXPECT_EQ(Times.getPreviousTime(1), 0.8);
-  EXPECT_EQ(Times.getNextTime(1), 1.2);
+  EXPECT_EQ(times.getTimes()[0], 0.2);
+  EXPECT_EQ(*times.getUniqueTimes().begin(), 0.2);
+  EXPECT_EQ(times.getTimeAtIndex(0), 0.2);
+  EXPECT_EQ(times.getCurrentTime(), 0);
+  EXPECT_EQ(times.getPreviousTime(1), 0.8);
+  EXPECT_EQ(times.getNextTime(1), 1.2);
 }


### PR DESCRIPTION
Closes #26947

- For objects created within a non-`MooseObjectAction`, their moose errors are associated with the syntax location for the associated action
- For objects created in any action whose parameters are applied with `applyParameters()` from the action's parameters, `paramError()` within said objects will be linked directly to the action's parameters
- All objects are forced to be created within the `Factory` or `ActionFactory`
- Uses the hit node context to figure out absolute paths for all files

App patches:

- [ ] SAM https://git-nse.egs.anl.gov/SAM/SAM/-/merge_requests/900
- [ ] Griffin https://github.inl.gov/ncrc/griffin/pull/1827
- [x] Pronghorn nonbreaking https://github.inl.gov/ncrc/pronghorn/pull/1257 (good after https://github.com/idaholab/moose/pull/27136 but pronghorn devel is broken)
- [x] Bison nonbreaking https://github.inl.gov/ncrc/bison/pull/5900 (good after https://github.com/idaholab/moose/pull/27136)
- [x] Zapdos https://github.com/shannon-lab/zapdos/pull/240
- [x] Crane https://github.com/lcpp-org/crane/pull/125