### PR TITLE
Remove execute_on from function parameters

### DIFF
--- a/framework/include/functions/Function.h
+++ b/framework/include/functions/Function.h
@@ -143,9 +143,10 @@ public:
   virtual Real average() const;
 
   void timestepSetup() override;
-  void residualSetup() override;
-  void jacobianSetup() override;
-  void customSetup(const ExecFlagType & exec_type) override;
+  // We will only allow initialSetup() and timestepSetup() to be overriden
+  void residualSetup() override final;
+  void jacobianSetup() override final;
+  void customSetup(const ExecFlagType & exec_type) override final;
 
   bool hasBlocks(SubdomainID) const override { return true; }
 

--- a/framework/src/functions/Function.C
+++ b/framework/src/functions/Function.C
@@ -17,6 +17,8 @@ Function::validParams()
   InputParameters params = MooseObject::validParams();
   params += SetupInterface::validParams();
 
+  // Functions should be executed on the fly
+  params.suppressParameter<ExecFlagEnum>("execute_on");
   params.registerBase("Function");
 
   return params;


### PR DESCRIPTION
Keep some function setup options
refs https://github.com/idaholab/moose/issues/28391

will need a downstream patch for an app