### PR TITLE
Suppress PETSc configure warnings

### DIFF
--- a/modules/doc/content/getting_started/installation/hpc_install_moose.md
+++ b/modules/doc/content/getting_started/installation/hpc_install_moose.md
@@ -27,20 +27,17 @@ This *usually* involves `module load` commands. Please note again, that Intel co
 supported.
 !style-end!
 
-Sometimes after loading a proper MPI environment, it is still necessary to set some variables.
-Check to see if the following variables are set:
-
+After loading a proper MPI environment, check to see if the following variables are set:
 ```bash
 echo $CC $CXX $FC $F90 $F77
 ```
 
-If nothing returns, or what does return does *not* include MPI naming conventions (`$CC` is `gcc`
-and not `mpicc` like we need), you need to set them manually each and every time you load said
-environment:
-
+If nothing returns, the following default values are used:
 ```bash
-export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77
+CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77
 ```
+If the returned variable values do *not* include MPI naming conventions (`$CC` is `gcc`
+and not `mpicc` like we need), you need to set the values manually.
 
 !include installation/start_up_profile.md
 

--- a/modules/doc/content/getting_started/installation/offline_installation.md
+++ b/modules/doc/content/getting_started/installation/offline_installation.md
@@ -47,17 +47,6 @@ dnf install mpich    # CentOS, Rocky, RHEL
 zypper install mpich # OpenSUSE
 ```
 
-If you choose this method, more likely than not you will still need to export variables to enable
-your MPI wrapper:
-
-```bash
-export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77
-```
-
-Note that PETSc ignores such environment variables unless explicitly passed its corresponding
-configure arguments. libMesh honors them. Exporting variables is only temporary in the session you
-execute them in.
-
 !include installation/start_up_profile.md
 
 !alert-end!

--- a/scripts/configure_petsc.sh
+++ b/scripts/configure_petsc.sh
@@ -105,11 +105,6 @@ function configure_petsc()
 
   cd $PETSC_DIR
   python3 ./configure \
-      CC=${CC:=mpicc} \
-      CXX=${CXX:=mpicxx} \
-      FC=${FC:=mpif90} \
-      F90=${F90:=mpif90} \
-      F77=${F77:=mpif77} \
       COPTFLAGS=${COPTFLAGS:="-g -O"} \
       CXXOPTFLAGS=${CXXOPTFLAGS:="-g -O"} \
       FOPTFLAGS=${FOPTFLAGS:="-g -O"} \

--- a/scripts/configure_petsc.sh
+++ b/scripts/configure_petsc.sh
@@ -105,10 +105,14 @@ function configure_petsc()
 
   cd $PETSC_DIR
   python3 ./configure \
-      CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77 \
-      COPTFLAGS="-g -O" \
-      CXXOPTFLAGS="-g -O" \
-      FOPTFLAGS="-g -O" \
+      CC=${CC:=mpicc} \
+      CXX=${CXX:=mpicxx} \
+      FC=${FC:=mpif90} \
+      F90=${F90:=mpif90} \
+      F77=${F77:=mpif77} \
+      COPTFLAGS=${COPTFLAGS:="-g -O"} \
+      CXXOPTFLAGS=${CXXOPTFLAGS:="-g -O"} \
+      FOPTFLAGS=${FOPTFLAGS:="-g -O"} \
       --with-64-bit-indices \
       --with-cxx-dialect=C++17 \
       --with-debugging=no \

--- a/scripts/configure_petsc.sh
+++ b/scripts/configure_petsc.sh
@@ -104,7 +104,12 @@ function configure_petsc()
   fi
 
   cd $PETSC_DIR
-  python3 ./configure --with-64-bit-indices \
+  python3 ./configure \
+      CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77 \
+      COPTFLAGS="-g -O" \
+      CXXOPTFLAGS="-g -O" \
+      FOPTFLAGS="-g -O" \
+      --with-64-bit-indices \
       --with-cxx-dialect=C++17 \
       --with-debugging=no \
       --with-fortran-bindings=0 \


### PR DESCRIPTION
- Pass compilers via PETSc's configure script
- Pass compiler flags via PETSc's configure script

This suppresses some potentially concerning warning messages (see issue).

close #28575