### PR TITLE
Add methods for array vars to the Coupleable API docs

### DIFF
--- a/framework/doc/content/source/interfaces/Coupleable.md
+++ b/framework/doc/content/source/interfaces/Coupleable.md
@@ -25,6 +25,17 @@ The following tables summarize the methods it provides.
 
 ---
 
+| Methods for array field variables | Description |
+| :--- | :--- |
+`coupledArrayValue`‡ | Value of a coupled array variable at q-points
+`coupledArrayGradient`‡ | Gradient of a coupled array variable at q-points
+`coupledArrayDot`† | Time derivative of a coupled array variable at q-points
+`coupledArrayDotDot`† | Second time derivative of a coupled array variable at q-points
+`coupledArrayDotDu` | Derivative with regards to the variable of the time derivative of a coupled array variable at q-points
+`coupledArrayGradientDot` | Time derivative of the gradient of a coupled array variable at q-points
+
+---
+
 | Methods for vector field variables | Description |
 | :--- | :--- |
 `coupledVectorValue`‡§ | Value of a coupled vector variable at q-points

--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -480,8 +480,8 @@ protected:
 
   /**
    * Returns value of a coupled array variable
-   * @param var_name Name of coupled vector variable
-   * @param comp Component number for vector of coupled vector variables
+   * @param var_name Name of coupled array variable
+   * @param comp Component number for vector of coupled array variables
    * @return Reference to a ArrayVariableValue for the coupled vector variable
    * @see ArrayKernel::_u
    */
@@ -589,9 +589,9 @@ protected:
                                                               unsigned int comp = 0) const;
 
   /**
-   * Returns an old value from previous time step  of a coupled array variable
-   * @param var_name Name of coupled variable
-   * @param comp Component number for vector of coupled variables
+   * Returns an old value from previous time step of a coupled array variable
+   * @param var_name Name of coupled array variable
+   * @param comp Component number for vector of coupled array variables
    * @return Reference to a ArrayVariableValue containing the old value of the coupled variable
    * @see ArrayKernel::_u_old
    */
@@ -600,8 +600,8 @@ protected:
 
   /**
    * Returns an old value from two time steps previous of a coupled array variable
-   * @param var_name Name of coupled variable
-   * @param comp Component number for vector of coupled variables
+   * @param var_name Name of coupled array variable
+   * @param comp Component number for vector of coupled array variables
    * @return Reference to a ArrayVariableValue containing the older value of the coupled variable
    * @see ArrayKernel::_u_older
    */
@@ -1137,8 +1137,8 @@ protected:
 
   /**
    * Time derivative of a coupled array variable with respect to the coefficients
-   * @param var_name Name of coupled vector variable
-   * @param comp Component number for vector of coupled vector variables
+   * @param var_name Name of coupled array variable
+   * @param comp Component number for vector of coupled array variables
    * @return Reference to a ArrayVariableValue containing the time derivative of the coupled
    * variable
    */


### PR DESCRIPTION
## Motivation
The table reworked in #27376 did not mention array variables in its comprehensive surveys of the APIs defined in the coupleable interface

## Design
Add entries for array variables, for the routines that are defined for array variables in the Coupleable interface

## Impact
More comprehensive documentation
Lessened user support needs


Hi @GiudGiud,

Apologies, I missed the methods for array variables in #27376...  partly because I didn't really understand array variables.

After some reading, my understanding is that an array variable is just another specialisation of `MooseVariableFE`, together with standard and vector variables. In particular, they are completely separate from the concept of a "vector of variables" which seems to be exclusive to the Coupleable API. Indeed, it seems you can have vectors of array variables!

One detail which isn't clear to me is if you can have arrays of vector variables: it seems you can't when reading the [docs](https://mooseframework.inl.gov/source/variables/ArrayMooseVariable.html), but it seems you can when reading this newsletter [entry](https://mooseframework.inl.gov/newsletter/2019/2019_07.html). In particular, that would allow the user to create vectors of arrays of vector variables (inception! :P).

-Nuno
