### PR TITLE
Added warnings when FixedPoint params are unused.

### DIFF
--- a/framework/src/executioners/FixedPointSolve.C
+++ b/framework/src/executioners/FixedPointSolve.C
@@ -176,6 +176,19 @@ FixedPointSolve::FixedPointSolve(Executioner & ex)
     _secondary_transformed_variables = _app.fixedPointConfig().sub_transformed_vars;
     _secondary_transformed_pps = _app.fixedPointConfig().sub_transformed_pps;
   }
+
+  if (!_has_fixed_point_norm && parameters().isParamSetByUser("fixed_point_rel_tol"))
+    paramWarning(
+        "disable_fixed_point_residual_norm_check",
+        "fixed_point_rel_tol will be ignored because the fixed point residual check is disabled.");
+  if (!_has_fixed_point_norm && parameters().isParamSetByUser("fixed_point_abs_tol"))
+    paramWarning(
+        "disable_fixed_point_residual_norm_check",
+        "fixed_point_abs_tol will be ignored because the fixed point residual check is disabled.");
+  if (!_has_fixed_point_norm && parameters().isParamSetByUser("fixed_point_force_norms"))
+    paramWarning("disable_fixed_point_residual_norm_check",
+                 "fixed_point_force_norms will be ignored because the fixed point residual check "
+                 "is disabled.");
 }
 
 bool

--- a/test/tests/executioners/fixed_point/tests
+++ b/test/tests/executioners/fixed_point/tests
@@ -41,4 +41,33 @@
       detail = "materials."
     []
   []
+
+  [warnings]
+    issues = '#26285'
+    requirement = 'The system shall provide informative warnings when '
+
+    [rel_tol]
+      type = RunException
+      input = '2d_diffusion_fixed_point.i'
+      cli_args = '"Problem/solve=false" "Executioner/disable_fixed_point_residual_norm_check=true" "Executioner/fixed_point_rel_tol=1"'
+      expect_err = "fixed_point_rel_tol will be ignored because the fixed point residual check is disabled."
+      detail = 'fixed_point_rel_tol is set by the user and disable_fixed_point_residual_norm_check is set to true.'
+    []
+
+    [abs_tol]
+      type = RunException
+      input = '2d_diffusion_fixed_point.i'
+      cli_args = '"Problem/solve=false" "Executioner/disable_fixed_point_residual_norm_check=true" "Executioner/fixed_point_abs_tol=1"'
+      expect_err = "fixed_point_abs_tol will be ignored because the fixed point residual check is disabled."
+      detail = 'fixed_point_abs_tol is set by the user and disable_fixed_point_residual_norm_check is set to true.'
+    []
+
+    [force_norms]
+      type = RunException
+      input = '2d_diffusion_fixed_point.i'
+      cli_args = '"Problem/solve=false" "Executioner/disable_fixed_point_residual_norm_check=true" "Executioner/fixed_point_force_norms=true"'
+      expect_err = "fixed_point_force_norms will be ignored because the fixed point residual check is disabled."
+      detail = 'fixed_point_force_norms is set by the user and disable_fixed_point_residual_norm_check is set to true.'
+    []
+  []
 []

--- a/test/tests/multiapps/picard/steady_picard_parent.i
+++ b/test/tests/multiapps/picard/steady_picard_parent.i
@@ -63,7 +63,6 @@
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
   fixed_point_max_its = 10
-  fixed_point_rel_tol = 1e-6
 []
 
 [Outputs]

--- a/test/tests/multiapps/picard/tests
+++ b/test/tests/multiapps/picard/tests
@@ -66,6 +66,7 @@
   [steady]
     type = 'Exodiff'
     input = 'steady_picard_parent.i'
+    cli_args = 'Executioner/fixed_point_rel_tol=1e-6'
     exodiff = 'steady_picard_parent_out.e steady_picard_parent_out_sub0.e'
     recover = false
     design = 'multiapps/FullSolveMultiApp.md'


### PR DESCRIPTION
When the 'disable_fixed_point_residual_norm_check' is set to true and the user sets one of 3 parameters, a warning is printed stating that these parameters will be ignored because the norm check is disabled. The 3 parameters are: fixed_point_rel_tol, fixed_point_abs_tol, and fixed_point_force_norms.

Closes #26285.
