### PR TITLE
Use the inexact LU with compression from strumpack

### DIFF
--- a/modules/navier_stokes/test/tests/finite_element/ins/lid_driven/steady_vector_fsp_al.i
+++ b/modules/navier_stokes/test/tests/finite_element/ins/lid_driven/steady_vector_fsp_al.i
@@ -69,12 +69,14 @@ gamma=${U}
     type = ADVectorFunctionDirichletBC
     variable = vel
     boundary = 'bottom right left'
+    preset = true
   []
   [lid]
     type = ADVectorFunctionDirichletBC
     variable = vel
     boundary = 'top'
     function_x = 'lid_function'
+    preset = true
   []
 []
 
@@ -120,15 +122,15 @@ gamma=${U}
     []
       [u]
         vars = 'vel'
-        # petsc_options = '-ksp_converged_reason'
-        petsc_options_iname = '-pc_type -ksp_type -ksp_rtol -ksp_gmres_restart -ksp_pc_side'
-        petsc_options_value = 'lu       gmres     1e-2      300                right'
+        petsc_options = '-ksp_converged_reason'
+        petsc_options_iname = '-pc_type -ksp_type -ksp_rtol -ksp_gmres_restart -ksp_pc_side -pc_factor_mat_solver_type'
+        petsc_options_value = 'ilu      gmres     1e-2      300                right        strumpack'
       []
       [p]
         vars = 'p'
         petsc_options = '-ksp_converged_reason'
         petsc_options_iname = '-ksp_type -ksp_gmres_restart -ksp_rtol -pc_type -ksp_pc_side'
-        petsc_options_value = 'gmres    300                 1e-2      lu       right'
+        petsc_options_value = 'gmres     300                1e-2      ilu      right'
       []
   []
 []


### PR DESCRIPTION
This appears to scale quite well when applied to the definite velocity block. It doesn't do nearly as well if applied to the global indefinite velocity-pressure system. For a 375x375 grid (~1.2 million dofs) with nu = 1e-2, the entire simulation ran in 69 seconds with 48 processes on my local machine

Closes #27126