### PR TITLE
Add more support for restarting variables manually and from exodus

### DIFF
--- a/modules/navier_stokes/src/physics/NavierStokesPhysicsBase.C
+++ b/modules/navier_stokes/src/physics/NavierStokesPhysicsBase.C
@@ -22,7 +22,9 @@ NavierStokesPhysicsBase::validParams()
   params.addParam<bool>(
       "define_variables",
       true,
-      "Whether to define variables if the variables with the specified names do not exist");
+      "Whether to define variables if the variables with the specified names do not exist. Note "
+      "that if the variables are defined externally from the Physics, the initial conditions will "
+      "not be created in the Physics either.");
 
   params.addParam<unsigned short>(
       "ghost_layers", 2, "Number of layers of elements to ghost near process domain boundaries");

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysics.C
@@ -1271,6 +1271,9 @@ WCNSFVFlowPhysics::addInitialConditions()
   // do not set initial conditions if we load from file
   if (getParam<bool>("initialize_variables_from_mesh_file"))
     return;
+  // do not set initial conditions if we are not defining variables
+  if (!_define_variables)
+    return;
 
   InputParameters params = getFactory().getValidParams("FunctionIC");
   assignBlocks(params, _blocks);

--- a/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysics.C
@@ -553,6 +553,12 @@ WCNSFVFluidHeatTransferPhysics::addInitialConditions()
         "initial_temperature",
         "T_fluid is defined externally of WCNSFVFluidHeatTransferPhysics, so should the inital "
         "condition");
+  // do not set initial conditions if we load from file
+  if (getParam<bool>("initialize_variables_from_mesh_file"))
+    return;
+  // do not set initial conditions if we are not defining variables
+  if (!_define_variables)
+    return;
 
   InputParameters params = getFactory().getValidParams("FunctionIC");
   assignBlocks(params, _blocks);

--- a/modules/navier_stokes/src/physics/WCNSFVScalarTransportPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVScalarTransportPhysics.C
@@ -365,6 +365,12 @@ WCNSFVScalarTransportPhysics::addInitialConditions()
     paramError("initial_scalar_variables",
                "Scalar variables are defined externally of NavierStokesFV, so should their inital "
                "conditions");
+  // do not set initial conditions if we load from file
+  if (getParam<bool>("initialize_variables_from_mesh_file"))
+    return;
+  // do not set initial conditions if we are not defining variables
+  if (!_define_variables)
+    return;
 
   InputParameters params = getFactory().getValidParams("FunctionIC");
   assignBlocks(params, _blocks);

--- a/modules/navier_stokes/src/physics/WCNSFVTurbulencePhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVTurbulencePhysics.C
@@ -166,7 +166,7 @@ WCNSFVTurbulencePhysics::addNonlinearVariables()
 void
 WCNSFVTurbulencePhysics::addAuxiliaryVariables()
 {
-  if (_turbulence_model == "mixing-length")
+  if (_turbulence_model == "mixing-length" && _define_variables)
   {
     auto params = getFactory().getValidParams("MooseVariableFVReal");
     assignBlocks(params, _blocks);
@@ -288,6 +288,7 @@ WCNSFVTurbulencePhysics::addScalarAdvectionTurbulenceKernels()
 void
 WCNSFVTurbulencePhysics::addAuxiliaryKernels()
 {
+  // Note that if we are restarting this will overwrite the restarted mixing-length
   if (_turbulence_model == "mixing-length")
   {
     const std::string ml_kernel_type = "WallDistanceMixingLengthAux";


### PR DESCRIPTION
refs #22058

This lets users skip the default initializations
I initially wanted to support restarting from exodus with the Physics, but then the mixed input (variables defined outside of the Physics) was not well supported