### PR TITLE
Improved documentation and readability of MultiMooseEnum class.

### DIFF
--- a/framework/include/auxkernels/TagAuxBase.h
+++ b/framework/include/auxkernels/TagAuxBase.h
@@ -61,7 +61,7 @@ TagAuxBase<T>::TagAuxBase(const InputParameters & parameters)
   : T(parameters), _scaled(this->template getParam<bool>("scaled"))
 {
   auto & execute_on = this->template getParam<ExecFlagEnum>("execute_on");
-  if (execute_on.size() != 1 || !execute_on.contains(EXEC_TIMESTEP_END))
+  if (execute_on.size() != 1 || !execute_on.isValueSet(EXEC_TIMESTEP_END))
     paramError("execute_on", "must be set to EXEC_TIMESTEP_END");
 }
 

--- a/framework/include/outputs/AdvancedOutput.h
+++ b/framework/include/outputs/AdvancedOutput.h
@@ -408,7 +408,7 @@ AdvancedOutput::initPostprocessorOrVectorPostprocessorLists(const std::string & 
     {
       if (!_advanced_execute_on.contains(execute_data_name) ||
           (_advanced_execute_on[execute_data_name].isValid() &&
-           _advanced_execute_on[execute_data_name].contains("none")))
+           _advanced_execute_on[execute_data_name].isValueSet("none")))
       {
         const bool is_pp_type = (execute_data_name == "postprocessors");
         const std::string pp_type_str = is_pp_type ? "post-processor" : "vector post-processor";

--- a/framework/include/reporters/IterationInfo.h
+++ b/framework/include/reporters/IterationInfo.h
@@ -50,7 +50,7 @@ template <typename T>
 T &
 IterationInfo::declareHelper(const std::string & item_name, T & dummy, bool extra_check)
 {
-  return (extra_check && (!_items.isValid() || _items.contains(item_name)))
+  return (extra_check && (!_items.isValid() || _items.isValueSet(item_name)))
              ? declareValueByName<T>(item_name, REPORTER_MODE_REPLICATED)
              : dummy;
 }

--- a/framework/include/reporters/MeshInfo.h
+++ b/framework/include/reporters/MeshInfo.h
@@ -94,8 +94,9 @@ template <typename T>
 T &
 MeshInfo::declareHelper(const std::string & item_name, const ReporterMode mode)
 {
-  return (!_items.isValid() || _items.contains(item_name)) ? declareValueByName<T>(item_name, mode)
-                                                           : declareUnusedValue<T>();
+  return (!_items.isValid() || _items.isValueSet(item_name))
+             ? declareValueByName<T>(item_name, mode)
+             : declareUnusedValue<T>();
 }
 
 void to_json(nlohmann::json & json, const std::map<BoundaryID, MeshInfo::SidesetInfo> & sidesets);

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -27,13 +27,15 @@ typedef std::vector<MooseEnumItem>::const_iterator MooseEnumIterator;
 
 /**
  * This is a "smart" enum class intended to replace many of the
- * shortcomings in the C++ enum type It should be initialized with a
- * comma-separated list of strings which become the enum values.  You
- * may also optionally supply numeric ints for one or more values
- * similar to a C++ enum.  This is done with the "=" sign. It can be
- * used any place where an integer (switch statements), const char* or
- * std::string is expected.  In addition the InputParameters system
- * has full support for this Enum type
+ * shortcomings in the C++ enum type. There are two parts to a MultiMooseEnum:
+ * 1) The list of all possible values that a variable can have and
+ * 2) The subset of these values that the variable is actually set to.
+ * It should be initialized with a comma-separated list of strings which
+ * become the possible enum values. You may also optionally supply numeric
+ * ints for one or more values similar to a C++ enum. This is done with the
+ * "=" sign. It can be used any place where an integer (switch statements),
+ * const char* or * std::string is expected. In addition the
+ * InputParameters system has full support for this Enum type.
  */
 class MultiMooseEnum : public MooseEnumBase
 {
@@ -41,11 +43,11 @@ public:
   /**
    * Constructor that takes a list of enumeration values, and a separate string to set a default for
    * this instance
-   * @param names - a list of names for this enumeration
-   * @param default_names - the default value for this enumeration instance
+   * @param names - a list of all possible values (names) for this enumeration
+   * @param default_names - the value(s), if any, to set this enumeration instance to
    * @param allow_out_of_range - determines whether this enumeration will accept values outside of
-   * it's range of
-   *                       defined values.
+   * it's range of initially defined values, allowing for the possiblity to add additional valid
+   * values to an object after it has been initialized.
    */
   MultiMooseEnum(std::string names,
                  std::string default_names = "",
@@ -76,8 +78,8 @@ public:
 
   ///@{
   /**
-   * Contains methods for seeing if a value is in the MultiMooseEnum.
-   * @return bool - the truth value indicating whether the value is present
+   * Contains methods for seeing if a value is set in the MultiMooseEnum.
+   * @return bool - the truth value indicating whether the value is set
    */
   bool contains(const std::string & value) const;
   bool contains(int value) const;
@@ -88,7 +90,7 @@ public:
 
   ///@{
   /**
-   * Assignment operators
+   * Assignment operators to set the objects value from the list of possible values.
    * @param names - a string, set, or vector representing one of the enumeration values.
    * @return A reference to this object for chaining
    */
@@ -99,7 +101,7 @@ public:
 
   ///@{
   /**
-   * Un-assign a value
+   * Un-assign, or unset a value
    * @param names - a string, set, or vector giving the name to erase from the enumeration values
    */
   void erase(const std::string & names);
@@ -112,7 +114,7 @@ public:
    * Insert operators
    * Operator to insert (push_back) values into the enum. Existing values are preserved and
    * duplicates are stored.
-   * @param names - a string, set, or vector representing one of the enumeration values.
+   * @param names - a string, set, or vector representing the enumeration values to set.
    */
   void push_back(const std::string & names);
   void push_back(const std::vector<std::string> & names);
@@ -190,7 +192,7 @@ protected:
   void remove(InputIterator first, InputIterator last);
 
   /**
-   * Set the current items.
+   * Set the current items/values.
    */
   void setCurrentItems(const std::vector<MooseEnumItem> & current_items);
 

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -99,16 +99,24 @@ public:
    * Methods for seeing if a value is set in the MultiMooseEnum.
    * @return bool - the truth value indicating whether the value is set
    */
+  bool contains(const std::string & value) const { return isValueSet(value); }
+  bool contains(int value) const { return isValueSet(value); }
+  bool contains(unsigned short value) const { return isValueSet(value); }
+  bool contains(const MultiMooseEnum & value) const { return isValueSet(value); }
+  bool contains(const MooseEnumItem & value) const { return isValueSet(value); }
+  ///@}
+
+  // The following are aliases for contains with more descriptive name
+  ///@{
+  /**
+   * Methods for seeing if a value is set in the MultiMooseEnum.
+   * @return bool - the truth value indicating whether the value is set
+   */
   bool isValueSet(const std::string & value) const;
   bool isValueSet(int value) const;
   bool isValueSet(unsigned short value) const;
   bool isValueSet(const MultiMooseEnum & value) const;
   bool isValueSet(const MooseEnumItem & value) const;
-  bool contains(const std::string & value) const;
-  bool contains(int value) const;
-  bool contains(unsigned short value) const;
-  bool contains(const MultiMooseEnum & value) const;
-  bool contains(const MooseEnumItem & value) const;
   ///@}
 
   ///@{
@@ -124,17 +132,39 @@ public:
 
   ///@{
   /**
+   * Un-assign, or unset a value. Deprecated, use eraseSetValue instead.
+   * @param names - a string, set, or vector giving the name to erase from the enumeration values
+   */
+  void erase(const std::string & names);
+  void erase(const std::vector<std::string> & names);
+  void erase(const std::set<std::string> & names);
+  ///@}
+
+  // The following replaces erase with a more descriptive name
+  ///@{
+  /**
    * Un-assign, or unset a value
    * @param names - a string, set, or vector giving the name to erase from the enumeration values
    */
   void eraseSetValue(const std::string & names);
   void eraseSetValue(const std::vector<std::string> & names);
   void eraseSetValue(const std::set<std::string> & names);
-  void erase(const std::string & names);
-  void erase(const std::vector<std::string> & names);
-  void erase(const std::set<std::string> & names);
   ///@}
 
+  ///@{
+  /**
+   * Insert operators
+   * Operator to insert (push_back) values into the enum. Existing values are preserved and
+   * duplicates are stored. Deprecated, use setAdditionalValue instead.
+   * @param names - a string, set, or vector representing the enumeration values to set.
+   */
+  void push_back(const std::string & names);
+  void push_back(const std::vector<std::string> & names);
+  void push_back(const std::set<std::string> & names);
+  void push_back(const MultiMooseEnum & other_enum);
+  ///@}
+
+  // The following replaces push_back with a more descriptive name
   ///@{
   /**
    * Insert operators
@@ -146,10 +176,6 @@ public:
   void setAdditionalValue(const std::vector<std::string> & names);
   void setAdditionalValue(const std::set<std::string> & names);
   void setAdditionalValue(const MultiMooseEnum & other_enum);
-  void push_back(const std::string & names);
-  void push_back(const std::vector<std::string> & names);
-  void push_back(const std::set<std::string> & names);
-  void push_back(const MultiMooseEnum & other_enum);
   ///@}
 
   /**
@@ -169,13 +195,14 @@ public:
    */
   unsigned int get(unsigned int i) const;
 
-  ///@{
+  /// get the current values cast to a vector of enum type T. Deprecated, use getSetValueIDs instead.
+  template <typename T>
+  std::vector<T> getEnum() const;
+
+  // The following replaces getEnum with a more descriptive name
   /// get the current values cast to a vector of enum type T
   template <typename T>
   std::vector<T> getSetValueIDs() const;
-  template <typename T>
-  std::vector<T> getEnum() const;
-  ///@}
 
   ///@{
   /**

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -146,8 +146,8 @@ public:
    * Returns a begin/end iterator to all of the items in the enum. Items will
    * always be capitalized.
    */
-  MooseEnumIterator begin() const { return _current.begin(); }
-  MooseEnumIterator end() const { return _current.end(); }
+  MooseEnumIterator begin() const { return _current_values.begin(); }
+  MooseEnumIterator end() const { return _current_values.end(); }
   ///@}
 
   /**
@@ -164,7 +164,7 @@ public:
    * IsValid
    * @return - a Boolean indicating whether this Enumeration has been set
    */
-  virtual bool isValid() const override { return !_current.empty(); }
+  virtual bool isValid() const override { return !_current_values.empty(); }
 
   // InputParameters and Output is allowed to create an empty enum but is responsible for
   // filling it in after the fact
@@ -192,10 +192,10 @@ protected:
   /**
    * Set the current items.
    */
-  void setCurrentItems(const std::vector<MooseEnumItem> & current);
+  void setCurrentItems(const std::vector<MooseEnumItem> & current_items);
 
-  /// The current id
-  std::vector<MooseEnumItem> _current;
+  /// The current value(s) of the MultiMooseEnum.
+  std::vector<MooseEnumItem> _current_values;
 
   /**
    * Protected constructor for use by libmesh::Parameters
@@ -218,7 +218,7 @@ MultiMooseEnum::getEnum() const
                 "The type requested from MooseEnum::getEnum must be an enum type!\n\n");
 #endif
   std::vector<T> enum_vec;
-  for (const auto & current : _current)
-    enum_vec.push_back(static_cast<T>(current.id()));
+  for (const auto & current_value : _current_values)
+    enum_vec.push_back(static_cast<T>(current_value.id()));
   return enum_vec;
 }

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -99,6 +99,11 @@ public:
    * Methods for seeing if a value is set in the MultiMooseEnum.
    * @return bool - the truth value indicating whether the value is set
    */
+  bool isValueSet(const std::string & value) const;
+  bool isValueSet(int value) const;
+  bool isValueSet(unsigned short value) const;
+  bool isValueSet(const MultiMooseEnum & value) const;
+  bool isValueSet(const MooseEnumItem & value) const;
   bool contains(const std::string & value) const;
   bool contains(int value) const;
   bool contains(unsigned short value) const;

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -40,18 +40,35 @@ typedef std::vector<MooseEnumItem>::const_iterator MooseEnumIterator;
 class MultiMooseEnum : public MooseEnumBase
 {
 public:
+  ///@{
   /**
-   * Constructor that takes a list of enumeration values, and a separate string to set a default for
-   * this instance
+   * Constructor that takes a list of valid enumeration values, and a separate string to set default
+   * values for this instance
    * @param valid_names - a list of all possible values (names) for this enumeration
-   * @param initialization_values - the value(s), if any, to set this enumeration instance to
+   * @param initialization_values - the value(s) to set this enumeration instance to
    * @param allow_out_of_range - determines whether this enumeration will accept values outside of
    * it's range of initially defined values, allowing for the possiblity to add additional valid
    * values to an object after it has been initialized.
    */
   MultiMooseEnum(std::string valid_names,
-                 std::string initialization_values = "",
+                 std::string initialization_values,
                  bool allow_out_of_range = false);
+  // We need to explicitly define this version so MultiMooseEnum("one two", "one")
+  // doesn't implicitly convert "one" to a bool use use the 2-parameter constructor
+  MultiMooseEnum(std::string valid_names,
+                 const char * initialization_values,
+                 bool allow_out_of_range = false);
+  ///@}
+
+  /**
+   * Constructor that takes a list of valid enumeration values, and does not set this instance to
+   * any particular value.
+   * @param valid_names - a list of all possible values (names) for this enumeration
+   * @param allow_out_of_range - determines whether this enumeration will accept values outside of
+   * it's range of initially defined values, allowing for the possiblity to add additional valid
+   * values to an object after it has been initialized.
+   */
+  MultiMooseEnum(std::string valid_names, bool allow_out_of_range = false);
 
   /**
    * Copy Constructor

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -101,7 +101,7 @@ EigenExecutionerBase::init()
   // check when the postprocessors are evaluated
   const ExecFlagEnum & bx_exec =
       _problem.getUserObject<UserObject>(getParam<PostprocessorName>("bx_norm")).getExecuteOnEnum();
-  if (!bx_exec.contains(EXEC_LINEAR))
+  if (!bx_exec.isValueSet(EXEC_LINEAR))
     mooseError("Postprocessor " + getParam<PostprocessorName>("bx_norm") +
                " requires execute_on = 'linear'");
 
@@ -112,7 +112,7 @@ EigenExecutionerBase::init()
     _norm_exec = bx_exec;
 
   // check if _source_integral has been evaluated during initialSetup()
-  if (!bx_exec.contains(EXEC_INITIAL))
+  if (!bx_exec.isValueSet(EXEC_INITIAL))
     _problem.execute(EXEC_LINEAR);
 
   if (_source_integral == 0.0)
@@ -185,7 +185,7 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
   {
     solution_diff = &_problem.getPostprocessorValueByName(xdiff);
     const ExecFlagEnum & xdiff_exec = _problem.getUserObject<UserObject>(xdiff).getExecuteOnEnum();
-    if (!xdiff_exec.contains(EXEC_LINEAR))
+    if (!xdiff_exec.isValueSet(EXEC_LINEAR))
       mooseError("Postprocessor " + xdiff + " requires execute_on = 'linear'");
   }
 
@@ -391,14 +391,14 @@ EigenExecutionerBase::postExecute()
   }
 
   Real s = 1.0;
-  if (_norm_exec.contains(EXEC_CUSTOM))
+  if (_norm_exec.isValueSet(EXEC_CUSTOM))
   {
     _console << " Cannot let the normalization postprocessor on custom.\n";
     _console << " Normalization is abandoned!" << std::endl;
   }
   else
   {
-    bool force = _norm_exec.contains(EXEC_TIMESTEP_END) || _norm_exec.contains(EXEC_LINEAR);
+    bool force = _norm_exec.isValueSet(EXEC_TIMESTEP_END) || _norm_exec.isValueSet(EXEC_LINEAR);
     s = normalizeSolution(force);
     if (!MooseUtils::absoluteFuzzyEqual(s, 1.0))
       _console << " Solution is rescaled with factor " << s << " for normalization!" << std::endl;

--- a/framework/src/executioners/Eigenvalue.C
+++ b/framework/src/executioners/Eigenvalue.C
@@ -156,7 +156,7 @@ Eigenvalue::init()
   {
     const auto & normpp = getParam<PostprocessorName>("normalization");
     const auto & exec = _eigen_problem.getUserObject<UserObject>(normpp).getExecuteOnEnum();
-    if (!exec.contains(EXEC_LINEAR))
+    if (!exec.isValueSet(EXEC_LINEAR))
       mooseError("Normalization postprocessor ", normpp, " requires execute_on = 'linear'");
   }
 

--- a/framework/src/ics/IntegralPreservingFunctionIC.C
+++ b/framework/src/ics/IntegralPreservingFunctionIC.C
@@ -37,7 +37,7 @@ void
 IntegralPreservingFunctionIC::initialSetup()
 {
   const UserObject & pp = _fe_problem.getUserObject<UserObject>(_pp_name);
-  if (!pp.getExecuteOnEnum().contains(EXEC_INITIAL))
+  if (!pp.getExecuteOnEnum().isValueSet(EXEC_INITIAL))
     mooseError("The 'execute_on' parameter for the '" + _pp_name +
                "' postprocessor must include 'initial'!");
 }

--- a/framework/src/interfaces/SetupInterface.C
+++ b/framework/src/interfaces/SetupInterface.C
@@ -31,7 +31,8 @@ SetupInterface::SetupInterface(const MooseObject * moose_object)
         (moose_object->parameters().getCheckedPointerParam<FEProblemBase *>("_fe_problem_base"))
             ->getCurrentExecuteOnFlag())
 {
-  _empty_execute_enum.clearSetValues(); // remove any flags for the case when "execute_on" is not used
+  _empty_execute_enum
+      .clearSetValues(); // remove any flags for the case when "execute_on" is not used
 }
 
 SetupInterface::~SetupInterface() {}

--- a/framework/src/interfaces/SetupInterface.C
+++ b/framework/src/interfaces/SetupInterface.C
@@ -31,7 +31,7 @@ SetupInterface::SetupInterface(const MooseObject * moose_object)
         (moose_object->parameters().getCheckedPointerParam<FEProblemBase *>("_fe_problem_base"))
             ->getCurrentExecuteOnFlag())
 {
-  _empty_execute_enum.clear(); // remove any flags for the case when "execute_on" is not used
+  _empty_execute_enum.clearSetValues(); // remove any flags for the case when "execute_on" is not used
 }
 
 SetupInterface::~SetupInterface() {}

--- a/framework/src/materials/ParsedMaterialHelper.C
+++ b/framework/src/materials/ParsedMaterialHelper.C
@@ -41,8 +41,8 @@ ParsedMaterialHelper<is_ad>::ParsedMaterialHelper(const InputParameters & parame
   : FunctionMaterialBase<is_ad>(parameters),
     FunctionParserUtils<is_ad>(parameters),
     _symbol_names(_nargs),
-    _extra_symbols(
-        this->template getParam<MultiMooseEnum>("extra_symbols").template getSetValueIDs<ExtraSymbols>()),
+    _extra_symbols(this->template getParam<MultiMooseEnum>("extra_symbols")
+                       .template getSetValueIDs<ExtraSymbols>()),
     _tol(0),
     _map_mode(map_mode),
     _upstream_mat_names(this->template getParam<std::vector<MaterialName>>("upstream_materials")),

--- a/framework/src/materials/ParsedMaterialHelper.C
+++ b/framework/src/materials/ParsedMaterialHelper.C
@@ -42,7 +42,7 @@ ParsedMaterialHelper<is_ad>::ParsedMaterialHelper(const InputParameters & parame
     FunctionParserUtils<is_ad>(parameters),
     _symbol_names(_nargs),
     _extra_symbols(
-        this->template getParam<MultiMooseEnum>("extra_symbols").template getEnum<ExtraSymbols>()),
+        this->template getParam<MultiMooseEnum>("extra_symbols").template getSetValueIDs<ExtraSymbols>()),
     _tol(0),
     _map_mode(map_mode),
     _upstream_mat_names(this->template getParam<std::vector<MaterialName>>("upstream_materials")),

--- a/framework/src/outputs/AdvancedOutput.C
+++ b/framework/src/outputs/AdvancedOutput.C
@@ -338,7 +338,7 @@ AdvancedOutput::wantOutput(const std::string & name, const ExecFlagType & type)
     return false;
 
   // Do not output if the 'none' is contained by the execute_on
-  if (_advanced_execute_on.contains(name) && _advanced_execute_on[name].contains("none"))
+  if (_advanced_execute_on.contains(name) && _advanced_execute_on[name].isValueSet("none"))
     return false;
 
   // Data output flag, true if data exists to be output
@@ -362,7 +362,7 @@ AdvancedOutput::wantOutput(const std::string & name, const ExecFlagType & type)
   //   (2) The current output type is contained in the list of output execution types
   //   (3) The current execution time is "final" or "forced" and the data has not already been
   //   output
-  if (execute_data_flag && _advanced_execute_on[name].contains(type) &&
+  if (execute_data_flag && _advanced_execute_on[name].isValueSet(type) &&
       !(type == EXEC_FINAL && _last_execute_time[name] == _time))
     return true;
   else
@@ -687,7 +687,7 @@ AdvancedOutput::addValidParams(InputParameters & params, const MultiMooseEnum & 
   empty_execute_on.addAvailableFlags(EXEC_FAILED);
 
   // Nodal output
-  if (types.contains("nodal"))
+  if (types.isValueSet("nodal"))
   {
     params.addParam<ExecFlagEnum>(
         "execute_nodal_on", empty_execute_on, "Control the output of nodal variables");
@@ -695,7 +695,7 @@ AdvancedOutput::addValidParams(InputParameters & params, const MultiMooseEnum & 
   }
 
   // Elemental output
-  if (types.contains("elemental"))
+  if (types.isValueSet("elemental"))
   {
     params.addParam<ExecFlagEnum>(
         "execute_elemental_on", empty_execute_on, "Control the output of elemental variables");
@@ -722,7 +722,7 @@ AdvancedOutput::addValidParams(InputParameters & params, const MultiMooseEnum & 
   }
 
   // Scalar variable output
-  if (types.contains("scalar"))
+  if (types.isValueSet("scalar"))
   {
     params.addParam<ExecFlagEnum>(
         "execute_scalars_on", empty_execute_on, "Control the output of scalar variables");
@@ -730,14 +730,14 @@ AdvancedOutput::addValidParams(InputParameters & params, const MultiMooseEnum & 
   }
 
   // Nodal and scalar output
-  if (types.contains("nodal") && types.contains("scalar"))
+  if (types.isValueSet("nodal") && types.isValueSet("scalar"))
   {
     params.addParam<bool>("scalar_as_nodal", false, "Output scalar variables as nodal");
     params.addParamNamesToGroup("scalar_as_nodal", "Conversions before output");
   }
 
   // Elemental and nodal
-  if (types.contains("elemental") && types.contains("nodal"))
+  if (types.isValueSet("elemental") && types.isValueSet("nodal"))
   {
     params.addParam<bool>(
         "elemental_as_nodal", false, "Output elemental nonlinear variables as nodal");
@@ -745,7 +745,7 @@ AdvancedOutput::addValidParams(InputParameters & params, const MultiMooseEnum & 
   }
 
   // Postprocessors
-  if (types.contains("postprocessor"))
+  if (types.isValueSet("postprocessor"))
   {
     params.addParam<ExecFlagEnum>(
         "execute_postprocessors_on", empty_execute_on, "Control of when postprocessors are output");
@@ -753,7 +753,7 @@ AdvancedOutput::addValidParams(InputParameters & params, const MultiMooseEnum & 
   }
 
   // Vector Postprocessors
-  if (types.contains("vector_postprocessor"))
+  if (types.isValueSet("vector_postprocessor"))
   {
     params.addParam<ExecFlagEnum>("execute_vector_postprocessors_on",
                                   empty_execute_on,
@@ -763,7 +763,7 @@ AdvancedOutput::addValidParams(InputParameters & params, const MultiMooseEnum & 
   }
 
   // Reporters
-  if (types.contains("reporter"))
+  if (types.isValueSet("reporter"))
   {
     params.addParam<ExecFlagEnum>(
         "execute_reporters_on", empty_execute_on, "Control of when Reporter values are output");
@@ -771,7 +771,7 @@ AdvancedOutput::addValidParams(InputParameters & params, const MultiMooseEnum & 
   }
 
   // Input file
-  if (types.contains("input"))
+  if (types.isValueSet("input"))
   {
     params.addParam<ExecFlagEnum>(
         "execute_input_on", empty_execute_on, "Enable/disable the output of the input file");
@@ -779,7 +779,7 @@ AdvancedOutput::addValidParams(InputParameters & params, const MultiMooseEnum & 
   }
 
   // System Information
-  if (types.contains("system_information"))
+  if (types.isValueSet("system_information"))
   {
     params.addParam<ExecFlagEnum>("execute_system_information_on",
                                   empty_execute_on,
@@ -792,7 +792,7 @@ bool
 AdvancedOutput::hasOutputHelper(const std::string & name)
 {
   return !_execute_data[name].output.empty() && _advanced_execute_on.contains(name) &&
-         _advanced_execute_on[name].isValid() && !_advanced_execute_on[name].contains("none");
+         _advanced_execute_on[name].isValid() && !_advanced_execute_on[name].isValueSet("none");
 }
 
 bool

--- a/framework/src/outputs/AdvancedOutput.C
+++ b/framework/src/outputs/AdvancedOutput.C
@@ -495,7 +495,7 @@ AdvancedOutput::initExecutionTypes(const std::string & name, ExecFlagEnum & inpu
   else if (!_pars.have_parameter<ExecFlagEnum>(param_name))
   {
     input = _execute_on;
-    input.clear();
+    input.clearSetValues();
   }
 }
 

--- a/framework/src/outputs/CSV.C
+++ b/framework/src/outputs/CSV.C
@@ -102,9 +102,9 @@ CSV::initialSetup()
   const auto n_pps = getPostprocessorOutput().size();
   const auto n_scalars = getScalarOutput().size();
   const auto n_reporters = getReporterOutput().size();
-  const bool pp_active = n_pps > 0 && !pp_execute_on.contains(EXEC_NONE);
-  const bool scalar_active = n_scalars > 0 && !scalar_execute_on.contains(EXEC_NONE);
-  const bool reporter_active = n_reporters > 0 && !reporter_execute_on.contains(EXEC_NONE);
+  const bool pp_active = n_pps > 0 && !pp_execute_on.isValueSet(EXEC_NONE);
+  const bool scalar_active = n_scalars > 0 && !scalar_execute_on.isValueSet(EXEC_NONE);
+  const bool reporter_active = n_reporters > 0 && !reporter_execute_on.isValueSet(EXEC_NONE);
   if ((pp_execute_on != scalar_execute_on && pp_active && scalar_active) ||
       (pp_execute_on != reporter_execute_on && pp_active && reporter_active))
     mooseError("The parameters 'execute_postprocessors_on', 'execute_scalars_on', and "

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -214,13 +214,13 @@ Console::Console(const InputParameters & parameters)
     // Honor the 'print_linear_residuals' option, only if 'linear' has not been set in 'execute_on'
     // by the user
     if (common && common->getParam<bool>("print_linear_residuals"))
-      _execute_on.push_back("linear");
+      _execute_on.setAdditionalValue("linear");
     else
-      _execute_on.erase("linear");
+      _execute_on.eraseSetValue("linear");
     if (common && common->getParam<bool>("print_nonlinear_residuals"))
-      _execute_on.push_back("nonlinear");
+      _execute_on.setAdditionalValue("nonlinear");
     else
-      _execute_on.erase("nonlinear");
+      _execute_on.eraseSetValue("nonlinear");
   }
 
   if (!_pars.isParamSetByUser("perf_log") && common && common->getParam<bool>("print_perf_log"))
@@ -235,12 +235,12 @@ Console::Console(const InputParameters & parameters)
   {
     const ExecFlagEnum & common_execute_on = common->getParam<ExecFlagEnum>("execute_on");
     for (auto & mme : common_execute_on)
-      _execute_on.push_back(mme);
+      _execute_on.setAdditionalValue(mme);
   }
 
   // If --show-outputs is used, enable it
   if (_app.getParam<bool>("show_outputs"))
-    _system_info_flags.push_back("output");
+    _system_info_flags.setAdditionalValue("output");
 }
 
 Console::~Console()
@@ -292,11 +292,11 @@ Console::initialSetup()
   if (_execute_on.contains("final"))
   {
     if (!_pars.isParamSetByUser("postprocessor_execute_on"))
-      _advanced_execute_on["postprocessors"].push_back("final");
+      _advanced_execute_on["postprocessors"].setAdditionalValue("final");
     if (!_pars.isParamSetByUser("scalars_execute_on"))
-      _advanced_execute_on["scalars"].push_back("final");
+      _advanced_execute_on["scalars"].setAdditionalValue("final");
     if (!_pars.isParamSetByUser("vector_postprocessor_execute_on"))
-      _advanced_execute_on["vector_postprocessors"].push_back("final");
+      _advanced_execute_on["vector_postprocessors"].setAdditionalValue("final");
   }
 }
 

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -289,7 +289,7 @@ Console::initialSetup()
   // If the user adds "final" to the execute on, append this to the postprocessors, scalars, etc.,
   // but only
   // if the parameter (e.g., postprocessor_execute_on) has not been modified by the user.
-  if (_execute_on.contains("final"))
+  if (_execute_on.isValueSet("final"))
   {
     if (!_pars.isParamSetByUser("postprocessor_execute_on"))
       _advanced_execute_on["postprocessors"].setAdditionalValue("final");
@@ -342,16 +342,16 @@ Console::output()
   // Write the timestep information ("Time Step 0 ..."), this is controlled with "execute_on"
   // We only write the initial and final here. All of the intermediate outputs will be written
   // through timestepSetup.
-  if (type == EXEC_INITIAL && _execute_on.contains(EXEC_INITIAL))
+  if (type == EXEC_INITIAL && _execute_on.isValueSet(EXEC_INITIAL))
     writeTimestepInformation(/*output_dt = */ false);
-  else if (type == EXEC_FINAL && _execute_on.contains(EXEC_FINAL))
+  else if (type == EXEC_FINAL && _execute_on.isValueSet(EXEC_FINAL))
   {
     if (wantOutput("postprocessors", type) || wantOutput("scalars", type))
       _console << "\nFINAL:\n";
   }
 
   // Print Non-linear Residual (control with "execute_on")
-  if (type == EXEC_NONLINEAR && _execute_on.contains(EXEC_NONLINEAR))
+  if (type == EXEC_NONLINEAR && _execute_on.isValueSet(EXEC_NONLINEAR))
   {
     if (_nonlinear_iter == 0)
       _old_nonlinear_norm = std::numeric_limits<Real>::max();
@@ -363,7 +363,7 @@ Console::output()
   }
 
   // Print Linear Residual (control with "execute_on")
-  else if (type == EXEC_LINEAR && _execute_on.contains(EXEC_LINEAR))
+  else if (type == EXEC_LINEAR && _execute_on.isValueSet(EXEC_LINEAR))
   {
     if (_linear_iter == 0)
       _old_linear_norm = std::numeric_limits<Real>::max();
@@ -698,13 +698,13 @@ Console::outputSystemInformation()
   if (_app.multiAppNumber() > 0)
     return;
 
-  if (_system_info_flags.contains("framework"))
+  if (_system_info_flags.isValueSet("framework"))
     _console << ConsoleUtils::outputFrameworkInformation(_app);
 
-  if (_system_info_flags.contains("mesh"))
+  if (_system_info_flags.isValueSet("mesh"))
     _console << ConsoleUtils::outputMeshInformation(*_problem_ptr);
 
-  if (_system_info_flags.contains("nonlinear"))
+  if (_system_info_flags.isValueSet("nonlinear"))
   {
     for (const auto i : make_range(_problem_ptr->numNonlinearSystems()))
     {
@@ -717,24 +717,24 @@ Console::outputSystemInformation()
     }
   }
 
-  if (_system_info_flags.contains("aux"))
+  if (_system_info_flags.isValueSet("aux"))
   {
     std::string output = ConsoleUtils::outputAuxiliarySystemInformation(*_problem_ptr);
     if (!output.empty())
       _console << "Auxiliary System:\n" << output;
   }
 
-  if (_system_info_flags.contains("relationship"))
+  if (_system_info_flags.isValueSet("relationship"))
   {
     std::string output = ConsoleUtils::outputRelationshipManagerInformation(_app);
     if (!output.empty())
       _console << "Relationship Managers:\n" << output;
   }
 
-  if (_system_info_flags.contains("execution"))
+  if (_system_info_flags.isValueSet("execution"))
     _console << ConsoleUtils::outputExecutionInformation(_app, *_problem_ptr);
 
-  if (_system_info_flags.contains("output"))
+  if (_system_info_flags.isValueSet("output"))
     _console << ConsoleUtils::outputOutputInformation(_app);
 
   // Output the legacy flags, these cannot be turned off so they become annoying to people.

--- a/framework/src/outputs/JSONOutput.C
+++ b/framework/src/outputs/JSONOutput.C
@@ -98,9 +98,9 @@ JSONOutput::outputReporters()
     // Add time/iteration information
     current_node["time"] = _problem_ptr->time();
     current_node["time_step"] = _problem_ptr->timeStep();
-    if (_execute_enum.contains(EXEC_LINEAR) && !_on_nonlinear_residual)
+    if (_execute_enum.isValueSet(EXEC_LINEAR) && !_on_nonlinear_residual)
       current_node["linear_iteration"] = _linear_iter;
-    if (_execute_enum.contains(EXEC_NONLINEAR))
+    if (_execute_enum.isValueSet(EXEC_NONLINEAR))
       current_node["nonlinear_iteration"] = _nonlinear_iter;
 
     // Inject processor info

--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -276,7 +276,7 @@ Output::outputStep(const ExecFlagType & type)
 bool
 Output::shouldOutput()
 {
-  if (_execute_on.contains(_current_execute_flag) || _current_execute_flag == EXEC_FORCED)
+  if (_execute_on.isValueSet(_current_execute_flag) || _current_execute_flag == EXEC_FORCED)
     return true;
   return false;
 }

--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -88,7 +88,7 @@ Output::validParams()
 
   // Add ability to append to the 'execute_on' list
   params.addParam<ExecFlagEnum>("additional_execute_on", exec_enum, exec_enum.getDocString());
-  params.set<ExecFlagEnum>("additional_execute_on").clear();
+  params.set<ExecFlagEnum>("additional_execute_on").clearSetValues();
   params.addParamNamesToGroup("execute_on additional_execute_on", "Execution scheduling");
 
   // 'Timing' group
@@ -201,7 +201,7 @@ Output::Output(const InputParameters & parameters)
   {
     const ExecFlagEnum & add = getParam<ExecFlagEnum>("additional_execute_on");
     for (auto & me : add)
-      _execute_on.push_back(me);
+      _execute_on.setAdditionalValue(me);
   }
 
   if (isParamValid("output_limiting_function"))

--- a/framework/src/outputs/PerfGraphOutput.C
+++ b/framework/src/outputs/PerfGraphOutput.C
@@ -61,7 +61,7 @@ bool
 PerfGraphOutput::shouldOutput()
 {
   // We don't want the Perflog to get dumped at odd times. Ignore the FORCED flag.
-  return _execute_on.contains(_current_execute_flag);
+  return _execute_on.isValueSet(_current_execute_flag);
 }
 
 void

--- a/framework/src/outputs/PetscOutput.C
+++ b/framework/src/outputs/PetscOutput.C
@@ -186,15 +186,15 @@ PetscOutput::PetscOutput(const InputParameters & parameters)
 {
   // Output toggle support
   if (getParam<bool>("output_linear"))
-    _execute_on.push_back("linear");
+    _execute_on.setAdditionalValue("linear");
   if (getParam<bool>("output_nonlinear"))
-    _execute_on.push_back("nonlinear");
+    _execute_on.setAdditionalValue("nonlinear");
 
   // Nonlinear residual start-time supplied by user
   if (isParamValid("nonlinear_residual_start_time"))
   {
     _nonlinear_start_time = getParam<Real>("nonlinear_residual_start_time");
-    _execute_on.push_back("nonlinear");
+    _execute_on.setAdditionalValue("nonlinear");
   }
 
   // Nonlinear residual end-time supplied by user
@@ -205,7 +205,7 @@ PetscOutput::PetscOutput(const InputParameters & parameters)
   if (isParamValid("linear_residual_start_time"))
   {
     _linear_start_time = getParam<Real>("linear_residual_start_time");
-    _execute_on.push_back("linear");
+    _execute_on.setAdditionalValue("linear");
   }
 
   // Linear residual end-time supplied by user

--- a/framework/src/outputs/XMLOutput.C
+++ b/framework/src/outputs/XMLOutput.C
@@ -54,9 +54,9 @@ XMLOutput::outputVectorPostprocessors()
   // is not required.
   vec_node.append_attribute("time") = _problem_ptr->time();
   vec_node.append_attribute("timestep") = _problem_ptr->timeStep();
-  if (_execute_enum.contains(EXEC_LINEAR) && !_on_nonlinear_residual)
+  if (_execute_enum.isValueSet(EXEC_LINEAR) && !_on_nonlinear_residual)
     vec_node.append_attribute("linear_iteration") = _linear_iter;
-  if (_execute_enum.contains(EXEC_NONLINEAR))
+  if (_execute_enum.isValueSet(EXEC_NONLINEAR))
     vec_node.append_attribute("nonlinear_iteration") = _nonlinear_iter;
 
   // The VPP objects to be output

--- a/framework/src/postprocessors/ChangeOverFixedPointPostprocessor.C
+++ b/framework/src/postprocessors/ChangeOverFixedPointPostprocessor.C
@@ -50,13 +50,13 @@ ChangeOverFixedPointPostprocessor::ChangeOverFixedPointPostprocessor(
     // ensure dependent post-processor is executed on initial
     const PostprocessorName & pp_name = getParam<PostprocessorName>("postprocessor");
     const UserObject & pp = _fe_problem.getUserObject<UserObject>(pp_name);
-    if (!pp.getExecuteOnEnum().contains(EXEC_INITIAL))
+    if (!pp.getExecuteOnEnum().isValueSet(EXEC_INITIAL))
       mooseError("When 'change_with_respect_to_initial' is specified to be true, 'execute_on' for "
                  "the dependent post-processor ('" +
                  pp_name + "') must include 'initial'");
 
     // ensure THIS post-processor is executed on initial
-    if (!_execute_enum.contains(EXEC_INITIAL))
+    if (!_execute_enum.isValueSet(EXEC_INITIAL))
       mooseError("When 'change_with_respect_to_initial' is specified to be true, 'execute_on' for "
                  "the ChangeOverFixedPointPostprocessor ('" +
                  name() + "') must include 'initial'");

--- a/framework/src/postprocessors/ChangeOverTimePostprocessor.C
+++ b/framework/src/postprocessors/ChangeOverTimePostprocessor.C
@@ -45,13 +45,13 @@ ChangeOverTimePostprocessor::ChangeOverTimePostprocessor(const InputParameters &
     // ensure dependent post-processor is executed on initial
     const PostprocessorName & pp_name = getParam<PostprocessorName>("postprocessor");
     const UserObject & pp = _fe_problem.getUserObject<UserObject>(pp_name);
-    if (!pp.getExecuteOnEnum().contains(EXEC_INITIAL))
+    if (!pp.getExecuteOnEnum().isValueSet(EXEC_INITIAL))
       mooseError("When 'change_with_respect_to_initial' is specified to be true, 'execute_on' for "
                  "the dependent post-processor ('" +
                  pp_name + "') must include 'initial'");
 
     // ensure THIS post-processor is executed on initial
-    if (!_execute_enum.contains(EXEC_INITIAL))
+    if (!_execute_enum.isValueSet(EXEC_INITIAL))
       mooseError("When 'change_with_respect_to_initial' is specified to be true, 'execute_on' for "
                  "the ChangeOverTimePostprocessor ('" +
                  name() + "') must include 'initial'");

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5288,7 +5288,7 @@ FEProblemBase::addTransfer(const std::string & transfer_name,
   // flag so the set by user flag is not reset, calling set with the true flag causes the set
   // by user status to be reset, which should only be done if the EXEC_SAME_AS_MULTIAPP is
   // being applied to the object.
-  if (parameters.get<ExecFlagEnum>("execute_on").contains(EXEC_SAME_AS_MULTIAPP))
+  if (parameters.get<ExecFlagEnum>("execute_on").isValueSet(EXEC_SAME_AS_MULTIAPP))
   {
     ExecFlagEnum & exec_enum = parameters.set<ExecFlagEnum>("execute_on", true);
     std::shared_ptr<MultiApp> multiapp;
@@ -5314,11 +5314,11 @@ FEProblemBase::addTransfer(const std::string & transfer_name,
       std::dynamic_pointer_cast<MultiAppTransfer>(transfer);
   if (multi_app_transfer)
   {
-    if (multi_app_transfer->directions().contains(MultiAppTransfer::TO_MULTIAPP))
+    if (multi_app_transfer->directions().isValueSet(MultiAppTransfer::TO_MULTIAPP))
       _to_multi_app_transfers.addObject(multi_app_transfer);
-    if (multi_app_transfer->directions().contains(MultiAppTransfer::FROM_MULTIAPP))
+    if (multi_app_transfer->directions().isValueSet(MultiAppTransfer::FROM_MULTIAPP))
       _from_multi_app_transfers.addObject(multi_app_transfer);
-    if (multi_app_transfer->directions().contains(MultiAppTransfer::BETWEEN_MULTIAPP))
+    if (multi_app_transfer->directions().isValueSet(MultiAppTransfer::BETWEEN_MULTIAPP))
       _between_multi_app_transfers.addObject(multi_app_transfer);
   }
   else
@@ -8757,8 +8757,8 @@ FEProblemBase::shouldPrintExecution(const THREAD_ID tid) const
   if (tid != 0)
     return false;
 
-  if (_print_execution_on.contains(_current_execute_on_flag) ||
-      _print_execution_on.contains(EXEC_ALWAYS))
+  if (_print_execution_on.isValueSet(_current_execute_on_flag) ||
+      _print_execution_on.isValueSet(EXEC_ALWAYS))
     return true;
   else
     return false;

--- a/framework/src/reporters/ElementReporter.C
+++ b/framework/src/reporters/ElementReporter.C
@@ -32,5 +32,5 @@ ElementReporter::shouldStore() const
 {
   // Either we always store, or we store if the current execution flag matches
   // a flag that is within this ElementReporter's 'execute_on'
-  return _always_store || getExecuteOnEnum().contains(_fe_problem.getCurrentExecuteOnFlag());
+  return _always_store || getExecuteOnEnum().isValueSet(_fe_problem.getCurrentExecuteOnFlag());
 }

--- a/framework/src/reporters/GeneralReporter.C
+++ b/framework/src/reporters/GeneralReporter.C
@@ -32,5 +32,5 @@ GeneralReporter::shouldStore() const
 {
   // Either we always store, or we store if the current execution flag matches
   // a flag that is within this GeneralReporter's 'execute_on'
-  return _always_store || getExecuteOnEnum().contains(_fe_problem.getCurrentExecuteOnFlag());
+  return _always_store || getExecuteOnEnum().isValueSet(_fe_problem.getCurrentExecuteOnFlag());
 }

--- a/framework/src/reporters/MeshInfo.C
+++ b/framework/src/reporters/MeshInfo.C
@@ -118,8 +118,8 @@ MeshInfo::possiblyAddSidesetInfo()
 
   const bool include_all = !_items.isValid();
 
-  if (include_all || _items.contains("local_sidesets") || _items.contains("local_sideset_elems") ||
-      _items.contains("sideset_elems"))
+  if (include_all || _items.isValueSet("local_sidesets") ||
+      _items.isValueSet("local_sideset_elems") || _items.isValueSet("sideset_elems"))
   {
     _local_sidesets.clear();
     _local_sideset_elems.clear();
@@ -137,7 +137,7 @@ MeshInfo::possiblyAddSidesetInfo()
       }
 
     // For local sidesets: copy over the local info, remove the sides, and add the names
-    if (include_all || _items.contains("local_sidesets"))
+    if (include_all || _items.isValueSet("local_sidesets"))
     {
       // Copy over the local sideset info, remove the sides, and add the names
       _local_sidesets = sidesets;
@@ -147,7 +147,7 @@ MeshInfo::possiblyAddSidesetInfo()
     }
 
     // For local sideset elems: copy over the local info, and add the names
-    if (include_all || _items.contains("local_sideset_elems"))
+    if (include_all || _items.isValueSet("local_sideset_elems"))
     {
       _local_sideset_elems = sidesets;
       sort_sides(_local_sideset_elems);
@@ -155,7 +155,7 @@ MeshInfo::possiblyAddSidesetInfo()
     }
 
     // For the global sideset elems, we need to communicate all of the elems
-    if (include_all || _items.contains("sideset_elems"))
+    if (include_all || _items.isValueSet("sideset_elems"))
     {
       // Set up a structure for sending each (id, elem id, side) tuple to root
       std::map<processor_id_type,
@@ -191,7 +191,7 @@ MeshInfo::possiblyAddSidesetInfo()
   // For global sideset information without elements, we can simplify communication.
   // All we need are the boundary IDs from libMesh (may not be reduced, so take the union)
   // and then add the names (global)
-  if (include_all || _items.contains("sidesets"))
+  if (include_all || _items.isValueSet("sidesets"))
   {
     _sidesets.clear();
 
@@ -269,8 +269,8 @@ MeshInfo::possiblyAddSubdomainInfo()
 
   const bool include_all = !_items.isValid();
 
-  if (include_all || _items.contains("local_subdomains") ||
-      _items.contains("local_subdomain_elems") || _items.contains("subdomain_elems"))
+  if (include_all || _items.isValueSet("local_subdomains") ||
+      _items.isValueSet("local_subdomain_elems") || _items.isValueSet("subdomain_elems"))
   {
     _local_subdomains.clear();
     _local_subdomain_elems.clear();
@@ -286,7 +286,7 @@ MeshInfo::possiblyAddSubdomainInfo()
     }
 
     // For local subdomains: copy over the local info, remove the elems, and add the names
-    if (include_all || _items.contains("local_subdomains"))
+    if (include_all || _items.isValueSet("local_subdomains"))
     {
       _local_subdomains = subdomains;
       for (auto & pair : _local_subdomains)
@@ -295,7 +295,7 @@ MeshInfo::possiblyAddSubdomainInfo()
     }
 
     // For local subdomain elems: copy over the local info, and add the names
-    if (include_all || _items.contains("local_subdomain_elems"))
+    if (include_all || _items.isValueSet("local_subdomain_elems"))
     {
       _local_subdomain_elems = subdomains;
       sort_elems(_local_subdomain_elems);
@@ -303,7 +303,7 @@ MeshInfo::possiblyAddSubdomainInfo()
     }
 
     // For the global subdomain elems, we need to communicate all of the elems
-    if (include_all || _items.contains("subdomain_elems"))
+    if (include_all || _items.isValueSet("subdomain_elems"))
     {
       // Set up a structure for sending each (id, elem id) to root
       std::map<processor_id_type, std::vector<std::pair<subdomain_id_type, dof_id_type>>> send_info;
@@ -338,7 +338,7 @@ MeshInfo::possiblyAddSubdomainInfo()
 
   // For global subdomain information without elements, we can simplify communication.
   // All we need are the subdomain IDs from libMesh and then add the names (global)
-  if (include_all || _items.contains("subdomains"))
+  if (include_all || _items.isValueSet("subdomains"))
   {
     _subdomains.clear();
 

--- a/framework/src/reporters/NodalReporter.C
+++ b/framework/src/reporters/NodalReporter.C
@@ -32,5 +32,5 @@ NodalReporter::shouldStore() const
 {
   // Either we always store, or we store if the current execution flag matches
   // a flag that is within this NodalReporter's 'execute_on'
-  return _always_store || getExecuteOnEnum().contains(_fe_problem.getCurrentExecuteOnFlag());
+  return _always_store || getExecuteOnEnum().isValueSet(_fe_problem.getCurrentExecuteOnFlag());
 }

--- a/framework/src/reporters/RestartableDataReporter.C
+++ b/framework/src/reporters/RestartableDataReporter.C
@@ -64,13 +64,13 @@ RestartableDataReporter::getDataParams() const
   const auto & entries = getParam<MultiMooseEnum>("entries");
 
   RestartableDataValue::StoreJSONParams params;
-  params.value = entries.contains("value");
-  params.type = entries.contains("type");
+  params.value = entries.isValueSet("value");
+  params.type = entries.isValueSet("type");
   params.name = false;
-  params.declared = entries.contains("declared");
-  params.loaded = entries.contains("loaded");
-  params.stored = entries.contains("stored");
-  params.has_context = entries.contains("has_context");
+  params.declared = entries.isValueSet("declared");
+  params.loaded = entries.isValueSet("loaded");
+  params.stored = entries.isValueSet("stored");
+  params.has_context = entries.isValueSet("has_context");
 
   return params;
 }

--- a/framework/src/splits/Split.C
+++ b/framework/src/splits/Split.C
@@ -183,7 +183,7 @@ Split::setup(NonlinearSystemBase & nl, const std::string & prefix)
       mooseError("Invalid PETSc option name ", op, " for Split ", _name);
 
     // push back PETSc options
-    po.flags.push_back(prefix + op.substr(1));
+    po.flags.setAdditionalValue(prefix + op.substr(1));
   }
 
   for (auto & option : _petsc_options.pairs)

--- a/framework/src/transfers/MultiAppConservativeTransfer.C
+++ b/framework/src/transfers/MultiAppConservativeTransfer.C
@@ -171,7 +171,7 @@ MultiAppConservativeTransfer::initialSetup()
       auto & execute_on = parent_problem.getUserObjectBase(pp).getExecuteOnEnum();
       const auto & type = parent_problem.getUserObjectBase(pp).type();
       // Check if parent app has transfer execute_on
-      if (!execute_on.contains(EXEC_TRANSFER))
+      if (!execute_on.isValueSet(EXEC_TRANSFER))
         mooseError(
             "execute_on='transfer' is required in the conservative transfer for " + type + " '",
             pp,
@@ -197,7 +197,7 @@ MultiAppConservativeTransfer::initialSetup()
         auto & execute_on = sub_problem.getUserObjectBase(sub_pp).getExecuteOnEnum();
         const auto & type = sub_problem.getUserObjectBase(sub_pp).type();
         // Check if sub pp has transfer execute_on
-        if (!execute_on.contains(EXEC_TRANSFER))
+        if (!execute_on.isValueSet(EXEC_TRANSFER))
           mooseError(
               "execute_on='transfer' is required in the conservative transfer for " + type + " '",
               sub_pp,

--- a/framework/src/transfers/MultiAppReporterTransfer.C
+++ b/framework/src/transfers/MultiAppReporterTransfer.C
@@ -69,7 +69,7 @@ MultiAppReporterTransfer::MultiAppReporterTransfer(const InputParameters & param
       paramError(
           "subapp_index",
           "The supplied sub-application index is greater than the number of sub-applications.");
-    else if (_directions.contains(FROM_MULTIAPP) &&
+    else if (_directions.isValueSet(FROM_MULTIAPP) &&
              _subapp_index == std::numeric_limits<unsigned int>::max() &&
              multi_app->numGlobalApps() > 1 && !_distribute_reporter_vector)
       paramError("from_multi_app",
@@ -95,7 +95,7 @@ MultiAppReporterTransfer::initialSetup()
   // that we consume a replicated version.
   // Find proper FEProblem
   FEProblemBase * problem_ptr = nullptr;
-  if (_directions.contains(TO_MULTIAPP))
+  if (_directions.isValueSet(TO_MULTIAPP))
     problem_ptr = &getToMultiApp()->problemBase();
   else if (_subapp_index == std::numeric_limits<unsigned int>::max() &&
            getFromMultiApp()->hasLocalApp(0))

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -129,11 +129,11 @@ MultiAppTransfer::MultiAppTransfer(const InputParameters & parameters)
   if (!isParamValid("direction"))
   {
     if (_from_multi_app && (!_to_multi_app || _from_multi_app == _to_multi_app))
-      _directions.push_back("from_multiapp");
+      _directions.setAdditionalValue("from_multiapp");
     if (_to_multi_app && (!_from_multi_app || _from_multi_app == _to_multi_app))
-      _directions.push_back("to_multiapp");
+      _directions.setAdditionalValue("to_multiapp");
     if (_from_multi_app && _to_multi_app && _from_multi_app != _to_multi_app)
-      _directions.push_back("between_multiapp");
+      _directions.setAdditionalValue("between_multiapp");
 
     // So it's available in the next constructors
     _direction = _directions[0];

--- a/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
@@ -68,7 +68,7 @@ MultiAppVariableValueSamplePostprocessorTransfer::MultiAppVariableValueSamplePos
   if (_directions.size() != 1)
     paramError("direction", "This transfer is only unidirectional");
 
-  if (_directions.contains("from_multiapp"))
+  if (_directions.isValueSet("from_multiapp"))
   {
     // Check that the variable is a CONSTANT MONOMIAL.
     auto & fe_type = _var.feType();
@@ -80,7 +80,7 @@ MultiAppVariableValueSamplePostprocessorTransfer::MultiAppVariableValueSamplePos
     if (!_fe_problem.getAuxiliarySystem().hasVariable(_var_name))
       paramError("source_variable", "Variable must be an auxiliary variable");
   }
-  else if (_directions.contains("between_multiapp"))
+  else if (_directions.isValueSet("between_multiapp"))
     mooseError("MultiAppVariableValueSamplePostprocessorTransfer has not been made to support "
                "sibling transfers");
 
@@ -97,7 +97,7 @@ MultiAppVariableValueSamplePostprocessorTransfer::MultiAppVariableValueSamplePos
 void
 MultiAppVariableValueSamplePostprocessorTransfer::setupPostprocessorCommunication()
 {
-  if (!_directions.contains("from_multiapp"))
+  if (!_directions.isValueSet("from_multiapp"))
     return;
 
   const auto num_global_apps = getFromMultiApp()->numGlobalApps();
@@ -125,7 +125,7 @@ MultiAppVariableValueSamplePostprocessorTransfer::setupPostprocessorCommunicatio
 void
 MultiAppVariableValueSamplePostprocessorTransfer::cacheElemToPostprocessorData()
 {
-  if (!_directions.contains("from_multiapp"))
+  if (!_directions.isValueSet("from_multiapp"))
     return;
 
   // Cache the Multiapp position ID for every element.
@@ -179,8 +179,9 @@ MultiAppVariableValueSamplePostprocessorTransfer::initialSetup()
 {
   MultiAppTransfer::initialSetup();
 
-  unsigned int num_apps = _directions.contains("from_multiapp") ? getFromMultiApp()->numGlobalApps()
-                                                                : getToMultiApp()->numGlobalApps();
+  unsigned int num_apps = _directions.isValueSet("from_multiapp")
+                              ? getFromMultiApp()->numGlobalApps()
+                              : getToMultiApp()->numGlobalApps();
   if (_map_comp_to_child && num_apps % _var.count() != 0)
     paramError("map_array_variable_components_to_child_apps",
                "The number of sub-applications (",

--- a/framework/src/userobjects/Terminator.C
+++ b/framework/src/userobjects/Terminator.C
@@ -95,7 +95,7 @@ Terminator::initialSetup()
     {
       const auto & pp_exec = _fe_problem.getUserObjectBase(_pp_names[i], _tid).getExecuteOnEnum();
       for (const auto & flag : getExecuteOnEnum())
-        if (!pp_exec.contains(flag) && flag != EXEC_FINAL)
+        if (!pp_exec.isValueSet(flag) && flag != EXEC_FINAL)
           paramWarning("expression",
                        "Postprocessor '" + _pp_names[i] + "' is not executed on " + flag.name() +
                            ", which it really should be to serve in the criterion "

--- a/framework/src/utils/ExecFlagEnum.C
+++ b/framework/src/utils/ExecFlagEnum.C
@@ -29,7 +29,7 @@ ExecFlagEnum::removeAvailableFlags(const ExecFlagType & flag)
                flag,
                "' is not an available enum item for the "
                "MultiMooseEnum object, thus it cannot be removed.");
-  else if (contains(flag))
+  else if (isValueSet(flag))
     mooseError("The supplied item '", flag, "' is a selected item, thus it can not be removed.");
 
   _items.erase(flag);

--- a/framework/src/utils/ExecFlagEnum.C
+++ b/framework/src/utils/ExecFlagEnum.C
@@ -86,5 +86,5 @@ ExecFlagEnum::appendCurrent(const ExecFlagType & item)
                item,
                "' is not an available item for the "
                "ExecFlagEnum object, thus it cannot be set as current.");
-  _current.push_back(item);
+  _current_values.push_back(item);
 }

--- a/framework/src/utils/ExecFlagEnum.C
+++ b/framework/src/utils/ExecFlagEnum.C
@@ -48,7 +48,7 @@ ExecFlagEnum::getDocString() const
 ExecFlagEnum &
 ExecFlagEnum::operator=(const std::initializer_list<ExecFlagType> & flags)
 {
-  clear();
+  clearSetValues();
   *this += flags;
   return *this;
 }
@@ -56,7 +56,7 @@ ExecFlagEnum::operator=(const std::initializer_list<ExecFlagType> & flags)
 ExecFlagEnum &
 ExecFlagEnum::operator=(const ExecFlagType & flag)
 {
-  clear();
+  clearSetValues();
   *this += flag;
   return *this;
 }

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -82,26 +82,12 @@ MultiMooseEnum::isValueSet(const std::string & value) const
 }
 
 bool
-MultiMooseEnum::contains(const std::string & value) const
-{
-  mooseDeprecated("MultiMooseEnum::contains is deprecated, use MultiMooseEnum::isValueSet");
-  return isValueSet(value);
-}
-
-bool
 MultiMooseEnum::isValueSet(int value) const
 {
   return std::find_if(_current_values.begin(),
                       _current_values.end(),
                       [&value](const MooseEnumItem & item)
                       { return item == value; }) != _current_values.end();
-}
-
-bool
-MultiMooseEnum::contains(int value) const
-{
-  mooseDeprecated("MultiMooseEnum::contains is deprecated, use MultiMooseEnum::isValueSet");
-  return isValueSet(value);
 }
 
 bool
@@ -114,13 +100,6 @@ MultiMooseEnum::isValueSet(unsigned short value) const
 }
 
 bool
-MultiMooseEnum::contains(unsigned short value) const
-{
-  mooseDeprecated("MultiMooseEnum::contains is deprecated, use MultiMooseEnum::isValueSet");
-  return isValueSet(value);
-}
-
-bool
 MultiMooseEnum::isValueSet(const MultiMooseEnum & value) const
 {
   for (const auto & item : value._current_values)
@@ -130,26 +109,12 @@ MultiMooseEnum::isValueSet(const MultiMooseEnum & value) const
 }
 
 bool
-MultiMooseEnum::contains(const MultiMooseEnum & value) const
-{
-  mooseDeprecated("MultiMooseEnum::contains is deprecated, use MultiMooseEnum::isValueSet");
-  return isValueSet(value);
-}
-
-bool
 MultiMooseEnum::isValueSet(const MooseEnumItem & value) const
 {
   return std::find_if(_current_values.begin(),
                       _current_values.end(),
                       [&value](const MooseEnumItem & item)
                       { return item == value; }) != _current_values.end();
-}
-
-bool
-MultiMooseEnum::contains(const MooseEnumItem & value) const
-{
-  mooseDeprecated("MultiMooseEnum::contains is deprecated, use MultiMooseEnum::isValueSet");
-  return isValueSet(value);
 }
 
 MultiMooseEnum &

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -63,7 +63,7 @@ MultiMooseEnum::operator==(const MultiMooseEnum & value) const
 
   // Return false if this enum does not contain an item from the other, since they are the same
   // size at this point if this is true then they are equal.
-  return contains(value);
+  return isValueSet(value);
 }
 
 bool
@@ -73,7 +73,23 @@ MultiMooseEnum::operator!=(const MultiMooseEnum & value) const
 }
 
 bool
+MultiMooseEnum::isValueSet(const std::string & value) const
+{
+  return std::find_if(_current_values.begin(),
+                      _current_values.end(),
+                      [&value](const MooseEnumItem & item)
+                      { return item == value; }) != _current_values.end();
+}
+
+bool
 MultiMooseEnum::contains(const std::string & value) const
+{
+  mooseDeprecated("MultiMooseEnum::contains is deprecated, use MultiMooseEnum::isValueSet");
+  return isValueSet(value);
+}
+
+bool
+MultiMooseEnum::isValueSet(int value) const
 {
   return std::find_if(_current_values.begin(),
                       _current_values.end(),
@@ -84,6 +100,13 @@ MultiMooseEnum::contains(const std::string & value) const
 bool
 MultiMooseEnum::contains(int value) const
 {
+  mooseDeprecated("MultiMooseEnum::contains is deprecated, use MultiMooseEnum::isValueSet");
+  return isValueSet(value);
+}
+
+bool
+MultiMooseEnum::isValueSet(unsigned short value) const
+{
   return std::find_if(_current_values.begin(),
                       _current_values.end(),
                       [&value](const MooseEnumItem & item)
@@ -93,28 +116,40 @@ MultiMooseEnum::contains(int value) const
 bool
 MultiMooseEnum::contains(unsigned short value) const
 {
-  return std::find_if(_current_values.begin(),
-                      _current_values.end(),
-                      [&value](const MooseEnumItem & item)
-                      { return item == value; }) != _current_values.end();
+  mooseDeprecated("MultiMooseEnum::contains is deprecated, use MultiMooseEnum::isValueSet");
+  return isValueSet(value);
 }
 
 bool
-MultiMooseEnum::contains(const MultiMooseEnum & value) const
+MultiMooseEnum::isValueSet(const MultiMooseEnum & value) const
 {
   for (const auto & item : value._current_values)
-    if (!contains(item))
+    if (!isValueSet(item))
       return false;
   return true;
 }
 
 bool
-MultiMooseEnum::contains(const MooseEnumItem & value) const
+MultiMooseEnum::contains(const MultiMooseEnum & value) const
+{
+  mooseDeprecated("MultiMooseEnum::contains is deprecated, use MultiMooseEnum::isValueSet");
+  return isValueSet(value);
+}
+
+bool
+MultiMooseEnum::isValueSet(const MooseEnumItem & value) const
 {
   return std::find_if(_current_values.begin(),
                       _current_values.end(),
                       [&value](const MooseEnumItem & item)
                       { return item == value; }) != _current_values.end();
+}
+
+bool
+MultiMooseEnum::contains(const MooseEnumItem & value) const
+{
+  mooseDeprecated("MultiMooseEnum::contains is deprecated, use MultiMooseEnum::isValueSet");
+  return isValueSet(value);
 }
 
 MultiMooseEnum &

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -184,7 +184,7 @@ void
 MultiMooseEnum::erase(const std::string & names)
 {
   mooseDeprecated("MultiMooseEnum::erase is deprecated, use MultiMooseEnum::eraseSetValue");
-  MultiMooseEnum::erase(names);
+  MultiMooseEnum::eraseSetValue(names);
 }
 
 void
@@ -197,7 +197,7 @@ void
 MultiMooseEnum::erase(const std::vector<std::string> & names)
 {
   mooseDeprecated("MultiMooseEnum::erase is deprecated, use MultiMooseEnum::eraseSetValue");
-  MultiMooseEnum::erase(names);
+  MultiMooseEnum::eraseSetValue(names);
 }
 
 void
@@ -210,7 +210,7 @@ void
 MultiMooseEnum::erase(const std::set<std::string> & names)
 {
   mooseDeprecated("MultiMooseEnum::erase is deprecated, use MultiMooseEnum::eraseSetValue");
-  MultiMooseEnum::erase(names);
+  MultiMooseEnum::eraseSetValue(names);
 }
 
 void

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -7,11 +7,13 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
+#include "MooseEnumBase.h"
 #include "MultiMooseEnum.h"
 #include "MooseUtils.h"
 #include "MooseError.h"
 #include "Conversion.h"
 
+#include <initializer_list>
 #include <sstream>
 #include <algorithm>
 #include <iterator>
@@ -144,15 +146,36 @@ MultiMooseEnum::eraseSetValue(const std::string & names)
 }
 
 void
+MultiMooseEnum::erase(const std::string & names)
+{
+  mooseDeprecated("MultiMooseEnum::erase is deprecated, use MultiMooseEnum::eraseSetValue");
+  MultiMooseEnum::erase(names);
+}
+
+void
 MultiMooseEnum::eraseSetValue(const std::vector<std::string> & names)
 {
   removeSetValues(names.begin(), names.end());
 }
 
 void
+MultiMooseEnum::erase(const std::vector<std::string> & names)
+{
+  mooseDeprecated("MultiMooseEnum::erase is deprecated, use MultiMooseEnum::eraseSetValue");
+  MultiMooseEnum::erase(names);
+}
+
+void
 MultiMooseEnum::eraseSetValue(const std::set<std::string> & names)
 {
   removeSetValues(names.begin(), names.end());
+}
+
+void
+MultiMooseEnum::erase(const std::set<std::string> & names)
+{
+  mooseDeprecated("MultiMooseEnum::erase is deprecated, use MultiMooseEnum::eraseSetValue");
+  MultiMooseEnum::erase(names);
 }
 
 void
@@ -164,9 +187,25 @@ MultiMooseEnum::setAdditionalValue(const std::string & names)
 }
 
 void
+MultiMooseEnum::push_back(const std::string & names)
+{
+  mooseDeprecated(
+      "MultiMooseEnum::push_back is deprecated, use MultiMooseEnum::setAdditionalValue");
+  MultiMooseEnum::setAdditionalValue(names);
+}
+
+void
 MultiMooseEnum::setAdditionalValue(const std::vector<std::string> & names)
 {
   assignValues(names.begin(), names.end(), true);
+}
+
+void
+MultiMooseEnum::push_back(const std::vector<std::string> & names)
+{
+  mooseDeprecated(
+      "MultiMooseEnum::push_back is deprecated, use MultiMooseEnum::setAdditionalValue");
+  MultiMooseEnum::setAdditionalValue(names);
 }
 
 void
@@ -176,9 +215,25 @@ MultiMooseEnum::setAdditionalValue(const std::set<std::string> & names)
 }
 
 void
+MultiMooseEnum::push_back(const std::set<std::string> & names)
+{
+  mooseDeprecated(
+      "MultiMooseEnum::push_back is deprecated, use MultiMooseEnum::setAdditionalValue");
+  MultiMooseEnum::setAdditionalValue(names);
+}
+
+void
 MultiMooseEnum::setAdditionalValue(const MultiMooseEnum & other_enum)
 {
   assignValues(other_enum.begin(), other_enum.end(), true);
+}
+
+void
+MultiMooseEnum::push_back(const MultiMooseEnum & other_enum)
+{
+  mooseDeprecated(
+      "MultiMooseEnum::push_back is deprecated, use MultiMooseEnum::setAdditionalValue");
+  MultiMooseEnum::setAdditionalValue(other_enum);
 }
 
 const std::string &
@@ -255,6 +310,13 @@ MultiMooseEnum::clearSetValues()
   _current_values.clear();
 }
 
+void
+MultiMooseEnum::clear()
+{
+  mooseDeprecated("MultiMooseEnum::clear is deprecated, use MultiMooseEnum::clearSetValues");
+  clearSetValues();
+}
+
 unsigned int
 MultiMooseEnum::size() const
 {
@@ -273,4 +335,32 @@ operator<<(std::ostream & out, const MultiMooseEnum & obj)
 {
   out << Moose::stringify(obj._current_values, " ");
   return out;
+}
+
+void
+MultiMooseEnum::addValidName(const std::string & name)
+{
+  addEnumerationName(name);
+  checkDeprecated();
+}
+
+MooseEnumBase &
+MultiMooseEnum::operator+=(const std::string & name)
+{
+  mooseDeprecated("MultiMooseEnum::operator+= is deprecated, use MultiMooseEnum::addValidName");
+  return MooseEnumBase::operator+=(name);
+}
+
+void
+MultiMooseEnum::addValidName(const std::initializer_list<std::string> & names)
+{
+  for (const auto & name : names)
+    addValidName(name);
+}
+
+MooseEnumBase &
+MultiMooseEnum::operator+=(const std::initializer_list<std::string> & names)
+{
+  mooseDeprecated("MultiMooseEnum::operator+= is deprecated, use MultiMooseEnum::addValidName");
+  return MooseEnumBase::operator+=(names);
 }

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -28,7 +28,7 @@ MultiMooseEnum::MultiMooseEnum(std::string names,
 }
 
 MultiMooseEnum::MultiMooseEnum(const MultiMooseEnum & other_enum)
-  : MooseEnumBase(other_enum), _current(other_enum._current)
+  : MooseEnumBase(other_enum), _current_values(other_enum._current_values)
 {
 }
 
@@ -60,34 +60,34 @@ MultiMooseEnum::operator!=(const MultiMooseEnum & value) const
 bool
 MultiMooseEnum::contains(const std::string & value) const
 {
-  return std::find_if(_current.begin(),
-                      _current.end(),
+  return std::find_if(_current_values.begin(),
+                      _current_values.end(),
                       [&value](const MooseEnumItem & item)
-                      { return item == value; }) != _current.end();
+                      { return item == value; }) != _current_values.end();
 }
 
 bool
 MultiMooseEnum::contains(int value) const
 {
-  return std::find_if(_current.begin(),
-                      _current.end(),
+  return std::find_if(_current_values.begin(),
+                      _current_values.end(),
                       [&value](const MooseEnumItem & item)
-                      { return item == value; }) != _current.end();
+                      { return item == value; }) != _current_values.end();
 }
 
 bool
 MultiMooseEnum::contains(unsigned short value) const
 {
-  return std::find_if(_current.begin(),
-                      _current.end(),
+  return std::find_if(_current_values.begin(),
+                      _current_values.end(),
                       [&value](const MooseEnumItem & item)
-                      { return item == value; }) != _current.end();
+                      { return item == value; }) != _current_values.end();
 }
 
 bool
 MultiMooseEnum::contains(const MultiMooseEnum & value) const
 {
-  for (const auto & item : value._current)
+  for (const auto & item : value._current_values)
     if (!contains(item))
       return false;
   return true;
@@ -96,10 +96,10 @@ MultiMooseEnum::contains(const MultiMooseEnum & value) const
 bool
 MultiMooseEnum::contains(const MooseEnumItem & value) const
 {
-  return std::find_if(_current.begin(),
-                      _current.end(),
+  return std::find_if(_current_values.begin(),
+                      _current_values.end(),
                       [&value](const MooseEnumItem & item)
-                      { return item == value; }) != _current.end();
+                      { return item == value; }) != _current_values.end();
 }
 
 MultiMooseEnum &
@@ -171,21 +171,21 @@ MultiMooseEnum::push_back(const MultiMooseEnum & other_enum)
 const std::string &
 MultiMooseEnum::operator[](unsigned int i) const
 {
-  mooseAssert(i < _current.size(),
-              "Access out of bounds in MultiMooseEnum (i: " << i << " size: " << _current.size()
-                                                            << ")");
+  mooseAssert(i < _current_values.size(),
+              "Access out of bounds in MultiMooseEnum (i: " << i << " size: "
+                                                            << _current_values.size() << ")");
 
-  return _current[i].rawName();
+  return _current_values[i].rawName();
 }
 
 unsigned int
 MultiMooseEnum::get(unsigned int i) const
 {
-  mooseAssert(i < _current.size(),
-              "Access out of bounds in MultiMooseEnum (i: " << i << " size: " << _current.size()
-                                                            << ")");
+  mooseAssert(i < _current_values.size(),
+              "Access out of bounds in MultiMooseEnum (i: " << i << " size: "
+                                                            << _current_values.size() << ")");
 
-  return _current[i].id();
+  return _current_values[i].id();
 }
 
 template <typename InputIterator>
@@ -210,11 +210,11 @@ MultiMooseEnum::assign(InputIterator first, InputIterator last, bool append)
       {
         MooseEnumItem created(*it, getNextValidID());
         addEnumerationItem(created);
-        _current.push_back(created);
+        _current_values.push_back(created);
       }
     }
     else
-      _current.push_back(*iter);
+      _current_values.push_back(*iter);
   }
   checkDeprecated();
   return *this;
@@ -227,35 +227,37 @@ MultiMooseEnum::remove(InputIterator first, InputIterator last)
   // Create a new list of enumerations by striping out the supplied values
   for (InputIterator it = first; it != last; ++it)
   {
-    std::vector<MooseEnumItem>::iterator iter = std::find_if(
-        _current.begin(), _current.end(), [it](const MooseEnumItem & item) { return item == *it; });
-    if (iter != _current.end())
-      _current.erase(iter);
+    std::vector<MooseEnumItem>::iterator iter =
+        std::find_if(_current_values.begin(),
+                     _current_values.end(),
+                     [it](const MooseEnumItem & item) { return item == *it; });
+    if (iter != _current_values.end())
+      _current_values.erase(iter);
   }
 }
 
 void
 MultiMooseEnum::clear()
 {
-  _current.clear();
+  _current_values.clear();
 }
 
 unsigned int
 MultiMooseEnum::size() const
 {
-  return _current.size();
+  return _current_values.size();
 }
 
 void
 MultiMooseEnum::checkDeprecated() const
 {
-  for (const auto & item : _current)
+  for (const auto & item : _current_values)
     MooseEnumBase::checkDeprecated(item);
 }
 
 std::ostream &
 operator<<(std::ostream & out, const MultiMooseEnum & obj)
 {
-  out << Moose::stringify(obj._current, " ");
+  out << Moose::stringify(obj._current_values, " ");
   return out;
 }

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -27,6 +27,19 @@ MultiMooseEnum::MultiMooseEnum(std::string valid_names,
   *this = initialization_values;
 }
 
+MultiMooseEnum::MultiMooseEnum(std::string valid_names,
+                               const char * initialization_values,
+                               bool allow_out_of_range)
+  : MultiMooseEnum(valid_names, std::string(initialization_values), allow_out_of_range)
+{
+}
+
+MultiMooseEnum::MultiMooseEnum(std::string valid_names, bool allow_out_of_range)
+  // Set default variable value to nothing ("")
+  : MultiMooseEnum(valid_names, "", allow_out_of_range)
+{
+}
+
 MultiMooseEnum::MultiMooseEnum(const MultiMooseEnum & other_enum)
   : MooseEnumBase(other_enum), _current_values(other_enum._current_values)
 {

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -19,12 +19,12 @@
 #include <string>
 #include <iostream>
 
-MultiMooseEnum::MultiMooseEnum(std::string names,
-                               std::string default_names,
+MultiMooseEnum::MultiMooseEnum(std::string valid_names,
+                               std::string initialization_values,
                                bool allow_out_of_range)
-  : MooseEnumBase(names, allow_out_of_range)
+  : MooseEnumBase(valid_names, allow_out_of_range)
 {
-  *this = default_names;
+  *this = initialization_values;
 }
 
 MultiMooseEnum::MultiMooseEnum(const MultiMooseEnum & other_enum)
@@ -107,65 +107,65 @@ MultiMooseEnum::operator=(const std::string & names)
 {
   std::vector<std::string> names_vector;
   MooseUtils::tokenize(names, names_vector, 1, " ");
-  return assign(names_vector.begin(), names_vector.end(), false);
+  return assignValues(names_vector.begin(), names_vector.end(), false);
 }
 
 MultiMooseEnum &
 MultiMooseEnum::operator=(const std::vector<std::string> & names)
 {
-  return assign(names.begin(), names.end(), false);
+  return assignValues(names.begin(), names.end(), false);
 }
 
 MultiMooseEnum &
 MultiMooseEnum::operator=(const std::set<std::string> & names)
 {
-  return assign(names.begin(), names.end(), false);
+  return assignValues(names.begin(), names.end(), false);
 }
 
 void
-MultiMooseEnum::erase(const std::string & names)
+MultiMooseEnum::eraseSetValue(const std::string & names)
 {
   std::vector<std::string> names_vector;
   MooseUtils::tokenize(names, names_vector, 1, " ");
-  remove(names_vector.begin(), names_vector.end());
+  removeSetValues(names_vector.begin(), names_vector.end());
 }
 
 void
-MultiMooseEnum::erase(const std::vector<std::string> & names)
+MultiMooseEnum::eraseSetValue(const std::vector<std::string> & names)
 {
-  remove(names.begin(), names.end());
+  removeSetValues(names.begin(), names.end());
 }
 
 void
-MultiMooseEnum::erase(const std::set<std::string> & names)
+MultiMooseEnum::eraseSetValue(const std::set<std::string> & names)
 {
-  remove(names.begin(), names.end());
+  removeSetValues(names.begin(), names.end());
 }
 
 void
-MultiMooseEnum::push_back(const std::string & names)
+MultiMooseEnum::setAdditionalValue(const std::string & names)
 {
   std::vector<std::string> names_vector;
   MooseUtils::tokenize(names, names_vector, 1, " ");
-  assign(names_vector.begin(), names_vector.end(), true);
+  assignValues(names_vector.begin(), names_vector.end(), true);
 }
 
 void
-MultiMooseEnum::push_back(const std::vector<std::string> & names)
+MultiMooseEnum::setAdditionalValue(const std::vector<std::string> & names)
 {
-  assign(names.begin(), names.end(), true);
+  assignValues(names.begin(), names.end(), true);
 }
 
 void
-MultiMooseEnum::push_back(const std::set<std::string> & names)
+MultiMooseEnum::setAdditionalValue(const std::set<std::string> & names)
 {
-  assign(names.begin(), names.end(), true);
+  assignValues(names.begin(), names.end(), true);
 }
 
 void
-MultiMooseEnum::push_back(const MultiMooseEnum & other_enum)
+MultiMooseEnum::setAdditionalValue(const MultiMooseEnum & other_enum)
 {
-  assign(other_enum.begin(), other_enum.end(), true);
+  assignValues(other_enum.begin(), other_enum.end(), true);
 }
 
 const std::string &
@@ -190,10 +190,10 @@ MultiMooseEnum::get(unsigned int i) const
 
 template <typename InputIterator>
 MultiMooseEnum &
-MultiMooseEnum::assign(InputIterator first, InputIterator last, bool append)
+MultiMooseEnum::assignValues(InputIterator first, InputIterator last, bool append)
 {
   if (!append)
-    clear();
+    clearSetValues();
 
   for (InputIterator it = first; it != last; ++it)
   {
@@ -222,7 +222,7 @@ MultiMooseEnum::assign(InputIterator first, InputIterator last, bool append)
 
 template <typename InputIterator>
 void
-MultiMooseEnum::remove(InputIterator first, InputIterator last)
+MultiMooseEnum::removeSetValues(InputIterator first, InputIterator last)
 {
   // Create a new list of enumerations by striping out the supplied values
   for (InputIterator it = first; it != last; ++it)
@@ -237,7 +237,7 @@ MultiMooseEnum::remove(InputIterator first, InputIterator last)
 }
 
 void
-MultiMooseEnum::clear()
+MultiMooseEnum::clearSetValues()
 {
   _current_values.clear();
 }

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -651,7 +651,7 @@ processPetscFlags(const MultiMooseEnum & petsc_flags, PetscOptions & po)
 
     // Update the stored items, but do not create duplicates
     if (!po.flags.contains(option))
-      po.flags.push_back(option);
+      po.flags.setAdditionalValue(option);
   }
 }
 
@@ -1043,7 +1043,7 @@ disableNonlinearConvergedReason(FEProblemBase & fe_problem)
 {
   auto & petsc_options = fe_problem.getPetscOptions();
 
-  petsc_options.flags.erase("-snes_converged_reason");
+  petsc_options.flags.eraseSetValue("-snes_converged_reason");
 
   auto & pairs = petsc_options.pairs;
   auto it = MooseUtils::findPair(pairs, "-snes_converged_reason", MooseUtils::Any);
@@ -1056,7 +1056,7 @@ disableLinearConvergedReason(FEProblemBase & fe_problem)
 {
   auto & petsc_options = fe_problem.getPetscOptions();
 
-  petsc_options.flags.erase("-ksp_converged_reason");
+  petsc_options.flags.eraseSetValue("-ksp_converged_reason");
 
   auto & pairs = petsc_options.pairs;
   auto it = MooseUtils::findPair(pairs, "-ksp_converged_reason", MooseUtils::Any);

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -650,7 +650,7 @@ processPetscFlags(const MultiMooseEnum & petsc_flags, PetscOptions & po)
     }
 
     // Update the stored items, but do not create duplicates
-    if (!po.flags.contains(option))
+    if (!po.flags.isValueSet(option))
       po.flags.setAdditionalValue(option);
   }
 }
@@ -667,7 +667,7 @@ processPetscPairs(const std::vector<std::pair<MooseEnumItem, std::string>> & pet
        std::make_pair(false, "-ksp_converged_reason")}};
 
   for (auto & reason_flag : reason_flags)
-    if (po.flags.contains(reason_flag.second))
+    if (po.flags.isValueSet(reason_flag.second))
       // We register the reason option as already existing
       reason_flag.first = true;
 

--- a/modules/geochemistry/unit/src/GeochemicalSystemTest.C
+++ b/modules/geochemistry/unit/src/GeochemicalSystemTest.C
@@ -19,7 +19,7 @@ TEST_F(GeochemicalSystemTest, constructWithMultiMooseEnum)
       "activity bulk_composition bulk_composition free_concentration");
   MultiMooseEnum constraint_unit("dimensionless moles molal kg g mg ug kg_per_kg_solvent "
                                  "g_per_kg_solvent mg_per_kg_solvent ug_per_kg_solvent cm3");
-  constraint_unit.push_back("dimensionless moles moles molal");
+  constraint_unit.setAdditionalValue("dimensionless moles moles molal");
   ModelGeochemicalDatabase mgd_calcite2 = _model_calcite.modelGeochemicalDatabase();
   const GeochemicalSystem egs(mgd_calcite2,
                               _ac3,

--- a/modules/geochemistry/unit/src/GeochemicalSystemTest.C
+++ b/modules/geochemistry/unit/src/GeochemicalSystemTest.C
@@ -15,7 +15,7 @@ TEST_F(GeochemicalSystemTest, constructWithMultiMooseEnum)
   MultiMooseEnum constraint_user_meaning(
       "kg_solvent_water bulk_composition bulk_composition_with_kinetic free_concentration "
       "free_mineral activity log10activity fugacity log10fugacity");
-  constraint_user_meaning.push_back(
+  constraint_user_meaning.setAdditionalValue(
       "activity bulk_composition bulk_composition free_concentration");
   MultiMooseEnum constraint_unit("dimensionless moles molal kg g mg ug kg_per_kg_solvent "
                                  "g_per_kg_solvent mg_per_kg_solvent ug_per_kg_solvent cm3");

--- a/modules/heat_transfer/src/actions/RadiationTransferAction.C
+++ b/modules/heat_transfer/src/actions/RadiationTransferAction.C
@@ -49,7 +49,7 @@ RadiationTransferAction::validParams()
                                                      "Number of radiation patches per sideset.");
   MultiMooseEnum partitioning(
       "default=-3 metis=-2 parmetis=-1 linear=0 centroid hilbert_sfc morton_sfc", "default");
-  partitioning += "grid";
+  partitioning.addValidName("grid");
   params.addParam<MultiMooseEnum>(
       "partitioners",
       partitioning,
@@ -488,9 +488,9 @@ RadiationTransferAction::addMeshGenerator()
   MultiMooseEnum partitioners = getParam<MultiMooseEnum>("partitioners");
   if (!_pars.isParamSetByUser("partitioners"))
   {
-    partitioners.clear();
+    partitioners.clearSetValues();
     for (unsigned int j = 0; j < _boundary_names.size(); ++j)
-      partitioners.push_back("metis");
+      partitioners.setAdditionalValue("metis");
   }
 
   MultiMooseEnum direction = getParam<MultiMooseEnum>("centroid_partitioner_directions");

--- a/modules/navier_stokes/src/postprocessors/VolumetricFlowRate.C
+++ b/modules/navier_stokes/src/postprocessors/VolumetricFlowRate.C
@@ -101,7 +101,7 @@ VolumetricFlowRate::initialSetup()
     // - the time integrator is not ready to compute time derivatives
     // - the setup routine is called too early for porosity functions to be initialized
     // We must check that the boundaries requested are all external
-    if (getExecuteOnEnum().contains(EXEC_INITIAL))
+    if (getExecuteOnEnum().isValueSet(EXEC_INITIAL))
       for (const auto bid : boundaryIDs())
       {
         if (!_mesh.isBoundaryFullyExternalToSubdomains(bid, _rc_uo->blockIDs()))

--- a/modules/navier_stokes/src/userobjects/NSPressurePin.C
+++ b/modules/navier_stokes/src/userobjects/NSPressurePin.C
@@ -77,7 +77,7 @@ NSPressurePin::initialSetup()
   if (_pressure_pin_type == "average" &&
       !_fe_problem.getUserObjectBase(getParam<PostprocessorName>("pressure_average"))
            .getExecuteOnEnum()
-           .contains(getExecuteOnEnum()))
+           .isValueSet(getExecuteOnEnum()))
     paramError("pressure_average",
                "Pressure average postprocessor must include the pin execute_on flags");
 }

--- a/modules/navier_stokes/src/userobjects/PINSFVRhieChowInterpolator.C
+++ b/modules/navier_stokes/src/userobjects/PINSFVRhieChowInterpolator.C
@@ -22,7 +22,7 @@ PINSFVRhieChowInterpolator::validParams()
   params.addClassDescription("Performs interpolations and reconstructions of porosity and computes "
                              "the Rhie-Chow face velocities.");
   ExecFlagEnum & exec_enum = params.set<ExecFlagEnum>("execute_on", /*quiet=*/true);
-  exec_enum.push_back(EXEC_INITIAL);
+  exec_enum.setAdditionalValue(EXEC_INITIAL);
   params.addRequiredParam<MooseFunctorName>(NS::porosity, "The porosity");
   params.addParam<unsigned short>(
       "smoothing_layers",

--- a/modules/optimization/include/reporters/OptimizationInfo.h
+++ b/modules/optimization/include/reporters/OptimizationInfo.h
@@ -48,7 +48,7 @@ template <typename T>
 T &
 OptimizationInfo::declareHelper(const std::string & item_name, const ReporterMode mode)
 {
-  if (!_items.isValid() || _items.contains(item_name))
+  if (!_items.isValid() || _items.isValueSet(item_name))
   {
     return declareValueByName<T>(item_name, mode);
   }

--- a/modules/optimization/src/executioners/OptimizeSolve.C
+++ b/modules/optimization/src/executioners/OptimizeSolve.C
@@ -436,7 +436,7 @@ OptimizeSolve::objectiveFunction()
     _problem.outputStep(OptimizationAppTypes::EXEC_FORWARD);
     mooseError("Forward solve multiapp failed!");
   }
-  if (_solve_on.contains(OptimizationAppTypes::EXEC_FORWARD))
+  if (_solve_on.isValueSet(OptimizationAppTypes::EXEC_FORWARD))
     _inner_solve->solve();
 
   _obj_iterate++;
@@ -454,7 +454,7 @@ OptimizeSolve::gradientFunction(libMesh::PetscVector<Number> & gradient)
   _problem.restoreMultiApps(OptimizationAppTypes::EXEC_ADJOINT);
   if (!_problem.execMultiApps(OptimizationAppTypes::EXEC_ADJOINT))
     mooseError("Adjoint solve multiapp failed!");
-  if (_solve_on.contains(OptimizationAppTypes::EXEC_ADJOINT))
+  if (_solve_on.isValueSet(OptimizationAppTypes::EXEC_ADJOINT))
     _inner_solve->solve();
 
   _grad_iterate++;
@@ -480,7 +480,7 @@ OptimizeSolve::applyHessian(libMesh::PetscVector<Number> & s, libMesh::PetscVect
   _problem.restoreMultiApps(OptimizationAppTypes::EXEC_HOMOGENEOUS_FORWARD);
   if (!_problem.execMultiApps(OptimizationAppTypes::EXEC_HOMOGENEOUS_FORWARD))
     mooseError("Homogeneous forward solve multiapp failed!");
-  if (_solve_on.contains(OptimizationAppTypes::EXEC_HOMOGENEOUS_FORWARD))
+  if (_solve_on.isValueSet(OptimizationAppTypes::EXEC_HOMOGENEOUS_FORWARD))
     _inner_solve->solve();
 
   _obj_function->setMisfitToSimulatedValues();
@@ -490,7 +490,7 @@ OptimizeSolve::applyHessian(libMesh::PetscVector<Number> & s, libMesh::PetscVect
   _problem.restoreMultiApps(OptimizationAppTypes::EXEC_ADJOINT);
   if (!_problem.execMultiApps(OptimizationAppTypes::EXEC_ADJOINT))
     mooseError("Adjoint solve multiapp failed!");
-  if (_solve_on.contains(OptimizationAppTypes::EXEC_ADJOINT))
+  if (_solve_on.isValueSet(OptimizationAppTypes::EXEC_ADJOINT))
     _inner_solve->solve();
 
   _obj_function->computeGradient(Hs);

--- a/modules/optimization/src/reporters/OptimizationInfo.C
+++ b/modules/optimization/src/reporters/OptimizationInfo.C
@@ -38,19 +38,19 @@ OptimizationInfo::OptimizationInfo(const InputParameters & parameters)
     _xdiff(declareHelper<std::vector<double>>("xdiff", REPORTER_MODE_REPLICATED)),
     _currentIterate(declareHelper<std::vector<int>>("current_iterate", REPORTER_MODE_REPLICATED)),
     _objectiveIterate(
-        (!_items.isValid() || _items.contains("current_iterate"))
+        (!_items.isValid() || _items.isValueSet("current_iterate"))
             ? declareValueByName<std::vector<int>>("objective_iterate", REPORTER_MODE_REPLICATED)
             : declareUnusedValue<std::vector<int>>()),
     _gradientIterate(
-        (!_items.isValid() || _items.contains("current_iterate"))
+        (!_items.isValid() || _items.isValueSet("current_iterate"))
             ? declareValueByName<std::vector<int>>("gradient_iterate", REPORTER_MODE_REPLICATED)
             : declareUnusedValue<std::vector<int>>()),
     _hessianIterate(
-        (!_items.isValid() || _items.contains("current_iterate"))
+        (!_items.isValid() || _items.isValueSet("current_iterate"))
             ? declareValueByName<std::vector<int>>("hessian_iterate", REPORTER_MODE_REPLICATED)
             : declareUnusedValue<std::vector<int>>()),
     _functionSolves(
-        (!_items.isValid() || _items.contains("current_iterate"))
+        (!_items.isValid() || _items.isValueSet("current_iterate"))
             ? declareValueByName<std::vector<int>>("function_solves", REPORTER_MODE_REPLICATED)
             : declareUnusedValue<std::vector<int>>())
 {

--- a/modules/porous_flow/src/userobjects/AdvectiveFluxCalculatorBase.C
+++ b/modules/porous_flow/src/userobjects/AdvectiveFluxCalculatorBase.C
@@ -66,7 +66,7 @@ AdvectiveFluxCalculatorBase::AdvectiveFluxCalculatorBase(const InputParameters &
     _pairs_to_send(),
     _allowable_MB_wastage(getParam<Real>("allowable_MB_wastage"))
 {
-  if (!_execute_enum.contains(EXEC_LINEAR))
+  if (!_execute_enum.isValueSet(EXEC_LINEAR))
     paramError(
         "execute_on",
         "The AdvectiveFluxCalculator UserObject " + name() +

--- a/modules/ray_tracing/src/userobjects/RayTracingStudy.C
+++ b/modules/ray_tracing/src/userobjects/RayTracingStudy.C
@@ -193,7 +193,7 @@ RayTracingStudy::RayTracingStudy(const InputParameters & parameters)
   }
 
   // Evaluating on residual and Jacobian evaluation
-  if (_execute_enum.contains(EXEC_PRE_KERNELS))
+  if (_execute_enum.isValueSet(EXEC_PRE_KERNELS))
   {
     if (_execute_enum.size() > 1)
       paramError("execute_on",
@@ -248,7 +248,7 @@ RayTracingStudy::initialSetup()
   std::vector<RayKernelBase *> ray_kernels;
   getRayKernels(ray_kernels, 0);
   for (const auto & rkb : ray_kernels)
-    if (dynamic_cast<RayKernel *>(rkb) && !_execute_enum.contains(EXEC_PRE_KERNELS))
+    if (dynamic_cast<RayKernel *>(rkb) && !_execute_enum.isValueSet(EXEC_PRE_KERNELS))
       mooseError("This study has RayKernel objects that contribute to residuals and Jacobians.",
                  "\nIn this case, the study must use the execute_on = PRE_KERNELS");
 

--- a/modules/solid_mechanics/src/actions/CohesiveZoneAction.C
+++ b/modules/solid_mechanics/src/actions/CohesiveZoneAction.C
@@ -239,7 +239,7 @@ CohesiveZoneAction::verifyOrderAndFamilyOutputs()
 
   // if no value was provided, chose the default CONSTANT
   if (_material_output_order.size() == 0)
-    _material_output_order.push_back("CONSTANT");
+    _material_output_order.setAdditionalValue("CONSTANT");
 
   // For only one order, make all orders the same magnitude
   if (_material_output_order.size() == 1)
@@ -254,7 +254,7 @@ CohesiveZoneAction::verifyOrderAndFamilyOutputs()
 
   // if no value was provided, chose the default MONOMIAL
   if (_material_output_family.size() == 0)
-    _material_output_family.push_back("MONOMIAL");
+    _material_output_family.setAdditionalValue("MONOMIAL");
 
   // For only one family, make all families that value
   if (_material_output_family.size() == 1)

--- a/modules/solid_mechanics/src/actions/CohesiveZoneActionBase.C
+++ b/modules/solid_mechanics/src/actions/CohesiveZoneActionBase.C
@@ -125,11 +125,11 @@ CohesiveZoneActionBase::CohesiveZoneActionBase(const InputParameters & params) :
         getParam<MultiMooseEnum>("additional_material_output_family");
 
     for (auto & output : additional_generate_output)
-      generate_output.push_back(output);
+      generate_output.setAdditionalValue(output);
     for (auto & order : additional_material_output_order)
-      material_output_order.push_back(order);
+      material_output_order.setAdditionalValue(order);
     for (auto & family : additional_material_output_family)
-      material_output_family.push_back(family);
+      material_output_family.setAdditionalValue(family);
 
     pars.set<MultiMooseEnum>("generate_output") = generate_output;
     pars.set<MultiMooseEnum>("material_output_order") = material_output_order;

--- a/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
+++ b/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
@@ -772,7 +772,7 @@ QuasiStaticSolidMechanicsPhysics::verifyOrderAndFamilyOutputs()
 
   // if no value was provided, chose the default CONSTANT
   if (_material_output_order.size() == 0)
-    _material_output_order.push_back("CONSTANT");
+    _material_output_order.setAdditionalValue("CONSTANT");
 
   // For only one order, make all orders the same magnitude
   if (_material_output_order.size() == 1)
@@ -787,7 +787,7 @@ QuasiStaticSolidMechanicsPhysics::verifyOrderAndFamilyOutputs()
 
   // if no value was provided, chose the default MONOMIAL
   if (_material_output_family.size() == 0)
-    _material_output_family.push_back("MONOMIAL");
+    _material_output_family.setAdditionalValue("MONOMIAL");
 
   // For only one family, make all families that value
   if (_material_output_family.size() == 1)

--- a/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysicsBase.C
+++ b/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysicsBase.C
@@ -275,11 +275,11 @@ QuasiStaticSolidMechanicsPhysicsBase::QuasiStaticSolidMechanicsPhysicsBase(
         getParam<MultiMooseEnum>("additional_material_output_family");
 
     for (auto & output : additional_generate_output)
-      generate_output.push_back(output);
+      generate_output.setAdditionalValue(output);
     for (auto & order : additional_material_output_order)
-      material_output_order.push_back(order);
+      material_output_order.setAdditionalValue(order);
     for (auto & family : additional_material_output_family)
-      material_output_family.push_back(family);
+      material_output_family.setAdditionalValue(family);
 
     pars.set<MultiMooseEnum>("generate_output") = generate_output;
     pars.set<MultiMooseEnum>("material_output_order") = material_output_order;

--- a/modules/stochastic_tools/src/actions/ParameterStudyAction.C
+++ b/modules/stochastic_tools/src/actions/ParameterStudyAction.C
@@ -499,7 +499,7 @@ ParameterStudyAction::act()
     const auto & output = getParam<MultiMooseEnum>("output_type");
 
     // Add csv output
-    if (output.contains("csv"))
+    if (output.isValueSet("csv"))
     {
       auto params = _factory.getValidParams("CSV");
       params.set<ExecFlagEnum>("execute_on") = {EXEC_TIMESTEP_END};
@@ -509,7 +509,7 @@ ParameterStudyAction::act()
     }
 
     // Add json output
-    if (output.contains("json") || _compute_stats)
+    if (output.isValueSet("json") || _compute_stats)
     {
       auto params = _factory.getValidParams("JSON");
       params.set<ExecFlagEnum>("execute_on") = {EXEC_TIMESTEP_END};
@@ -556,11 +556,11 @@ ParameterStudyAction::act()
     // Specify output objects
     const auto & output_type = getParam<MultiMooseEnum>("output_type");
     auto & outputs = params.set<std::vector<OutputName>>("outputs");
-    if (output_type.contains("csv"))
+    if (output_type.isValueSet("csv"))
       outputs.push_back(outputName("csv"));
-    if (output_type.contains("json"))
+    if (output_type.isValueSet("json"))
       outputs.push_back(outputName("json"));
-    if (output_type.contains("none"))
+    if (output_type.isValueSet("none"))
       outputs = {"none"};
 
     params.set<ExecFlagEnum>("execute_on") = {EXEC_TIMESTEP_END};

--- a/modules/stochastic_tools/src/controls/MultiAppSamplerControl.C
+++ b/modules/stochastic_tools/src/controls/MultiAppSamplerControl.C
@@ -48,7 +48,7 @@ MultiAppSamplerControl::MultiAppSamplerControl(const InputParameters & parameter
     _sampler(SamplerInterface::getSampler("sampler")),
     _param_names(getParam<std::vector<std::string>>("param_names"))
 {
-  if (!_sampler.getParam<ExecFlagEnum>("execute_on").contains(EXEC_PRE_MULTIAPP_SETUP))
+  if (!_sampler.getParam<ExecFlagEnum>("execute_on").isValueSet(EXEC_PRE_MULTIAPP_SETUP))
     _sampler.paramError(
         "execute_on",
         "The sampler object, '",

--- a/modules/thermal_hydraulics/src/base/Simulation.C
+++ b/modules/thermal_hydraulics/src/base/Simulation.C
@@ -706,7 +706,7 @@ Simulation::setupCoordinateSystem()
       {
         blocks.push_back(subdomains[i]);
         // coord_types.push_back("XYZ");
-        coord_types.push_back(coord_sys[i] == Moose::COORD_RZ ? "RZ" : "XYZ");
+        coord_types.setAdditionalValue(coord_sys[i] == Moose::COORD_RZ ? "RZ" : "XYZ");
       }
     }
   }

--- a/unit/src/MooseEnumTest.C
+++ b/unit/src/MooseEnumTest.C
@@ -25,7 +25,7 @@ TEST(MooseEnum, multiTestOne)
   EXPECT_EQ(mme.contains("three"), false);
   EXPECT_EQ(mme.contains("four"), false);
 
-  mme.push_back("four");
+  mme.setAdditionalValue("four");
   EXPECT_EQ(mme.contains("one"), false);
   EXPECT_EQ(mme.contains("two"), true);
   EXPECT_EQ(mme.contains("three"), false);
@@ -34,10 +34,10 @@ TEST(MooseEnum, multiTestOne)
   // isValid
   EXPECT_EQ(mme.isValid(), true);
 
-  mme.clear();
+  mme.clearSetValues();
   EXPECT_EQ(mme.isValid(), false);
 
-  mme.push_back("one three");
+  mme.setAdditionalValue("one three");
   EXPECT_EQ(mme.contains("one"), true);
   EXPECT_EQ(mme.contains("two"), false);
   EXPECT_EQ(mme.contains("three"), true);
@@ -65,30 +65,30 @@ TEST(MooseEnum, multiTestOne)
   EXPECT_EQ(mme.contains("four"), false);
 
   // Insert
-  mme.push_back(mvec);
+  mme.setAdditionalValue(mvec);
   EXPECT_EQ(mme.contains("one"), true);
   EXPECT_EQ(mme.contains("two"), true);
   EXPECT_EQ(mme.contains("three"), true);
   EXPECT_EQ(mme.contains("four"), false);
 
   // Insert another valid multi-enum
-  mme.clear();
+  mme.clearSetValues();
   mme = "one four";
   MultiMooseEnum mme2("one two three four", "three");
-  mme.push_back(mme2);
+  mme.setAdditionalValue(mme2);
   EXPECT_EQ(mme.contains("one"), true);
   EXPECT_EQ(mme.contains("two"), false);
   EXPECT_EQ(mme.contains("three"), true);
   EXPECT_EQ(mme.contains("four"), true);
 
-  mme.clear();
+  mme.clearSetValues();
   mme = "one four";
   EXPECT_EQ(mme.contains("one"), true);
   EXPECT_EQ(mme.contains("two"), false);
   EXPECT_EQ(mme.contains("three"), false);
   EXPECT_EQ(mme.contains("four"), true);
 
-  mme.push_back("three four");
+  mme.setAdditionalValue("three four");
   EXPECT_EQ(mme.contains("one"), true);
   EXPECT_EQ(mme.contains("two"), false);
   EXPECT_EQ(mme.contains("three"), true);
@@ -114,7 +114,7 @@ TEST(MooseEnum, multiTestOne)
   EXPECT_EQ(difference.size(), 0);
 
   // Order and indexing
-  mme.clear();
+  mme.clearSetValues();
   mme = "one two four";
   EXPECT_EQ(mme.contains("three"), false);
 
@@ -157,7 +157,7 @@ TEST(MooseEnum, testDeprecate)
   {
     MultiMooseEnum mme("one too two three four");
     mme.deprecate("too", "two");
-    mme.push_back("one");
+    mme.setAdditionalValue("one");
     mme = "too";
     FAIL() << "missing expected error";
   }
@@ -369,25 +369,6 @@ TEST(MooseEnum, operatorEqual)
     ASSERT_NE(msg.find("Invalid id \"3\" in MooseEnum. Valid ids are \"1, 2\"."), std::string::npos)
         << "failed with unexpected error: " << msg;
   }
-}
-
-TEST(MooseEnum, operatorPlus)
-{
-  MooseEnum a("a=1 b=2", "a");
-  a += "c=3";
-  a += {"d=4", "e=5"};
-
-  MooseEnum b("a=1 b=2 c=3 d=4 e=5");
-
-  EXPECT_TRUE(a.items() == b.items());
-
-  MultiMooseEnum c("a=1 b=2", "a");
-  c += "c=3";
-  c += {"d=4", "e=5"};
-
-  MultiMooseEnum d("a=1 b=2 c=3 d=4 e=5");
-
-  EXPECT_TRUE(c.items() == d.items());
 }
 
 TEST(MooseEnum, getIDs)


### PR DESCRIPTION
Improves the documentation of the `MultiMooseEnum` class. The following attributes/methods are renamed:

`_current` -> `_current_values`
`erase` -> `eraseSetValue`
`push_back` -> `setAdditionalValue`
`getEnum` -> `getSetValueIDs`
`clear` -> `clearSetValues`
`assign` -> `assignValues`
`remove` -> `removeSetValues`
`operator+=` -> `addValidName`
`contains` -> `isValueSet`


Closes #28134.
