### PR TITLE
Update libmesh

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,8 +4,8 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 2 %}
-{% set version = "2024.07.27" %}
+{% set build = 0 %}
+{% set version = "2024.08.17" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2024.07.27 mpich_2
-  - moose-libmesh 2024.07.27 openmpi_2
+  - moose-libmesh 2024.08.17 mpich_0
+  - moose-libmesh 2024.08.17 openmpi_0
 
 moose_wasp:
   - moose-wasp 2024.05.08

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -6,7 +6,7 @@
 #   framework/doc/packages_config.yml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.08.12" %}
+{% set version = "2024.08.17" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2024.08.12
+  - moose-dev 2024.08.17
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=055e533d329961be6e88900e574be6c6dfcea84d
+ARG LIBMESH_REV=3855e00043601e0a45d83ed8b639991c2b288553
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -11,7 +11,7 @@ mpich: 4.2.1
 openmpi: 4.1.6
 petsc_alt: 3.11.4
 petsc: 3.21.4
-moose_dev: 2024.08.12
+moose_dev: 2024.08.17
 moose_tools: 2024.07.19
 apptainer_rockylinux: 8.8.20230518
 apptainer_mpich: 3.4.3

--- a/modules/doc/content/newsletter/2024/2024_08.md
+++ b/modules/doc/content/newsletter/2024/2024_08.md
@@ -9,6 +9,22 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+- Don't leak temporary Netgen `LDFLAGS` into `libmesh_LDFLAGS`.
+- Include `<memory>` in `getpot.h` for more compiler compatibility.
+- Implemented an improved `ASPECT_RATIO` quality metric for Quad elements.
+- Added `Quad::quality(WARP)` implementation.
+- Added unit tests for mesh smoothers.
+- Fixed `ReplicatedMesh(DistributedMesh &)` construction.
+- Report a more useful error message when asked to tetrahedralize a broken boundary.
+- Add `Elem::edges_adjacent_to_node()` API
+- Allow all Petsc matrix types to proceed from a common base class.
+- Call netgen only on rank 0, then broadcast, for better reliability when tetrahedralizing in parallel.
+- Add generic `Elem::quality(MIN,MAX_DIHEDRAL_ANGLE)` implementation.
+- Close solution before zeroing for eigen systems.
+- Add matrix iterator APIs to match vector iterator APIs.
+- Fixes for compilations using single/triple/quadruple precision
+- Netgen handling for unprepared inputs, non-contained holes
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/modules/navier_stokes/test/tests/finite_element/ins/block-restriction/tests
+++ b/modules/navier_stokes/test/tests/finite_element/ins/block-restriction/tests
@@ -6,6 +6,7 @@
     input = two-mats-two-eqn-sets.i
     exodiff = two-mats-two-eqn-sets_out.e
     requirement = 'The system shall be able to solve two different kernel sets with two different material domains.'
+    rel_err = 2e-5
   []
   [one-mat-two-eqn-sets]
     type = Exodiff

--- a/modules/stochastic_tools/test/tests/transfers/sampler_postprocessor/tests
+++ b/modules/stochastic_tools/test/tests/transfers/sampler_postprocessor/tests
@@ -41,6 +41,7 @@
       csvdiff = 'cartesian_diverge_out_storage_0001.csv cartesian_diverge_out_storage_0002.csv'
 
       detail = "transfer last computed postprocessor value, "
+      valgrind = 'none' # too slow
     []
     [nan]
       type = CheckFiles
@@ -50,6 +51,7 @@
       check_files = 'cartesian_diverge_nan_storage_0001.csv'
       file_expect_out = 'data:avg\nnan\n0\.269307.*\n0\.269307.*\n0\.269307.*\n0\.269307.*\n'
       detail = "or transfer NaN."
+      valgrind = 'none' # too slow
     []
   []
 []

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -309,3 +309,9 @@ bcfdf8828910757299379973a97333791a093402: #26839
   libmesh: 2b5b000
   moose-dev: 39d7388
   wasp: 33b8e6b
+aa749eea6ea1bc7945fb90ad29ac41620c8c2390: #28411
+  mpi: b19f0fe
+  petsc: 24f0aee
+  libmesh: 34b8a4a
+  moose-dev: 271acbe
+  wasp: 33b8e6b

--- a/test/tests/executioners/fixed_point/tests
+++ b/test/tests/executioners/fixed_point/tests
@@ -19,7 +19,7 @@
 
       detail = "nonlinear problems."
       # nonlinear tolerance (fixed point problem) is only 1e-2
-      rel_err = 1e-5
+      rel_err = 2e-5
     []
   []
 


### PR DESCRIPTION
- Fixes for `--disable-amr`                                                                                               
- Don't leak temporary Netgen `LDFLAGS` into `libmesh_LDFLAGS`                                                            
- Include `<memory>` in `getpot.h`                                                                                        
- Always build all unit tests with plain `make`                                                                           
- Implement improved `ASPECT_RATIO` quality metric for Quad elements                                                      
- Add `Quad::quality(WARP)` implementation                                                                                
- Smoother unit tests                                                                                                     
- Fix `ReplicatedMesh(DistributedMesh &)` construction                                                                    
- Better error when asked to tetrahedralize a broken boundary                                                             
- Add `Elem::edges_adjacent_to_node()` API                                                                                
- Allow all Petsc matrix types to proceed from a common base class                                                        
- Fix bad calls to `LibmeshPetscCall` when we don't have `this->comm()`                                                   
- Call netgen only on rank 0                                                                                              
- Add generic `Elem::quality(MIN,MAX_DIHEDRAL_ANGLE)` implementation                                                      
- Close solution before zeroing for eigen systems                                                                         
- Add matrix iterator APIs to match vector iterator APIs 