### PR TITLE
Patch for MultiAppVectorPostprocessorTransfer for distributed subapps.

### DIFF
--- a/framework/src/transfers/MultiAppVectorPostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVectorPostprocessorTransfer.C
@@ -88,8 +88,13 @@ MultiAppVectorPostprocessorTransfer::executeFromMultiapp()
 
   VectorPostprocessorValue value(getFromMultiApp()->numGlobalApps(), 0.0);
   for (unsigned int i = 0; i < getFromMultiApp()->numGlobalApps(); ++i)
-    if (getFromMultiApp()->hasLocalApp(i))
+  {
+    // To avoid duplication and thus a wrong pp value after summing value accross procs, we should
+    // ensure that value[i] is only set by one procs. To do this, we check isFirstLocalRank to see
+    // if the current proc is the first rank that subapp i lives on.
+    if (getFromMultiApp()->hasLocalApp(i) && getFromMultiApp()->isFirstLocalRank())
       value[i] = getFromMultiApp()->appProblemBase(i).getPostprocessorValueByName(_sub_pp_name);
+  }
 
   for (auto & v : value)
     _communicator.sum(v);

--- a/framework/src/transfers/MultiAppVectorPostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVectorPostprocessorTransfer.C
@@ -96,6 +96,7 @@ MultiAppVectorPostprocessorTransfer::executeFromMultiapp()
       value[i] = getFromMultiApp()->appProblemBase(i).getPostprocessorValueByName(_sub_pp_name);
   }
 
+  // Sum to distribute entries of 'value' accross all procs
   for (auto & v : value)
     _communicator.sum(v);
 

--- a/test/tests/transfers/multiapp_vector_pp_transfer/parent.i
+++ b/test/tests/transfers/multiapp_vector_pp_transfer/parent.i
@@ -55,7 +55,6 @@
     type = TransientMultiApp
     input_files = 'sub.i'
     positions = '0.25 1.25 0 0.5 1.5 0'
-    min_procs_per_app = 2
   [../]
 []
 

--- a/test/tests/transfers/multiapp_vector_pp_transfer/parent.i
+++ b/test/tests/transfers/multiapp_vector_pp_transfer/parent.i
@@ -55,7 +55,7 @@
     type = TransientMultiApp
     input_files = 'sub.i'
     positions = '0.25 1.25 0 0.5 1.5 0'
-    max_procs_per_app = 1
+    min_procs_per_app = 2
   [../]
 []
 

--- a/test/tests/transfers/multiapp_vector_pp_transfer/tests
+++ b/test/tests/transfers/multiapp_vector_pp_transfer/tests
@@ -1,5 +1,5 @@
 [Tests]
-  issues = '#10319'
+  issues = '#10319 #27047'
   design = 'MultiAppVectorPostprocessorTransfer.md'
   [vector_pp_transfer]
     type = 'CSVDiff'


### PR DESCRIPTION
This PR patches the bug reported in #27047, where the MultiAppVectorPostprocessorTransfer gives incorrect results when pp values are transfered from subapps distributed over more than 1 proc to the parent app. The transfer is executed by defining on each proc a vector of zeros with length equal to the number of subapps. The intention is that each subapp will put its pp value into the corresponding entry of this vector, leaving the other entries as zero. In order to fill the remaining zeros on each proc with the pp values from subapps not on the given proc, the vector values are summed element-wise accross all processors. The old implementation of this approach uses hasLocalApp(i) to check if subapp i belongs to the current processor. If so, the corresponding vector value is changed from 0 to the pp value. When a subapp is distributed accross more than one processor, this approach does not work because hasLocalApp(i) returns true on multiple processors, thus the vector that holds pp values gets the value for the distributed subapp on all processors that it lives on. These values are added together, resulting in an overall incorrect pp value transfered to the vpp. The solution to this issue is, in addition to checking hasLocalApp(i) to see if subapp i lives on the current processors, also check isFirstLocalRank() to determine if the current processor is the first proc that subapp i is distributed on. This avoids the erroneous duplication and summation of the same subapp's pp value.

Additionally, the test for the MultiAppVectorPostprocessorTransfer was updated to distribute each subapp over at least 2 processors so issues like these are not overlooked in the future.

Closes #27047.
