### PR TITLE
Add Interpolation Scheme (Steinbach-Apel's scheme)

### DIFF
--- a/modules/solid_mechanics/include/materials/ComputeComplianceTensorBase.h
+++ b/modules/solid_mechanics/include/materials/ComputeComplianceTensorBase.h
@@ -1,0 +1,39 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "DerivativeMaterialInterface.h"
+#include "Material.h"
+#include "RankFourTensor.h"
+
+template <bool is_ad>
+class ComputeComplianceTensorBaseTempl : public DerivativeMaterialInterface<Material>
+{
+public:
+  static InputParameters validParams();
+
+  ComputeComplianceTensorBaseTempl(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+  virtual void computeQpElasticityTensor() = 0;
+
+  /// Base name of the material system
+  const std::string _base_name;
+
+  std::string _elasticity_tensor_name;
+  std::string _compliance_tensor_name;
+
+  GenericMaterialProperty<RankFourTensor, is_ad> & _compliance_tensor;
+  GenericMaterialProperty<RankFourTensor, is_ad> & _elasticity_tensor;
+};
+
+typedef ComputeComplianceTensorBaseTempl<false> ComputeComplianceTensorBase;
+typedef ComputeComplianceTensorBaseTempl<true> ADComputeComplianceTensorBase;

--- a/modules/solid_mechanics/include/materials/ComputeHarmonicElasticityTensor.h
+++ b/modules/solid_mechanics/include/materials/ComputeHarmonicElasticityTensor.h
@@ -1,0 +1,44 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+#include "DerivativeMaterialInterface.h"
+#include "RankTwoTensorForward.h"
+#include "RankFourTensorForward.h"
+
+class ComputeHarmonicElasticityTensor : public DerivativeMaterialInterface<Material>
+{
+public:
+  static InputParameters validParams();
+
+  ComputeHarmonicElasticityTensor(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  // switching function
+  const MaterialProperty<Real> & _h_eta;
+
+  // phase A material properties
+  std::string _base_A;
+  const MaterialProperty<RankFourTensor> & _compliance_A;
+
+  // phase B material properties
+  std::string _base_B;
+  const MaterialProperty<RankFourTensor> & _compliance_B;
+
+  // global material properties
+  MaterialProperty<RankFourTensor> & _compliance;
+  MaterialProperty<RankFourTensor> & _elasticity_tensor;
+
+  const std::string _base_name;
+  const std::string _elasticity_name;
+};

--- a/modules/solid_mechanics/include/materials/ComputeInverseElasticityTensor.h
+++ b/modules/solid_mechanics/include/materials/ComputeInverseElasticityTensor.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "ComputeInverseRotatedElasticityTensorBase.h"
+#include "DerivativeFunctionMaterialBase.h"
+
+template <bool is_ad>
+class ComputeInverseElasticityTensorTempl
+  : public ComputeInverseRotatedElasticityTensorBaseTempl<is_ad>
+{
+public:
+  static InputParameters validParams();
+
+  ComputeInverseElasticityTensorTempl(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpElasticityTensor() override;
+
+  /// Individual material information
+  RankFourTensor _Cijkl;
+  RankFourTensor _Sijkl;
+
+  using ComputeInverseRotatedElasticityTensorBaseTempl<is_ad>::isParamValid;
+  using ComputeInverseRotatedElasticityTensorBaseTempl<is_ad>::_compliance_tensor_name;
+  using ComputeInverseRotatedElasticityTensorBaseTempl<is_ad>::_elasticity_tensor_name;
+  using ComputeInverseRotatedElasticityTensorBaseTempl<is_ad>::_compliance_tensor;
+  using ComputeInverseRotatedElasticityTensorBaseTempl<is_ad>::_elasticity_tensor;
+  using ComputeInverseRotatedElasticityTensorBaseTempl<is_ad>::_qp;
+};
+
+typedef ComputeInverseElasticityTensorTempl<false> ComputeInverseElasticityTensor;
+typedef ComputeInverseElasticityTensorTempl<true> ADComputeInverseElasticityTensor;

--- a/modules/solid_mechanics/include/materials/ComputeInverseRotatedElasticityTensorBase.h
+++ b/modules/solid_mechanics/include/materials/ComputeInverseRotatedElasticityTensorBase.h
@@ -1,0 +1,30 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ComputeComplianceTensorBase.h"
+#include "RankTwoTensor.h"
+
+template <bool is_ad>
+class ComputeInverseRotatedElasticityTensorBaseTempl
+  : public ComputeComplianceTensorBaseTempl<is_ad>
+{
+public:
+  static InputParameters validParams();
+
+  ComputeInverseRotatedElasticityTensorBaseTempl(const InputParameters & parameters);
+
+protected:
+};
+
+typedef ComputeInverseRotatedElasticityTensorBaseTempl<false>
+    ComputeInverseRotatedElasticityTensorBase;
+typedef ComputeInverseRotatedElasticityTensorBaseTempl<true>
+    ADComputeInverseRotatedElasticityTensorBase;

--- a/modules/solid_mechanics/include/materials/ComputeSteinbachApelStrain.h
+++ b/modules/solid_mechanics/include/materials/ComputeSteinbachApelStrain.h
@@ -1,0 +1,52 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+#include "DerivativeMaterialInterface.h"
+
+class ComputeSteinbachApelStrain : public DerivativeMaterialInterface<Material>
+{
+public:
+  static InputParameters validParams();
+
+  ComputeSteinbachApelStrain(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties() override;
+
+  const std::string _base_name;
+
+  const MaterialProperty<Real> & _h_eta;
+
+  std::vector<const MaterialProperty<Real> *> _dh;
+
+  std::string _base_A;
+  std::string _base_B;
+
+  const std::string _elasticity_tensor_B_name;
+  const MaterialProperty<RankFourTensor> & _elasticity_tensor_B;
+
+  const std::string _compliance_tensor_A_name;
+  const MaterialProperty<RankFourTensor> & _compliance_tensor_A;
+
+  const std::string _global_strain_name;
+  const MaterialProperty<RankTwoTensor> & _global_mechanical_strain;
+
+  MaterialProperty<RankTwoTensor> & _mechanical_strain_a;
+  MaterialProperty<RankTwoTensor> & _mechanical_strain_b;
+
+  MaterialProperty<RankFourTensor> & _ref;
+  MaterialProperty<RankFourTensor> & _ref_inv;
+
+  MaterialProperty<RankFourTensor> & _identity;
+
+  float _identity_two[6][6];
+};

--- a/modules/solid_mechanics/include/materials/ElasticEnergyMaterialSAS.h
+++ b/modules/solid_mechanics/include/materials/ElasticEnergyMaterialSAS.h
@@ -1,0 +1,55 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "DerivativeFunctionMaterialBase.h"
+#include "ADRankTwoTensorForward.h"
+#include "ADRankFourTensorForward.h"
+
+/**
+ * Material class to compute the elastic free energy and its derivatives
+ */
+class ElasticEnergyMaterialSAS : public DerivativeFunctionMaterialBase
+{
+public:
+  static InputParameters validParams();
+
+  ElasticEnergyMaterialSAS(const InputParameters & parameters);
+
+  virtual void initialSetup() override;
+
+protected:
+  virtual Real computeF() override;
+  virtual Real computeDF(unsigned int i_var) override;
+
+  const MaterialProperty<Real> &_prop_Fa, &_prop_Fb;
+  const std::string _base_name;
+
+  std::string _base_A;
+  std::string _base_B;
+
+  const unsigned int _num_eta;
+  const std::vector<const VariableValue *> _eta;
+  const std::vector<VariableName> _eta_names;
+
+  // Switching Function and its derivative
+  std::string _h_name;
+  const MaterialProperty<Real> & _h_eta;
+  std::vector<const MaterialProperty<Real> *> _dh_eta;
+
+  /// Stress tensor
+  const MaterialProperty<RankTwoTensor> & _stress;
+
+  ///@{ Strain and derivatives
+  const MaterialProperty<RankTwoTensor> & _strain_A;
+  const MaterialProperty<RankTwoTensor> & _strain_B;
+
+  const MaterialProperty<RankTwoTensor> & _eigenstrain_B;
+};

--- a/modules/solid_mechanics/include/materials/TwoPhaseStrainMaterial.h
+++ b/modules/solid_mechanics/include/materials/TwoPhaseStrainMaterial.h
@@ -1,0 +1,40 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+#include "DerivativeMaterialInterface.h"
+#include "RankTwoTensorForward.h"
+#include "RankFourTensorForward.h"
+
+class TwoPhaseStrainMaterial : public DerivativeMaterialInterface<Material>
+{
+public:
+  static InputParameters validParams();
+
+  TwoPhaseStrainMaterial(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  // switching function
+  const MaterialProperty<Real> & _h_eta;
+
+  // phase A material properties
+  std::string _base_A;
+  const MaterialProperty<RankTwoTensor> & _mechanical_strain_A;
+
+  // phase B material properties
+  std::string _base_B;
+  const MaterialProperty<RankTwoTensor> & _mechanical_strain_B;
+
+  // global material properties
+  MaterialProperty<RankTwoTensor> & _strain;
+};

--- a/modules/solid_mechanics/src/materials/ComputeComplianceTensorBase.C
+++ b/modules/solid_mechanics/src/materials/ComputeComplianceTensorBase.C
@@ -1,0 +1,42 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeComplianceTensorBase.h"
+#include "Function.h"
+
+template <bool is_ad>
+InputParameters
+ComputeComplianceTensorBaseTempl<is_ad>::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addParam<std::string>("base_name", "Optional parameter that allows the user to define ");
+  return params;
+}
+
+template <bool is_ad>
+ComputeComplianceTensorBaseTempl<is_ad>::ComputeComplianceTensorBaseTempl(
+    const InputParameters & parameters)
+  : DerivativeMaterialInterface<Material>(parameters),
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
+    _compliance_tensor_name(_base_name + "compliance_tensor"),
+    _elasticity_tensor_name(_base_name + "elasticity_tensor"),
+    _compliance_tensor(declareGenericProperty<RankFourTensor, is_ad>(_compliance_tensor_name)),
+    _elasticity_tensor(declareGenericProperty<RankFourTensor, is_ad>(_elasticity_tensor_name))
+{
+}
+
+template <bool is_ad>
+void
+ComputeComplianceTensorBaseTempl<is_ad>::computeQpProperties()
+{
+  computeQpElasticityTensor();
+}
+
+template class ComputeComplianceTensorBaseTempl<false>;
+template class ComputeComplianceTensorBaseTempl<true>;

--- a/modules/solid_mechanics/src/materials/ComputeHarmonicElasticityTensor.C
+++ b/modules/solid_mechanics/src/materials/ComputeHarmonicElasticityTensor.C
@@ -1,0 +1,52 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeHarmonicElasticityTensor.h"
+#include "RankTwoTensor.h"
+#include "RankFourTensor.h"
+
+registerMooseObject("TensorMechanicsApp", ComputeHarmonicElasticityTensor);
+
+InputParameters
+ComputeHarmonicElasticityTensor::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addClassDescription("Compute a stiffness tensor in a two phase model");
+  params.addParam<MaterialPropertyName>(
+      "h", "h", "Switching Function Material that provides h(eta)");
+  params.addRequiredParam<std::string>("base_A", "Base name for the Phase A");
+  params.addRequiredParam<std::string>("base_B", "Base name for the Phase B");
+  params.addParam<std::string>("base_name", "Base name (optional).");
+  return params;
+}
+
+ComputeHarmonicElasticityTensor::ComputeHarmonicElasticityTensor(const InputParameters & parameters)
+  : DerivativeMaterialInterface<Material>(parameters),
+    _h_eta(getMaterialProperty<Real>("h")),
+
+    _base_A(getParam<std::string>("base_A") + "_"),
+    _compliance_A(getMaterialPropertyByName<RankFourTensor>(_base_A + "compliance_tensor")),
+
+    _base_B(getParam<std::string>("base_B") + "_"),
+    _compliance_B(getMaterialPropertyByName<RankFourTensor>(_base_B + "compliance_tensor")),
+
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
+    _compliance(declareProperty<RankFourTensor>(_base_name + "compliance_tensor")),
+    _elasticity_name(_base_name + "elasticity_tensor"),
+    _elasticity_tensor(declareProperty<RankFourTensor>(_base_name + "elasticity_tensor"))
+{
+}
+
+void
+ComputeHarmonicElasticityTensor::computeQpProperties()
+{
+  _compliance[_qp] = _h_eta[_qp] * _compliance_B[_qp] + (1.0 - _h_eta[_qp]) * _compliance_A[_qp];
+
+  _elasticity_tensor[_qp] = _compliance[_qp].invSymm();
+}

--- a/modules/solid_mechanics/src/materials/ComputeInverseElasticityTensor.C
+++ b/modules/solid_mechanics/src/materials/ComputeInverseElasticityTensor.C
@@ -1,0 +1,42 @@
+#include "ComputeInverseElasticityTensor.h"
+#include "RotationTensor.h"
+
+registerMooseObject("TensorMechanicsApp", ComputeInverseElasticityTensor);
+registerMooseObject("TensorMechanicsApp", ADComputeInverseElasticityTensor);
+
+template <bool is_ad>
+InputParameters
+ComputeInverseElasticityTensorTempl<is_ad>::validParams()
+{
+  InputParameters params = ComputeInverseRotatedElasticityTensorBaseTempl<is_ad>::validParams();
+  params.addClassDescription("Compute an compliance tensor.");
+  params.addRequiredParam<std::vector<Real>>("C_ijkl", "Stiffness tensor for material");
+  params.addParam<MooseEnum>(
+      "fill_method", RankFourTensor::fillMethodEnum() = "symmetric9", "The fill method");
+  return params;
+}
+
+template <bool is_ad>
+ComputeInverseElasticityTensorTempl<is_ad>::ComputeInverseElasticityTensorTempl(
+    const InputParameters & parameters)
+  : ComputeInverseRotatedElasticityTensorBaseTempl<is_ad>(parameters),
+    _Cijkl(this->template getParam<std::vector<Real>>("C_ijkl"),
+           (RankFourTensor::FillMethod)(int)this->template getParam<MooseEnum>("fill_method"))
+{
+}
+
+template <bool is_ad>
+void
+ComputeInverseElasticityTensorTempl<is_ad>::computeQpElasticityTensor()
+{
+  // Assign compliance tensor at a given quad point
+  // This code is made for symmetric9
+
+  _Sijkl = _Cijkl.invSymm();
+
+  _elasticity_tensor[_qp] = _Cijkl;
+  _compliance_tensor[_qp] = _Sijkl;
+}
+
+template class ComputeInverseElasticityTensorTempl<false>;
+template class ComputeInverseElasticityTensorTempl<true>;

--- a/modules/solid_mechanics/src/materials/ComputeInverseRotatedElasticityTensorBase.C
+++ b/modules/solid_mechanics/src/materials/ComputeInverseRotatedElasticityTensorBase.C
@@ -1,0 +1,29 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeInverseRotatedElasticityTensorBase.h"
+#include "RotationTensor.h"
+
+template <bool is_ad>
+InputParameters
+ComputeInverseRotatedElasticityTensorBaseTempl<is_ad>::validParams()
+{
+  InputParameters params = ComputeComplianceTensorBaseTempl<is_ad>::validParams();
+  return params;
+}
+
+template <bool is_ad>
+ComputeInverseRotatedElasticityTensorBaseTempl<
+    is_ad>::ComputeInverseRotatedElasticityTensorBaseTempl(const InputParameters & parameters)
+  : ComputeComplianceTensorBaseTempl<is_ad>(parameters)
+{
+}
+
+template class ComputeInverseRotatedElasticityTensorBaseTempl<false>;
+template class ComputeInverseRotatedElasticityTensorBaseTempl<true>;

--- a/modules/solid_mechanics/src/materials/ComputeSteinbachApelStrain.C
+++ b/modules/solid_mechanics/src/materials/ComputeSteinbachApelStrain.C
@@ -1,0 +1,69 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeSteinbachApelStrain.h"
+#include "Assembly.h"
+#include "libmesh/quadrature.h"
+
+registerMooseObject("TensorMechanicsApp", ComputeSteinbachApelStrain);
+
+InputParameters
+ComputeSteinbachApelStrain::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addParam<std::string>("base_name", "Base name for the computed strain.");
+  params.addParam<MaterialPropertyName>(
+      "h", "h", "Switching Function Material that provides h(eta)");
+  params.addRequiredParam<std::string>("base_A", "Base name for the alpha phase.");
+  params.addRequiredParam<std::string>("base_B", "Base name for the beta phase.");
+  return params;
+}
+
+ComputeSteinbachApelStrain::ComputeSteinbachApelStrain(const InputParameters & parameters)
+  : DerivativeMaterialInterface<Material>(parameters),
+    _h_eta(getMaterialProperty<Real>("h")),
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
+    _base_A(getParam<std::string>("base_A") + "_"),
+    _base_B(getParam<std::string>("base_B") + "_"),
+    _elasticity_tensor_B_name(_base_B + "elasticity_tensor"),
+    _elasticity_tensor_B(getMaterialPropertyByName<RankFourTensor>(_elasticity_tensor_B_name)),
+    _compliance_tensor_A_name(_base_A + "compliance_tensor"),
+    _compliance_tensor_A(getMaterialPropertyByName<RankFourTensor>(_compliance_tensor_A_name)),
+    _global_strain_name("mechanical_strain"),
+    _global_mechanical_strain(getMaterialPropertyByName<RankTwoTensor>(_global_strain_name)),
+    _ref(declareProperty<RankFourTensor>("ref")),
+    _ref_inv(declareProperty<RankFourTensor>("ref_inv")),
+    _mechanical_strain_b(declareProperty<RankTwoTensor>(_base_B + "mechanical_strain")),
+    _mechanical_strain_a(declareProperty<RankTwoTensor>(_base_A + "mechanical_strain")),
+    _identity(declareProperty<RankFourTensor>("identity"))
+{
+}
+
+void
+ComputeSteinbachApelStrain::computeQpProperties()
+{
+  for (unsigned int i = 0; i < 6; i++)
+    _identity_two[i][i] = 1.0;
+
+  _identity[_qp](0, 0, 0, 0) = _identity_two[0][0];
+  _identity[_qp](1, 1, 1, 1) = _identity_two[1][1];
+  _identity[_qp](2, 2, 2, 2) = _identity_two[2][2];
+  _identity[_qp](1, 2, 1, 2) = _identity_two[3][3];
+  _identity[_qp](0, 2, 0, 2) = _identity_two[4][4];
+  _identity[_qp](0, 1, 0, 1) = _identity_two[5][5];
+
+  _ref[_qp] = _h_eta[_qp] * _identity[_qp] +
+              (1.0 - _h_eta[_qp]) * _compliance_tensor_A[_qp] * _elasticity_tensor_B[_qp];
+
+  _ref_inv[_qp] = _ref[_qp].invSymm();
+
+  _mechanical_strain_b[_qp] = _ref_inv[_qp] * _global_mechanical_strain[_qp];
+  _mechanical_strain_a[_qp] =
+      _compliance_tensor_A[_qp] * _elasticity_tensor_B[_qp] * _mechanical_strain_b[_qp];
+}

--- a/modules/solid_mechanics/src/materials/ElasticEnergyMaterialSAS.C
+++ b/modules/solid_mechanics/src/materials/ElasticEnergyMaterialSAS.C
@@ -1,0 +1,82 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ElasticEnergyMaterialSAS.h"
+#include "RankTwoTensor.h"
+#include "RankFourTensor.h"
+
+registerMooseObject("PhaseFieldApp", ElasticEnergyMaterialSAS);
+
+InputParameters
+ElasticEnergyMaterialSAS::validParams()
+{
+  InputParameters params = DerivativeFunctionMaterialBase::validParams();
+  params.addClassDescription("Free energy material for the elastic energy contributions.");
+  params.addParam<std::string>("base_name", "Material property base name");
+  params.addRequiredParam<MaterialPropertyName>("fa_name", "Phase A material");
+  params.addRequiredParam<MaterialPropertyName>("fb_name", "Phase B material");
+  params.addDeprecatedCoupledVar("args",
+                                 "Arguments of the free energy function",
+                                 "args is deprecated, use 'coupled_variables' instead");
+  params.addCoupledVar("coupled_variables",
+                       "Vector of variable arguments of the free energy function");
+  params.addCoupledVar("displacement_gradients",
+                       "Vector of displacement gradient variables (see "
+                       "Modules/PhaseField/DisplacementGradients "
+                       "action)");
+  params.addRequiredParam<std::string>("base_A", "Base name for the Phase A");
+  params.addRequiredParam<std::string>("base_B", "Base name for the Phase B");
+  params.addRequiredParam<MaterialPropertyName>(
+      "h_name", "Name of the switching function material property for the given phase");
+  return params;
+}
+
+ElasticEnergyMaterialSAS::ElasticEnergyMaterialSAS(const InputParameters & parameters)
+  : DerivativeFunctionMaterialBase(parameters),
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
+    _prop_Fa(getMaterialProperty<Real>("fa_name")),
+    _prop_Fb(getMaterialProperty<Real>("fb_name")),
+    _h_name(getParam<MaterialPropertyName>("h_name")),
+    _stress(getMaterialPropertyByName<RankTwoTensor>(_base_name + "stress")),
+    _strain_A(getMaterialPropertyByName<RankTwoTensor>(_base_A + "elastic_strain")),
+    _strain_B(getMaterialPropertyByName<RankTwoTensor>(_base_B + "elastic_strain")),
+    _eigenstrain_B(getMaterialPropertyByName<RankTwoTensor>(_base_B + "eigenstrain")),
+    _num_eta(coupledComponents("coupled_variables")),
+    _eta(coupledValues("coupled_variables")),
+    _eta_names(coupledNames("coupled_variables")),
+    _h_eta(getMaterialProperty<Real>("h_name")),
+    _dh_eta(_num_eta)
+{
+  for (unsigned int i = 0; i < _num_eta; ++i)
+  {
+    _dh_eta[i] = &getMaterialPropertyDerivativeByName<Real>(_h_name, _eta_names[i]);
+  }
+}
+
+void
+ElasticEnergyMaterialSAS::initialSetup()
+{
+  validateCoupling<RankTwoTensor>(_base_name + "elastic_strain");
+}
+
+Real
+ElasticEnergyMaterialSAS::computeF()
+{
+  return (_h_eta[_qp] * _prop_Fb[_qp] + (1.0 - _h_eta[_qp]) * _prop_Fa[_qp]);
+}
+
+Real
+ElasticEnergyMaterialSAS::computeDF(unsigned int i_var)
+{
+  unsigned int i = argIndex(i_var);
+
+  return -1.0 * (*_dh_eta[i])[_qp] *
+         _stress[_qp].doubleContraction(_eigenstrain_B[_qp] +
+                                        0.5 * (_strain_B[_qp] - _strain_A[_qp]));
+}

--- a/modules/solid_mechanics/src/materials/TwoPhaseStrainMaterial.C
+++ b/modules/solid_mechanics/src/materials/TwoPhaseStrainMaterial.C
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "TwoPhaseStrainMaterial.h"
+#include "RankTwoTensor.h"
+#include "RankFourTensor.h"
+
+registerMooseObject("TensorMechanicsApp", TwoPhaseStrainMaterial);
+
+InputParameters
+TwoPhaseStrainMaterial::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addClassDescription("Compute a global strain in a two phase model");
+  params.addParam<MaterialPropertyName>(
+      "h", "h", "Switching Function Material that provides h(eta)");
+  params.addRequiredParam<std::string>("base_A", "Base name for the Phase A strain.");
+  params.addRequiredParam<std::string>("base_B", "Base name for the Phase B strain.");
+  return params;
+}
+
+TwoPhaseStrainMaterial::TwoPhaseStrainMaterial(const InputParameters & parameters)
+  : DerivativeMaterialInterface<Material>(parameters),
+    _h_eta(getMaterialProperty<Real>("h")),
+
+    _base_A(getParam<std::string>("base_A") + "_"),
+    _mechanical_strain_A(getMaterialPropertyByName<RankTwoTensor>(_base_A + "mechanical_strain")),
+
+    _base_B(getParam<std::string>("base_B") + "_"),
+    _mechanical_strain_B(getMaterialPropertyByName<RankTwoTensor>(_base_B + "mechanical_strain")),
+
+    _strain(declareProperty<RankTwoTensor>("mechanical_strain"))
+{
+}
+
+void
+TwoPhaseStrainMaterial::computeQpProperties()
+{
+  _strain[_qp] =
+      _h_eta[_qp] * _mechanical_strain_B[_qp] + (1.0 - _h_eta[_qp]) * _mechanical_strain_A[_qp];
+}


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
The Steinbach-Apel's interpolation scheme is one of the interpolation schemes for the combining microelasticity and phase-field modeling with KHS and VTS. I thought it would be good to add this scheme into the MOOSE.

## Design
<!--A concise description (design) of the enhancement.-->
- ComputeInverseElasticityTensor: Inverse matrix of the stiffness which is the compliance matrix for each phase could be computed.
- ComputeHarmonicElasticityTensor: Compute the total compliance matrix using the compliance matrices obtained with 'ComputeInverseElasticityTensor' and the function h(eta) which is the switchingfunction, and inverse the total compliance matrix to obtain the total stiffness tensor.
- ComputeSteinbachApelStrain: Compute the elastic strain for each phase based on the equal stress assumption between the phases.
- TwoPhaseStrainMaterial: Compute the global elastic strain using the switchingfunction h(eta).

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
