### PR TITLE
Make ConsoleStream/GeneralRegistry thread-safe

### DIFF
--- a/framework/include/interfaces/SolutionInvalidInterface.h
+++ b/framework/include/interfaces/SolutionInvalidInterface.h
@@ -33,7 +33,7 @@ public:
   SolutionInvalidInterface(MooseObject * const moose_object);
 
 protected:
-  void flagInvalidSolutionInternal(InvalidSolutionID _invalid_solution_id) const;
+  void flagInvalidSolutionInternal(InvalidSolutionID invalid_solution_id) const;
 
   // Register invalid solution with a message
   InvalidSolutionID registerInvalidSolutionInternal(const std::string & message) const;

--- a/framework/include/outputs/ConsoleStream.h
+++ b/framework/include/outputs/ConsoleStream.h
@@ -96,9 +96,10 @@ private:
   /// of something in AutomaticMortarGeneration that requires
   /// this to be trivially copyable.
   mutable std::shared_ptr<std::ostringstream> _oss;
-};
 
-extern std::mutex _stream_mutex;
+  /// Mutex to prevent concurrent read/writes, write/writes
+  static std::mutex _stream_mutex;
+};
 
 template <typename StreamType>
 const ConsoleStream &

--- a/framework/include/utils/GeneralRegistry.h
+++ b/framework/include/utils/GeneralRegistry.h
@@ -11,7 +11,7 @@
 
 #include <unordered_map>
 #include <mutex>
-#include <vector>
+#include <deque>
 
 #include "MooseError.h"
 
@@ -63,18 +63,13 @@ protected:
   template <typename CreateItem>
   std::size_t registerItem(const Key & key, CreateItem & create_item);
 
-  /**
-   * Reserves \p size entires in the item vector, _id_to_item
-   */
-  void reserve(const std::size_t size);
-
   /// The name of this registry; used in error handling
   const std::string _name;
 
   /// Map of keys to IDs
   std::unordered_map<Key, std::size_t, KeyHash> _key_to_id;
   /// Vector of IDs to Items
-  std::vector<Item> _id_to_item;
+  std::deque<Item> _id_to_item;
 
   /// Mutex for locking access to _key_to_id
   /// NOTE: These can be changed to shared_mutexes once we get C++17
@@ -159,12 +154,4 @@ GeneralRegistry<Key, Item, KeyHash>::registerItem(const Key & key, CreateItem & 
   _key_to_id.emplace(key, id);
   _id_to_item.emplace_back(std::move(create_item(id)));
   return id;
-}
-
-template <class Key, class Item, class KeyHash>
-void
-GeneralRegistry<Key, Item, KeyHash>::reserve(const std::size_t size)
-{
-  std::lock_guard<std::mutex> lock(_id_to_item_mutex);
-  _id_to_item.reserve(size);
 }

--- a/framework/src/interfaces/SolutionInvalidInterface.C
+++ b/framework/src/interfaces/SolutionInvalidInterface.C
@@ -23,12 +23,12 @@ SolutionInvalidInterface::SolutionInvalidInterface(MooseObject * const moose_obj
 
 /// Set solution invalid mark for the given solution ID
 void
-SolutionInvalidInterface::flagInvalidSolutionInternal(InvalidSolutionID _invalid_solution_id) const
+SolutionInvalidInterface::flagInvalidSolutionInternal(InvalidSolutionID invalid_solution_id) const
 {
   auto & solution_invalidity = _si_moose_object.getMooseApp().solutionInvalidity();
   if (_si_problem.immediatelyPrintInvalidSolution())
-    solution_invalidity.printDebug(_invalid_solution_id);
-  return solution_invalidity.flagInvalidSolutionInternal(_invalid_solution_id);
+    solution_invalidity.printDebug(invalid_solution_id);
+  return solution_invalidity.flagInvalidSolutionInternal(invalid_solution_id);
 }
 
 InvalidSolutionID

--- a/framework/src/outputs/ConsoleStream.C
+++ b/framework/src/outputs/ConsoleStream.C
@@ -12,19 +12,17 @@
 #include "MooseUtils.h"
 #include "OutputWarehouse.h"
 
-std::mutex _stream_mutex;
+std::mutex ConsoleStream::_stream_mutex;
 
 ConsoleStream::ConsoleStream(OutputWarehouse & output_warehouse)
   : _output_warehouse(output_warehouse), _oss(std::make_shared<std::ostringstream>())
 {
 }
 
-static std::mutex manip_mutex;
-
 const ConsoleStream &
 ConsoleStream::operator<<(const StandardEndLine & manip) const
 {
-  const std::lock_guard<std::mutex> lock(manip_mutex);
+  const std::lock_guard<std::mutex> lock(_stream_mutex);
 
   if (manip == (std::basic_ostream<char> & (*)(std::basic_ostream<char> &)) & std::endl)
     (*_oss) << '\n';

--- a/framework/src/utils_nonunity/PerfGraphRegistry.C
+++ b/framework/src/utils_nonunity/PerfGraphRegistry.C
@@ -28,10 +28,6 @@ getPerfGraphRegistry()
 PerfGraphRegistry::PerfGraphRegistry()
   : GeneralRegistry<std::string, PerfGraphSectionInfo>("PerfGraphRegistry")
 {
-  // Reserve space so that re-allocation doesn't need to happen much
-  // This does not take much memory and, for most cases, will keep a single
-  // reallocation from happening
-  reserve(5000);
 }
 
 unsigned int


### PR DESCRIPTION
- Use the same mutex for both `operator<<` overloads. 
- Use a deque instead of a vector for general registry items as the former will not have its references invalidated

Refs CIVET failure https://civet.inl.gov/job/2295949/ on libmesh/libmesh#3883

Closes #23926 