### PR TITLE
Fix test needing slepc restriction

### DIFF
--- a/test/tests/problems/no_solve/tests
+++ b/test/tests/problems/no_solve/tests
@@ -15,6 +15,8 @@
     input = 'ne_fail.i'
     design = 'Problem/index.md'
     issues = '#27084'
+    slepc = true
+    slepc_version = '>=3.13.0'
   []    
   [eigen_problem_skip_solve]
     type = 'RunApp'
@@ -27,5 +29,7 @@
     cli_args = Problem/solve=false
     design = 'Problem/index.md'
     issues = '#27084'
+    slepc = true
+    slepc_version = '>=3.13.0'
   []
 []


### PR DESCRIPTION
refs #27084 

Test will issue `mooseDeprecated` because it needs to be restricted to slepc>=3.13
