### PR TITLE
Minor changes for MOOSE training

### DIFF
--- a/tutorials/darcy_thermo_mech/doc/content/workshop/systems/timesteppers.md
+++ b/tutorials/darcy_thermo_mech/doc/content/workshop/systems/timesteppers.md
@@ -15,10 +15,10 @@ Custom objects are created by inheriting from `TimeStepper` overriding `computeD
 MOOSE includes many built-in TimeStepper objects:
 
 - `ConstantDT`
-- `SolutionTimeAdaptiveDT`
 - `IterationAdaptiveDT`
 - `FunctionDT`
 - `PostprocessorDT`
+- `FixedPointIterationAdaptiveDT`
 - `TimeSequenceStepper`
 
 !---
@@ -48,7 +48,7 @@ inserted and the step is resolved.
 
 ## Composing TimeSteppers
 
-+New Feature+: Time steppers can now be composed to follow complex time histories.
+Time steppers can now be composed to follow complex time histories.
 By default, the minimum of all the time steps computed by all the time steppers is used!
 
 What steps will be taken, starting at time = 0s?

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5b_transient.i
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5b_transient.i
@@ -25,6 +25,8 @@
   [heat_conduction_time_derivative]
     type = ADHeatConductionTimeDerivative
     variable = temperature
+    specific_heat = specific_heat
+    density_name = density
   []
 []
 


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
1. Remove 'SolutionTimeAdaptiveDT' from TimeStepper slide since it is not a commonly-used one. Replace it with the recently-added Timestepper 'FixedPointIterationAdaptiveDT'
2. Add material property name for 'ADHeatConductionTimeDerivative' to explicitly show this kernel use value from material kernel
