### PR TITLE
Add method for setting input parameter unit for purposes of documentation

### DIFF
--- a/framework/doc/content/css/moose.css
+++ b/framework/doc/content/css/moose.css
@@ -569,6 +569,7 @@ li{
 .moose-parameter-description span,
 .moose-parameter-description-default span,
 .moose-parameter-description-cpptype span,
+.moose-parameter-description-doc-unit span,
 .moose-parameter-description-options span,
 .moose-parameter-description-controllable span{
     padding-right:10px;

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -212,10 +212,10 @@ public:
 
   ///@{
   /**
-   * These methods add an option parameter and a documentation string to the InputParameters object.
-   * The first version of this function takes a default value which is used if the parameter is not
-   * found in the input file. The second method will leave the parameter uninitialized but can be
-   * checked with "isParamValid" before use.
+   * These methods add an optional parameter and a documentation string to the InputParameters
+   * object. The first version of this function takes a default value which is used if the parameter
+   * is not found in the input file. The second method will leave the parameter uninitialized but
+   * can be checked with "isParamValid" before use.
    */
   template <typename T, typename S>
   void addParam(const std::string & name, const S & value, const std::string & doc_string);
@@ -506,6 +506,19 @@ public:
    * existing parameter, such as a parameter that is supplied from an interface class.
    */
   void setDocString(const std::string & name, const std::string & doc);
+
+  /**
+   * Returns the documentation unit string for the specified parameter name
+   */
+  std::string getDocUnit(const std::string & name) const;
+
+  /**
+   * Set the unit string of a parameter.
+   *
+   * This method is only used within MooseDocs and the input syntax dump in order to provide a
+   * developer-expected unit for software quality assurance purposes.
+   */
+  void setDocUnit(const std::string & name, const std::string & doc_unit);
 
   /**
    * Returns a boolean indicating whether the specified parameter is required or not
@@ -1130,6 +1143,8 @@ private:
   struct Metadata
   {
     std::string _doc_string;
+    /// The developer-designated unit of the parameter for use in documentation
+    std::string _doc_unit;
     /// The custom type that will be printed in the YAML dump for a parameter if supplied
     std::string _custom_type;
     /// The data pertaining to a command line parameter (empty if not a command line param)
@@ -1872,20 +1887,21 @@ template <>
 void InputParameters::addPrivateParam<MultiMooseEnum>(const std::string & /*name*/);
 
 template <>
-void InputParameters::addDeprecatedParam<MooseEnum>(const std::string & name,
-                                                    const std::string & doc_string,
-                                                    const std::string & deprecation_message);
+void InputParameters::addDeprecatedParam<MooseEnum>(const std::string & /*name*/,
+                                                    const std::string & /*doc_string*/,
+                                                    const std::string & /*deprecation_message*/);
 
 template <>
-void InputParameters::addDeprecatedParam<MultiMooseEnum>(const std::string & name,
-                                                         const std::string & doc_string,
-                                                         const std::string & deprecation_message);
+void
+InputParameters::addDeprecatedParam<MultiMooseEnum>(const std::string & /*name*/,
+                                                    const std::string & /*doc_string*/,
+                                                    const std::string & /*deprecation_message*/);
 
 template <>
 void InputParameters::addDeprecatedParam<std::vector<MooseEnum>>(
-    const std::string & name,
-    const std::string & doc_string,
-    const std::string & deprecation_message);
+    const std::string & /*name*/,
+    const std::string & /*doc_string*/,
+    const std::string & /*deprecation_message*/);
 
 // Forward declare specializations for setParamHelper
 template <>

--- a/framework/src/outputs/formatters/JsonInputFileFormatter.C
+++ b/framework/src/outputs/formatters/JsonInputFileFormatter.C
@@ -179,6 +179,11 @@ JsonInputFileFormatter::addParameters(const nlohmann::json & params)
     auto desc = nlohmann::to_string(param["description"]);
     addLine(l, max_len, desc);
 
+    const auto doc_unit = nlohmann::to_string(param["doc_unit"]);
+    if (!doc_unit.empty())
+      addLine("", max_len + 1,
+              "Unit: " + doc_unit); // a +1 to account for an empty line
+
     const auto group = nlohmann::to_string(param["group_name"]);
     if (!group.empty())
       addLine("", max_len + 1,

--- a/framework/src/outputs/formatters/YAMLFormatter.C
+++ b/framework/src/outputs/formatters/YAMLFormatter.C
@@ -102,6 +102,12 @@ YAMLFormatter::printParams(const std::string & prefix,
       oss << "'" << group_name << "'";
     oss << "\n";
 
+    oss << indent << "    doc_unit: ";
+    std::string doc_unit = params.getDocUnit(iter.first);
+    if (!doc_unit.empty())
+      oss << "'" << doc_unit << "'";
+    oss << "\n";
+
     if (params.have_parameter<MooseEnum>(name))
       addEnumOptionsAndDocs(oss, params.get<MooseEnum>(name), indent);
     if (params.have_parameter<MultiMooseEnum>(name))

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -356,6 +356,20 @@ InputParameters::setDocString(const std::string & name_in, const std::string & d
   it->second._doc_string = doc;
 }
 
+std::string
+InputParameters::getDocUnit(const std::string & name_in) const
+{
+  const auto name = checkForRename(name_in);
+  return _params.at(name)._doc_unit;
+}
+
+void
+InputParameters::setDocUnit(const std::string & name_in, const std::string & doc_unit)
+{
+  const auto name = checkForRename(name_in);
+  _params[name]._doc_unit = doc_unit;
+}
+
 bool
 InputParameters::isParamRequired(const std::string & name_in) const
 {

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -144,6 +144,9 @@ JsonSyntaxTree::setParams(InputParameters * params, bool search_match, nlohmann:
     std::string doc = params->getDocString(iter.first);
     MooseUtils::escape(doc);
     param_json["description"] = doc;
+
+    param_json["doc_unit"] = params->getDocUnit(iter.first);
+
     param_json["controllable"] = params->isControllable(iter.first);
     param_json["deprecated"] = params->isParamDeprecated(iter.first);
     all_params[iter.first] = param_json;

--- a/python/MooseDocs/extensions/appsyntax.py
+++ b/python/MooseDocs/extensions/appsyntax.py
@@ -772,6 +772,11 @@ class RenderParameterToken(components.RenderComponent):
         html.Tag(p, 'span', string='C++ Type:')
         html.String(p, content=cpp_type, escape=True)
 
+        doc_unit = param['doc_unit']
+        p = html.Tag(body, 'p', class_='moose-parameter-description-doc-unit')
+        html.Tag(p, 'span', string='Unit:')
+        html.String(p, content=doc_unit)
+
         if param['options']:
             p = html.Tag(body, 'p', class_='moose-parameter-description-options')
             html.Tag(p, 'span', string='Options:')

--- a/python/MooseDocs/extensions/appsyntax.py
+++ b/python/MooseDocs/extensions/appsyntax.py
@@ -775,7 +775,10 @@ class RenderParameterToken(components.RenderComponent):
         doc_unit = param['doc_unit']
         p = html.Tag(body, 'p', class_='moose-parameter-description-doc-unit')
         html.Tag(p, 'span', string='Unit:')
-        html.String(p, content=doc_unit)
+        if not doc_unit:
+            html.String(p, content='(no unit assumed for this parameter)')
+        else:
+            html.String(p, content=doc_unit)
 
         if param['options']:
             p = html.Tag(body, 'p', class_='moose-parameter-description-options')

--- a/python/MooseDocs/extensions/appsyntax.py
+++ b/python/MooseDocs/extensions/appsyntax.py
@@ -776,7 +776,7 @@ class RenderParameterToken(components.RenderComponent):
         p = html.Tag(body, 'p', class_='moose-parameter-description-doc-unit')
         html.Tag(p, 'span', string='Unit:')
         if not doc_unit:
-            html.String(p, content='(no unit assumed for this parameter)')
+            html.String(p, content='(no unit assumed)')
         else:
             html.String(p, content=doc_unit)
 

--- a/python/MooseDocs/test/extensions/test_appsyntax.py
+++ b/python/MooseDocs/test/extensions/test_appsyntax.py
@@ -207,7 +207,7 @@ class TestParam(AppSyntaxTestCase):
         self.assertHTMLTag(res(1, 0, 1), 'p', size=2, class_='moose-parameter-description-cpptype')
         self.assertEqual(u"NonlinearVariableName", res(1, 0, 1, 1)['content'])
         self.assertHTMLTag(res(1, 0, 2), 'p', size=2, class_='moose-parameter-description-doc-unit')
-        self.assertEqual(u"(no unit assumed for this parameter)", res(1, 0, 2, 1)['content'])
+        self.assertEqual(u"(no unit assumed)", res(1, 0, 2, 1)['content'])
         self.assertHTMLTag(res(1, 0, 3), 'p', size=2, class_='moose-parameter-description-controllable')
         self.assertHTMLString(res(1, 0, 3, 1), 'No')
         self.assertHTMLTag(res(1, 0, 4), 'p', size=2, class_='moose-parameter-description')

--- a/python/MooseDocs/test/extensions/test_appsyntax.py
+++ b/python/MooseDocs/test/extensions/test_appsyntax.py
@@ -126,10 +126,11 @@ class TestParameters(AppSyntaxTestCase):
         self.assertHTMLTag(res(2,0,0,1), 'span', class_='moose-parameter-header-description', size=1)
         self.assertIn('The name of the variable', res(2,0,0,1,0)['content'])
 
-        self.assertHTMLTag(res(2,0,1), 'div', size=3, class_='collapsible-body')
+        self.assertHTMLTag(res(2,0,1), 'div', size=4, class_='collapsible-body')
         self.assertHTMLTag(res(2,0,1,0), 'p', size=2, class_='moose-parameter-description-cpptype')
-        self.assertHTMLTag(res(2,0,1,1), 'p', size=2, class_='moose-parameter-description-controllable')
-        self.assertHTMLTag(res(2,0,1,2), 'p', size=2, class_='moose-parameter-description')
+        self.assertHTMLTag(res(2,0,1,1), 'p', size=2, class_='moose-parameter-description-doc-unit')
+        self.assertHTMLTag(res(2,0,1,2), 'p', size=2, class_='moose-parameter-description-controllable')
+        self.assertHTMLTag(res(2,0,1,3), 'p', size=2, class_='moose-parameter-description')
 
         self.assertHTMLTag(res(3), 'h3')
         self.assertEqual(res(3)['data-details-open'], 'open')
@@ -201,14 +202,16 @@ class TestParam(AppSyntaxTestCase):
         self.assertHTMLTag(res(0,0), 'a', string=u'"variable"', class_='moose-modal-link modal-trigger')
 
         self.assertHTMLTag(res(1), 'div', size=1, class_='moose-modal modal')
-        self.assertHTMLTag(res(1, 0), 'div', size=4, class_='modal-content')
+        self.assertHTMLTag(res(1, 0), 'div', size=5, class_='modal-content')
         self.assertHTMLTag(res(1, 0, 0), 'h4', size=1, string=u'variable')
         self.assertHTMLTag(res(1, 0, 1), 'p', size=2, class_='moose-parameter-description-cpptype')
         self.assertEqual(u"NonlinearVariableName", res(1, 0, 1, 1)['content'])
-        self.assertHTMLTag(res(1, 0, 2), 'p', size=2, class_='moose-parameter-description-controllable')
-        self.assertHTMLString(res(1, 0, 2, 1), 'No')
-        self.assertHTMLTag(res(1, 0, 3), 'p', size=2, class_='moose-parameter-description')
-        self.assertIn(u"The name of the variable", res(1, 0, 3, 1)['content'])
+        self.assertHTMLTag(res(1, 0, 2), 'p', size=2, class_='moose-parameter-description-doc-unit')
+        self.assertEqual(u"(no unit assumed for this parameter)", res(1, 0, 2, 1)['content'])
+        self.assertHTMLTag(res(1, 0, 3), 'p', size=2, class_='moose-parameter-description-controllable')
+        self.assertHTMLString(res(1, 0, 3, 1), 'No')
+        self.assertHTMLTag(res(1, 0, 4), 'p', size=2, class_='moose-parameter-description')
+        self.assertIn(u"The name of the variable", res(1, 0, 4, 1)['content'])
 
     def testLatex(self):
         _, res = self.execute(self.TEXT, renderer=base.LatexRenderer())

--- a/scripts/stork.sh
+++ b/scripts/stork.sh
@@ -152,7 +152,7 @@ if [[ "$kind" == "app" ]]; then
     echo "following steps after adding your git repository remote:"
     echo ""
     echo "    1. Navigate to $dir/doc"
-    echo "    2. Run './moosedocs.py init sqa --app '$dstnamespace' --category $dstnamelow'"
+    echo "    2. Run './moosedocs.py init sqa --app '$dstnamespace' --category '$dstnamelow'"
     echo "    3. Commit the initial SQA changes using the following commands:"
     echo "         git add $dir/doc"
     echo '         git commit -m "Initial SQA changes"'
@@ -181,7 +181,7 @@ if [[ "$kind" == "module" ]]; then
     echo "       a. Add the module to the content listing (alphabetical)"
     echo "    5. Initialize module SQA (reach out to the MOOSE development team with questions)"
     echo "       a. Navigate to moose/modules/$dstnamelow/doc"
-    echo "       b. Run './moosedocs.py init sqa --module '$dstnamespace' --category $dstnamelow'"
+    echo "       b. Run './moosedocs.py init sqa --module '$dstnamespace' --category '$dstnamelow'"
     echo "       c. Add new module to SQA extension categories in modules/doc/config.yml (alphabetical)"
     echo "       d. Add new module to Applications and Requirements sections of modules/doc/sqa_reports.yml (alphabetical)"
     echo "    6. Ensure that no stork files hang around before committing"


### PR DESCRIPTION
## Reason
This change is intended to address corrective action CA 2021-1199 for BlackBear/Grizzly (and other MOOSE-based application to which a similar CA applies) and provide a new capability to framework and application developers who with to provide more context regarding intended units for a given parameter. This is **not** intended to provide automatic unit conversion for input parameters (but could likely be used as the API to tweak further in the future). 

## Design
Create `setDocoUnit` and `getDocoUnit` methods for setting a unit in the object source code and getting it for use in other code or, in this case, in the JSON output for use in MooseDocs. MooseDocs infrastructure to display this new parameter metadata should also be constructed in accordance with the other parameter metadata already presented. 

## Impact
New documentation for intended units in calculations will improve software quality. This is not a simulation enhancement but a user/developer quality-of-life one.