### PR TITLE
Supply Euler angles from aux-variables for CP

### DIFF
--- a/modules/solid_mechanics/include/materials/crystal_plasticity/ComputeElasticityTensorCP.h
+++ b/modules/solid_mechanics/include/materials/crystal_plasticity/ComputeElasticityTensorCP.h
@@ -52,4 +52,8 @@ protected:
 
   /// flag for user-defined rotation matrix, supplied in input file
   bool _user_provided_rotation_matrix;
+
+  // The coupled Euler angles component variables
+  unsigned int _n_euler_angle_vars;
+  const std::vector<const VariableValue *> _euler_angle_vars;
 };

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/euler_ang_file.txt
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/euler_ang_file.txt
@@ -1,0 +1,1 @@
+../stress_update_material_based/euler_ang_file.txt

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/euler_angle_auxvar.i
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/euler_angle_auxvar.i
@@ -1,0 +1,179 @@
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  elem_type = HEX8
+[]
+
+[AuxVariables]
+  [euler_angle_1]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [euler_angle_2]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [euler_angle_3]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  # Euler angles aux variable to check the correctness of value assignments
+  [check_euler_angle_1]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [check_euler_angle_2]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [check_euler_angle_3]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+[]
+
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
+      [all]
+        strain = FINITE
+        add_variables = true
+        generate_output = stress_zz
+      []
+    []
+  []
+[]
+
+[AuxKernels]
+  [euler_angle_1]
+    type = FunctionAux
+    variable = euler_angle_1
+    function = '10*t'
+  []
+  [euler_angle_2]
+    type = FunctionAux
+    variable = euler_angle_2
+    function = '20*t'
+  []
+  [euler_angle_3]
+    type = FunctionAux
+    variable = euler_angle_3
+    function = '30*t'
+  []
+  # output Euler angles material property to check correctness of value assignment
+  [mat_euler_angle_1]
+    type = MaterialRealVectorValueAux
+    variable = check_euler_angle_1
+    property = 'Euler_angles'
+    component = 0
+   []
+   [mat_euler_angle_2]
+    type = MaterialRealVectorValueAux
+    variable = check_euler_angle_2
+    property = 'Euler_angles'
+    component = 1
+   []
+   [mat_euler_angle_3]
+    type = MaterialRealVectorValueAux
+    variable = check_euler_angle_3
+    property = 'Euler_angles'
+    component = 2
+   []
+[]
+
+[BCs]
+  [Periodic]
+    [all]
+      variable = 'disp_x'
+      auto_direction = 'z'
+    []
+  []
+  [fix_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = 'left'
+    value = 0
+  []
+  [fix_y]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 'bottom'
+    value = 0
+  []
+  [fix_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = 'back'
+    value = 0
+  []
+  [tdisp]
+    type = FunctionDirichletBC
+    variable = disp_z
+    boundary = 'front'
+    function = '0.01*t'
+  []
+[]
+
+[Materials]
+  [elasticity_tensor]
+    type = ComputeElasticityTensorCP
+    C_ijkl = '1.684e5 1.214e5 1.214e5 1.684e5 1.214e5 1.684e5 0.754e5 0.754e5 0.754e5'
+    fill_method = symmetric9
+    euler_angle_variables = 'euler_angle_1 euler_angle_2 euler_angle_3'
+  []
+  [stress]
+    type = ComputeMultipleCrystalPlasticityStress
+    crystal_plasticity_models = 'trial_xtalpl'
+    tan_mod_type = exact
+  []
+  [trial_xtalpl]
+    type = CrystalPlasticityKalidindiUpdate
+    number_slip_systems = 12
+    slip_sys_file_name = input_slip_sys.txt
+  []
+[]
+
+[Postprocessors]
+  [check_euler_angle_1]
+    type = ElementAverageValue
+    variable = check_euler_angle_1
+  []
+  [check_euler_angle_2]
+    type = ElementAverageValue
+    variable = check_euler_angle_2
+  []
+  [check_euler_angle_3]
+    type = ElementAverageValue
+    variable = check_euler_angle_3
+  []
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = ' lu '
+  nl_abs_tol = 1e-10
+  nl_rel_tol = 1e-10
+  nl_abs_step_tol = 1e-10
+
+  dt = 0.1
+  dtmin = 0.01
+  end_time = 0.5
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/euler_angle_conflict.i
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/euler_angle_conflict.i
@@ -1,0 +1,192 @@
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  xmax = 4
+  nx = 4
+  elem_type = HEX8
+[]
+
+[AuxVariables]
+  [euler_angle_1]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [euler_angle_2]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [euler_angle_3]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  # Euler angles aux variable to check the correctness of value assignments
+  [check_euler_angle_1]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [check_euler_angle_2]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [check_euler_angle_3]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+[]
+
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
+      [all]
+        strain = FINITE
+        add_variables = true
+        generate_output = stress_zz
+      []
+    []
+  []
+[]
+
+[AuxKernels]
+  [euler_angle_1]
+    type = FunctionAux
+    variable = euler_angle_1
+    function = '10*t'
+  []
+  [euler_angle_2]
+    type = FunctionAux
+    variable = euler_angle_2
+    function = '20*t'
+  []
+  [euler_angle_3]
+    type = FunctionAux
+    variable = euler_angle_3
+    function = '30*t'
+  []
+  # output Euler angles material property to check correctness of value assignment
+  [mat_euler_angle_1]
+    type = MaterialRealVectorValueAux
+    variable = check_euler_angle_1
+    property = 'Euler_angles'
+    component = 0
+   []
+   [mat_euler_angle_2]
+    type = MaterialRealVectorValueAux
+    variable = check_euler_angle_2
+    property = 'Euler_angles'
+    component = 1
+   []
+   [mat_euler_angle_3]
+    type = MaterialRealVectorValueAux
+    variable = check_euler_angle_3
+    property = 'Euler_angles'
+    component = 2
+   []
+[]
+
+[BCs]
+  [Periodic]
+    [all]
+      variable = 'disp_x'
+      auto_direction = 'z'
+    []
+  []
+  [fix_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = 'left'
+    value = 0
+  []
+  [fix_y]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 'bottom'
+    value = 0
+  []
+  [fix_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = 'back'
+    value = 0
+  []
+  [tdisp]
+    type = FunctionDirichletBC
+    variable = disp_z
+    boundary = 'front'
+    function = '0.01*t'
+  []
+[]
+
+[Materials]
+  [elasticity_tensor]
+    type = ComputeElasticityTensorCP
+    C_ijkl = '1.684e5 1.214e5 1.214e5 1.684e5 1.214e5 1.684e5 0.754e5 0.754e5 0.754e5'
+    fill_method = symmetric9
+    read_prop_user_object = prop_read
+    euler_angle_variables = 'euler_angle_1 euler_angle_2 euler_angle_3'
+  []
+  [stress]
+    type = ComputeMultipleCrystalPlasticityStress
+    crystal_plasticity_models = 'trial_xtalpl'
+    tan_mod_type = exact
+  []
+  [trial_xtalpl]
+    type = CrystalPlasticityKalidindiUpdate
+    number_slip_systems = 12
+    slip_sys_file_name = input_slip_sys.txt
+  []
+[]
+
+[UserObjects]
+  [prop_read]
+    type = PropertyReadFile
+    prop_file_name = 'euler_ang_file.txt'
+    # Enter file data as prop#1, prop#2, .., prop#nprop
+    nprop = 3
+    read_type = element
+  []
+[]
+
+[Postprocessors]
+  [check_euler_angle_1]
+    type = ElementAverageValue
+    variable = check_euler_angle_1
+  []
+  [check_euler_angle_2]
+    type = ElementAverageValue
+    variable = check_euler_angle_2
+  []
+  [check_euler_angle_3]
+    type = ElementAverageValue
+    variable = check_euler_angle_3
+  []
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = ' lu '
+  nl_abs_tol = 1e-10
+  nl_rel_tol = 1e-10
+  nl_abs_step_tol = 1e-10
+
+  dt = 0.1
+  dtmin = 0.01
+  end_time = 0.5
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/gold/euler_angle_auxvar_out.csv
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/gold/euler_angle_auxvar_out.csv
@@ -1,0 +1,7 @@
+time,check_euler_angle_1,check_euler_angle_2,check_euler_angle_3
+0,0,0,0
+0.1,1,2,3
+0.2,2,4,6
+0.3,3,6,9
+0.4,4,8,12
+0.5,5,10,15

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/input_slip_sys.txt
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/input_slip_sys.txt
@@ -1,0 +1,1 @@
+./../stress_update_material_based/input_slip_sys.txt

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/tests
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/euler_angles/tests
@@ -1,0 +1,23 @@
+[Tests]
+  issues = '#19497'
+  design = 'ComputeElasticityTensorCP.md'
+  [euler_angle_auxvar]
+    type = 'CSVDiff'
+    input = 'euler_angle_auxvar.i'
+    csvdiff = 'euler_angle_auxvar_out.csv'
+    requirement = 'The crystal plasticity models should be able to utilize Euler angle values supplied through AuxVariables.'
+  []
+  [euler_angle_auxvar_conflict]
+    type = 'RunException'
+    input = 'euler_angle_conflict.i'
+    expect_err = 'Euler angles cannot be supplied from both coupled variables and auxiliary input file in the option `read_prop_user_object`.'
+    requirement = 'An error will be thrown when trying to set Euler angles information from a text file and AuxVariables at the same time.'
+  []
+  [euler_angle_components]
+    type = 'RunException'
+    input = 'euler_angle_auxvar.i'
+    expect_err = 'The Euler angles should have three components.'
+    cli_args = 'Materials/elasticity_tensor/euler_angle_variables="euler_angle_1"'
+    requirement = 'An error will be thrown when trying to set Euler angles information with less than three components.'
+  []
+[]


### PR DESCRIPTION
Add an option in `ComputeElasticityTensorCP` for getting Euler angle values from `AuxVariables`. This would be useful for coupling crystal plasticity with phase-field simulations. 