### PR TITLE
Respect CXX in HIT when libmesh_CXX is unavailable

### DIFF
--- a/framework/contrib/hit/Makefile
+++ b/framework/contrib/hit/Makefile
@@ -1,6 +1,10 @@
 hit_CXX := $(libmesh_CXX)
 
 ifeq ($(hit_CXX),)
+  hit_CXX := $(CXX)
+endif
+
+ifeq ($(hit_CXX),)
   hit_CXX := g++
 endif
 


### PR DESCRIPTION
Refs #27787.

`g++` is not available in some of our containers, so `$(CXX)` should be used.

Fixing https://civet.inl.gov/job/2420829/.

@milljm 