### PR TITLE
[Physics/SolidMechanics/QuasiStatic]: add displacement variables with block restriction

### DIFF
--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_adaptivity.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_adaptivity.i
@@ -31,6 +31,24 @@
   reference_vector = 'ref'
 []
 
+[Variables]
+  [disp_x]
+    order = FIRST
+    family = LAGRANGE
+  []
+  [disp_y]
+    order = FIRST
+    family = LAGRANGE
+  []
+[]
+
+[Physics/SolidMechanics/QuasiStatic/all]
+  strain = FINITE
+  extra_vector_tags = 'ref'
+  block = '1 2 3 4 5 6 7'
+  generate_output = 'stress_xx stress_yy stress_xy'
+[]
+
 [AuxVariables]
   [penalty_normal_pressure]
   []
@@ -59,14 +77,6 @@
     x = '0. 1. 3.5'
     y = '0. 0.0 0.015'
   []
-[]
-
-[Physics/SolidMechanics/QuasiStatic/all]
-  strain = FINITE
-  add_variables = true
-  extra_vector_tags = 'ref'
-  block = '1 2 3 4 5 6 7'
-  generate_output = 'stress_xx stress_yy stress_xy'
 []
 
 [AuxKernels]

--- a/modules/solid_mechanics/src/actions/CommonSolidMechanicsAction.C
+++ b/modules/solid_mechanics/src/actions/CommonSolidMechanicsAction.C
@@ -10,8 +10,12 @@
 #include "CommonSolidMechanicsAction.h"
 #include "QuasiStaticSolidMechanicsPhysics.h"
 #include "ActionWarehouse.h"
+#include "FEProblemBase.h"
+#include "Factory.h"
 
 registerMooseAction("SolidMechanicsApp", CommonSolidMechanicsAction, "meta_action");
+
+registerMooseAction("SolidMechanicsApp", CommonSolidMechanicsAction, "add_variable");
 
 InputParameters
 CommonSolidMechanicsAction::validParams()
@@ -29,8 +33,97 @@ CommonSolidMechanicsAction::CommonSolidMechanicsAction(const InputParameters & p
 void
 CommonSolidMechanicsAction::act()
 {
+
   // check if sub-blocks block are found which will use the common parameters
-  auto action = _awh.getActions<QuasiStaticSolidMechanicsPhysicsBase>();
-  if (action.size() == 0)
+  auto actions = _awh.getActions<QuasiStaticSolidMechanicsPhysicsBase>();
+  if (actions.size() == 0)
     mooseWarning("Common parameters are supplied, but not used in ", parameters().blockLocation());
+
+  // Add disp-variables
+  if (_current_task == "add_variable")
+  {
+
+    // helper variables to collect what the user wants
+    bool do_add_variables = isParamSetByUser("add_variables") && getParam<bool>("add_variables");
+    auto displacement_variables = getParam<std::vector<VariableName>>("displacements");
+    bool add_variables_block_restricted = true;
+    std::set<SubdomainName> add_variables_blocks;
+    bool scaling_set = isParamSetByUser("scaling");
+    Real scaling_value = (scaling_set) ? getParam<Real>("scaling") : 1.0;
+
+    // check all sub-actions
+    for (const auto & action : actions)
+    {
+      if (action->getParam<bool>("add_variables"))
+      {
+        // this sub-action wants the disp-variables added.
+        do_add_variables = true;
+        const auto v = action->getParam<std::vector<VariableName>>("displacements");
+        if (v.size() > 0)
+        {
+          if (displacement_variables.size() == 0)
+            displacement_variables.insert(displacement_variables.end(), v.begin(), v.end());
+          else if (displacement_variables != v)
+            paramError("displacements",
+                       "The vector of displacement variables of the actions differ.");
+        }
+
+        // with block-restriction?
+        if (add_variables_block_restricted && action->isParamSetByUser("block"))
+        {
+          auto action_blocks = action->getParam<std::vector<SubdomainName>>("block");
+          add_variables_blocks.insert(action_blocks.cbegin(), action_blocks.cend());
+        }
+        else
+          add_variables_block_restricted = false;
+
+        // scaling?
+        if (action->getParam<bool>("add_variables") && action->isParamSetByUser("scaling"))
+        {
+          const auto scaling = action->getParam<Real>("scaling");
+
+          // sanity-check
+          if (scaling_set && scaling_value != scaling)
+            paramError("scaling", "The scaling parameter of the actions differ.");
+
+          // set local scaling variables
+          scaling_set = true;
+          scaling_value = scaling;
+        }
+      }
+    }
+
+    // add the disp-variables, if desired
+    if (do_add_variables)
+    {
+
+      auto params = _factory.getValidParams("MooseVariable");
+      // determine necessary order
+      const bool second = _problem->mesh().hasSecondOrderElements();
+
+      params.set<MooseEnum>("order") = second ? "SECOND" : "FIRST";
+      params.set<MooseEnum>("family") = "LAGRANGE";
+      if (add_variables_block_restricted && add_variables_blocks.size() > 0)
+      {
+        std::vector<SubdomainName> blks(add_variables_blocks.begin(), add_variables_blocks.end());
+        params.set<std::vector<SubdomainName>>("block") = blks;
+      }
+      if (scaling_set)
+        params.set<std::vector<Real>>("scaling") = {scaling_value};
+
+      // Loop through the displacement variables
+      const auto n = displacement_variables.size();
+      if (n == 0)
+        paramError("displacements", "The vector of displacement variables is not set.");
+      if (n != _problem->mesh().dimension())
+        paramError("displacements",
+                   "The number of displacement variables differs from the number of dimensions of "
+                   "the mesh.");
+      for (const auto & disp : displacement_variables)
+      {
+        // Create displacement variables
+        _problem->addVariable("MooseVariable", disp, params);
+      }
+    }
+  }
 }

--- a/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
+++ b/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
@@ -382,24 +382,7 @@ QuasiStaticSolidMechanicsPhysics::act()
   // Add variables
   else if (_current_task == "add_variable")
   {
-    if (getParam<bool>("add_variables"))
-    {
-      auto params = _factory.getValidParams("MooseVariable");
-      // determine necessary order
-      const bool second = _problem->mesh().hasSecondOrderElements();
-
-      params.set<MooseEnum>("order") = second ? "SECOND" : "FIRST";
-      params.set<MooseEnum>("family") = "LAGRANGE";
-      if (isParamValid("scaling"))
-        params.set<std::vector<Real>>("scaling") = {getParam<Real>("scaling")};
-
-      // Loop through the displacement variables
-      for (const auto & disp : _displacements)
-      {
-        // Create displacement variables
-        _problem->addVariable("MooseVariable", disp, params);
-      }
-    }
+    // getParam<bool>("add_variables") is handled in CommonSolidMechanicsAction
 
     // Homogenization scalar
     if (_lk_homogenization)

--- a/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
+++ b/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
@@ -14,6 +14,7 @@
 #include "MooseObjectAction.h"
 #include "QuasiStaticSolidMechanicsPhysics.h"
 #include "Material.h"
+#include "CommonSolidMechanicsAction.h"
 
 #include "BlockRestrictable.h"
 
@@ -55,8 +56,8 @@ QuasiStaticSolidMechanicsPhysics::validParams()
   InputParameters params = QuasiStaticSolidMechanicsPhysicsBase::validParams();
   params.addClassDescription("Set up stress divergence kernels with coordinate system aware logic");
 
-  // parameters specified here only appear in the input file sub-blocks of the
-  // Master action, not in the common parameters area
+  // parameters specified here only appear in the input file sub-blocks of the solid mechanics
+  // action, not in the common parameters area
   params.addParam<std::vector<SubdomainName>>("block",
                                               {},
                                               "The list of ids of the blocks (subdomain) "
@@ -382,7 +383,30 @@ QuasiStaticSolidMechanicsPhysics::act()
   // Add variables
   else if (_current_task == "add_variable")
   {
-    // getParam<bool>("add_variables") is handled in CommonSolidMechanicsAction
+    // Add variables here only if the CommonSolidMechanicsAction does not exist.
+    // This happens notably if the QuasiStaticSolidMechanics was created by a meta_action
+    const auto common_actions = _awh.getActions<CommonSolidMechanicsAction>();
+    if (common_actions.empty() && getParam<bool>("add_variables"))
+    {
+      auto params = _factory.getValidParams("MooseVariable");
+      // determine necessary order
+      const bool second = _problem->mesh().hasSecondOrderElements();
+
+      params.set<MooseEnum>("order") = second ? "SECOND" : "FIRST";
+      params.set<MooseEnum>("family") = "LAGRANGE";
+      if (isParamValid("scaling"))
+        params.set<std::vector<Real>>("scaling") = {getParam<Real>("scaling")};
+
+      // Note how we do not add the block restriction because BISON's meta-actions
+      // currently rely on them not being added.
+
+      // Loop through the displacement variables
+      for (const auto & disp : _displacements)
+      {
+        // Create displacement variables
+        _problem->addVariable("MooseVariable", disp, params);
+      }
+    }
 
     // Homogenization scalar
     if (_lk_homogenization)

--- a/modules/solid_mechanics/test/tests/j_integral/tests
+++ b/modules/solid_mechanics/test/tests/j_integral/tests
@@ -19,8 +19,9 @@
     issues = '#24795'
     input = 'j_integral_2d_block_restrict.i'
     cli_args = "DomainIntegral/block='1 2'"
-    expect_err = "'EshelbyTensor' is not defined on block lowerd_dummy."
-    requirement = 'The domain integral action shall error out if the blocks selected do not have the adequate material objects.'
+    expect_err = "The 'block' parameter of the object 'EshelbyTensor' must be a subset of the 'block' parameter of the variable 'disp_x'"
+    requirement = 'The domain integral action shall error out if the blocks selected do not have the '
+                  'adequate material objects.'
   []
   [j_2d_output_vpp]
     type = 'CheckFiles'


### PR DESCRIPTION
When using [Physics/SolidMechanics/QuasiStatic].add_variables = true, Moose adds the displacement variables without block-restriction. As suggested by the syntax of [Physics/SolidMechanics/QuasiStatic], the variables should be added with block-restriction.

closes #28307
