### PR TITLE
add_subdomain_names

### DIFF
--- a/framework/doc/content/source/mesh/MooseMesh.md
+++ b/framework/doc/content/source/mesh/MooseMesh.md
@@ -39,6 +39,7 @@ construct the relevant side sets and node sets earlier in the mesh generation pr
 To declare subdomain IDs which are not found on the mesh right after the mesh is setup, a list of IDs can be 
 specified using the `Mesh/add_subdomain_ids` parameter. This permits setting up block restricted objects that
 will only act on subdomains created during the simulation (e.g. using the [CoupledVarThresholdElementSubdomainModifier.md]).
+These IDs can optionally be assigned names using the `Mesh/add_subdomain_names` parameter.
 
 ## Minimal interface
 

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -410,7 +410,8 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
   } 
   else if (isParamValid("add_subdomain_ids") && isParamValid("add_subdomain_names"))
   {
-    const auto add_subdomain = getParam<SubdomainID, SubdomainName>("add_subdomain_ids", "add_subdomain_names");
+    const auto add_subdomain =
+        getParam<SubdomainID, SubdomainName>("add_subdomain_ids", "add_subdomain_names");
     for (const auto & [sub_id, sub_name] : add_subdomain)
     {
       // add subdomain id

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -407,7 +407,7 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
     // only subdomain ids are explicitly given
     const auto & add_subdomain_id = getParam<std::vector<SubdomainID>>("add_subdomain_ids");
     _mesh_subdomains.insert(add_subdomain_id.begin(), add_subdomain_id.end());
-  } 
+  }
   else if (isParamValid("add_subdomain_ids") && isParamValid("add_subdomain_names"))
   {
     const auto add_subdomain =

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -168,7 +168,8 @@ MooseMesh::validParams()
 
   params.addParam<std::vector<SubdomainName>>(
       "add_subdomain_names",
-      "Optional list of subdomain names to be applied to the ids given in add_subdomain_ids.");
+      "Optional list of subdomain names to be applied to the ids given in add_subdomain_ids. "
+      "This list must contain the same number of items as add_subdomain_ids.");
 
   params += MooseAppCoordTransform::validParams();
 
@@ -406,6 +407,7 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
     const auto add_subdomain_id = getParam<std::vector<SubdomainID>>("add_subdomain_ids");
     _mesh_subdomains.insert(add_subdomain_id.begin(), add_subdomain_id.end());
     
+    // do we have subdomain names explicitly given?
     if (isParamValid("add_subdomain_names"))
     {
       const auto add_subdomain_name = getParam<std::vector<SubdomainName>>("add_subdomain_names");

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -166,6 +166,10 @@ MooseMesh::validParams()
       "restrictions for subdomains initially containing no elements, which can occur, for example, "
       "in additive manufacturing simulations which dynamically add and remove elements.");
 
+  params.addParam<std::vector<SubdomainName>>(
+      "add_subdomain_names",
+      "Optional list of subdomain names to be applied to the ids given in add_subdomain_ids.");
+
   params += MooseAppCoordTransform::validParams();
 
   // This indicates that the derived mesh type accepts a MeshGenerator, and should be set to true in
@@ -401,6 +405,24 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
   {
     const auto add_subdomain_id = getParam<std::vector<SubdomainID>>("add_subdomain_ids");
     _mesh_subdomains.insert(add_subdomain_id.begin(), add_subdomain_id.end());
+    
+    if (isParamValid("add_subdomain_names"))
+    {
+      const auto add_subdomain_name = getParam<std::vector<SubdomainName>>("add_subdomain_names");
+      const int n_ids = add_subdomain_id.size();
+      const int n_names = add_subdomain_name.size();
+
+      if (n_ids != n_names)
+        mooseError("Number of items provided in add_subdomain_ids and add_subdomain_names does not match.");
+
+      for (int i = 0; i < n_ids; ++i)
+        setSubdomainName(add_subdomain_id[i], add_subdomain_name[i]);
+    };
+
+  } else if (isParamValid("add_subdomain_names"))
+  {
+    // the user has defined add_subdomain_names, but not add_subdomain_ids
+    mooseError("In combination with add_subdomain_names, add_subdomain_ids must be defined.");
   }
 
   // Make sure nodesets have been generated

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -405,18 +405,18 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
   if (isParamValid("add_subdomain_ids") && !isParamValid("add_subdomain_names"))
   {
     // only subdomain ids are explicitly given
-    const auto add_subdomain_id = getParam<std::vector<SubdomainID>>("add_subdomain_ids");
+    const auto & add_subdomain_id = getParam<std::vector<SubdomainID>>("add_subdomain_ids");
     _mesh_subdomains.insert(add_subdomain_id.begin(), add_subdomain_id.end());
   } 
-  else if (isParamValid("add_subdomain_ids") && isParamValid("add_subdomain_names")) 
+  else if (isParamValid("add_subdomain_ids") && isParamValid("add_subdomain_names"))
   {
     const auto add_subdomain = getParam<SubdomainID, SubdomainName>("add_subdomain_ids", "add_subdomain_names");
-    for (const auto & i : add_subdomain)
+    for (const auto & [sub_id, sub_name] : add_subdomain)
     {
       // add subdomain id
-      _mesh_subdomains.insert(i.first);
+      _mesh_subdomains.insert(sub_id);
       // set name of the subdomain just added
-      setSubdomainName(i.first, i.second);
+      setSubdomainName(sub_id, sub_name);
     }
   }
   else if (isParamValid("add_subdomain_names"))

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -402,31 +402,26 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
     _mesh_subdomains.insert(elem->subdomain_id());
 
   // add explicitly requested subdomains
-  if (isParamValid("add_subdomain_ids"))
+  if (isParamValid("add_subdomain_ids") && !isParamValid("add_subdomain_names"))
   {
+    // only subdomain ids are explicitly given
     const auto add_subdomain_id = getParam<std::vector<SubdomainID>>("add_subdomain_ids");
     _mesh_subdomains.insert(add_subdomain_id.begin(), add_subdomain_id.end());
-
-    // do we have subdomain names explicitly given?
-    if (isParamValid("add_subdomain_names"))
+  } 
+  else if (isParamValid("add_subdomain_ids") && isParamValid("add_subdomain_names")) 
+  {
+    const auto add_subdomain = getParam<SubdomainID, SubdomainName>("add_subdomain_ids", "add_subdomain_names");
+    for (const auto & i : add_subdomain)
     {
-      const auto add_subdomain_name = getParam<std::vector<SubdomainName>>("add_subdomain_names");
-      const int n_ids = add_subdomain_id.size();
-      const int n_names = add_subdomain_name.size();
-
-      if (n_ids != n_names)
-        mooseError("Number of items provided in add_subdomain_ids and add_subdomain_names does not "
-                   "match.");
-
-      for (int i = 0; i < n_ids; ++i)
-        setSubdomainName(add_subdomain_id[i], add_subdomain_name[i]);
-    };
+      // add subdomain id
+      _mesh_subdomains.insert(i.first);
+      // set name of the subdomain just added
+      setSubdomainName(i.first, i.second);
+    }
   }
   else if (isParamValid("add_subdomain_names"))
-  {
     // the user has defined add_subdomain_names, but not add_subdomain_ids
     mooseError("In combination with add_subdomain_names, add_subdomain_ids must be defined.");
-  }
 
   // Make sure nodesets have been generated
   buildNodeListFromSideList();

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -406,7 +406,7 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
   {
     const auto add_subdomain_id = getParam<std::vector<SubdomainID>>("add_subdomain_ids");
     _mesh_subdomains.insert(add_subdomain_id.begin(), add_subdomain_id.end());
-    
+
     // do we have subdomain names explicitly given?
     if (isParamValid("add_subdomain_names"))
     {
@@ -415,13 +415,14 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
       const int n_names = add_subdomain_name.size();
 
       if (n_ids != n_names)
-        mooseError("Number of items provided in add_subdomain_ids and add_subdomain_names does not match.");
+        mooseError("Number of items provided in add_subdomain_ids and add_subdomain_names does not "
+                   "match.");
 
       for (int i = 0; i < n_ids; ++i)
         setSubdomainName(add_subdomain_id[i], add_subdomain_name[i]);
     };
-
-  } else if (isParamValid("add_subdomain_names"))
+  }
+  else if (isParamValid("add_subdomain_names"))
   {
     // the user has defined add_subdomain_names, but not add_subdomain_ids
     mooseError("In combination with add_subdomain_names, add_subdomain_ids must be defined.");

--- a/test/tests/mesh/add_subdomain_ids/tests
+++ b/test/tests/mesh/add_subdomain_ids/tests
@@ -7,4 +7,13 @@
     design = MooseMesh.md
     requirement = 'The system shall allow specifying valid subdomain IDs that do not exist on the initial mesh.'
   []
+  [add_subdomain_ids_and_names]
+    type = Exodiff
+    input = add_subdomain_ids.i
+    exodiff = add_subdomain_ids_out.e
+    cli_args = "Mesh/add_subdomain_names='future'"
+    issues = '#27474'
+    design = MooseMesh.md
+    requirement = 'The system shall allow specifying valid subdomain IDs and names that do not exist on the initial mesh.'
+  []
 []

--- a/unit/src/MooseServerTest.C
+++ b/unit/src/MooseServerTest.C
@@ -1045,7 +1045,7 @@ TEST_F(MooseServerTest, CompletionMeshDefaultedType)
 
   EXPECT_EQ(request_id, response_id);
 
-  EXPECT_EQ(47u, completions_array.size());
+  EXPECT_EQ(48u, completions_array.size());
 
   std::ostringstream completions_actual;
 
@@ -1056,6 +1056,7 @@ TEST_F(MooseServerTest, CompletionMeshDefaultedType)
   std::string completions_expect = R"INPUT(
 label: active                                 text: active = '${1:__all__}'                             desc: If specified only... pos: [6.0]-[6.0] kind:  7 format: snippet
 label: add_subdomain_ids                      text: add_subdomain_ids =                                 desc: The listed subdom... pos: [6.0]-[6.0] kind: 14 format: regular
+label: add_subdomain_names                    text: add_subdomain_names =                               desc: Optional list of ... pos: [6.0]-[6.0] kind: 14 format: regular
 label: allow_renumbering                      text: allow_renumbering = ${1:true}                       desc: If allow_renumber... pos: [6.0]-[6.0] kind:  8 format: snippet
 label: alpha_rotation                         text: alpha_rotation =                                    desc: The number of deg... pos: [6.0]-[6.0] kind: 14 format: regular
 label: beta_rotation                          text: beta_rotation =                                     desc: The number of deg... pos: [6.0]-[6.0] kind: 14 format: regular


### PR DESCRIPTION
refs #27415

## Reason
Using the property add_subdomain_ids of the MooseMesh base class a user can add (initially empty) subdomains to an existing mesh for later usage. Up to my knowledge today only subdomain IDs can be added and no name is provided for these subdomains. This PR proposes the property add_subdomain_names addessing this issue.

## Design
This PR adds the proeprty add_subdomain_names to the MooseMesh base class

## Impact
This PR only adds functionality. Existing Moose apps should be able to cope with the proposed changes without any problems.