### PR TITLE
Restore transient multiapps by default

### DIFF
--- a/framework/include/multiapps/FullSolveMultiApp.h
+++ b/framework/include/multiapps/FullSolveMultiApp.h
@@ -48,9 +48,6 @@ protected:
    */
   virtual void showStatusMessage(unsigned int i) const;
 
-  /// Whether or not to skip restoring
-  const bool _no_restore;
-
 private:
   /// Switch to tell executioner to keep going despite app solve not converging
   const bool _ignore_diverge;

--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -207,7 +207,7 @@ public:
    * Whether or not this MultiApp should be restored at the beginning of
    * each Picard iteration.
    */
-  virtual bool needsRestoration() { return true; }
+  bool needsRestoration() { return !_no_restore; }
 
   /**
    * @param app The global app number to get the Executioner for
@@ -593,6 +593,9 @@ protected:
 
   /// Flag indicates if or not restart from the latest solution
   bool _keep_solution_during_restore;
+
+  /// Whether or not to skip restoring completely
+  const bool _no_restore;
 
   /// The solution from the end of the previous solve, this is cloned from the Nonlinear solution during restore
   std::vector<std::unique_ptr<NumericVector<Real>>> _end_solutions;

--- a/framework/include/multiapps/TransientMultiApp.h
+++ b/framework/include/multiapps/TransientMultiApp.h
@@ -38,8 +38,6 @@ public:
 
   virtual void finishStep(bool recurse_through_multiapp_levels = false) override;
 
-  virtual bool needsRestoration() override;
-
   virtual void resetApp(unsigned int global_app, Real time) override;
 
   /**

--- a/framework/src/multiapps/FullSolveMultiApp.C
+++ b/framework/src/multiapps/FullSolveMultiApp.C
@@ -24,13 +24,6 @@ FullSolveMultiApp::validParams()
   InputParameters params = MultiApp::validParams();
   params.addClassDescription("Performs a complete simulation during each execution.");
   params.addParam<bool>(
-      "no_backup_and_restore",
-      false,
-      "True to turn off restore for this multiapp. This is useful when doing steady-state "
-      "Picard iterations where we want to use the solution of previous Picard iteration as the "
-      "initial guess of the current Picard iteration.");
-  params.deprecateParam("no_backup_and_restore", "no_restore", "01/01/2025");
-  params.addParam<bool>(
       "keep_full_output_history",
       false,
       "Whether or not to keep the full output history when this multiapp has multiple entries");
@@ -41,9 +34,7 @@ FullSolveMultiApp::validParams()
 }
 
 FullSolveMultiApp::FullSolveMultiApp(const InputParameters & parameters)
-  : MultiApp(parameters),
-    _no_restore(getParam<bool>("no_restore")),
-    _ignore_diverge(getParam<bool>("ignore_solve_not_converge"))
+  : MultiApp(parameters), _ignore_diverge(getParam<bool>("ignore_solve_not_converge"))
 {
   // You could end up with some dirty hidden behavior if you do this. We could remove this check,
   // but I don't think that it's sane to do so.

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -216,6 +216,13 @@ MultiApp::validParams()
                         "final solution from the previous coupling iteration"
                         "and re-uses it as the initial guess "
                         "for the next coupling iteration");
+  params.addParam<bool>(
+      "no_backup_and_restore",
+      false,
+      "True to turn off restore for this multiapp. This is useful when doing steady-state "
+      "Picard iterations where we want to use the solution of previous Picard iteration as the "
+      "initial guess of the current Picard iteration.");
+  params.deprecateParam("no_backup_and_restore", "no_restore", "01/01/2025");
 
   params.addDeprecatedParam<bool>("clone_master_mesh",
                                   false,
@@ -280,6 +287,7 @@ MultiApp::MultiApp(const InputParameters & parameters)
     _has_an_app(true),
     _cli_args(getParam<std::vector<CLIArgString>>("cli_args")),
     _keep_solution_during_restore(getParam<bool>("keep_solution_during_restore")),
+    _no_restore(getParam<bool>("no_restore")),
     _run_in_position(getParam<bool>("run_in_position")),
     _sub_app_backups(declareRestartableDataWithContext<SubAppBackups>("sub_app_backups", this)),
     _solve_step_timer(registerTimedSection("solveStep", 3, "Executing MultiApps", false)),

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -597,12 +597,6 @@ TransientMultiApp::finishStep(bool recurse_through_multiapp_levels)
   }
 }
 
-bool
-TransientMultiApp::needsRestoration()
-{
-  return _sub_cycling || _catch_up || _auto_advance || _tolerate_failure || _detect_steady_state;
-}
-
 Real
 TransientMultiApp::computeDT()
 {

--- a/test/tests/multiapps/picard/picard_adaptive_parent.i
+++ b/test/tests/multiapps/picard/picard_adaptive_parent.i
@@ -82,6 +82,9 @@
     app_type = MooseTestApp
     positions = '0 0 0'
     input_files = picard_adaptive_sub.i
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
 []
 

--- a/test/tests/multiapps/picard_multilevel/picard_parent.i
+++ b/test/tests/multiapps/picard_multilevel/picard_parent.i
@@ -80,6 +80,9 @@
     positions = '0 0 0'
     input_files = picard_sub.i
     execute_on = 'timestep_end'
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
 []
 

--- a/test/tests/multiapps/picard_postprocessor/transient_main.i
+++ b/test/tests/multiapps/picard_postprocessor/transient_main.i
@@ -85,6 +85,9 @@
     input_files = 'transient_sub.i'
     clone_parent_mesh = true
     execute_on = 'timestep_begin'
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
 []
 

--- a/test/tests/multiapps/relaxation/picard_parent.i
+++ b/test/tests/multiapps/relaxation/picard_parent.i
@@ -91,6 +91,9 @@
     execute_on = timestep_begin
     positions = '0 0 0'
     input_files = picard_relaxed_sub.i
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
 []
 

--- a/test/tests/multiapps/relaxation/picard_relaxed_parent.i
+++ b/test/tests/multiapps/relaxation/picard_relaxed_parent.i
@@ -93,6 +93,9 @@
     execute_on = timestep_begin
     positions = '0 0 0'
     input_files = picard_relaxed_sub.i
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
 []
 

--- a/test/tests/multiapps/relaxation/sub_relaxed_parent.i
+++ b/test/tests/multiapps/relaxation/sub_relaxed_parent.i
@@ -93,6 +93,9 @@
     input_files = sub_relaxed_sub.i
     transformed_variables = v
     relaxation_factor = 0.94
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
 []
 

--- a/test/tests/multiapps/secant/transient_main.i
+++ b/test/tests/multiapps/secant/transient_main.i
@@ -83,6 +83,9 @@
     input_files = 'transient_sub.i'
     clone_parent_mesh = true
     execute_on = 'timestep_begin'
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
 []
 

--- a/test/tests/multiapps/secant_postprocessor/transient_main.i
+++ b/test/tests/multiapps/secant_postprocessor/transient_main.i
@@ -85,6 +85,9 @@
     input_files = 'transient_sub.i'
     clone_parent_mesh = true
     execute_on = 'timestep_begin'
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
 []
 

--- a/test/tests/multiapps/steffensen/transient_main.i
+++ b/test/tests/multiapps/steffensen/transient_main.i
@@ -87,6 +87,9 @@
     input_files = 'transient_sub.i'
     clone_parent_mesh = true
     execute_on = 'timestep_begin'
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
 []
 

--- a/test/tests/multiapps/steffensen_postprocessor/transient_main.i
+++ b/test/tests/multiapps/steffensen_postprocessor/transient_main.i
@@ -85,6 +85,9 @@
     input_files = 'transient_sub.i'
     clone_parent_mesh = true
     execute_on = 'timestep_begin'
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
 []
 

--- a/test/tests/transfers/transfer_once_per_fixed_point/parent.i
+++ b/test/tests/transfers/transfer_once_per_fixed_point/parent.i
@@ -31,12 +31,18 @@
     input_files = sub.i
     cli_args = "MultiApps/active='';Outputs/active=''"
     execute_on = 'INITIAL TIMESTEP_END'
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
   # This app is used to test the fixed point begin/end execute_on for transfers and multiapps
   [sub]
     type = TransientMultiApp
     input_files = sub.i
     execute_on = 'INITIAL TIMESTEP_END'
+    # The input was originally created with effectively no restore
+    # see the changes made for #5554 then reverted in #28115
+    no_restore = true
   []
 []
 


### PR DESCRIPTION
The default is not safe at all. It is wrong for simulation with states, which can be from material properties

it is wrong for simulations with simply posptprocessors executed on timestep begin (of the subapp, now working with timestep_end data) and transferred on timestep begin (of the main app)

lots of diffs