### PR TITLE
Set verify_holes to false in RGMB FlexiblePatternGenerator mesh subgenerator calls

### DIFF
--- a/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
@@ -531,6 +531,7 @@ AssemblyMeshGenerator::generateFlexibleAssemblyBoundaries()
     params.set<boundary_id_type>("external_boundary_id") = _assembly_boundary_id;
     params.set<BoundaryName>("external_boundary_name") = _assembly_boundary_name;
     params.set<SubdomainName>("background_subdomain_name") = block_to_delete + "_TRI";
+    params.set<bool>("verify_holes") = false;
     params.set<unsigned short>("background_subdomain_id") = RGMB::ASSEMBLY_BLOCK_ID_TRI_FLEXIBLE;
 
     addMeshSubgenerator("FlexiblePatternGenerator", name() + "_fpg", params);

--- a/modules/reactor/src/meshgenerators/PinMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PinMeshGenerator.C
@@ -512,6 +512,7 @@ PinMeshGenerator::generateFlexibleAssemblyBoundaries()
       params.set<std::vector<unsigned int>>("extra_positions_mg_indices") = {0};
     }
     params.set<bool>("use_auto_area_func") = true;
+    params.set<bool>("verify_holes") = false;
     params.set<MooseEnum>("boundary_type") = (_mesh_geometry == "Hex") ? "HEXAGON" : "CARTESIAN";
     params.set<unsigned int>("boundary_sectors") =
         getReactorParam<unsigned int>(RGMB::num_sectors_flexible_stitching);


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->

refs #28316
