### PR TITLE
Serialize ValueCache

### DIFF
--- a/framework/doc/content/source/utils/ValueCache.md
+++ b/framework/doc/content/source/utils/ValueCache.md
@@ -1,0 +1,18 @@
+# ValueCache
+
+The `ValueCache<T>` class can cache value of type `T` indexed by n-dimensional vectors. Retrieval is performed using a kd-tree data structure (using nanoflann).
+
+## Persistence
+
+When the object is constructed using the
+
+```C++
+ValueCache(const std::string & file_name, std::size_t in_dim, std::size_t max_leaf_size = 10);
+```
+
+constructor, the state of the cache is saved to a file upon destuction of the cache object (usually at teh ond of a simulation), and read in at construction of the cache object. Thus teh cached knowledge from a previous simulation will be available in future runs.
+
+!alert warning
+It is up to the developer to ensure that the cache state from previous runs is applicable to the following runs when teh persistence feature is used!
+
+Note that overloads for `dataLoad` and `dataStore` for type `T` must be implemented. If full persistence is not desired the cache object can still be declared as restartable.

--- a/framework/doc/content/source/utils/ValueCache.md
+++ b/framework/doc/content/source/utils/ValueCache.md
@@ -10,9 +10,9 @@ When the object is constructed using the
 ValueCache(const std::string & file_name, std::size_t in_dim, std::size_t max_leaf_size = 10);
 ```
 
-constructor, the state of the cache is saved to a file upon destuction of the cache object (usually at teh ond of a simulation), and read in at construction of the cache object. Thus teh cached knowledge from a previous simulation will be available in future runs.
+constructor, the state of the cache is saved to a file upon destruction of the cache object (usually at the ond of a simulation), and read in at construction of the cache object. Thus the cached knowledge from a previous simulation will be available in future runs.
 
 !alert warning
-It is up to the developer to ensure that the cache state from previous runs is applicable to the following runs when teh persistence feature is used!
+It is up to the developer to ensure that the cache state from previous runs is applicable to the following runs when the persistence feature is used!
 
 Note that overloads for `dataLoad` and `dataStore` for type `T` must be implemented. If full persistence is not desired the cache object can still be declared as restartable.

--- a/framework/doc/content/source/utils/ValueCache.md
+++ b/framework/doc/content/source/utils/ValueCache.md
@@ -10,7 +10,7 @@ When the object is constructed using the
 ValueCache(const std::string & file_name, std::size_t in_dim, std::size_t max_leaf_size = 10);
 ```
 
-constructor, the state of the cache is saved to a file upon destruction of the cache object (usually at the ond of a simulation), and read in at construction of the cache object. Thus the cached knowledge from a previous simulation will be available in future runs.
+constructor, the state of the cache is saved to a file upon destruction of the cache object (usually at the end of a simulation), and read in at construction of the cache object. Thus the cached knowledge from a previous simulation will be available in future runs.
 
 !alert warning
 It is up to the developer to ensure that the cache state from previous runs is applicable to the following runs when the persistence feature is used!

--- a/framework/include/utils/ValueCache.h
+++ b/framework/include/utils/ValueCache.h
@@ -41,8 +41,13 @@ template <typename T>
 class ValueCache
 {
 public:
+  /// Construct a ValueCache with indices in in_dim dimensions
   ValueCache(std::size_t in_dim, std::size_t max_leaf_size = 10);
+
+  /// Same as above, but provide a filename for storing/restoring the cache content between runs
   ValueCache(const std::string & file_name, std::size_t in_dim, std::size_t max_leaf_size = 10);
+
+  /// Object destructor. If the cache was constructed with a file name, it gets written here.
   ~ValueCache();
 
   /// insert a new value out_value at the position in_val

--- a/framework/include/utils/ValueCache.h
+++ b/framework/include/utils/ValueCache.h
@@ -10,10 +10,22 @@
 #pragma once
 
 #include "MooseTypes.h"
+#include "MooseUtils.h"
+#include "DataIO.h"
 #include "libmesh/nanoflann.hpp"
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
 #include <memory>
 #include <vector>
 #include <tuple>
+
+template <typename T>
+class ValueCache;
+template <typename T>
+void dataStore(std::ostream & stream, ValueCache<T> & c, void * context);
+template <typename T>
+void dataLoad(std::istream & stream, ValueCache<T> & c, void * context);
 
 /**
  * ValueCache is a generic helper template to implement an unstructured data
@@ -28,9 +40,12 @@ class ValueCache
 {
 public:
   ValueCache(std::size_t in_dim, std::size_t max_leaf_size = 10);
+  ValueCache(const std::string & file_name, std::size_t in_dim, std::size_t max_leaf_size = 10);
+  ~ValueCache();
 
   void insert(const std::vector<Real> & in_val, const T & out_val);
   std::size_t size();
+  void clear();
   bool guess(const std::vector<Real> & in_val, T & out_val, Real & distance_sqr);
   std::vector<std::tuple<std::vector<Real> &, T &, Real>>
   kNearestNeighbors(const std::vector<Real> & in_val, const std::size_t k);
@@ -67,6 +82,11 @@ protected:
   const std::size_t _in_dim;
   const std::size_t _max_leaf_size;
   const std::size_t _max_subtrees;
+
+  std::optional<std::string> _persistent_storage_file;
+
+  friend void dataStore<T>(std::ostream & stream, ValueCache<T> & c, void * context);
+  friend void dataLoad<T>(std::istream & stream, ValueCache<T> & c, void * context);
 };
 
 template <typename T>
@@ -77,6 +97,43 @@ ValueCache<T>::ValueCache(std::size_t in_dim, std::size_t max_leaf_size)
     _max_leaf_size(max_leaf_size),
     _max_subtrees(100)
 {
+}
+
+template <typename T>
+ValueCache<T>::ValueCache(const std::string & file_name,
+                          std::size_t in_dim,
+                          std::size_t max_leaf_size)
+  : ValueCache(in_dim, max_leaf_size)
+{
+  _persistent_storage_file = file_name;
+
+  // if the persistent storage file exists and is readable, load it
+  if (MooseUtils::checkFileReadable(*_persistent_storage_file,
+                                    /*check_line_endings =*/false,
+                                    /*throw_on_unreadable =*/false))
+  {
+    std::ifstream in_file(_persistent_storage_file->c_str());
+    if (!in_file)
+      mooseError("Failed to open '", *_persistent_storage_file, "' for reading.");
+    dataLoad(in_file, *this, nullptr);
+
+    // build kd-tree
+    _kd_tree = std::make_unique<KdTreeT>(_in_dim, _point_cloud, _max_leaf_size);
+    mooseAssert(_kd_tree != nullptr, "KDTree was not properly initialized.");
+  }
+}
+
+template <typename T>
+ValueCache<T>::~ValueCache()
+{
+  // if a persistent storage file was specified, write results back to it
+  if (_persistent_storage_file.has_value())
+  {
+    std::ofstream out_file(_persistent_storage_file->c_str());
+    if (!out_file)
+      mooseWarning("Failed to open '", *_persistent_storage_file, "' for writing.");
+    dataStore(out_file, *this, nullptr);
+  }
 }
 
 template <typename T>
@@ -110,6 +167,15 @@ std::size_t
 ValueCache<T>::size()
 {
   return _data.size();
+}
+
+template <typename T>
+void
+ValueCache<T>::clear()
+{
+  _data.clear();
+  _point_cloud._pts.clear();
+  _kd_tree = nullptr;
 }
 
 template <typename T>
@@ -159,4 +225,20 @@ ValueCache<T>::kNearestNeighbors(const std::vector<Real> & in_val, const std::si
         std::tie((_point_cloud._pts[return_indices[i]]), (_data[return_indices[i]]), distances[i]));
 
   return nearest_neighbors;
+}
+
+template <typename T>
+inline void
+dataStore(std::ostream & stream, ValueCache<T> & c, void * context)
+{
+  storeHelper(stream, c._point_cloud._pts, context);
+  storeHelper(stream, c._data, context);
+}
+
+template <typename T>
+inline void
+dataLoad(std::istream & stream, ValueCache<T> & c, void * context)
+{
+  loadHelper(stream, c._point_cloud._pts, context);
+  loadHelper(stream, c._data, context);
 }

--- a/unit/src/ValueCacheTest.C
+++ b/unit/src/ValueCacheTest.C
@@ -53,22 +53,26 @@ TEST(ValueCacheTest, kNN)
   nearest_neighbors = cache.kNearestNeighbors({0, 0, 0}, 3);
 
   // First nearest neighbor
-  auto [key, value, distance] = nearest_neighbors[0];
-  EXPECT_NEAR(key[0], 3.1, 1e-9);
-  EXPECT_NEAR(key[1], 1.2, 1e-9);
-  EXPECT_NEAR(key[2], 0.1, 1e-9);
-  EXPECT_EQ(value[0], 3);
-  EXPECT_EQ(value[1], 4);
-  EXPECT_NEAR(distance, 3.1 * 3.1 + 1.2 * 1.2 + 0.1 * 0.1, 1e-9);
+  {
+    auto [key, value, distance] = nearest_neighbors[0];
+    EXPECT_NEAR(key[0], 3.1, 1e-9);
+    EXPECT_NEAR(key[1], 1.2, 1e-9);
+    EXPECT_NEAR(key[2], 0.1, 1e-9);
+    EXPECT_EQ(value[0], 3);
+    EXPECT_EQ(value[1], 4);
+    EXPECT_NEAR(distance, 3.1 * 3.1 + 1.2 * 1.2 + 0.1 * 0.1, 1e-9);
+  }
 
   // Second nearest neighbor
-  std::tie(key, value, distance) = nearest_neighbors[1];
-  EXPECT_NEAR(key[0], 2.8, 1e-9);
-  EXPECT_NEAR(key[1], 2.1, 1e-9);
-  EXPECT_NEAR(key[2], 0.6, 1e-9);
-  EXPECT_EQ(value[0], 9);
-  EXPECT_EQ(value[1], 10);
-  EXPECT_NEAR(distance, 2.8 * 2.8 + 2.1 * 2.1 + 0.6 * 0.6, 1e-9);
+  {
+    auto [key, value, distance] = nearest_neighbors[1];
+    EXPECT_NEAR(key[0], 2.8, 1e-9);
+    EXPECT_NEAR(key[1], 2.1, 1e-9);
+    EXPECT_NEAR(key[2], 0.6, 1e-9);
+    EXPECT_EQ(value[0], 9);
+    EXPECT_EQ(value[1], 10);
+    EXPECT_NEAR(distance, 2.8 * 2.8 + 2.1 * 2.1 + 0.6 * 0.6, 1e-9);
+  }
 }
 
 TEST(ValueCacheTest, rebuildTree)

--- a/unit/src/ValueCacheTest.C
+++ b/unit/src/ValueCacheTest.C
@@ -83,3 +83,23 @@ TEST(ValueCacheTest, rebuildTree)
   EXPECT_EQ(out, 57);
   EXPECT_NEAR(d2, 0.3 * 0.3, 1e-9);
 }
+
+TEST(ValueCacheTest, persistence)
+{
+  {
+    ValueCache<std::vector<Real>> cache("test.cache", 3);
+    cache.clear(); // clear it in case a file was hanging around from a previous test
+    cache.insert({4.2, 2.7, 1.6}, {1, 2});
+    cache.insert({3.1, 1.2, 0.1}, {3, 4});
+  }
+
+  {
+    ValueCache<std::vector<Real>> cache("test.cache", 3);
+    auto nearest_neighbors = cache.kNearestNeighbors({0, 0, 0}, 3);
+    EXPECT_EQ(nearest_neighbors.size(), 2);
+    auto [key, value, distance] = nearest_neighbors[0];
+    EXPECT_NEAR(key[0], 3.1, 1e-9);
+    EXPECT_NEAR(key[1], 1.2, 1e-9);
+    EXPECT_NEAR(key[2], 0.1, 1e-9);
+  }
+}

--- a/unit/src/ValueCacheTest.C
+++ b/unit/src/ValueCacheTest.C
@@ -14,43 +14,42 @@
 TEST(ValueCacheTest, empty)
 {
   ValueCache<int> cache(2);
-
-  int out;
-  Real d2;
-  EXPECT_EQ(cache.guess({1, 1}, out, d2), false);
+  EXPECT_THROW(cache.getNeighbor({1, 1}), std::runtime_error);
+  EXPECT_EQ(cache.getNeighbors({1, 1}, 1).size(), 0);
 }
 
-TEST(ValueCacheTest, guess)
+TEST(ValueCacheTest, getNeighbor)
 {
+  // retrieving a single value
   ValueCache<std::vector<Real>> cache(3);
   cache.insert({4.2, 2.7, 1.6}, {1, 2});
   cache.insert({3.1, 1.2, 0.1}, {3, 4});
   cache.insert({5.8, 1.9, 3.6}, {5, 6});
 
-  std::vector<Real> out;
-  Real d2;
-
-  EXPECT_EQ(cache.guess({0, 0, 0}, out, d2), true);
-  EXPECT_EQ(out[0], 3);
-  EXPECT_EQ(out[1], 4);
-  EXPECT_NEAR(d2, 3.1 * 3.1 + 1.2 * 1.2 + 0.1 * 0.1, 1e-9);
+  const auto & [point, value, distance] = cache.getNeighbor({0, 0, 0});
+  EXPECT_EQ(value[0], 3);
+  EXPECT_EQ(value[1], 4);
+  EXPECT_EQ(point[0], 3.1);
+  EXPECT_EQ(point[1], 1.2);
+  EXPECT_EQ(point[2], 0.1);
+  EXPECT_NEAR(distance, 3.1 * 3.1 + 1.2 * 1.2 + 0.1 * 0.1, 1e-9);
 }
 
-TEST(ValueCacheTest, kNN)
+TEST(ValueCacheTest, getNeighbors)
 {
+  // retrieving multiple neighbors
   ValueCache<std::vector<Real>> cache(3);
-
   cache.insert({4.2, 2.7, 1.6}, {1, 2});
   cache.insert({3.1, 1.2, 0.1}, {3, 4});
 
-  auto nearest_neighbors = cache.kNearestNeighbors({0, 0, 0}, 3);
+  auto nearest_neighbors = cache.getNeighbors({0, 0, 0}, 3);
   EXPECT_EQ(nearest_neighbors.size(), 2);
 
   cache.insert({5.8, 1.9, 3.6}, {5, 6});
   cache.insert({7.1, 2.2, 4.1}, {7, 8});
   cache.insert({2.8, 2.1, 0.6}, {9, 10});
 
-  nearest_neighbors = cache.kNearestNeighbors({0, 0, 0}, 3);
+  nearest_neighbors = cache.getNeighbors({0, 0, 0}, 3);
 
   // First nearest neighbor
   {
@@ -81,11 +80,10 @@ TEST(ValueCacheTest, rebuildTree)
   for (int i = 0; i < 110; ++i)
     cache.insert({Real(i)}, i);
 
-  int out;
-  Real d2;
-  EXPECT_EQ(cache.guess({57.3}, out, d2), true);
-  EXPECT_EQ(out, 57);
-  EXPECT_NEAR(d2, 0.3 * 0.3, 1e-9);
+  const auto & [point, value, distance] = cache.getNeighbor({57.3});
+  EXPECT_EQ(value, 57);
+  EXPECT_EQ(point[0], 57.0);
+  EXPECT_NEAR(distance, 0.3 * 0.3, 1e-9);
 }
 
 TEST(ValueCacheTest, persistence)
@@ -99,7 +97,7 @@ TEST(ValueCacheTest, persistence)
 
   {
     ValueCache<std::vector<Real>> cache("test.cache", 3);
-    auto nearest_neighbors = cache.kNearestNeighbors({0, 0, 0}, 3);
+    auto nearest_neighbors = cache.getNeighbors({0, 0, 0}, 3);
     EXPECT_EQ(nearest_neighbors.size(), 2);
     auto [key, value, distance] = nearest_neighbors[0];
     EXPECT_NEAR(key[0], 3.1, 1e-9);


### PR DESCRIPTION
Closes #26695

This adds `DataIO` support to `ValueCache`. That means value caches can now be restartable, or with the new constructor, persistent between runs.