### PR TITLE
Give objects the ability to fine-tune petsc options

### DIFF
--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -252,6 +252,7 @@ public:
   /// Extends the range of possible values the variable can be set to
   void addValidName(const std::string & name);
   void addValidName(const std::initializer_list<std::string> & names);
+  void addValidName(const MultiMooseEnum & names);
 
 protected:
   /// Check whether any of the current values are deprecated when called

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -38,13 +38,16 @@ namespace PetscSupport
 class PetscOptions
 {
 public:
-  PetscOptions() : flags("", "", true) {}
+  PetscOptions() : flags("", "", true), ignored_flags("", "", true) {}
 
   /// PETSc key-value pairs
   std::vector<std::pair<std::string, std::string>> pairs;
 
   /// Single value PETSc options (flags)
   MultiMooseEnum flags;
+
+  /// Flags to explicitly not set, even if they are specified in flags
+  MultiMooseEnum ignored_flags;
 
   /// Preconditioner description
   std::string pc_description;
@@ -212,6 +215,19 @@ void colorAdjacencyMatrix(PetscScalar * adjacency_matrix,
                           const char * coloring_algorithm);
 
 /**
+ * disable a particular petsc flag
+ */
+void disablePetscFlag(const std::string & flag, PetscOptions & petsc_options);
+
+/**
+ * disable "ignored" petsc flags
+ * @param ignored_petsc_flags Container holding the flags of the petsc options to be ignored
+ * @param petsc_options Data structure which handles petsc options within moose
+ */
+void disableIgnoredPetscFlags(const MultiMooseEnum & ignored_petsc_flags,
+                              PetscOptions & petsc_options);
+
+/**
  * disable printing of the nonlinear convergence reason
  */
 void disableNonlinearConvergedReason(FEProblemBase & fe_problem);
@@ -220,6 +236,16 @@ void disableNonlinearConvergedReason(FEProblemBase & fe_problem);
  * disable printing of the linear convergence reason
  */
 void disableLinearConvergedReason(FEProblemBase & fe_problem);
+
+/**
+ * disable common ksp flags
+ */
+void disableCommonKSPFlags(FEProblemBase & fe_problem);
+
+/**
+ * disable common snes flags
+ */
+void disableCommonSNESFlags(FEProblemBase & fe_problem);
 
 #define SNESGETLINESEARCH SNESGetLineSearch
 }

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -202,7 +202,7 @@ void setSinglePetscOption(const std::string & name,
 
 /**
  * Same as setSinglePetscOption, but does not set the option if it doesn't make sense for the
- * current simulation type.
+ * current simulation type, e.g. if \p name is contained within \p dont_add_these_options
  */
 void setSinglePetscOptionIfAppropriate(const MultiMooseEnum & dont_add_these_options,
                                        const std::string & name,
@@ -234,7 +234,7 @@ void colorAdjacencyMatrix(PetscScalar * adjacency_matrix,
                           const char * coloring_algorithm);
 
 /**
- * Function to ensure that particular petsc option is not added to the PetscOptions
+ * Function to ensure that a particular petsc option is not added to the PetscOptions
  * storage object to be later set unless explicitly specified in input or on the command line.
  */
 void dontAddPetscFlag(const std::string & flag, PetscOptions & petsc_options);

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -107,6 +107,12 @@ void outputNorm(libMesh::Real old_norm, libMesh::Real norm, bool use_color = fal
 PetscErrorCode petscLinearMonitor(KSP /*ksp*/, PetscInt its, PetscReal rnorm, void * void_ptr);
 
 /**
+ * Process some MOOSE-wrapped PETSc options.
+ */
+void processSingletonMooseWrappedOptions(FEProblemBase & fe_problem,
+                                         const InputParameters & params);
+
+/**
  * Stores the PETSc options supplied from the InputParameters with MOOSE
  */
 void storePetscOptions(FEProblemBase & fe_problem, const InputParameters & params);

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -138,7 +138,7 @@ void storePetscOptionsFromParams(PetscOptions & po,
  * @param petsc_flags Container holding the flags of the petsc options
  * @param petsc_options Data structure which handles petsc options within moose
  */
-void AddPetscFlagsToPetscOptions(const MultiMooseEnum & petsc_flags, PetscOptions & petsc_options);
+void addPetscFlagsToPetscOptions(const MultiMooseEnum & petsc_flags, PetscOptions & petsc_options);
 
 /**
  * Populate name and value pairs in a given PetscOptions object using vectors of input arguments
@@ -146,7 +146,7 @@ void AddPetscFlagsToPetscOptions(const MultiMooseEnum & petsc_flags, PetscOption
  * @param mesh_dimension The mesh dimension, needed for multigrid settings
  * @param petsc_options Data structure which handles petsc options within moose
  */
-void AddPetscPairsToPetscOptions(
+void addPetscPairsToPetscOptions(
     const std::vector<std::pair<MooseEnumItem, std::string>> & petsc_pair_options,
     const unsigned int mesh_dimension,
     PetscOptions & petsc_options);

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -107,7 +107,7 @@ void storePetscOptions(FEProblemBase & fe_problem, const InputParameters & param
  * @param petsc_flags Container holding the flags of the petsc options
  * @param petsc_options Data structure which handles petsc options within moose
  */
-void processPetscFlags(const MultiMooseEnum & petsc_flags, PetscOptions & petsc_options);
+void AddPetscFlagsToPetscOptions(const MultiMooseEnum & petsc_flags, PetscOptions & petsc_options);
 
 /**
  * Populate name and value pairs in a given PetscOptions object using vectors of input arguments
@@ -115,10 +115,10 @@ void processPetscFlags(const MultiMooseEnum & petsc_flags, PetscOptions & petsc_
  * @param mesh_dimension The mesh dimension, needed for multigrid settings
  * @param petsc_options Data structure which handles petsc options within moose
  */
-void
-processPetscPairs(const std::vector<std::pair<MooseEnumItem, std::string>> & petsc_pair_options,
-                  const unsigned int mesh_dimension,
-                  PetscOptions & petsc_options);
+void AddPetscPairsToPetscOptions(
+    const std::vector<std::pair<MooseEnumItem, std::string>> & petsc_pair_options,
+    const unsigned int mesh_dimension,
+    PetscOptions & petsc_options);
 
 /**
  * Returns the valid petsc line search options as a set of strings

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -38,7 +38,10 @@ namespace PetscSupport
 class PetscOptions
 {
 public:
-  PetscOptions() : flags("", "", true), ignored_flags("", "", true) {}
+  PetscOptions()
+    : flags("", "", true), ignored_options("", "", true), user_set_options("", "", true)
+  {
+  }
 
   /// PETSc key-value pairs
   std::vector<std::pair<std::string, std::string>> pairs;
@@ -47,7 +50,10 @@ public:
   MultiMooseEnum flags;
 
   /// Flags to explicitly not set, even if they are specified in flags
-  MultiMooseEnum ignored_flags;
+  MultiMooseEnum ignored_options;
+
+  /// Options that are set by the user at the input level
+  MultiMooseEnum user_set_options;
 
   /// Preconditioner description
   std::string pc_description;
@@ -190,6 +196,15 @@ void setSinglePetscOption(const std::string & name,
                           const std::string & value = "",
                           FEProblemBase * const problem = nullptr);
 
+/**
+Same as setSinglePetscOption, but does not set the option if it belongs to the given list of
+ignored options.
+*/
+void setSinglePetscOptionIfNotIgnored(const MultiMooseEnum & ignored_options,
+                                      const std::string & name,
+                                      const std::string & value = "",
+                                      FEProblemBase * const problem = nullptr);
+
 void addPetscOptionsFromCommandline();
 
 /**
@@ -220,14 +235,6 @@ void colorAdjacencyMatrix(PetscScalar * adjacency_matrix,
 void disablePetscFlag(const std::string & flag, PetscOptions & petsc_options);
 
 /**
- * disable "ignored" petsc flags
- * @param ignored_petsc_flags Container holding the flags of the petsc options to be ignored
- * @param petsc_options Data structure which handles petsc options within moose
- */
-void disableIgnoredPetscFlags(const MultiMooseEnum & ignored_petsc_flags,
-                              PetscOptions & petsc_options);
-
-/**
  * disable printing of the nonlinear convergence reason
  */
 void disableNonlinearConvergedReason(FEProblemBase & fe_problem);
@@ -240,12 +247,12 @@ void disableLinearConvergedReason(FEProblemBase & fe_problem);
 /**
  * disable common ksp flags
  */
-void disableCommonKSPFlags(FEProblemBase & fe_problem);
+void ignoreCommonKSPOptions(FEProblemBase & fe_problem);
 
 /**
  * disable common snes flags
  */
-void disableCommonSNESFlags(FEProblemBase & fe_problem);
+void ignoreCommonSNESOptions(FEProblemBase & fe_problem);
 
 #define SNESGETLINESEARCH SNESGetLineSearch
 }

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -159,8 +159,20 @@ InputParameters getPetscValidParams();
 /// A helper function to produce a MultiMooseEnum with commonly used PETSc single options (flags)
 MultiMooseEnum getCommonPetscFlags();
 
+/// A helper function to produce a MultiMooseEnum with commonly used PETSc snes single options (flags)
+MultiMooseEnum getCommonSNESFlags();
+
+/// A helper function to produce a MultiMooseEnum with commonly used PETSc ksp single options (flags)
+MultiMooseEnum getCommonKSPFlags();
+
 /// A helper function to produce a MultiMooseEnum with commonly used PETSc iname options (keys in key-value pairs)
 MultiMooseEnum getCommonPetscKeys();
+
+/// A helper function to produce a MultiMooseEnum with commonly used PETSc snes option names (keys)
+MultiMooseEnum getCommonSNESKeys();
+
+/// A helper function to produce a MultiMooseEnum with commonly used PETSc ksp option names (keys)
+MultiMooseEnum getCommonKSPKeys();
 
 /// check if SNES type is variational inequalities (VI) solver
 bool isSNESVI(FEProblemBase & fe_problem);

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -39,7 +39,7 @@ class PetscOptions
 {
 public:
   PetscOptions()
-    : flags("", "", true), ignored_options("", "", true), user_set_options("", "", true)
+    : flags("", "", true), dont_add_these_options("", "", true), user_set_options("", "", true)
   {
   }
 
@@ -50,7 +50,7 @@ public:
   MultiMooseEnum flags;
 
   /// Flags to explicitly not set, even if they are specified in flags
-  MultiMooseEnum ignored_options;
+  MultiMooseEnum dont_add_these_options;
 
   /// Options that are set by the user at the input level
   MultiMooseEnum user_set_options;
@@ -197,13 +197,13 @@ void setSinglePetscOption(const std::string & name,
                           FEProblemBase * const problem = nullptr);
 
 /**
-Same as setSinglePetscOption, but does not set the option if it belongs to the given list of
-ignored options.
+Same as setSinglePetscOption, but does not set the option if it doesn't make sense for the current
+simulation type.
 */
-void setSinglePetscOptionIfNotIgnored(const MultiMooseEnum & ignored_options,
-                                      const std::string & name,
-                                      const std::string & value = "",
-                                      FEProblemBase * const problem = nullptr);
+void setSinglePetscOptionIfAppropriate(const MultiMooseEnum & dont_add_these_options,
+                                       const std::string & name,
+                                       const std::string & value = "",
+                                       FEProblemBase * const problem = nullptr);
 
 void addPetscOptionsFromCommandline();
 
@@ -247,12 +247,12 @@ void disableLinearConvergedReason(FEProblemBase & fe_problem);
 /**
  * disable common ksp flags
  */
-void ignoreCommonKSPOptions(FEProblemBase & fe_problem);
+void dontSetCommonKSPOptions(FEProblemBase & fe_problem);
 
 /**
  * disable common snes flags
  */
-void ignoreCommonSNESOptions(FEProblemBase & fe_problem);
+void dontSetCommonSNESOptions(FEProblemBase & fe_problem);
 
 #define SNESGETLINESEARCH SNESGetLineSearch
 }

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -103,6 +103,28 @@ PetscErrorCode petscLinearMonitor(KSP /*ksp*/, PetscInt its, PetscReal rnorm, vo
 void storePetscOptions(FEProblemBase & fe_problem, const InputParameters & params);
 
 /**
+ * Sets the FE problem's solve type from the input params.
+ */
+void setSolveTypeFromParams(SolveType & fe_problem_solve_type, const InputParameters & params);
+
+/**
+ * Sets the FE problem's line search from the input params.
+ */
+void setLineSearchFromParams(FEProblemBase & fe_problem, const InputParameters & params);
+
+/**
+ *  Sets the FE problem's MFFD type from the input params.
+ */
+void setMFFDTypeFromParams(MffdType & fe_problem_mffd_type, const InputParameters & params);
+
+/**
+ * Stores the Petsc flags and pair options fron the input params in the given PetscOptions object.
+ */
+void storePetscOptionsFromParams(PetscOptions & po,
+                                 const unsigned int mesh_dimension,
+                                 const InputParameters & params);
+
+/**
  * Populate flags in a given PetscOptions object using a vector of input arguments
  * @param petsc_flags Container holding the flags of the petsc options
  * @param petsc_options Data structure which handles petsc options within moose

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -49,7 +49,7 @@ public:
   /// Single value PETSc options (flags)
   MultiMooseEnum flags;
 
-  /// Flags to explicitly not set, even if they are specified in flags
+  /// Flags to explicitly not set, even if they are specified programmatically
   MultiMooseEnum dont_add_these_options;
 
   /// Options that are set by the user at the input level
@@ -114,7 +114,7 @@ void storePetscOptions(FEProblemBase & fe_problem, const InputParameters & param
 /**
  * Sets the FE problem's solve type from the input params.
  */
-void setSolveTypeFromParams(SolveType & fe_problem_solve_type, const InputParameters & params);
+void setSolveTypeFromParams(FEProblemBase & fe_problem, const InputParameters & params);
 
 /**
  * Sets the FE problem's line search from the input params.
@@ -122,16 +122,14 @@ void setSolveTypeFromParams(SolveType & fe_problem_solve_type, const InputParame
 void setLineSearchFromParams(FEProblemBase & fe_problem, const InputParameters & params);
 
 /**
- *  Sets the FE problem's MFFD type from the input params.
+ *  Sets the FE problem's matrix-free finite difference type from the input params.
  */
-void setMFFDTypeFromParams(MffdType & fe_problem_mffd_type, const InputParameters & params);
+void setMFFDTypeFromParams(FEProblemBase & fe_problem, const InputParameters & params);
 
 /**
  * Stores the Petsc flags and pair options fron the input params in the given PetscOptions object.
  */
-void storePetscOptionsFromParams(PetscOptions & po,
-                                 const unsigned int mesh_dimension,
-                                 const InputParameters & params);
+void storePetscOptionsFromParams(FEProblemBase & fe_problem, const InputParameters & params);
 
 /**
  * Populate flags in a given PetscOptions object using a vector of input arguments
@@ -197,9 +195,9 @@ void setSinglePetscOption(const std::string & name,
                           FEProblemBase * const problem = nullptr);
 
 /**
-Same as setSinglePetscOption, but does not set the option if it doesn't make sense for the current
-simulation type.
-*/
+ * Same as setSinglePetscOption, but does not set the option if it doesn't make sense for the
+ * current simulation type.
+ */
 void setSinglePetscOptionIfAppropriate(const MultiMooseEnum & dont_add_these_options,
                                        const std::string & name,
                                        const std::string & value = "",
@@ -230,29 +228,34 @@ void colorAdjacencyMatrix(PetscScalar * adjacency_matrix,
                           const char * coloring_algorithm);
 
 /**
- * disable a particular petsc flag
+ * Function to ensure that particular petsc option is not added to the PetscOptions
+ * storage object to be later set unless explicitly specified in input or on the command line.
  */
-void disablePetscFlag(const std::string & flag, PetscOptions & petsc_options);
+void dontAddPetscFlag(const std::string & flag, PetscOptions & petsc_options);
 
 /**
- * disable printing of the nonlinear convergence reason
+ * Function to ensure that -snes_converged_reason is not added to the PetscOptions storage
+ * object to be later set unless explicitly specified in input or on the command line.
  */
-void disableNonlinearConvergedReason(FEProblemBase & fe_problem);
+void dontAddNonlinearConvergedReason(FEProblemBase & fe_problem);
 
 /**
- * disable printing of the linear convergence reason
+ * Function to ensure that -ksp_converged_reason is not added to the PetscOptions storage
+ * object to be later set unless explicitly specified in input or on the command line.
  */
-void disableLinearConvergedReason(FEProblemBase & fe_problem);
+void dontAddLinearConvergedReason(FEProblemBase & fe_problem);
 
 /**
- * disable common ksp flags
+ * Function to ensure that common KSP options are not added to the PetscOptions storage
+ * object to be later set unless explicitly specified in input or on the command line.
  */
-void dontSetCommonKSPOptions(FEProblemBase & fe_problem);
+void dontAddCommonKSPOptions(FEProblemBase & fe_problem);
 
 /**
- * disable common snes flags
+ * Function to ensure that common SNES options are not added to the PetscOptions storage
+ * object to be later set unless explicitly specified in input or on the command line.
  */
-void dontSetCommonSNESOptions(FEProblemBase & fe_problem);
+void dontAddCommonSNESOptions(FEProblemBase & fe_problem);
 
 #define SNESGETLINESEARCH SNESGetLineSearch
 }

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -293,11 +293,11 @@ CommonOutputAction::act()
 
     if (!getParam<bool>("console") || (isParamValid("print_nonlinear_converged_reason") &&
                                        !getParam<bool>("print_nonlinear_converged_reason")))
-      Moose::PetscSupport::disableNonlinearConvergedReason(*_problem);
+      Moose::PetscSupport::dontAddNonlinearConvergedReason(*_problem);
 
     if (!getParam<bool>("console") || (isParamValid("print_linear_converged_reason") &&
                                        !getParam<bool>("print_linear_converged_reason")))
-      Moose::PetscSupport::disableLinearConvergedReason(*_problem);
+      Moose::PetscSupport::dontAddLinearConvergedReason(*_problem);
   }
   else
     mooseError("unrecognized task ", _current_task, " in CommonOutputAction.");

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -21,6 +21,8 @@
 #include "libmesh/parallel_algebra.h"
 #include "libmesh/parallel_sync.h"
 
+#include "PetscSupport.h"
+
 CommandLine::CommandLine() {}
 CommandLine::CommandLine(int argc, char * argv[]) { addArguments(argc, argv); }
 CommandLine::CommandLine(const std::vector<std::string> & args) { addArguments(args); }
@@ -414,6 +416,10 @@ CommandLine::printUsage() const
 
   Moose::out << "Solver Options:\n"
              << "  See PETSc manual for details" << std::endl;
+
+  // If we get here, we are not running a simulation and should silence petsc's unused options
+  // warning
+  Moose::PetscSupport::setSinglePetscOption("-options_left", "0");
 }
 
 std::vector<std::string>

--- a/framework/src/physics/DiffusionPhysicsBase.C
+++ b/framework/src/physics/DiffusionPhysicsBase.C
@@ -91,7 +91,7 @@ DiffusionPhysicsBase::addPreconditioning()
         std::make_pair<MooseEnumItem, std::string>(MooseEnumItem("-pc_type"), "hypre");
     const auto option_pair2 =
         std::make_pair<MooseEnumItem, std::string>(MooseEnumItem("-pc_hypre_type"), "boomeramg");
-    AddPetscPairsToPetscOptions({option_pair1, option_pair2}, _problem->mesh().dimension(), po);
+    addPetscPairsToPetscOptions({option_pair1, option_pair2}, _problem->mesh().dimension(), po);
   }
 }
 

--- a/framework/src/physics/DiffusionPhysicsBase.C
+++ b/framework/src/physics/DiffusionPhysicsBase.C
@@ -91,7 +91,7 @@ DiffusionPhysicsBase::addPreconditioning()
         std::make_pair<MooseEnumItem, std::string>(MooseEnumItem("-pc_type"), "hypre");
     const auto option_pair2 =
         std::make_pair<MooseEnumItem, std::string>(MooseEnumItem("-pc_hypre_type"), "boomeramg");
-    processPetscPairs({option_pair1, option_pair2}, _problem->mesh().dimension(), po);
+    AddPetscPairsToPetscOptions({option_pair1, option_pair2}, _problem->mesh().dimension(), po);
   }
 }
 

--- a/framework/src/timeintegrators/ExplicitTimeIntegrator.C
+++ b/framework/src/timeintegrators/ExplicitTimeIntegrator.C
@@ -54,8 +54,8 @@ ExplicitTimeIntegrator::ExplicitTimeIntegrator(const InputParameters & parameter
   if (_solve_type == LUMPED || _solve_type == LUMP_PRECONDITIONED)
     _ones = addVector("ones", false, PARALLEL);
 
-  // ignore all common SNES-related petsc options to prevent unused option warnings
-  Moose::PetscSupport::ignoreCommonSNESOptions(_fe_problem);
+  // don't set any of the common SNES-related petsc options to prevent unused option warnings
+  Moose::PetscSupport::dontSetCommonSNESOptions(_fe_problem);
 }
 
 void

--- a/framework/src/timeintegrators/ExplicitTimeIntegrator.C
+++ b/framework/src/timeintegrators/ExplicitTimeIntegrator.C
@@ -55,7 +55,7 @@ ExplicitTimeIntegrator::ExplicitTimeIntegrator(const InputParameters & parameter
     _ones = addVector("ones", false, PARALLEL);
 
   // don't set any of the common SNES-related petsc options to prevent unused option warnings
-  Moose::PetscSupport::dontSetCommonSNESOptions(_fe_problem);
+  Moose::PetscSupport::dontAddCommonSNESOptions(_fe_problem);
 }
 
 void

--- a/framework/src/timeintegrators/ExplicitTimeIntegrator.C
+++ b/framework/src/timeintegrators/ExplicitTimeIntegrator.C
@@ -54,15 +54,8 @@ ExplicitTimeIntegrator::ExplicitTimeIntegrator(const InputParameters & parameter
   if (_solve_type == LUMPED || _solve_type == LUMP_PRECONDITIONED)
     _ones = addVector("ones", false, PARALLEL);
 
-  // Petsc
-  const auto snes_options = Moose::PetscSupport::getCommonSNESFlags();
-  auto & petsc_options = _fe_problem.getPetscOptions();
-  for (const auto & flag : snes_options.items())
-  {
-    const auto & flag_name = flag.rawName();
-    if (!petsc_options.ignored_flags.contains(flag_name))
-      petsc_options.ignored_flags.setAdditionalValue(flag_name);
-  }
+  // ignore all common SNES-related petsc options to prevent unused option warnings
+  Moose::PetscSupport::ignoreCommonSNESOptions(_fe_problem);
 }
 
 void

--- a/framework/src/timeintegrators/ExplicitTimeIntegrator.C
+++ b/framework/src/timeintegrators/ExplicitTimeIntegrator.C
@@ -53,6 +53,16 @@ ExplicitTimeIntegrator::ExplicitTimeIntegrator(const InputParameters & parameter
 
   if (_solve_type == LUMPED || _solve_type == LUMP_PRECONDITIONED)
     _ones = addVector("ones", false, PARALLEL);
+
+  // Petsc
+  const auto snes_options = Moose::PetscSupport::getCommonSNESFlags();
+  auto & petsc_options = _fe_problem.getPetscOptions();
+  for (const auto & flag : snes_options.items())
+  {
+    const auto & flag_name = flag.rawName();
+    if (!petsc_options.ignored_flags.contains(flag_name))
+      petsc_options.ignored_flags.setAdditionalValue(flag_name);
+  }
 }
 
 void

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -364,3 +364,10 @@ MultiMooseEnum::operator+=(const std::initializer_list<std::string> & names)
   mooseDeprecated("MultiMooseEnum::operator+= is deprecated, use MultiMooseEnum::addValidName");
   return MooseEnumBase::operator+=(names);
 }
+
+void
+MultiMooseEnum::addValidName(const MultiMooseEnum & names)
+{
+  for (const auto & item : names._items)
+    addEnumerationItem(MooseEnumItem(item.name(), getNextValidID()));
+}

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -467,12 +467,30 @@ petscSetDefaults(FEProblemBase & problem)
 }
 
 void
-storePetscOptions(FEProblemBase & fe_problem, const InputParameters & params)
+processSingletonMooseWrappedOptions(FEProblemBase & fe_problem, const InputParameters & params)
 {
   setSolveTypeFromParams(fe_problem, params);
   setLineSearchFromParams(fe_problem, params);
   setMFFDTypeFromParams(fe_problem, params);
-  storePetscOptionsFromParams(fe_problem, params);
+}
+
+void
+storePetscOptions(FEProblemBase & fe_problem, const InputParameters & params)
+{
+  processSingletonMooseWrappedOptions(fe_problem, params);
+
+  // The parameters contained in the Action
+  const auto & petsc_options = params.get<MultiMooseEnum>("petsc_options");
+  const auto & petsc_pair_options =
+      params.get<MooseEnumItem, std::string>("petsc_options_iname", "petsc_options_value");
+
+  auto & po = fe_problem.getPetscOptions();
+
+  // First process the single petsc options/flags
+  addPetscFlagsToPetscOptions(petsc_options, po);
+
+  // Then process the option-value pairs
+  addPetscPairsToPetscOptions(petsc_pair_options, fe_problem.mesh().dimension(), po);
 }
 
 void
@@ -526,23 +544,6 @@ setMFFDTypeFromParams(FEProblemBase & fe_problem, const InputParameters & params
     MooseEnum mffd_type = params.get<MooseEnum>("mffd_type");
     fe_problem.solverParams()._mffd_type = Moose::stringToEnum<Moose::MffdType>(mffd_type);
   }
-}
-
-void
-storePetscOptionsFromParams(FEProblemBase & fe_problem, const InputParameters & params)
-{
-  // The parameters contained in the Action
-  const auto & petsc_options = params.get<MultiMooseEnum>("petsc_options");
-  const auto & petsc_pair_options =
-      params.get<MooseEnumItem, std::string>("petsc_options_iname", "petsc_options_value");
-
-  auto & po = fe_problem.getPetscOptions();
-
-  // First process the single petsc options/flags
-  addPetscFlagsToPetscOptions(petsc_options, po);
-
-  // Then process the option-value pairs
-  addPetscPairsToPetscOptions(petsc_pair_options, fe_problem.mesh().dimension(), po);
 }
 
 void

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -541,7 +541,7 @@ setMFFDTypeFromParams(FEProblemBase & fe_problem, const InputParameters & params
 {
   if (params.isParamValid("mffd_type"))
   {
-    MooseEnum mffd_type = params.get<MooseEnum>("mffd_type");
+    const auto & mffd_type = params.get<MooseEnum>("mffd_type");
     fe_problem.solverParams()._mffd_type = Moose::stringToEnum<Moose::MffdType>(mffd_type);
   }
 }

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -536,14 +536,14 @@ storePetscOptionsFromParams(PetscOptions & po,
       params.get<MooseEnumItem, std::string>("petsc_options_iname", "petsc_options_value");
 
   // First process the single petsc options/flags
-  AddPetscFlagsToPetscOptions(petsc_options, po);
+  addPetscFlagsToPetscOptions(petsc_options, po);
 
   // Then process the option-value pairs
-  AddPetscPairsToPetscOptions(petsc_pair_options, mesh_dimension, po);
+  addPetscPairsToPetscOptions(petsc_pair_options, mesh_dimension, po);
 }
 
 void
-AddPetscFlagsToPetscOptions(const MultiMooseEnum & petsc_flags, PetscOptions & po)
+addPetscFlagsToPetscOptions(const MultiMooseEnum & petsc_flags, PetscOptions & po)
 {
   // Update the PETSc single flags
   for (const auto & option : petsc_flags)
@@ -586,7 +586,7 @@ AddPetscFlagsToPetscOptions(const MultiMooseEnum & petsc_flags, PetscOptions & p
 }
 
 void
-AddPetscPairsToPetscOptions(
+addPetscPairsToPetscOptions(
     const std::vector<std::pair<MooseEnumItem, std::string>> & petsc_pair_options,
     const unsigned int mesh_dimension,
     PetscOptions & po)

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -511,14 +511,14 @@ storePetscOptions(FEProblemBase & fe_problem, const InputParameters & params)
   Moose::PetscSupport::PetscOptions & po = fe_problem.getPetscOptions();
 
   // First process the single petsc options/flags
-  processPetscFlags(petsc_options, po);
+  AddPetscFlagsToPetscOptions(petsc_options, po);
 
   // Then process the option-value pairs
-  processPetscPairs(petsc_pair_options, fe_problem.mesh().dimension(), po);
+  AddPetscPairsToPetscOptions(petsc_pair_options, mesh_dimension, po);
 }
 
 void
-processPetscFlags(const MultiMooseEnum & petsc_flags, PetscOptions & po)
+AddPetscFlagsToPetscOptions(const MultiMooseEnum & petsc_flags, PetscOptions & po)
 {
   // Update the PETSc single flags
   for (const auto & option : petsc_flags)
@@ -558,9 +558,10 @@ processPetscFlags(const MultiMooseEnum & petsc_flags, PetscOptions & po)
 }
 
 void
-processPetscPairs(const std::vector<std::pair<MooseEnumItem, std::string>> & petsc_pair_options,
-                  const unsigned int mesh_dimension,
-                  PetscOptions & po)
+AddPetscPairsToPetscOptions(
+    const std::vector<std::pair<MooseEnumItem, std::string>> & petsc_pair_options,
+    const unsigned int mesh_dimension,
+    PetscOptions & po)
 {
   // the boolean in these pairs denote whether the user has specified any of the reason flags in the
   // input file

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -802,31 +802,63 @@ getPetscValidParams()
 }
 
 MultiMooseEnum
-getCommonPetscFlags()
+getCommonSNESFlags()
 {
   return MultiMooseEnum(
-      "-dm_moose_print_embedding -dm_view -ksp_converged_reason -ksp_gmres_modifiedgramschmidt "
-      "-ksp_monitor -ksp_monitor_snes_lg-snes_ksp_ew -ksp_snes_ew -snes_converged_reason "
-      "-snes_ksp -snes_ksp_ew -snes_linesearch_monitor -snes_mf -snes_mf_operator -snes_monitor "
-      "-snes_test_display -snes_view",
+      "-ksp_monitor_snes_lg -snes_ksp_ew -ksp_snes_ew -snes_converged_reason "
+      "-snes_ksp -snes_linesearch_monitor -snes_mf -snes_mf_operator -snes_monitor "
+      "-snes_test_display -snes_view -snes_monitor_cancel",
       "",
       true);
 }
 
 MultiMooseEnum
-getCommonPetscKeys()
+getCommonKSPFlags()
 {
-  return MultiMooseEnum("-ksp_atol -ksp_gmres_restart -ksp_max_it -ksp_pc_side -ksp_rtol "
-                        "-ksp_type -mat_fd_coloring_err -mat_fd_type -mat_mffd_type "
-                        "-pc_asm_overlap -pc_factor_levels "
-                        "-pc_factor_mat_ordering_type -pc_hypre_boomeramg_grid_sweeps_all "
-                        "-pc_hypre_boomeramg_max_iter "
-                        "-pc_hypre_boomeramg_strong_threshold -pc_hypre_type -pc_type -snes_atol "
-                        "-snes_linesearch_type "
-                        "-snes_ls -snes_max_it -snes_rtol -snes_divergence_tolerance -snes_type "
-                        "-sub_ksp_type -sub_pc_type",
+  return MultiMooseEnum(
+      "-ksp_converged_reason -ksp_gmres_modifiedgramschmidt -ksp_monitor", "", true);
+}
+
+MultiMooseEnum
+getCommonPetscFlags()
+{
+  auto options = MultiMooseEnum("-dm_moose_print_embedding -dm_view", "", true);
+  options.addValidName(getCommonKSPFlags());
+  options.addValidName(getCommonSNESFlags());
+  return options;
+}
+
+MultiMooseEnum
+getCommonSNESKeys()
+{
+  return MultiMooseEnum("-snes_atol -snes_linesearch_type -snes_ls -snes_max_it -snes_rtol "
+                        "-snes_divergence_tolerance -snes_type",
                         "",
                         true);
+}
+
+MultiMooseEnum
+getCommonKSPKeys()
+{
+  return MultiMooseEnum("-ksp_atol -ksp_gmres_restart -ksp_max_it -ksp_pc_side -ksp_rtol "
+                        "-ksp_type -sub_ksp_type",
+                        "",
+                        true);
+}
+MultiMooseEnum
+getCommonPetscKeys()
+{
+  auto options = MultiMooseEnum("-mat_fd_coloring_err -mat_fd_type -mat_mffd_type "
+                                "-pc_asm_overlap -pc_factor_levels "
+                                "-pc_factor_mat_ordering_type -pc_hypre_boomeramg_grid_sweeps_all "
+                                "-pc_hypre_boomeramg_max_iter "
+                                "-pc_hypre_boomeramg_strong_threshold -pc_hypre_type -pc_type "
+                                "-sub_pc_type",
+                                "",
+                                true);
+  options.addValidName(getCommonKSPKeys());
+  options.addValidName(getCommonSNESKeys());
+  return options;
 }
 
 bool

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -510,7 +510,7 @@ setLineSearchFromParams(FEProblemBase & fe_problem, const InputParameters & para
 {
   if (params.isParamValid("line_search"))
   {
-    const MooseEnum line_search = params.get<MooseEnum>("line_search");
+    const auto & line_search = params.get<MooseEnum>("line_search");
     if (fe_problem.solverParams()._line_search == Moose::LS_INVALID || line_search != "default")
     {
       Moose::LineSearchType enum_line_search =

--- a/modules/heat_transfer/src/physics/HeatConductionPhysicsBase.C
+++ b/modules/heat_transfer/src/physics/HeatConductionPhysicsBase.C
@@ -118,6 +118,6 @@ HeatConductionPhysicsBase::addPreconditioning()
         std::make_pair<MooseEnumItem, std::string>(MooseEnumItem("-pc_type"), "hypre");
     const auto option_pair2 =
         std::make_pair<MooseEnumItem, std::string>(MooseEnumItem("-pc_hypre_type"), "boomeramg");
-    processPetscPairs({option_pair1, option_pair2}, _problem->mesh().dimension(), po);
+    addPetscPairsToPetscOptions({option_pair1, option_pair2}, _problem->mesh().dimension(), po);
   }
 }

--- a/modules/navier_stokes/src/executioners/SIMPLESolveBase.C
+++ b/modules/navier_stokes/src/executioners/SIMPLESolveBase.C
@@ -291,8 +291,8 @@ SIMPLESolveBase::SIMPLESolveBase(Executioner & ex)
   const auto & momentum_petsc_options = getParam<MultiMooseEnum>("momentum_petsc_options");
   const auto & momentum_petsc_pair_options = getParam<MooseEnumItem, std::string>(
       "momentum_petsc_options_iname", "momentum_petsc_options_value");
-  Moose::PetscSupport::processPetscFlags(momentum_petsc_options, _momentum_petsc_options);
-  Moose::PetscSupport::processPetscPairs(
+  Moose::PetscSupport::addPetscFlagsToPetscOptions(momentum_petsc_options, _momentum_petsc_options);
+  Moose::PetscSupport::addPetscPairsToPetscOptions(
       momentum_petsc_pair_options, _problem.mesh().dimension(), _momentum_petsc_options);
 
   _momentum_linear_control.real_valued_data["rel_tol"] = getParam<Real>("momentum_l_tol");
@@ -303,8 +303,8 @@ SIMPLESolveBase::SIMPLESolveBase(Executioner & ex)
   const auto & pressure_petsc_options = getParam<MultiMooseEnum>("pressure_petsc_options");
   const auto & pressure_petsc_pair_options = getParam<MooseEnumItem, std::string>(
       "pressure_petsc_options_iname", "pressure_petsc_options_value");
-  Moose::PetscSupport::processPetscFlags(pressure_petsc_options, _pressure_petsc_options);
-  Moose::PetscSupport::processPetscPairs(
+  Moose::PetscSupport::addPetscFlagsToPetscOptions(pressure_petsc_options, _pressure_petsc_options);
+  Moose::PetscSupport::addPetscPairsToPetscOptions(
       pressure_petsc_pair_options, _problem.mesh().dimension(), _pressure_petsc_options);
 
   _pressure_linear_control.real_valued_data["rel_tol"] = getParam<Real>("pressure_l_tol");
@@ -317,8 +317,8 @@ SIMPLESolveBase::SIMPLESolveBase(Executioner & ex)
     const auto & energy_petsc_options = getParam<MultiMooseEnum>("energy_petsc_options");
     const auto & energy_petsc_pair_options = getParam<MooseEnumItem, std::string>(
         "energy_petsc_options_iname", "energy_petsc_options_value");
-    Moose::PetscSupport::processPetscFlags(energy_petsc_options, _energy_petsc_options);
-    Moose::PetscSupport::processPetscPairs(
+    Moose::PetscSupport::addPetscFlagsToPetscOptions(energy_petsc_options, _energy_petsc_options);
+    Moose::PetscSupport::addPetscPairsToPetscOptions(
         energy_petsc_pair_options, _problem.mesh().dimension(), _energy_petsc_options);
 
     _energy_linear_control.real_valued_data["rel_tol"] = getParam<Real>("energy_l_tol");
@@ -356,11 +356,11 @@ SIMPLESolveBase::SIMPLESolveBase(Executioner & ex)
         getParam<MultiMooseEnum>("passive_scalar_petsc_options");
     const auto & passive_scalar_petsc_pair_options = getParam<MooseEnumItem, std::string>(
         "passive_scalar_petsc_options_iname", "passive_scalar_petsc_options_value");
-    Moose::PetscSupport::processPetscFlags(passive_scalar_petsc_options,
-                                           _passive_scalar_petsc_options);
-    Moose::PetscSupport::processPetscPairs(passive_scalar_petsc_pair_options,
-                                           _problem.mesh().dimension(),
-                                           _passive_scalar_petsc_options);
+    Moose::PetscSupport::addPetscFlagsToPetscOptions(passive_scalar_petsc_options,
+                                                     _passive_scalar_petsc_options);
+    Moose::PetscSupport::addPetscPairsToPetscOptions(passive_scalar_petsc_pair_options,
+                                                     _problem.mesh().dimension(),
+                                                     _passive_scalar_petsc_options);
 
     _passive_scalar_linear_control.real_valued_data["rel_tol"] =
         getParam<Real>("passive_scalar_l_tol");

--- a/modules/navier_stokes/src/executioners/SIMPLESolveNonlinearAssembly.C
+++ b/modules/navier_stokes/src/executioners/SIMPLESolveNonlinearAssembly.C
@@ -228,11 +228,11 @@ SIMPLESolveNonlinearAssembly::SIMPLESolveNonlinearAssembly(Executioner & ex)
           getParam<MultiMooseEnum>("solid_energy_petsc_options");
       const auto & solid_energy_petsc_pair_options = getParam<MooseEnumItem, std::string>(
           "solid_energy_petsc_options_iname", "solid_energy_petsc_options_value");
-      Moose::PetscSupport::processPetscFlags(solid_energy_petsc_options,
-                                             _solid_energy_petsc_options);
-      Moose::PetscSupport::processPetscPairs(solid_energy_petsc_pair_options,
-                                             _problem.mesh().dimension(),
-                                             _solid_energy_petsc_options);
+      Moose::PetscSupport::addPetscFlagsToPetscOptions(solid_energy_petsc_options,
+                                                       _solid_energy_petsc_options);
+      Moose::PetscSupport::addPetscPairsToPetscOptions(solid_energy_petsc_pair_options,
+                                                       _problem.mesh().dimension(),
+                                                       _solid_energy_petsc_options);
 
       _solid_energy_linear_control.real_valued_data["rel_tol"] =
           getParam<Real>("solid_energy_l_tol");
@@ -258,8 +258,9 @@ SIMPLESolveNonlinearAssembly::SIMPLESolveNonlinearAssembly(Executioner & ex)
     const auto & turbulence_petsc_options = getParam<MultiMooseEnum>("turbulence_petsc_options");
     const auto & turbulence_petsc_pair_options = getParam<MooseEnumItem, std::string>(
         "turbulence_petsc_options_iname", "turbulence_petsc_options_value");
-    Moose::PetscSupport::processPetscFlags(turbulence_petsc_options, _turbulence_petsc_options);
-    Moose::PetscSupport::processPetscPairs(
+    Moose::PetscSupport::addPetscFlagsToPetscOptions(turbulence_petsc_options,
+                                                     _turbulence_petsc_options);
+    Moose::PetscSupport::addPetscPairsToPetscOptions(
         turbulence_petsc_pair_options, _problem.mesh().dimension(), _turbulence_petsc_options);
 
     _turbulence_linear_control.real_valued_data["rel_tol"] = getParam<Real>("turbulence_l_tol");

--- a/modules/scalar_transport/src/physics/MultiSpeciesDiffusionPhysicsBase.C
+++ b/modules/scalar_transport/src/physics/MultiSpeciesDiffusionPhysicsBase.C
@@ -117,7 +117,7 @@ MultiSpeciesDiffusionPhysicsBase::addPreconditioning()
         std::make_pair<MooseEnumItem, std::string>(MooseEnumItem("-pc_type"), "hypre");
     const auto option_pair2 =
         std::make_pair<MooseEnumItem, std::string>(MooseEnumItem("-pc_hypre_type"), "boomeramg");
-    processPetscPairs({option_pair1, option_pair2}, _problem->mesh().dimension(), po);
+    addPetscPairsToPetscOptions({option_pair1, option_pair2}, _problem->mesh().dimension(), po);
   }
 }
 

--- a/test/tests/mesh/preparedness/test.i
+++ b/test/tests/mesh/preparedness/test.i
@@ -322,7 +322,7 @@
 [Executioner]
   type = Transient
   solve_type = NEWTON
-  petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_pc_factor_shift_type'
+  petsc_options_iname = '-pc_type -ksp_gmres_restart -pc_factor_shift_type'
   petsc_options_value = 'lu        100                NONZERO'
 
   # Tolerances.

--- a/test/tests/misc/petsc_option_left/2d_diffusion_petsc_option.i
+++ b/test/tests/misc/petsc_option_left/2d_diffusion_petsc_option.i
@@ -40,9 +40,17 @@
 []
 
 [Executioner]
-  type = Steady
+  type = Transient
 
-  solve_type = 'NEWTON'
+  solve_type = 'LINEAR'
+
+  start_time = 0.0
+  num_steps = 1
+  dt = 0.00005
+
+  [./TimeIntegrator]
+    type = ActuallyExplicitEuler
+  [../]
 
   petsc_options_iname = "-pc_type"
   petsc_options_value = "hypre"

--- a/test/tests/misc/petsc_option_left/tests
+++ b/test/tests/misc/petsc_option_left/tests
@@ -20,4 +20,14 @@
     issues = '#25577'
     petsc_version = '>=3.19.2'
   []
+
+  [test_user_set_petsc_options_left]
+    type = RunApp
+    input = '2d_diffusion_petsc_option.i'
+    cli_args = 'Executioner/petsc_options_iname="-pc_type -snes_type" Executioner/petsc_options_value="hypre ksponly"'
+    expect_out = "Option left:\s+name:-SNES_TYPE\s+value:\s+ksponly"
+    requirement = "The system shall warn the user of unused petsc options that are not set programatically."
+    issues = '#28053'
+    petsc_version = '>=3.19.2'
+  []
 []


### PR DESCRIPTION
Currently, petsc options are handled in the `MOOSE::PetscSupport` namespace in `PetscSupport.C`. The functions defined here set petsc options for various general cases. However, these general settings are not applicable to some cases and can result in unused petsc option warmings.

This PR is the first step to address #28053. A capability is introduced such that various moose objects can specify exceptions to the general cases in `PetscSupport`. These exceptions are given as a list of options that are to be ignored, or they would otherwise cause unused option warnings. With this design, special cases that cause warnings can be addressed by ignoring the irrelevant petsc options. An example of how to use this new features is given in `ExplicitTimeIntegrator`. With this change, the unused option warnings that appeared when running `test/tests/time_integrators/actually_explicit_euler_verification/ee-1d-linear.i` disappear.

If we want to go with this proposed design, the test suite should be examined for all occurrences of unused option warnings and these options should be turned off for those tests. This examination can be easily conducted by setting a default value for the `absent_out` parameter in the `RunApp` tester to identify relevant tests that have unused option warnings.
