### PR TITLE
Ensure duplicates are not added to list of checkpoint files.

### DIFF
--- a/framework/include/outputs/Checkpoint.h
+++ b/framework/include/outputs/Checkpoint.h
@@ -43,6 +43,12 @@ struct CheckpointFileNames
 
   /// Filenames for restartable data
   std::vector<std::filesystem::path> restart;
+
+  bool operator==(const CheckpointFileNames & rhs) const
+  {
+    // Compare the relevant members for equality
+    return (this->checkpoint == rhs.checkpoint) && (this->restart == rhs.restart);
+  }
 };
 
 /**

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -183,8 +183,12 @@ Checkpoint::output()
 void
 Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
 {
-  // Update the list of stored files
-  _file_names.push_back(file_struct);
+  // Update the list of stored files if it does not already contain file_struct
+  // This ensures that we don't store duplicates, which will cause issues when
+  // we delete files later and only pop one of the duplicates off.
+  auto it = std::find(_file_names.begin(), _file_names.end(), file_struct);
+  if (it == _file_names.end())
+    _file_names.push_back(file_struct);
 
   // Remove the file and the corresponding directory if it's empty
   const auto remove_file = [this](const std::filesystem::path & path)

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -183,12 +183,24 @@ Checkpoint::output()
 void
 Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
 {
-  // Update the list of stored files if it does not already contain file_struct
-  // This ensures that we don't store duplicates, which will cause issues when
-  // we delete files later and only pop one of the duplicates off.
-  auto it = std::find(_file_names.begin(), _file_names.end(), file_struct);
-  if (it == _file_names.end())
-    _file_names.push_back(file_struct);
+  // It is possible to have already written a checkpoint with the same file
+  // names contained in file_struct. If this is the case, file_struct will
+  // already be stored in _file_names. When this happens, the current state of
+  // the simulation is likely different than the state when the duplicately
+  // named checkpoint was last written. Because of this, we want to go ahead and
+  // rewrite the duplicately named checkpoint, overwritting the files
+  // representing the old state. For accurate bookkeeping, we will delete the
+  // existing instance of file_struct from _file_names and re-append it to the
+  // end of _file_names (to keep the order in which checkpoints are written
+  // accurate).
+
+  const auto it = std::find(_file_names.begin(), _file_names.end(), file_struct);
+  // file_struct was found in _file_names.
+  // Delete it so it can be re-added as the last element.
+  if (it != _file_names.end())
+    _file_names.erase(it);
+
+  _file_names.push_back(file_struct);
 
   // Remove the file and the corresponding directory if it's empty
   const auto remove_file = [this](const std::filesystem::path & path)

--- a/test/tests/outputs/checkpoint/checkpoint_child.i
+++ b/test/tests/outputs/checkpoint/checkpoint_child.i
@@ -40,7 +40,7 @@
 
 [Executioner]
   type = Transient
-  num_steps = 11
+  num_steps = 2
   dt = 0.1
   solve_type = PJFNK
   petsc_options_iname = '-pc_type -pc_hypre_type'

--- a/test/tests/outputs/checkpoint/checkpoint_parent.i
+++ b/test/tests/outputs/checkpoint/checkpoint_parent.i
@@ -40,7 +40,7 @@
 
 [MultiApps]
   [sub_app]
-    type = TransientMultiApp
+    type = FullSolveMultiApp
     input_files = "checkpoint_child.i"
     positions = '0 0 0'
   []

--- a/test/tests/outputs/checkpoint/tests
+++ b/test/tests/outputs/checkpoint/tests
@@ -349,3 +349,18 @@
     expect_err = "Shortcut checkpoint syntax cannot be used with another Checkpoint object in the 'Outputs' block"
   []
 []
+
+[subapp_only_cp]
+  issues = "#24777"
+  type = CheckFiles
+  recover = false
+  input = checkpoint_parent.i
+  cli_args = 'Outputs/checkpoint=false sub_app:Outputs/cp/type=Checkpoint sub_app:Outputs/cp/num_files=1 sub_app:Outputs/cp/execute_on=final'
+  check_files = "checkpoint_parent_out_sub_app0_cp_cp/0003-restart-0.rd/data "
+                "checkpoint_parent_out_sub_app0_cp_cp/0003-restart-0.rd/header "
+                "checkpoint_parent_out_sub_app0_cp_cp/0003-mesh.cpa.gz/1/header.gz "
+                "checkpoint_parent_out_sub_app0_cp_cp/0003-mesh.cpa.gz/1/split-1-0.gz "
+                "checkpoint_parent_out_sub_app0_cp_cp/0003-mesh.cpa.gz/meta_data_mesh.rd/data "
+                "checkpoint_parent_out_sub_app0_cp_cp/0003-mesh.cpa.gz/meta_data_mesh.rd/header"
+  requirement = "The system shall support outputting checkpoint files at the subapp level with checkpoints disabled in the main app"
+[]


### PR DESCRIPTION
## Reason
Checkpoint objects keep a list of currently written checkpoint files in the _file_names attribute. When the number of checkpoints stored in this variable exceeds the _num_files variable, the oldest checkpoint is deleted from the hard drive. Sometimes, a checkpoint has the same file names as older checkpoints. For instance, this happens in a multiapp where the parent is a transient and the subapp is a FullSolveMultiApp, with a checkpoint executed on final, executed after every parent time step. When this occurs, the previously output checkpoint is overwritten by the new checkpoint that shares the same file names. This can be though of unintentionally "deleting" a checkpoint without checking the size of _file_names. The size check on _file_names doesn't know about this deletion and deletes the most recent checkpoint, not knowing that the old checkpoint was already overwritten. In this manner, all checkpoints can be deleted, leaving the user with nothing at the end of the simulation.

## Design
This PR adds a check to see if the most recent checkpoint file names are contained in _file_names before re-adding them, triggering the extra deletion.

## Impact
Users will get checkpoints from their subapps when they request them.

Closes #24777.
