### PR TITLE
Make MOOSE folder resistent to folder-wide whitespace trimming

### DIFF
--- a/scripts/delete_trailing_whitespace.sh
+++ b/scripts/delete_trailing_whitespace.sh
@@ -25,5 +25,5 @@ else
       echo "Adding newline at EOF: $fname"
       sed -i -e '$a\' "$fname"
     fi
-  done < <( find "$REPO_DIR" -path "*/contrib" -prune -o -path "*/libmesh" -prune -o \( -name "*.[Chi]" -o -name "*.py" -o -name "*.tex" \) -type f -print0)
+  done < <( find "$REPO_DIR" -path "*/contrib" -prune -o -path "*/libmesh" -prune -o \( -name "*.[Chi]" -o -name "*.py" \) -type f -print0)
 fi


### PR DESCRIPTION
The tex files trigger diffs if you trim their whitespace by running the script in moose/.

So we might as well not modify them.
Modifying moosedocs to not use trailing white spaces would be much more work and require a regold

closes https://github.com/idaholab/moose/issues/28512