### PR TITLE
Update NEML2 Makefile

### DIFF
--- a/modules/solid_mechanics/contrib/neml2.mk
+++ b/modules/solid_mechanics/contrib/neml2.mk
@@ -72,8 +72,9 @@ $(info Compiling MOOSE with NEML2.)
 app_non_unity_dirs += $(shell find $(APPLICATION_DIR)/src/neml2 -type d -not -path '*/.libs*' 2> /dev/null)
 app_non_unity_dirs += $(shell find $(APPLICATION_DIR)/test/src/neml2 -type d -not -path '*/.libs*' 2> /dev/null)
 
-NEML2_INCLUDE        := $(NEML2_DIR)/include
-NEML2_SRC            := $(shell find $(NEML2_DIR)/src -name "*.cxx")
+NEML2_INCLUDE        := $(NEML2_DIR)/include $(addsuffix /include,$(ADDITIONAL_NEML2_DIRS))
+NEML2_SRC_DIRS       := $(NEML2_DIR)/src $(addsuffix /src,$(ADDITIONAL_NEML2_DIRS))
+NEML2_SRC            := $(shell find $(NEML2_SRC_DIRS) -name "*.cxx")
 NEML2_OBJ            := $(patsubst %.cxx,%.$(obj-suffix),$(NEML2_SRC))
 NEML2_LIB            := $(NEML2_DIR)/libNEML2-$(METHOD).la
 
@@ -83,12 +84,12 @@ $(NEML2_LIB): $(NEML2_OBJ)
 	  $(libmesh_CC) $(libmesh_CFLAGS) -o $@ $(NEML2_OBJ) $(libmesh_LDFLAGS) $(EXTERNAL_FLAGS) -rpath $(NEML2_DIR)
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $(NEML2_LIB) $(NEML2_DIR)
 
-$(NEML2_DIR)/src/%.$(obj-suffix) : $(NEML2_DIR)/src/%.cxx
+$(NEML2_OBJ) : %.$(obj-suffix) : %.cxx
 	@echo "Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -w -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
-ADDITIONAL_INCLUDES  += -iquote$(NEML2_INCLUDE)
+ADDITIONAL_INCLUDES  += $(addprefix -iquote,$(NEML2_INCLUDE))
 ADDITIONAL_CPPFLAGS  += -DNEML2_ENABLED -DDTYPE=Float64 -DINT_DTYPE=Int64
 ADDITIONAL_LIBS      += -L$(NEML2_DIR) -lNEML2-$(METHOD)
 ADDITIONAL_DEPEND_LIBS += $(NEML2_LIB)


### PR DESCRIPTION
Closes #27438

This approach breaks with the `src/system/*` and `include/system/*` pattern and forces the neml2 objects to reside in `additional_neml2_dir/src` and `additional_neml2_dir/include`.

For once, the neml2 objects are not MOOSE objects, and I don't want them to be accidentally picked up by the MOOSE build system, as they would be compiled with the wrong flags.

For example in the Bison `Makefile` I'm adding

```
ADDITIONAL_NEML2_DIRS += $(CURDIR)/neml2
```