### PR TITLE
Libmesh submodule update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,8 +4,8 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 1 %}
-{% set version = "2024.05.05" %}
+{% set build = 0 %}
+{% set version = "2024.07.18" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2024.05.05 mpich_1
-  - moose-libmesh 2024.05.05 openmpi_1
+  - moose-libmesh 2024.07.18 mpich_0
+  - moose-libmesh 2024.07.18 openmpi_0
 
 moose_wasp:
   - moose-wasp 2024.05.08

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -6,7 +6,7 @@
 #   framework/doc/packages_config.yml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.07.15" %}
+{% set version = "2024.07.18" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2024.07.15
+  - moose-dev 2024.07.18
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=1c5369aa05eaae8ebeb7930845fce3b1d59cbb37
+ARG LIBMESH_REV=81a423f6eaa813c5d6d3a92eb2a24cc7cc2b8e34
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -11,7 +11,7 @@ mpich: 4.2.1
 openmpi: 4.1.6
 petsc_alt: 3.11.4
 petsc: 3.20.3
-moose_dev: 2024.07.15
+moose_dev: 2024.07.18
 moose_tools: 2024.07.10
 apptainer_rockylinux: 8.8.20230518
 apptainer_mpich: 3.4.3

--- a/modules/doc/content/newsletter/2024/2024_07.md
+++ b/modules/doc/content/newsletter/2024/2024_07.md
@@ -9,6 +9,47 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2024.07.16` Update
+
+- Support for `QuadShell9` elements, and fixes for refinement of
+  `QuadShell8` elements.  This is a behavior-changing update:
+  `QuadShell4` elements, when elevated to second order, now become
+  `QuadShell9` (with a full biquadratic Lagrange space) rather than
+  `QuadShell8` (with a "Serendipity element" space).
+- Fixes for libMesh `make dist` and `make distcheck` with new
+  submodules and new contributed packages.
+- Support and unit tests for non-square EigenSparseMatrix matrices
+- Support and unit tests for reading sparse matrices from
+  gzipped-Matlab format files.
+- Utility for converting sparse matrix files from PETSc binary formats
+  to Matlab format.
+- Improved speed for reading sparse matrices.
+- Refactoring of some solution transfer code; exposure of
+  `MeshfreeInterpolationFunction` class to users.
+- Support and unit tests in TIMPI for `set_union` of `multiset` and
+  `multimap` containers, including `unordered_` versions.
+- Refactored Nedelec finite element code for simplification and
+  generality.
+- Fixes and testing for more IsoGeometricAnalysis use cases on
+  distributed meshes.
+- Additional fparser headers installed, to enable user subclassing
+- Assorted bug fixes: configure now supports preexisting `-Werror` in
+  compiler flags (with tested compilers), more standard treatment of
+  PETSc error codes.
+- PetscVector subvectors can now be created by supplying only local
+  subvector indices.
+- Incoming vectors to `local_variable_indices()` are now cleared
+  before filling.
+- PerfLog profiling of matrix reads and mesh constraint
+  initialization.
+- Refactoring and optional debugging features for mesh constraint
+  code.
+- Added `RBConstruction::is_serial_training_type()` and EIM updates to
+  reduced basis code.
+- Added a DofMap API for users to request full matrix sparsity pattern
+  retention even with linear algebra packages that do not need it
+  themselves.
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/modules/doc/content/newsletter/2024/2024_07.md
+++ b/modules/doc/content/newsletter/2024/2024_07.md
@@ -32,12 +32,18 @@ for a complete description of all MOOSE changes.
   generality.
 - Fixes and testing for more IsoGeometricAnalysis use cases on
   distributed meshes.
+- More test coverage: `ExodusII_IO` with shell elements, PETSc
+  DMlibMesh interface
+- New `Elem::is_internal()` API for local node indices
 - Additional fparser headers installed, to enable user subclassing
 - Assorted bug fixes: configure now supports preexisting `-Werror` in
   compiler flags (with tested compilers), more standard treatment of
-  PETSc error codes.
+  PETSc error codes, `--node-major-dofs` now works with FE types that
+  have element DoFs too.
+- Added `LIBMESH_PETSC_SUCCESS` shim
 - PetscVector subvectors can now be created by supplying only local
   subvector indices.
+- Slight change to `restore_subvector()` arguments
 - Incoming vectors to `local_variable_indices()` are now cleared
   before filling.
 - PerfLog profiling of matrix reads and mesh constraint
@@ -49,6 +55,7 @@ for a complete description of all MOOSE changes.
 - Added a DofMap API for users to request full matrix sparsity pattern
   retention even with linear algebra packages that do not need it
   themselves.
+- `System::is_initialized()` is now `const`
 
 ## PETSc-level Changes
 

--- a/modules/doc/content/newsletter/2024/2024_07.md
+++ b/modules/doc/content/newsletter/2024/2024_07.md
@@ -56,6 +56,7 @@ for a complete description of all MOOSE changes.
   retention even with linear algebra packages that do not need it
   themselves.
 - `System::is_initialized()` is now `const`
+- Added `LibmeshPetscCall` macro that can wrap any PETSc function call without need for `LIBMESH_CHKERR(ierr)`
 
 ## PETSc-level Changes
 

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -285,3 +285,9 @@ bcfdf8828910757299379973a97333791a093402: #26839
   libmesh: b91dcd2
   moose-dev: 91f1f5f
   wasp: 33b8e6b
+64615a5d3b31aac3e6b2fc49139fc77d74a1501d: #28014
+  mpi: c279c23
+  petsc: 52857f3
+  libmesh: 9675f30
+  moose-dev: 2faac4b
+  wasp: 33b8e6b


### PR DESCRIPTION
This shouldn't be merged yet, since we don't want to make @milljm 's job in #26848 even harder; plus there's another libMesh PR that I'd be happy to see snuck in under the wire if we really take too long ... but I'm anxious like to see what downstream CI makes of the changes that are here so far; it's entirely possible that we have users who are reading QuadShell4 meshes (because that's a Cubit default) and turning them second-order, and any golded results based on that will break when "full second-order" becomes *actually*-full second-order - see #27987 for the fix to such a failure in the Navier-Stokes module.

Summary of changes:

- Support for `QuadShell9` elements, and fixes for refinement of
  `QuadShell8` elements.  This is a behavior-changing update:
  `QuadShell4` elements, when elevated to second order, now become
  `QuadShell9` (with a full biquadratic Lagrange space) rather than
  `QuadShell8` (with a "Serendipity element" space).
- Fixes for libMesh `make dist` and `make distcheck` with new
  submodules and new contributed packages.
- Support and unit tests for non-square EigenSparseMatrix matrices
- Support and unit tests for reading sparse matrices from
  gzipped-Matlab format files.
- Utility for converting sparse matrix files from PETSc binary formats
  to Matlab format.
- Improved speed for reading sparse matrices.
- Refactoring of some solution transfer code; exposure of
  `MeshfreeInterpolationFunction` class to users.
- Support and unit tests in TIMPI for `set_union` of `multiset` and
  `multimap` containers, including `unordered_` versions.
- Refactored Nedelec finite element code for simplification and
  generality.
- Fixes and testing for more IsoGeometricAnalysis use cases on
  distributed meshes.
- Additional fparser headers installed, to enable user subclassing
- Assorted bug fixes: configure now supports preexisting `-Werror` in
  compiler flags (with tested compilers), more standard treatment of
  PETSc error codes.
- PetscVector subvectors can now be created by supplying only local
  subvector indices.
- Incoming vectors to `local_variable_indices()` are now cleared
  before filling.
- PerfLog profiling of matrix reads and mesh constraint
  initialization.
- Refactoring and optional debugging features for mesh constraint
  code.
- Added `RBConstruction::is_serial_training_type()` and EIM updates to
  reduced basis code.
- Added a DofMap API for users to request full matrix sparsity pattern
  retention even with linear algebra packages that do not need it
  themselves.