### PR TITLE
Use libmesh cast_int extensively

### DIFF
--- a/framework/src/auxkernels/NodalPatchRecovery.C
+++ b/framework/src/auxkernels/NodalPatchRecovery.C
@@ -32,14 +32,14 @@ NodalPatchRecovery::NodalPatchRecovery(const InputParameters & parameters)
   : AuxKernel(parameters),
     _patch_polynomial_order(
         isParamValid("patch_polynomial_order")
-            ? static_cast<unsigned int>(getParam<MooseEnum>("patch_polynomial_order"))
-            : static_cast<unsigned int>(_var.order())),
+            ? libMesh::cast_int<unsigned int>(getParam<MooseEnum>("patch_polynomial_order"))
+            : libMesh::cast_int<unsigned int>(_var.order())),
     _fe_problem(*parameters.get<FEProblemBase *>("_fe_problem_base")),
     _multi_index(multiIndex(_mesh.dimension(), _patch_polynomial_order))
 {
   // if the patch polynomial order is lower than the variable order,
   // it is very likely that the patch recovery is not used at its max accuracy
-  if (_patch_polynomial_order < static_cast<unsigned int>(_var.order()))
+  if (_patch_polynomial_order < libMesh::cast_int<unsigned int>(_var.order()))
     mooseWarning("Specified 'patch_polynomial_order' is lower than the AuxVariable's order");
 
   // TODO remove the manual ghosting once relationship manager is working correctly

--- a/framework/src/base/Attributes.C
+++ b/framework/src/base/Attributes.C
@@ -110,7 +110,7 @@ AttribMatrixTags::initFrom(const MooseObject * obj)
   if (t)
   {
     for (auto & tag : t->getMatrixTags({}))
-      _vals.push_back(static_cast<int>(tag));
+      _vals.push_back(libMesh::cast_int<int>(tag));
   }
 }
 
@@ -122,7 +122,7 @@ AttribVectorTags::initFrom(const MooseObject * obj)
   if (t)
   {
     for (auto & tag : t->getVectorTags({}))
-      _vals.push_back(static_cast<int>(tag));
+      _vals.push_back(libMesh::cast_int<int>(tag));
   }
 }
 
@@ -455,7 +455,7 @@ AttribVar::initFrom(const MooseObject * obj)
 {
   auto vi = dynamic_cast<const MooseVariableInterface<Real> *>(obj);
   if (vi)
-    _val = static_cast<int>(vi->mooseVariableBase()->number());
+    _val = libMesh::cast_int<int>(vi->mooseVariableBase()->number());
 }
 bool
 AttribVar::isMatch(const Attribute & other) const

--- a/framework/src/dirackernels/DiracKernelBase.C
+++ b/framework/src/dirackernels/DiracKernelBase.C
@@ -146,7 +146,7 @@ DiracKernelBase::addPointWithValidId(Point p, unsigned id)
   point_cache_t::iterator it = _point_cache.find(id);
 
   // Was the point found in a _point_cache on at least one processor?
-  unsigned int i_found_it = static_cast<unsigned int>(it != _point_cache.end());
+  unsigned int i_found_it = libMesh::cast_int<unsigned int>(it != _point_cache.end());
   unsigned int we_found_it = i_found_it;
   comm().max(we_found_it);
 
@@ -296,7 +296,7 @@ DiracKernelBase::addPointWithValidId(Point p, unsigned id)
   // early in the code above...
 
   // Does we need to call findPoint() on all processors.
-  unsigned int we_need_find_point = static_cast<unsigned int>(i_need_find_point);
+  unsigned int we_need_find_point = libMesh::cast_int<unsigned int>(i_need_find_point);
   comm().max(we_need_find_point);
 
   if (we_need_find_point)

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -592,7 +592,7 @@ Transient::keepGoing()
       }
 
       // Check for stop condition based upon number of simulation steps and/or solution end time:
-      if (static_cast<unsigned int>(_t_step) >= _num_steps)
+      if (libMesh::cast_int<unsigned int>(_t_step) >= _num_steps)
         keep_going = false;
 
       if ((_time >= _end_time) || (fabs(_time - _end_time) <= _timestep_tolerance))

--- a/framework/src/functions/PiecewiseMultiInterpolation.C
+++ b/framework/src/functions/PiecewiseMultiInterpolation.C
@@ -125,7 +125,7 @@ PiecewiseMultiInterpolation::getNeighborIndices(std::vector<Real> in_arr,
     // std::distance returns std::difference_type, which can be negative in theory, but
     // in this context will always be >=0.  Therefore the explicit cast is just to shut
     // the compiler up.
-    upper_x = static_cast<unsigned int>(std::distance(in_arr.begin(), up));
+    upper_x = libMesh::cast_int<unsigned int>(std::distance(in_arr.begin(), up));
     if (in_arr[upper_x] == x)
       lower_x = upper_x;
     else

--- a/framework/src/geomsearch/SecondaryNeighborhoodThread.C
+++ b/framework/src/geomsearch/SecondaryNeighborhoodThread.C
@@ -51,7 +51,7 @@ void
 SecondaryNeighborhoodThread::operator()(const NodeIdRange & range)
 {
   unsigned int patch_size =
-      std::min(_patch_size, static_cast<unsigned int>(_trial_primary_nodes.size()));
+      std::min(_patch_size, libMesh::cast_int<unsigned int>(_trial_primary_nodes.size()));
 
   std::vector<std::size_t> return_index(patch_size);
 

--- a/framework/src/mesh/ConcentricCircleMesh.C
+++ b/framework/src/mesh/ConcentricCircleMesh.C
@@ -245,7 +245,7 @@ ConcentricCircleMesh::buildMesh()
   // adding elements
   int index = 0;
   int limit = 0;
-  int standard = static_cast<int>(_num_sectors);
+  int standard = libMesh::cast_int<int>(_num_sectors);
 
   // This is to set the limit for the index
   if (standard > 4)
@@ -330,7 +330,7 @@ ConcentricCircleMesh::buildMesh()
 
   // adding elements for other concentric circles
   index = Utility::pow<2>(_num_sectors / 2 + 1);
-  limit = static_cast<int>(num_total_nodes) - standard - 2;
+  limit = libMesh::cast_int<int>(num_total_nodes) - standard - 2;
   int num_nodes_boundary = Utility::pow<2>(_num_sectors / 2 + 1) + _num_sectors + 1;
 
   counter = 0;
@@ -343,7 +343,7 @@ ConcentricCircleMesh::buildMesh()
     elem->set_node(2) = nodes[index + _num_sectors + 2];
     elem->set_node(3) = nodes[index + 1];
 
-    for (int i = 0; i < static_cast<int>(subdomainIDs.size()) - 1; ++i)
+    for (int i = 0; i < libMesh::cast_int<int>(subdomainIDs.size()) - 1; ++i)
       if (index < limit - (standard + 1) * i && index >= limit - (standard + 1) * (i + 1))
         elem->subdomain_id() = subdomainIDs[subdomainIDs.size() - 1 - i];
 

--- a/framework/src/mesh/GeneratedMesh.C
+++ b/framework/src/mesh/GeneratedMesh.C
@@ -247,7 +247,7 @@ GeneratedMesh::buildMesh()
     {
       pows[dir].resize(nelem[dir] + 1);
       for (unsigned int i = 0; i < pows[dir].size(); ++i)
-        pows[dir][i] = std::pow(bias[dir], static_cast<int>(i));
+        pows[dir][i] = std::pow(bias[dir], libMesh::cast_int<int>(i));
     }
 
     // Loop over the nodes and move them to the desired location
@@ -279,7 +279,8 @@ GeneratedMesh::buildMesh()
             // lot (e.g. we want 3.9999 to map to 4.0 instead of 3.0).
             int index = round(float_index);
 
-            mooseAssert(index >= static_cast<int>(0) && index < static_cast<int>(pows[dir].size()),
+            mooseAssert(index >= libMesh::cast_int<int>(0) &&
+                            index < libMesh::cast_int<int>(pows[dir].size()),
                         "Scaled \"index\" out of range");
 
             // Move node to biased location.

--- a/framework/src/mesh/ImageMesh.C
+++ b/framework/src/mesh/ImageMesh.C
@@ -124,9 +124,9 @@ ImageMesh::buildMesh3D(const std::vector<std::string> & filenames)
   // Compute the number of cells in the x and y direction based on
   // the user's cells_per_pixel parameter.  Note: we use ints here
   // because the GeneratedMesh params object uses ints for these...
-  _nx = static_cast<int>(_cells_per_pixel * xpixels);
-  _ny = static_cast<int>(_cells_per_pixel * ypixels);
-  _nz = static_cast<int>(_cells_per_pixel * zpixels);
+  _nx = libMesh::cast_int<int>(_cells_per_pixel * xpixels);
+  _ny = libMesh::cast_int<int>(_cells_per_pixel * ypixels);
+  _nz = libMesh::cast_int<int>(_cells_per_pixel * zpixels);
 
   // Actually build the Mesh
   MeshTools::Generation::build_cube(dynamic_cast<UnstructuredMesh &>(getMesh()),
@@ -165,8 +165,8 @@ ImageMesh::buildMesh2D(const std::string & filename)
   // Compute the number of cells in the x and y direction based on
   // the user's cells_per_pixel parameter.  Note: we use ints here
   // because the GeneratedMesh params object uses ints for these...
-  _nx = static_cast<int>(_cells_per_pixel * xpixels);
-  _ny = static_cast<int>(_cells_per_pixel * ypixels);
+  _nx = libMesh::cast_int<int>(_cells_per_pixel * xpixels);
+  _ny = libMesh::cast_int<int>(_cells_per_pixel * ypixels);
 
   // Actually build the Mesh
   MeshTools::Generation::build_square(dynamic_cast<UnstructuredMesh &>(getMesh()),

--- a/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
+++ b/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
@@ -282,7 +282,7 @@ ConcentricCircleMeshGenerator::generate()
   // adding elements
   int index = 0;
   int limit = 0;
-  int standard = static_cast<int>(_num_sectors);
+  int standard = libMesh::cast_int<int>(_num_sectors);
 
   // This is to set the limit for the index
   if (standard > 4)
@@ -390,7 +390,7 @@ ConcentricCircleMeshGenerator::generate()
     elem->set_node(2) = nodes[index + standard + 2];
     elem->set_node(3) = nodes[index + 1];
 
-    for (int i = 0; i < static_cast<int>(subdomainIDs.size() - 1); ++i)
+    for (int i = 0; i < libMesh::cast_int<int>(subdomainIDs.size() - 1); ++i)
       if (index < limit - (standard + 1) * i && index >= limit - (standard + 1) * (i + 1))
         elem->subdomain_id() = subdomainIDs[subdomainIDs.size() - 1 - i];
 
@@ -448,7 +448,7 @@ ConcentricCircleMeshGenerator::generate()
         elem->set_node(3) = nodes[index + 1 + _rings.back()];
         elem->subdomain_id() = subdomainIDs.back() + 1;
 
-        if (index < (initial2 + static_cast<int>(_rings.back())))
+        if (index < (initial2 + libMesh::cast_int<int>(_rings.back())))
           boundary_info.add_side(elem, 0, 1);
 
         if (index == initial)
@@ -458,10 +458,10 @@ ConcentricCircleMeshGenerator::generate()
 
         // As mentioned before, increment by 2 indices may be required depending on where the index
         // points to.
-        if ((index - initial) % static_cast<int>(_rings.back()) == 0)
+        if ((index - initial) % libMesh::cast_int<int>(_rings.back()) == 0)
         {
           ++index;
-          initial = initial + (static_cast<int>(_rings.back()) + 1);
+          initial = initial + (libMesh::cast_int<int>(_rings.back()) + 1);
         }
       }
 
@@ -484,18 +484,18 @@ ConcentricCircleMeshGenerator::generate()
         elem->set_node(0) = nodes[index + 1];
         elem->subdomain_id() = subdomainIDs.back() + 1;
 
-        if (index >= static_cast<int>(limit - (_rings.back() + 1)))
+        if (index >= libMesh::cast_int<int>(limit - (_rings.back() + 1)))
           boundary_info.add_side(elem, 1, 3);
 
-        if ((index - initial) % static_cast<int>(_rings.back() + 2) == 0)
+        if ((index - initial) % libMesh::cast_int<int>(_rings.back() + 2) == 0)
           boundary_info.add_side(elem, 2, 4);
 
         ++index;
 
-        if ((index - initial) % static_cast<int>(_rings.back() + 1) == 0)
+        if ((index - initial) % libMesh::cast_int<int>(_rings.back() + 1) == 0)
         {
           ++index;
-          initial = initial + (static_cast<int>(_rings.back()) + 2);
+          initial = initial + (libMesh::cast_int<int>(_rings.back()) + 2);
         }
       }
 
@@ -671,10 +671,10 @@ ConcentricCircleMeshGenerator::generate()
 
           ++index;
 
-          if ((index - initial) % static_cast<int>(_rings.back()) == 0)
+          if ((index - initial) % libMesh::cast_int<int>(_rings.back()) == 0)
           {
             ++index;
-            initial = initial + (static_cast<int>(_rings.back()) + 1);
+            initial = initial + (libMesh::cast_int<int>(_rings.back()) + 1);
           }
         }
       }

--- a/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
+++ b/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
@@ -1368,7 +1368,7 @@ DistributedRectilinearMeshGenerator::generate()
     {
       pows[dir].resize(nelem[dir] + 1);
       for (dof_id_type i = 0; i < pows[dir].size(); ++i)
-        pows[dir][i] = std::pow(bias[dir], static_cast<int>(i));
+        pows[dir][i] = std::pow(bias[dir], libMesh::cast_int<int>(i));
     }
 
     // Loop over the nodes and move them to the desired location

--- a/framework/src/meshgenerators/GeneratedMeshGenerator.C
+++ b/framework/src/meshgenerators/GeneratedMeshGenerator.C
@@ -302,7 +302,8 @@ GeneratedMeshGenerator::generate()
             // lot (e.g. we want 3.9999 to map to 4.0 instead of 3.0).
             int index = round(float_index);
 
-            mooseAssert(index >= static_cast<int>(0) && index < static_cast<int>(pows[dir].size()),
+            mooseAssert(index >= libMesh::cast_int<int>(0) &&
+                            index < libMesh::cast_int<int>(pows[dir].size()),
                         "Scaled \"index\" out of range");
 
             // Move node to biased location.

--- a/framework/src/meshgenerators/ImageMeshGenerator.C
+++ b/framework/src/meshgenerators/ImageMeshGenerator.C
@@ -117,9 +117,9 @@ ImageMeshGenerator::buildMesh3D(const std::vector<std::string> & filenames, Mesh
   // Compute the number of cells in the x and y direction based on
   // the user's cells_per_pixel parameter.  Note: we use ints here
   // because the GeneratedMesh params object uses ints for these...
-  _nx = static_cast<int>(_cells_per_pixel * xpixels);
-  _ny = static_cast<int>(_cells_per_pixel * ypixels);
-  _nz = static_cast<int>(_cells_per_pixel * zpixels);
+  _nx = libMesh::cast_int<int>(_cells_per_pixel * xpixels);
+  _ny = libMesh::cast_int<int>(_cells_per_pixel * ypixels);
+  _nz = libMesh::cast_int<int>(_cells_per_pixel * zpixels);
 
   // Actually build the Mesh
   MeshTools::Generation::build_cube(dynamic_cast<UnstructuredMesh &>(mesh),
@@ -158,8 +158,8 @@ ImageMeshGenerator::buildMesh2D(const std::string & filename, MeshBase & mesh)
   // Compute the number of cells in the x and y direction based on
   // the user's cells_per_pixel parameter.  Note: we use ints here
   // because the GeneratedMesh params object uses ints for these...
-  _nx = static_cast<int>(_cells_per_pixel * xpixels);
-  _ny = static_cast<int>(_cells_per_pixel * ypixels);
+  _nx = libMesh::cast_int<int>(_cells_per_pixel * xpixels);
+  _ny = libMesh::cast_int<int>(_cells_per_pixel * ypixels);
 
   // Actually build the Mesh
   MeshTools::Generation::build_square(dynamic_cast<UnstructuredMesh &>(mesh),

--- a/framework/src/meshgenerators/StackGenerator.C
+++ b/framework/src/meshgenerators/StackGenerator.C
@@ -67,7 +67,7 @@ StackGenerator::generate()
                _input_names[0],
                "is not a ReplicatedMesh.");
 
-  int dim = static_cast<int>(_dim);
+  int dim = libMesh::cast_int<int>(_dim);
 
   if (dim != int(mesh->mesh_dimension()))
     paramError("dim",
@@ -90,7 +90,7 @@ StackGenerator::generate()
       mooseError("StackGenerator only works with ReplicatedMesh : mesh from Meshgenerator ",
                  _input_names[i + 1],
                  "is not a ReplicatedMesh.");
-    if (static_cast<int>(_meshes[i]->mesh_dimension()) != dim)
+    if (libMesh::cast_int<int>(_meshes[i]->mesh_dimension()) != dim)
       mooseError("Mesh from MeshGenerator : ", _input_names[i + 1], " is not in ", _dim, "D.");
   }
 

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -288,13 +288,13 @@ Exodus::setOutputDimensionInExodusWriter(ExodusII_IO & exodus_io,
       if (mesh.getMesh().mesh_dimension() == 1)
         exodus_io.write_as_dimension(3);
       else
-        exodus_io.write_as_dimension(static_cast<int>(mesh.effectiveSpatialDimension()));
+        exodus_io.write_as_dimension(libMesh::cast_int<int>(mesh.effectiveSpatialDimension()));
       break;
 
     case OutputDimension::ONE:
     case OutputDimension::TWO:
     case OutputDimension::THREE:
-      exodus_io.write_as_dimension(static_cast<int>(output_dimension));
+      exodus_io.write_as_dimension(libMesh::cast_int<int>(output_dimension));
       break;
 
     case OutputDimension::PROBLEM_DIMENSION:

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -8280,7 +8280,7 @@ FEProblemBase::checkNonlinearConvergence(std::string & msg,
   }
 
   system._last_nl_rnorm = fnorm;
-  system._current_nl_its = static_cast<unsigned int>(it);
+  system._current_nl_its = libMesh::cast_int<unsigned int>(it);
 
   msg = oss.str();
   if (_app.multiAppLevel() > 0)

--- a/framework/src/reporters/AccumulateReporter.C
+++ b/framework/src/reporters/AccumulateReporter.C
@@ -57,7 +57,7 @@ AccumulateReporter::declareLateValues()
 void
 AccumulateReporter::execute()
 {
-  unsigned int ind = static_cast<unsigned int>(_t_step);
+  unsigned int ind = libMesh::cast_int<unsigned int>(_t_step);
   for (auto & val : _accumulated_values)
     val->accumulate(ind);
 }

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -3818,7 +3818,7 @@ NonlinearSystemBase::setupScalingData()
 
     _num_scaling_groups = _scaling_group_variables.size() + var_numbers_not_covered.size();
 
-    auto index = static_cast<unsigned int>(_scaling_group_variables.size());
+    auto index = libMesh::cast_int<unsigned int>(_scaling_group_variables.size());
     for (auto var_number : var_numbers_not_covered)
       _var_to_group_var.emplace(var_number, index++);
   }

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -453,7 +453,7 @@ MultiAppUserObjectTransfer::execute()
             const auto sub_app = findSubAppToTransferFrom(transformed_node);
 
             // Check to see if a sub-app was found
-            if (sub_app == static_cast<unsigned int>(-1))
+            if (sub_app == libMesh::cast_int<unsigned int>(-1))
               continue;
 
             const auto & from_transform = *_from_transforms[sub_app];
@@ -517,7 +517,7 @@ MultiAppUserObjectTransfer::execute()
             const auto sub_app = findSubAppToTransferFrom(point);
 
             // Check to see if a sub-app was found
-            if (sub_app == static_cast<unsigned int>(-1))
+            if (sub_app == libMesh::cast_int<unsigned int>(-1))
               continue;
 
             const auto & from_transform = *_from_transforms[sub_app];
@@ -649,7 +649,7 @@ MultiAppUserObjectTransfer::findSubAppToTransferFrom(const Point & p)
         _multi_app->getBoundingBox(i, _displaced_source_mesh, _from_transforms[i].get());
 
     if (_skip_bbox_check || app_box.contains_point(p))
-      return static_cast<unsigned int>(i);
+      return libMesh::cast_int<unsigned int>(i);
   }
 
   return -1;

--- a/framework/src/userobjects/LayeredBase.C
+++ b/framework/src/userobjects/LayeredBase.C
@@ -371,7 +371,7 @@ LayeredBase::getLayer(Point p) const
 
     if (one_higher == _layer_bounds.end())
     {
-      return static_cast<unsigned int>(
+      return libMesh::cast_int<unsigned int>(
           _layer_bounds.size() -
           2); // Just return the last layer.  -2 because layers are "in-between" bounds
     }
@@ -380,7 +380,7 @@ LayeredBase::getLayer(Point p) const
     else
       // The -1 is because the interval that we fall in is just _before_ the number that is bigger
       // (which is what we found
-      return static_cast<unsigned int>(std::distance(_layer_bounds.begin(), one_higher - 1));
+      return libMesh::cast_int<unsigned int>(std::distance(_layer_bounds.begin(), one_higher - 1));
   }
 }
 

--- a/framework/src/userobjects/ProjectedStatefulMaterialNodalPatchRecovery.C
+++ b/framework/src/userobjects/ProjectedStatefulMaterialNodalPatchRecovery.C
@@ -73,7 +73,7 @@ ProjectedStatefulMaterialNodalPatchRecoveryTempl<T, is_ad>::
     _qp(0),
     _n_components(Moose::SerialAccess<T>::size()),
     _patch_polynomial_order(
-        static_cast<unsigned int>(getParam<MooseEnum>("patch_polynomial_order"))),
+        libMesh::cast_int<unsigned int>(getParam<MooseEnum>("patch_polynomial_order"))),
     _multi_index(MathUtils::multiIndex(_mesh.dimension(), _patch_polynomial_order)),
     _q(_multi_index.size()),
     _prop(getGenericMaterialProperty<T, is_ad>("property")),

--- a/framework/src/utils/FormattedTable.C
+++ b/framework/src/utils/FormattedTable.C
@@ -544,7 +544,7 @@ FormattedTable::makeGnuplot(const std::string & base_file, const std::string & f
     gpfile << " '" << dat_name << "' using 1:" << column << " title '" << col_name
            << "' with linespoints";
     column++;
-    if (column - 2 < static_cast<int>(_column_names.size()))
+    if (column - 2 < libMesh::cast_int<int>(_column_names.size()))
       gpfile << ", \\\n";
   }
   gpfile << "\n\n";

--- a/framework/src/utils/MemoryUtils.C
+++ b/framework/src/utils/MemoryUtils.C
@@ -176,7 +176,7 @@ convertBytes(std::size_t bytes, MemUnits unit)
   if (unit == MemUnits::Bytes)
     return bytes;
 
-  unsigned int nunit = static_cast<unsigned int>(unit);
+  unsigned int nunit = libMesh::cast_int<unsigned int>(unit);
 
   // kibi, mebi, gibi
   if (nunit <= 3)

--- a/framework/src/utils/MooseAppCoordTransform.C
+++ b/framework/src/utils/MooseAppCoordTransform.C
@@ -356,7 +356,7 @@ MooseAppCoordTransform::minimalDataDescription() const
           scale_factor,
           static_cast<short int>(bool(_rotate)),
           _euler_angles,
-          static_cast<int>(_coord_type),
+          libMesh::cast_int<int>(_coord_type),
           libMesh::cast_int<unsigned int>(_r_axis),
           libMesh::cast_int<unsigned int>(_z_axis),
           static_cast<short int>(_has_different_coord_sys),

--- a/framework/src/utils/MooseAppCoordTransform.C
+++ b/framework/src/utils/MooseAppCoordTransform.C
@@ -175,7 +175,7 @@ MooseAppCoordTransform::setCoordinateSystem(const MooseMesh & mesh)
   else
     setCoordinateSystem(
         map_it->second,
-        Direction(static_cast<unsigned int>(int(params.get<MooseEnum>("rz_coord_axis")))));
+        Direction(libMesh::cast_int<unsigned int>(int(params.get<MooseEnum>("rz_coord_axis")))));
   for (; map_it != coord_sys.end(); ++map_it)
     coord_types.insert(map_it->second);
 
@@ -292,7 +292,7 @@ MooseAppCoordTransform::MooseAppCoordTransform(const MooseMesh & mesh)
     setRotation(alpha, beta, gamma);
   }
   else if (up_direction.isValid())
-    setUpDirection(Direction(static_cast<unsigned int>(int(up_direction))));
+    setUpDirection(Direction(libMesh::cast_int<unsigned int>(int(up_direction))));
 
   //
   // Scaling
@@ -357,8 +357,8 @@ MooseAppCoordTransform::minimalDataDescription() const
           static_cast<short int>(bool(_rotate)),
           _euler_angles,
           static_cast<int>(_coord_type),
-          static_cast<unsigned int>(_r_axis),
-          static_cast<unsigned int>(_z_axis),
+          libMesh::cast_int<unsigned int>(_r_axis),
+          libMesh::cast_int<unsigned int>(_z_axis),
           static_cast<short int>(_has_different_coord_sys),
           static_cast<short int>(_using_general_rz_coord_axes),
           static_cast<short int>(_mesh_transformed)};

--- a/framework/src/utils/RayTracing.C
+++ b/framework/src/utils/RayTracing.C
@@ -47,7 +47,7 @@ sideIntersectedByLine(const Elem * elem,
   {
     // Don't search the "not_side"
     // Note: A linear search is fine here because this vector is going to be < n_sides
-    if (std::find(not_side.begin(), not_side.end(), static_cast<int>(i)) != not_side.end())
+    if (std::find(not_side.begin(), not_side.end(), libMesh::cast_int<int>(i)) != not_side.end())
       continue;
 
     // Get a simplified side element

--- a/framework/src/variables/MooseVariableDataBase.C
+++ b/framework/src/variables/MooseVariableDataBase.C
@@ -259,7 +259,7 @@ MooseVariableDataBase<OutputType>::stateToTagHelper(const Moose::SolutionState s
   if (state > 0)
   {
     // We need to request all states that are between current and the requested state
-    stateToTagHelper<ReturnType>(Moose::SolutionState(static_cast<int>(state) - 1), functor);
+    stateToTagHelper<ReturnType>(Moose::SolutionState(libMesh::cast_int<int>(state) - 1), functor);
     needSolutionState(cast_int<unsigned int>(state));
   }
 

--- a/framework/src/vectorpostprocessors/SpatialAverageBase.C
+++ b/framework/src/vectorpostprocessors/SpatialAverageBase.C
@@ -76,7 +76,7 @@ SpatialAverageBase::execute()
     auto bin = computeDistance() / _deltaR;
 
     // add the volume contributed by the current quadrature point
-    if (bin >= 0 && bin < static_cast<int>(_nbins))
+    if (bin >= 0 && bin < libMesh::cast_int<int>(_nbins))
     {
       for (MooseIndex(_nvals) j = 0; j < _nvals; ++j)
         (*_average[j])[bin] += (*_values[j])[_qp];

--- a/framework/src/vectorpostprocessors/VariableValueVolumeHistogram.C
+++ b/framework/src/vectorpostprocessors/VariableValueVolumeHistogram.C
@@ -69,7 +69,7 @@ VariableValueVolumeHistogram::execute()
     int bin = (_value[_qp] - _min_value) / _deltaV;
 
     // add the volume contributed by the current quadrature point
-    if (bin >= 0 && static_cast<unsigned int>(bin) < _nbins)
+    if (bin >= 0 && libMesh::cast_int<unsigned int>(bin) < _nbins)
       _volume[bin] += computeVolume();
   }
 }

--- a/framework/src/vectorpostprocessors/WorkBalance.C
+++ b/framework/src/vectorpostprocessors/WorkBalance.C
@@ -169,10 +169,10 @@ public:
     }
     else // Particular system
     {
-      auto n_vars = elem->n_vars(static_cast<unsigned int>(_system));
+      auto n_vars = elem->n_vars(libMesh::cast_int<unsigned int>(_system));
 
       for (decltype(n_vars) var = 0; var < n_vars; var++)
-        _local_num_dofs += elem->n_dofs(static_cast<unsigned int>(_system), var);
+        _local_num_dofs += elem->n_dofs(libMesh::cast_int<unsigned int>(_system), var);
     }
   }
 
@@ -278,10 +278,10 @@ public:
     }
     else // Particular system
     {
-      auto n_vars = node.n_vars(static_cast<unsigned int>(_system));
+      auto n_vars = node.n_vars(libMesh::cast_int<unsigned int>(_system));
 
       for (decltype(n_vars) var = 0; var < n_vars; var++)
-        _local_num_dofs += node.n_dofs(static_cast<unsigned int>(_system), var);
+        _local_num_dofs += node.n_dofs(libMesh::cast_int<unsigned int>(_system), var);
     }
   }
 

--- a/modules/contact/src/constraints/RANFSNormalMechanicalContact.C
+++ b/modules/contact/src/constraints/RANFSNormalMechanicalContact.C
@@ -105,7 +105,7 @@ RANFSNormalMechanicalContact::overwriteSecondaryResidual()
   if (_tie_nodes)
     return true;
   else
-    return _largest_component == libMesh::cast_int<unsigned int>(_component);
+    return _largest_component == static_cast<unsigned int>(_component);
 }
 
 bool
@@ -278,7 +278,7 @@ RANFSNormalMechanicalContact::computeQpResidual(Moose::ConstraintType type)
         return (*_current_node - *_nearest_node)(_component);
       else
       {
-        if (_largest_component == libMesh::cast_int<unsigned int>(_component))
+        if (_largest_component == static_cast<unsigned int>(_component))
         {
           mooseAssert(_pinfo->_normal(_component) != 0,
                       "We should be selecting the largest normal component, hence it should be "
@@ -325,7 +325,7 @@ RANFSNormalMechanicalContact::computeQpJacobian(Moose::ConstraintJacobianType ty
       else
       {
         // corresponds to gap equation
-        if (_largest_component == libMesh::cast_int<unsigned int>(_component))
+        if (_largest_component == static_cast<unsigned int>(_component))
           // _phi_secondary has been set such that it is 1 when _j corresponds to the degree of
           // freedom associated with the _current node and 0 otherwise
           return std::abs(_pinfo->_normal(_component)) * _phi_secondary[_j][_qp];
@@ -365,7 +365,7 @@ RANFSNormalMechanicalContact::computeQpJacobian(Moose::ConstraintJacobianType ty
       }
       else
       {
-        if (_largest_component == libMesh::cast_int<unsigned int>(_component))
+        if (_largest_component == static_cast<unsigned int>(_component))
           return -std::abs(_pinfo->_normal(_component)) * _phi_primary[_j][_qp];
 
         // If we're not applying the gap constraint equation on this _component, then we're

--- a/modules/contact/src/constraints/RANFSNormalMechanicalContact.C
+++ b/modules/contact/src/constraints/RANFSNormalMechanicalContact.C
@@ -105,7 +105,7 @@ RANFSNormalMechanicalContact::overwriteSecondaryResidual()
   if (_tie_nodes)
     return true;
   else
-    return _largest_component == static_cast<unsigned int>(_component);
+    return _largest_component == libMesh::cast_int<unsigned int>(_component);
 }
 
 bool
@@ -278,7 +278,7 @@ RANFSNormalMechanicalContact::computeQpResidual(Moose::ConstraintType type)
         return (*_current_node - *_nearest_node)(_component);
       else
       {
-        if (_largest_component == static_cast<unsigned int>(_component))
+        if (_largest_component == libMesh::cast_int<unsigned int>(_component))
         {
           mooseAssert(_pinfo->_normal(_component) != 0,
                       "We should be selecting the largest normal component, hence it should be "
@@ -325,7 +325,7 @@ RANFSNormalMechanicalContact::computeQpJacobian(Moose::ConstraintJacobianType ty
       else
       {
         // corresponds to gap equation
-        if (_largest_component == static_cast<unsigned int>(_component))
+        if (_largest_component == libMesh::cast_int<unsigned int>(_component))
           // _phi_secondary has been set such that it is 1 when _j corresponds to the degree of
           // freedom associated with the _current node and 0 otherwise
           return std::abs(_pinfo->_normal(_component)) * _phi_secondary[_j][_qp];
@@ -365,7 +365,7 @@ RANFSNormalMechanicalContact::computeQpJacobian(Moose::ConstraintJacobianType ty
       }
       else
       {
-        if (_largest_component == static_cast<unsigned int>(_component))
+        if (_largest_component == libMesh::cast_int<unsigned int>(_component))
           return -std::abs(_pinfo->_normal(_component)) * _phi_primary[_j][_qp];
 
         // If we're not applying the gap constraint equation on this _component, then we're

--- a/modules/heat_transfer/src/bcs/GapHeatTransfer.C
+++ b/modules/heat_transfer/src/bcs/GapHeatTransfer.C
@@ -219,7 +219,7 @@ GapHeatTransfer::computeJacobian()
 
       for (_i = 0; _i < _test.size(); _i++)
         for (_secondary_j = 0;
-             _secondary_j < static_cast<unsigned int>(secondary_side_dof_indices.size());
+             _secondary_j < libMesh::cast_int<unsigned int>(secondary_side_dof_indices.size());
              ++_secondary_j)
           K_secondary(_i, _secondary_j) += _JxW[_qp] * _coord[_qp] * computeSecondaryQpJacobian();
 
@@ -285,7 +285,7 @@ GapHeatTransfer::computeOffDiagJacobian(const unsigned int jvar_num)
 
       for (_i = 0; _i < _test.size(); _i++)
         for (_secondary_j = 0;
-             _secondary_j < static_cast<unsigned int>(secondary_side_dof_indices.size());
+             _secondary_j < libMesh::cast_int<unsigned int>(secondary_side_dof_indices.size());
              ++_secondary_j)
           K_secondary(_i, _secondary_j) +=
               _JxW[_qp] * _coord[_qp] * computeSecondaryQpOffDiagJacobian(jvar_num);

--- a/modules/misc/src/postprocessors/GeneralSensorPostprocessor.C
+++ b/modules/misc/src/postprocessors/GeneralSensorPostprocessor.C
@@ -204,7 +204,7 @@ GeneralSensorPostprocessor::getIntegral(std::vector<Real> integrand)
     {
       n = _time_values.size();
       // if interval is not a multiple of 3, make it
-      while (static_cast<int>(n) % 3 != 0)
+      while (libMesh::cast_int<int>(n) % 3 != 0)
         n = n + 1;
     }
 

--- a/modules/navier_stokes/src/loops/GatherRCDataElementThread.C
+++ b/modules/navier_stokes/src/loops/GatherRCDataElementThread.C
@@ -48,7 +48,8 @@ GatherRCDataElementThread::subdomainChanged()
     // both var number 0 and 1)
     auto copied_queries = queries;
     std::vector<FVElementalKernel *> var_eks;
-    copied_queries.template condition<AttribVar>(static_cast<int>(var_num)).queryInto(var_eks);
+    copied_queries.template condition<AttribVar>(libMesh::cast_int<int>(var_num))
+        .queryInto(var_eks);
     for (auto var_ek : var_eks)
       if (auto insfv_ek = dynamic_cast<INSFVMomentumResidualObject *>(var_ek))
         _insfv_elemental_kernels.push_back(insfv_ek);

--- a/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
+++ b/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
@@ -278,7 +278,7 @@ INSFVRhieChowInterpolator::initialSetup()
     std::vector<MooseObject *> var_objects;
     _fe_problem.theWarehouse()
         .query()
-        .template condition<AttribVar>(static_cast<int>(var_num))
+        .template condition<AttribVar>(libMesh::cast_int<int>(var_num))
         .template condition<AttribResidualObject>(true)
         .template condition<AttribSysNum>(_u->sys().number())
         .queryInto(var_objects);

--- a/modules/navier_stokes/src/variables/INSFVVelocityVariable.C
+++ b/modules/navier_stokes/src/variables/INSFVVelocityVariable.C
@@ -324,7 +324,7 @@ INSFVVelocityVariable::adGradSln(const Elem * const elem,
         ebf_faces.size() < UINT_MAX,
         "You've created a mystical element that has more faces than can be held by unsigned "
         "int. I applaud you.");
-    const auto num_ebfs = static_cast<unsigned int>(ebf_faces.size());
+    const auto num_ebfs = libMesh::cast_int<unsigned int>(ebf_faces.size());
 
     // test for simple case
     if (num_ebfs == 0)
@@ -333,7 +333,8 @@ INSFVVelocityVariable::adGradSln(const Elem * const elem,
     {
       // We have to solve a system
       const unsigned int sys_dim =
-          lm_dim + num_ebfs + lm_dim * static_cast<unsigned int>(fdf_grad_centroid_coeffs.size());
+          lm_dim + num_ebfs +
+          lm_dim * libMesh::cast_int<unsigned int>(fdf_grad_centroid_coeffs.size());
       DenseVector<ADReal> x(sys_dim), b(sys_dim);
       DenseMatrix<ADReal> A(sys_dim, sys_dim);
 

--- a/modules/phase_field/src/vectorpostprocessors/FeatureVolumeVectorPostprocessor.C
+++ b/modules/phase_field/src/vectorpostprocessors/FeatureVolumeVectorPostprocessor.C
@@ -103,13 +103,13 @@ FeatureVolumeVectorPostprocessor::execute()
       _var_num[feature_num] = var_num;
 
     _intersects_bounds[feature_num] =
-        static_cast<unsigned int>(_feature_counter.doesFeatureIntersectBoundary(feature_num));
+        libMesh::cast_int<unsigned int>(_feature_counter.doesFeatureIntersectBoundary(feature_num));
 
-    _intersects_specified_bounds[feature_num] = static_cast<unsigned int>(
+    _intersects_specified_bounds[feature_num] = libMesh::cast_int<unsigned int>(
         _feature_counter.doesFeatureIntersectSpecifiedBoundary(feature_num));
 
     _percolated[feature_num] =
-        static_cast<unsigned int>(_feature_counter.isFeaturePercolated(feature_num));
+        libMesh::cast_int<unsigned int>(_feature_counter.isFeaturePercolated(feature_num));
   }
 
   if (_output_centroids)

--- a/modules/solid_mechanics/src/loops/UELThread.C
+++ b/modules/solid_mechanics/src/loops/UELThread.C
@@ -69,7 +69,7 @@ UELThread::onElement(const Elem * elem)
     // sanity checks
     if (_variables[i]->scalingFactor() != 1)
       mooseError("Scaling factors other than unity are not yet supported");
-    if (static_cast<int>(_var_dof_indices.size()) != nnode)
+    if (libMesh::cast_int<int>(_var_dof_indices.size()) != nnode)
       mooseError("All coupled variables must be full order lagrangian");
 
     for (const auto j : make_range(nnode))
@@ -110,7 +110,7 @@ UELThread::onElement(const Elem * elem)
   {
     _aux_variables[i]->getDofIndices(elem, _aux_var_dof_indices);
 
-    if (static_cast<int>(_aux_var_dof_indices.size()) != nnode)
+    if (libMesh::cast_int<int>(_aux_var_dof_indices.size()) != nnode)
       mooseError("All auxiliary variables must be full order Lagrangian");
 
     for (const auto j : make_range(nnode))

--- a/modules/solid_mechanics/src/materials/ADComputeSmearedCrackingStress.C
+++ b/modules/solid_mechanics/src/materials/ADComputeSmearedCrackingStress.C
@@ -100,7 +100,7 @@ ADComputeSmearedCrackingStress::ADComputeSmearedCrackingStress(const InputParame
         if (prescribed_crack_directions[i] == prescribed_crack_directions[j])
           mooseError("Entries in 'prescribed_crack_directions' cannot be repeated");
       _prescribed_crack_directions.push_back(
-          static_cast<unsigned int>(prescribed_crack_directions.get(i)));
+          libMesh::cast_int<unsigned int>(prescribed_crack_directions.get(i)));
     }
 
     // Fill in the last remaining direction if 2 are specified

--- a/modules/solid_mechanics/src/materials/ComputeSmearedCrackingStress.C
+++ b/modules/solid_mechanics/src/materials/ComputeSmearedCrackingStress.C
@@ -99,7 +99,7 @@ ComputeSmearedCrackingStress::ComputeSmearedCrackingStress(const InputParameters
         if (prescribed_crack_directions[i] == prescribed_crack_directions[j])
           mooseError("Entries in 'prescribed_crack_directions' cannot be repeated");
       _prescribed_crack_directions.push_back(
-          static_cast<unsigned int>(prescribed_crack_directions.get(i)));
+          libMesh::cast_int<unsigned int>(prescribed_crack_directions.get(i)));
     }
 
     // Fill in the last remaining direction if 2 are specified

--- a/modules/solid_mechanics/src/materials/crystal_plasticity/FiniteStrainCrystalPlasticity.C
+++ b/modules/solid_mechanics/src/materials/crystal_plasticity/FiniteStrainCrystalPlasticity.C
@@ -289,8 +289,8 @@ FiniteStrainCrystalPlasticity::getInitSlipSysRes()
       mooseError("FiniteStrainCrystalPLasticity: Error in reading slip system resistances: Values "
                  "specifying start and end number of slip system groups should be integer");
 
-    is = static_cast<unsigned int>(vs);
-    ie = static_cast<unsigned int>(ve);
+    is = libMesh::cast_int<unsigned int>(vs);
+    ie = libMesh::cast_int<unsigned int>(ve);
 
     if (is > ie)
       mooseError("FiniteStrainCrystalPLasticity: Start index is = ",
@@ -373,8 +373,8 @@ FiniteStrainCrystalPlasticity::getFlowRateParams()
       mooseError("FiniteStrainCrystalPLasticity: Error in reading flow props: Values specifying "
                  "start and end number of slip system groups should be integer");
 
-    is = static_cast<unsigned int>(vs);
-    ie = static_cast<unsigned int>(ve);
+    is = libMesh::cast_int<unsigned int>(vs);
+    ie = libMesh::cast_int<unsigned int>(ve);
 
     if (is > ie)
       mooseError("FiniteStrainCrystalPLasticity: Start index is = ",

--- a/modules/solid_mechanics/src/userobjects/CrystalPlasticitySlipRateGSS.C
+++ b/modules/solid_mechanics/src/userobjects/CrystalPlasticitySlipRateGSS.C
@@ -99,8 +99,8 @@ CrystalPlasticitySlipRateGSS::getFlowRateParams()
       mooseError("CrystalPlasticitySlipRateGSS: Error in reading flow props: Values specifying "
                  "start and end number of slip system groups should be integer");
 
-    is = static_cast<unsigned int>(vs);
-    ie = static_cast<unsigned int>(ve);
+    is = libMesh::cast_int<unsigned int>(vs);
+    ie = libMesh::cast_int<unsigned int>(ve);
 
     if (is > ie)
       mooseError("CrystalPlasticitySlipRateGSS: Start index is = ",

--- a/modules/solid_mechanics/src/utils/MultiPlasticityLinearSystem.C
+++ b/modules/solid_mechanics/src/utils/MultiPlasticityLinearSystem.C
@@ -670,6 +670,6 @@ MultiPlasticityLinearSystem::nrStep(const RankTwoTensor & stress,
     if (anyActiveSurfaces(model, active_not_deact))
       dintnl[model] = rhs[ind++];
 
-  mooseAssert(static_cast<int>(ind) == system_size,
+  mooseAssert(libMesh::cast_int<int>(ind) == system_size,
               "Incorrect extracting of changes from NR solution in nrStep");
 }

--- a/modules/stochastic_tools/src/samplers/CartesianProductSampler.C
+++ b/modules/stochastic_tools/src/samplers/CartesianProductSampler.C
@@ -50,7 +50,7 @@ CartesianProductSampler::CartesianProductSampler(const InputParameters & paramet
                  "The third entry for each item must be positive; it provides the number of "
                  "entries in the resulting item vector.");
 
-    unsigned int div = static_cast<unsigned int>(items[i + 2]);
+    unsigned int div = libMesh::cast_int<unsigned int>(items[i + 2]);
     grid_items.emplace_back(std::vector<Real>(div));
     for (std::size_t j = 0; j < grid_items.back().size(); ++j)
       grid_items.back()[j] = items[i] + j * items[i + 1];

--- a/modules/thermal_hydraulics/src/components/FileMeshComponent.C
+++ b/modules/thermal_hydraulics/src/components/FileMeshComponent.C
@@ -183,7 +183,7 @@ FileMeshComponent::buildMesh()
     // Map the zero-based Exodus side numbering to the libmesh side numbering
     unsigned int raw_side_index = exio_helper.side_list[e] - 1;
     std::size_t side_index_offset = conv.get_shellface_index_offset();
-    unsigned int side_index = static_cast<unsigned int>(raw_side_index - side_index_offset);
+    unsigned int side_index = libMesh::cast_int<unsigned int>(raw_side_index - side_index_offset);
     int mapped_side = conv.get_side_map(side_index);
 
     // Get the boundary ID and add the elem/side pair to the boundary

--- a/modules/thermal_hydraulics/src/interfaces/HSBoundaryInterface.C
+++ b/modules/thermal_hydraulics/src/interfaces/HSBoundaryInterface.C
@@ -27,7 +27,7 @@ HSBoundaryInterface::HSBoundaryInterface(Component * component)
   : _hs_name(component->getParam<std::string>("hs")),
     _hs_side_enum(component->getParam<MooseEnum>("hs_side")),
     _hs_side(component->getEnumParam<Component2D::ExternalBoundaryType>("hs_side")),
-    _hs_side_valid(static_cast<int>(_hs_side) >= 0)
+    _hs_side_valid(libMesh::cast_int<int>(_hs_side) >= 0)
 {
   component->addDependency(_hs_name);
 }

--- a/modules/xfem/src/userobjects/CrackMeshCut3DUserObject.C
+++ b/modules/xfem/src/userobjects/CrackMeshCut3DUserObject.C
@@ -1033,7 +1033,7 @@ CrackMeshCut3DUserObject::refineFront()
 
       if (distance > _size_control)
       {
-        unsigned int n = static_cast<int>(distance / _size_control);
+        unsigned int n = libMesh::cast_int<int>(distance / _size_control);
         std::array<Real, 3> x1;
         std::array<Real, 3> x2;
 

--- a/modules/xfem/src/userobjects/CrackMeshCut3DUserObject.C
+++ b/modules/xfem/src/userobjects/CrackMeshCut3DUserObject.C
@@ -606,7 +606,7 @@ CrackMeshCut3DUserObject::refineBoundary()
 
     if (distance > _size_control)
     {
-      unsigned int n = static_cast<unsigned int>(distance / _size_control);
+      unsigned int n = libMesh::cast_int<unsigned int>(distance / _size_control);
       std::array<Real, 3> x1;
       std::array<Real, 3> x2;
 


### PR DESCRIPTION
## Reason
Libmesh has a safe int cast we could use in lieu of the static_cast which can be unsafe with overflow

## Design
use set to replace `static_cast<...>` with `libMesh::cast_int<...>`

## Impact
Overflow protection on a ton of existing code
In a lot of instances, likely unnecessary