### PR TITLE
Skip tests needing re-golding with fixed libMesh

### DIFF
--- a/test/tests/transfers/general_field/nearest_node/regular/tests
+++ b/test/tests/transfers/general_field/nearest_node/regular/tests
@@ -13,6 +13,7 @@
     []
 
     [projection_needed_receiving]
+      skip = 'libMesh issue, #26605'
       type = 'Exodiff'
       input = 'main.i'
       exodiff = 'projection_receive.e projection_receive_sub0_out.e projection_receive_sub1_out.e projection_receive_sub2_out.e'

--- a/test/tests/transfers/general_field/shape_evaluation/subdomain/tests
+++ b/test/tests/transfers/general_field/shape_evaluation/subdomain/tests
@@ -34,6 +34,7 @@
     []
 
     [projection_needed_receiving]
+      skip = 'libMesh issue, #26605'
       type = 'Exodiff'
       input = 'main.i'
       exodiff = 'projection_receive.e projection_receive_sub0.e projection_receive_sub1.e projection_receive_sub2.e'

--- a/test/tests/transfers/general_field/user_object/subdomain/tests
+++ b/test/tests/transfers/general_field/user_object/subdomain/tests
@@ -35,6 +35,7 @@
     []
 
     [projection_needed_receiving]
+      skip = 'libMesh issue, #26605'
       type = 'Exodiff'
       input = 'main.i'
       exodiff = 'projection_receive.e projection_receive_sub0.e projection_receive_sub1.e projection_receive_sub2.e'


### PR DESCRIPTION
The fix in https://github.com/libMesh/libmesh/pull/3814 invalidates our gold files here (by reducing the previously excessive quadrature order used to compute them), so we need the tests disabled until we can get that fix into a submodule update.

Refs https://github.com/idaholab/moose/issues/26605