### PR TITLE
Avoid Subgenerator Name Confliting When Using Multiple FlexPatternG

### DIFF
--- a/modules/reactor/src/meshgenerators/FlexiblePatternGenerator.C
+++ b/modules/reactor/src/meshgenerators/FlexiblePatternGenerator.C
@@ -447,7 +447,8 @@ FlexiblePatternGenerator::FlexiblePatternGenerator(const InputParameters & param
       params.set<std::vector<BoundaryName>>("boundary_names") = {std::to_string(OUTER_SIDESET_ID)};
 
       addMeshSubgenerator("BoundaryDeletionGenerator",
-                          input_name + static_cast<MeshGeneratorName>("_del_ext_bdry"),
+                          input_name +
+                              static_cast<MeshGeneratorName>("_" + name() + "_del_ext_bdry"),
                           params);
     }
   }
@@ -459,7 +460,7 @@ FlexiblePatternGenerator::FlexiblePatternGenerator(const InputParameters & param
     params.set<MeshGeneratorName>("input") =
         _input_names[_positions[i].second] +
         static_cast<MeshGeneratorName>(
-            _delete_default_external_boundary_from_inputs ? "_del_ext_bdry" : "");
+            _delete_default_external_boundary_from_inputs ? ("_" + name() + "_del_ext_bdry") : "");
     params.set<MooseEnum>("transform") = 1;
     params.set<RealVectorValue>("vector_value") = _positions[i].first;
 


### PR DESCRIPTION
closes #27540

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
