### PR TITLE
Guard multithread access of `_completed_tasks`

### DIFF
--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -367,4 +367,7 @@ private:
   std::string _final_task;
 
   const std::list<Action *> _empty_action_list;
+
+  /// Mutex for preventing read/write races for _completed_tasks
+  mutable std::mutex _completed_tasks_mutex;
 };

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -344,6 +344,7 @@ ActionWarehouse::executeAllActions()
   for (const auto & task : _ordered_names)
   {
     executeActionsWithAction(task);
+    std::scoped_lock lock(_completed_tasks_mutex);
     _completed_tasks.insert(task);
     if (_final_task != "" && task == _final_task)
       break;
@@ -468,5 +469,6 @@ ActionWarehouse::isTaskComplete(const std::string & task) const
 {
   if (!hasTask(task))
     mooseError("\"", task, "\" is not a registered task.");
+  std::scoped_lock lock(_completed_tasks_mutex);
   return _completed_tasks.count(task);
 }


### PR DESCRIPTION
This comes up with perf graph live execution during the action phase because of this line of code in `OutputWarehouse::mooseConsole`:

```c++
else if (!_app.actionWarehouse().isTaskComplete("add_output"))
```

Refs threading failure on #28452

## Reason
There are thread issues with the `ActionWarehouse`

## Design
Use a mutex to protect certain data

## Impact
Less random failures in CIVET or potentially for users running the test harness
