### PR TITLE
Fix shared pointer factory create 

### DIFF
--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -34,7 +34,8 @@ class MooseObject : public MooseBase,
                     public MooseBaseParameterInterface,
                     public MooseBaseErrorInterface,
                     public libMesh::ParallelObject,
-                    public DataFileInterface<MooseObject>
+                    public DataFileInterface<MooseObject>,
+                    public std::enable_shared_from_this<MooseObject>
 {
 public:
   static InputParameters validParams();
@@ -47,6 +48,12 @@ public:
    * Return the enabled status of the object.
    */
   virtual bool enabled() const { return _enabled; }
+
+  /**
+   * Get another shared pointer to this object that has the same ownership group. Wrapper around
+   * shared_from_this().
+   */
+  std::shared_ptr<MooseObject> getSharedPtr();
 
 protected:
   /// Reference to the "enable" InputParameters, used by Controls for toggling on/off MooseObjects

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -60,3 +60,17 @@ MooseObject::MooseObject(const InputParameters & parameters)
     mooseError(
         "This registered object was not constructed using the Factory, which is not supported.");
 }
+
+std::shared_ptr<MooseObject>
+MooseObject::getSharedPtr()
+{
+  try
+  {
+    return shared_from_this();
+  }
+  catch (std::bad_weak_ptr &)
+  {
+    mooseError("MooseObject::getSharedPtr() must only be called for objects that are managed by a "
+               "shared pointer. Make sure this object is build using Factory::create(...).");
+  }
+}

--- a/unit/src/MooseObjectTest.C
+++ b/unit/src/MooseObjectTest.C
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest/gtest.h"
+#include "MooseMain.h"
+#include "MeshGeneratorMesh.h"
+
+template <class T, bool shared>
+void
+getSharedTest()
+{
+  // create an app to obtain a factory
+  std::shared_ptr<MooseApp> app = Moose::createMooseApp("MooseUnitApp", 0, nullptr);
+  auto * factory = &app->getFactory();
+
+  // build a MooseObject
+  std::string type = "MeshGeneratorMesh";
+  InputParameters params = factory->getValidParams(type);
+
+  if constexpr (shared)
+  {
+    auto mesh = factory->create<T>(type, "mesh", params);
+
+    // check usage
+    EXPECT_EQ(mesh.use_count(), 1);
+    {
+      auto mesh2 = mesh->getSharedPtr();
+      EXPECT_EQ(mesh.use_count(), 2);
+    }
+    EXPECT_EQ(mesh.use_count(), 1);
+  }
+  else
+  {
+    auto mesh = factory->createUnique<T>(type, "mesh", params);
+    EXPECT_THROW({ auto mesh2 = mesh->getSharedPtr(); }, std::exception);
+  }
+}
+
+TEST(MooseObjectTest, getSharedPtr_base) { getSharedTest<MooseObject, true>(); }
+TEST(MooseObjectTest, getSharedPtr_derived) { getSharedTest<MeshGeneratorMesh, true>(); }
+TEST(MooseObjectTest, getSharedPtr_error) { getSharedTest<MeshGeneratorMesh, false>(); }


### PR DESCRIPTION
## Reason
The Apollo code uses `std::enable_shared_from_this`, and now throws an exception since https://github.com/idaholab/moose/pull/26945/files#diff-42b65125f9d80b395d9ba504930bc4e95069965a6a7014069ee5524a746edb26L91-L101

## Design
Create a shared pointer properly.

## Impact
Fix Apollo.