### PR TITLE
Libmesh submodule update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2024.08.17" %}
+{% set version = "2024.08.30" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2024.08.17 mpich_0
-  - moose-libmesh 2024.08.17 openmpi_0
+  - moose-libmesh 2024.08.30 mpich_0
+  - moose-libmesh 2024.08.30 openmpi_0
 
 moose_wasp:
   - moose-wasp 2024.05.08

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -6,7 +6,7 @@
 #   framework/doc/packages_config.yml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.08.26" %}
+{% set version = "2024.08.30" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2024.08.26
+  - moose-dev 2024.08.30
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=3855e00043601e0a45d83ed8b639991c2b288553
+ARG LIBMESH_REV=80e8b6c591a704cd426fb50f8cc05d97994b2241
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -11,7 +11,7 @@ mpich: 4.2.1
 openmpi: 4.1.6
 petsc_alt: 3.11.4
 petsc: 3.21.4
-moose_dev: 2024.08.26
+moose_dev: 2024.08.30
 moose_tools: 2024.07.19
 apptainer_rockylinux: 8.8.20230518
 apptainer_mpich: 3.4.3

--- a/modules/doc/content/newsletter/2024/2024_08.md
+++ b/modules/doc/content/newsletter/2024/2024_08.md
@@ -108,6 +108,25 @@ gas. Such a flow model is planned for one-dimensional components in the
 - Fixes for compilations using single/triple/quadruple precision
 - Netgen handling for unprepared inputs, non-contained holes
 
+### `2024.08.30` Update
+
+- Temporarily disable SIGFPE (if it's enabled) before opening ExodusII
+  files, to work around a bug in HDF5 1.14.3
+- Fixes for SIGFPE in fparser, Clough-Tocher FE, and example codes
+- Added `FPEDisabler` class to make temporarily disabling SIGFPE easy
+  for users
+- Netgen submodule updates, including bug fixes for undefined behavior
+  (which caused `-fsanitize` error messages) and for a
+  node-ordering-dependent bug in tetrahedralizing domains with holes
+- Added `init_condensed_matrices` API, as part of ongoing work for
+  doing more solves after condensing away constrained Degrees of
+  Freedom
+- Added generic `Elem::quality(JACOBIAN, SCALED_JACOBIAN)` implementations
+- Disabled default Netgen build behavior of `-march=native`.  This was
+  causing "Illegal instruction" errors at program startup on some
+  systems whose native architecture does not support the full
+  instruction set available on our build boxes.
+
 ## PETSc-level Changes
 
 ### PETSc updated to 3.21.4

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -321,3 +321,9 @@ aa749eea6ea1bc7945fb90ad29ac41620c8c2390: #28411
   libmesh: 34b8a4a
   moose-dev: 0416bb4
   wasp: 33b8e6b
+3d69e63fed3908e65502e1c882e53adbc0a36bea: #28508
+  mpi: b19f0fe
+  petsc: 24f0aee
+  libmesh: 4c19b6f
+  moose-dev: 561161b
+  wasp: 33b8e6b


### PR DESCRIPTION
This is based off of #28479 to avoid conflicts with the newsletter edits there.

- Temporarily disable SIGFPE (if it's enabled) before opening ExodusII files, to work around a bug in HDF5 1.14.3
- Fixes for SIGFPE in fparser, Clough-Tocher FE, and example codes
- Added `FPEDisabler` class to make temporarily disabling SIGFPE easy for users
- Netgen submodule updates, including bug fixes for undefined behavior (which caused `-fsanitize` error messages) and for a node-ordering-dependent bug in tetrahedralizing domains with holes
- Added `init_condensed_matrices` API, as part of ongoing work for doing more solves after condensing away constrained Degrees of Freedom
- Added generic `Elem::quality(JACOBIAN, SCALED_JACOBIAN)` implementations
- Disabled default Netgen build behavior of `-march=native`.  This was causing "Illegal instruction" errors at program startup on some systems whose native architecture does not support the full instruction set available on our build boxes.