### PR TITLE
Add .git to saline URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,7 +14,7 @@
     update = none
 [submodule "modules/fluid_properties/contrib/saline"]
     path = modules/fluid_properties/contrib/saline
-    url = https://code.ornl.gov/neams/saline
+    url = https://code.ornl.gov/neams/saline.git
     update = none
 [submodule "framework/contrib/wasp"]
     path = framework/contrib/wasp


### PR DESCRIPTION
Without this you get warnings
```
Cloning into '/data/civet2/build/moose/modules/fluid_properties/contrib/saline'...
warning: redirecting to https://code.ornl.gov/neams/saline.git/
warning: redirecting to https://code.ornl.gov/neams/saline.git/
warning: redirecting to https://code.ornl.gov/neams/saline.git/
```
and I'm pretty sure this could have led to my horribly broken local moose repo