### PR TITLE
Increase MacOS minimum supported version to Big Sur

### DIFF
--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,19 +1,9 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_16
+  - moose-mpich 4.0.2 build_17
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
-  - /opt/MacOSX11.3.sdk                                     # [arm64]
-
-macos_min_version:                                          # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
-
-macos_machine:                                              # [osx]
-  - x86_64-apple-darwin13.4.0                               # [not arm64 and osx]
-  - arm64-apple-darwin20.0.0                                # [arm64]
+  - /opt/MacOSX11.3.sdk                                     # [osx]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
+  - 11.3                                                    # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 9 %}
+{% set build = 10 %}
 {% set vtk_version = "9.2.6" %}
 {% set vtk_friendly_version = "9.2" %}
 {% set sha256 = "06fc8d49c4e56f498c40fcb38a563ed8d4ec31358d0101e8988f0bb4d539dd12" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,22 +1,12 @@
 moose_petsc:
-  - moose-petsc 3.20.3 build_1
+  - moose-petsc 3.20.3 build_2
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.2.6 build_9
+  - moose-libmesh-vtk 9.2.6 build_10
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
-  - /opt/MacOSX11.3.sdk                                     # [arm64]
-
-macos_min_version:                                          # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
-
-macos_machine:                                              # [osx]
-  - x86_64-apple-darwin13.4.0                               # [not arm64 and osx]
-  - arm64-apple-darwin20.0.0                                # [arm64]
+  - /opt/MacOSX11.3.sdk                                     # [osx]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
+  - 11.3                                                    # [osx]

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = "2024.05.05" %}
 {% set vtk_friendly_version = "9.2" %}
 

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -1,11 +1,11 @@
 moose_libmesh:
-  - moose-libmesh 2024.05.05 build_0
+  - moose-libmesh 2024.05.05 build_1
 
 moose_wasp:
-  - moose-wasp 2024.05.08
+  - moose-wasp 2024.05.20
 
 moose_tools:
   - moose-tools 2024.05.02
 
 moose_peacock:
-  - moose-peacock 2023.04.11
+  - moose-peacock 2024.05.20

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -6,7 +6,7 @@
 #   framework/doc/packages_config.yml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.05.13" %}
+{% set version = "2024.05.20" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,19 +1,9 @@
 moose_dev:
-  - moose-dev 2024.05.13
+  - moose-dev 2024.05.20
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
-  - /opt/MacOSX11.3.sdk                                     # [arm64]
-
-macos_min_version:                                          # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
-
-macos_machine:                                              # [osx]
-  - x86_64-apple-darwin13.4.0                               # [not arm64 and osx]
-  - arm64-apple-darwin20.0.0                                # [arm64]
+  - /opt/MacOSX11.3.sdk                                     # [osx]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
+  - 11.3                                                    # [osx]

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -82,17 +82,7 @@ moose_mesalib:                                              # [linux]
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
-  - /opt/MacOSX11.3.sdk                                     # [arm64]
-
-macos_min_version:                                          # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
-
-macos_machine:                                              # [osx]
-  - x86_64-apple-darwin13.4.0                               # [not arm64 and osx]
-  - arm64-apple-darwin20.0.0                                # [arm64]
+  - /opt/MacOSX11.3.sdk                                     # [osx]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
+  - 11.3                                                    # [osx]

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -6,7 +6,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 16 %}
+{% set build = 17 %}
 {% set version = "4.0.2" %}
 
 # permanent

--- a/conda/peacock/conda_build_config.yaml
+++ b/conda/peacock/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_16
+  - moose-mpich 4.0.2 build_17
 
 # Pesky packages that break internal CI
 # Note: Modifying/Updating this will require changes to conda/mpich!

--- a/conda/peacock/meta.yaml
+++ b/conda/peacock/meta.yaml
@@ -3,7 +3,7 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2023.04.11" %}
+{% set version = "2024.05.20" %}
 
 package:
   name: moose-peacock

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -1,19 +1,9 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_16
+  - moose-mpich 4.0.2 build_17
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
-  - /opt/MacOSX11.3.sdk                                     # [arm64]
-
-macos_min_version:                                          # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
-
-macos_machine:                                              # [osx]
-  - x86_64-apple-darwin13.4.0                               # [not arm64 and osx]
-  - arm64-apple-darwin20.0.0                                # [arm64]
+  - /opt/MacOSX11.3.sdk                                     # [osx]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
+  - 11.3                                                    # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -7,7 +7,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 1 %}
+{% set build = 2 %}
 {% set version = "3.20.3" %}
 
 # permanent

--- a/conda/pyhit/conda_build_config.yaml
+++ b/conda/pyhit/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_wasp:
-  moose-wasp 2024.05.08
+  moose-wasp 2024.05.20
 
 moose_python:
   - python 3.10
@@ -15,17 +15,7 @@ pin_run_as_build:
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
-  - /opt/MacOSX11.3.sdk                                     # [arm64]
-
-macos_min_version:                                          # [osx]
-  - 10.12                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
-
-macos_machine:                                              # [osx]
-  - x86_64-apple-darwin13.4.0                               # [not arm64 and osx]
-  - arm64-apple-darwin20.0.0                                # [arm64]
+  - /opt/MacOSX11.3.sdk                                     # [osx]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.12                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
+  - 11.3                                                    # [osx]

--- a/conda/pyhit/meta.yaml
+++ b/conda/pyhit/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2024.05.08" %}
+{% set version = "2024.05.20" %}
 
 package:
   name: moose-pyhit

--- a/conda/seacas/conda_build_config.yaml
+++ b/conda/seacas/conda_build_config.yaml
@@ -1,7 +1,6 @@
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
-  - /opt/MacOSX11.3.sdk                                     # [arm64]
+  - /opt/MacOSX11.3.sdk                                     # [osx]
 
 c_compiler_version:                                         # [unix]
   - 10.4.0                                                  # [linux]
@@ -16,14 +15,5 @@ fortran_compiler_version:                                   # [unix]
   - 9.3.0                                                   # [not arm64 and osx]
   - 11.0.1                                                  # [arm64]
 
-macos_min_version:                                          # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
-
-macos_machine:                                              # [osx]
-  - x86_64-apple-darwin13.4.0                               # [not arm64 and osx]
-  - arm64-apple-darwin20.0.0                                # [arm64]
-
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
+  - 11.3                                                    # [osx]

--- a/conda/seacas/meta.yaml
+++ b/conda/seacas/meta.yaml
@@ -1,5 +1,5 @@
 # MAKE SURE THAT seacas_version and seacas_git_rev match if performing a version update!
-{% set build = "0" %}
+{% set build = "1" %}
 {% set seacas_version = "2024.03.11" %}
 {% set seacas_git_rev = "v2024-03-11" %}
 {% set strbuild = "build_" + build|string %}

--- a/conda/wasp/conda_build_config.yaml
+++ b/conda/wasp/conda_build_config.yaml
@@ -1,7 +1,6 @@
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
-  - /opt/MacOSX11.3.sdk                                     # [arm64]
+  - /opt/MacOSX11.3.sdk                                     # [osx]
 
 c_compiler_version:                                         # [unix]
   - 10.4.0                                                  # [linux]
@@ -16,14 +15,5 @@ fortran_compiler_version:                                   # [unix]
   - 9.3.0                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]
 
-macos_min_version:                                          # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
-
-macos_machine:                                              # [osx]
-  - x86_64-apple-darwin13.4.0                               # [not arm64 and osx]
-  - arm64-apple-darwin20.0.0                                # [arm64]
-
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.15                                                   # [not arm64 and osx]
-  - 11.3                                                    # [arm64]
+  - 11.3                                                    # [osx]

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -5,7 +5,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2024.05.08" %}
+{% set version = "2024.05.20" %}
 
 package:
   name: moose-wasp

--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -10,7 +10,7 @@ maximum_python: 3.11
 mpich: 4.0.2
 petsc_alt: 3.11.4
 petsc: 3.20.3
-moose_dev: 2024.05.13
+moose_dev: 2024.05.20
 moose_tools: 2024.05.02
 apptainer_rockylinux: 8.8.20230518
 apptainer_mpich: 3.4.3

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -261,3 +261,9 @@ cd156d7fc3c253b266689e1a8ac2ce5c18e8b5af: #27349
   libmesh: 9fefe49
   moose-dev: 4b79189
   wasp: 33b8e6b
+1c223fd722a9e45c9a6c5cb24318e43431bf0299: #27670
+  mpich: f5930db
+  petsc: 3beaff0
+  libmesh: c748356
+  moose-dev: 1130ded
+  wasp: 8020833


### PR DESCRIPTION
Bump MacOS minimum version to Big Sur

A change to a MOOSE contrib is forcing that we move the MacOS minimum
to Big Sur (SDK 11.x). This should be fine, as we state we only support
the last two MacOS versions anyway (Big Sur was 4 versions ago).

Closes #27670