### PR TITLE
Fix an issue with PerfGraphLivePrint trying to print too early

### DIFF
--- a/framework/doc/content/source/utils/PerfGraphLivePrint.md
+++ b/framework/doc/content/source/utils/PerfGraphLivePrint.md
@@ -4,11 +4,11 @@
 
 The `PerfGraphLivePrint` (PGLP) object is responsible for printing information to the screen as a code is executing.  To perform this action PGLP is executing on a separate thread from the main thread.  This thread will be referred to as the "print thread".  The main thread keeps track of what is executing using the `TIME_SECTION` macro as part of [/PerfGraph.md].  PGLP then reads this information and decides whether or not to print information about what is currently happening.
 
-By default, PGLP prints information any time a section takes longer than one second to execute.  It will print out the "live print message" at that point, then it will print a single `.` for every second until the section ends.  When the section ends, both the memory and the time will be printed. By default, the total memory used (by the simulation at this point) and the increment in time (e.g. the time for this section only) are printed.
+By default, PGLP prints information any time a section takes longer than five seconds to execute.  It will print out the "live print message" at that point, then it will print a single `.` every five seconds until the section ends.  When the section ends, both the memory and the time will be printed. By default, the total memory used (by the simulation at this point) and the increment in time (e.g. the time for this section only) are printed. The time limit is configurable from the input file.
 
-The other reason that PGLP prints is for a large increase in memory (by default 100MB).  If, after a section executes, the memory usage increased by more than the limit, then PGLP will print the live print message and show the current total memory consumption as well as the time was used by the section.  The memory limit is configurable from the input file.
+The other reason that PGLP prints is for a large increase in memory (by default 100MB).  If, after a section executes, the memory usage increased by more than the limit, then PGLP will print the live print message and show the current total memory consumption as well as the time used by the section.  The memory limit is configurable from the input file.
 
-The PGLP primarily works by waking up every second and inspecting what the program has done / is currently doing, printing any necessary information and then going back to sleep.  It should be lightweight enough that it should not significantly disrupt the operation of the program.
+The PGLP primarily works by waking up every five seconds and inspecting what the program has done / is currently doing, printing any necessary information and then going back to sleep.  It should be lightweight enough that it should not significantly disrupt the operation of the program.
 
 ## Objects/Data Structures Used By PerfGraphLivePrint
 
@@ -30,7 +30,7 @@ The `SectionIncrement` objects are stored in a `std::array` called `_execution_l
 
 The execution list is stored in the `PerfGraph` and keeps a running list of every timed section starting and stopping.  As mentioned above, it is a `std::array` of `SectionIncrement` objects that are statically allocated at the start of execution.  The execution list works as a "circular buffer"... when the end of the list is reached, filling continues by wrapping around to the beginning of the list.  To do this, a simple counter is kept for where the beginning and ending of the current execution list are.  The beginning and ending are kept in atomic variables so that they are threadsafe since they will be read and written to by both the main thread and the print thread.
 
-The entire execution history is necessary because the PGLP only wakes up every second - and it needs to be able to see everything that transpired.  This allows it to know what has finished so that it can print finishing information and gives it the ability to keep track of what is currently executing by developing a print thread stack.
+The entire execution history is necessary because the PGLP only wakes up every five seconds - and it needs to be able to see everything that transpired.  This allows it to know what has finished so that it can print finishing information and gives it the ability to keep track of what is currently executing by developing a print thread stack.
 
 ### PerfGraphLivePrint::_print_thread_stack
 
@@ -40,17 +40,17 @@ The print thread stack is developed by the PGLP by reading the execution list fr
 
 ## Threading and Thread Safety
 
-Threading is accomplished using C++ threading mechanisms.  The PGLP is started in the constructor of `PerfGraph` as a `std::thread`.  The destructor of `PerfGraph` tells the PGLP to finish and calls `join()` on it to delete it.
+Threading is accomplished using C++ threading mechanisms.  The PGLP is started as a `std::thread`.  The destructor of `PerfGraph` tells the PGLP to finish and calls `join()` on it to delete it.
 
 ### Memory Synchronization
 
-With the main thread writing to the execution list and the PGLP reading from it on its own thread, memory synchronization is critical.  In `PerfGraph:addToExecutionList` a `SectionIncrement` has its data filled in, then a `std::atomic_thread_fence()` is used to make sure the changes to that `SectionIncrement`'s data is "published" to all threads _before_ incrementing the end of the execution list.  That thread fence "synchronizes with" the a thread fence in `PerfGraphLivePrint::start()`.  This means that if the PGLP wakes up as the `SectionInfo` is being written to, that it won't ever access the data mid-change.  All of this is achieved without any locking on the main thread.
+With the main thread writing to the execution list and the PGLP reading from it on its own thread, memory synchronization is critical.  In `PerfGraph:addToExecutionList` a `SectionIncrement` has its data filled in, then a `std::atomic_thread_fence()` is used to make sure the changes to that `SectionIncrement`'s data is "published" to all threads _before_ incrementing the end of the execution list.  That thread fence "synchronizes with" a thread fence in `PerfGraphLivePrint::start()`.  This means that if the PGLP wakes up as the `SectionInfo` is being written to, that it won't ever access the data mid-change.  All of this is achieved without any locking on the main thread.
 
 ### Waiting and Waking Up
 
 The main execution loop for PGLP is in `start()` and is a `while()` loop that is dependent on the object-local `_currently_destructing` variable.  Details about `_currently_destructing` are below - but the gist is that the loop will continue until `PerfGraph` tells it not to.
 
-PGLP waits on a section completing so that we can instantly print the finishing info for it.  To do this, we use a `std::condition_variable`.  A `condition_variable` can be used to wait for a notification from the main thread.  By using `wait_for()` it is possible to wait until either the specified amount of time has passed or the thread is signaled to wakeup.  This allows the PGLP to sleep for 1 second, or until the main thread tells it that a section is complete.
+PGLP waits on a section completing so that we can instantly print the finishing info for it.  To do this, we use a `std::condition_variable`.  A `condition_variable` can be used to wait for a notification from the main thread.  By using `wait_for()` it is possible to wait until either the specified amount of time has passed or the thread is signaled to wakeup.  This allows the PGLP to sleep for 5 seconds, or until the main thread tells it that a section is complete.
 
 However, the actual workings of a `condition_variable` are complex.  There are actually three reasons why a `wait_for()` may wakeup:
 
@@ -60,11 +60,11 @@ However, the actual workings of a `condition_variable` are complex.  There are a
 
 The third type of wakeup occurs when an OS wakes the thread up early, which can happen randomly.  This is ok with us, because it gives us a moment to check to see if sections have completed while the thread has been asleep.  To do that, there is a predicate functor passed to `wait_for` that does exactly this check.  In addition, it also checks to see if the `PerfGraph` is `_destructing`... which would mean the PGLP should stop waiting and print the final info.
 
-I want to take a moment and talk about locking and `condition_variable`.  Usually, you want to use a lock to guard the evaluation of the predicate and the setting of variable values in the main thread.  In our case, we really don't want locking in the execution pathway of the main thread because it could slow down execution.  To get around this, the variables used in the predicate are atomic.  However, this isn't without its own flaws.  There is a tiny chance that the predicate can be evaluated when it is false, but then, in-between checking the predicate and waiting for the signal the main thread signals, then the PGLP starts looking for a signal.  In this case, the PGLP may wait one second more before finding out that there is work to be done.  This is incredibly rare, and is not worth fixing by having a lock on the main thread.
+I want to take a moment and talk about locking and `condition_variable`.  Usually, you want to use a lock to guard the evaluation of the predicate and the setting of variable values in the main thread.  In our case, we really don't want locking in the execution pathway of the main thread because it could slow down execution.  To get around this, the variables used in the predicate are atomic.  However, this isn't without its own flaws.  There is a tiny chance that the predicate can be evaluated when it is false, but then, in-between checking the predicate and waiting for the signal the main thread signals, then the PGLP starts looking for a signal.  In this case, the PGLP may wait five seconds more before finding out that there is work to be done.  This is incredibly rare, and is not worth fixing by having a lock on the main thread.
 
 ### Destructing
 
-As mentioned above, the PGLP is looping until the `PerfGraph` signals that it is destructing.  The `_destructing` variable in `PerfGraph` is guarded by a mutex that is also utilized when checking the predicate of the condition variable mentioned above.  This is done because we don't want to accidentally miss the destructing signal and wait for 1 more second - delaying the ending of the program.  That could be hugely detrimental to a run that is running thousands of cases (like a stochastic sampling or even just running tests).
+As mentioned above, the PGLP is looping until the `PerfGraph` signals that it is destructing.  The `_destructing` variable in `PerfGraph` is guarded by a mutex that is also utilized when checking the predicate of the condition variable mentioned above.  This is done because we don't want to accidentally miss the destructing signal and wait for 5 more seconds - delaying the ending of the program.  That could be hugely detrimental to a run that is running thousands of cases (like a stochastic sampling or even just running tests).
 
 One more small detail about destructing is that the value of it needs to be captured _before_ capturing the value of the end of the execution list.  This is to make sure that the final end of the execution list is available for the last run-through of the PGLP... so that everything can be completely printed.
 
@@ -78,7 +78,7 @@ If the execution list is not in the same place, then it must be iterated through
 
 The different reasons (ways) things are printed are:
 
-1. Has been running for 1 second (print live message)
+1. Has been running for 5 seconds (print live message)
 2. Is still running (print dots)
 3. Was the current thing running that had already been printed and finished (print stats)
 4. Is continuing to run after an internal scope was running and was printed (print "Still")

--- a/framework/include/utils_nonunity/PerfGraph.h
+++ b/framework/include/utils_nonunity/PerfGraph.h
@@ -122,6 +122,11 @@ public:
   void setLivePrintActive(bool active) { _live_print_active = active; }
 
   /**
+   * Enables Live Print
+   */
+  void enableLivePrint();
+
+  /**
    * Completely disables Live Print (cannot be restarted)
    */
   void disableLivePrint();

--- a/framework/include/utils_nonunity/PerfGraph.h
+++ b/framework/include/utils_nonunity/PerfGraph.h
@@ -117,19 +117,7 @@ public:
   void printHeaviestSections(const ConsoleStream & console, const unsigned int num_sections);
 
   /**
-   * Whether or not timing is active
-   *
-   * When not active no timing information will be kept
-   */
-  bool active() const { return _active; }
-
-  /**
-   * Turn on or off timing
-   */
-  void setActive(bool active) { _active = active; }
-
-  /**
-   * Turn on or off live printing (if timing is off then live printing will be off too)
+   * Turn on or off live printing
    */
   void setLivePrintActive(bool active) { _live_print_active = active; }
 
@@ -382,9 +370,6 @@ protected:
   /// to iterate over the above map much - and it makes it
   /// easier to sort
   std::vector<CumulativeSectionInfo *> _cumulative_section_info_ptrs;
-
-  /// Whether or not timing is active
-  bool _active;
 
   /// Whether or not live printing is active
   std::atomic<bool> _live_print_active;

--- a/framework/include/utils_nonunity/PerfGraph.h
+++ b/framework/include/utils_nonunity/PerfGraph.h
@@ -239,9 +239,6 @@ protected:
     /// This section has already started printing
     PRINTED,
 
-    /// Something else printed, but now this printed again
-    CONTINUED,
-
     /// The section is complete
     FINISHED
   };

--- a/framework/include/utils_nonunity/PerfGraphLivePrint.h
+++ b/framework/include/utils_nonunity/PerfGraphLivePrint.h
@@ -122,9 +122,6 @@ private:
   /// The current output count from the console
   unsigned long long int _console_num_printed;
 
-  /// Whether or not printing happened in this iteration
-  bool _printed;
-
   /// Whether or not the top thing on the stack is set to print dots
   bool _stack_top_print_dots;
 };

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -540,6 +540,8 @@ MooseApp::MooseApp(InputParameters parameters)
   _the_warehouse->registerAttribute<AttribSorted>("sorted");
   _the_warehouse->registerAttribute<AttribDisplaced>("displaced", -1);
 
+  _perf_graph.enableLivePrint();
+
   if (isParamValid("_argc") && isParamValid("_argv"))
   {
     int argc = getParam<int>("_argc");

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -723,7 +723,7 @@ MooseApp::setupOptions()
   {
     _pars.set<bool>("timing") = false;
 
-    _perf_graph.setActive(false);
+    _perf_graph.setLivePrintActive(false);
   }
 
   if (isParamValid("trap_fpe") && isParamValid("no_trap_fpe"))

--- a/framework/src/utils_nonunity/PerfGraph.C
+++ b/framework/src/utils_nonunity/PerfGraph.C
@@ -41,7 +41,6 @@ PerfGraph::PerfGraph(const std::string & root_name,
     _stack(),
     _execution_list_begin(0),
     _execution_list_end(0),
-    _active(true),
     _live_print_active(true),
     _destructing(false),
     _live_print_time_limit(5.0),
@@ -180,7 +179,7 @@ PerfGraph::addToExecutionList(const PerfID id,
 void
 PerfGraph::push(const PerfID id)
 {
-  if (!_active && !_live_print_active)
+  if (!_live_print_active)
     return;
 
   PerfNode * new_node = nullptr;
@@ -226,7 +225,7 @@ PerfGraph::push(const PerfID id)
 void
 PerfGraph::pop()
 {
-  if (!_active && !_live_print_active)
+  if (!_live_print_active)
     return;
 
   auto current_time = std::chrono::steady_clock::now();

--- a/framework/src/utils_nonunity/PerfGraph.C
+++ b/framework/src/utils_nonunity/PerfGraph.C
@@ -47,16 +47,20 @@ PerfGraph::PerfGraph(const std::string & root_name,
     _live_print_mem_limit(100),
     _live_print(std::make_unique<PerfGraphLivePrint>(*this, app))
 {
+  push(_root_node_id);
+}
+
+PerfGraph::~PerfGraph() { disableLivePrint(); }
+
+void
+PerfGraph::enableLivePrint()
+{
   if (_pid == 0 && !_disable_live_print)
   {
     // Start the printing thread
     _print_thread = std::thread([this] { this->_live_print->start(); });
   }
-
-  push(_root_node_id);
 }
-
-PerfGraph::~PerfGraph() { disableLivePrint(); }
 
 void
 PerfGraph::disableLivePrint()

--- a/framework/src/utils_nonunity/PerfGraphLivePrint.C
+++ b/framework/src/utils_nonunity/PerfGraphLivePrint.C
@@ -315,18 +315,18 @@ PerfGraphLivePrint::start()
   {
     std::unique_lock<std::mutex> lock(_perf_graph._destructing_mutex);
 
-    // Wait for one second, or until notified that a section is finished
+    // Wait for five seconds (by default), or until notified that a section is finished
     // For a section to have finished the execution list has to have been appended to
     // This keeps spurious wakeups from happening
     // Note that the `lock` is only protecting _destructing since the execution list uses atomics.
     // It must be atomic in order to keep the main thread from having to lock as it
     // executes.  The only downside to this is that it is possible for this thread to wake,
     // check the condition, miss the notification, then wait.  In our case this is not detrimental,
-    // as the only thing that will happen is we will wait 1 more second.  This is also very
+    // as the only thing that will happen is we will wait 5 more seconds.  This is also very
     // unlikely.
-    // One other thing: wait_for() is not guaranteed to wait for 1 second.  "Spurious" wakeups
+    // One other thing: wait_for() is not guaranteed to wait for 5 seconds.  "Spurious" wakeups
     // can occur - but the predicate here keeps us from doing anything in that case.
-    // This will either wait until 1 second has passed, the signal is sent, _or_ a spurious
+    // This will either wait until 5 seconds have passed, the signal is sent, _or_ a spurious
     // wakeup happens to find that there is work to do.
     _perf_graph._finished_section.wait_for(
         lock,


### PR DESCRIPTION
## Bug description
Under some circumstances (e.g. when the memory usage is high enough right at the start of the program), the `PerfGraphLivePrint` thread will try to print time and memory usage stats before the main thread has had the time to register the `add_output` task. 

## Steps to reproduce
Use MPICH4.2 with CUDA support enabled and run a case
OR 
add a large allocation before the 'add_output' task is run

## Impact
Does not print as expected. Impossible to disable


-----------
Hi Alex (@lindsayad),

As discussed over Slack, the issue seems to be that under some circumstances (e.g. when the memory usage is high enough right at the start of the program), the `PerfGraphLivePrint` thread will try to print time and memory usage stats before the main thread has had the time to register the `add_output` task. To solve this, I've moved the thread start to just after the main thread finishes doing that.

I've also updated the docs and added a commit to remove some functionality that I thought was redundant and probably not working as intended.

Note this was originally discovered when trying to run a MOOSE app with MPICH 4.2.x with CUDA support enabled.
It seems newer MPICH versions have increased the footprint of its memory allocations enough to cause a print by `PerfGraphLivePrint`, thereby triggering the bug.

Cheers,
-Nuno