### PR TITLE
Formatted how wall time checkpoint interval is displayed in console output

### DIFF
--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -264,7 +264,8 @@ Checkpoint::checkpointInfo() const
 
   std::string interval_info;
   if (getParam<bool>("wall_time_checkpoint"))
-    interval_info = "Every " + std::to_string(_wall_time_interval) + " s";
+    interval_info =
+        (std::stringstream() << "Every " << std::defaultfloat << _wall_time_interval << " s").str();
   else
     interval_info = "Disabled";
 

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 // C POSIX includes
+#include <sstream>
 #include <sys/stat.h>
 
 #include <system_error>
@@ -264,8 +265,11 @@ Checkpoint::checkpointInfo() const
 
   std::string interval_info;
   if (getParam<bool>("wall_time_checkpoint"))
-    interval_info =
-        (std::stringstream() << "Every " << std::defaultfloat << _wall_time_interval << " s").str();
+  {
+    std::stringstream interval_info_ss;
+    interval_info_ss << "Every " << std::defaultfloat << _wall_time_interval << " s";
+    interval_info = interval_info_ss.str();
+  }
   else
     interval_info = "Disabled";
 

--- a/test/tests/outputs/checkpoint/tests
+++ b/test/tests/outputs/checkpoint/tests
@@ -70,7 +70,7 @@
       type = CheckFiles
       input = checkpoint.i
       cli_args = 'Outputs/checkpoint=true --test-checkpoint-half-transient'
-      expect_out = "Checkpoint:\s+ Wall Time Interval:\s+ Every 3600.000000 s\s+ User Checkpoint:\s+ Outputs/checkpoint\s+ # Checkpoints Kept:\s+ 2\s+ Execute On:\s+ TIMESTEP_END"
+      expect_out = "Checkpoint:\s+ Wall Time Interval:\s+ Every 3600 s\s+ User Checkpoint:\s+ Outputs/checkpoint\s+ # Checkpoints Kept:\s+ 2\s+ Execute On:\s+ TIMESTEP_END"
       recover = false
 
       check_files = "checkpoint_out_cp/0004-restart-0.rd/data "
@@ -124,7 +124,7 @@
       input = checkpoint.i
       recover = false
       cli_args = 'Outputs/file_base=checkpoint_wall_time_interval_out --output-wall-time-interval 0.02'
-      expect_out = "Checkpoint:\s+ Wall Time Interval:\s+ Every 0.020000 s\s+ User Checkpoint:\s+ Disabled\s+ # Checkpoints Kept:\s+ 2\s+ Execute On:\s+ TIMESTEP_END"
+      expect_out = "Checkpoint:\s+ Wall Time Interval:\s+ Every 0.02 s\s+ User Checkpoint:\s+ Disabled\s+ # Checkpoints Kept:\s+ 2\s+ Execute On:\s+ TIMESTEP_END"
       detail = " at specified wall time intervals and"
     []
     [wall_time_interval_recover]
@@ -195,7 +195,7 @@
       type = CheckFiles
       input = checkpoint_parent.i
       cli_args = '--output-wall-time-interval 1e-50'
-      expect_out = "Checkpoint:\s+ Wall Time Interval:\s+ Every 0.000000 s\s+ User Checkpoint:\s+ Outputs/checkpoint\s+ # Checkpoints Kept:\s+ 2\s+ Execute On:\s+ TIMESTEP_END"
+      expect_out = "Checkpoint:\s+ Wall Time Interval:\s+ Every 1e-50 s\s+ User Checkpoint:\s+ Outputs/checkpoint\s+ # Checkpoints Kept:\s+ 2\s+ Execute On:\s+ TIMESTEP_END"
       recover = false
 
       check_files = "checkpoint_parent_out_cp/0010-restart-0.rd/data "
@@ -292,7 +292,7 @@
       input = checkpoint_block.i
       recover = false
       cli_args = 'Outputs/file_base=checkpoint_block_wall_time_interval_out --output-wall-time-interval 0.02'
-      expect_out = "Checkpoint:\s+ Wall Time Interval:\s+ Every 0.020000 s\s+ User Checkpoint:\s+ Outputs/out\s+ # Checkpoints Kept:\s+ 2\s+ Execute On:\s+ TIMESTEP_END"
+      expect_out = "Checkpoint:\s+ Wall Time Interval:\s+ Every 0.02 s\s+ User Checkpoint:\s+ Outputs/out\s+ # Checkpoints Kept:\s+ 2\s+ Execute On:\s+ TIMESTEP_END"
       detail = "at specified wall time intervals"
     []
     [wall_time_interval_recover]


### PR DESCRIPTION
Formatted wall time checkpoint interval to not use a bajillion zeros in console output. Small addition to the already closed #27240.