### PR TITLE
Fix off-by-one error in HexagonalGridPositions.C

### DIFF
--- a/modules/reactor/src/positions/HexagonalGridPositions.C
+++ b/modules/reactor/src/positions/HexagonalGridPositions.C
@@ -66,11 +66,11 @@ HexagonalGridPositions::HexagonalGridPositions(const InputParameters & parameter
   }
   else
   {
-    if (MooseUtils::absoluteFuzzyGreaterThan((_nr - 1) * _pin_pitch * sqrt(3),
+    if (MooseUtils::absoluteFuzzyGreaterThan((3 * _nr - 1) * _pin_pitch / sqrt(3),
                                              _lattice_flat_to_flat))
       paramError("lattice_flat_to_flat",
-                 "Lattice flat to flat distance is less than the minimum, (nr - 1) * pin_pitch * "
-                 "sqrt(3), given nr rings with a pitch of pin_pitch");
+                 "Lattice flat to flat distance is less than the minimum (3 * nr - 1) * pin_pitch "
+                 "/ sqrt(3) given nr rings with a pitch of pin_pitch");
   }
   if ((_include_in_pattern.empty() && _pattern.size()) ||
       (_include_in_pattern.size() && _pattern.empty()))

--- a/modules/reactor/src/positions/HexagonalGridPositions.C
+++ b/modules/reactor/src/positions/HexagonalGridPositions.C
@@ -58,9 +58,10 @@ HexagonalGridPositions::HexagonalGridPositions(const InputParameters & parameter
         std::set<unsigned int>(getParam<std::vector<unsigned int>>("include_in_pattern").begin(),
                                getParam<std::vector<unsigned int>>("include_in_pattern").end()))
 {
-  if (MooseUtils::absoluteFuzzyGreaterThan(_nr * _pin_pitch * sqrt(3), _lattice_flat_to_flat))
+  if (MooseUtils::absoluteFuzzyGreaterThan((_nr - 1) * _pin_pitch * sqrt(3), _lattice_flat_to_flat))
     paramError("lattice_flat_to_flat",
-               "Bundle pitch is too small to fit this many rings at that pin pitch");
+               "Lattice flat to flat distance is less than the minimum, (nr - 1) * pin_pitch * "
+               "sqrt(3), given nr rings with a pitch of pin_pitch");
   if ((_include_in_pattern.empty() && _pattern.size()) ||
       (_include_in_pattern.size() && _pattern.empty()))
     paramError(

--- a/modules/reactor/src/positions/HexagonalGridPositions.C
+++ b/modules/reactor/src/positions/HexagonalGridPositions.C
@@ -58,10 +58,20 @@ HexagonalGridPositions::HexagonalGridPositions(const InputParameters & parameter
         std::set<unsigned int>(getParam<std::vector<unsigned int>>("include_in_pattern").begin(),
                                getParam<std::vector<unsigned int>>("include_in_pattern").end()))
 {
-  if (MooseUtils::absoluteFuzzyGreaterThan((_nr - 1) * _pin_pitch * sqrt(3), _lattice_flat_to_flat))
-    paramError("lattice_flat_to_flat",
-               "Lattice flat to flat distance is less than the minimum, (nr - 1) * pin_pitch * "
-               "sqrt(3), given nr rings with a pitch of pin_pitch");
+  if (_nr == 1)
+  {
+    if (MooseUtils::absoluteFuzzyGreaterThan(_pin_pitch, _lattice_flat_to_flat))
+      paramError("lattice_flat_to_flat",
+                 "For one ring, the lattice flat to flat must be at least the pin pitch");
+  }
+  else
+  {
+    if (MooseUtils::absoluteFuzzyGreaterThan((_nr - 1) * _pin_pitch * sqrt(3),
+                                             _lattice_flat_to_flat))
+      paramError("lattice_flat_to_flat",
+                 "Lattice flat to flat distance is less than the minimum, (nr - 1) * pin_pitch * "
+                 "sqrt(3), given nr rings with a pitch of pin_pitch");
+  }
   if ((_include_in_pattern.empty() && _pattern.size()) ||
       (_include_in_pattern.size() && _pattern.empty()))
     paramError(

--- a/modules/reactor/test/tests/positions/tests
+++ b/modules/reactor/test/tests/positions/tests
@@ -45,4 +45,22 @@
       detail = 'a three-dimensional cartesian grid with some positions excluded.'
     []
   []
+
+  [errors]
+    requirement = "The system shall error"
+    [1ring_too_big]
+      type = RunException
+      input = 'hexagonal_grid_positions.i'
+      cli_args = "Positions/hex_grid/nr=1 Positions/hex_grid/lattice_flat_to_flat=0.49"
+      expect_err = "For one ring, the lattice flat to flat must be at least the pin pitch"
+      detail = 'if the hexagonal lattice flat-to-flat specified is too small for a single pin to fit,'
+    []
+    [more_rings_too_big]
+      type = RunException
+      input = 'hexagonal_grid_positions.i'
+      cli_args = "Positions/hex_grid/lattice_flat_to_flat=1.43"
+      expect_err = "Lattice flat to flat distance is less than the minimum"
+      detail = 'and if the hexagonal lattice flat-to-flat specified is too small for the rings of pins to fit.'
+    []
+  []
 []


### PR DESCRIPTION
Closes #27051

## Reason
Corrects the formula for the minimum lattice flat-to-flat distance

## Design
Updated the `paramError` condition and error message.

## Impact
Fix bug