### PR TITLE
Rbg surface num

### DIFF
--- a/framework/include/utils/MooseMeshUtils.h
+++ b/framework/include/utils/MooseMeshUtils.h
@@ -289,4 +289,15 @@ void makeOrderedNodeList(std::vector<std::pair<dof_id_type, dof_id_type>> & node
                          std::vector<dof_id_type> & elem_id_list,
                          std::vector<dof_id_type> & ordered_node_list,
                          std::vector<dof_id_type> & ordered_elem_id_list);
+
+template <typename T, typename Q>
+Q
+getIDFromName(const T & name)
+{
+  const auto id = stoi(name);
+  if (id < std::numeric_limits<Q>::min() || id > std::numeric_limits<Q>::max())
+    mooseError(name, " is not within the numeric limits of the expected ID type.");
+
+  return Q(id);
+}
 }

--- a/framework/include/utils/MooseMeshUtils.h
+++ b/framework/include/utils/MooseMeshUtils.h
@@ -290,6 +290,12 @@ void makeOrderedNodeList(std::vector<std::pair<dof_id_type, dof_id_type>> & node
                          std::vector<dof_id_type> & ordered_node_list,
                          std::vector<dof_id_type> & ordered_elem_id_list);
 
+/**
+ * Converts a given name (BoundaryName or SubdomainName) into a corresponding ID (BoundaryID or
+ * SubdomainID) and performs bounds checking to ensure that overflow doesn't happen.
+ * @param name Name that is to be converted into an ID.
+ * @return ID type corresponding to the type of name.
+ */
 template <typename T, typename Q>
 Q
 getIDFromName(const T & name)

--- a/framework/include/utils/MooseMeshUtils.h
+++ b/framework/include/utils/MooseMeshUtils.h
@@ -300,10 +300,17 @@ template <typename T, typename Q>
 Q
 getIDFromName(const T & name)
 {
-  const auto id = stoi(name);
+  std::istringstream ss(name);
+  long long id = std::stoll(name);
+  Q id_Q = Q(id);
   if (id < std::numeric_limits<Q>::min() || id > std::numeric_limits<Q>::max())
-    mooseError(name, " is not within the numeric limits of the expected ID type.");
+    mooseError(MooseUtils::prettyCppType<T>(&name),
+               " ",
+               name,
+               " is not within the numeric limits of the expected ID type ",
+               MooseUtils::prettyCppType<Q>(&id_Q),
+               ".");
 
-  return Q(id);
+  return id_Q;
 }
 }

--- a/framework/include/utils/MooseMeshUtils.h
+++ b/framework/include/utils/MooseMeshUtils.h
@@ -291,8 +291,9 @@ void makeOrderedNodeList(std::vector<std::pair<dof_id_type, dof_id_type>> & node
                          std::vector<dof_id_type> & ordered_elem_id_list);
 
 /**
- * Converts a given name (BoundaryName or SubdomainName) into a corresponding ID (BoundaryID or
- * SubdomainID) and performs bounds checking to ensure that overflow doesn't happen.
+ * Converts a given name (BoundaryName or SubdomainName) that is known to only contain digits into a
+ * corresponding ID (BoundaryID or SubdomainID) and performs bounds checking to ensure that overflow
+ * doesn't happen.
  * @param name Name that is to be converted into an ID.
  * @return ID type corresponding to the type of name.
  */
@@ -300,7 +301,9 @@ template <typename T, typename Q>
 Q
 getIDFromName(const T & name)
 {
-  std::istringstream ss(name);
+  if (!MooseUtils::isDigits(name))
+    mooseError(
+        "'name' ", name, " should only contain digits that can be converted to a numerical type.");
   long long id = std::stoll(name);
   Q id_Q = Q(id);
   if (id < std::numeric_limits<Q>::min() || id > std::numeric_limits<Q>::max())

--- a/framework/src/meshgenerators/RenameBoundaryGenerator.C
+++ b/framework/src/meshgenerators/RenameBoundaryGenerator.C
@@ -24,33 +24,12 @@ RenameBoundaryGenerator::validParams()
   InputParameters params = MeshGenerator::validParams();
 
   params.addRequiredParam<MeshGeneratorName>("input", "The mesh we want to modify");
-  params.addDeprecatedParam<std::vector<BoundaryID>>(
-      "old_boundary_id",
-      "Elements with these boundary ID(s) will be given the new boundary ID(s) and/or name(s). You "
-      "must supply either 'old_boundary_id' or 'old_boundary_name'.",
-      "Use 'old_boundary' instead of 'old_boundary_id'.");
-  params.addDeprecatedParam<std::vector<BoundaryName>>(
-      "old_boundary_name",
-      "Elements with these boundary name(s) will be given the new boundary ID(s) and/or name(s). "
-      "You must supply either 'old_boundary_id' or 'old_boundary_name'.",
-      "Use 'old_boundary' instead of 'old_boundary_name'");
-  params.addDeprecatedParam<std::vector<BoundaryID>>(
-      "new_boundary_id",
-      "The new boundary ID(s) for the elements defined by "
-      "'old_boundary_id' or 'old_boundary_name'.",
-      "Use 'new_boundary' instead of 'new_boundary_id'.");
-  params.addDeprecatedParam<std::vector<BoundaryName>>(
-      "new_boundary_name",
-      "The new boundary name(s) for the elements defined by "
-      "'old_boundary_id' or 'old_boundary_name'. If 'new_boundary_id' is not provided and a "
-      "boundary with the given name does not exist, a new boundary ID will be created.",
-      "Use 'new_boundary' instead of 'new_boundary_name'.");
 
-  params.addParam<std::vector<BoundaryName>>(
+  params.addRequiredParam<std::vector<BoundaryName>>(
       "old_boundary",
       "Elements with these boundary ID(s)/name(s) will be given the new boundary information "
       "specified in 'new_boundary'");
-  params.addParam<std::vector<BoundaryName>>(
+  params.addRequiredParam<std::vector<BoundaryName>>(
       "new_boundary",
       "The new boundary ID(s)/name(s) to be given by the boundary elements defined in "
       "'old_boundary'.");
@@ -66,62 +45,12 @@ RenameBoundaryGenerator::validParams()
 RenameBoundaryGenerator::RenameBoundaryGenerator(const InputParameters & params)
   : MeshGenerator(params), _input(getMesh("input"))
 {
-  if (isParamValid("old_boundary_id") && isParamValid("old_boundary_name"))
-    paramError("old_boundary_id",
-               "Cannot use in combination with 'old_boundary_name'. Please use 'old_boundary' "
-               "instead; 'old_boundary_id' and 'old_boundary_name' are deprecated.");
-  if (isParamValid("new_boundary_id") && isParamValid("new_boundary_name"))
-    paramError("new_boundary_id",
-               "Cannot use in combination with 'new_boundary_name'. Please use 'new_boundary' "
-               "instead; 'new_boundary_id' and 'new_boundary_name' are deprecated.");
+  _old_boundary = getParam<std::vector<BoundaryName>>("old_boundary");
 
-  if (isParamValid("old_boundary_id") && isParamValid("old_boundary"))
-    paramError("old_boundary_id",
-               "Cannot use with 'old_boundary'. Use only 'old_boundary'; 'old_boundary_id' is "
-               "deprecated.");
-  if (isParamValid("old_boundary_name") && isParamValid("old_boundary"))
-    paramError(
-        "old_boundary_name",
-        "Cannot use with 'old_boundary_name'. Use only 'old_boundary'; 'old_boundary_id_name' is "
-        "deprecated.");
-
-  if (params.isParamValid("old_boundary"))
-  {
-    _old_boundary = getParam<std::vector<BoundaryName>>("old_boundary");
-    _old_boundary_param_name = "old_boundary";
-  }
-  else if (params.isParamValid("old_boundary_id"))
-  {
-    for (const auto id : getParam<std::vector<BoundaryID>>("old_boundary_id"))
-      _old_boundary.push_back(std::to_string(id));
-    _old_boundary_param_name = "old_boundary_id";
-  }
-  else
-  {
-    _old_boundary = getParam<std::vector<BoundaryName>>("old_boundary_name");
-    _old_boundary_param_name = "old_boundary_name";
-  }
-
-  if (params.isParamValid("new_boundary"))
-  {
-    _new_boundary = getParam<std::vector<BoundaryName>>("new_boundary");
-    _new_boundary_param_name = "new_boundary";
-  }
-  else if (params.isParamValid("new_boundary_id"))
-  {
-    for (const auto id : getParam<std::vector<BoundaryID>>("new_boundary_id"))
-      _new_boundary.push_back(std::to_string(id));
-    _new_boundary_param_name = "new_boundary_id";
-  }
-  else
-  {
-    _new_boundary = getParam<std::vector<BoundaryName>>("new_boundary_name");
-    _new_boundary_param_name = "new_boundary_name";
-  }
+  _new_boundary = getParam<std::vector<BoundaryName>>("new_boundary");
 
   if (_old_boundary.size() != _new_boundary.size())
-    paramError(
-        _new_boundary_param_name, "Must be the same length as '", _old_boundary_param_name, "'");
+    paramError("new_boundary", "Must be the same length as 'old_boundary'");
 }
 
 std::unique_ptr<MeshBase>
@@ -166,7 +95,7 @@ RenameBoundaryGenerator::generate()
   std::vector<BoundaryID> old_boundary_ids(num_boundaries, Moose::INVALID_BOUNDARY_ID);
   std::vector<std::string> old_boundary_names(num_boundaries);
   std::stringstream missing_boundary;
-  for (std::size_t i = 0; i < num_boundaries; ++i)
+  for (const auto i : make_range(num_boundaries))
   {
     const BoundaryName & name = _old_boundary[i];
 
@@ -191,14 +120,14 @@ RenameBoundaryGenerator::generate()
       old_boundary_names[i] = name;
   }
   if (missing_boundary.str().size())
-    paramError(_old_boundary_param_name,
+    paramError("old_boundary",
                "The following boundaries were requested to be renamed, but do not exist: ",
                missing_boundary.str());
 
   // Get the boundary IDs that we're moving to
   std::vector<BoundaryID> new_boundary_ids(num_boundaries, Moose::INVALID_BOUNDARY_ID);
   std::map<BoundaryID, std::string> new_names;
-  for (std::size_t i = 0; i < num_boundaries; ++i)
+  for (const auto i : make_range(num_boundaries))
   {
     const BoundaryName & name = _new_boundary[i];
 
@@ -265,12 +194,12 @@ RenameBoundaryGenerator::generate()
   auto temp_new_boundary_ids = new_boundary_ids;
   std::vector<std::pair<BoundaryID, BoundaryID>> temp_change_ids;
   // Loop through all new IDs
-  for (std::size_t new_i = 0; new_i < num_boundaries; ++new_i)
+  for (const auto new_i : make_range(num_boundaries))
   {
     // Look at all of the old IDs that will be moved after the move to the new ID.
     // If any of the old IDs after are IDs that we are moving to, create a temprorary
     // and keep track of it so we can move it back at the end.
-    for (std::size_t old_i = new_i + 1; old_i < num_boundaries; ++old_i)
+    for (const auto old_i : make_range(new_i + 1, num_boundaries))
       if (new_boundary_ids[new_i] == old_boundary_ids[old_i])
       {
         const auto temp_id = get_unused_boundary_id();
@@ -281,7 +210,7 @@ RenameBoundaryGenerator::generate()
   }
 
   // First pass through changing the boundary ids
-  for (std::size_t i = 0; i < num_boundaries; ++i)
+  for (const auto i : make_range(num_boundaries))
     MeshTools::Modification::change_boundary_id(
         *mesh, old_boundary_ids[i], temp_new_boundary_ids[i]);
 
@@ -290,7 +219,7 @@ RenameBoundaryGenerator::generate()
     MeshTools::Modification::change_boundary_id(*mesh, pair.first, pair.second);
 
   // First go through and remove all of the old names
-  for (std::size_t i = 0; i < num_boundaries; ++i)
+  for (const auto i : make_range(num_boundaries))
   {
     if (boundary_info.get_sideset_name_map().count(old_boundary_ids[i]))
       boundary_info.set_sideset_name_map().erase(old_boundary_ids[i]);

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -138,16 +138,7 @@ getBoundaryIDs(const MeshBase & mesh,
         id = boundary_info.get_id_by_name(boundary_name[i]);
     }
     else
-    {
-      std::istringstream ss(boundary_name[i]);
-      ss >> id;
-      if (ss.fail())
-        mooseError("Failed to convert integer ",
-                   boundary_name[i],
-                   " to a boundary id.  Got ",
-                   id,
-                   " instead.  Is the integer too large for boundary_id_type?");
-    }
+      id = getIDFromName<BoundaryName, BoundaryID>(boundary_name[i]);
 
     ids[i] = id;
   }
@@ -185,15 +176,7 @@ getBoundaryID(const BoundaryName & boundary_name, const MeshBase & mesh)
   if (!MooseUtils::isDigits(boundary_name))
     id = mesh.get_boundary_info().get_id_by_name(boundary_name);
   else
-  {
-    const auto tmp_id = stoi(boundary_name);
-    if (tmp_id >= std::numeric_limits<BoundaryID>::min() &&
-        tmp_id <= std::numeric_limits<BoundaryID>::max())
-      id = tmp_id;
-    else
-      mooseError(
-          "Boundary ID ", boundary_name, " is not within the numeric limits of type BoundaryID.");
-  }
+    id = getIDFromName<BoundaryName, BoundaryID>(boundary_name);
 
   return id;
 }
@@ -211,10 +194,7 @@ getSubdomainID(const SubdomainName & subdomain_name, const MeshBase & mesh)
   if (!MooseUtils::isDigits(subdomain_name))
     id = mesh.get_id_by_name(subdomain_name);
   else
-  {
-    std::istringstream ss(subdomain_name);
-    ss >> id;
-  }
+    id = getIDFromName<SubdomainName, SubdomainID>(subdomain_name);
 
   return id;
 }

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -186,8 +186,13 @@ getBoundaryID(const BoundaryName & boundary_name, const MeshBase & mesh)
     id = mesh.get_boundary_info().get_id_by_name(boundary_name);
   else
   {
-    std::istringstream ss(boundary_name);
-    ss >> id;
+    const auto tmp_id = stoi(boundary_name);
+    if (tmp_id >= std::numeric_limits<BoundaryID>::min() &&
+        tmp_id <= std::numeric_limits<BoundaryID>::max())
+      id = tmp_id;
+    else
+      mooseError(
+          "Boundary ID ", boundary_name, " is not within the numeric limits of type BoundaryID.");
   }
 
   return id;

--- a/test/tests/meshgenerators/polyline_mesh_generator/tests
+++ b/test/tests/meshgenerators/polyline_mesh_generator/tests
@@ -47,14 +47,4 @@
     recover = false
     requirement = "The system shall set a boundary name or id if requested."
   []
-  [polyline_bad_boundary]
-    design = 'meshgenerators/PolyLineMeshGenerator.md'
-    type = 'RunException'
-    input = 'polyline_mesh_generator_bad_boundary.i'
-    expect_err = "Failed to convert integer"
-    issues = '#24950'
-    cli_args = '--mesh-only'
-    recover = false
-    requirement = "The system shall detect any unsatisfiable boundary id requests."
-  []
 []

--- a/test/tests/meshgenerators/rename_boundary_generator/tests
+++ b/test/tests/meshgenerators/rename_boundary_generator/tests
@@ -109,7 +109,7 @@
       cli_args = 'Mesh/rename/old_boundary="0"
                   Mesh/rename/new_boundary="40000"
                   --mesh-only'
-      expect_err = "40000 is not within the numeric limits of the expected ID type."
+      expect_err = "BoundaryName 40000 is not within the numeric limits of the expected ID type"
 
       detail = 'when the user requests new boundary IDs outside the valid range of type BoundaryID.'
     []

--- a/test/tests/meshgenerators/rename_boundary_generator/tests
+++ b/test/tests/meshgenerators/rename_boundary_generator/tests
@@ -100,7 +100,7 @@
                   --mesh-only'
       expect_err = "Must be the same length as 'old_boundary'"
 
-      detail = 'and when the provided old and new boundaries are not the same length.'
+      detail = 'when the provided old and new boundaries are not the same length.'
     []
 
     [id_out_of_bounds]
@@ -111,7 +111,7 @@
                   --mesh-only'
       expect_err = "40000 is not within the numeric limits of the expected ID type."
 
-      detail = 'and when the provided old and new boundaries are not the same length.'
+      detail = 'when the user requests new boundary IDs outside the valid range of type BoundaryID.'
     []
   []
 []

--- a/test/tests/meshgenerators/rename_boundary_generator/tests
+++ b/test/tests/meshgenerators/rename_boundary_generator/tests
@@ -109,7 +109,7 @@
       cli_args = 'Mesh/rename/old_boundary="0"
                   Mesh/rename/new_boundary="40000"
                   --mesh-only'
-      expect_err = "Boundary ID 40000 is not within the numeric limits of type BoundaryID."
+      expect_err = "40000 is not within the numeric limits of the expected ID type."
 
       detail = 'and when the provided old and new boundaries are not the same length.'
     []

--- a/test/tests/meshgenerators/rename_boundary_generator/tests
+++ b/test/tests/meshgenerators/rename_boundary_generator/tests
@@ -1,6 +1,6 @@
 [Tests]
   design = 'meshgenerators/RenameBoundaryGenerator.md'
-  issues = '#11640 #14128 #16885 #21268'
+  issues = '#11640 #14128 #16885 #21268 #27175'
 
   [rename]
     requirement = 'The system shall be able to rename or renumber mesh boundaries by:'
@@ -99,6 +99,17 @@
                   Mesh/rename/new_boundary="1 2"
                   --mesh-only'
       expect_err = "Must be the same length as 'old_boundary'"
+
+      detail = 'and when the provided old and new boundaries are not the same length.'
+    []
+
+    [id_out_of_bounds]
+      type = RunException
+      input = 'rename_boundary.i'
+      cli_args = 'Mesh/rename/old_boundary="0"
+                  Mesh/rename/new_boundary="40000"
+                  --mesh-only'
+      expect_err = "Boundary ID 40000 is not within the numeric limits of type BoundaryID."
 
       detail = 'and when the provided old and new boundaries are not the same length.'
     []

--- a/test/tests/mortar/convergence-studies/gap-conductance/gap-conductance.i
+++ b/test/tests/mortar/convergence-studies/gap-conductance/gap-conductance.i
@@ -18,7 +18,7 @@
   [./left_block_sidesets]
     type = RenameBoundaryGenerator
     input = left_block
-    old_boundary_id = '0 1 2 3'
+    old_boundary = '0 1 2 3'
     new_boundary = 'lb_bottom lb_right lb_top lb_left'
   [../]
   [./left_block_id]
@@ -45,8 +45,8 @@
   [right_block_change_boundary_id]
     type = RenameBoundaryGenerator
     input = right_block_id
-    old_boundary_id = '0 1 2 3'
-    new_boundary_id = '100 101 102 103'
+    old_boundary = '0 1 2 3'
+    new_boundary = '100 101 102 103'
   []
   [./combined]
     type = MeshCollectionGenerator

--- a/test/tests/mortar/convergence-studies/solution-continuity/continuity.i
+++ b/test/tests/mortar/convergence-studies/solution-continuity/continuity.i
@@ -14,8 +14,8 @@
   [./left_block_sidesets]
     type = RenameBoundaryGenerator
     input = left_block
-    old_boundary_id = '0 1 2 3'
-    new_boundary_name = 'lb_bottom lb_right lb_top lb_left'
+    old_boundary = '0 1 2 3'
+    new_boundary = 'lb_bottom lb_right lb_top lb_left'
   [../]
   [./left_block_id]
     type = SubdomainIDGenerator
@@ -41,8 +41,8 @@
   [right_block_change_boundary_id]
     type = RenameBoundaryGenerator
     input = right_block_id
-    old_boundary_id = '0 1 2 3'
-    new_boundary_id = '100 101 102 103'
+    old_boundary = '0 1 2 3'
+    new_boundary = '100 101 102 103'
   []
   [./combined]
     type = MeshCollectionGenerator


### PR DESCRIPTION
This PR addresses #27175, which reports an issue with the
RenameBoundaryGenerator. When the 'new_boundary' parameter value is given as
boundary id values instead of boundary names, and the new ids are greater than
2^15, type overflow occurs and the boundary is renamed to the largest possible
value for type BoundaryID instead of what the user requested. This PR adds
bounds checking to user-requested boundary and subdomain ids and emits a descriptive error
if the user requests to use id values outside the range of the
respective BoundaryID and SubdomainID types.

Closes #27175
