### PR TITLE
Fix parallel test failure of invalid solution warning feature

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -148,7 +148,10 @@ public:
   /**
    * Get the SolutionInvalidity for this app
    */
+  ///@{
   SolutionInvalidity & solutionInvalidity() { return _solution_invalidity; }
+  const SolutionInvalidity & solutionInvalidity() const { return _solution_invalidity; }
+  ///@}
 
   ///@{
   /**

--- a/framework/include/interfaces/SolutionInvalidInterface.h
+++ b/framework/include/interfaces/SolutionInvalidInterface.h
@@ -12,23 +12,23 @@
 // MOOSE includes
 #include "Moose.h"
 #include "SolutionInvalidity.h"
-#include "FEProblemBase.h"
 
 // Forward declarations
 class MooseObject;
+class FEProblemBase;
 
 #define flagInvalidSolution(message)                                                               \
   do                                                                                               \
   {                                                                                                \
-    static const auto __invalid_id = this->registerInvalidSolutionInternal(message);               \
-    this->flagInvalidSolutionInternal(__invalid_id);                                               \
+    static const auto __invalid_id = this->registerInvalidSolutionInternal(message, false);        \
+    this->flagInvalidSolutionInternal<false>(__invalid_id);                                        \
   } while (0)
 
 #define flagSolutionWarning(message)                                                               \
   do                                                                                               \
   {                                                                                                \
-    static const auto __invalid_id = this->registerInvalidSolutionInternal(message);               \
-    this->flagSolutionWarningInternal(__invalid_id);                                               \
+    static const auto __invalid_id = this->registerInvalidSolutionInternal(message, true);         \
+    this->flagInvalidSolutionInternal<true>(__invalid_id);                                         \
   } while (0)
 
 /**
@@ -40,12 +40,12 @@ public:
   SolutionInvalidInterface(MooseObject * const moose_object);
 
 protected:
-  void flagInvalidSolutionInternal(InvalidSolutionID invalid_solution_id) const;
-
-  void flagSolutionWarningInternal(InvalidSolutionID invalid_solution_id) const;
+  template <bool warning>
+  void flagInvalidSolutionInternal(const InvalidSolutionID invalid_solution_id) const;
 
   // Register invalid solution with a message
-  InvalidSolutionID registerInvalidSolutionInternal(const std::string & message) const;
+  InvalidSolutionID registerInvalidSolutionInternal(const std::string & message,
+                                                    const bool warning) const;
 
 private:
   /// The MooseObject that owns this interface

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1874,23 +1874,12 @@ public:
   }
 
   /**
-   * Whether or not an solution warning has been flagged
+   * Whether or not to accept the solution based on its invalidity.
+   *
+   * If this returns false, it means that an invalid solution was encountered
+   * (an error) that was not allowed.
    */
-  bool hasSolutionWarning() { return _app.solutionInvalidity().hasSolutionWarning(); }
-
-  /**
-   * Whether or not an invalid solution has been flagged
-   */
-  bool hasInvalidSolution() { return _app.solutionInvalidity().hasInvalidSolution(); }
-
-  /**
-   * Whether or not to accept the solution
-   */
-  bool acceptInvalidSolution()
-  {
-    return (hasSolutionWarning() && !hasInvalidSolution()) || allowInvalidSolution();
-  }
-
+  bool acceptInvalidSolution() const;
   /**
    * Whether to accept / allow an invalid solution
    */

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -35,6 +35,7 @@
 #include "MooseObjectWarehouse.h"
 #include "MaterialPropertyRegistry.h"
 #include "RestartableEquationSystems.h"
+#include "SolutionInvalidity.h"
 
 #include "libmesh/enum_quadrature_type.h"
 #include "libmesh/equation_systems.h"
@@ -88,6 +89,7 @@ class VectorPostprocessor;
 class Function;
 class MooseAppCoordTransform;
 class MortarUserObject;
+class SolutionInvalidity;
 
 // libMesh forward declarations
 namespace libMesh
@@ -1874,16 +1876,12 @@ public:
   /**
    * Whether or not an solution warning has been flagged
    */
-  bool hasSolutionWarning() { return _has_solution_warning; }
-
-  bool hasSolutionWarning(bool state) { return _has_solution_warning = state; }
+  bool hasSolutionWarning() { return _app.solutionInvalidity().hasSolutionWarning(); }
 
   /**
    * Whether or not an invalid solution has been flagged
    */
-  bool hasInvalidSolution() { return _has_invalid_solution; }
-
-  bool hasInvalidSolution(bool state) { return _has_invalid_solution = state; }
+  bool hasInvalidSolution() { return _app.solutionInvalidity().hasInvalidSolution(); }
 
   /**
    * Whether or not to accept the solution
@@ -2849,11 +2847,9 @@ private:
   const bool _allow_ics_during_restart;
   const bool _skip_nl_system_check;
   bool _fail_next_nonlinear_convergence_check;
-  bool _allow_invalid_solution;
-  bool _show_invalid_solution_console;
+  const bool _allow_invalid_solution;
+  const bool _show_invalid_solution_console;
   const bool & _immediately_print_invalid_solution;
-  bool _has_solution_warning;
-  bool _has_invalid_solution;
 
   /// At or beyond initialSteup stage
   bool _started_initial_setup;

--- a/framework/include/utils/SolutionInvalidity.h
+++ b/framework/include/utils/SolutionInvalidity.h
@@ -45,7 +45,13 @@ public:
   SolutionInvalidity(MooseApp & app);
 
   /// Increments solution invalid occurrences for each solution id
-  void flagInvalidSolutionInternal(InvalidSolutionID _invalid_solution_id);
+  void flagInvalidSolutionInternal(InvalidSolutionID _invalid_solution_id, const bool warning);
+
+  /// Loop over all the tracked objects and determine whether any solution warning check is registered by users
+  bool hasSolutionWarning() const;
+
+  /// Loop over all the tracked objects and determine whether any invalid solution check is registered by users
+  bool hasInvalidSolution() const;
 
   /// Loop over all the tracked objects and determine whether solution invalid is detected
   bool solutionInvalid() const;
@@ -65,6 +71,7 @@ public:
   /// Struct used in _counts for storing invalid occurrences
   struct InvalidCounts
   {
+    bool warning = false;
     unsigned int counts;
     unsigned int timestep_counts;
     unsigned int total_counts;

--- a/framework/include/utils/SolutionInvalidity.h
+++ b/framework/include/utils/SolutionInvalidity.h
@@ -72,9 +72,9 @@ public:
   struct InvalidCounts
   {
     bool warning = false;
-    unsigned int counts;
-    unsigned int timestep_counts;
-    unsigned int total_counts;
+    unsigned int counts = 0;
+    unsigned int timestep_counts = 0;
+    unsigned int total_counts = 0;
   };
 
   /// Access the private solution invalidity counts

--- a/framework/include/utils/SolutionInvalidity.h
+++ b/framework/include/utils/SolutionInvalidity.h
@@ -45,16 +45,28 @@ public:
   SolutionInvalidity(MooseApp & app);
 
   /// Increments solution invalid occurrences for each solution id
-  void flagInvalidSolutionInternal(InvalidSolutionID _invalid_solution_id, const bool warning);
+  void flagInvalidSolutionInternal(const InvalidSolutionID _invalid_solution_id);
 
-  /// Loop over all the tracked objects and determine whether any solution warning check is registered by users
-  bool hasSolutionWarning() const;
+  /**
+   * Whether or not an invalid solution was encountered that was a warning.
+   *
+   * This must be called after a sync.
+   */
+  bool hasInvalidSolutionWarning() const;
 
-  /// Loop over all the tracked objects and determine whether any invalid solution check is registered by users
+  /**
+   * Whether or not an invalid solution was encountered that was an error.
+   *
+   * This must be called after a sync.
+   */
+  bool hasInvalidSolutionError() const;
+
+  /**
+   * Whether or not any invalid solution was encountered (error or warning).
+   *
+   * This must be called after a sync.
+   */
   bool hasInvalidSolution() const;
-
-  /// Loop over all the tracked objects and determine whether solution invalid is detected
-  bool solutionInvalid() const;
 
   /// Reset the number of solution invalid occurrences back to zero for the current time step
   void resetSolutionInvalidTimeStep();
@@ -71,7 +83,6 @@ public:
   /// Struct used in _counts for storing invalid occurrences
   struct InvalidCounts
   {
-    bool warning = false;
     unsigned int counts = 0;
     unsigned int timestep_counts = 0;
     unsigned int total_counts = 0;
@@ -116,6 +127,13 @@ private:
 
   /// Store the solution invalidity counts
   std::vector<InvalidCounts> _counts;
+
+  /// Whether or not we've synced (can check counts/existance of warnings or errors)
+  bool _has_synced;
+  /// Whether or not we have a warning (only after a sync)
+  bool _has_solution_warning;
+  /// Whether or not we have an invalid solution (only after a sync)
+  bool _has_solution_error;
 };
 
 // datastore and dataload for recover

--- a/framework/include/utils/SolutionInvalidityRegistry.h
+++ b/framework/include/utils/SolutionInvalidityRegistry.h
@@ -73,13 +73,16 @@ class SolutionInvalidityInfo : public SolutionInvalidityName
 public:
   SolutionInvalidityInfo(const std::string & object_type,
                          const std::string & message,
-                         const InvalidSolutionID id)
-    : SolutionInvalidityName(object_type, message), id(id)
+                         const InvalidSolutionID id,
+                         const bool warning)
+    : SolutionInvalidityName(object_type, message), id(id), warning(warning)
   {
   }
 
   /// The solution ID
   InvalidSolutionID id;
+  /// Whether or not this is a warning
+  bool warning;
 };
 
 /**
@@ -95,10 +98,12 @@ public:
    *
    * @param object_type The type of the object doing the registration
    * @param message The description of the solution invalid warning
+   * @param warning Whether or not it is a warning
    * @return The registered ID
    */
   InvalidSolutionID registerInvalidity(const std::string & object_type,
-                                       const std::string & message);
+                                       const std::string & message,
+                                       const bool warning);
 
 private:
   SolutionInvalidityRegistry();

--- a/framework/src/interfaces/SolutionInvalidInterface.C
+++ b/framework/src/interfaces/SolutionInvalidInterface.C
@@ -28,16 +28,14 @@ SolutionInvalidInterface::flagInvalidSolutionInternal(InvalidSolutionID invalid_
   auto & solution_invalidity = _si_moose_object.getMooseApp().solutionInvalidity();
   if (_si_problem.immediatelyPrintInvalidSolution())
     solution_invalidity.printDebug(invalid_solution_id);
-  _si_problem.hasInvalidSolution(true);
-  return solution_invalidity.flagInvalidSolutionInternal(invalid_solution_id);
+  return solution_invalidity.flagInvalidSolutionInternal(invalid_solution_id, false);
 }
 
 void
 SolutionInvalidInterface::flagSolutionWarningInternal(InvalidSolutionID invalid_solution_id) const
 {
   auto & solution_invalidity = _si_moose_object.getMooseApp().solutionInvalidity();
-  _si_problem.hasSolutionWarning(true);
-  return solution_invalidity.flagInvalidSolutionInternal(invalid_solution_id);
+  return solution_invalidity.flagInvalidSolutionInternal(invalid_solution_id, true);
 }
 
 InvalidSolutionID

--- a/framework/src/interfaces/SolutionInvalidInterface.C
+++ b/framework/src/interfaces/SolutionInvalidInterface.C
@@ -22,25 +22,30 @@ SolutionInvalidInterface::SolutionInvalidInterface(MooseObject * const moose_obj
 }
 
 /// Set solution invalid mark for the given solution ID
+template <bool warning>
 void
-SolutionInvalidInterface::flagInvalidSolutionInternal(InvalidSolutionID invalid_solution_id) const
+SolutionInvalidInterface::flagInvalidSolutionInternal(
+    const InvalidSolutionID invalid_solution_id) const
 {
+  mooseAssert(
+      warning == moose::internal::getSolutionInvalidityRegistry().item(invalid_solution_id).warning,
+      "Inconsistent warning flag");
   auto & solution_invalidity = _si_moose_object.getMooseApp().solutionInvalidity();
-  if (_si_problem.immediatelyPrintInvalidSolution())
-    solution_invalidity.printDebug(invalid_solution_id);
-  return solution_invalidity.flagInvalidSolutionInternal(invalid_solution_id, false);
-}
-
-void
-SolutionInvalidInterface::flagSolutionWarningInternal(InvalidSolutionID invalid_solution_id) const
-{
-  auto & solution_invalidity = _si_moose_object.getMooseApp().solutionInvalidity();
-  return solution_invalidity.flagInvalidSolutionInternal(invalid_solution_id, true);
+  if constexpr (!warning)
+    if (_si_problem.immediatelyPrintInvalidSolution())
+      solution_invalidity.printDebug(invalid_solution_id);
+  return solution_invalidity.flagInvalidSolutionInternal(invalid_solution_id);
 }
 
 InvalidSolutionID
-SolutionInvalidInterface::registerInvalidSolutionInternal(const std::string & message) const
+SolutionInvalidInterface::registerInvalidSolutionInternal(const std::string & message,
+                                                          const bool warning) const
 {
   return moose::internal::getSolutionInvalidityRegistry().registerInvalidity(
-      _si_moose_object.type(), message);
+      _si_moose_object.type(), message, warning);
 }
+
+template void SolutionInvalidInterface::flagInvalidSolutionInternal<true>(
+    const InvalidSolutionID invalid_solution_id) const;
+template void SolutionInvalidInterface::flagInvalidSolutionInternal<false>(
+    const InvalidSolutionID invalid_solution_id) const;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -469,8 +469,6 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _allow_invalid_solution(getParam<bool>("allow_invalid_solution")),
     _show_invalid_solution_console(getParam<bool>("show_invalid_solution_console")),
     _immediately_print_invalid_solution(getParam<bool>("immediately_print_invalid_solution")),
-    _has_solution_warning(false),
-    _has_invalid_solution(false),
     _started_initial_setup(false),
     _has_internal_edge_residual_objects(false),
     _u_dot_requested(false),

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3497,6 +3497,13 @@ FEProblemBase::getMaterialData(Moose::MaterialDataType type, const THREAD_ID tid
   mooseError("FEProblemBase::getMaterialData(): Invalid MaterialDataType ", type);
 }
 
+bool
+FEProblemBase::acceptInvalidSolution() const
+{
+  return allowInvalidSolution() || // invalid solutions are always allowed
+         !_app.solutionInvalidity().hasInvalidSolutionError(); // if not allowed, check for errors
+}
+
 void
 FEProblemBase::addFunctorMaterial(const std::string & functor_material_name,
                                   const std::string & name,

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -351,7 +351,7 @@ NonlinearSystem::converged()
 {
   if (_fe_problem.hasException() || _fe_problem.getFailNextNonlinearConvergenceCheck())
     return false;
-  if (!_fe_problem.acceptInvalidSolution() && _solution_is_invalid)
+  if (!_fe_problem.acceptInvalidSolution())
   {
     mooseWarning("The solution is not converged due to the solution being invalid.");
     return false;

--- a/framework/src/systems/SolverSystem.C
+++ b/framework/src/systems/SolverSystem.C
@@ -108,25 +108,23 @@ SolverSystem::setMooseKSPNormType(MooseEnum kspnorm)
 void
 SolverSystem::checkInvalidSolution()
 {
-  // determine whether solution invalid occurs in the converged solution
-  _solution_is_invalid = _app.solutionInvalidity().solutionInvalid();
+  auto & solution_invalidity = _app.solutionInvalidity();
 
-  // output the solution invalid summary
-  if (_solution_is_invalid)
+  // sync all solution invalid counts to rank 0 process
+  solution_invalidity.sync();
+
+  if (solution_invalidity.hasInvalidSolution())
   {
-    // sync all solution invalid counts to rank 0 process
-    _app.solutionInvalidity().sync();
-
     if (_fe_problem.acceptInvalidSolution())
       if (_fe_problem.showInvalidSolutionConsole())
-        _app.solutionInvalidity().print(_console);
+        solution_invalidity.print(_console);
       else
         mooseWarning("The Solution Invalidity warnings are detected but silenced! "
                      "Use Problem/show_invalid_solution_console=true to show solution counts");
     else
       // output the occurrence of solution invalid in a summary table
       if (_fe_problem.showInvalidSolutionConsole())
-        _app.solutionInvalidity().print(_console);
+        solution_invalidity.print(_console);
   }
 }
 

--- a/framework/src/utils/SolutionInvalidity.C
+++ b/framework/src/utils/SolutionInvalidity.C
@@ -26,81 +26,51 @@
 SolutionInvalidity::SolutionInvalidity(MooseApp & app)
   : ConsoleStreamInterface(app),
     ParallelObject(app.comm()),
-    _solution_invalidity_registry(moose::internal::getSolutionInvalidityRegistry())
+    _solution_invalidity_registry(moose::internal::getSolutionInvalidityRegistry()),
+    _has_synced(false),
+    _has_solution_warning(false),
+    _has_solution_error(false)
 {
 }
 
 void
-SolutionInvalidity::flagInvalidSolutionInternal(InvalidSolutionID _invalid_solution_id,
-                                                const bool warning)
+SolutionInvalidity::flagInvalidSolutionInternal(const InvalidSolutionID _invalid_solution_id)
 {
   std::lock_guard<std::mutex> lock_id(_invalid_mutex);
   if (_counts.size() <= _invalid_solution_id)
     _counts.resize(_invalid_solution_id + 1);
 
-  auto & count_entry = _counts[_invalid_solution_id];
-  ++count_entry.counts;
-  if (warning)
-    count_entry.warning = true;
+  ++_counts[_invalid_solution_id].counts;
 }
 
 bool
-SolutionInvalidity::solutionInvalid() const
+SolutionInvalidity::hasInvalidSolutionWarning() const
 {
-  libmesh_parallel_only(comm());
-
-  bool is_invalid = false;
-  for (auto & entry : _counts)
-  {
-    if (entry.counts)
-    {
-      is_invalid = true;
-      break;
-    }
-  }
-
-  comm().max(is_invalid);
-  return is_invalid > 0;
+  mooseAssert(_has_synced, "Has not synced");
+  return _has_solution_warning;
 }
 
 bool
-SolutionInvalidity::hasSolutionWarning() const
+SolutionInvalidity::hasInvalidSolutionError() const
 {
-  libmesh_parallel_only(comm());
-
-  bool has_warning = false;
-  for (auto & entry : _counts)
-    if (entry.warning)
-      has_warning = true;
-      break;
-
-  comm().max(has_warning);
-  return has_warning > 0;
+  mooseAssert(_has_synced, "Has not synced");
+  return _has_solution_error;
 }
 
 bool
 SolutionInvalidity::hasInvalidSolution() const
 {
-  libmesh_parallel_only(comm());
-
-  bool has_invalid = false;
-  for (auto & entry : _counts)
-    if (!entry.warning)
-      has_invalid = true;
-      break;
-
-  comm().max(has_invalid);
-  return has_invalid > 0;
+  return hasInvalidSolutionWarning() || hasInvalidSolutionError();
 }
 
 void
 SolutionInvalidity::resetSolutionInvalidCurrentIteration()
 {
+  // Reset that we have synced because we're on a new iteration
+  _has_synced = false;
+  // Zero current counts
   for (auto & entry : _counts)
-  {
-    entry.warning = false;
     entry.counts = 0;
-  }
 }
 
 void
@@ -134,42 +104,71 @@ SolutionInvalidity::print(const ConsoleStream & console) const
 void
 SolutionInvalidity::sync()
 {
-  std::map<processor_id_type, std::vector<std::tuple<std::string, std::string, unsigned int>>>
+  std::map<processor_id_type, std::vector<std::tuple<std::string, std::string, int, unsigned int>>>
       data_to_send;
 
-  if (processor_id() != 0)
-    for (const auto id : index_range(_counts))
+  // Reset this as we need to see if we have new counts
+  _has_solution_warning = false;
+  _has_solution_error = false;
+
+  for (const auto id : index_range(_counts))
+  {
+    auto & entry = _counts[id];
+    if (entry.counts)
     {
-      auto & entry = _counts[id];
-      if (entry.counts)
-      {
-        const auto & info = _solution_invalidity_registry.item(id);
-        data_to_send[0].emplace_back(info.object_type, info.message, entry.counts);
-        entry.counts = 0;
-      }
+      const auto & info = _solution_invalidity_registry.item(id);
+      data_to_send[0].emplace_back(info.object_type, info.message, info.warning, entry.counts);
+      entry.counts = 0;
     }
+  }
 
   const auto receive_data = [this](const processor_id_type libmesh_dbg_var(pid), const auto & data)
   {
-    mooseAssert(pid != 0, "Should not be used except processor 0");
+    mooseAssert(processor_id() == 0, "Should only receive on processor 0");
 
-    for (const auto & [object_type, message, counts] : data)
+    for (const auto & [object_type, message, warning_int, counts] : data)
     {
+      mooseAssert(counts, "Should not send data without counts");
+
+      // We transfer this as an integer (which is guaranteed by the standard to cast to a bool)
+      // because TIMPI doesn't currently support transferring bools
+      const bool warning = warning_int;
+
       InvalidSolutionID main_id = 0;
       const moose::internal::SolutionInvalidityName name(object_type, message);
       if (_solution_invalidity_registry.keyExists(name))
+      {
         main_id = _solution_invalidity_registry.id(name);
+        mooseAssert(_solution_invalidity_registry.item(main_id).warning == warning,
+                    "Inconsistent registration of invalidity warning and error");
+      }
       else
-        main_id = moose::internal::getSolutionInvalidityRegistry().registerInvalidity(object_type,
-                                                                                      message);
+      {
+        mooseAssert(pid != 0, "Should only hit on other processors");
+        main_id = moose::internal::getSolutionInvalidityRegistry().registerInvalidity(
+            object_type, message, warning);
+      }
       if (_counts.size() <= main_id)
         _counts.resize(main_id + 1);
 
       _counts[main_id].counts += counts;
+
+      if (warning)
+        _has_solution_warning = true;
+      else
+        _has_solution_error = true;
     }
   };
 
+  // Communicate the counts
   TIMPI::push_parallel_vector_data(comm(), data_to_send, receive_data);
+
+  // Set the state across all processors
+  comm().max(_has_solution_warning);
+  comm().max(_has_solution_error);
+
+  // We've now synced
+  _has_synced = true;
 }
 
 void
@@ -182,6 +181,8 @@ SolutionInvalidity::printDebug(InvalidSolutionID _invalid_solution_id) const
 SolutionInvalidity::FullTable
 SolutionInvalidity::summaryTable() const
 {
+  mooseAssert(_has_synced, "Has not synced");
+
   FullTable vtable({"Object", "Converged", "Timestep", "Total", "Message"}, 4);
 
   vtable.setColumnFormat({
@@ -224,6 +225,8 @@ SolutionInvalidity::summaryTable() const
 void
 dataStore(std::ostream & stream, SolutionInvalidity & solution_invalidity, void * context)
 {
+  mooseAssert(solution_invalidity._has_synced, "Has not synced");
+
   if (solution_invalidity.processor_id() != 0)
     return;
 
@@ -237,8 +240,10 @@ dataStore(std::ostream & stream, SolutionInvalidity & solution_invalidity, void 
     const auto & info = solution_invalidity._solution_invalidity_registry.item(id);
     std::string type = info.object_type;
     std::string message = info.message;
+    bool warning = info.warning;
     dataStore(stream, type, context);
     dataStore(stream, message, context);
+    dataStore(stream, warning, context);
     dataStore(stream, entry.counts, context);
     dataStore(stream, entry.timestep_counts, context);
     dataStore(stream, entry.total_counts, context);
@@ -256,6 +261,7 @@ dataLoad(std::istream & stream, SolutionInvalidity & solution_invalidity, void *
   dataLoad(stream, num_counts, context);
 
   std::string object_type, message;
+  bool warning;
   InvalidSolutionID id;
 
   // loop over and load stored data
@@ -263,13 +269,14 @@ dataLoad(std::istream & stream, SolutionInvalidity & solution_invalidity, void *
   {
     dataLoad(stream, object_type, context);
     dataLoad(stream, message, context);
+    dataLoad(stream, warning, context);
 
     const moose::internal::SolutionInvalidityName name(object_type, message);
     if (solution_invalidity._solution_invalidity_registry.keyExists(name))
       id = solution_invalidity._solution_invalidity_registry.id(name);
     else
-      id =
-          moose::internal::getSolutionInvalidityRegistry().registerInvalidity(object_type, message);
+      id = moose::internal::getSolutionInvalidityRegistry().registerInvalidity(
+          object_type, message, warning);
 
     if (solution_invalidity._counts.size() <= id)
       solution_invalidity._counts.resize(id + 1);

--- a/framework/src/utils/SolutionInvalidity.C
+++ b/framework/src/utils/SolutionInvalidity.C
@@ -27,7 +27,7 @@ SolutionInvalidity::SolutionInvalidity(MooseApp & app)
   : ConsoleStreamInterface(app),
     ParallelObject(app.comm()),
     _solution_invalidity_registry(moose::internal::getSolutionInvalidityRegistry()),
-    _has_synced(false),
+    _has_synced(true),
     _has_solution_warning(false),
     _has_solution_error(false)
 {
@@ -66,8 +66,6 @@ SolutionInvalidity::hasInvalidSolution() const
 void
 SolutionInvalidity::resetSolutionInvalidCurrentIteration()
 {
-  // Reset that we have synced because we're on a new iteration
-  _has_synced = false;
   // Zero current counts
   for (auto & entry : _counts)
     entry.counts = 0;
@@ -76,6 +74,8 @@ SolutionInvalidity::resetSolutionInvalidCurrentIteration()
 void
 SolutionInvalidity::resetSolutionInvalidTimeStep()
 {
+  // Reset that we have synced because we're on a new iteration
+  _has_synced = false;
   for (auto & entry : _counts)
     entry.timestep_counts = 0;
 }
@@ -225,7 +225,7 @@ SolutionInvalidity::summaryTable() const
 void
 dataStore(std::ostream & stream, SolutionInvalidity & solution_invalidity, void * context)
 {
-  mooseAssert(solution_invalidity._has_synced, "Has not synced");
+  solution_invalidity.sync();
 
   if (solution_invalidity.processor_id() != 0)
     return;

--- a/framework/src/utils/SolutionInvalidity.C
+++ b/framework/src/utils/SolutionInvalidity.C
@@ -66,18 +66,13 @@ SolutionInvalidity::solutionInvalid() const
 bool
 SolutionInvalidity::hasSolutionWarning() const
 {
-
   libmesh_parallel_only(comm());
 
   bool has_warning = false;
   for (auto & entry : _counts)
-  {
     if (entry.warning)
-    {
       has_warning = true;
       break;
-    }
-  }
 
   comm().max(has_warning);
   return has_warning > 0;
@@ -86,18 +81,13 @@ SolutionInvalidity::hasSolutionWarning() const
 bool
 SolutionInvalidity::hasInvalidSolution() const
 {
-
   libmesh_parallel_only(comm());
 
   bool has_invalid = false;
   for (auto & entry : _counts)
-  {
     if (!entry.warning)
-    {
       has_invalid = true;
       break;
-    }
-  }
 
   comm().max(has_invalid);
   return has_invalid > 0;

--- a/framework/src/utils/SolutionInvalidityRegistry.C
+++ b/framework/src/utils/SolutionInvalidityRegistry.C
@@ -31,11 +31,14 @@ SolutionInvalidityRegistry::SolutionInvalidityRegistry()
 
 InvalidSolutionID
 SolutionInvalidityRegistry::registerInvalidity(const std::string & object_type,
-                                               const std::string & message)
+                                               const std::string & message,
+                                               const bool warning)
 {
   const SolutionInvalidityName name(object_type, message);
-  const auto create_item = [&object_type, &message](const std::size_t id)
-  { return SolutionInvalidityInfo(object_type, message, id); };
+  if (keyExists(name))
+    mooseAssert(item(id(name)).warning == warning, "Inconsistent registration for a warning");
+  const auto create_item = [&object_type, &message, &warning](const std::size_t id)
+  { return SolutionInvalidityInfo(object_type, message, id, warning); };
   return registerItem(name, create_item);
 }
 

--- a/test/tests/misc/solution_invalid/tests
+++ b/test/tests/misc/solution_invalid/tests
@@ -29,10 +29,16 @@
       detail = 'unless the user specifies to silence them,'
     []
     [console_output]
-      type = 'JSONDiff'
+      type = 'RunApp'
       input = 'solution_invalid.i'
       cli_args = "Materials/filter/flag_solution_warning=true Outputs/file_base='solution_invalid_warning'"
-      jsondiff = 'solution_invalid_warning.json'
+      expect_out = "Solution Invalid Warnings:
+------------------------------------------------------------------------------
+|     Object      | Converged | Timestep | Total |          Message          |
+------------------------------------------------------------------------------
+| NonsafeMaterial |        16 |       48 |    48 | Solution invalid warning! |
+------------------------------------------------------------------------------
+"
       detail = 'and otherwise both in the console window and a json file.'
     []
   []


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->
Fix the parallel test failure of previous invalid solution warning implementation. An error appears when 6 or more cores are using. 

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->
A new bool variable `warning` is add to `SolutionInvalidity::flagInvalidSolutionInternal` function to help determining whether the user flag a solution warning or invalid solution

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
Fix a bug

