### PR TITLE
wip: adding inelastic strain increment predictor to radial return creep stressupdate materials.

### DIFF
--- a/modules/solid_mechanics/include/materials/PowerLawCreepStressUpdate.h
+++ b/modules/solid_mechanics/include/materials/PowerLawCreepStressUpdate.h
@@ -90,6 +90,8 @@ protected:
   using RadialReturnCreepStressUpdateBaseTempl<is_ad>::_three_shear_modulus;
   using RadialReturnCreepStressUpdateBaseTempl<is_ad>::_creep_strain;
   using RadialReturnCreepStressUpdateBaseTempl<is_ad>::_creep_strain_old;
+  using RadialReturnCreepStressUpdateBaseTempl<is_ad>::_eff_creep_strain_inc;
+  using RadialReturnCreepStressUpdateBaseTempl<is_ad>::_eff_creep_strain_inc_old;
 
 private:
   template <typename ScalarType>

--- a/modules/solid_mechanics/include/materials/RadialReturnCreepStressUpdateBase.h
+++ b/modules/solid_mechanics/include/materials/RadialReturnCreepStressUpdateBase.h
@@ -33,6 +33,9 @@ protected:
   virtual void
   computeStressFinalize(const GenericRankTwoTensor<is_ad> & plastic_strain_increment) override;
 
+  virtual GenericReal<is_ad>
+  initialGuess(const GenericReal<is_ad> & /*effective_trial_stress*/) override;
+
   /**
    * This method returns the derivative of the creep strain with respect to the von mises stress. It
    * assumes the stress delta (von mises stress used to determine the creep rate) is calculated as:
@@ -50,9 +53,16 @@ protected:
     return TangentCalculationMethod::PARTIAL;
   }
 
+  ///intialGuess scalar scaling factor for creep strain increment from previous step
+  const Real _eff_creep_strain_inc_predictor_scale;
+
   /// Creep strain material property
   GenericMaterialProperty<RankTwoTensor, is_ad> & _creep_strain;
   const MaterialProperty<RankTwoTensor> & _creep_strain_old;
+
+  /// Creep strain increment property
+  MaterialProperty<Real> & _eff_creep_strain_inc;
+  const MaterialProperty<Real> & _eff_creep_strain_inc_old;
 };
 
 typedef RadialReturnCreepStressUpdateBaseTempl<false> RadialReturnCreepStressUpdateBase;

--- a/modules/solid_mechanics/src/materials/LAROMANCEStressUpdateBase.C
+++ b/modules/solid_mechanics/src/materials/LAROMANCEStressUpdateBase.C
@@ -534,6 +534,9 @@ LAROMANCEStressUpdateBaseTempl<is_ad>::resetIncrementalMaterialProperties()
 
   _wall_dislocations_step[_qp] = 0.0;
   _cell_dislocations_step[_qp] = 0.0;
+  // fixme lynn should this call
+  // RadialReturnCreepStressUpdateBaseTempl<is_ad>::resetIncrementalMaterialProperties()
+  //  to reset creep_strain_increment
 }
 
 template <bool is_ad>
@@ -546,6 +549,7 @@ LAROMANCEStressUpdateBaseTempl<is_ad>::storeIncrementalMaterialProperties(
   _number_of_substeps[_qp] = total_number_of_substeps;
 }
 
+// fixme lynn -- this needs to use a predicted effective_trial_stress.  Not yet implemented
 template <bool is_ad>
 void
 LAROMANCEStressUpdateBaseTempl<is_ad>::computeStressInitialize(

--- a/modules/solid_mechanics/src/materials/PowerLawCreepStressUpdate.C
+++ b/modules/solid_mechanics/src/materials/PowerLawCreepStressUpdate.C
@@ -113,13 +113,21 @@ PowerLawCreepStressUpdateTempl<is_ad>::computeStressFinalize(
     const GenericRankTwoTensor<is_ad> & plastic_strain_increment)
 {
   _creep_strain[_qp] += plastic_strain_increment;
+  // compute effective_strain_increment from tensor
+  // plastic_strain_increment is already deviatoric.
+  const Real deviatoric_strain_inc_squared =
+      MetaPhysicL::raw_value(plastic_strain_increment)
+          .doubleContraction(MetaPhysicL::raw_value(plastic_strain_increment));
+  _eff_creep_strain_inc[_qp] += std::sqrt(2.0 / 3.0 * deviatoric_strain_inc_squared);
 }
 
 template <bool is_ad>
 void
 PowerLawCreepStressUpdateTempl<is_ad>::resetIncrementalMaterialProperties()
 {
+  // fixme lynn should this be in RadialReturnCreepStressUpdateBaseTempl
   _creep_strain[_qp] = _creep_strain_old[_qp];
+  _eff_creep_strain_inc[_qp] = _eff_creep_strain_inc_old[_qp];
 }
 
 template <bool is_ad>

--- a/modules/solid_mechanics/src/materials/RadialReturnCreepStressUpdateBase.C
+++ b/modules/solid_mechanics/src/materials/RadialReturnCreepStressUpdateBase.C
@@ -14,6 +14,9 @@ InputParameters
 RadialReturnCreepStressUpdateBaseTempl<is_ad>::validParams()
 {
   InputParameters params = RadialReturnStressUpdateTempl<is_ad>::validParams();
+  params.addParam<Real>("eff_creep_strain_inc_predictor_scale",
+                        0.0,
+                        "Scaling factor for creep strain increment from previous step.");
   params.set<std::string>("effective_inelastic_strain_name") = "effective_creep_strain";
   return params;
 }
@@ -22,10 +25,16 @@ template <bool is_ad>
 RadialReturnCreepStressUpdateBaseTempl<is_ad>::RadialReturnCreepStressUpdateBaseTempl(
     const InputParameters & parameters)
   : RadialReturnStressUpdateTempl<is_ad>(parameters),
+    _eff_creep_strain_inc_predictor_scale(
+        this->template getParam<Real>("eff_creep_strain_inc_predictor_scale")),
     _creep_strain(this->template declareGenericProperty<RankTwoTensor, is_ad>(this->_base_name +
                                                                               "creep_strain")),
     _creep_strain_old(
-        this->template getMaterialPropertyOld<RankTwoTensor>(this->_base_name + "creep_strain"))
+        this->template getMaterialPropertyOld<RankTwoTensor>(this->_base_name + "creep_strain")),
+    _eff_creep_strain_inc(
+        this->template declareProperty<Real>(this->_base_name + "eff_creep_strain_inc")),
+    _eff_creep_strain_inc_old(
+        this->template getMaterialPropertyOld<Real>(this->_base_name + "eff_creep_strain_inc"))
 {
 }
 
@@ -34,7 +43,7 @@ void
 RadialReturnCreepStressUpdateBaseTempl<is_ad>::initQpStatefulProperties()
 {
   _creep_strain[_qp].zero();
-
+  _eff_creep_strain_inc[_qp] = 0.;
   RadialReturnStressUpdateTempl<is_ad>::initQpStatefulProperties();
 }
 
@@ -43,7 +52,7 @@ void
 RadialReturnCreepStressUpdateBaseTempl<is_ad>::propagateQpStatefulProperties()
 {
   _creep_strain[_qp] = _creep_strain_old[_qp];
-
+  _eff_creep_strain_inc[_qp] = _eff_creep_strain_inc_old[_qp];
   propagateQpStatefulPropertiesRadialReturn();
 }
 
@@ -64,11 +73,25 @@ RadialReturnCreepStressUpdateBaseTempl<false>::computeStressDerivative(
 }
 
 template <bool is_ad>
+GenericReal<is_ad>
+RadialReturnCreepStressUpdateBaseTempl<is_ad>::initialGuess(
+    const GenericReal<is_ad> & /*effective_trial_stress*/)
+{
+  return _eff_creep_strain_inc_predictor_scale * _eff_creep_strain_inc_old[_qp];
+}
+
+template <bool is_ad>
 void
 RadialReturnCreepStressUpdateBaseTempl<is_ad>::computeStressFinalize(
     const GenericRankTwoTensor<is_ad> & plastic_strain_increment)
 {
   _creep_strain[_qp] = _creep_strain_old[_qp] + plastic_strain_increment;
+  // compute effective_strain_increment from tensor
+  // plastic_strain_increment is already deviatoric.
+  const Real deviatoric_strain_inc_squared =
+      MetaPhysicL::raw_value(plastic_strain_increment)
+          .doubleContraction(MetaPhysicL::raw_value(plastic_strain_increment));
+  _eff_creep_strain_inc[_qp] = std::sqrt(2.0 / 3.0 * deviatoric_strain_inc_squared);
 }
 
 template class RadialReturnCreepStressUpdateBaseTempl<false>;


### PR DESCRIPTION
This implements what Wen had but it is still calling computeStressInitialize with the wrong trial stress
ref #27428
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
