### PR TITLE
Improves error message for invalid dump parameter

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -832,7 +832,7 @@ MooseApp::setupOptions()
       _ready_to_exit = true;
     }
     else
-      mooseError("Invalid search parameter ", param_search);
+      mooseError("Search parameter '", param_search, "' was not found in the registered syntax.");
   }
   else if (isParamValid("registry"))
   {

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -820,13 +820,19 @@ MooseApp::setupOptions()
       _builder.buildJsonSyntaxTree(tree);
     }
 
-    // Turn off live printing so that it doesn't mess with the dump
+    // Check if second arg is valid or not
+    if ((tree.getRoot()).is_object())
+    {
+      // Turn off live printing so that it doesn't mess with the dump
     _perf_graph.disableLivePrint();
 
     JsonInputFileFormatter formatter;
     Moose::out << "\n### START DUMP DATA ###\n"
                << formatter.toString(tree.getRoot()) << "\n### END DUMP DATA ###" << std::endl;
     _ready_to_exit = true;
+    }
+    else
+      mooseError("Invalid search parameter ", param_search);
   }
   else if (isParamValid("registry"))
   {

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -824,12 +824,12 @@ MooseApp::setupOptions()
     if ((tree.getRoot()).is_object())
     {
       // Turn off live printing so that it doesn't mess with the dump
-    _perf_graph.disableLivePrint();
+      _perf_graph.disableLivePrint();
 
-    JsonInputFileFormatter formatter;
-    Moose::out << "\n### START DUMP DATA ###\n"
-               << formatter.toString(tree.getRoot()) << "\n### END DUMP DATA ###" << std::endl;
-    _ready_to_exit = true;
+      JsonInputFileFormatter formatter;
+      Moose::out << "\n### START DUMP DATA ###\n"
+                 << formatter.toString(tree.getRoot()) << "\n### END DUMP DATA ###" << std::endl;
+      _ready_to_exit = true;
     }
     else
       mooseError("Invalid search parameter ", param_search);

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -1169,4 +1169,13 @@
     design = 'MooseUtils.md'
     issues = '#17407'
   []
+  [dump_error_with_unrecogized_param]
+    type = 'RunException'
+    input = ''
+    cli_args = '--dump bad_parameter'
+    expect_err = "Search parameter 'bad_parameter' was not found in the registered syntax."
+
+    requirement = 'The system shall report a helpful error when the dump parameter does not match any valid parameters'
+    issues = '#26714'
+  []
 []


### PR DESCRIPTION
-Checks if dump parameter is valid before trying to use it. 
-If invalid it prints an error message that includes the parameter name

closes #26714