### PR TITLE
Changed default value of 'normal_tol' in SideSetsFromNormalsGenerator

### DIFF
--- a/framework/src/meshgenerators/SideSetsFromNormalsGenerator.C
+++ b/framework/src/meshgenerators/SideSetsFromNormalsGenerator.C
@@ -42,6 +42,10 @@ SideSetsFromNormalsGenerator::validParams()
                                   "Deprecated, use 'normal_tol' instead");
   params.deprecateParam("tolerance", "normal_tol", "4/01/2025");
 
+  // We want to use a different normal_tol for this generator than from the base class to preserve
+  // old behavior.
+  params.setParameters("normal_tol", 1e-5);
+
   // We are using 'normals' instead
   params.suppressParameter<Point>("normal");
 

--- a/modules/porous_flow/examples/groundwater/ex02_steady_state.i
+++ b/modules/porous_flow/examples/groundwater/ex02_steady_state.i
@@ -14,6 +14,7 @@
   [zmax]
     type = SideSetsFromNormalsGenerator
     input = name_blocks
+    normal_tol = 0.1
     new_boundary = zmax
     normals = '0 0 1'
   []


### PR DESCRIPTION
This PR patches a bug reported by @aprilnovak. When capabilities from several sideset generators were refactored into a base class in #26869, the default value of the parameter controlling the tolerance for comparing normals changed from 1e-5 to 0.1 for the `SideSetsFromNormalsGenerator`. This PR sets the default value of the `normal_tol` parameter to 1e-5 for this generator, preserving the old behavior.

Closes Ref #26252 (for the third time)

