### PR TITLE
Fix for time derivatives after linear solves

### DIFF
--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -187,6 +187,9 @@ NonlinearSystem::solve()
     _n_linear_iters = solver.get_total_linear_iterations();
   }
 
+  if (_fe_problem.solverParams()._type == Moose::ST_LINEAR)
+    _fe_problem.computeResidualSys(_nl_implicit_sys, *_current_solution, *_nl_implicit_sys.rhs);
+
   // store info about the solve
   _final_residual = _nl_implicit_sys.final_nonlinear_residual();
 

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -187,7 +187,8 @@ NonlinearSystem::solve()
     _n_linear_iters = solver.get_total_linear_iterations();
   }
 
-  if (_fe_problem.solverParams()._type == Moose::ST_LINEAR)
+  if (_fe_problem.solverParams()._type == Moose::ST_LINEAR && _time_integrator &&
+      !_time_integrator->isExplicit())
     _fe_problem.computeResidualSys(_nl_implicit_sys, *_current_solution, *_nl_implicit_sys.rhs);
 
   // store info about the solve

--- a/framework/src/timeintegrators/CentralDifference.C
+++ b/framework/src/timeintegrators/CentralDifference.C
@@ -34,7 +34,6 @@ CentralDifference::CentralDifference(const InputParameters & parameters)
     _solution_older(_sys.solutionState(2)),
     _solution_old_old_old(_sys.solutionState(3))
 {
-  _is_explicit = true;
   if (_solve_type == LUMPED)
     _is_lumped = true;
 

--- a/framework/src/timeintegrators/ExplicitSSPRungeKutta.C
+++ b/framework/src/timeintegrators/ExplicitSSPRungeKutta.C
@@ -182,6 +182,9 @@ ExplicitSSPRungeKutta::postResidual(NumericVector<Number> & residual)
   // The time residual is not included in the steady-state residual
   residual += _Re_non_time;
 
+  // Prevent misbehavior on calls to this method after the solve loop
+  _stage = std::min(_stage, _n_stages - 1);
+
   // Compute \sum_{k=0}^{s-1} a_{s,k} u^(k) - u^(s-1)
   _tmp_solution.zero();
   for (unsigned int k = 0; k <= _stage; k++)

--- a/framework/src/timeintegrators/ExplicitTimeIntegrator.C
+++ b/framework/src/timeintegrators/ExplicitTimeIntegrator.C
@@ -43,6 +43,8 @@ ExplicitTimeIntegrator::ExplicitTimeIntegrator(const InputParameters & parameter
     _solution_update(_nl.addVector("solution_update", true, PARALLEL)),
     _mass_matrix_diag(_nl.addVector("mass_matrix_diag", false, PARALLEL))
 {
+  _is_explicit = true;
+
   _Ke_time_tag = _fe_problem.getMatrixTagID("TIME");
 
   // This effectively changes the default solve_type to LINEAR instead of PJFNK,

--- a/test/include/kernels/DotCouplingKernel.h
+++ b/test/include/kernels/DotCouplingKernel.h
@@ -23,9 +23,10 @@ public:
   virtual ~DotCouplingKernel(){};
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpOffDiagJacobian(unsigned jvar) override;
 
+  unsigned int _v_var_num;
   const VariableValue & _v_dot;
   const VariableValue & _dv_dot_dv;
 };

--- a/test/src/kernels/DotCouplingKernel.C
+++ b/test/src/kernels/DotCouplingKernel.C
@@ -20,7 +20,10 @@ DotCouplingKernel::validParams()
 }
 
 DotCouplingKernel::DotCouplingKernel(const InputParameters & parameters)
-  : Kernel(parameters), _v_dot(coupledDot("v")), _dv_dot_dv(coupledDotDu("v"))
+  : Kernel(parameters),
+    _v_var_num(coupled("v")),
+    _v_dot(coupledDot("v")),
+    _dv_dot_dv(coupledDotDu("v"))
 {
 }
 
@@ -31,7 +34,10 @@ DotCouplingKernel::computeQpResidual()
 }
 
 Real
-DotCouplingKernel::computeQpJacobian()
+DotCouplingKernel::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  return -_dv_dot_dv[_qp] * _phi[_j][_qp] * _test[_i][_qp];
+  if (_v_var_num == jvar)
+    return -_dv_dot_dv[_qp] * _phi[_j][_qp] * _test[_i][_qp];
+
+  return 0.0;
 }

--- a/test/tests/auxkernels/time_derivative/tests
+++ b/test/tests/auxkernels/time_derivative/tests
@@ -15,7 +15,18 @@
     requirement = "AuxKernel objects shall be able to couple to the time derivative of a nonlinear variable."
   [../]
 
-  [./coupled_aux_time_derivative]
+  [coupled_aux_time_derivative]
+    type = Exodiff
+    input = time_derivative_nl.i
+    exodiff = time_derivative_nl_out.e
+    cli_args = 'Executioner/solve_type=linear'
+    issues = '#27197'
+    requirement = 'AuxKernel objects shall be able to couple to the time '
+                  'derivative of a nonlinear variable even if the problem is '
+                  'in fact linear and solved as such.'
+  []
+
+  [./coupled_aux_time_derivative_to_aux]
     type = 'RunException'
     input = 'coupled_aux_time_derivative.i'
     expect_err = 'g_k: Unable to couple time derivative of an auxiliary variable into the auxiliary system.'

--- a/test/tests/auxkernels/time_derivative/time_derivative_nl.i
+++ b/test/tests/auxkernels/time_derivative/time_derivative_nl.i
@@ -77,6 +77,8 @@
   solve_type = 'NEWTON'
   dt = 0.1
   num_steps = 5
+  petsc_options_iname = -ksp_rtol
+  petsc_options_value = 1e-12
 []
 
 


### PR DESCRIPTION
Hi Alex (@lindsayad),

As discussed on Slack, the fix here works for my use case, but I'm aware it breaks some tests (let's see how many).

For context, the problem is when asking for a time derivative in an aux kernel _after_ a linear solve gets you only zeros.
The issue doesn't affect `TimeDerivativeAux` because this uses the MOOSE functor infrastructure, which uses AD to get the derivatives "just-in-time". This fix also has the advantage of fixing the "Outlier Variable Residual Norms:" message which, even though it's  printed _after_ the solve,  is currently showing the residual _before_ the solve.

Cheers,
-Nuno