### PR TITLE
Prerequest curls whenever we `_need_curl`

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -1585,7 +1585,7 @@ public:
   template <typename OutputType>
   const typename OutputTools<OutputType>::VariablePhiSecond & feSecondPhi(FEType type) const
   {
-    _need_second_derivative[type] = true;
+    _need_second_derivative.insert(type);
     buildFE(type);
     return _fe_shape_data[type]->_second_phi;
   }
@@ -1626,7 +1626,7 @@ public:
   template <typename OutputType>
   const typename OutputTools<OutputType>::VariablePhiSecond & feSecondPhiFace(FEType type) const
   {
-    _need_second_derivative[type] = true;
+    _need_second_derivative.insert(type);
     buildFaceFE(type);
     return _fe_shape_data_face[type]->_second_phi;
   }
@@ -1648,7 +1648,7 @@ public:
   template <typename OutputType>
   const typename OutputTools<OutputType>::VariablePhiSecond & feSecondPhiNeighbor(FEType type) const
   {
-    _need_second_derivative_neighbor[type] = true;
+    _need_second_derivative_neighbor.insert(type);
     buildNeighborFE(type);
     return _fe_shape_data_neighbor[type]->_second_phi;
   }
@@ -1672,7 +1672,7 @@ public:
   const typename OutputTools<OutputType>::VariablePhiSecond &
   feSecondPhiFaceNeighbor(FEType type) const
   {
-    _need_second_derivative_neighbor[type] = true;
+    _need_second_derivative_neighbor.insert(type);
     buildFaceNeighborFE(type);
     return _fe_shape_data_face_neighbor[type]->_second_phi;
   }
@@ -1680,7 +1680,7 @@ public:
   template <typename OutputType>
   const typename OutputTools<OutputType>::VariablePhiCurl & feCurlPhi(FEType type) const
   {
-    _need_curl[type] = true;
+    _need_curl.insert(type);
     buildFE(type);
     return _fe_shape_data[type]->_curl_phi;
   }
@@ -1688,7 +1688,7 @@ public:
   template <typename OutputType>
   const typename OutputTools<OutputType>::VariablePhiCurl & feCurlPhiFace(FEType type) const
   {
-    _need_curl[type] = true;
+    _need_curl.insert(type);
     buildFaceFE(type);
     return _fe_shape_data_face[type]->_curl_phi;
   }
@@ -1696,7 +1696,7 @@ public:
   template <typename OutputType>
   const typename OutputTools<OutputType>::VariablePhiCurl & feCurlPhiNeighbor(FEType type) const
   {
-    _need_curl[type] = true;
+    _need_curl.insert(type);
     buildNeighborFE(type);
     return _fe_shape_data_neighbor[type]->_curl_phi;
   }
@@ -1704,7 +1704,7 @@ public:
   template <typename OutputType>
   const typename OutputTools<OutputType>::VariablePhiCurl & feCurlPhiFaceNeighbor(FEType type) const
   {
-    _need_curl[type] = true;
+    _need_curl.insert(type);
     buildFaceNeighborFE(type);
     return _fe_shape_data_face_neighbor[type]->_curl_phi;
   }
@@ -2809,13 +2809,13 @@ protected:
   /// adCoordTransformation()
   mutable bool _calculate_ad_coord;
 
-  mutable std::map<FEType, bool> _need_second_derivative;
-  mutable std::map<FEType, bool> _need_second_derivative_neighbor;
-  mutable std::map<FEType, bool> _need_curl;
-  mutable std::map<FEType, bool> _need_div;
-  mutable std::map<FEType, bool> _need_face_div;
-  mutable std::map<FEType, bool> _need_neighbor_div;
-  mutable std::map<FEType, bool> _need_face_neighbor_div;
+  mutable std::set<FEType> _need_second_derivative;
+  mutable std::set<FEType> _need_second_derivative_neighbor;
+  mutable std::set<FEType> _need_curl;
+  mutable std::set<FEType> _need_div;
+  mutable std::set<FEType> _need_face_div;
+  mutable std::set<FEType> _need_neighbor_div;
+  mutable std::set<FEType> _need_face_neighbor_div;
 
   /// The map from global index to variable scaling factor
   const NumericVector<Real> * _scaling_vector = nullptr;

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -470,7 +470,7 @@ Assembly::buildVectorFE(const FEType type) const
 
     _vector_fe[dim][type]->get_phi();
     _vector_fe[dim][type]->get_dphi();
-    if (type.family == NEDELEC_ONE)
+    if (_need_curl.count(type))
       _vector_fe[dim][type]->get_curl_phi();
     if (_need_div.count(type))
       _vector_fe[dim][type]->get_div_phi();
@@ -501,7 +501,7 @@ Assembly::buildVectorFaceFE(const FEType type) const
 
     _vector_fe_face[dim][type]->get_phi();
     _vector_fe_face[dim][type]->get_dphi();
-    if (type.family == NEDELEC_ONE)
+    if (_need_curl.count(type))
       _vector_fe_face[dim][type]->get_curl_phi();
     if (_need_face_div.count(type))
       _vector_fe_face[dim][type]->get_div_phi();
@@ -531,7 +531,7 @@ Assembly::buildVectorNeighborFE(const FEType type) const
 
     _vector_fe_neighbor[dim][type]->get_phi();
     _vector_fe_neighbor[dim][type]->get_dphi();
-    if (type.family == NEDELEC_ONE)
+    if (_need_curl.count(type))
       _vector_fe_neighbor[dim][type]->get_curl_phi();
     if (_need_neighbor_div.count(type))
       _vector_fe_neighbor[dim][type]->get_div_phi();
@@ -562,7 +562,7 @@ Assembly::buildVectorFaceNeighborFE(const FEType type) const
 
     _vector_fe_face_neighbor[dim][type]->get_phi();
     _vector_fe_face_neighbor[dim][type]->get_dphi();
-    if (type.family == NEDELEC_ONE)
+    if (_need_curl.count(type))
       _vector_fe_face_neighbor[dim][type]->get_curl_phi();
     if (_need_face_neighbor_div.count(type))
       _vector_fe_face_neighbor[dim][type]->get_div_phi();

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -4660,6 +4660,12 @@ Assembly::feSecondPhiFace<VectorValue<Real>>(FEType type) const
 {
   _need_second_derivative.insert(type);
   buildVectorFaceFE(type);
+
+  // If we're building for a face we probably need to build for a
+  // neighbor while _need_second_derivative is set;
+  // onInterface/reinitNeighbor/etc don't distinguish
+  buildVectorFaceNeighborFE(type);
+
   return _vector_fe_shape_data_face[type]->_second_phi;
 }
 
@@ -4728,6 +4734,12 @@ Assembly::feCurlPhiFace<VectorValue<Real>>(FEType type) const
 {
   _need_curl.insert(type);
   buildVectorFaceFE(type);
+
+  // If we're building for a face we probably need to build for a
+  // neighbor while _need_curl is set;
+  // onInterface/reinitNeighbor/etc don't distinguish
+  buildVectorFaceNeighborFE(type);
+
   return _vector_fe_shape_data_face[type]->_curl_phi;
 }
 
@@ -4746,6 +4758,7 @@ Assembly::feCurlPhiFaceNeighbor<VectorValue<Real>>(FEType type) const
 {
   _need_curl.insert(type);
   buildVectorFaceNeighborFE(type);
+
   return _vector_fe_shape_data_face_neighbor[type]->_curl_phi;
 }
 
@@ -4764,6 +4777,12 @@ Assembly::feDivPhiFace<VectorValue<Real>>(FEType type) const
 {
   _need_face_div.insert(type);
   buildVectorFaceFE(type);
+
+  // If we're building for a face we probably need to build for a
+  // neighbor while _need_face_div is set;
+  // onInterface/reinitNeighbor/etc don't distinguish
+  buildVectorFaceNeighborFE(type);
+
   return _vector_fe_shape_data_face[type]->_div_phi;
 }
 

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -281,7 +281,7 @@ Assembly::buildFE(FEType type) const
     // recent optimizations in libmesh, we now need to explicity
     // request it, since apps (Yak) may rely on it being computed.
     _fe[dim][type]->get_xyz();
-    if (_need_second_derivative.find(type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(type))
       _fe[dim][type]->get_d2phi();
   }
 }
@@ -303,7 +303,7 @@ Assembly::buildFaceFE(FEType type) const
 
     _fe_face[dim][type]->get_phi();
     _fe_face[dim][type]->get_dphi();
-    if (_need_second_derivative.find(type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(type))
       _fe_face[dim][type]->get_d2phi();
   }
 }
@@ -325,7 +325,7 @@ Assembly::buildNeighborFE(FEType type) const
 
     _fe_neighbor[dim][type]->get_phi();
     _fe_neighbor[dim][type]->get_dphi();
-    if (_need_second_derivative_neighbor.find(type) != _need_second_derivative_neighbor.end())
+    if (_need_second_derivative_neighbor.count(type))
       _fe_neighbor[dim][type]->get_d2phi();
   }
 }
@@ -347,7 +347,7 @@ Assembly::buildFaceNeighborFE(FEType type) const
 
     _fe_face_neighbor[dim][type]->get_phi();
     _fe_face_neighbor[dim][type]->get_dphi();
-    if (_need_second_derivative_neighbor.find(type) != _need_second_derivative_neighbor.end())
+    if (_need_second_derivative_neighbor.count(type))
       _fe_face_neighbor[dim][type]->get_d2phi();
   }
 }
@@ -371,7 +371,7 @@ Assembly::buildLowerDFE(FEType type) const
 
     _fe_lower[dim][type]->get_phi();
     _fe_lower[dim][type]->get_dphi();
-    if (_need_second_derivative.find(type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(type))
       _fe_lower[dim][type]->get_d2phi();
   }
 }
@@ -392,7 +392,7 @@ Assembly::buildLowerDDualFE(FEType type) const
 
     _fe_lower[dim][type]->get_dual_phi();
     _fe_lower[dim][type]->get_dual_dphi();
-    if (_need_second_derivative.find(type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(type))
       _fe_lower[dim][type]->get_dual_d2phi();
   }
 }
@@ -417,7 +417,7 @@ Assembly::buildVectorLowerDFE(FEType type) const
 
     _vector_fe_lower[dim][type]->get_phi();
     _vector_fe_lower[dim][type]->get_dphi();
-    if (_need_second_derivative.find(type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(type))
       _vector_fe_lower[dim][type]->get_d2phi();
   }
 }
@@ -442,7 +442,7 @@ Assembly::buildVectorDualLowerDFE(FEType type) const
 
     _vector_fe_lower[dim][type]->get_dual_phi();
     _vector_fe_lower[dim][type]->get_dual_dphi();
-    if (_need_second_derivative.find(type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(type))
       _vector_fe_lower[dim][type]->get_dual_d2phi();
   }
 }
@@ -461,9 +461,6 @@ Assembly::buildVectorFE(const FEType type) const
   else
     min_dim = 0;
 
-  const auto div_it = _need_div.find(type);
-  const bool need_div = (div_it != _need_div.end()) && div_it->second;
-
   // Build an FE object for this type for each dimension from the min_dim up to the dimension of the
   // current mesh
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
@@ -475,7 +472,7 @@ Assembly::buildVectorFE(const FEType type) const
     _vector_fe[dim][type]->get_dphi();
     if (type.family == NEDELEC_ONE)
       _vector_fe[dim][type]->get_curl_phi();
-    if (need_div)
+    if (_need_div.count(type))
       _vector_fe[dim][type]->get_div_phi();
     _vector_fe[dim][type]->get_xyz();
   }
@@ -495,9 +492,6 @@ Assembly::buildVectorFaceFE(const FEType type) const
   else
     min_dim = 0;
 
-  const auto div_it = _need_face_div.find(type);
-  const bool need_div = (div_it != _need_face_div.end()) && div_it->second;
-
   // Build an FE object for this type for each dimension from the min_dim up to the dimension of the
   // current mesh
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
@@ -509,7 +503,7 @@ Assembly::buildVectorFaceFE(const FEType type) const
     _vector_fe_face[dim][type]->get_dphi();
     if (type.family == NEDELEC_ONE)
       _vector_fe_face[dim][type]->get_curl_phi();
-    if (need_div)
+    if (_need_face_div.count(type))
       _vector_fe_face[dim][type]->get_div_phi();
   }
 }
@@ -528,9 +522,6 @@ Assembly::buildVectorNeighborFE(const FEType type) const
   else
     min_dim = 0;
 
-  const auto div_it = _need_neighbor_div.find(type);
-  const bool need_div = (div_it != _need_neighbor_div.end()) && div_it->second;
-
   // Build an FE object for this type for each dimension from the min_dim up to the dimension of the
   // current mesh
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
@@ -542,7 +533,7 @@ Assembly::buildVectorNeighborFE(const FEType type) const
     _vector_fe_neighbor[dim][type]->get_dphi();
     if (type.family == NEDELEC_ONE)
       _vector_fe_neighbor[dim][type]->get_curl_phi();
-    if (need_div)
+    if (_need_neighbor_div.count(type))
       _vector_fe_neighbor[dim][type]->get_div_phi();
   }
 }
@@ -561,9 +552,6 @@ Assembly::buildVectorFaceNeighborFE(const FEType type) const
   else
     min_dim = 0;
 
-  const auto div_it = _need_face_neighbor_div.find(type);
-  const bool need_div = (div_it != _need_face_neighbor_div.end()) && div_it->second;
-
   // Build an FE object for this type for each dimension from the min_dim up to the dimension of the
   // current mesh
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
@@ -576,7 +564,7 @@ Assembly::buildVectorFaceNeighborFE(const FEType type) const
     _vector_fe_face_neighbor[dim][type]->get_dphi();
     if (type.family == NEDELEC_ONE)
       _vector_fe_face_neighbor[dim][type]->get_curl_phi();
-    if (need_div)
+    if (_need_face_neighbor_div.count(type))
       _vector_fe_face_neighbor[dim][type]->get_div_phi();
   }
 }
@@ -785,7 +773,7 @@ Assembly::reinitFE(const Elem * elem)
     fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe.get_dphi()));
-    if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(fe_type))
       fesd._second_phi.shallowCopy(
           const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe.get_d2phi()));
   }
@@ -803,13 +791,13 @@ Assembly::reinitFE(const Elem * elem)
     fesd._phi.shallowCopy(const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe.get_dphi()));
-    if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(fe_type))
       fesd._second_phi.shallowCopy(
           const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe.get_d2phi()));
-    if (_need_curl.find(fe_type) != _need_curl.end())
+    if (_need_curl.count(fe_type))
       fesd._curl_phi.shallowCopy(
           const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe.get_curl_phi()));
-    if (_need_div.find(fe_type) != _need_div.end())
+    if (_need_div.count(fe_type))
       fesd._div_phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe.get_div_phi()));
   }
   if (!_unique_fe_helper.empty())
@@ -1286,7 +1274,7 @@ Assembly::reinitFEFace(const Elem * elem, unsigned int side)
     fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_face.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face.get_dphi()));
-    if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(fe_type))
       fesd._second_phi.shallowCopy(
           const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face.get_d2phi()));
   }
@@ -1305,13 +1293,13 @@ Assembly::reinitFEFace(const Elem * elem, unsigned int side)
         const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face.get_dphi()));
-    if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(fe_type))
       fesd._second_phi.shallowCopy(
           const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe_face.get_d2phi()));
-    if (_need_curl.find(fe_type) != _need_curl.end())
+    if (_need_curl.count(fe_type))
       fesd._curl_phi.shallowCopy(
           const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face.get_curl_phi()));
-    if (_need_face_div.find(fe_type) != _need_face_div.end())
+    if (_need_face_div.count(fe_type))
       fesd._div_phi.shallowCopy(
           const_cast<std::vector<std::vector<Real>> &>(fe_face.get_div_phi()));
   }
@@ -1589,7 +1577,7 @@ Assembly::reinitFEFaceNeighbor(const Elem * neighbor, const std::vector<Point> &
     fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_face_neighbor.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<RealGradient>> &>(fe_face_neighbor.get_dphi()));
-    if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
+    if (_need_second_derivative_neighbor.count(fe_type))
       fesd._second_phi.shallowCopy(
           const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor.get_d2phi()));
   }
@@ -1608,13 +1596,13 @@ Assembly::reinitFEFaceNeighbor(const Elem * neighbor, const std::vector<Point> &
         const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face_neighbor.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor.get_dphi()));
-    if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(fe_type))
       fesd._second_phi.shallowCopy(const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(
           fe_face_neighbor.get_d2phi()));
-    if (_need_curl.find(fe_type) != _need_curl.end())
+    if (_need_curl.count(fe_type))
       fesd._curl_phi.shallowCopy(const_cast<std::vector<std::vector<VectorValue<Real>>> &>(
           fe_face_neighbor.get_curl_phi()));
-    if (_need_face_neighbor_div.find(fe_type) != _need_face_neighbor_div.end())
+    if (_need_face_neighbor_div.count(fe_type))
       fesd._div_phi.shallowCopy(
           const_cast<std::vector<std::vector<Real>> &>(fe_face_neighbor.get_div_phi()));
   }
@@ -1648,7 +1636,7 @@ Assembly::reinitFENeighbor(const Elem * neighbor, const std::vector<Point> & ref
     fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_neighbor.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<RealGradient>> &>(fe_neighbor.get_dphi()));
-    if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
+    if (_need_second_derivative_neighbor.count(fe_type))
       fesd._second_phi.shallowCopy(
           const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_neighbor.get_d2phi()));
   }
@@ -1667,13 +1655,13 @@ Assembly::reinitFENeighbor(const Elem * neighbor, const std::vector<Point> & ref
         const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_neighbor.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_neighbor.get_dphi()));
-    if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(fe_type))
       fesd._second_phi.shallowCopy(
           const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe_neighbor.get_d2phi()));
-    if (_need_curl.find(fe_type) != _need_curl.end())
+    if (_need_curl.count(fe_type))
       fesd._curl_phi.shallowCopy(
           const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_neighbor.get_curl_phi()));
-    if (_need_neighbor_div.find(fe_type) != _need_neighbor_div.end())
+    if (_need_neighbor_div.count(fe_type))
       fesd._div_phi.shallowCopy(
           const_cast<std::vector<std::vector<Real>> &>(fe_neighbor.get_div_phi()));
   }
@@ -2063,7 +2051,7 @@ Assembly::reinitElemFaceRef(const Elem * elem,
     fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_face.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<RealGradient>> &>(fe_face.get_dphi()));
-    if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
+    if (_need_second_derivative_neighbor.count(fe_type))
       fesd._second_phi.shallowCopy(
           const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face.get_d2phi()));
   }
@@ -2082,13 +2070,13 @@ Assembly::reinitElemFaceRef(const Elem * elem,
         const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face.get_dphi()));
-    if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(fe_type))
       fesd._second_phi.shallowCopy(
           const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe_face.get_d2phi()));
-    if (_need_curl.find(fe_type) != _need_curl.end())
+    if (_need_curl.count(fe_type))
       fesd._curl_phi.shallowCopy(
           const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face.get_curl_phi()));
-    if (_need_face_div.find(fe_type) != _need_face_div.end())
+    if (_need_face_div.count(fe_type))
       fesd._div_phi.shallowCopy(
           const_cast<std::vector<std::vector<Real>> &>(fe_face.get_div_phi()));
   }
@@ -2231,7 +2219,7 @@ Assembly::reinitNeighborFaceRef(const Elem * neighbor,
     fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_face_neighbor.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<RealGradient>> &>(fe_face_neighbor.get_dphi()));
-    if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
+    if (_need_second_derivative_neighbor.count(fe_type))
       fesd._second_phi.shallowCopy(
           const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor.get_d2phi()));
   }
@@ -2250,13 +2238,13 @@ Assembly::reinitNeighborFaceRef(const Elem * neighbor,
         const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face_neighbor.get_phi()));
     fesd._grad_phi.shallowCopy(
         const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor.get_dphi()));
-    if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
+    if (_need_second_derivative.count(fe_type))
       fesd._second_phi.shallowCopy(const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(
           fe_face_neighbor.get_d2phi()));
-    if (_need_curl.find(fe_type) != _need_curl.end())
+    if (_need_curl.count(fe_type))
       fesd._curl_phi.shallowCopy(const_cast<std::vector<std::vector<VectorValue<Real>>> &>(
           fe_face_neighbor.get_curl_phi()));
-    if (_need_face_neighbor_div.find(fe_type) != _need_face_neighbor_div.end())
+    if (_need_face_neighbor_div.count(fe_type))
       fesd._div_phi.shallowCopy(
           const_cast<std::vector<std::vector<Real>> &>(fe_face_neighbor.get_div_phi()));
   }
@@ -2330,7 +2318,7 @@ Assembly::reinitLowerDElem(const Elem * elem,
       fesd->_phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_lower.get_phi()));
       fesd->_grad_phi.shallowCopy(
           const_cast<std::vector<std::vector<RealGradient>> &>(fe_lower.get_dphi()));
-      if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
+      if (_need_second_derivative_neighbor.count(fe_type))
         fesd->_second_phi.shallowCopy(
             const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_lower.get_d2phi()));
     }
@@ -2341,7 +2329,7 @@ Assembly::reinitLowerDElem(const Elem * elem,
       fesd->_phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_lower.get_dual_phi()));
       fesd->_grad_phi.shallowCopy(
           const_cast<std::vector<std::vector<RealGradient>> &>(fe_lower.get_dual_dphi()));
-      if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
+      if (_need_second_derivative_neighbor.count(fe_type))
         fesd->_second_phi.shallowCopy(
             const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_lower.get_dual_d2phi()));
     }
@@ -4613,7 +4601,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiSecond &
 Assembly::feSecondPhi<VectorValue<Real>>(FEType type) const
 {
-  _need_second_derivative[type] = true;
+  _need_second_derivative.insert(type);
   buildVectorFE(type);
   return _vector_fe_shape_data[type]->_second_phi;
 }
@@ -4670,7 +4658,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiSecond &
 Assembly::feSecondPhiFace<VectorValue<Real>>(FEType type) const
 {
-  _need_second_derivative[type] = true;
+  _need_second_derivative.insert(type);
   buildVectorFaceFE(type);
   return _vector_fe_shape_data_face[type]->_second_phi;
 }
@@ -4695,7 +4683,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiSecond &
 Assembly::feSecondPhiNeighbor<VectorValue<Real>>(FEType type) const
 {
-  _need_second_derivative_neighbor[type] = true;
+  _need_second_derivative_neighbor.insert(type);
   buildVectorNeighborFE(type);
   return _vector_fe_shape_data_neighbor[type]->_second_phi;
 }
@@ -4720,7 +4708,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiSecond &
 Assembly::feSecondPhiFaceNeighbor<VectorValue<Real>>(FEType type) const
 {
-  _need_second_derivative_neighbor[type] = true;
+  _need_second_derivative_neighbor.insert(type);
   buildVectorFaceNeighborFE(type);
   return _vector_fe_shape_data_face_neighbor[type]->_second_phi;
 }
@@ -4729,7 +4717,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiCurl &
 Assembly::feCurlPhi<VectorValue<Real>>(FEType type) const
 {
-  _need_curl[type] = true;
+  _need_curl.insert(type);
   buildVectorFE(type);
   return _vector_fe_shape_data[type]->_curl_phi;
 }
@@ -4738,7 +4726,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiCurl &
 Assembly::feCurlPhiFace<VectorValue<Real>>(FEType type) const
 {
-  _need_curl[type] = true;
+  _need_curl.insert(type);
   buildVectorFaceFE(type);
   return _vector_fe_shape_data_face[type]->_curl_phi;
 }
@@ -4747,7 +4735,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiCurl &
 Assembly::feCurlPhiNeighbor<VectorValue<Real>>(FEType type) const
 {
-  _need_curl[type] = true;
+  _need_curl.insert(type);
   buildVectorNeighborFE(type);
   return _vector_fe_shape_data_neighbor[type]->_curl_phi;
 }
@@ -4756,7 +4744,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiCurl &
 Assembly::feCurlPhiFaceNeighbor<VectorValue<Real>>(FEType type) const
 {
-  _need_curl[type] = true;
+  _need_curl.insert(type);
   buildVectorFaceNeighborFE(type);
   return _vector_fe_shape_data_face_neighbor[type]->_curl_phi;
 }
@@ -4765,7 +4753,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiDivergence &
 Assembly::feDivPhi<VectorValue<Real>>(FEType type) const
 {
-  _need_div[type] = true;
+  _need_div.insert(type);
   buildVectorFE(type);
   return _vector_fe_shape_data[type]->_div_phi;
 }
@@ -4774,7 +4762,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiDivergence &
 Assembly::feDivPhiFace<VectorValue<Real>>(FEType type) const
 {
-  _need_face_div[type] = true;
+  _need_face_div.insert(type);
   buildVectorFaceFE(type);
   return _vector_fe_shape_data_face[type]->_div_phi;
 }
@@ -4783,7 +4771,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiDivergence &
 Assembly::feDivPhiNeighbor<VectorValue<Real>>(FEType type) const
 {
-  _need_neighbor_div[type] = true;
+  _need_neighbor_div.insert(type);
   buildVectorNeighborFE(type);
   return _vector_fe_shape_data_neighbor[type]->_div_phi;
 }
@@ -4792,7 +4780,7 @@ template <>
 const typename OutputTools<VectorValue<Real>>::VariablePhiDivergence &
 Assembly::feDivPhiFaceNeighbor<VectorValue<Real>>(FEType type) const
 {
-  _need_face_neighbor_div[type] = true;
+  _need_face_neighbor_div.insert(type);
   buildVectorFaceNeighborFE(type);
   return _vector_fe_shape_data_face_neighbor[type]->_div_phi;
 }


### PR DESCRIPTION
## Reason
While investigating #28153 I found that, although I couldn't replicate that exact bug in a recent MOOSE, there was a similar bug that could be triggered when using kernels that require curls vs divs.

## Design
Use `_need_curl` where appropriate, don't just hard-code that `NEDELEC_ONE` always needs kernels and other FE types always don't.

While I was at it I also turned those `map`s-to-`true` into `set`s, because that's an isomorphism and the code looks a lot cleaner afterward.

## Impact
If I didn't make any typos (and I tried to use regexps as much as possible to avoid that) and if we don't have any bugs in curl-based kernels, this shouldn't affect any already-working cases' results.  Anyone using `NEDELEC_ONE` with kernels that don't need curl should get a faster runtime.  Anyone using kernels that need curl with other vector FE types should see their code stop failing assertions in `devel` and segfaulting in `opt`.