### PR TITLE
Supress PETSc's unused options warning when not solving

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -528,6 +528,14 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
   if (!_app.isUltimateMaster())
     PetscOptionsCreate(&_petsc_option_data_base);
 #endif
+
+  if (!_solve)
+  {
+    // If we are not solving, we do not care about seeing unused petsc options
+    Moose::PetscSupport::setSinglePetscOption("-options_left", "0");
+    // We don't want petscSetOptions being called in solve and clearing the option that was just set
+    _is_petsc_options_inserted = true;
+  }
 }
 
 const MooseMesh &
@@ -5926,10 +5934,10 @@ FEProblemBase::solve(const unsigned int nl_sys_num)
   _fail_next_nonlinear_convergence_check = false;
 
   if (_solve)
+  {
     _current_nl_sys->solve();
-
-  if (_solve)
     _current_nl_sys->update();
+  }
 
   // sync solutions in displaced problem
   if (_displaced_problem)

--- a/test/tests/problems/no_solve/tests
+++ b/test/tests/problems/no_solve/tests
@@ -5,6 +5,7 @@
     exodiff = 'no_solve_out.e'
 
     requirement = 'The system shall have the ability to disable the actual nonlinear system solve in a simulation.'
+    absent_out = 'WARNING! There are options you set that were not used!'
     issues = '#1978'
     design = 'Problem/index.md'
   [../]
@@ -17,7 +18,7 @@
     issues = '#27084'
     slepc = true
     slepc_version = '>=3.13.0'
-  []    
+  []
   [eigen_problem_skip_solve]
     type = 'RunApp'
     prereq = eigen_problem_solve_fail
@@ -25,6 +26,7 @@
     # regex meant to make sure no messaged about solve failing is printed last
     # \S+ is to consume the ansi color characters
     expect_out = 'Solve Skipped!\S+\s+(?!Aborting)'
+    absent_out = 'WARNING! There are options you set that were not used!'
     input = 'ne_fail.i'
     cli_args = Problem/solve=false
     design = 'Problem/index.md'


### PR DESCRIPTION


## Reason
Users can choose to run an MOOSE input without solving by setting Problem/solve=false. When this is done, however, PETSc sees options that are used during the solve as 'unused', and emits a warning. Since the user intentionally instructs MOOSE not to solve, these warnings are irrelevant and should not be displayed to the user.

## Design
PETSc's 'options_left' parameter is set to false when Problem/solve=false. This suppresses the warning.

## Impact
Less annoying warnings to the user.

Closes #27602 