### PR TITLE
Restore ability to sort single and two phase fps in FluidPropertiesInterrogatorPlugin

### DIFF
--- a/modules/fluid_properties/src/fluidproperties/FluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/FluidProperties.C
@@ -20,6 +20,7 @@ FluidProperties::validParams()
       false,
       "true to allow unimplemented property derivative terms to be set to zero for the AD API");
   params.addCustomTypeParam<std::string>("fp_type", "FPType", "Type of the fluid property object");
+  params.set<std::string>("fp_type") = "unspecified-type";
   params.addParamNamesToGroup("fp_type allow_imperfect_jacobians", "Advanced");
   params.registerBase("FluidProperties");
   return params;

--- a/modules/fluid_properties/src/fluidproperties/SodiumProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/SodiumProperties.C
@@ -16,6 +16,7 @@ SodiumProperties::validParams()
 {
   InputParameters params = FluidProperties::validParams();
   params.addClassDescription("Fluid properties for sodium");
+  params.set<std::string>("fp_type") = "sodium-specific-fp";
   params.addParam<Real>(
       "thermal_conductivity",
       "Optional value for thermal conductivity that overrides interal calculations");


### PR DESCRIPTION
Somewhat of a revert of 610574673db2c2f5bd49a7bd59c97bf20b81a566. Without this the FPIP test fails for me on my system and on @oanaoana's as well. I'm pretty sure this is never tested on CIVET

Refs issue #20535 and PR #23505