### PR TITLE
Check whether `_eigen_sys` was cast successfully

### DIFF
--- a/framework/src/kernels/EigenKernel.C
+++ b/framework/src/kernels/EigenKernel.C
@@ -185,6 +185,9 @@ EigenKernel::enabled() const
   bool flag = MooseObject::enabled();
   if (_eigen)
   {
+    if (!_eigen_sys)
+      mooseError("EigenKernel has eigen=true, but system is not a MooseEigenSystem.");
+
     if (_is_implicit)
       return flag && (!_eigen_sys->activeOnOld());
     else

--- a/framework/src/kernels/EigenKernel.C
+++ b/framework/src/kernels/EigenKernel.C
@@ -186,7 +186,11 @@ EigenKernel::enabled() const
   if (_eigen)
   {
     if (!_eigen_sys)
-      mooseError("EigenKernel has eigen=true, but system is not a MooseEigenSystem.");
+      mooseError("Eigen kernel ",
+                 name(),
+                 " requires a MooseEigenSystem and was designed to work with old eigenvalue",
+                 " executioners such as 'NonlinearEigen'.  It is suggested to use the new",
+                 " eigenvalue executioner 'Eigenvalue' along with kernel tagging");
 
     if (_is_implicit)
       return flag && (!_eigen_sys->activeOnOld());


### PR DESCRIPTION
Maybe @YaqiWang can suggest a better error message here, but this is at least a big step up from a segfault.

Fixes #27286