### PR TITLE
improved error messages for invalid subdomain names in QuasiStaticSolidMechanicsPhysics

### DIFF
--- a/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
+++ b/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
@@ -512,7 +512,13 @@ QuasiStaticSolidMechanicsPhysics::actSubdomainChecks()
   {
     // get subdomain IDs
     for (auto & name : _subdomain_names)
-      _subdomain_ids.insert(_mesh->getSubdomainID(name));
+    {
+      auto id = _mesh->getSubdomainID(name);
+      if (id == Moose::INVALID_BLOCK_ID)
+        paramError("block", "Subdomain \"" + name + "\" not found in mesh.");
+      else
+        _subdomain_ids.insert(id);
+    }
   }
 
   if (_current_task == "validate_coordinate_systems")


### PR DESCRIPTION
If the user specifies invalid subdomain names during block restricting [Physics/Solid Mechanics/QuasiStatics], the error message does not point to the actual culprit. This PR aims to improve this error message.

closes #28040

