### PR TITLE
Fix scaling of pressure mass matrix for preconditioning

### DIFF
--- a/modules/navier_stokes/test/tests/finite_element/ins/lid_driven/steady_vector_fsp_al.i
+++ b/modules/navier_stokes/test/tests/finite_element/ins/lid_driven/steady_vector_fsp_al.i
@@ -41,7 +41,7 @@ gamma=${U}
     type = MassMatrix
     variable = p
     matrix_tags = 'mass'
-    density = ${fparse -gamma - mu}
+    density = ${fparse -1/(gamma + mu)}
   []
   [momentum_advection]
     type = INSADMomentumAdvection


### PR DESCRIPTION
This makes the scaling consistent with the markdown page and with what it should be. Sometimes it can be easy to not do the inversion in your brain. For instance in the markdown page, we outline the formula for $S^{-1} = -\left(\nu + \gamma\right)M_p^{-1}$. Which means that we want to approximate $S$ by $-\frac{1}{\nu + \gamma}M_p$

Refs #27127