### PR TITLE
Prep for MooseObject error improvements

### DIFF
--- a/framework/include/interfaces/DataFileInterface.h
+++ b/framework/include/interfaces/DataFileInterface.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "MooseTypes.h"
+
 #include <string>
 
 /**
@@ -18,6 +20,11 @@ template <class T>
 class DataFileInterface
 {
 public:
+  /**
+   * The parameter type this interface expects for a data file name.
+   */
+  using DataFileParameterType = FileName;
+
   /**
    * Constructing the object
    * @param parent Parent object (either MooseObject or Action) for params and  output

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -717,7 +717,7 @@ public:
    *   (1) A local parameter must exist with the same name as common parameter
    *   (2) Common parameter must valid
    *   (3) Local parameter must be invalid OR not have been set from its default
-   *   (4) Both cannot be private
+   *   (4) Both cannot be private (unless \p allow_private = true)
    *
    * Output objects have a set of common parameters that are passed
    * down to each of the output objects created. This method is used for
@@ -726,7 +726,8 @@ public:
    * @see CommonOutputAction AddOutputAction
    */
   void applyParameters(const InputParameters & common,
-                       std::vector<std::string> exclude = std::vector<std::string>());
+                       const std::vector<std::string> & exclude = {},
+                       const bool allow_private = false);
 
   /**
    * Method for applying common parameters

--- a/framework/src/interfaces/DataFileInterface.C
+++ b/framework/src/interfaces/DataFileInterface.C
@@ -23,7 +23,7 @@ DataFileInterface<T>::getDataFileName(const std::string & param) const
 {
   /// - relative to the input file directory
   {
-    const auto & absolute_path = _parent.template getParam<FileName>(param);
+    const auto & absolute_path = _parent.template getParam<DataFileParameterType>(param);
     if (MooseUtils::checkFileReadable(absolute_path, false, false, false))
     {
       _parent.paramInfo(param, "Data file '", absolute_path, "' found relative to the input file.");

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -825,7 +825,8 @@ InputParameters::getGroupName(const std::string & param_name_in) const
 
 void
 InputParameters::applyParameters(const InputParameters & common,
-                                 const std::vector<std::string> exclude)
+                                 const std::vector<std::string> & exclude,
+                                 const bool allow_private)
 {
   // Loop through the common parameters
   for (const auto & it : common)
@@ -836,7 +837,7 @@ InputParameters::applyParameters(const InputParameters & common,
     if (std::find(exclude.begin(), exclude.end(), common_name) != exclude.end())
       continue;
 
-    applyParameter(common, common_name);
+    applyParameter(common, common_name, allow_private);
   }
 
   // Loop through the coupled variables


### PR DESCRIPTION
Refs #26947

- Allows us to not break apps that use this type.
- Allows us to not break apps that aren't using the `Factory` where they should.

Will come in before https://github.com/idaholab/moose/pull/26945 to fix bison and pronghorn ahead of time.