### PR TITLE
Filter out valid non-petsc options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ failed-unittest
 compile_commands.json
 build
 framework/contrib/libtorch
+test.cache
 
 # Allow certain files in gold directories
 !**/gold/*.e

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -1570,6 +1570,10 @@ InputParameters::addCommandLineParamHelper(const std::string & name, const std::
     cl_data->argument_type = CommandLineMetadata::ArgumentType::REQUIRED;
   else
     cl_data->argument_type = CommandLineMetadata::ArgumentType::OPTIONAL;
+
+  for (const auto & token : cl_data->syntax)
+    if (token[0] == '-')
+      libMesh::add_command_line_name(token);
 }
 
 template <typename T>

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -54,7 +54,6 @@
 #include "RestartableDataWriter.h"
 #include "StringInputStream.h"
 #include "MooseMain.h"
-#include "PetscSupport.h"
 
 // Regular expression includes
 #include "pcrecpp.h"
@@ -984,9 +983,6 @@ MooseApp::setupOptions()
       _syntax.addDependency("mesh_only", "setup_mesh_complete");
       _syntax.addDependency("determine_system_type", "mesh_only");
       _action_warehouse.setFinalTask("mesh_only");
-      // Turn off Petsc's warning about unused petsc options since we do not use petsc in mesh-only
-      // mode
-      Moose::PetscSupport::setSinglePetscOption("-options_left", "0");
     }
     else if (isParamValid("split_mesh"))
     {

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -670,10 +670,6 @@ processPetscPairs(const std::vector<std::pair<MooseEnumItem, std::string>> & pet
   bool matptap_found = false;
   bool hmg_strong_threshold_found = false;
 #endif
-#if !PETSC_VERSION_LESS_THAN(3, 19, 2)
-  // Check for if users have set the options_left option
-  bool options_left_set = false;
-#endif
   std::vector<std::pair<std::string, std::string>> new_options;
 
   for (const auto & option : petsc_pair_options)
@@ -743,11 +739,6 @@ processPetscPairs(const std::vector<std::pair<MooseEnumItem, std::string>> & pet
         fact_pattern_found = true;
       if (option.first == "-mat_superlu_dist_replacetinypivot")
         tiny_pivot_found = true;
-#endif
-
-#if !PETSC_VERSION_LESS_THAN(3, 19, 2)
-      if (option.first == "-options_left")
-        options_left_set = true;
 #endif
 
       if (!new_options.empty())
@@ -829,13 +820,6 @@ processPetscPairs(const std::vector<std::pair<MooseEnumItem, std::string>> & pet
 #endif
   // Set Preconditioner description
   po.pc_description += pc_description;
-
-  // Turn off default options_left warnings added in 3.19.3 pre-release for all PETSc builds
-  // (PETSc commit: 59f199a7), unless the user has set a preference.
-#if !PETSC_VERSION_LESS_THAN(3, 19, 2)
-  if (!options_left_set && !po.flags.contains("-options_left"))
-    po.pairs.emplace_back("-options_left", "0");
-#endif
 }
 
 std::set<std::string>

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -196,10 +196,6 @@ class RunApp(Tester):
         if options.scaling and specs['scale_refine'] > 0:
             cli_args.insert(0, ' -r ' + str(specs['scale_refine']))
 
-        # The test harness should never use GDB backtraces: they don't
-        # work well when dozens of expect_err jobs run at the same time.
-        cli_args.append('--no-gdb-backtrace')
-
         # Get the number of processors and threads the Tester requires
         ncpus = self.getProcs(options)
         nthreads = self.getThreads(options)

--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -43,7 +43,7 @@ class Test:
         self.args = args
         self.dur_secs = 0
         self.perflog = []
-        self.getpot_options = ['Outputs/console=false', 'Outputs/exodus=false', 'Outputs/csv=false', '--no-gdb-backtrace']
+        self.getpot_options = ['Outputs/console=false', 'Outputs/exodus=false', 'Outputs/csv=false']
         self.have_perflog = perflog
         if self.have_perflog:
             self.getpot_options.append('UserObjects/perflog/type=PerflogDumper')

--- a/python/jacobiandebug/analyzejacobian.py
+++ b/python/jacobiandebug/analyzejacobian.py
@@ -351,7 +351,7 @@ if __name__ == '__main__':
     dofmapfilename = basename + '_' + dofoutname + '.json'
     if not options.noauto :
         mooseparams = moosebaseparams[:]
-        mooseparams.extend(['Problem/solve=false', 'BCs/active=', 'Outputs/' + dofoutname+ '/type=DOFMap', 'Outputs/active=' + dofoutname, 'Outputs/file_base=' + basename + '_' + dofoutname, '--no-gdb-backtrace'])
+        mooseparams.extend(['Problem/solve=false', 'BCs/active=', 'Outputs/' + dofoutname+ '/type=DOFMap', 'Outputs/active=' + dofoutname, 'Outputs/file_base=' + basename + '_' + dofoutname])
         if options.cli_args != None:
             mooseparams.extend([options.cli_args])
         if options.debug :
@@ -428,7 +428,7 @@ if __name__ == '__main__':
 
         mooseparams.extend(petsc_test_options + ['-mat_fd_type', 'ds',
                                                  'BCs/active=', 'Outputs/exodus=false', 'Outputs/csv=false',
-                                                 'Outputs/active=', 'Executioner/solve_type=NEWTON', '--no-gdb-backtrace'])
+                                                 'Outputs/active=', 'Executioner/solve_type=NEWTON'])
     if options.cli_args != None:
         mooseparams.extend([options.cli_args])
 

--- a/test/tests/misc/petsc_option_left/2d_diffusion_petsc_option.i
+++ b/test/tests/misc/petsc_option_left/2d_diffusion_petsc_option.i
@@ -44,7 +44,6 @@
 
   solve_type = 'NEWTON'
 
-  petsc_options = "-options_left"
   petsc_options_iname = "-pc_type"
   petsc_options_value = "hypre"
 []

--- a/test/tests/misc/petsc_option_left/tests
+++ b/test/tests/misc/petsc_option_left/tests
@@ -1,6 +1,5 @@
 [Tests]
   design = 'FEProblem.md'
-  issues = '#15129'
 
   [test_options_not_left]
     type = RunApp
@@ -8,5 +7,16 @@
     expect_out = 'PETSc Option Table'
     absent_out = "Option left.*value.*hypre"
     requirement = "The system shall use the default PETSc option database in the parent app to handle system-level PETSc parameters"
+    issues = '#15129'
+  []
+
+  [test_non_petsc_options_not_left]
+    type = RunApp
+    input = '2d_diffusion_petsc_option.i'
+    cli_args = "-not_a_moose_or_petsc_option 20 --show-input"
+    expect_out = "Option left:\s+name:-not_a_moose_or_petsc_option\s+value:\s+20"
+    absent_out = "Option left:\s+name:--show_input"
+    requirement = "The system shall warn the user of unused options if and only if they are not valid moose options."
+    issues = '#25577'
   []
 []

--- a/test/tests/misc/petsc_option_left/tests
+++ b/test/tests/misc/petsc_option_left/tests
@@ -8,6 +8,7 @@
     absent_out = "Option left.*value.*hypre"
     requirement = "The system shall use the default PETSc option database in the parent app to handle system-level PETSc parameters"
     issues = '#15129'
+    petsc_version = '>=3.19.2'
   []
 
   [test_non_petsc_options_not_left]
@@ -18,5 +19,6 @@
     absent_out = "Option left:\s+name:--show_input"
     requirement = "The system shall warn the user of unused options if and only if they are not valid moose options."
     issues = '#25577'
+    petsc_version = '>=3.19.2'
   []
 []

--- a/test/tests/misc/petsc_option_left/tests
+++ b/test/tests/misc/petsc_option_left/tests
@@ -4,7 +4,6 @@
   [test_options_not_left]
     type = RunApp
     input = '2d_diffusion_petsc_option.i'
-    expect_out = 'PETSc Option Table'
     absent_out = "Option left.*value.*hypre"
     requirement = "The system shall use the default PETSc option database in the parent app to handle system-level PETSc parameters"
     issues = '#15129'


### PR DESCRIPTION
This PR uses functionality in libmesh to add valid MOOSE command line parameters to a "safe list" so they are not interpreted by petsc as unused parameters. This implementation has the added benefit that any invalid command line parameters are still passed to petsc, which then warns the user.

Closes #25577
