### PR TITLE
Fix message for automatic switch from parMETIS to PTscotch

### DIFF
--- a/framework/src/partitioner/PetscExternalPartitioner.C
+++ b/framework/src/partitioner/PetscExternalPartitioner.C
@@ -86,7 +86,7 @@ PetscExternalPartitioner::partition(MeshBase & mesh, const unsigned int n_parts)
 {
   // We want to use a parallel partitioner that requires a distributed graph
   // Simply calling a linear partitioner provides us the distributed graph
-  // We shold not do anything when using a distributed mesh since the mesh itself
+  // We should not do anything when using a distributed mesh since the mesh itself
   // is already distributed
   // When n_parts=1, we do not need to run any partitioner, instead, let libmesh
   // handle this
@@ -96,8 +96,8 @@ PetscExternalPartitioner::partition(MeshBase & mesh, const unsigned int n_parts)
   if ((mesh.n_elem() / n_parts < 28) && _part_package == "parmetis")
   {
     Moose::out
-        << "Number of elements per compute node must be less than 28, otherwise we switch to "
-           "PTScotch"
+        << "Average number of elements per partition (" << mesh.n_elem() / n_parts
+        << ") is less than 28. We are switching from ParMETIS to PTScotch for the partitioning."
         << std::endl;
     _part_package = "ptscotch";
   }

--- a/test/tests/partitioners/petsc_partitioner/gold/petsc_partitioner_parmetis_out.csv
+++ b/test/tests/partitioners/petsc_partitioner/gold/petsc_partitioner_parmetis_out.csv
@@ -1,2 +1,2 @@
 time,max_elems,min_elems,sum_sides
-2,103,99,86
+2,201,199,130

--- a/test/tests/partitioners/petsc_partitioner/gold/petsc_partitioner_parmetis_weight_both_out.csv
+++ b/test/tests/partitioners/petsc_partitioner/gold/petsc_partitioner_parmetis_weight_both_out.csv
@@ -1,2 +1,2 @@
 time,max_elems,min_elems,sum_sides
-2,152,146,86
+2,303,297,114

--- a/test/tests/partitioners/petsc_partitioner/gold/petsc_partitioner_parmetis_weight_element_out.csv
+++ b/test/tests/partitioners/petsc_partitioner/gold/petsc_partitioner_parmetis_weight_element_out.csv
@@ -1,2 +1,2 @@
 time,max_elems,min_elems,sum_sides
-2,154,148,88
+2,300,300,110

--- a/test/tests/partitioners/petsc_partitioner/gold/petsc_partitioner_parmetis_weight_side_out.csv
+++ b/test/tests/partitioners/petsc_partitioner/gold/petsc_partitioner_parmetis_weight_side_out.csv
@@ -1,2 +1,2 @@
 time,max_elems,min_elems,sum_sides
-2,102,99,88
+2,202,199,124

--- a/test/tests/partitioners/petsc_partitioner/tests
+++ b/test/tests/partitioners/petsc_partitioner/tests
@@ -82,7 +82,11 @@
     type = 'CSVDiff'
     input = 'petsc_partitioner.i'
     csvdiff = 'petsc_partitioner_parmetis_out.csv'
-    cli_args = 'Mesh/Partitioner/part_package=parmetis Outputs/file_base=petsc_partitioner_parmetis_out Outputs/exodus=false'
+    # Make the mesh big enough to use parmetis (ptscotch is used for <28 elems per processor)
+    cli_args = "Mesh/nx=20
+                Mesh/Partitioner/part_package=parmetis
+                Outputs/file_base=petsc_partitioner_parmetis_out
+                Outputs/exodus=false"
     # Want to insure the partitioned mesh can be used by solver
     expect_out = 'Solve Converged!'
     parmetis = true
@@ -97,7 +101,12 @@
     type = 'CSVDiff'
     input = 'petsc_partitioner.i'
     csvdiff = 'petsc_partitioner_parmetis_weight_element_out.csv'
-    cli_args = 'Mesh/Partitioner/part_package=parmetis Mesh/Partitioner/type=PartitionerWeightTest Outputs/file_base=petsc_partitioner_parmetis_weight_element_out Mesh/Partitioner/apply_element_weight=true Outputs/exodus=false'
+    cli_args = "Mesh/nx=20
+                Mesh/Partitioner/part_package=parmetis
+                Mesh/Partitioner/type=PartitionerWeightTest
+                Mesh/Partitioner/apply_element_weight=true
+                Outputs/file_base=petsc_partitioner_parmetis_weight_element_out
+                Outputs/exodus=false"
     parmetis = true
     # Want to insure the partitioned mesh can be used by solver
     expect_out = 'Solve Converged!'
@@ -113,7 +122,12 @@
     type = 'CSVDiff'
     input = 'petsc_partitioner.i'
     csvdiff = 'petsc_partitioner_parmetis_weight_side_out.csv'
-    cli_args = 'Mesh/Partitioner/part_package=parmetis Mesh/Partitioner/type=PartitionerWeightTest Outputs/file_base=petsc_partitioner_parmetis_weight_side_out Mesh/Partitioner/apply_side_weight=true Outputs/exodus=false'
+    cli_args = "Mesh/nx=20
+                Mesh/Partitioner/part_package=parmetis
+                Mesh/Partitioner/type=PartitionerWeightTest
+                Mesh/Partitioner/apply_side_weight=true
+                Outputs/file_base=petsc_partitioner_parmetis_weight_side_out
+                Outputs/exodus=false"
     parmetis = true
     # Want to insure the partitioned mesh can be used by solver
     expect_out = 'Solve Converged!'
@@ -129,7 +143,13 @@
     type = 'CSVDiff'
     input = 'petsc_partitioner.i'
     csvdiff = 'petsc_partitioner_parmetis_weight_both_out.csv'
-    cli_args = 'Mesh/Partitioner/part_package=parmetis Mesh/Partitioner/type=PartitionerWeightTest Outputs/file_base=petsc_partitioner_parmetis_weight_both_out Mesh/Partitioner/apply_side_weight=true Mesh/Partitioner/apply_element_weight=true Outputs/exodus=false'
+    cli_args = "Mesh/nx=20
+                Mesh/Partitioner/part_package=parmetis
+                Mesh/Partitioner/type=PartitionerWeightTest
+                Mesh/Partitioner/apply_element_weight=true
+                Mesh/Partitioner/apply_side_weight=true
+                Outputs/file_base=petsc_partitioner_parmetis_weight_both_out
+                Outputs/exodus=false"
     parmetis = true
     # Want to insure the partitioned mesh can be used by solver
     expect_out = 'Solve Converged!'


### PR DESCRIPTION
Use parmetis for the parmetis partitioning test by increasing above threshold for switch to ptscotch
refs #25691
Regold because the number of elements changed

tthis PR makes sure we keep using parmetis for the parmetis tests