### PR TITLE
Forward parameter errors to `MooseBase` when possible 

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1493,14 +1493,14 @@ template <typename T>
 const T &
 MooseApp::getParam(const std::string & name)
 {
-  return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
+  return _pars.getParamHelper<T>(name);
 }
 
 template <typename T>
 const T &
 MooseApp::getParam(const std::string & name) const
 {
-  return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0), this);
+  return _pars.getParamHelper<T>(name);
 }
 
 template <typename T>
@@ -1510,13 +1510,13 @@ MooseApp::getRenamedParam(const std::string & old_name, const std::string & new_
   // this enables having a default on the new parameter but bypassing it with the old one
   // Most important: accept new parameter
   if (isParamSetByUser(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), this);
+    return _pars.getParamHelper<T>(new_name);
   // Second most: accept old parameter
   else if (isParamValid(old_name) && !isParamSetByUser(new_name))
-    return InputParameters::getParamHelper(old_name, _pars, static_cast<T *>(0), this);
+    return _pars.getParamHelper<T>(old_name);
   // Third most: accept default for new parameter
   else if (isParamValid(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), this);
+    return _pars.getParamHelper<T>(new_name);
   // Refuse: no default, no value passed
   else if (!isParamValid(old_name) && !isParamValid(new_name))
     mooseError(_pars.blockFullpath() + ": parameter '" + new_name +

--- a/framework/include/base/MooseBaseParameterInterface.h
+++ b/framework/include/base/MooseBaseParameterInterface.h
@@ -203,7 +203,7 @@ template <typename T>
 const T &
 MooseBaseParameterInterface::getParam(const std::string & name) const
 {
-  return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0), &_moose_base);
+  return _pars.getParamHelper<T>(name);
 }
 
 template <typename T>
@@ -214,13 +214,13 @@ MooseBaseParameterInterface::getRenamedParam(const std::string & old_name,
   // this enables having a default on the new parameter but bypassing it with the old one
   // Most important: accept new parameter
   if (isParamSetByUser(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), &_moose_base);
+    return _pars.getParamHelper<T>(new_name);
   // Second most: accept old parameter
   else if (isParamValid(old_name) && !isParamSetByUser(new_name))
-    return InputParameters::getParamHelper(old_name, _pars, static_cast<T *>(0), &_moose_base);
+    return _pars.getParamHelper<T>(old_name);
   // Third most: accept default for new parameter
   else if (isParamValid(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), &_moose_base);
+    return _pars.getParamHelper<T>(new_name);
   // Refuse: no default, no value passed
   else if (!isParamValid(old_name) && !isParamValid(new_name))
     mooseError(_pars.blockFullpath() + ": parameter '" + new_name +

--- a/framework/src/base/MooseBase.C
+++ b/framework/src/base/MooseBase.C
@@ -21,6 +21,9 @@ MooseBase::MooseBase(const std::string & type,
                      const InputParameters & params)
   : _app(app), _type(type), _name(name), _params(params)
 {
+  // This allows mooseError() within InputParameters to call the mooseError
+  // from within this base instead, providing more context
+  _params.setMooseBase(*this, {});
 }
 
 std::string
@@ -32,7 +35,8 @@ MooseBase::typeAndName() const
 [[noreturn]] void
 MooseBase::callMooseError(std::string msg, const bool with_prefix) const
 {
-  _app.getOutputWarehouse().mooseConsole();
+  _app.getOutputWarehouse().mooseConsole(); // flush output first
+
   const std::string prefix = _app.isUltimateMaster() ? "" : _app.name();
   if (with_prefix)
     msg = errorPrefix("error") + msg;

--- a/modules/thermal_hydraulics/include/base/FlowModelSetup.h
+++ b/modules/thermal_hydraulics/include/base/FlowModelSetup.h
@@ -81,5 +81,5 @@ template <typename T>
 const T &
 FlowModelSetup::getParam(const std::string & name) const
 {
-  return InputParameters::getParamHelper(name, _this_params, static_cast<T *>(0));
+  return _this_params.getParamHelper<T>(name);
 }


### PR DESCRIPTION
Closes #28413

This ties all errors in `InputParameters` to the moose object that uses the parameters, if possible.