### PR TITLE
Link banner to 2025 MOOSE Conference

### DIFF
--- a/modules/doc/content/index.md
+++ b/modules/doc/content/index.md
@@ -2,7 +2,7 @@
 
 # HOME style=visibility:hidden;
 
-!media large_media/organization_logos/2025-conference-webbanner.png style=display:block;margin-left:auto;margin-right:auto;width:80%;
+!media large_media/organization_logos/2025-conference-webbanner.png link=https://inl.gov/mooseworkshop2025/ style=display:block;margin-left:auto;margin-right:auto;width:80%;
 
 !style! halign=center fontsize=140%
 [Abstract submission form](https://inlhrfedramp.gov1.qualtrics.com/jfe/form/SV_1zeoLEagiVVm9wO)

--- a/modules/doc/content/training/index.md
+++ b/modules/doc/content/training/index.md
@@ -4,7 +4,6 @@
 Upcoming MOOSE related training in chronological order:
 !style-end!
 
-- [MOOSE Framework Fundamentals (2024 June 4-6, Idaho Falls)](more_detail/MOOSE_2024_06_04-06_IF.md)
 - [MOOSE Framework Fundamentals (2024 October 15-17, University of Illinois Urbana-Champaign)](more_detail/MOOSE_2024_10_15-17_UIUC.md)
 
 # Conferences
@@ -13,9 +12,11 @@ Upcoming MOOSE related training in chronological order:
 Upcoming MOOSE related Conferences:
 !style-end!
 
-- MOOSE Conference (2025 March 10-14, Idaho Falls) - Registration link coming soon.
+- [MOOSE Internation Workshop (2025 March 10-14, Idaho Falls)](https://inl.gov/mooseworkshop2025/)
 
 #### Past Training:
+
+- MOOSE Framework Fundamentals (2024 June 4-6, Idaho Falls)
 
 - ART/NEAMS M&S Molten Salt Reactors @PHYSOR24 (2024 April 21)
 

--- a/modules/doc/content/training/index.md
+++ b/modules/doc/content/training/index.md
@@ -12,7 +12,7 @@ Upcoming MOOSE related training in chronological order:
 Upcoming MOOSE related Conferences:
 !style-end!
 
-- [MOOSE Internation Workshop (2025 March 10-14, Idaho Falls)](https://inl.gov/mooseworkshop2025/)
+- [MOOSE International Workshop (2025 March 10-14, Idaho Falls)](https://inl.gov/mooseworkshop2025/)
 
 #### Past Training:
 

--- a/modules/doc/content/training/more_detail/MOOSE_2024_06_04-06_IF.md
+++ b/modules/doc/content/training/more_detail/MOOSE_2024_06_04-06_IF.md
@@ -1,7 +1,0 @@
-#### MOOSE Framework Fundamentals at INL (2024 June 4-6, Idaho Falls)
-
-!style! halign=left
-!include training/more_detail/registration_link.md
-!style-end!
-
-!include training/more_detail/generic_moose_training.md


### PR DESCRIPTION
Link banner, remove current training, update training page with updated conference information.

Closes #27805

