### PR TITLE
Must compute time derivatives ahead of Jacobian for coloring

### DIFF
--- a/framework/include/systems/NonlinearSystem.h
+++ b/framework/include/systems/NonlinearSystem.h
@@ -100,5 +100,7 @@ private:
    */
   void setupColoringFiniteDifferencedPreconditioner();
 
+  virtual bool matrixFromColoring() const override { return _use_coloring_finite_difference; }
+
   bool _use_coloring_finite_difference;
 };

--- a/framework/include/systems/SolverSystem.h
+++ b/framework/include/systems/SolverSystem.h
@@ -85,6 +85,13 @@ protected:
 
   /// Boolean to see if solution is invalid
   bool _solution_is_invalid;
+
+private:
+  /**
+   * Whether a system matrix is formed from coloring. This influences things like when to compute
+   * time derivatives
+   */
+  virtual bool matrixFromColoring() const { return false; }
 };
 
 inline const NumericVector<Number> * const &

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -232,14 +232,14 @@ NonlinearSystem::setupFiniteDifferencedPreconditioner()
 
   if (fdp->finiteDifferenceType() == "coloring")
   {
-    setupColoringFiniteDifferencedPreconditioner();
     _use_coloring_finite_difference = true;
+    setupColoringFiniteDifferencedPreconditioner();
   }
 
   else if (fdp->finiteDifferenceType() == "standard")
   {
-    setupStandardFiniteDifferencedPreconditioner();
     _use_coloring_finite_difference = false;
+    setupStandardFiniteDifferencedPreconditioner();
   }
   else
     mooseError("Unknown finite difference type");

--- a/framework/src/systems/SolverSystem.C
+++ b/framework/src/systems/SolverSystem.C
@@ -135,7 +135,7 @@ SolverSystem::compute(const ExecFlagType type)
     compute_tds = true;
   else if (type == EXEC_NONLINEAR)
   {
-    if (_fe_problem.computingScalingJacobian())
+    if (_fe_problem.computingScalingJacobian() || matrixFromColoring())
       compute_tds = true;
   }
   else if ((type == EXEC_TIMESTEP_END) || (type == EXEC_FINAL))


### PR DESCRIPTION
With the change to not compute a pre-SMO residual, when we are computing a finite difference Jacobian via coloring, the initial Jacobian computation happens before any residual evaluations. In this case we must ensure that we compute time derivatives on the `NONLINEAR` exec flag

Refs #23472