### PR TITLE
Store NEML2 stateful data in MOOSE-managed material properties

### DIFF
--- a/modules/solid_mechanics/include/neml2/materials/NEML2ToMOOSEMaterialProperty.h
+++ b/modules/solid_mechanics/include/neml2/materials/NEML2ToMOOSEMaterialProperty.h
@@ -36,11 +36,16 @@ public:
   virtual void computeProperties() override;
 
 protected:
+  virtual void initQpStatefulProperties() override;
+
   /// User object managing the execution of the NEML2 model
   const ExecuteNEML2Model & _execute_neml2_model;
 
   /// Emitted material property
   MaterialProperty<T> & _prop;
+
+  /// Initial condition
+  const MaterialProperty<T> * _prop0;
 
   /// labled view to the requested output
   const neml2::BatchTensor & _output_view;

--- a/modules/solid_mechanics/include/neml2/userobjects/MOOSEMaterialPropertyToNEML2.h
+++ b/modules/solid_mechanics/include/neml2/userobjects/MOOSEMaterialPropertyToNEML2.h
@@ -15,13 +15,19 @@
 #ifndef NEML2_ENABLED
 NEML2ObjectStubHeader(MOOSERealMaterialPropertyToNEML2, ElementUserObject);
 NEML2ObjectStubHeader(MOOSERankTwoTensorMaterialPropertyToNEML2, ElementUserObject);
+NEML2ObjectStubHeader(MOOSESymmetricRankTwoTensorMaterialPropertyToNEML2, ElementUserObject);
 NEML2ObjectStubHeader(MOOSEStdVectorRealMaterialPropertyToNEML2, ElementUserObject);
+
+NEML2ObjectStubHeader(MOOSEOldRealMaterialPropertyToNEML2, ElementUserObject);
+NEML2ObjectStubHeader(MOOSEOldRankTwoTensorMaterialPropertyToNEML2, ElementUserObject);
+NEML2ObjectStubHeader(MOOSEOldSymmetricRankTwoTensorMaterialPropertyToNEML2, ElementUserObject);
+NEML2ObjectStubHeader(MOOSEOldStdVectorRealMaterialPropertyToNEML2, ElementUserObject);
 #else
 
 /**
  * Gather a MOOSE material property for insertion into the specified input of a NEML2 model.
  */
-template <typename T>
+template <typename T, unsigned int state>
 class MOOSEMaterialPropertyToNEML2 : public MOOSEToNEML2
 {
 public:
@@ -30,14 +36,24 @@ public:
   MOOSEMaterialPropertyToNEML2(const InputParameters & params);
 
 protected:
-  virtual void execute() override;
+  virtual torch::Tensor convertQpMOOSEData() const override;
 
   /// MOOSE material property to read data from
   const MaterialProperty<T> & _mat_prop;
 };
 
-typedef MOOSEMaterialPropertyToNEML2<Real> MOOSERealMaterialPropertyToNEML2;
-typedef MOOSEMaterialPropertyToNEML2<RankTwoTensor> MOOSERankTwoTensorMaterialPropertyToNEML2;
-typedef MOOSEMaterialPropertyToNEML2<std::vector<Real>> MOOSEStdVectorRealMaterialPropertyToNEML2;
+typedef MOOSEMaterialPropertyToNEML2<Real, 0> MOOSERealMaterialPropertyToNEML2;
+typedef MOOSEMaterialPropertyToNEML2<RankTwoTensor, 0> MOOSERankTwoTensorMaterialPropertyToNEML2;
+typedef MOOSEMaterialPropertyToNEML2<SymmetricRankTwoTensor, 0>
+    MOOSESymmetricRankTwoTensorMaterialPropertyToNEML2;
+typedef MOOSEMaterialPropertyToNEML2<std::vector<Real>, 0>
+    MOOSEStdVectorRealMaterialPropertyToNEML2;
+
+typedef MOOSEMaterialPropertyToNEML2<Real, 1> MOOSEOldRealMaterialPropertyToNEML2;
+typedef MOOSEMaterialPropertyToNEML2<RankTwoTensor, 1> MOOSEOldRankTwoTensorMaterialPropertyToNEML2;
+typedef MOOSEMaterialPropertyToNEML2<SymmetricRankTwoTensor, 1>
+    MOOSEOldSymmetricRankTwoTensorMaterialPropertyToNEML2;
+typedef MOOSEMaterialPropertyToNEML2<std::vector<Real>, 1>
+    MOOSEOldStdVectorRealMaterialPropertyToNEML2;
 
 #endif

--- a/modules/solid_mechanics/include/neml2/userobjects/MOOSEToNEML2.h
+++ b/modules/solid_mechanics/include/neml2/userobjects/MOOSEToNEML2.h
@@ -19,6 +19,7 @@ NEML2ObjectStubHeader(MOOSEToNEML2, ElementUserObject);
 #include "neml2/tensors/LabeledVector.h"
 #include "neml2/tensors/LabeledMatrix.h"
 #include "neml2/models/Model.h"
+
 class MOOSEToNEML2 : public ElementUserObject
 {
 public:
@@ -36,14 +37,21 @@ public:
 
 protected:
   virtual void initialize() override;
+  virtual void execute() override;
   virtual void finalize() override {}
   virtual void threadJoin(const UserObject &) override;
+
+  /// Convert the underlying MOOSE data to a torch::Tensor
+  virtual torch::Tensor convertQpMOOSEData() const = 0;
 
   /// NEML2 input variable to transfer data to
   const neml2::VariableName _neml2_variable;
 
   /// Intermediate data buffer, filled during the element loop
   std::vector<torch::Tensor> _buffer;
+
+  /// Current element's quadrature point indexing
+  unsigned int _qp;
 };
 
 #endif

--- a/modules/solid_mechanics/include/neml2/userobjects/MOOSEVariableToNEML2.h
+++ b/modules/solid_mechanics/include/neml2/userobjects/MOOSEVariableToNEML2.h
@@ -13,23 +13,28 @@
 
 #ifndef NEML2_ENABLED
 NEML2ObjectStubHeader(MOOSEVariableToNEML2, MOOSEToNEML2);
+NEML2ObjectStubHeader(MOOSEOldVariableToNEML2, MOOSEToNEML2);
 #else
 
 /**
  * Gather a MOOSE variable for insertion into the specified input of a NEML2 model.
  */
-class MOOSEVariableToNEML2 : public MOOSEToNEML2
+template <unsigned int state>
+class MOOSEVariableToNEML2Templ : public MOOSEToNEML2
 {
 public:
   static InputParameters validParams();
 
-  MOOSEVariableToNEML2(const InputParameters & params);
+  MOOSEVariableToNEML2Templ(const InputParameters & params);
 
 protected:
-  virtual void execute() override;
+  virtual torch::Tensor convertQpMOOSEData() const override;
 
   /// Coupled MOOSE variable to read data from
   const VariableValue & _moose_variable;
 };
+
+typedef MOOSEVariableToNEML2Templ<0> MOOSEVariableToNEML2;
+typedef MOOSEVariableToNEML2Templ<1> MOOSEOldVariableToNEML2;
 
 #endif

--- a/modules/solid_mechanics/include/neml2/utils/NEML2Utils.h
+++ b/modules/solid_mechanics/include/neml2/utils/NEML2Utils.h
@@ -42,6 +42,9 @@ namespace NEML2Utils
 
 #ifdef NEML2_ENABLED
 
+/// Map a variable name onto the old_xxx sub-axis
+neml2::VariableName getOldName(const neml2::VariableName & var);
+
 /**
  * Convert a MOOSE data structure to its NEML2 counterpart
  */
@@ -183,7 +186,7 @@ set(neml2::LabeledVector & v,
 
   // Recursively act on the rest of the data
   // The compiler should be able to easily deduce the rest of the template parameters...
-  if constexpr (sizeof...(Ts) > 1)
+  if constexpr (sizeof...(Ts) > 0)
     set<I + 1>(v, indices, t...);
 }
 

--- a/modules/solid_mechanics/src/neml2/userobjects/MOOSEMaterialPropertyToNEML2.C
+++ b/modules/solid_mechanics/src/neml2/userobjects/MOOSEMaterialPropertyToNEML2.C
@@ -11,7 +11,13 @@
 
 registerMooseObject("SolidMechanicsApp", MOOSERealMaterialPropertyToNEML2);
 registerMooseObject("SolidMechanicsApp", MOOSERankTwoTensorMaterialPropertyToNEML2);
+registerMooseObject("SolidMechanicsApp", MOOSESymmetricRankTwoTensorMaterialPropertyToNEML2);
 registerMooseObject("SolidMechanicsApp", MOOSEStdVectorRealMaterialPropertyToNEML2);
+
+registerMooseObject("SolidMechanicsApp", MOOSEOldRealMaterialPropertyToNEML2);
+registerMooseObject("SolidMechanicsApp", MOOSEOldRankTwoTensorMaterialPropertyToNEML2);
+registerMooseObject("SolidMechanicsApp", MOOSEOldSymmetricRankTwoTensorMaterialPropertyToNEML2);
+registerMooseObject("SolidMechanicsApp", MOOSEOldStdVectorRealMaterialPropertyToNEML2);
 
 #ifndef NEML2_ENABLED
 #define MOOSEMaterialPropertyToNEML2Stub(name)                                                     \
@@ -19,14 +25,21 @@ registerMooseObject("SolidMechanicsApp", MOOSEStdVectorRealMaterialPropertyToNEM
   NEML2ObjectStubParam(MaterialPropertyName, "moose_material_property");                           \
   NEML2ObjectStubParam(std::string, "neml2_variable");                                             \
   NEML2ObjectStubImplementationClose(name, ElementUserObject)
+
 MOOSEMaterialPropertyToNEML2Stub(MOOSERealMaterialPropertyToNEML2);
 MOOSEMaterialPropertyToNEML2Stub(MOOSERankTwoTensorMaterialPropertyToNEML2);
+MOOSEMaterialPropertyToNEML2Stub(MOOSESymmetricRankTwoTensorMaterialPropertyToNEML2);
 MOOSEMaterialPropertyToNEML2Stub(MOOSEStdVectorRealMaterialPropertyToNEML2);
+
+MOOSEMaterialPropertyToNEML2Stub(MOOSEOldRealMaterialPropertyToNEML2);
+MOOSEMaterialPropertyToNEML2Stub(MOOSEOldRankTwoTensorMaterialPropertyToNEML2);
+MOOSEMaterialPropertyToNEML2Stub(MOOSEOldSymmetricRankTwoTensorMaterialPropertyToNEML2);
+MOOSEMaterialPropertyToNEML2Stub(MOOSEOldStdVectorRealMaterialPropertyToNEML2);
 #else
 
-template <typename T>
+template <typename T, unsigned int state>
 InputParameters
-MOOSEMaterialPropertyToNEML2<T>::validParams()
+MOOSEMaterialPropertyToNEML2<T, state>::validParams()
 {
   auto params = MOOSEToNEML2::validParams();
   params.addClassDescription("Gather a MOOSE material property of type " +
@@ -39,24 +52,42 @@ MOOSEMaterialPropertyToNEML2<T>::validParams()
   return params;
 }
 
-template <typename T>
-MOOSEMaterialPropertyToNEML2<T>::MOOSEMaterialPropertyToNEML2(const InputParameters & params)
-  : MOOSEToNEML2(params), _mat_prop(getMaterialProperty<T>("moose_material_property"))
+template <typename T, unsigned int state>
+MOOSEMaterialPropertyToNEML2<T, state>::MOOSEMaterialPropertyToNEML2(const InputParameters & params)
+  : MOOSEToNEML2(params),
+    _mat_prop(getGenericMaterialProperty<T, false>("moose_material_property", state))
 {
+  if constexpr (state == 0)
+    if (!_neml2_variable.start_with("forces") && !_neml2_variable.start_with("state"))
+      paramError("neml2_variable",
+                 "neml2_variable should be defined on the forces or the state sub-axis, got ",
+                 _neml2_variable.slice(0, 1),
+                 " instead");
+
+  if constexpr (state == 1)
+    if (!_neml2_variable.start_with("old_forces") && !_neml2_variable.start_with("old_state"))
+      paramError(
+          "neml2_variable",
+          "neml2_variable should be defined on the old_forces or the old_state sub-axis, got ",
+          _neml2_variable.slice(0, 1),
+          " instead");
 }
 
-template <typename T>
-void
-MOOSEMaterialPropertyToNEML2<T>::execute()
+template <typename T, unsigned int state>
+torch::Tensor
+MOOSEMaterialPropertyToNEML2<T, state>::convertQpMOOSEData() const
 {
-#ifdef NEML2_ENABLED
-  for (unsigned int qp = 0; qp < _qrule->n_points(); qp++)
-    _buffer.push_back(NEML2Utils::toNEML2<T>(_mat_prop[qp]));
-#endif
+  return NEML2Utils::toNEML2<T>(_mat_prop[_qp]);
 }
 
-template class MOOSEMaterialPropertyToNEML2<Real>;
-template class MOOSEMaterialPropertyToNEML2<RankTwoTensor>;
-template class MOOSEMaterialPropertyToNEML2<std::vector<Real>>;
+template class MOOSEMaterialPropertyToNEML2<Real, 0>;
+template class MOOSEMaterialPropertyToNEML2<RankTwoTensor, 0>;
+template class MOOSEMaterialPropertyToNEML2<SymmetricRankTwoTensor, 0>;
+template class MOOSEMaterialPropertyToNEML2<std::vector<Real>, 0>;
+
+template class MOOSEMaterialPropertyToNEML2<Real, 1>;
+template class MOOSEMaterialPropertyToNEML2<RankTwoTensor, 1>;
+template class MOOSEMaterialPropertyToNEML2<SymmetricRankTwoTensor, 1>;
+template class MOOSEMaterialPropertyToNEML2<std::vector<Real>, 1>;
 
 #endif

--- a/modules/solid_mechanics/src/neml2/userobjects/MOOSEToNEML2.C
+++ b/modules/solid_mechanics/src/neml2/userobjects/MOOSEToNEML2.C
@@ -22,7 +22,7 @@ MOOSEToNEML2::validParams()
 {
   auto params = ElementUserObject::validParams();
 
-  params.addRequiredParam<std::string>("neml2_variable", "NEML2 variable accessor to write to");
+  params.addRequiredParam<std::string>("neml2_variable", "Name of the NEML2 variable to write to");
 
   // Since we use the NEML2 model to evaluate the residual AND the Jacobian at the same time, we
   // want to execute this user object only at execute_on = LINEAR (i.e. during residual evaluation).
@@ -51,6 +51,13 @@ void
 MOOSEToNEML2::initialize()
 {
   _buffer.clear();
+}
+
+void
+MOOSEToNEML2::execute()
+{
+  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    _buffer.push_back(convertQpMOOSEData());
 }
 
 void

--- a/modules/solid_mechanics/src/neml2/utils/NEML2Utils.C
+++ b/modules/solid_mechanics/src/neml2/utils/NEML2Utils.C
@@ -54,6 +54,23 @@ namespace NEML2Utils
 
 #ifdef NEML2_ENABLED
 
+neml2::VariableName
+getOldName(const neml2::VariableName & var)
+{
+  if (var.start_with("forces"))
+    return var.slice(1).on("old_forces");
+
+  if (var.start_with("state"))
+    return var.slice(1).on("old_state");
+
+  mooseError("An error occurred when trying to map a stateful NEML2 variable name '",
+             var,
+             "' onto its old counterpart. The leading sub-axis of the variable should either be "
+             "'state' or 'forces'. However, we got '",
+             var.slice(0, 1),
+             "'");
+}
+
 template <>
 neml2::BatchTensor
 toNEML2(const Real & v)

--- a/modules/solid_mechanics/test/tests/neml2/fem_modular.i
+++ b/modules/solid_mechanics/test/tests/neml2/fem_modular.i
@@ -1,3 +1,4 @@
+neml2_input = elasticity
 N = 2
 
 [GlobalParams]
@@ -23,31 +24,110 @@ N = 2
 []
 
 [UserObjects]
-  [gather_strain]
+  active = 'model input_strain'
+  [input_temperature]
+    type = MOOSEVariableToNEML2
+    moose_variable = T
+    neml2_variable = forces/T
+  []
+  [input_strain]
     type = MOOSERankTwoTensorMaterialPropertyToNEML2
     moose_material_property = mechanical_strain
     neml2_variable = forces/E
   []
-  [gather_temperature]
-    type = MOOSEVariableToNEML2
-    moose_variable = T
-    neml2_variable = forces/T
+  [input_old_strain]
+    type = MOOSEOldRankTwoTensorMaterialPropertyToNEML2
+    moose_material_property = mechanical_strain
+    neml2_variable = old_forces/E
+  []
+  [input_old_stress]
+    type = MOOSEOldRankTwoTensorMaterialPropertyToNEML2
+    moose_material_property = small_stress
+    neml2_variable = old_state/S
+  []
+  [input_old_ep]
+    type = MOOSEOldRealMaterialPropertyToNEML2
+    moose_material_property = equivalent_plastic_strain
+    neml2_variable = old_state/internal/ep
+  []
+  [input_old_Kp]
+    type = MOOSEOldSymmetricRankTwoTensorMaterialPropertyToNEML2
+    moose_material_property = kinematic_plastic_strain
+    neml2_variable = old_state/internal/Kp
+  []
+  [input_old_X1]
+    type = MOOSEOldSymmetricRankTwoTensorMaterialPropertyToNEML2
+    moose_material_property = backstress_1
+    neml2_variable = old_state/internal/X1
+  []
+  [input_old_X2]
+    type = MOOSEOldSymmetricRankTwoTensorMaterialPropertyToNEML2
+    moose_material_property = backstress_2
+    neml2_variable = old_state/internal/X2
+  []
+  [input_old_Ep]
+    type = MOOSEOldSymmetricRankTwoTensorMaterialPropertyToNEML2
+    moose_material_property = plastic_strain
+    neml2_variable = old_state/internal/Ep
+  []
+  [input_old_gamma]
+    type = MOOSEOldRealMaterialPropertyToNEML2
+    moose_material_property = consistency_parameter
+    neml2_variable = old_state/internal/gamma
   []
 
   [model]
     type = ExecuteNEML2Model
     model = model
-    # add gather_temperature here if needed
-    gather_uos = 'gather_strain'
+    # add other gatherers here if needed
+    gather_uos = 'input_strain'
   []
 []
 
 [Materials]
-  [neml2_stress_jacobian]
+  # add other outputs here if needed
+  active = 'output_stress_jacobian'
+  [output_stress_jacobian]
     type = NEML2StressToMOOSE
     execute_neml2_model_uo = model
     neml2_stress_output = state/S
     neml2_strain_input = forces/E
+  []
+  [output_ep]
+    type = NEML2ToRealMOOSEMaterialProperty
+    execute_neml2_model_uo = model
+    neml2_variable = state/internal/ep
+    moose_material_property = equivalent_plastic_strain
+  []
+  [output_Kp]
+    type = NEML2ToSymmetricRankTwoTensorMOOSEMaterialProperty
+    execute_neml2_model_uo = model
+    neml2_variable = state/internal/Kp
+    moose_material_property = kinematic_plastic_strain
+  []
+  [output_X1]
+    type = NEML2ToSymmetricRankTwoTensorMOOSEMaterialProperty
+    execute_neml2_model_uo = model
+    neml2_variable = state/internal/X1
+    moose_material_property = backstress_1
+  []
+  [output_X2]
+    type = NEML2ToSymmetricRankTwoTensorMOOSEMaterialProperty
+    execute_neml2_model_uo = model
+    neml2_variable = state/internal/X2
+    moose_material_property = backstress_2
+  []
+  [output_Ep]
+    type = NEML2ToSymmetricRankTwoTensorMOOSEMaterialProperty
+    execute_neml2_model_uo = model
+    neml2_variable = state/internal/Ep
+    moose_material_property = plastic_strain
+  []
+  [output_gamma]
+    type = NEML2ToRealMOOSEMaterialProperty
+    execute_neml2_model_uo = model
+    neml2_variable = state/internal/gamma
+    moose_material_property = consistency_parameter
   []
 []
 

--- a/modules/solid_mechanics/test/tests/neml2/tests
+++ b/modules/solid_mechanics/test/tests/neml2/tests
@@ -29,7 +29,10 @@
     [elasticity]
       type = Exodiff
       input = 'fem_modular.i'
-      cli_args = 'neml2_input=elasticity'
+      cli_args = "neml2_input=elasticity
+                  UserObjects/active='model input_strain'
+                  UserObjects/model/gather_uos='input_strain'
+                  Materials/active='output_stress_jacobian'"
       exodiff = 'elasticity.e'
       detail = 'to solve an elasticity problem;'
       required_submodule = 'contrib/neml2'
@@ -40,7 +43,10 @@
     [viscoplasticity_perfect]
       type = Exodiff
       input = 'fem_modular.i'
-      cli_args = 'neml2_input=viscoplasticity_perfect'
+      cli_args = "neml2_input=viscoplasticity_perfect
+                  UserObjects/active='model input_strain input_old_strain input_old_stress'
+                  UserObjects/model/gather_uos='input_strain input_old_strain input_old_stress'
+                  Materials/active='output_stress_jacobian'"
       exodiff = 'viscoplasticity_perfect.e'
       detail = 'to solve a perfect viscoplasticity problem;'
       required_submodule = 'contrib/neml2'
@@ -51,7 +57,10 @@
     [viscoplasticity_isoharden]
       type = Exodiff
       input = 'fem_modular.i'
-      cli_args = 'neml2_input=viscoplasticity_isoharden'
+      cli_args = "neml2_input=viscoplasticity_isoharden
+                  UserObjects/active='model input_strain input_old_strain input_old_stress input_old_ep'
+                  UserObjects/model/gather_uos='input_strain input_old_strain input_old_stress input_old_ep'
+                  Materials/active='output_stress_jacobian output_ep'"
       exodiff = 'viscoplasticity_isoharden.e'
       detail = 'to solve a viscoplasticity problem with isotropic hardening;'
       required_submodule = 'contrib/neml2'
@@ -62,7 +71,10 @@
     [viscoplasticity_kinharden]
       type = Exodiff
       input = 'fem_modular.i'
-      cli_args = 'neml2_input=viscoplasticity_kinharden'
+      cli_args = "neml2_input=viscoplasticity_kinharden
+                  UserObjects/active='model input_strain input_old_strain input_old_stress input_old_Kp'
+                  UserObjects/model/gather_uos='input_strain input_old_strain input_old_stress input_old_Kp'
+                  Materials/active='output_stress_jacobian output_Kp'"
       exodiff = 'viscoplasticity_kinharden.e'
       detail = 'to solve a viscoplasticity problem with kinematic hardening;'
       required_submodule = 'contrib/neml2'
@@ -73,7 +85,10 @@
     [viscoplasticity_isokinharden]
       type = Exodiff
       input = 'fem_modular.i'
-      cli_args = 'neml2_input=viscoplasticity_isokinharden'
+      cli_args = "neml2_input=viscoplasticity_isokinharden
+                  UserObjects/active='model input_strain input_old_strain input_old_stress input_old_ep input_old_Kp'
+                  UserObjects/model/gather_uos='input_strain input_old_strain input_old_stress input_old_ep input_old_Kp'
+                  Materials/active='output_stress_jacobian output_ep output_Kp'"
       exodiff = 'viscoplasticity_isokinharden.e'
       detail = 'to solve a viscoplasticity problem with both isotropic and kinematic hardening;'
       required_submodule = 'contrib/neml2'
@@ -84,7 +99,10 @@
     [viscoplasticity_chaboche]
       type = Exodiff
       input = 'fem_modular.i'
-      cli_args = 'neml2_input=viscoplasticity_chaboche'
+      cli_args = "neml2_input=viscoplasticity_chaboche
+                  UserObjects/active='model input_strain input_old_strain input_old_stress input_old_ep input_old_X1 input_old_X2'
+                  UserObjects/model/gather_uos='input_strain input_old_strain input_old_stress input_old_ep input_old_X1 input_old_X2'
+                  Materials/active='output_stress_jacobian output_ep output_X1 output_X2'"
       exodiff = 'viscoplasticity_chaboche.e'
       detail = 'to solve a viscoplasticity problem with non-associative Chaboche hardening;'
       required_submodule = 'contrib/neml2'
@@ -95,7 +113,10 @@
     [viscoplasticity_radial_return]
       type = Exodiff
       input = 'fem_modular.i'
-      cli_args = 'neml2_input=viscoplasticity_radial_return'
+      cli_args = "neml2_input=viscoplasticity_radial_return
+                  UserObjects/active='model input_strain input_old_Ep input_old_gamma'
+                  UserObjects/model/gather_uos='input_strain input_old_Ep input_old_gamma'
+                  Materials/active='output_stress_jacobian output_Ep output_gamma'"
       exodiff = 'viscoplasticity_radial_return.e'
       detail = 'to solve a viscoplasticity problem using radial return;'
       required_submodule = 'contrib/neml2'
@@ -105,7 +126,10 @@
     [rate_independent_plasticity_perfect]
       type = Exodiff
       input = 'fem_modular.i'
-      cli_args = 'neml2_input=rate_independent_plasticity_perfect'
+      cli_args = "neml2_input=rate_independent_plasticity_perfect
+                  UserObjects/active='model input_strain input_old_Ep'
+                  UserObjects/model/gather_uos='input_strain input_old_Ep'
+                  Materials/active='output_stress_jacobian output_Ep'"
       exodiff = 'rate_independent_plasticity_perfect.e'
       detail = 'to solve a rate-independent problem with perfect plasticity;'
       required_submodule = 'contrib/neml2'
@@ -116,7 +140,10 @@
     [rate_independent_plasticity_isoharden]
       type = Exodiff
       input = 'fem_modular.i'
-      cli_args = 'neml2_input=rate_independent_plasticity_isoharden'
+      cli_args = "neml2_input=rate_independent_plasticity_isoharden
+                  UserObjects/active='model input_strain input_old_Ep input_old_ep'
+                  UserObjects/model/gather_uos='input_strain input_old_Ep input_old_ep'
+                  Materials/active='output_stress_jacobian output_Ep output_ep'"
       exodiff = 'rate_independent_plasticity_isoharden.e'
       detail = 'to solve a rate-independent problem with isotropic hardening;'
       required_submodule = 'contrib/neml2'
@@ -127,7 +154,10 @@
     [rate_independent_plasticity_kinharden]
       type = Exodiff
       input = 'fem_modular.i'
-      cli_args = 'neml2_input=rate_independent_plasticity_kinharden'
+      cli_args = "neml2_input=rate_independent_plasticity_kinharden
+                  UserObjects/active='model input_strain input_old_Ep input_old_Kp'
+                  UserObjects/model/gather_uos='input_strain input_old_Ep input_old_Kp'
+                  Materials/active='output_stress_jacobian output_Ep output_Kp'"
       exodiff = 'rate_independent_plasticity_kinharden.e'
       detail = 'to solve a rate-independent problem with kinematic hardening;'
       required_submodule = 'contrib/neml2'
@@ -138,7 +168,10 @@
     [rate_independent_plasticity_isokinharden]
       type = Exodiff
       input = 'fem_modular.i'
-      cli_args = 'neml2_input=rate_independent_plasticity_isokinharden'
+      cli_args = "neml2_input=rate_independent_plasticity_isokinharden
+                  UserObjects/active='model input_strain input_old_Ep input_old_ep input_old_Kp'
+                  UserObjects/model/gather_uos='input_strain input_old_Ep input_old_ep input_old_Kp'
+                  Materials/active='output_stress_jacobian output_Ep output_ep output_Kp'"
       exodiff = 'rate_independent_plasticity_isokinharden.e'
       detail = 'to solve a rate-independent problem with both isotropic and kinematic hardening.'
       required_submodule = 'contrib/neml2'


### PR DESCRIPTION
close #27904

## Reason
<!--Why do you need this feature or what is the enhancement?-->

Currently, we store stateful data of a NEML2 model inside the NEML2 model itself, and advance the stateful data at `timestepSetup`. This implementation saves an additional copying from MOOSE old material properties. However, it has the following drawbacks:
- Upon solve failure, it is not possible revert back stateful data without additional infrastructure such as the one proposed in #27905
- Upon events that change the batch size, such as mesh change, it is not possible to handle material property reprojection and/or stateful material property initialization
- Does not work with checkpoint/restart. Although this could be easily addressed by adding custom DataIO methods.

## Design
<!--A concise description (design) of the enhancement.-->

Perform the laborious copy from and to MOOSE material property.

Some implementational details
- `NEML2ToMOOSEMaterialProperty` now also accepts an optional material property as the "initial condition" for the corresponding NEML2 variable. This is significant IMO because there has been no generic way of handling this in native MOOSE materials. We could use this to initialize for example the internal variables such as plastic strain.
- In `ExecuteNEML2Model`, I added a check to prevent retrieval of output (and derivative) views after the construction phase.
- `ExecuteNEML2Model::timestepSetup` and `ExecuteNEML2Model::advanceStep` are removed as they are no longer needed.
- In `ExecuteNEML2Model`, `_in_out_allocated` is removed in favor of a more general approach.
- Minor changes in the gatherer UOs and NEML2-to-MOOSE materials.
- A bug fix in `NEML2Utils::set`.
- Adapted all the regression input files. No regolding needed.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->

This addresses all the drawbacks mentioned above.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
