### PR TITLE
Throw a paramError when an incorrect strain base name is provided

### DIFF
--- a/modules/porous_flow/src/postprocessors/PorousFlowFluidMass.C
+++ b/modules/porous_flow/src/postprocessors/PorousFlowFluidMass.C
@@ -143,6 +143,10 @@ PorousFlowFluidMassTempl<is_ad>::PorousFlowFluidMassTempl(const InputParameters 
   if (_phase_index.empty())
     for (unsigned int i = 0; i < num_phases; ++i)
       _phase_index.push_back(i);
+
+  // Error if a strain base_name is provided but doesn't exist
+  if (parameters.isParamSetByUser("base_name") && !_has_total_strain)
+    paramError("base_name", "A strain base_name ", _base_name, " does not exist");
 }
 
 template <bool is_ad>

--- a/modules/porous_flow/src/postprocessors/PorousFlowHeatEnergy.C
+++ b/modules/porous_flow/src/postprocessors/PorousFlowHeatEnergy.C
@@ -103,6 +103,10 @@ PorousFlowHeatEnergy::PorousFlowHeatEnergy(const InputParameters & parameters)
   // Now that we know kernel_variable_number is OK, _var must be OK,
   // so ensure that reinit is called on _var:
   addMooseVariableDependency(_var);
+
+  // Error if a strain base_name is provided but doesn't exist
+  if (parameters.isParamSetByUser("base_name") && !_has_total_strain)
+    paramError("base_name", "A strain base_name ", _base_name, " does not exist");
 }
 
 Real

--- a/modules/porous_flow/test/tests/energy_conservation/except03.i
+++ b/modules/porous_flow/test/tests/energy_conservation/except03.i
@@ -1,0 +1,124 @@
+# Checking that the heat energy postprocessor correctly throws a paramError when an incorrect
+# strain base_name is given
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 3
+  xmin = 0
+  xmax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [pp]
+  []
+  [temp]
+  []
+[]
+
+[ICs]
+  [tinit]
+    type = FunctionIC
+    function = '100*x'
+    variable = temp
+  []
+  [pinit]
+    type = FunctionIC
+    function = x
+    variable = pp
+  []
+[]
+
+[Kernels]
+  [dummyt]
+    type = TimeDerivative
+    variable = temp
+  []
+  [dummyp]
+    type = TimeDerivative
+    variable = pp
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'temp pp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+  [pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 1
+    density0 = 1
+    viscosity = 0.001
+    thermal_expansion = 0
+    cv = 1.3
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = PorousFlowTemperature
+    temperature = temp
+  []
+  [porosity]
+    type = PorousFlowPorosity
+    porosity_zero = 0.1
+  []
+  [rock_heat]
+    type = PorousFlowMatrixInternalEnergy
+    specific_heat_capacity = 2.2
+    density = 0.5
+  []
+  [ppss]
+    type = PorousFlow1PhaseP
+    porepressure = pp
+    capillary_pressure = pc
+  []
+  [massfrac]
+    type = PorousFlowMassFraction
+  []
+  [simple_fluid]
+    type = PorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+[]
+
+[Postprocessors]
+  [heat]
+    type = PorousFlowHeatEnergy
+    base_name = incorrect_base_name
+  []
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  execute_on = 'timestep_end'
+[]

--- a/modules/porous_flow/test/tests/energy_conservation/tests
+++ b/modules/porous_flow/test/tests/energy_conservation/tests
@@ -1,23 +1,32 @@
 [Tests]
-  [./except01]
+  [except01]
     type = 'RunException'
     input = 'except01.i'
     expect_err = 'The Dictator proclaims that the phase index 1 is greater than the largest phase index possible, which is 0'
     threading = '!pthreads'
     issues = '#8123'
     design = 'PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'PorousFlow shall produce an error if the user specifies a phase number that is too large for the simulation according to the PorousFlowDictator'
-  [../]
-  [./except02]
+    requirement = 'The system shall produce an error if the user specifies a phase number that is too large for the simulation according to the PorousFlowDictator.'
+  []
+  [except02]
     type = 'RunException'
     input = 'except02.i'
     expect_err = 'The Dictator pronounces that the number of PorousFlow variables is 2, however you have used 2. This is an error'
     threading = '!pthreads'
     issues = '#8123'
     design = 'PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'PorousFlow shall produce an error if the user specifies a porous-flow variable that is too large for the simulation according to the PorousFlowDictator'
-  [../]
-  [./heat01]
+    requirement = 'The system shall produce an error if the user specifies a porous-flow variable that is too large for the simulation according to the PorousFlowDictator.'
+  []
+  [except03]
+    type = 'RunException'
+    input = 'except03.i'
+    expect_err = 'A strain base_name incorrect_base_name_ does not exist'
+    threading = '!pthreads'
+    requirement = 'If the user enters a base_name strain that does not exist, the system should produce an error.'
+    design = 'PorousFlowHeatEnergy.md'
+    issues = '#25673'
+  []
+  [heat01]
     type = 'CSVDiff'
     input = 'heat01.i'
     csvdiff = 'heat01.csv'
@@ -25,9 +34,9 @@
     threading = '!pthreads'
     issues = '#8123'
     design = 'PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'PorousFlow shall correctly calculate the heat energy using the heat-energy postprocessor when there are no fluids and constant porosity'
-  [../]
-  [./heat02]
+    requirement = 'The system shall correctly calculate the heat energy using the heat-energy postprocessor when there are no fluids and constant porosity.'
+  []
+  [heat02]
     type = 'CSVDiff'
     input = 'heat02.i'
     csvdiff = 'heat02.csv'
@@ -35,9 +44,9 @@
     threading = '!pthreads'
     issues = '#8123'
     design = 'PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'PorousFlow shall correctly calculate the heat energy using the heat-energy postprocessor when there is 1 fluid phase and constant porosity'
-  [../]
-  [./heat03]
+    requirement = 'The system shall correctly calculate the heat energy using the heat-energy postprocessor when there is 1 fluid phase and constant porosity.'
+  []
+  [heat03]
     type = 'CSVDiff'
     input = 'heat03.i'
     csvdiff = 'heat03.csv'
@@ -45,9 +54,9 @@
     threading = '!pthreads'
     issues = '#8123'
     design = 'PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'PorousFlow shall correctly conserve heat energy in a THM simulation when the model is squashed mechanically'
-  [../]
-  [./heat03_rz]
+    requirement = 'The system shall correctly conserve heat energy in a THM simulation when the model is squashed mechanically.'
+  []
+  [heat03_rz]
     type = 'CSVDiff'
     input = 'heat03_rz.i'
     csvdiff = 'heat03_rz_csv.csv'
@@ -55,9 +64,9 @@
     threading = '!pthreads'
     issues = '#18324'
     design = 'PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'PorousFlow shall correctly conserve heat energy in a THM simulation when the model is squashed mechanically, in RZ coordinates'
-  [../]
-  [./heat04]
+    requirement = 'The system shall correctly conserve heat energy in a THM simulation when the model is squashed mechanically, in RZ coordinates.'
+  []
+  [heat04]
     type = 'CSVDiff'
     input = 'heat04.i'
     csvdiff = 'heat04.csv'
@@ -65,9 +74,9 @@
     threading = '!pthreads'
     issues = '#8123'
     design = 'PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'PorousFlow shall correctly calculate time-varying temperature, porepressure, stress and porosity in a model containing a source of heat energy'
-  [../]
-  [./heat04_rz]
+    requirement = 'The system shall correctly calculate time-varying temperature, porepressure, stress and porosity in a model containing a source of heat energy.'
+  []
+  [heat04_rz]
     type = 'CSVDiff'
     input = 'heat04_rz.i'
     csvdiff = 'heat04_rz_csv.csv'
@@ -75,9 +84,9 @@
     threading = '!pthreads'
     issues = '#8123'
     design = 'PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'PorousFlow shall correctly calculate time-varying temperature, porepressure, stress and porosity in a model containing a source of heat energy and fluid, in RZ coordinates'
-  [../]
-  [./heat04_action]
+    requirement = 'The system shall correctly calculate time-varying temperature, porepressure, stress and porosity in a model containing a source of heat energy and fluid, in RZ coordinates.'
+  []
+  [heat04_action]
     type = 'CSVDiff'
     input = 'heat04_action.i'
     csvdiff = 'heat04_action.csv'
@@ -85,9 +94,9 @@
     threading = '!pthreads'
     issues = '#18324'
     design = 'PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'PorousFlow shall correctly calculate time-varying temperature, porepressure, stress and porosity in a model containing a source of heat energy, when using the PorousFlowUnsaturated Action'
-  [../]
-  [./heat04_fullysat_action]
+    requirement = 'The system shall correctly calculate time-varying temperature, porepressure, stress and porosity in a model containing a source of heat energy, when using the PorousFlowUnsaturated Action.'
+  []
+  [heat04_fullysat_action]
     type = 'CSVDiff'
     input = 'heat04_fullysat_action.i'
     csvdiff = 'heat04_fullysat_action.csv'
@@ -95,9 +104,9 @@
     threading = '!pthreads'
     issues = '#8123'
     design = 'PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'PorousFlow shall correctly calculate time-varying temperature, porepressure, stress and porosity in a model containing a source of heat energy, when using the PorousFlowFullySaturated Action'
-  [../]
-  [./heat04_action_KT]
+    requirement = 'The system shall correctly calculate time-varying temperature, porepressure, stress and porosity in a model containing a source of heat energy, when using the PorousFlowFullySaturated Action.'
+  []
+  [heat04_action_KT]
     type = 'CSVDiff'
     input = 'heat04_action_KT.i'
     csvdiff = 'heat04_action.csv'
@@ -106,15 +115,15 @@
     threading = '!pthreads'
     issues = '#8123 #10426'
     design = 'porous_flow/numerical_diffusion.md porous_flow/kt_worked.md porous_flow/kt.md PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'PorousFlow shall correctly calculate time-varying temperature, porepressure, stress and porosity in a model containing a source of heat energy, when using the PorousFlowUnsaturated Action with Kuzmin-Turek stabilization'
-  [../]
-  [./heat05]
+    requirement = 'The system shall correctly calculate time-varying temperature, porepressure, stress and porosity in a model containing a source of heat energy, when using the PorousFlowUnsaturated Action with Kuzmin-Turek stabilization.'
+  []
+  [heat05]
     type = 'CSVDiff'
     input = 'heat05.i'
     csvdiff = 'heat05.csv'
     threading = '!pthreads'
     issues = '#8123'
     design = 'PorousFlowHeatEnergy.md PorousFlowHeatVolumetricExpansion.md PorousFlowEnergyTimeDerivative.md PorousFlowFullySaturatedHeatAdvection.md PorousFlowHeatAdvection.md PorousFlowHeatConduction.md PorousFlowPlasticHeatEnergy.md'
-    requirement = 'In fully-coupled THM situations, PorousFlow shall correctly initialize the porosity when it depends on all Variables'
-  [../]
+    requirement = 'In fully-coupled THM situations, the system shall correctly initialize the porosity when it depends on all Variables.'
+  []
 []

--- a/modules/porous_flow/test/tests/mass_conservation/mass15.i
+++ b/modules/porous_flow/test/tests/mass_conservation/mass15.i
@@ -1,0 +1,108 @@
+# Checking that the mass postprocessor correctly throws a paramError when an incorrect
+# strain base_name is given
+
+[Mesh]
+  [mesh]
+    type = GeneratedMeshGenerator
+    dim = 1
+    nx = 3
+    xmin = -1
+    xmax = 1
+  []
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [pp]
+  []
+[]
+
+[ICs]
+  [pinit]
+    type = FunctionIC
+    function = x
+    variable = pp
+  []
+[]
+
+[Kernels]
+  [mass0]
+    type = PorousFlowMassTimeDerivative
+    fluid_component = 0
+    variable = pp
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+  [pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 1
+    density0 = 1
+    thermal_expansion = 0
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = PorousFlowTemperature
+  []
+  [ppss]
+    type = PorousFlow1PhaseP
+    porepressure = pp
+    capillary_pressure = pc
+  []
+  [massfrac]
+    type = PorousFlowMassFraction
+  []
+  [simple_fluid]
+    type = PorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+  [porosity]
+    type = PorousFlowPorosityConst
+    porosity = 0.1
+  []
+[]
+
+[Postprocessors]
+  [total_mass]
+    type = PorousFlowFluidMass
+    base_name = incorrect_base_name
+  []
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  execute_on = 'timestep_end'
+[]

--- a/modules/porous_flow/test/tests/mass_conservation/tests
+++ b/modules/porous_flow/test/tests/mass_conservation/tests
@@ -129,8 +129,17 @@
     input = 'mass14.i'
     expect_err = 'A strain base_name incorrect_base_name_ does not exist'
     threading = '!pthreads'
-    requirement = 'If the user enters a base_name strain that does not exist, the system should produce an error.'
+    requirement = 'If the user enters a base_name strain that does not exist when using FV variables, the system should produce an error.'
     design = 'porous_flow/tests/mass_conservation/mass_conservation_tests.md FVPorousFlowFluidMass.md'
+    issues = '#25673'
+  []
+  [mass15]
+    type = 'RunException'
+    input = 'mass15.i'
+    expect_err = 'A strain base_name incorrect_base_name_ does not exist'
+    threading = '!pthreads'
+    requirement = 'If the user enters a base_name strain that does not exist when using FE variables, the system should produce an error.'
+    design = 'porous_flow/tests/mass_conservation/mass_conservation_tests.md PorousFlowFluidMass.md'
     issues = '#25673'
   []
 []


### PR DESCRIPTION
Instead of silently failing, alert the user that the strain base_name does not exist.

Fixes #25673

