### PR TITLE
Documentation improvements

### DIFF
--- a/framework/doc/content/source/postprocessors/ElementExtremeValue.md
+++ b/framework/doc/content/source/postprocessors/ElementExtremeValue.md
@@ -8,13 +8,14 @@ find the quadrature point at which the proxy variable reaches the max/min value,
 and then return the value of the specified variable at that point.
 
 This postprocessor can operate on both elemental and nodal variables. Note,
-however, that since it works by sampling the variable at quadrature points,
+however, that since it works by sampling the variable at the quadrature points,
 its returned value won't exactly match the variable's extreme value on the
 domain (or blocks) the postprocessor is defined over. This is the case, unless
 that extremum happens to be at a quadrature point, e.g., if the variable is
 constant over any given element.
 An alternative scheme is provided by [ElementExtremeFunctorValue.md], which
-instead of comparing values at quadrature points, compares element averages.
+instead of sampling the variable at the quadrature points, samples the variable
+at the centroid of each element in the domain (or blocks) of interest.
 The corresponding postprocessor that finds (exact) extreme values of nodal
 variables evaluated at nodes is [NodalExtremeValue.md].
 

--- a/framework/doc/content/syntax/AuxKernels/index.md
+++ b/framework/doc/content/syntax/AuxKernels/index.md
@@ -35,8 +35,10 @@ of the shape function at that node.
 
 In the elemental case the `computeValue` method will be executed on each quadrature point of an
 +element+ of the finite element mesh. The values computed at the quadrature points are used to
-perform the correct finite element interpolation automatically and set the values for the degrees
-of freedom. Typically, in the elemental case the order of the monomial finite element is set to
+perform the correct finite element projection automatically and set the values for the degrees
+of freedom. This is achieved by assembling and solving a *local* finite element projection
+problem for each and every element in the domain (or blocks) of interest.
+Typically, in the elemental case the order of the monomial finite element is set to
 constant so there is a single DOF per element, but higher monomials are also supported.
 
 As is evident by the functionality detailed, the distinction between the two arises from the nature

--- a/framework/doc/content/syntax/Mesh/index.md
+++ b/framework/doc/content/syntax/Mesh/index.md
@@ -5,14 +5,14 @@
 There are two primary ways of creating a mesh for use in a MOOSE simulation: "offline generation" through
 a tool like [CUBIT](https://cubit.sandia.gov/) from [Sandia National Laboratories](http://www.sandia.gov/), and
 "online generation" through programmatic interfaces. CUBIT is useful for creating complex geometries, and can be
-licensed from CSimSoft for a fee depending on the type of organization and work
+licensed from Coreform for a fee depending on the type of organization and work
 being performed. Other mesh generators can work as long as they output a file format that is
 supported by the [FileMesh](/FileMesh.md) object.
 
 ## Example Syntax and Mesh Objects
 
-Mesh settings are applied with the `[Mesh]` of the input files, for example the basic input file
-syntax for reading a file from a mesh is shown below. For additional information on the other types
+Mesh settings are applied with the `[Mesh]` section in input files, for example the basic input file
+syntax for generating a simple square mesh is shown below. For additional information on the other types
 of Mesh objects refer to the individual object pages listed below.
 
 !listing test/tests/auxkernels/solution_aux/build.i block=Mesh

--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -1655,7 +1655,7 @@ public:
    * Helper method to return (and insert if necessary) the default value for Automatic
    * Differentiation for an uncoupled variable.
    * @param var_name the name of the variable for which to retrieve a default value
-   * @return VariableValue * a pointer to the associated VarirableValue.
+   * @return VariableValue * a pointer to the associated VariableValue.
    */
   const ADVariableValue * getADDefaultValue(const std::string & var_name) const;
 
@@ -1663,7 +1663,7 @@ public:
    * Helper method to return (and insert if necessary) the default vector value for Automatic
    * Differentiation for an uncoupled variable.
    * @param var_name the name of the vector variable for which to retrieve a default value
-   * @return VariableVectorValue * a pointer to the associated VarirableVectorValue.
+   * @return VectorVariableValue * a pointer to the associated VectorVariableValue.
    */
   const ADVectorVariableValue * getADDefaultVectorValue(const std::string & var_name) const;
 

--- a/framework/include/interfaces/ScalarCoupleable.h
+++ b/framework/include/interfaces/ScalarCoupleable.h
@@ -248,7 +248,7 @@ private:
    * Helper method to return (and insert if necessary) the default value
    * for an uncoupled variable.
    * @param var_name the name of the variable for which to retrieve a default value
-   * @return VariableValue * a pointer to the associated VarirableValue.
+   * @return VariableValue * a pointer to the associated VariableValue.
    */
   const VariableValue * getDefaultValue(const std::string & var_name) const;
 


### PR DESCRIPTION
Hi @GiudGiud,

The main purpose is to amend what I wrote in #28459: `ElementExtremeFunctorValue` compares values at the centroid of each element, not averages, at least for finite element variables (are these equivalent for FV?).
The other commits cover stuff I found while looking through the docs/src to debug my app, so I thought I'd add them here to make the PR a bit more meaningful.

Cheers,
-N