### PR TITLE
Add `h5py` to `moose-tools`

### DIFF
--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -5,7 +5,7 @@ moose_wasp:
   - moose-wasp 2024.05.08
 
 moose_tools:
-  - moose-tools 2024.05.02
+  - moose-tools 2024.06.17
 
 moose_peacock:
   - moose-peacock 2023.04.11

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -6,7 +6,7 @@
 #   framework/doc/packages_config.yml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.05.13" %}
+{% set version = "2024.06.17" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_dev:
-  - moose-dev 2024.05.13
+  - moose-dev 2024.06.17
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -6,7 +6,7 @@
 #   framework/doc/packages_config.yml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.05.02" %}
+{% set version = "2024.06.17" %}
 
 package:
   name: moose-tools
@@ -36,6 +36,7 @@ requirements:
     - git-lfs
     - gitpython
     - graphviz
+    - h5py
     - jinja2
     - livereload
     - lxml

--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -10,8 +10,8 @@ maximum_python: 3.11
 mpich: 4.0.2
 petsc_alt: 3.11.4
 petsc: 3.20.3
-moose_dev: 2024.05.13
-moose_tools: 2024.05.02
+moose_dev: 2024.06.17
+moose_tools: 2024.06.17
 apptainer_rockylinux: 8.8.20230518
 apptainer_mpich: 3.4.3
 apptainer_gcc: 12.2.1

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -261,3 +261,9 @@ cd156d7fc3c253b266689e1a8ac2ce5c18e8b5af: #27349
   libmesh: 9fefe49
   moose-dev: 4b79189
   wasp: 33b8e6b
+ac6326aa71015a55b71b7d3aa860cf3df5390c1b: #27923
+  mpich: ac30c0c
+  petsc: 6a35350
+  libmesh: 9fefe49
+  moose-dev: f616f32
+  wasp: 33b8e6b


### PR DESCRIPTION
Closes https://github.com/idaholab/moose/issues/27922

With a fresh install of moose-dev, this doesn't downgrade anything:

```
(moose) [INL654123][~/projects/moose]> conda install h5py
Channels:
 - https://conda.software.inl.gov/public
 - conda-forge
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /Users/harblh/miniforge/envs/moose

  added / updated specs:
    - h5py


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    cached-property-1.5.2      |       hd8ed1ab_1           4 KB  conda-forge
    cached_property-1.5.2      |     pyha770c72_1          11 KB  conda-forge
    h5py-3.8.0                 |nompi_py310h3419284_100         967 KB  conda-forge
    ------------------------------------------------------------
                                           Total:         982 KB

The following NEW packages will be INSTALLED:

  cached-property    conda-forge/noarch::cached-property-1.5.2-hd8ed1ab_1
  cached_property    conda-forge/noarch::cached_property-1.5.2-pyha770c72_1
  h5py               conda-forge/osx-arm64::h5py-3.8.0-nompi_py310h3419284_100


Proceed ([y]/n)?
```