### PR TITLE
Libmesh submodule update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2024.07.18" %}
+{% set version = "2024.07.27" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2024.07.18 mpich_0
-  - moose-libmesh 2024.07.18 openmpi_0
+  - moose-libmesh 2024.07.27 mpich_0
+  - moose-libmesh 2024.07.27 openmpi_0
 
 moose_wasp:
   - moose-wasp 2024.05.08

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -6,7 +6,7 @@
 #   framework/doc/packages_config.yml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.07.19" %}
+{% set version = "2024.07.27" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2024.07.19
+  - moose-dev 2024.07.27
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=81a423f6eaa813c5d6d3a92eb2a24cc7cc2b8e34
+ARG LIBMESH_REV=055e533d329961be6e88900e574be6c6dfcea84d
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -11,7 +11,7 @@ mpich: 4.2.1
 openmpi: 4.1.6
 petsc_alt: 3.11.4
 petsc: 3.20.3
-moose_dev: 2024.07.19
+moose_dev: 2024.07.27
 moose_tools: 2024.07.19
 apptainer_rockylinux: 8.8.20230518
 apptainer_mpich: 3.4.3

--- a/modules/doc/content/newsletter/2024/2024_07.md
+++ b/modules/doc/content/newsletter/2024/2024_07.md
@@ -58,6 +58,24 @@ for a complete description of all MOOSE changes.
 - `System::is_initialized()` is now `const`
 - Added `LibmeshPetscCall` macro that can wrap any PETSc function call without need for `LIBMESH_CHKERR(ierr)`
 
+### `2024.07.27` Update
+
+- Bounding box testing for .msh $Entities in GmshIO::read(), to detect
+  file inconsistencies
+- Added Netgen as an optional submodule.  With Netgen enabled, libMesh
+  now includes a `NetGenMeshInterface` class which can be used to
+  generate tetrahedral meshes within triangulated boundaries or within
+  volume mesh domains.
+- Added `libmesh/fuzzy_equals.h` methods: `absolute_fuzzy_equals()`
+  and `relative_fuzzy_equals()`, for checking equality to within a
+  specified absolute or relative tolerance.  Added `l1_norm()` and
+  `l1_norm_diff()` methods as necessary to classes (`TypeVector`,
+  `NumericVector`, `SparseMatrix`) and subclasses which might be
+  compared.
+- Fixes for `make distcheck` testing of release candidate tarballs
+- Updates to EIM error indicator normalization in Reduced Basis code
+
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -297,3 +297,9 @@ bcfdf8828910757299379973a97333791a093402: #26839
   libmesh: 9675f30
   moose-dev: c321a7a
   wasp: 33b8e6b
+78832349b20027a5b4db59bff57188b2fd93cc39: #28244
+  mpi: c279c23
+  petsc: 52857f3
+  libmesh: c1691a9
+  moose-dev: 4b2f08f
+  wasp: 33b8e6b


### PR DESCRIPTION
- Bounding box testing for .msh $Entities in GmshIO::read(), to detect
  file inconsistencies
- Added Netgen as an optional submodule.  With Netgen enabled, libMesh
  now includes a `NetGenMeshInterface` class which can be used to
  generate tetrahedral meshes within triangulated boundaries or within
  volume mesh domains.
- Added `libmesh/fuzzy_equals.h` methods: `absolute_fuzzy_equals()`
  and `relative_fuzzy_equals()`, for checking equality to within a
  specified absolute or relative tolerance.  Added `l1_norm()` and
  `l1_norm_diff()` methods as necessary to classes (`TypeVector`,
  `NumericVector`, `SparseMatrix`) and subclasses which might be
  compared.
- Fixes for `make distcheck` testing of release candidate tarballs
- Updates to EIM error indicator normalization in Reduced Basis code