### PR TITLE
Handle a corner case when formatting time in Console output

### DIFF
--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -522,6 +522,8 @@ Console::formatTime(const Real t) const
         oss << std::scientific;
       oss << second;
     }
+    else if (days == 0)
+      oss << "0s";
   }
   return oss.str();
 }


### PR DESCRIPTION
Closes #28323.
