### PR TITLE
Improve the implementation/docs for ElementExtreme(Functor)Value

### DIFF
--- a/framework/doc/content/source/postprocessors/ElementExtremeFunctorValue.md
+++ b/framework/doc/content/source/postprocessors/ElementExtremeFunctorValue.md
@@ -8,8 +8,11 @@ find the element at which the proxy functor reaches the max/min value,
 and then return the value of the specified functor at that element.
 
 !alert note
-Unlike the [ElementExtremeValue.md] postprocessor, this postprocessor does not examine the quadrature
-point values, but instead passes the element argument to the functor.
+Like the [ElementExtremeValue.md] postprocessor, this postprocessor can also
+operate on both elemental and nodal variables.
+However, unlike the [ElementExtremeValue.md] postprocessor, this postprocessor
+does not examine the quadrature point values, but instead passes the element
+argument to the functor.
 
 ## Example Input File Syntax
 

--- a/framework/doc/content/source/postprocessors/ElementExtremeValue.md
+++ b/framework/doc/content/source/postprocessors/ElementExtremeValue.md
@@ -7,8 +7,16 @@ which will change the behavior of this postprocessor to
 find the quadrature point at which the proxy variable reaches the max/min value,
 and then return the value of the specified variable at that point.
 
-The corresponding postprocessor that finds extreme values of nodal variables
-evaluated at nodes is [NodalExtremeValue](NodalExtremeValue.md)
+This postprocessor can operate on both elemental and nodal variables. Note,
+however, that since it works by sampling the variable at quadrature points,
+its returned value won't exactly match the variable's extreme value on the
+domain (or blocks) the postprocessor is defined over. This is the case, unless
+that extremum happens to be at a quadrature point, e.g., if the variable is
+constant over any given element.
+An alternative scheme is provided by [ElementExtremeFunctorValue.md], which
+instead of comparing values at quadrature points, compares element averages.
+The corresponding postprocessor that finds (exact) extreme values of nodal
+variables evaluated at nodes is [NodalExtremeValue.md].
 
 ## Example Input File Syntax
 

--- a/framework/src/postprocessors/ElementExtremeFunctorValue.C
+++ b/framework/src/postprocessors/ElementExtremeFunctorValue.C
@@ -37,8 +37,6 @@ ElementExtremeFunctorValueTempl<is_ad>::ElementExtremeFunctorValueTempl(
     _proxy_functor(isParamValid("proxy_functor") ? getFunctor<GenericReal<is_ad>>("proxy_functor")
                                                  : getFunctor<GenericReal<is_ad>>("functor"))
 {
-  if (this->isNodal())
-    this->paramError("variable", "This AuxKernel only supports Elemental fields");
   _use_proxy = isParamValid("proxy_functor");
 }
 

--- a/framework/src/postprocessors/ElementExtremeFunctorValue.C
+++ b/framework/src/postprocessors/ElementExtremeFunctorValue.C
@@ -25,7 +25,7 @@ ElementExtremeFunctorValueTempl<is_ad>::validParams()
       "the functor value should be taken; if not provided, this defaults "
       "to the 'functor' parameter.");
   params.addClassDescription(
-      "Finds either the min or max elemental value of a variable over the domain.");
+      "Finds either the min or max elemental value of a functor over the domain.");
   return params;
 }
 

--- a/framework/src/postprocessors/ElementExtremeValue.C
+++ b/framework/src/postprocessors/ElementExtremeValue.C
@@ -28,8 +28,6 @@ ElementExtremeValue::ElementExtremeValue(const InputParameters & parameters)
   : ExtremeValueBase<ElementVariablePostprocessor>(parameters),
     _proxy_variable(isParamValid("proxy_variable") ? coupledValue("proxy_variable") : _u)
 {
-  if (this->isNodal())
-    this->paramError("variable", "This AuxKernel only supports Elemental fields");
   _use_proxy = isParamValid("proxy_variable");
 }
 

--- a/framework/src/postprocessors/ExtremeValueBase.C
+++ b/framework/src/postprocessors/ExtremeValueBase.C
@@ -41,18 +41,12 @@ template <class T>
 void
 ExtremeValueBase<T>::initialize()
 {
-  switch (_type)
-  {
-    case ExtremeType::MAX:
-      _proxy_value =
-          std::make_pair(-std::numeric_limits<Real>::max(), -std::numeric_limits<Real>::max());
-      break;
-
-    case ExtremeType::MIN:
-      _proxy_value =
-          std::make_pair(std::numeric_limits<Real>::max(), std::numeric_limits<Real>::max());
-      break;
-  }
+  if (_type == ExtremeType::MAX)
+    _proxy_value =
+        std::make_pair(-std::numeric_limits<Real>::max(), -std::numeric_limits<Real>::max());
+  else if (_type == ExtremeType::MIN)
+    _proxy_value =
+        std::make_pair(std::numeric_limits<Real>::max(), std::numeric_limits<Real>::max());
 }
 
 template <class T>
@@ -60,18 +54,10 @@ void
 ExtremeValueBase<T>::computeExtremeValue()
 {
   const auto pv = getProxyValuePair();
-  switch (_type)
-  {
-    case ExtremeType::MAX:
-      if (pv > _proxy_value)
-        _proxy_value = pv;
-      break;
 
-    case ExtremeType::MIN:
-      if (pv < _proxy_value)
-        _proxy_value = pv;
-      break;
-  }
+  if ((_type == ExtremeType::MAX && pv > _proxy_value) ||
+      (_type == ExtremeType::MIN && pv < _proxy_value))
+    _proxy_value = pv;
 }
 
 template <class T>
@@ -85,26 +71,19 @@ template <class T>
 void
 ExtremeValueBase<T>::finalize()
 {
-  switch (_type)
+  if (_type == ExtremeType::MAX)
   {
-    case ExtremeType::MAX:
-      if (_use_proxy)
-        this->gatherProxyValueMax(_proxy_value.first, _proxy_value.second);
-      else
-      {
-        this->gatherMax(_proxy_value.first);
-        _proxy_value.second = _proxy_value.first;
-      }
-      break;
-    case ExtremeType::MIN:
-      if (_use_proxy)
-        this->gatherProxyValueMin(_proxy_value.first, _proxy_value.second);
-      else
-      {
-        this->gatherMin(_proxy_value.first);
-        _proxy_value.second = _proxy_value.first;
-      }
-      break;
+    if (_use_proxy)
+      this->gatherProxyValueMax(_proxy_value.first, _proxy_value.second);
+    else
+      this->gatherMax(_proxy_value.second);
+  }
+  else if (_type == ExtremeType::MIN)
+  {
+    if (_use_proxy)
+      this->gatherProxyValueMin(_proxy_value.first, _proxy_value.second);
+    else
+      this->gatherMin(_proxy_value.second);
   }
 }
 
@@ -114,17 +93,9 @@ ExtremeValueBase<T>::threadJoin(const UserObject & y)
 {
   const auto & pps = static_cast<const ExtremeValueBase<T> &>(y);
 
-  switch (_type)
-  {
-    case ExtremeType::MAX:
-      if (pps._proxy_value > _proxy_value)
-        _proxy_value = pps._proxy_value;
-      break;
-    case ExtremeType::MIN:
-      if (pps._proxy_value < _proxy_value)
-        _proxy_value = pps._proxy_value;
-      break;
-  }
+  if ((_type == ExtremeType::MAX && pps._proxy_value > _proxy_value) ||
+      (_type == ExtremeType::MIN && pps._proxy_value < _proxy_value))
+    _proxy_value = pps._proxy_value;
 }
 
 template class ExtremeValueBase<ElementPostprocessor>;


### PR DESCRIPTION
## Reason
Context from a previous Slack conversation:

"in both `ElementExtremeValue`  and `ElementExtremeFunctorValue` we check, in their respective constructors, `if (this->isNodal())` and error out if true. But this check is, in fact, pointless, i.e. never true, even if you pass a nodal variable. That’s because these construct `MooseVariableInterface` and `RandomInterface` objects respectively, but in both cases we’re passing a hardcoded/literal false to the nodal/is_nodal constructor parameter."

## Design
Again, from Slack:

"Opted to remove the check and add a disclaimer to the docs. Since I’m not sure it'd make sense to fix the check. After all, the postprocessor is as wrong for a nodal variable as it is for any elemental variable which is not constant."

## Impact
Minimal, just a bit more clarity for users and developers.

