### PR TITLE
Set petsc's options_left option to false for mesh-only mode.

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -54,6 +54,7 @@
 #include "RestartableDataWriter.h"
 #include "StringInputStream.h"
 #include "MooseMain.h"
+#include "PetscSupport.h"
 
 // Regular expression includes
 #include "pcrecpp.h"
@@ -983,6 +984,9 @@ MooseApp::setupOptions()
       _syntax.addDependency("mesh_only", "setup_mesh_complete");
       _syntax.addDependency("determine_system_type", "mesh_only");
       _action_warehouse.setFinalTask("mesh_only");
+      // Turn off Petsc's warning about unused petsc options since we do not use petsc in mesh-only
+      // mode
+      Moose::PetscSupport::setSinglePetscOption("-options_left", "0");
     }
     else if (isParamValid("split_mesh"))
     {

--- a/test/tests/mesh/mesh_only/tests
+++ b/test/tests/mesh/mesh_only/tests
@@ -19,8 +19,9 @@
     recover = false
     method = '!dbg'
     expect_out = 'Mesh Information'
-    issues = '#11917 #11921'
-    requirement = 'The system shall print out information about the mesh when writing out the mesh.'
+    absent_out = 'Option left: name:--mesh-only'
+    issues = '#11917 #11921 #26002'
+    requirement = 'The system shall print out information about the mesh when writing out the mesh and avoid emitting petsc warnings in mesh-only mode.'
   []
 
   [mesh_only_warning]


### PR DESCRIPTION
Set petsc's options_left option to false for mesh-only mode. Doing this keeps petsc from emitting irrelevant warnings when running MOOSE in mesh-only mode. Closes #26002.
