### PR TITLE
Delete heat conduction module folder

### DIFF
--- a/modules/heat_conduction/Makefile
+++ b/modules/heat_conduction/Makefile
@@ -1,1 +1,0 @@
-../heat_transfer/Makefile

--- a/modules/heat_conduction/doc
+++ b/modules/heat_conduction/doc
@@ -1,1 +1,0 @@
-../heat_transfer/doc/

--- a/modules/heat_conduction/include
+++ b/modules/heat_conduction/include
@@ -1,1 +1,0 @@
-../heat_transfer/include/

--- a/modules/heat_conduction/src
+++ b/modules/heat_conduction/src
@@ -1,1 +1,0 @@
-../heat_transfer/src


### PR DESCRIPTION
refs #25584

it s been 6 months since the rename
and also the apps will still build even if they have not moved on, with this warning

/Users/giudgl/projects/pronghorn/moose/modules/modules.mk:80: The heat conduction module was renamed to the heat transfer module. Please update your Makefile and replace HEAT_CONDUCTION with HEAT_TRANSFER

I m doing this now because this has started to cause more and more failures in CI, due to some obscure timing of building the code which used to be fine but no longer. The script attempts to build both heat_transfer and heat_conduction, which is fine if one is done building before the other