### PR TITLE
MooseVariableBase - isLowerD - mooseError to mooseWarning

### DIFF
--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -148,12 +148,12 @@ MooseVariableBase::MooseVariableBase(const InputParameters & parameters)
 #ifdef DEBUG
     for (auto it = ++blk_ids.begin(); it != blk_ids.end(); ++it)
       if (_is_lower_d != _mesh.isLowerD(*it))
-        mooseError("A user should not specify a mix of lower-dimensional and higher-dimensional "
-                   "blocks for variable '" +
-                   _var_name + "'. This variable is " + (_is_lower_d ? "" : "not ") +
-                   "recognised as lower-dimensional, but is also defined for the " +
-                   (_is_lower_d ? "higher" : "lower") + "-dimensional block '" +
-                   _mesh.getSubdomainName(*it) + "' (block-id " + std::to_string(*it) + ").");
+        mooseWarning("A user should not specify a mix of lower-dimensional and higher-dimensional "
+                     "blocks for variable '" +
+                     _var_name + "'. This variable is " + (_is_lower_d ? "" : "not ") +
+                     "recognised as lower-dimensional, but is also defined for the " +
+                     (_is_lower_d ? "higher" : "lower") + "-dimensional block '" +
+                     _mesh.getSubdomainName(*it) + "' (block-id " + std::to_string(*it) + ").");
 #endif
   }
 }


### PR DESCRIPTION
This minimal PR just changes this mooseError into an mooseWarning as discussed [here](https://github.com/idaholab/moose/issues/28204#issuecomment-2337917769):

https://github.com/idaholab/moose/blob/6271a40236eb166e603f72aadfe474b6c06786de/framework/src/variables/MooseVariableBase.C#L151-L156

refs #28204

This PR is only a temporary solution to allow models run in dbg-mode until the underlying problem is solved:
- Why does this check take place in the fisrt place? What does ist try to avoid?
- Why only in debug mode?
- The text of the error message does not seem to match the facts being checked (contrary to its name, isLowerD does not check whether a subdomain is ‘low-dimensional’) 