### PR TITLE
Update moose-pprof

### DIFF
--- a/conda/pprof/build.sh
+++ b/conda/pprof/build.sh
@@ -10,11 +10,10 @@ rm -rf ${GOPATH}/pkg
 # Set GPERF_DIR path (influential environment variable in MOOSE make files)
 mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
 cat <<EOF > "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
-export GPERF_DIR=${PREFIX}
-export PPROF_OLDPATH=\${PATH}
+export GPERF_DIR=${PREFIX}/pprof
 export PATH=${PREFIX}/pprof/bin:\${PATH}
 EOF
 cat <<EOF > "${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
 unset GPERF_DIR
-export PATH=\${PPROF_OLDPATH}
+export PATH=\${PATH%":${PREFIX}/pprof/bin"}
 EOF

--- a/conda/pprof/conda_build_config.yaml
+++ b/conda/pprof/conda_build_config.yaml
@@ -1,10 +1,10 @@
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
+  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
   - /opt/MacOSX11.3.sdk                                     # [arm64]
 
 macos_min_version:                                          # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]
 
 macos_machine:                                              # [osx]
@@ -12,5 +12,5 @@ macos_machine:                                              # [osx]
   - arm64-apple-darwin20.0.0                                # [arm64]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]

--- a/conda/pprof/meta.yaml
+++ b/conda/pprof/meta.yaml
@@ -1,6 +1,4 @@
-{% set version = "2022.12.05" %}
-{% set build = 0 %}
-{% set strbuild = "build_" + build|string %}
+{% set version = "2024.06.11" %}
 
 package:
   name: moose-pprof
@@ -11,15 +9,32 @@ source:
     ../pprof
 
 build:
-  number: {{ build }}
-  string: {{ strbuild }}
+  number: 0
+  string: build_0
   skip: true  # [win]
+  missing_dso_whitelist:
+    - System
+    - resolve
+    - CoreFoundation
+    - CommonAuth
+    - Security
+    - c++abi
+    - system_malloc
+  runpath_whitelist:
+    - System
+    - resolve
+  ignore_run_exports:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - libcxx
+    - gperftools
+    - perl
 
 requirements:
   build:
-    - make
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - make
     - gperftools
     - libunwind                          # [linux]
     - sysroot_linux-64 2.17              # [linux64]


### PR DESCRIPTION
Build moose-pprof using latest compilers.
Note: We will need to tie this into moose-mpi when that becomes available.

Closes #27751

