### PR TITLE
Update PETSc to 3.21.1

### DIFF
--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_petsc:
-  - moose-petsc 3.20.3 build_1
+  - moose-petsc 3.21.1 build_0
 
 moose_libmesh_vtk:
   - moose-libmesh-vtk 9.2.6 build_9

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 1 %}
+{% set build = 2 %}
 {% set version = "2024.04.03" %}
 {% set vtk_friendly_version = "9.2" %}
 

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
-  - moose-libmesh 2024.04.03 build_1
+  - moose-libmesh 2024.04.03 build_2
 
 moose_wasp:
   - moose-wasp 2024.04.23

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -6,7 +6,7 @@
 #   framework/doc/packages_config.yml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.05.02" %}
+{% set version = "2024.05.11" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_dev:
-  - moose-dev 2024.05.02
+  - moose-dev 2024.05.11
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -7,8 +7,8 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 1 %}
-{% set version = "3.20.3" %}
+{% set build = 0 %}
+{% set version = "3.21.1" %}
 
 # permanent
 {% set strbuild = "build_" + build|string %}

--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -9,8 +9,8 @@ minimum_python: 3.7
 maximum_python: 3.11
 mpich: 4.0.2
 petsc_alt: 3.11.4
-petsc: 3.20.3
-moose_dev: 2024.05.02
+petsc: 3.21.1
+moose_dev: 2024.05.11
 moose_tools: 2024.05.02
 apptainer_rockylinux: 8.8.20230518
 apptainer_mpich: 3.4.3

--- a/scripts/tests/test_premake.py
+++ b/scripts/tests/test_premake.py
@@ -78,10 +78,10 @@ gold_conda_list = [{
     "build_number": 0,
     "build_string": "build_0",
     "channel": "public",
-    "dist_name": "moose-petsc-3.20.3-build_0",
+    "dist_name": "moose-petsc-3.21.1-build_0",
     "name": "moose-petsc",
     "platform": "osx-arm64",
-    "version": "3.20.3"
+    "version": "3.21.1"
 },
 {
     "base_url": "https://conda.software.inl.gov/public",

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -249,3 +249,9 @@ cd156d7fc3c253b266689e1a8ac2ce5c18e8b5af: #27349
   libmesh: 7142db2
   moose-dev: a307875
   wasp: c3b8cf2
+1a01adda99de0c612da5b5575330aba66e6f699b: #27604
+  mpich: ac30c0c
+  petsc: 985f253
+  libmesh: 13f500f
+  moose-dev: 3056b2e
+  wasp: c3b8cf2


### PR DESCRIPTION
## Reason

Allows compilations of the whole stack with gcc 14.1.0.
