### PR TITLE
Add mooseDocumentedError

### DIFF
--- a/framework/include/base/MooseBaseErrorInterface.h
+++ b/framework/include/base/MooseBaseErrorInterface.h
@@ -45,6 +45,30 @@ public:
   }
 
   /**
+   * Emits a documented error with object name and type.
+   *
+   * Documented errors are errors that have an issue associated with them.
+   *
+   * The repository name \p repo_name links a named repository to a URL
+   * and should be registered at the application level with registerRepository().
+   * See Moose.C for an example of the "moose" repository registration.
+   *
+   * @param repo_name The repository name where the issue resides
+   * @param issue_num The number of the issue
+   * @param args The error message to be combined
+   */
+  template <typename... Args>
+  [[noreturn]] void mooseDocumentedError(const std::string & repo_name,
+                                         const unsigned int issue_num,
+                                         Args &&... args) const
+  {
+    std::ostringstream oss;
+    moose::internal::mooseStreamAll(oss, std::forward<Args>(args)...);
+    const auto msg = moose::internal::formatMooseDocumentedError(repo_name, issue_num, oss.str());
+    _moose_base.callMooseError(msg, /* with_prefix = */ true);
+  }
+
+  /**
    * Emits a warning prefixed with object name and type.
    */
   template <typename... Args>

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -267,6 +267,21 @@ mooseDeprecatedStream(S & oss, const bool expired, const bool print_title, Args 
  * @}
  */
 
+/**
+ * Formats a documented error. A documented error is an error that has
+ * an issue associated with it.
+ *
+ * The repository name \p repo_name links a named repository to a URL
+ * and should be registered at the application level with registerRepository().
+ * See Moose.C for an example of the "moose" repository registration.
+ *
+ * @param repo_name The repository name where the issue resides
+ * @param issue_num The number of the issue
+ * @param msg The specific error message
+ */
+std::string formatMooseDocumentedError(const std::string & repo_name,
+                                       const unsigned int issue_num,
+                                       const std::string & msg);
 } // namespace internal
 
 /**
@@ -286,6 +301,28 @@ mooseError(Args &&... args)
   std::ostringstream oss;
   moose::internal::mooseStreamAll(oss, std::forward<Args>(args)...);
   moose::internal::mooseErrorRaw(oss.str());
+}
+
+/**
+ * Emit a documented error message with the given stringified, concatenated args
+ * and terminate the application.  Inside static functions, you will need to
+ * explicitly scope your mooseError call - i.e. do "::mooseError(arg1, ...);".
+ *
+ * Here, a documented error message is one with an associated issue. See
+ * formatMooseDocumentedError for more information.
+ *
+ * @param repo_name The repository name where the issue resides
+ * @param issue_num The number of the issue
+ * @param args The error message to stringify
+ **/
+template <typename... Args>
+[[noreturn]] void
+mooseDocumentedError(const std::string & repo_name, const unsigned int issue_num, Args &&... args)
+{
+  std::ostringstream oss;
+  moose::internal::mooseStreamAll(oss, std::forward<Args>(args)...);
+  moose::internal::mooseErrorRaw(
+      moose::internal::formatMooseDocumentedError(repo_name, issue_num, oss.str()));
 }
 
 /// Emit a warning message with the given stringified, concatenated args.

--- a/framework/include/base/Registry.h
+++ b/framework/include/base/Registry.h
@@ -79,6 +79,8 @@
 
 #define registerDataFilePath() Registry::addDataFilePath(__FILE__)
 
+#define registerRepository(repo_name, repo_url) Registry::addRepository(repo_name, repo_url);
+
 class Factory;
 class ActionFactory;
 class MooseObject;
@@ -200,6 +202,9 @@ public:
   /// register search paths for built-in data files
   static void addDataFilePath(const std::string & path);
 
+  /// register a repository
+  static void addRepository(const std::string & repo_name, const std::string & repo_url);
+
   /// Returns a per-label keyed map of all MooseObjects in the registry.
   static const std::map<std::string, std::vector<std::shared_ptr<RegistryEntryBase>>> & allObjects()
   {
@@ -227,6 +232,9 @@ public:
     return getRegistry()._data_file_paths;
   }
 
+  /// Returns the repository URL associated with \p repo_name
+  static const std::string & getRepositoryURL(const std::string & repo_name);
+
   /// returns the name() for a registered class
   template <typename T>
   static std::string getRegisteredName();
@@ -247,6 +255,8 @@ private:
   std::map<std::string, std::vector<std::shared_ptr<RegistryEntryBase>>> _per_label_actions;
   std::set<std::string> _known_labels;
   std::vector<std::string> _data_file_paths;
+  /// Repository name -> repository URL; used for mooseDocumentedError
+  std::map<std::string, std::string> _repos;
   std::map<std::string, std::string> _type_to_classname;
 };
 

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -59,6 +59,7 @@ registerAll(Factory & f, ActionFactory & af, Syntax & s)
   associateSyntaxInner(s, af);
   registerActions(s, af, {"MooseApp"});
   registerDataFilePath();
+  registerRepository("moose", "github.com/idaholab/moose");
 }
 
 void

--- a/framework/src/base/MooseError.C
+++ b/framework/src/base/MooseError.C
@@ -10,6 +10,7 @@
 #include "MooseError.h"
 #include "MooseUtils.h"
 #include "MooseVariable.h"
+#include "Registry.h"
 
 #include "libmesh/string_to_enum.h"
 
@@ -90,6 +91,17 @@ mooseErrorRaw(std::string msg, const std::string prefix)
 void
 mooseStreamAll(std::ostringstream &)
 {
+}
+
+std::string
+formatMooseDocumentedError(const std::string & repo_name,
+                           const unsigned int issue_num,
+                           const std::string & msg)
+{
+  const auto & repo_url = Registry::getRepositoryURL(repo_name);
+  std::stringstream oss;
+  oss << msg << "\n\nThis error is documented at " << repo_url << "/issues/" << issue_num << ".";
+  return oss.str();
 }
 
 } // namespace internal

--- a/framework/src/base/Registry.C
+++ b/framework/src/base/Registry.C
@@ -102,3 +102,25 @@ Registry::addDataFilePath(const std::string & fullpath)
       std::find(dfp.begin(), dfp.end(), data_dir) == dfp.end())
     dfp.push_back(data_dir);
 }
+
+void
+Registry::addRepository(const std::string & repo_name, const std::string & repo_url)
+{
+  auto & repos = getRegistry()._repos;
+  const auto [it, inserted] = repos.emplace(repo_name, repo_url);
+  if (!inserted && it->second != repo_url)
+    mooseError("Registry::registerRepository(): The repository '",
+               repo_name,
+               "' is already registered with a different URL '",
+               it->second,
+               "'.");
+}
+
+const std::string &
+Registry::getRepositoryURL(const std::string & repo_name)
+{
+  const auto & repos = getRegistry()._repos;
+  if (const auto it = repos.find(repo_name); it != repos.end())
+    return it->second;
+  mooseError("Registry::getRepositoryURL(): The repository '", repo_name, "' is not registered.");
+}

--- a/modules/doc/content/framework_development/error_warning_messaging.md
+++ b/modules/doc/content/framework_development/error_warning_messaging.md
@@ -1,0 +1,61 @@
+# Error, Warning, and Informational Messaging
+
+MOOSE provides several macros/functions for emitting errors, warnings, and informational
+messages:
+
+- `mooseError(args)`: Emits an error with a message formed by concatenating `args`.
+- `mooseDocumentedError(repo_name, issue_num, args)`: Same as `mooseError(args)`, but
+  for errors tied to defects documented in an issue tracker. See [#documented_errors].
+- `mooseAssert(condition, msg)`: In a debug executable, emits an error with message
+  `msg` if the boolean value/expression `condition` is `false`. If not in a debug
+  executable, does nothing.
+- `mooseWarning(args)`: Emits a warning with a message formed by concatenating `args`.
+  If the command-line flag `--error` is supplied, then these warnings are promoted
+  to errors.
+- `mooseDeprecated(args)`: Emits a warning related to a deprecated object/feature.
+  If the command-line flag `--error-deprecated` is supplied, then these warnings
+  are promoted to errors.
+- `mooseInfo(args)`: Emits an informational message formed by concatenating `args`.
+- `mooseDoOnce(statement)`: Executes the statement `statement` only once. Useful
+  for warnings and informational messages that would otherwise occur frequently,
+  such as during residual evaluations or for multiple time steps during a transient.
+  Example:
+
+  ```
+  mooseDoOnce(mooseWarning("This correlation is not recommended at this temperature"));
+  ```
+
+## Documented Errors id=documented_errors
+
+The `mooseDocumentedError(repo_name, issue_num, args)` function is used for errors that are tied to
+defects documented in the issue tracker of the framework or an application. This
+function is preferred over `mooseError` when it applies. For example, when
+there is some missing functionality or incompatibility, one can create an
+issue in the issue tracker for that repository, and then a developer can call
+`mooseDocumentedError` with the registered repository name `repo_name` (see below), the issue number `issue_num`
+(provided as an integer, not a string), and the error message arguments `args`.
+
+To register a repository name for an application, one must use `registerRepository(repo_name, repo_url)`
+in their application's `registerAll` method, where `repo_url` corresponds to the
+URL of the Github or Gitlab repository; for example,
+
+```
+void
+ExampleApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
+{
+  // some statements
+  registerRepository("exampleapp", "github.com/someuser/exampleapp");
+}
+```
+
+One can then call `mooseDocumentedError` with the registered repository `exampleapp`:
+
+```
+mooseDocumentedError("exampleapp", 235, "Feature ABC is not currently supported.");
+```
+
+where this error is documented in `exampleapp`'s issue #235 at `github.com/someuser/exampleapp/235`.
+
+Note that for errors in the MOOSE framework itself, the MOOSE repository is
+registered with the name `moose` already, which occurs in the constructor
+of `MooseApp`, from which every app should inherit.

--- a/modules/doc/content/framework_development/error_warning_messaging.md
+++ b/modules/doc/content/framework_development/error_warning_messaging.md
@@ -17,9 +17,12 @@ messages:
   are promoted to errors.
 - `mooseInfo(args)`: Emits an informational message formed by concatenating `args`.
   Example:
+- `mooseInfoRepeated(args)`: The same as `mooseInfo(args)` but only prints a message
+  once, even if called multiple times.
 
 !alert note title=Warnings in repeating sections
-For warnings in sections of the code that are often executed, it is better practice to leverage the SolutionInvalidityInterface, which will only output the warning once but keep track of the occurence of the problem. It can also force the solver to reject a converged solution that still presents the warning/invalid condition.
+For warnings in sections of the code that are often executed, it is recommended to leverage the [SolutionInvalidityInterface.md], which will only output the warning once but keep track of the occurence of the problem. It can also force the solver to reject a converged solution that still presents the warning/invalid condition.
+
 ## Documented Errors id=documented_errors
 
 The `mooseDocumentedError(repo_name, issue_num, args)` function is used for errors that are tied to

--- a/modules/doc/content/framework_development/error_warning_messaging.md
+++ b/modules/doc/content/framework_development/error_warning_messaging.md
@@ -21,7 +21,10 @@ messages:
   once, even if called multiple times.
 
 !alert note title=Warnings in repeating sections
-For warnings in sections of the code that are often executed, it is recommended to leverage the [SolutionInvalidityInterface.md], which will only output the warning once but keep track of the occurence of the problem. It can also force the solver to reject a converged solution that still presents the warning/invalid condition.
+For warnings in sections of the code that are often executed, it is recommended to leverage
+the [SolutionInvalidInterface.md], which will only output the warning once but keep track of
+the occurence of the problem. It can also force the solver to reject a converged solution that
+still presents the warning/invalid condition.
 
 ## Documented Errors id=documented_errors
 

--- a/modules/doc/content/framework_development/error_warning_messaging.md
+++ b/modules/doc/content/framework_development/error_warning_messaging.md
@@ -16,15 +16,10 @@ messages:
   If the command-line flag `--error-deprecated` is supplied, then these warnings
   are promoted to errors.
 - `mooseInfo(args)`: Emits an informational message formed by concatenating `args`.
-- `mooseDoOnce(statement)`: Executes the statement `statement` only once. Useful
-  for warnings and informational messages that would otherwise occur frequently,
-  such as during residual evaluations or for multiple time steps during a transient.
   Example:
 
-  ```
-  mooseDoOnce(mooseWarning("This correlation is not recommended at this temperature"));
-  ```
-
+!alert note title=Warnings in repeating sections
+For warnings in sections of the code that are often executed, it is better practice to leverage the SolutionInvalidityInterface, which will only output the warning once but keep track of the occurence of the problem. It can also force the solver to reject a converged solution that still presents the warning/invalid condition.
 ## Documented Errors id=documented_errors
 
 The `mooseDocumentedError(repo_name, issue_num, args)` function is used for errors that are tied to

--- a/modules/doc/content/framework_development/index.md
+++ b/modules/doc/content/framework_development/index.md
@@ -56,6 +56,8 @@ For development of MOOSE-based applications see [Application Development](applic
 
 [Utils](utils/index.md) - Basic utilities used throughout the framework
 
+[framework_development/error_warning_messaging.md] - How to emit error, warning, and informational messages
+
 [System Integrity Checking](sanity_checking.md) - Parsing and system integrity checks
 
 ## MOOSE Internal Systems

--- a/modules/doc/content/newsletter/2024/2024_03.md
+++ b/modules/doc/content/newsletter/2024/2024_03.md
@@ -15,6 +15,28 @@ current time step converges, whichever occurs later. The wall time output interv
 by changing the value of the [!param](/Outputs/Checkpoint/wall_time_interval) parameter (in seconds)
 in the checkpoint definition.
 
+### Linking errors to issues
+
+The error method `mooseDocumentedError()` was added, which enables tying error output directly
+to a documented issue. This method should be preferred over `mooseError()` when it applies.
+
+This new method is used as:
+
+```
+mooseDocumentedError("moose", 1234, "Your very nasty error");
+```
+
+where the accompanying error will look something like:
+
+```
+*** ERROR ***
+Your very nasty error
+
+This error is documented at github.com/idaholab/moose/issues/1234.
+```
+
+For more information, see [error_warning_messaging.md#documented_errors].
+
 ## libMesh-level Changes
 
 ### `2024.02.28` Update

--- a/unit/include/MooseDocumentedErrorTest.h
+++ b/unit/include/MooseDocumentedErrorTest.h
@@ -1,0 +1,18 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseObjectUnitTest.h"
+
+class MooseDocumentedErrorTest : public MooseObjectUnitTest
+{
+public:
+  MooseDocumentedErrorTest() : MooseObjectUnitTest("MooseUnitApp") {}
+};

--- a/unit/src/MooseDocumentedErrorTest.C
+++ b/unit/src/MooseDocumentedErrorTest.C
@@ -1,0 +1,48 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "MooseDocumentedErrorTest.h"
+
+TEST_F(MooseDocumentedErrorTest, mooseObjectError)
+{
+  EXPECT_THROW(
+      {
+        try
+        {
+          _fe_problem->mooseDocumentedError("moose", 1234, "foo");
+        }
+        catch (const std::exception & e)
+        {
+          EXPECT_EQ(std::string(e.what()),
+                    "The following error occurred in the Problem 'problem' of type "
+                    "FEProblem.\n\nfoo\n\nThis error is documented at "
+                    "github.com/idaholab/moose/issues/1234.");
+          throw;
+        }
+      },
+      std::exception);
+}
+
+TEST_F(MooseDocumentedErrorTest, staticError)
+{
+  EXPECT_THROW(
+      {
+        try
+        {
+          ::mooseDocumentedError("moose", 5678, "bar");
+        }
+        catch (const std::exception & e)
+        {
+          EXPECT_EQ(std::string(e.what()),
+                    "bar\n\nThis error is documented at github.com/idaholab/moose/issues/5678.");
+          throw;
+        }
+      },
+      std::exception);
+}

--- a/unit/src/RegistryTest.C
+++ b/unit/src/RegistryTest.C
@@ -28,3 +28,30 @@ TEST(RegistryTest, getClassName)
   // This tests the lookup of an action class name
   EXPECT_EQ(Registry::getClassName<CheckOutputAction>(), "CheckOutputAction");
 }
+
+TEST(RegistryTest, repositoryURL)
+{
+  const std::string repo_name = "bar";
+  const std::string repo_url = "github.com/foo/bar";
+
+  // not registered
+  EXPECT_THROW(
+      {
+        try
+        {
+          Registry::getRepositoryURL(repo_name);
+        }
+        catch (const std::exception & e)
+        {
+          EXPECT_EQ(std::string(e.what()),
+                    "Registry::getRepositoryURL(): The repository '" + repo_name +
+                        "' is not registered.");
+          throw;
+        }
+      },
+      std::exception);
+
+  // register it
+  Registry::addRepository(repo_name, repo_url);
+  EXPECT_EQ(Registry::getRepositoryURL(repo_name), repo_url);
+}

--- a/unit/src/RegistryTest.C
+++ b/unit/src/RegistryTest.C
@@ -54,4 +54,23 @@ TEST(RegistryTest, repositoryURL)
   // register it
   Registry::addRepository(repo_name, repo_url);
   EXPECT_EQ(Registry::getRepositoryURL(repo_name), repo_url);
+
+  // re-register, different URL
+  EXPECT_THROW(
+      {
+        try
+        {
+          Registry::addRepository(repo_name, "badurl");
+        }
+        catch (const std::exception & e)
+        {
+          EXPECT_EQ(std::string(e.what()),
+                    "Registry::registerRepository(): The repository '" + repo_name +
+                        "' is already registered "
+                        "with a different URL '" +
+                        repo_url + "'.");
+          throw;
+        }
+      },
+      std::exception);
 }


### PR DESCRIPTION
Closes #27170

Object error example:

```
object.mooseDocumentedError("moose", 1234, "Something something your error");
```

yields

```
*** ERROR **
The following error occurred in the Problem 'problem' of type FEProblem.

Something something your error

This error is documented at github.com/idaholab/moose/issues/1234.
```

The static option (non MooseObject) exists as well without the prefix.

I went with this method of registering a repository:

```
registerRepository("moose", "github.com/idaholab/moose");
```

so that the repositories are not tied to applications. That is, it's totally valid to have an error in an application that links back to a MOOSE issue. Additionally, if an application wants to use this error, they can simply register their own application,  i.e.

```
registerRepository("bison", "github.inl.gov/ncrc/bison");
```