### PR TITLE
Fix petsc_alt next

### DIFF
--- a/modules/optimization/examples/diffusion_reaction/forward_and_adjoint.i
+++ b/modules/optimization/examples/diffusion_reaction/forward_and_adjoint.i
@@ -101,8 +101,8 @@
   type = TransientAndAdjoint
   forward_system = nl0
   adjoint_system = adjoint
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu superlu_dist'
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
   dt = 0.1
   end_time = 1
 

--- a/modules/optimization/examples/diffusion_reaction/tests
+++ b/modules/optimization/examples/diffusion_reaction/tests
@@ -29,6 +29,7 @@
       type = Exodiff
       input = optimize.i
       exodiff = optimize_out_forward0.e
+      rel_err = 1e-4
       prereq = diffusion_reaction/forward_and_adjoint
       max_threads = 1 # Optimize executioner does not support multiple threads
       # steady solve

--- a/modules/optimization/examples/diffusion_reaction/tests
+++ b/modules/optimization/examples/diffusion_reaction/tests
@@ -24,7 +24,6 @@
       exodiff = forward_and_adjoint_out.e
       prereq = 'diffusion_reaction/forward_exact diffusion_reaction/parameter_mesh'
       detail = 'performing a forward and adjoint simulation, and '
-      petsc_version = ">=3.15"
     []
     [optimize]
       type = Exodiff
@@ -35,7 +34,6 @@
       # steady solve
       recover = false
       detail = 'using TAO to perform optimization.'
-      petsc_version = ">=3.15"
     []
   []
 []

--- a/modules/optimization/examples/diffusion_reaction/tests
+++ b/modules/optimization/examples/diffusion_reaction/tests
@@ -24,6 +24,7 @@
       exodiff = forward_and_adjoint_out.e
       prereq = 'diffusion_reaction/forward_exact diffusion_reaction/parameter_mesh'
       detail = 'performing a forward and adjoint simulation, and '
+      petsc_version = ">=3.15"
     []
     [optimize]
       type = Exodiff
@@ -34,6 +35,7 @@
       # steady solve
       recover = false
       detail = 'using TAO to perform optimization.'
+      petsc_version = ">=3.15"
     []
   []
 []


### PR DESCRIPTION
Limit this test to running on versions of PETSc greater than 3.15 Note: 3.15 was arbitrarily chosen. I am not sure what exact version is required:

PETSC ERROR: --------------------- Error Message ------------------
PETSC ERROR: No support for this operation for this object type
Matrix type superlu_dist

Full error can be seen here: https://civet.inl.gov/job/2157448/

Closes #27270
