### PR TITLE
Report a module name instead if we can

### DIFF
--- a/scripts/premake.py
+++ b/scripts/premake.py
@@ -9,13 +9,21 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import subprocess, os, platform, re, sys, traceback
-from versioner import Versioner
 from datetime import date
 
 class PreMake:
     def __init__(self):
         self.conda_env = self.getCondaEnv()
         self.apptainer_env = self.getApptainerEnv()
+
+        try:
+            from versioner import Versioner
+        except Exception as e:
+            warning = 'Failed to initialize PreMake for version checking; '
+            warning += 'this may be ignored but may suggest an environment issue.'
+            warning += f'\n\n{traceback.format_exc()}'
+            self.warn(warning)
+
         self.versioner_meta = Versioner().version_meta()
 
     @staticmethod

--- a/scripts/premake.py
+++ b/scripts/premake.py
@@ -8,7 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-import subprocess, os, re, sys, traceback
+import subprocess, os, platform, re, sys, traceback
 from versioner import Versioner
 from datetime import date
 
@@ -206,12 +206,19 @@ class PreMake:
             message += f'and the required version is {required_version}.\n'
             message += f'Before updating the container, make sure that your version '
             message += f'of MOOSE is up to date.\n\n'
-            message += 'You can obtain the correct container at '
-            if name_base == 'moose-dev':
-                harbor = 'harbor.hpc.inl.gov'
+
+            # Using a loaded module on INL HPC
+            CONTAINER_MODULE_NAME = os.environ.get('CONTAINER_MODULE_NAME')
+            if CONTAINER_MODULE_NAME == name.replace(f'-{platform.machine()}', ''):
+                message += 'You can obtain the correct container via the module '
+                message += f'{CONTAINER_MODULE_NAME}/{required_version}.'
             else:
-                harbor = 'mooseharbor.hpc.inl.gov'
-            message += f'oras://{harbor}/{name_base}/{name}:{required_version}.'
+                message += 'You can obtain the correct container at '
+                if name_base == 'moose-dev':
+                    harbor = 'harbor.hpc.inl.gov'
+                else:
+                    harbor = 'mooseharbor.hpc.inl.gov'
+                message += f'oras://{harbor}/{name_base}/{name}:{required_version}.'
             raise self.ApptainerVersionMismatch(message)
 
     def _check(self):

--- a/scripts/tests/test_premake.py
+++ b/scripts/tests/test_premake.py
@@ -104,6 +104,14 @@ gold_conda_list = [{
     "version": "2024.02.19"
 }]
 
+# Have a gold for the apptainer environment so that we can
+# test it without being in apptainer
+gold_apptainer_env = {'TAG': '561161b',
+                      'VERSION': '561161b',
+                      'LIBRARY': 'moose-dev',
+                      'NAME': 'moose-dev-openmpi-x86_64',
+                      'SUMMARY': 'moose-dev-openmpi-x86_64:561161b'}
+
 class Test(unittest.TestCase):
     def testCondaList(self):
         # Can only test this if we actually have conda
@@ -203,6 +211,65 @@ class Test(unittest.TestCase):
 
         # Set this back once we're done
         os.environ['CONDA_PREFIX'] = CONDA_PREFIX
+
+    def testGetApptainerEnv(self):
+        prefix = 'MOOSE_APPTAINER_GENERATOR_'
+        keys = ['TAG', 'VERSION', 'LIBRARY', 'NAME', 'NAME_SUMMARY']
+        apptainer_env = {}
+        for key in keys:
+            entry = os.environ.get(f'{prefix}{key}')
+            if entry:
+                apptainer_env[key] = entry
+
+        # If we have one of the keys, it means we're in an apptainer environment
+        # and we should have all of them
+        if os.environ.get(f'{prefix}{keys[0]}') is not None:
+            self.assertEqual(len(apptainer_env), len(keys))
+        # Otherwise, we should expect none
+        else:
+            self.assertEqual(len(apptainer_env), 0)
+
+        if len(apptainer_env) == 0:
+            apptainer_env = None
+        self.assertEqual(apptainer_env, PreMake.getApptainerEnv())
+
+    @patch.object(PreMake, "getApptainerEnv")
+    def testCheckApptainer(self, mock_get_apptainer_env):
+        # So that we can still test this on systems outside of apptainer
+        mock_get_apptainer_env.return_value = gold_apptainer_env
+        library = 'moose-dev'
+
+        # The current apptainer info for moose-dev
+        pre_make = PreMake()
+        apptainer_meta = pre_make.versioner_meta[library]['apptainer']
+        tag = apptainer_meta['tag']
+
+        # Same version
+        pre_make = PreMake()
+        pre_make.apptainer_env['TAG'] = tag
+        pre_make.apptainer_env['VERSION'] = tag
+        pre_make._checkApptainer()
+
+        # Different version
+        different_tag = 'abcd123'
+        pre_make = PreMake()
+        pre_make.apptainer_env['TAG'] = different_tag
+        pre_make.apptainer_env['VERSION'] = different_tag
+        with self.assertRaises(PreMake.ApptainerVersionMismatch) as e:
+            pre_make._checkApptainer()
+        self.assertEqual(e.exception.name, gold_apptainer_env['NAME'])
+        self.assertEqual(e.exception.name_base, apptainer_meta['name_base'])
+        self.assertEqual(e.exception.current_version, different_tag)
+        self.assertEqual(e.exception.required_version, tag)
+        self.assertIn(f'oras://harbor.hpc.inl.gov/{library}/{gold_apptainer_env["NAME"]}:{tag}', str(e.exception))
+
+        # Message with a module instead
+        container_module_name_before = os.environ.get('CONTIANER_MODULE_NAME')
+        container_module_name = 'moose-dev-openmpi-foo'
+        os.environ['CONTAINER_MODULE_NAME'] = container_module_name
+        with self.assertRaises(PreMake.ApptainerVersionMismatch) as e:
+            pre_make._checkApptainer()
+            self.assertIn(f'{container_module_name}/{tag}', str(e.exception))
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, buffer=True)

--- a/scripts/tests/test_premake.py
+++ b/scripts/tests/test_premake.py
@@ -106,11 +106,15 @@ gold_conda_list = [{
 
 # Have a gold for the apptainer environment so that we can
 # test it without being in apptainer
-gold_apptainer_env = {'TAG': '561161b',
-                      'VERSION': '561161b',
-                      'LIBRARY': 'moose-dev',
-                      'NAME': 'moose-dev-openmpi-x86_64',
-                      'SUMMARY': 'moose-dev-openmpi-x86_64:561161b'}
+gold_apptainer_tag = '561161b'
+gold_apptainer_library = 'moose-dev'
+gold_apptainer_suffix = '-openmpi'
+gold_apptainer_arch = 'x86_64'
+gold_apptainer_env = {'TAG': gold_apptainer_tag,
+                      'VERSION': gold_apptainer_tag,
+                      'LIBRARY': gold_apptainer_library,
+                      'NAME': f'{gold_apptainer_library}{gold_apptainer_suffix}-{gold_apptainer_arch}',
+                      'NAME_SUMMARY': f'{gold_apptainer_library}{gold_apptainer_suffix}-{gold_apptainer_arch}:{gold_apptainer_tag}'}
 
 class Test(unittest.TestCase):
     def testCondaList(self):
@@ -214,8 +218,8 @@ class Test(unittest.TestCase):
 
     def testGetApptainerEnv(self):
         prefix = 'MOOSE_APPTAINER_GENERATOR_'
-        keys = ['TAG', 'VERSION', 'LIBRARY', 'NAME', 'NAME_SUMMARY']
         apptainer_env = {}
+        keys = list(gold_apptainer_env.keys())
         for key in keys:
             entry = os.environ.get(f'{prefix}{key}')
             if entry:
@@ -237,7 +241,7 @@ class Test(unittest.TestCase):
     def testCheckApptainer(self, mock_get_apptainer_env):
         # So that we can still test this on systems outside of apptainer
         mock_get_apptainer_env.return_value = gold_apptainer_env
-        library = 'moose-dev'
+        library = gold_apptainer_library
 
         # The current apptainer info for moose-dev
         pre_make = PreMake()


### PR DESCRIPTION
Closes #28571

When using:

```
> module load use.moose moose-dev-openmpi
> moose-dev-shell
```

with an invalid version, the error used to be:

```
WARNING: Container moose-dev-openmpi-x86_64 is currently at version 561161b and the required version is 0416bb4.
Before updating the container, make sure that your version of MOOSE is up to date.

You can obtain the correct container at oras://harbor.hpc.inl.gov/moose-dev/moose-dev-openmpi-x86_64:0416bb4.
```

and it is now:

```
WARNING: Container moose-dev-openmpi-x86_64 is currently at version 561161b and the required version is 0416bb4.
Before updating the container, make sure that your version of MOOSE is up to date.

You can obtain the correct container via the module moose-dev-openmpi/0416bb4.
```