### PR TITLE
Miscellaneous fixes for mesh divisions

### DIFF
--- a/framework/src/meshdivisions/CartesianGridDivision.C
+++ b/framework/src/meshdivisions/CartesianGridDivision.C
@@ -105,7 +105,7 @@ CartesianGridDivision::initialize()
     // Note that if the positions are not co-planar, the distance reported would be bigger but there
     // could still be an overlap. Looking at min_center_dist is not enough
     if (MooseUtils::absoluteFuzzyGreaterThan(min_dist, min_center_dist))
-      mooseError(
+      mooseWarning(
           "Cartesian grids centered on the positions are too close to each other (min distance: ",
           min_center_dist,
           "), closer than the extent of each grid. Mesh division is ill-defined");
@@ -148,7 +148,7 @@ CartesianGridDivision::divisionIndex(const Point & pt) const
     // look at the relative position of the point compared to that position
     const bool initial = _fe_problem->getCurrentExecuteOnFlag() == EXEC_INITIAL;
     const auto nearest_grid_center_index = _center_positions->getNearestPositionIndex(pt, initial);
-    offset = nearest_grid_center_index * getNumDivisions();
+    offset = nearest_grid_center_index * _nx * _ny * _nz;
     const auto nearest_grid_center =
         _center_positions->getPosition(nearest_grid_center_index, initial);
     bottom_left = -_widths / 2;

--- a/framework/src/meshdivisions/CylindricalGridDivision.C
+++ b/framework/src/meshdivisions/CylindricalGridDivision.C
@@ -130,7 +130,7 @@ CylindricalGridDivision::initialize()
     // Note that if the positions are not co-planar, the distance reported would be bigger but there
     // could still be an overlap. Looking at min_center_dist is not enough
     if (MooseUtils::absoluteFuzzyGreaterThan(min_dist, min_center_dist))
-      mooseError(
+      mooseWarning(
           "Cylindrical grids centered on the positions are too close to each other (min distance: ",
           min_center_dist,
           "), closer than the radial extent of each grid. Mesh division is ill-defined");
@@ -167,7 +167,7 @@ CylindricalGridDivision::divisionIndex(const Point & pt) const
     // If dividing using positions, find the closest position
     const bool initial = _fe_problem->getCurrentExecuteOnFlag() == EXEC_INITIAL;
     const auto nearest_center_index = _center_positions->getNearestPositionIndex(pt, initial);
-    offset = nearest_center_index * getNumDivisions();
+    offset = nearest_center_index * _n_radial * _n_azim * _n_axial;
     const auto new_center = _center_positions->getPosition(nearest_center_index, initial);
     pc(2) = (pt - new_center) * _direction;
     in_plane = (pt - new_center) - pc(2) * _direction;

--- a/framework/src/meshdivisions/SphericalGridDivision.C
+++ b/framework/src/meshdivisions/SphericalGridDivision.C
@@ -87,7 +87,7 @@ SphericalGridDivision::initialize()
     // Note that if the positions are not co-planar, the distance reported would be bigger but there
     // could still be an overlap. Looking at min_center_dist is not enough
     if (MooseUtils::absoluteFuzzyGreaterThan(min_dist, min_center_dist))
-      mooseError(
+      mooseWarning(
           "Spherical grids centered on the positions are too close to each other (min distance: ",
           min_center_dist,
           "), closer than the radial extent of each grid. Mesh division is ill-defined");
@@ -120,7 +120,7 @@ SphericalGridDivision::divisionIndex(const Point & pt) const
     // If distributing using positions, find the closest position
     const bool initial = _fe_problem->getCurrentExecuteOnFlag() == EXEC_INITIAL;
     const auto nearest_center_index = _center_positions->getNearestPositionIndex(pt, initial);
-    offset = nearest_center_index * getNumDivisions();
+    offset = nearest_center_index * _n_radial;
     pc(0) = (pt - _center_positions->getPosition(nearest_center_index, initial)).norm();
   }
 

--- a/framework/src/meshdivisions/SphericalGridDivision.C
+++ b/framework/src/meshdivisions/SphericalGridDivision.C
@@ -29,7 +29,7 @@ SphericalGridDivision::validParams()
 
   // Spatial bounds of the sphere
   params.addRangeCheckedParam<Real>(
-      "r_min", 0, "r_min>0", "Minimum radial coordinate (for a hollow sphere)");
+      "r_min", 0, "r_min>=0", "Minimum radial coordinate (for a hollow sphere)");
   params.addRequiredRangeCheckedParam<Real>("r_max", "r_max>0", "Maximum radial coordinate");
 
   // Number of bins

--- a/modules/reactor/src/meshdivisions/HexagonalGridDivision.C
+++ b/modules/reactor/src/meshdivisions/HexagonalGridDivision.C
@@ -93,7 +93,7 @@ HexagonalGridDivision::initialize()
     // this bound is not sufficiently strict. The simplest example would be non-coplanar
     // points, which can be a great distance away axially but be on the same axis
     if (MooseUtils::absoluteFuzzyGreaterThan(_lattice_flat_to_flat, min_center_dist))
-      mooseError(
+      mooseWarning(
           "Hexagonal grids centered on the positions are too close to each other (min distance: ",
           min_center_dist,
           "), closer than the extent of each grid (",


### PR DESCRIPTION
things I noticed using them for the highlight

- [x] filled sphere doesnt work
- [x] grid indexes are not continuous
- [x] closeness tolerance is obnoxious
