### PR TITLE
Add ! character to hit as it is used now in input file includes

### DIFF
--- a/framework/contrib/hit/src/hit/lex.cc
+++ b/framework/contrib/hit/src/hit/lex.cc
@@ -15,7 +15,7 @@ const std::string space = " \t";
 const std::string allspace = " \t\n\r";
 const std::string newline = "\n\r";
 const std::string alphanumeric = digits + alpha;
-const std::string identchars = alphanumeric + "_./:<>-+*";
+const std::string identchars = alphanumeric + "_./:<>-+*!";
 
 _LexFunc::_LexFunc(LexFunc pp) : p(pp) {}
 _LexFunc::operator LexFunc() { return p; }


### PR DESCRIPTION
refs #20125
 
this is the error we are hitting in the doco
https://civet.inl.gov/job/2240717/