### PR TITLE
Set vscode intellisense database to a location in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,6 @@ share/
 /modules/misc/misc.yaml
 /tutorials/tutorial01_app_development/*/babbler.yaml
 /tutorials/darcy_thermo_mech/*/darcy_thermo_mech.yaml
+
+# Intellisense database
+/.vscode/cpp_intellisense.db*

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -2,6 +2,7 @@
     "configurations": [
         {
             "name": "Apptainer moose-dev",
+            "browse": {"databaseFilename": "${workspaceFolder}/.vscode/cpp_intellisense.db"},
             "includePath": [
                 "${workspaceFolder}/**",
                 "/opt/libmesh/include/**",

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 /conda @loganharbour @milljm @cticenhour
+/.vscode @loganharbour
 /docker_ci @loganharbour
 /m4 @lindsayad
 


### PR DESCRIPTION
This could potentially speed up intellisense on systems where HOME is very slow and the repo is in a faster location.

Closes #28179