### PR TITLE
Add a default to skip missing external modules during doco build

### DIFF
--- a/python/MooseDocs/common/get_content.py
+++ b/python/MooseDocs/common/get_content.py
@@ -63,7 +63,7 @@ def _find_files(filenames, pattern):
         out.add(pattern)
     return out
 
-def _doc_import(root_dir, content=None):
+def _doc_import(root_dir, content=None, optional=False):
     """
     Creates a list of files to "include" from patterns.
 
@@ -74,8 +74,12 @@ def _doc_import(root_dir, content=None):
     """
     # Check root_dir
     if not os.path.isdir(root_dir):
-        LOG.error('The "root_dir" must be a valid directory: %s', root_dir)
-        return None
+        if not optional:
+            LOG.error('The "root_dir" must be a valid directory: %s', root_dir)
+        else:
+            LOG.warning("Part of the content specified in 'config.yml' is not included in documentation since " +
+                        root_dir + ' is not a valid directory')
+        return set()
 
     # Loop through the base directory and create a set of matching filenames
     filenames = set()
@@ -140,11 +144,14 @@ def get_files(items, in_ext):
             LOG.error('The supplied items must be a list of dict items, each with a "root_dir" and '
                       'optionally a "content" entry.')
 
+        # Get path from specified root_dir
         root = mooseutils.eval_path(value['root_dir'])
         if not os.path.isabs(root):
             root = os.path.join(MooseDocs.ROOT_DIR, root)
 
-        for fname in _doc_import(root, content=value.get('content', None)):
+        # We default external content to be optional because we wont always have
+        # all the submodules downloaded
+        for fname in _doc_import(root, content=value.get('content', None), optional=value.get('external', False)):
             filenames.append((root, fname, value.get('external', False)))
 
     return filenames

--- a/python/MooseDocs/common/get_content.py
+++ b/python/MooseDocs/common/get_content.py
@@ -79,7 +79,7 @@ def _doc_import(root_dir, content=None, optional=False):
         else:
             LOG.warning("Part of the content specified in 'config.yml' is not included in documentation since " +
                         root_dir + ' is not a valid directory')
-        return set()
+        return None
 
     # Loop through the base directory and create a set of matching filenames
     filenames = set()
@@ -149,10 +149,12 @@ def get_files(items, in_ext):
         if not os.path.isabs(root):
             root = os.path.join(MooseDocs.ROOT_DIR, root)
 
-        # We default external content to be optional because we wont always have
+        # We default external content to be optional because we won't always have
         # all the submodules downloaded
-        for fname in _doc_import(root, content=value.get('content', None), optional=value.get('external', False)):
-            filenames.append((root, fname, value.get('external', False)))
+        files = _doc_import(root, content=value.get('content', None), optional=value.get('external', False))
+        if files is not None:
+            for fname in files:
+                filenames.append((root, fname, value.get('external', False)))
 
     return filenames
 

--- a/python/MooseDocs/test/extensions/test_content.py
+++ b/python/MooseDocs/test/extensions/test_content.py
@@ -457,5 +457,20 @@ class testContentPagination(MooseDocsTestCase):
         self.assertHTMLTag(res(1)(1)(1), 'i', size=1, class_='material-icons right')
         self.assertHTMLString(res(1)(1)(1)(0), content='arrow_forward')
 
+class TestMissingExternalContentList(MooseDocsTestCase):
+    EXTENSIONS = [extensions.core, extensions.command, extensions.heading, extensions.content]
+
+    def setupContent(self):
+        config = [dict(root_dir='python/MooseDocs/test/invalid_content',
+                       content=['file.md'],
+                       external=True)]
+        with self.assertLogs(level=logging.WARNING) as cm:
+             common.get_content(config, '.md')
+        self.assertIn("Part of the content specified in \'config.yml\' is not included in documentation", cm.output[0])
+
+    def testAST(self):
+        self.setupContent()
+        return
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
refs #27097

I m splitting this off from #27027 to try to get downstream apps to be green and have a smooth merge