### PR TITLE
Revert "Cache the results for the civet_results tests"

### DIFF
--- a/python/mooseutils/tests/test_civet_results.py
+++ b/python/mooseutils/tests/test_civet_results.py
@@ -14,7 +14,7 @@ import platform
 import mooseutils
 import mooseutils.civet_results as cr
 
-SITE = 'https://mooseframework.inl.gov/docs/civettest'
+SITE = 'https://civet.inl.gov'
 REPO = 'idaholab/moose'
 SHAS = ['681ba2f4274dc8465bb2a54e1353cfa24765a5c1', 'febe3476040fe6af1df1d67e8cc8c04c4760afb6']
 


### PR DESCRIPTION
Reverts idaholab/moose#23296

We can revert now to getting actual results because CIVET doesn't timeout.