### PR TITLE
Make June 2024 news public

### DIFF
--- a/modules/doc/content/newsletter/2024/2024_06.md
+++ b/modules/doc/content/newsletter/2024/2024_06.md
@@ -1,10 +1,5 @@
 # MOOSE Newsletter (June 2024)
 
-!alert! construction title=In Progress
-This MOOSE Newsletter edition is in progress. Please check back in July 2024
-for a complete description of all MOOSE changes.
-!alert-end!
-
 ## MOOSE Improvements
 
 ## libMesh-level Changes

--- a/modules/doc/content/newsletter/2024/2024_06.md
+++ b/modules/doc/content/newsletter/2024/2024_06.md
@@ -2,23 +2,18 @@
 
 ## MOOSE Improvements
 
-
 ### Using Physics on Components
 
-A new component, [FileMeshPhysicsComponent.md], was created in the thermal hydraulics module to leverage the [Physics](Physics/index.md) system. This facilitates the use of multi-dimensional equations in a thermal-hydraulics simulations, including notably the finite volume computational fluid dynamics capabilities of the Navier Stokes module.
+A new component, [FileMeshPhysicsComponent.md], was created in the thermal hydraulics module to leverage the [Physics](Physics/index.md) system. This facilitates the use of multi-dimensional equations in a thermal hydraulics simulation including, notably, the finite volume computational fluid dynamics capabilities of the Navier Stokes module.
 
 ### Facilitating the use of mixture models
 
-The [WCNSFVTwoPhaseMixturePhysics.md] was added to the Navier Stokes module. This facilitates the set up of fully coupled finite volume simulations using this simple two phase mixture model. It can be used for both solidification and liquid mixture problems.
-
-## libMesh-level Changes
-
-## PETSc-level Changes
+The [WCNSFVTwoPhaseMixturePhysics.md] was added to the Navier Stokes module. This facilitates the setup of fully coupled finite volume simulations using a simple two phase mixture model. It can be used for both solidification and liquid mixture problems.
 
 ## Bug Fixes and Minor Enhancements
 
-- Support for finite volume variables was added to the [ProjectionAux.md]
-- Support for specifying functors in parsed expressions was added to the [ParsedAux.md]
+- Support for finite volume variables was added to [ProjectionAux.md]
+- Support for specifying functors in parsed expressions was added to [ParsedAux.md]
 - Subdomain names can now be pre-declared in the `[Mesh]` block, for subdomains that will be created during the simulation but do not exist at initialization. Objects can be block-restricted to these blocks at initialization.
-- Sideset ids and names can now be pre-declared in the `[Mesh]` block, for sidesets that will be created during the simulation but do not exist at initialization. Objects can be boundaries-restricted to these boundaries at initialization.
-- The [CombinerGenerator.md] now has the option to avoid merging subdomains and sidesets with the same ids in the meshes that it combines. When these options are selected, the ids are offset based on the maximum ids used in the meshes to combine with.
+- Sideset IDs and names can now be pre-declared in the `[Mesh]` block, for sidesets that will be created during the simulation but do not exist at initialization. Objects can be boundaries-restricted to these boundaries at initialization.
+- The [CombinerGenerator.md] now has the option to avoid merging subdomains and sidesets with the same IDs in the meshes that it combines. When these options are selected, the IDs are offset based on the maximum ID used in the meshes being combined.

--- a/modules/doc/content/newsletter/2024/2024_06.md
+++ b/modules/doc/content/newsletter/2024/2024_06.md
@@ -2,8 +2,23 @@
 
 ## MOOSE Improvements
 
+
+### Using Physics on Components
+
+A new component, [FileMeshPhysicsComponent.md], was created in the thermal hydraulics module to leverage the [Physics](Physics/index.md) system. This facilitates the use of multi-dimensional equations in a thermal-hydraulics simulations, including notably the finite volume computational fluid dynamics capabilities of the Navier Stokes module.
+
+### Facilitating the use of mixture models
+
+The [WCNSFVTwoPhaseMixturePhysics.md] was added to the Navier Stokes module. This facilitates the set up of fully coupled finite volume simulations using this simple two phase mixture model. It can be used for both solidification and liquid mixture problems.
+
 ## libMesh-level Changes
 
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements
+
+- Support for finite volume variables was added to the [ProjectionAux.md]
+- Support for specifying functors in parsed expressions was added to the [ParsedAux.md]
+- Subdomain names can now be pre-declared in the `[Mesh]` block, for subdomains that will be created during the simulation but do not exist at initialization. Objects can be block-restricted to these blocks at initialization.
+- Sideset ids and names can now be pre-declared in the `[Mesh]` block, for sidesets that will be created during the simulation but do not exist at initialization. Objects can be boundaries-restricted to these boundaries at initialization.
+- The [CombinerGenerator.md] now has the option to avoid merging subdomains and sidesets with the same ids in the meshes that it combines. When these options are selected, the ids are offset based on the maximum ids used in the meshes to combine with.

--- a/modules/doc/content/newsletter/2024/2024_07.md
+++ b/modules/doc/content/newsletter/2024/2024_07.md
@@ -1,0 +1,14 @@
+# MOOSE Newsletter (July 2024)
+
+!alert! construction title=In Progress
+This MOOSE Newsletter edition is in progress. Please check back in August 2024
+for a complete description of all MOOSE changes.
+!alert-end!
+
+## MOOSE Improvements
+
+## libMesh-level Changes
+
+## PETSc-level Changes
+
+## Bug Fixes and Minor Enhancements

--- a/modules/doc/content/newsletter/index.md
+++ b/modules/doc/content/newsletter/index.md
@@ -6,6 +6,7 @@ monthly to the [MOOSE discussion forum](contact_us.md) as well as provided below
 
 ## 2024
 
+- [June, 2024](2024_06.md)
 - [May, 2024](2024_05.md)
 - [April, 2024](2024_04.md)
 - [March, 2024](2024_03.md)


### PR DESCRIPTION
Add July 2024 template

Refs #11447 

@idaholab/moose-ccb The June 2024 news is currently empty. Please add any contributions, big or small, that have been merged this month by you or your collaborators!
