### PR TITLE
Accelerate nonconvergence tests in STM

### DIFF
--- a/modules/stochastic_tools/test/tests/transfers/sampler_postprocessor/sub.i
+++ b/modules/stochastic_tools/test/tests/transfers/sampler_postprocessor/sub.i
@@ -39,6 +39,8 @@
   type = Transient
   num_steps = 5
   dt = 0.01
+  dtmin = 1e-4
+  nl_max_its = 10
   solve_type = PJFNK
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'


### PR DESCRIPTION
Closes #28447

Faster tests would waste less time in CI, especially when we use Valgrind.
