### PR TITLE
Emit an error if retrieving a MooseEnum value without it being set

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1493,14 +1493,14 @@ template <typename T>
 const T &
 MooseApp::getParam(const std::string & name)
 {
-  return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
+  return _pars.getParamHelper<T>(name);
 }
 
 template <typename T>
 const T &
 MooseApp::getParam(const std::string & name) const
 {
-  return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0), this);
+  return _pars.getParamHelper<T>(name);
 }
 
 template <typename T>
@@ -1510,13 +1510,13 @@ MooseApp::getRenamedParam(const std::string & old_name, const std::string & new_
   // this enables having a default on the new parameter but bypassing it with the old one
   // Most important: accept new parameter
   if (isParamSetByUser(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), this);
+    return _pars.getParamHelper<T>(new_name);
   // Second most: accept old parameter
   else if (isParamValid(old_name) && !isParamSetByUser(new_name))
-    return InputParameters::getParamHelper(old_name, _pars, static_cast<T *>(0), this);
+    return _pars.getParamHelper<T>(old_name);
   // Third most: accept default for new parameter
   else if (isParamValid(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), this);
+    return _pars.getParamHelper<T>(new_name);
   // Refuse: no default, no value passed
   else if (!isParamValid(old_name) && !isParamValid(new_name))
     mooseError(_pars.blockFullpath() + ": parameter '" + new_name +

--- a/framework/include/base/MooseBaseParameterInterface.h
+++ b/framework/include/base/MooseBaseParameterInterface.h
@@ -203,7 +203,7 @@ template <typename T>
 const T &
 MooseBaseParameterInterface::getParam(const std::string & name) const
 {
-  return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0), &_moose_base);
+  return _pars.getParamHelper<T>(name);
 }
 
 template <typename T>
@@ -214,13 +214,13 @@ MooseBaseParameterInterface::getRenamedParam(const std::string & old_name,
   // this enables having a default on the new parameter but bypassing it with the old one
   // Most important: accept new parameter
   if (isParamSetByUser(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), &_moose_base);
+    return _pars.getParamHelper<T>(new_name);
   // Second most: accept old parameter
   else if (isParamValid(old_name) && !isParamSetByUser(new_name))
-    return InputParameters::getParamHelper(old_name, _pars, static_cast<T *>(0), &_moose_base);
+    return _pars.getParamHelper<T>(old_name);
   // Third most: accept default for new parameter
   else if (isParamValid(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0), &_moose_base);
+    return _pars.getParamHelper<T>(new_name);
   // Refuse: no default, no value passed
   else if (!isParamValid(old_name) && !isParamValid(new_name))
     mooseError(_pars.blockFullpath() + ": parameter '" + new_name +

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -108,6 +108,11 @@ public:
     DISTRIBUTED
   };
 
+  /// The list of supported geometrical elements
+  static const std::string list_geom_elem;
+  /// MooseEnum of the supported geometrical elements; useful for "elem_type" params
+  static const MooseEnum elem_type_enum;
+
   /**
    * Clone method.  Allocates memory you are responsible to clean up.
    */
@@ -1364,6 +1369,18 @@ public:
    * block faces
    */
   bool hasLowerD() const { return _has_lower_d; }
+
+  /**
+   * Helper for determining the ElemType to use given a MooseMesh::elem_type_enum parameter.
+   *
+   * @param params The InputParameters to pull from
+   * @param elem_type_param_name The name of the MooseEnum parameter set to
+   * MooseMesh::elem_type_enum
+   * @param dim The dimension
+   */
+  static ElemType determineElemType(const InputParameters & params,
+                                    const std::string & elem_type_param_name,
+                                    const unsigned int dim);
 
 protected:
   /// Deprecated (DO NOT USE)

--- a/framework/include/meshgenerators/ElementGenerator.h
+++ b/framework/include/meshgenerators/ElementGenerator.h
@@ -23,8 +23,6 @@ public:
 
   std::unique_ptr<MeshBase> generate() override;
 
-  Elem * getElemType(const std::string & type);
-
 protected:
   /// Mesh that possibly comes from another generator
   std::unique_ptr<MeshBase> & _input;

--- a/framework/include/transfers/MultiAppPostprocessorTransfer.h
+++ b/framework/include/transfers/MultiAppPostprocessorTransfer.h
@@ -45,5 +45,5 @@ protected:
   PostprocessorName _to_pp_name;
 
   /// Reduction operation to perform when transferring from multiple child apps to the parent app
-  MooseEnum _reduction_type;
+  const MooseEnum * const _reduction_type;
 };

--- a/framework/include/utils/MooseEnum.h
+++ b/framework/include/utils/MooseEnum.h
@@ -113,7 +113,7 @@ public:
    * IsValid
    * @return - a Boolean indicating whether this Enumeration has been set
    */
-  virtual bool isValid() const override { return _current.id() > MooseEnumItem::INVALID_ID; }
+  virtual bool isValid() const override { return _current.hasValue(); }
 
   // InputParameters is allowed to create an empty enum but is responsible for
   // filling it in after the fact

--- a/framework/include/utils/MooseEnumItem.h
+++ b/framework/include/utils/MooseEnumItem.h
@@ -31,9 +31,21 @@ public:
   /**
    * Return the numeric, name, or raw name.
    */
-  const int & id() const { return _id; }
-  const std::string & name() const { return _name; }
-  const std::string & rawName() const { return _raw_name; }
+  const int & id() const
+  {
+    checkValue();
+    return _id;
+  }
+  const std::string & name() const
+  {
+    checkValue();
+    return _name;
+  }
+  const std::string & rawName() const
+  {
+    checkValue();
+    return _raw_name;
+  }
   ///@}
 
   ///@{
@@ -87,6 +99,16 @@ public:
    * ID is assigned when ExecFlagEnum::addAvailableFlags is called.
    */
   void setID(const int & id);
+
+  /**
+   * @returns Whether or not a value is set
+   */
+  bool hasValue() const { return _id != INVALID_ID; }
+
+  /**
+   * Throws an error if a value is being retrieved without it being set.
+   */
+  void checkValue() const;
 
 private:
   /// The name as provided in constructor

--- a/framework/src/base/MooseBase.C
+++ b/framework/src/base/MooseBase.C
@@ -21,6 +21,9 @@ MooseBase::MooseBase(const std::string & type,
                      const InputParameters & params)
   : _app(app), _type(type), _name(name), _params(params)
 {
+  // This allows mooseError() within InputParameters to call the mooseError
+  // from within this base instead, providing more context
+  _params.setMooseBase(*this, {});
 }
 
 std::string
@@ -32,7 +35,8 @@ MooseBase::typeAndName() const
 [[noreturn]] void
 MooseBase::callMooseError(std::string msg, const bool with_prefix) const
 {
-  _app.getOutputWarehouse().mooseConsole();
+  _app.getOutputWarehouse().mooseConsole(); // flush output first
+
   const std::string prefix = _app.isUltimateMaster() ? "" : _app.name();
   if (with_prefix)
     msg = errorPrefix("error") + msg;

--- a/framework/src/mesh/GeneratedMesh.C
+++ b/framework/src/mesh/GeneratedMesh.C
@@ -29,8 +29,6 @@ GeneratedMesh::validParams()
 {
   InputParameters params = MooseMesh::validParams();
 
-  MooseEnum elem_types(LIST_GEOM_ELEM); // no default
-
   MooseEnum dims("1=1 2 3");
   params.addRequiredParam<MooseEnum>(
       "dim", dims, "The dimension of the mesh to be generated"); // Make this parameter required
@@ -45,7 +43,7 @@ GeneratedMesh::validParams()
   params.addParam<Real>("ymax", 1.0, "Upper Y Coordinate of the generated mesh");
   params.addParam<Real>("zmax", 1.0, "Upper Z Coordinate of the generated mesh");
   params.addParam<MooseEnum>("elem_type",
-                             elem_types,
+                             MooseMesh::elem_type_enum,
                              "The type of element from libMesh to "
                              "generate (default: linear element for "
                              "requested dimension)");
@@ -158,26 +156,7 @@ GeneratedMesh::safeClone() const
 void
 GeneratedMesh::buildMesh()
 {
-  MooseEnum elem_type_enum = getParam<MooseEnum>("elem_type");
-
-  if (!isParamValid("elem_type"))
-  {
-    // Switching on MooseEnum
-    switch (_dim)
-    {
-      case 1:
-        elem_type_enum = "EDGE2";
-        break;
-      case 2:
-        elem_type_enum = "QUAD4";
-        break;
-      case 3:
-        elem_type_enum = "HEX8";
-        break;
-    }
-  }
-
-  ElemType elem_type = Utility::string_to_enum<ElemType>(elem_type_enum);
+  const auto elem_type = determineElemType(_pars, "elem_type", _dim);
 
   // Switching on MooseEnum
   switch (_dim)

--- a/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
+++ b/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
@@ -82,9 +82,8 @@ DistributedRectilinearMeshGenerator::validParams()
   params.addParam<MooseEnum>(
       "partition", partition, "Which method (graph linear square) use to partition mesh");
 
-  MooseEnum elem_types(LIST_GEOM_ELEM); // no default
   params.addParam<MooseEnum>("elem_type",
-                             elem_types,
+                             MooseMesh::elem_type_enum,
                              "The type of element from libMesh to "
                              "generate (default: linear element for "
                              "requested dimension)");
@@ -1279,26 +1278,7 @@ DistributedRectilinearMeshGenerator::generate()
   // DistributedRectilinearMeshGenerator always generates a distributed mesh
   auto mesh = buildDistributedMesh();
 
-  MooseEnum elem_type_enum = getParam<MooseEnum>("elem_type");
-
-  if (!isParamValid("elem_type"))
-  {
-    // Switching on MooseEnum
-    switch (_dim)
-    {
-      case 1:
-        elem_type_enum = "EDGE2";
-        break;
-      case 2:
-        elem_type_enum = "QUAD4";
-        break;
-      case 3:
-        elem_type_enum = "HEX8";
-        break;
-    }
-  }
-
-  _elem_type = Utility::string_to_enum<ElemType>(elem_type_enum);
+  _elem_type = MooseMesh::determineElemType(_pars, "elem_type", _dim);
 
   mesh->set_mesh_dimension(_dim);
   mesh->set_spatial_dimension(_dim);

--- a/framework/src/meshgenerators/ElementGenerator.C
+++ b/framework/src/meshgenerators/ElementGenerator.C
@@ -22,8 +22,6 @@ ElementGenerator::validParams()
 {
   InputParameters params = MeshGenerator::validParams();
 
-  MooseEnum elem_types(LIST_GEOM_ELEM); // no default
-
   params.addParam<MeshGeneratorName>("input", "Optional input mesh to add the elements to");
 
   params.addRequiredParam<std::vector<Point>>("nodal_positions",
@@ -32,8 +30,8 @@ ElementGenerator::validParams()
   params.addRequiredParam<std::vector<dof_id_type>>("element_connectivity",
                                                     "List of nodes to use for each element");
 
-  params.addParam<MooseEnum>(
-      "elem_type", elem_types, "The type of element from libMesh to generate");
+  params.addRequiredParam<MooseEnum>(
+      "elem_type", MooseMesh::elem_type_enum, "The type of element from libMesh to generate");
 
   params.addClassDescription("Generates individual elements given a list of nodal positions.");
 
@@ -49,12 +47,6 @@ ElementGenerator::ElementGenerator(const InputParameters & parameters)
 {
 }
 
-Elem *
-ElementGenerator::getElemType(const std::string & type)
-{
-  return Elem::build(Utility::string_to_enum<ElemType>(type)).release();
-}
-
 std::unique_ptr<MeshBase>
 ElementGenerator::generate()
 {
@@ -64,8 +56,8 @@ ElementGenerator::generate()
   if (!mesh)
     mesh = buildMeshBaseObject();
 
-  MooseEnum elem_type_enum = getParam<MooseEnum>("elem_type");
-  auto elem = getElemType(elem_type_enum);
+  const auto elem_type = getParam<MooseEnum>("elem_type");
+  auto elem = Elem::build(Utility::string_to_enum<ElemType>(elem_type)).release();
 
   mesh->set_mesh_dimension(std::max((unsigned int)elem->dim(), mesh->mesh_dimension()));
 

--- a/framework/src/meshgenerators/GeneratedMeshGenerator.C
+++ b/framework/src/meshgenerators/GeneratedMeshGenerator.C
@@ -29,8 +29,6 @@ GeneratedMeshGenerator::validParams()
 {
   InputParameters params = MeshGenerator::validParams();
 
-  MooseEnum elem_types(LIST_GEOM_ELEM); // no default
-
   MooseEnum dims("1=1 2 3");
   params.addRequiredParam<MooseEnum>("dim", dims, "The dimension of the mesh to be generated");
 
@@ -44,7 +42,7 @@ GeneratedMeshGenerator::validParams()
   params.addParam<Real>("ymax", 1.0, "Upper Y Coordinate of the generated mesh");
   params.addParam<Real>("zmax", 1.0, "Upper Z Coordinate of the generated mesh");
   params.addParam<MooseEnum>("elem_type",
-                             elem_types,
+                             MooseMesh::elem_type_enum,
                              "The type of element from libMesh to "
                              "generate (default: linear element for "
                              "requested dimension)");
@@ -127,26 +125,7 @@ GeneratedMeshGenerator::generate()
       mesh->add_elem_integer(name);
   }
 
-  MooseEnum elem_type_enum = getParam<MooseEnum>("elem_type");
-
-  if (!isParamValid("elem_type"))
-  {
-    // Switching on MooseEnum
-    switch (_dim)
-    {
-      case 1:
-        elem_type_enum = "EDGE2";
-        break;
-      case 2:
-        elem_type_enum = "QUAD4";
-        break;
-      case 3:
-        elem_type_enum = "HEX8";
-        break;
-    }
-  }
-
-  ElemType elem_type = Utility::string_to_enum<ElemType>(elem_type_enum);
+  const auto elem_type = MooseMesh::determineElemType(_pars, "elem_type", _dim);
 
   // Switching on MooseEnum
   switch (_dim)

--- a/framework/src/userobjects/NearestRadiusLayeredAverage.C
+++ b/framework/src/userobjects/NearestRadiusLayeredAverage.C
@@ -24,7 +24,11 @@ NearestRadiusLayeredAverage::validParams()
   params.suppressParameter<MooseEnum>("dist_norm");
 
   // 'direction' in this case corresponds to 'axis' so the user shouldn't input it
-  params.set<MooseEnum>("axis") = params.get<MooseEnum>("direction");
+  if (params.isParamValid("direction"))
+  {
+    const std::string direction = params.get<MooseEnum>("direction");
+    params.set<MooseEnum>("axis").assign(direction);
+  }
   params.suppressParameter<MooseEnum>("axis");
 
   params.addClassDescription(

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -1325,7 +1325,15 @@ const MooseEnum &
 InputParameters::getParamHelper<MooseEnum>(const std::string & name_in) const
 {
   const auto name = checkForRename(name_in);
-  return get<MooseEnum>(name);
+  const auto & value = get<MooseEnum>(name);
+  if (!value.isValid())
+    mooseError("The MooseEnum parameter \"",
+               name,
+               "\" is being retrieved but does not have a value set.\n\n",
+               "To resolve this, you should:\n",
+               " - Set a default value for this MooseEnum parameter\n",
+               " - Make this parameter required");
+  return value;
 }
 
 template <>

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -382,7 +382,7 @@ InputParameters::isParamValid(const std::string & name_in) const
   else if (have_parameter<std::vector<MooseEnum>>(name))
   {
     for (const auto & entry : get<std::vector<MooseEnum>>(name))
-      if (entry.isValid())
+      if (!entry.isValid())
         return false;
     return true;
   }

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -381,10 +381,8 @@ InputParameters::isParamValid(const std::string & name_in) const
     return get<MooseEnum>(name).isValid();
   else if (have_parameter<std::vector<MooseEnum>>(name))
   {
-    for (auto it = get<std::vector<MooseEnum>>(name).begin();
-         it != get<std::vector<MooseEnum>>(name).end();
-         ++it)
-      if (!it->isValid())
+    for (const auto & entry : get<std::vector<MooseEnum>>(name))
+      if (entry.isValid())
         return false;
     return true;
   }

--- a/framework/src/utils/MooseEnumItem.C
+++ b/framework/src/utils/MooseEnumItem.C
@@ -82,13 +82,20 @@ operator<<(std::ostream & out, const MooseEnumItem & item)
 void
 MooseEnumItem::setID(const int & id)
 {
-  if (_id != INVALID_ID)
+  if (hasValue())
     mooseError("The ID of a MooseEnumItem can not be changed if it is valid, the item ",
                _name,
                " has a valid id of ",
                _id,
                ".");
   _id = id;
+}
+
+void
+MooseEnumItem::checkValue() const
+{
+  if (!hasValue())
+    mooseError("A MooseEnumItem value is being retrieved without being set.");
 }
 
 const int MooseEnumItem::INVALID_ID = std::numeric_limits<int>::min();

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -183,10 +183,12 @@ setEigenProblemSolverParams(EigenProblem & eigen_problem, const InputParameters 
   else
     mooseError("Have to specify a valid eigen problem type");
 
-  const std::string & which_eigen_pairs = params.get<MooseEnum>("which_eigen_pairs");
-  if (!which_eigen_pairs.empty())
+  if (params.isParamValid("which_eigen_pairs"))
+  {
+    const std::string & which_eigen_pairs = params.get<MooseEnum>("which_eigen_pairs");
     eigen_problem.solverParams()._which_eigen_pairs =
         Moose::stringToEnum<Moose::WhichEigenPairs>(which_eigen_pairs);
+  }
 
   // Set necessary parametrs used in EigenSystem::solve(),
   // i.e. the number of requested eigenpairs nev and the number

--- a/modules/electromagnetics/test/include/functions/ElectricalContactTestFunc.h
+++ b/modules/electromagnetics/test/include/functions/ElectricalContactTestFunc.h
@@ -61,7 +61,7 @@ protected:
    * MooseEnum to determine which stainless steel region needs to be enabled in
    * the three block analytic solution.
    */
-  const MooseEnum & _side;
+  const MooseEnum * const _side;
 
 private:
   /**

--- a/modules/electromagnetics/test/src/functions/ElectricalContactTestFunc.C
+++ b/modules/electromagnetics/test/src/functions/ElectricalContactTestFunc.C
@@ -62,7 +62,7 @@ ElectricalContactTestFunc::ElectricalContactTestFunc(const InputParameters & par
     _electrical_contact_conductance(getParam<Real>("contact_conductance")),
     _domain(getParam<MooseEnum>("domain")),
     _is_three_block(getParam<bool>("three_block")),
-    _side(getParam<MooseEnum>("three_block_side"))
+    _side(isParamValid("three_block_side") ? &getParam<MooseEnum>("three_block_side") : nullptr)
 {
 }
 
@@ -146,11 +146,12 @@ ElectricalContactTestFunc::threeBlockFunction(Real /*t*/, const Point & p) const
     RIGHT
   };
 
-  if (_domain == STAINLESS_STEEL && _side == LEFT)
+  mooseAssert(_side, "Not set");
+  if (_domain == STAINLESS_STEEL && *_side == LEFT)
   {
     return stainless_steel_func_left;
   }
-  else if (_domain == STAINLESS_STEEL && _side == RIGHT)
+  else if (_domain == STAINLESS_STEEL && *_side == RIGHT)
   {
     return stainless_steel_func_right;
   }

--- a/modules/functional_expansion_tools/include/functions/FunctionSeries.h
+++ b/modules/functional_expansion_tools/include/functions/FunctionSeries.h
@@ -102,13 +102,13 @@ protected:
    * these will be provided for any one series.
    */
   /// Stores the name of the single function series to use in the x direction
-  const MooseEnum & _x;
+  const MooseEnum * const _x;
   /// Stores the name of the single function series to use in the y direction
-  const MooseEnum & _y;
+  const MooseEnum * const _y;
   /// Stores the name of the single function series to use in the z direction
-  const MooseEnum & _z;
+  const MooseEnum * const _z;
   /// Stores the name of the single function series to use for a unit disc
-  const MooseEnum & _disc;
+  const MooseEnum * const _disc;
   /// The normalization type for expansion
   const MooseEnum & _expansion_type;
   /// The normalization type for generation

--- a/modules/functional_expansion_tools/src/functions/FunctionSeries.C
+++ b/modules/functional_expansion_tools/src/functions/FunctionSeries.C
@@ -76,10 +76,10 @@ FunctionSeries::FunctionSeries(const InputParameters & parameters)
     _orders(convertOrders(getParam<std::vector<unsigned int>>("orders"))),
     _physical_bounds(getParam<std::vector<Real>>("physical_bounds")),
     _series_type_name(getParam<MooseEnum>("series_type")),
-    _x(getParam<MooseEnum>("x")),
-    _y(getParam<MooseEnum>("y")),
-    _z(getParam<MooseEnum>("z")),
-    _disc(getParam<MooseEnum>("disc")),
+    _x(isParamValid("x") ? &getParam<MooseEnum>("x") : nullptr),
+    _y(isParamValid("y") ? &getParam<MooseEnum>("y") : nullptr),
+    _z(isParamValid("z") ? &getParam<MooseEnum>("z") : nullptr),
+    _disc(isParamValid("disc") ? &getParam<MooseEnum>("disc") : nullptr),
     _expansion_type(getParam<MooseEnum>("expansion_type")),
     _generation_type(getParam<MooseEnum>("generation_type"))
 {
@@ -95,20 +95,20 @@ FunctionSeries::FunctionSeries(const InputParameters & parameters)
      * they appear in the input file). Hence, the 'orders' and 'physical_bounds' vectors must always
      * be specified in x, y, z order.
      */
-    if (isParamValid("x"))
+    if (_x)
     {
       domains.push_back(FunctionalBasisInterface::_domain_options = "x");
-      types.push_back(_x);
+      types.push_back(*_x);
     }
-    if (isParamValid("y"))
+    if (_y)
     {
       domains.push_back(FunctionalBasisInterface::_domain_options = "y");
-      types.push_back(_y);
+      types.push_back(*_y);
     }
-    if (isParamValid("z"))
+    if (_z)
     {
       domains.push_back(FunctionalBasisInterface::_domain_options = "z");
-      types.push_back(_z);
+      types.push_back(*_z);
     }
     if (types.size() == 0)
       mooseError("Must specify one of 'x', 'y', or 'z' for 'Cartesian' series!");
@@ -126,26 +126,26 @@ FunctionSeries::FunctionSeries(const InputParameters & parameters)
      * order. The first entry in _domains is interpreted as the axial direction, and the following
      * two as the planar.
      */
-    if (isParamValid("x"))
+    if (_x)
     {
       domains = {FunctionalBasisInterface::_domain_options = "x",
                  FunctionalBasisInterface::_domain_options = "y",
                  FunctionalBasisInterface::_domain_options = "z"};
-      types.push_back(_x);
+      types.push_back(*_x);
     }
-    if (isParamValid("y"))
+    if (_y)
     {
       domains = {FunctionalBasisInterface::_domain_options = "y",
                  FunctionalBasisInterface::_domain_options = "x",
                  FunctionalBasisInterface::_domain_options = "z"};
-      types.push_back(_y);
+      types.push_back(*_y);
     }
-    if (isParamValid("z"))
+    if (_z)
     {
       domains = {FunctionalBasisInterface::_domain_options = "z",
                  FunctionalBasisInterface::_domain_options = "x",
                  FunctionalBasisInterface::_domain_options = "y"};
-      types.push_back(_z);
+      types.push_back(*_z);
     }
 
     if (types.size() == 0)
@@ -154,7 +154,8 @@ FunctionSeries::FunctionSeries(const InputParameters & parameters)
     if (types.size() > 1)
       mooseError("Cannot specify more than one of 'x', 'y', or 'z' for 'CylindricalDuo' series!");
 
-    types.push_back(_disc);
+    mooseAssert(_disc, "Not set");
+    types.push_back(*_disc);
     _series_type = std::make_unique<CylindricalDuo>(
         domains, _orders, types, name(), _expansion_type, _generation_type);
   }

--- a/modules/navier_stokes/src/fvbcs/PCNSFVStrongBC.C
+++ b/modules/navier_stokes/src/fvbcs/PCNSFVStrongBC.C
@@ -86,7 +86,7 @@ PCNSFVStrongBC::PCNSFVStrongBC(const InputParameters & params)
     _eps_elem(getMaterialProperty<Real>(NS::porosity)),
     _eps_neighbor(getNeighborMaterialProperty<Real>(NS::porosity)),
     _eqn(getParam<MooseEnum>("eqn")),
-    _index(getParam<MooseEnum>("momentum_component")),
+    _index(isParamValid("momentum_component") ? getParam<MooseEnum>("momentum_component") : -1),
     _sup_vel_provided(isParamValid(NS::superficial_velocity)),
     _pressure_provided(isParamValid(NS::pressure)),
     _T_fluid_provided(isParamValid(NS::T_fluid)),

--- a/modules/navier_stokes/src/fvkernels/PCNSFVKT.C
+++ b/modules/navier_stokes/src/fvkernels/PCNSFVKT.C
@@ -73,7 +73,7 @@ PCNSFVKT::PCNSFVKT(const InputParameters & params)
     _eps_elem(getMaterialProperty<Real>(NS::porosity)),
     _eps_neighbor(getNeighborMaterialProperty<Real>(NS::porosity)),
     _eqn(getParam<MooseEnum>("eqn")),
-    _index(getParam<MooseEnum>("momentum_component")),
+    _index(isParamValid("momentum_component") ? getParam<MooseEnum>("momentum_component") : -1),
     _scalar_elem(_u_elem),
     _scalar_neighbor(_u_neighbor),
     _grad_scalar_elem((_eqn == "scalar") ? &_var.adGradSln() : nullptr),

--- a/modules/peridynamics/include/actions/MechanicsActionPD.h
+++ b/modules/peridynamics/include/actions/MechanicsActionPD.h
@@ -49,7 +49,7 @@ protected:
 
   /// Option of stabilization scheme for correspondence material model:
   /// FORCE, BOND_HORIZON_I or BOND_HORIZON_II
-  const MooseEnum _stabilization;
+  const MooseEnum * const _stabilization;
 
   /// Option of strain formulation: SMALL or FINITE
   const MooseEnum _strain;

--- a/modules/peridynamics/include/auxkernels/NodalRankTwoPD.h
+++ b/modules/peridynamics/include/auxkernels/NodalRankTwoPD.h
@@ -67,7 +67,7 @@ protected:
   std::string _output_type;
 
   /// specific scalar type to be output
-  MooseEnum _scalar_type;
+  const MooseEnum * const _scalar_type;
 
   ///@{ component index
   unsigned int _i;

--- a/modules/peridynamics/src/actions/MechanicsActionPD.C
+++ b/modules/peridynamics/src/actions/MechanicsActionPD.C
@@ -67,7 +67,7 @@ MechanicsActionPD::MechanicsActionPD(const InputParameters & params)
     _displacements(getParam<std::vector<VariableName>>("displacements")),
     _ndisp(_displacements.size()),
     _formulation(getParam<MooseEnum>("formulation")),
-    _stabilization(getParam<MooseEnum>("stabilization")),
+    _stabilization(isParamValid("stabilization") ? &getParam<MooseEnum>("stabilization") : nullptr),
     _strain(getParam<MooseEnum>("strain")),
     _subdomain_names(getParam<std::vector<SubdomainName>>("block")),
     _subdomain_ids(),
@@ -75,7 +75,7 @@ MechanicsActionPD::MechanicsActionPD(const InputParameters & params)
     _diag_save_in(getParam<std::vector<AuxVariableName>>("diag_save_in"))
 {
   // Consistency check
-  if (_formulation == "NONORDINARY_STATE" && !isParamValid("stabilization"))
+  if (_formulation == "NONORDINARY_STATE" && !_stabilization)
     mooseError("'stabilization' is a required parameter for non-ordinary state-based models only.");
 
   if (_save_in.size() != 0 && _save_in.size() != _ndisp)
@@ -197,18 +197,18 @@ MechanicsActionPD::getKernelName()
   }
   else if (_formulation == "NONORDINARY_STATE")
   {
-    if (_stabilization == "FORCE")
+    if (_stabilization && *_stabilization == "FORCE")
     {
       name = "ForceStabilizedSmallStrainMechanicsNOSPD";
     }
-    else if (_stabilization == "BOND_HORIZON_I")
+    else if (_stabilization && *_stabilization == "BOND_HORIZON_I")
     {
       if (_strain == "SMALL")
         name = "HorizonStabilizedFormISmallStrainMechanicsNOSPD";
       else
         name = "HorizonStabilizedFormIFiniteStrainMechanicsNOSPD";
     }
-    else if (_stabilization == "BOND_HORIZON_II")
+    else if (_stabilization && *_stabilization == "BOND_HORIZON_II")
     {
       if (_strain == "SMALL")
         name = "HorizonStabilizedFormIISmallStrainMechanicsNOSPD";

--- a/modules/peridynamics/src/auxkernels/NodalRankTwoPD.C
+++ b/modules/peridynamics/src/auxkernels/NodalRankTwoPD.C
@@ -68,7 +68,7 @@ NodalRankTwoPD::NodalRankTwoPD(const InputParameters & parameters)
     _temp_ref(getParam<Real>("stress_free_temperature")),
     _rank_two_tensor(getParam<std::string>("rank_two_tensor")),
     _output_type(getParam<std::string>("output_type")),
-    _scalar_type(getParam<MooseEnum>("scalar_type")),
+    _scalar_type(isParamValid("scalar_type") ? &getParam<MooseEnum>("scalar_type") : nullptr),
     _point1(parameters.get<Point>("point1")),
     _point2(parameters.get<Point>("point2"))
 {
@@ -117,7 +117,7 @@ NodalRankTwoPD::NodalRankTwoPD(const InputParameters & parameters)
     }
   }
 
-  if (_output_type == "scalar" && !isParamValid("scalar_type"))
+  if (_output_type == "scalar" && !_scalar_type)
     mooseError("The output_type is 'scalar', but no 'scalar_type' is provided!");
 }
 
@@ -144,7 +144,11 @@ NodalRankTwoPD::computeValue()
   if (_output_type == "component")
     val = RankTwoScalarTools::component(tensor, _i, _j);
   else if (_output_type == "scalar")
-    val = RankTwoScalarTools::getQuantity(tensor, _scalar_type, _point1, _point2, _q_point[_qp], p);
+  {
+    mooseAssert(_scalar_type, "Not set");
+    val =
+        RankTwoScalarTools::getQuantity(tensor, *_scalar_type, _point1, _point2, _q_point[_qp], p);
+  }
   else
     mooseError("NodalRankTwoPD Error: Pass valid output type - component or scalar");
 

--- a/modules/stochastic_tools/include/reporters/StatisticsReporter.h
+++ b/modules/stochastic_tools/include/reporters/StatisticsReporter.h
@@ -145,7 +145,7 @@ private:
   const MultiMooseEnum & _compute_stats;
 
   // CI Method to be computed (optional)
-  const MooseEnum & _ci_method;
+  const MooseEnum * const _ci_method;
 
   // CI levels to be computed
   const std::vector<Real> & _ci_levels;

--- a/modules/stochastic_tools/include/vectorpostprocessors/Statistics.h
+++ b/modules/stochastic_tools/include/vectorpostprocessors/Statistics.h
@@ -36,7 +36,7 @@ protected:
   const MultiMooseEnum & _compute_stats;
 
   /// Bootstrap Confidence Level method
-  const MooseEnum & _ci_method;
+  const MooseEnum * const _ci_method;
 
   /// Confidence levels to compute (see computeLevels)
   const std::vector<Real> _ci_levels;

--- a/modules/stochastic_tools/src/reporters/StatisticsReporter.C
+++ b/modules/stochastic_tools/src/reporters/StatisticsReporter.C
@@ -63,14 +63,14 @@ StatisticsReporter::validParams()
 StatisticsReporter::StatisticsReporter(const InputParameters & parameters)
   : GeneralReporter(parameters),
     _compute_stats(getParam<MultiMooseEnum>("compute")),
-    _ci_method(getParam<MooseEnum>("ci_method")),
+    _ci_method(isParamValid("ci_method") ? &getParam<MooseEnum>("ci_method") : nullptr),
     _ci_levels(getParam<std::vector<Real>>("ci_levels")),
     _ci_replicates(getParam<unsigned int>("ci_replicates")),
     _ci_seed(getParam<unsigned int>("ci_seed")),
     _initialized(false)
 {
   // CI levels error checking
-  if (_ci_method.isValid())
+  if (_ci_method)
   {
     if (_ci_levels.empty())
       paramError("ci_levels",
@@ -145,8 +145,8 @@ void
 StatisticsReporter::store(nlohmann::json & json) const
 {
   Reporter::store(json);
-  if (_ci_method.isValid())
-    json["confidence_intervals"] = {{"method", _ci_method},
+  if (_ci_method)
+    json["confidence_intervals"] = {{"method", *_ci_method},
                                     {"levels", _ci_levels},
                                     {"replicates", _ci_replicates},
                                     {"seed", _ci_seed}};
@@ -162,14 +162,14 @@ StatisticsReporter::declareValueHelper(const ReporterName & r_name)
   {
     const std::string s_name =
         r_name.getObjectName() + "_" + r_name.getValueName() + "_" + item.name();
-    if (_ci_method.isValid())
+    if (_ci_method)
       declareValueByName<std::pair<OutType, std::vector<OutType>>,
                          ReporterStatisticsContext<InType, OutType>>(s_name,
                                                                      REPORTER_MODE_ROOT,
                                                                      data,
                                                                      mode,
                                                                      item,
-                                                                     _ci_method,
+                                                                     *_ci_method,
                                                                      _ci_levels,
                                                                      _ci_replicates,
                                                                      _ci_seed);

--- a/modules/thermal_hydraulics/include/base/FlowModelSetup.h
+++ b/modules/thermal_hydraulics/include/base/FlowModelSetup.h
@@ -81,5 +81,5 @@ template <typename T>
 const T &
 FlowModelSetup::getParam(const std::string & name) const
 {
-  return InputParameters::getParamHelper(name, _this_params, static_cast<T *>(0));
+  return _this_params.getParamHelper<T>(name);
 }

--- a/test/include/executioners/TestSteady.h
+++ b/test/include/executioners/TestSteady.h
@@ -39,7 +39,7 @@ public:
 
 private:
   /// The type of test that this object is to perform
-  MooseEnum _test_type;
+  const MooseEnum * const _test_type;
 
   /// A value to report (used for addAttributeReporter test)
   PostprocessorValue * _some_value_that_needs_to_be_reported;

--- a/test/include/samplers/TestSampler.h
+++ b/test/include/samplers/TestSampler.h
@@ -22,5 +22,5 @@ protected:
 
 private:
   const bool _use_rand;
-  const MooseEnum _error_test;
+  const MooseEnum * const _error_test;
 };

--- a/test/src/executioners/TestSteady.C
+++ b/test/src/executioners/TestSteady.C
@@ -27,9 +27,10 @@ TestSteady::validParams()
 }
 
 TestSteady::TestSteady(const InputParameters & parameters)
-  : Steady(parameters), _test_type(getParam<MooseEnum>("test_type"))
+  : Steady(parameters),
+    _test_type(isParamValid("test_type") ? &getParam<MooseEnum>("test_type") : nullptr)
 {
-  if (_test_type == "addAttributeReporter")
+  if (_test_type && *_test_type == "addAttributeReporter")
     _some_value_that_needs_to_be_reported = &addAttributeReporter("luggage_combo", 0);
 }
 
@@ -45,7 +46,7 @@ TestSteady::preProblemInit()
 void
 TestSteady::preExecute()
 {
-  if (_test_type == "addAttributeReporter")
+  if (_test_type && *_test_type == "addAttributeReporter")
     *_some_value_that_needs_to_be_reported = 12345;
 }
 

--- a/test/src/samplers/TestSampler.C
+++ b/test/src/samplers/TestSampler.C
@@ -31,35 +31,35 @@ TestSampler::validParams()
 TestSampler::TestSampler(const InputParameters & parameters)
   : Sampler(parameters),
     _use_rand(getParam<bool>("use_rand")),
-    _error_test(getParam<MooseEnum>("error_test"))
+    _error_test(isParamValid("error_test") ? &getParam<MooseEnum>("error_test") : nullptr)
 {
   setNumberOfRows(getParam<dof_id_type>("num_rows"));
   setNumberOfCols(getParam<dof_id_type>("num_cols"));
-  if (_error_test == "set_number_of_seeds_to_zero")
+  if (_error_test && *_error_test == "set_number_of_seeds_to_zero")
     setNumberOfRandomSeeds(0);
 }
 
 void
 TestSampler::executeSetUp()
 {
-  if (_error_test.isValid())
+  if (_error_test)
   {
     setNumberOfRows(getNumberOfRows() + 1);
-    if (_error_test == "reinit_getGlobalSamples")
+    if (*_error_test == "reinit_getGlobalSamples")
       getGlobalSamples();
-    else if (_error_test == "reinit_getLocalSamples")
+    else if (*_error_test == "reinit_getLocalSamples")
       getLocalSamples();
-    else if (_error_test == "reinit_getNextLocalRow")
+    else if (*_error_test == "reinit_getNextLocalRow")
       getNextLocalRow();
-    else if (_error_test == "reinit_getNumberOfRows")
+    else if (*_error_test == "reinit_getNumberOfRows")
       getNumberOfRows();
-    else if (_error_test == "reinit_getNumberOfLocalRows")
+    else if (*_error_test == "reinit_getNumberOfLocalRows")
       getNumberOfLocalRows();
-    else if (_error_test == "reinit_getNumberOfCols")
+    else if (*_error_test == "reinit_getNumberOfCols")
       getNumberOfCols();
-    else if (_error_test == "reinit_getLocalRowBegin")
+    else if (*_error_test == "reinit_getLocalRowBegin")
       getLocalRowBegin();
-    else if (_error_test == "reinit_getLocalRowEnd")
+    else if (*_error_test == "reinit_getLocalRowEnd")
       getLocalRowEnd();
   }
 }
@@ -67,12 +67,15 @@ TestSampler::executeSetUp()
 Real
 TestSampler::computeSample(dof_id_type row_index, dof_id_type col_index)
 {
-  if (_error_test == "call_set_number_of_rows")
-    setNumberOfRows(1980);
-  else if (_error_test == "call_set_number_of_cols")
-    setNumberOfCols(1980);
-  else if (_error_test == "call_set_number_of_seeds")
-    setNumberOfRandomSeeds(1980);
+  if (_error_test)
+  {
+    if (*_error_test == "call_set_number_of_rows")
+      setNumberOfRows(1980);
+    else if (*_error_test == "call_set_number_of_cols")
+      setNumberOfCols(1980);
+    else if (*_error_test == "call_set_number_of_seeds")
+      setNumberOfRandomSeeds(1980);
+  }
 
   if (_use_rand)
     return getRand();


### PR DESCRIPTION
Closes #28412

@grmnptr came across issues with a MooseEnum being retrieved from parameters without being required. The resulting value was invalid when not set, causing indexing with a phony value. This forces us to check for validity when using a `MooseEnum` value before actually getting it. In Peter's case, it will result in an error instead of a crash.