### PR TITLE
Use template specialization declarations to prevent multiple definition of template specialization in each translation unit

### DIFF
--- a/framework/include/auxkernels/AuxKernel.h
+++ b/framework/include/auxkernels/AuxKernel.h
@@ -333,3 +333,16 @@ AuxKernelTempl<ComputeValueType>::getMaterialPropertyOlder(const std::string & n
 
   return MaterialPropertyInterface::getMaterialPropertyOlder<T>(name);
 }
+
+// Declare all the specializations, as the template specialization declaration below must know
+template <>
+void AuxKernelTempl<Real>::setDofValueHelper(const Real & value);
+template <>
+void AuxKernelTempl<RealVectorValue>::setDofValueHelper(const RealVectorValue &);
+template <>
+void AuxKernelTempl<RealEigenVector>::compute();
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class AuxKernelTempl<Real>;
+extern template class AuxKernelTempl<RealVectorValue>;
+extern template class AuxKernelTempl<RealEigenVector>;

--- a/framework/include/auxkernels/MortarNodalAuxKernel.h
+++ b/framework/include/auxkernels/MortarNodalAuxKernel.h
@@ -84,3 +84,7 @@ private:
 
 typedef MortarNodalAuxKernelTempl<Real> MortarNodalAuxKernel;
 typedef MortarNodalAuxKernelTempl<RealVectorValue> VectorMortarNodalAuxKernel;
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class MortarNodalAuxKernelTempl<Real>;
+extern template class MortarNodalAuxKernelTempl<RealVectorValue>;

--- a/framework/include/auxkernels/ProjectedStatefulMaterialAux.h
+++ b/framework/include/auxkernels/ProjectedStatefulMaterialAux.h
@@ -55,3 +55,13 @@ typedef ProjectedStatefulMaterialAuxTempl<RankFourTensor, false>
     ProjectedStatefulMaterialRankFourTensorAux;
 typedef ProjectedStatefulMaterialAuxTempl<RankFourTensor, true>
     ADProjectedStatefulMaterialRankFourTensorAux;
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class ProjectedStatefulMaterialAuxTempl<Real, false>;
+extern template class ProjectedStatefulMaterialAuxTempl<Real, true>;
+extern template class ProjectedStatefulMaterialAuxTempl<RealVectorValue, false>;
+extern template class ProjectedStatefulMaterialAuxTempl<RealVectorValue, true>;
+extern template class ProjectedStatefulMaterialAuxTempl<RankTwoTensor, false>;
+extern template class ProjectedStatefulMaterialAuxTempl<RankTwoTensor, true>;
+extern template class ProjectedStatefulMaterialAuxTempl<RankFourTensor, false>;
+extern template class ProjectedStatefulMaterialAuxTempl<RankFourTensor, true>;

--- a/framework/include/fvics/FVInitialConditionTempl.h
+++ b/framework/include/fvics/FVInitialConditionTempl.h
@@ -73,3 +73,6 @@ FVInitialConditionTempl<T>::validParams()
 }
 
 typedef FVInitialConditionTempl<Real> FVInitialCondition;
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class FVInitialConditionTempl<Real>;

--- a/framework/include/ics/InitialConditionTempl.h
+++ b/framework/include/ics/InitialConditionTempl.h
@@ -197,3 +197,24 @@ InitialConditionTempl<T>::validParams()
 typedef InitialConditionTempl<Real> InitialCondition;
 typedef InitialConditionTempl<RealVectorValue> VectorInitialCondition;
 typedef InitialConditionTempl<RealEigenVector> ArrayInitialCondition;
+
+// Declare all the specializations, as the template specialization declaration below must know
+template <>
+void InitialConditionTempl<RealVectorValue>::setCZeroVertices();
+template <>
+RealVectorValue InitialConditionTempl<RealVectorValue>::gradientComponent(GradientType grad,
+                                                                          unsigned int i);
+template <>
+RealEigenVector InitialConditionTempl<RealEigenVector>::gradientComponent(GradientType grad,
+                                                                          unsigned int i);
+template <>
+void InitialConditionTempl<RealVectorValue>::setHermiteVertices();
+template <>
+void InitialConditionTempl<RealVectorValue>::setOtherCOneVertices();
+template <>
+void InitialConditionTempl<RealEigenVector>::choleskySolve(bool is_volume);
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class InitialConditionTempl<Real>;
+extern template class InitialConditionTempl<RealVectorValue>;
+extern template class InitialConditionTempl<RealEigenVector>;

--- a/framework/include/materials/InterpolatedStatefulMaterial.h
+++ b/framework/include/materials/InterpolatedStatefulMaterial.h
@@ -53,3 +53,9 @@ typedef InterpolatedStatefulMaterialTempl<RealVectorValue>
 typedef InterpolatedStatefulMaterialTempl<RankTwoTensor> InterpolatedStatefulMaterialRankTwoTensor;
 typedef InterpolatedStatefulMaterialTempl<RankFourTensor>
     InterpolatedStatefulMaterialRankFourTensor;
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class InterpolatedStatefulMaterialTempl<Real>;
+extern template class InterpolatedStatefulMaterialTempl<RealVectorValue>;
+extern template class InterpolatedStatefulMaterialTempl<RankTwoTensor>;
+extern template class InterpolatedStatefulMaterialTempl<RankFourTensor>;

--- a/framework/include/userobjects/ProjectedStatefulMaterialNodalPatchRecovery.h
+++ b/framework/include/userobjects/ProjectedStatefulMaterialNodalPatchRecovery.h
@@ -121,3 +121,13 @@ typedef ProjectedStatefulMaterialNodalPatchRecoveryTempl<RankFourTensor, false>
     ProjectedStatefulMaterialNodalPatchRecoveryRankFourTensor;
 typedef ProjectedStatefulMaterialNodalPatchRecoveryTempl<RankFourTensor, true>
     ADProjectedStatefulMaterialNodalPatchRecoveryRankFourTensor;
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class ProjectedStatefulMaterialNodalPatchRecoveryTempl<Real, false>;
+extern template class ProjectedStatefulMaterialNodalPatchRecoveryTempl<Real, true>;
+extern template class ProjectedStatefulMaterialNodalPatchRecoveryTempl<RealVectorValue, false>;
+extern template class ProjectedStatefulMaterialNodalPatchRecoveryTempl<RealVectorValue, true>;
+extern template class ProjectedStatefulMaterialNodalPatchRecoveryTempl<RankTwoTensor, false>;
+extern template class ProjectedStatefulMaterialNodalPatchRecoveryTempl<RankTwoTensor, true>;
+extern template class ProjectedStatefulMaterialNodalPatchRecoveryTempl<RankFourTensor, false>;
+extern template class ProjectedStatefulMaterialNodalPatchRecoveryTempl<RankFourTensor, true>;

--- a/framework/include/variables/MooseLinearVariableFV.h
+++ b/framework/include/variables/MooseLinearVariableFV.h
@@ -513,5 +513,9 @@ MooseLinearVariableFV<OutputType>::adError() const
              this->name());
 }
 
+// Declare all the specializations, as the template specialization declarations below must know
 template <>
 ADReal MooseLinearVariableFV<Real>::evaluateDot(const ElemArg & elem, const StateArg & state) const;
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class MooseLinearVariableFV<Real>;

--- a/framework/include/variables/MooseVariableFE.h
+++ b/framework/include/variables/MooseVariableFE.h
@@ -859,3 +859,49 @@ MooseVariableFE<OutputType>::setActiveTags(const std::set<TagID> & vtags)
   _neighbor_data->setActiveTags(vtags);
   _lower_data->setActiveTags(vtags);
 }
+
+// Declare all the specializations, as the template specialization declarations below must know
+template <>
+InputParameters MooseVariableFE<Real>::validParams();
+template <>
+InputParameters MooseVariableFE<RealVectorValue>::validParams();
+template <>
+InputParameters MooseVariableFE<RealEigenVector>::validParams();
+template <>
+RealEigenVector
+MooseVariableFE<RealEigenVector>::getValue(const Elem * elem,
+                                           const std::vector<std::vector<Real>> & phi) const;
+template <>
+RealVectorArrayValue MooseVariableFE<RealEigenVector>::getGradient(
+    const Elem * elem, const std::vector<std::vector<RealVectorValue>> & grad_phi) const;
+template <>
+void MooseVariableFE<RealEigenVector>::evaluateOnElement(const ElemQpArg &,
+                                                         const StateArg &,
+                                                         bool) const;
+template <>
+void MooseVariableFE<RealEigenVector>::evaluateOnElementSide(const ElemSideQpArg &,
+                                                             const StateArg &,
+                                                             bool) const;
+template <>
+typename MooseVariableFE<RealEigenVector>::ValueType
+MooseVariableFE<RealEigenVector>::evaluate(const ElemQpArg &, const StateArg &) const;
+template <>
+typename MooseVariableFE<RealEigenVector>::ValueType
+MooseVariableFE<RealEigenVector>::evaluate(const ElemSideQpArg &, const StateArg &) const;
+template <>
+typename MooseVariableFE<RealEigenVector>::GradientType
+MooseVariableFE<RealEigenVector>::evaluateGradient(const ElemQpArg &, const StateArg &) const;
+template <>
+typename MooseVariableFE<RealEigenVector>::GradientType
+MooseVariableFE<RealEigenVector>::evaluateGradient(const ElemSideQpArg &, const StateArg &) const;
+template <>
+typename MooseVariableFE<RealEigenVector>::DotType
+MooseVariableFE<RealEigenVector>::evaluateDot(const ElemQpArg &, const StateArg &) const;
+template <>
+typename MooseVariableFE<RealEigenVector>::DotType
+MooseVariableFE<RealEigenVector>::evaluateDot(const ElemSideQpArg &, const StateArg &) const;
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class MooseVariableFE<Real>;
+extern template class MooseVariableFE<RealVectorValue>;
+extern template class MooseVariableFE<RealEigenVector>;

--- a/framework/include/variables/MooseVariableFV.h
+++ b/framework/include/variables/MooseVariableFV.h
@@ -841,5 +841,13 @@ MooseVariableFV<OutputType>::lowerDError() const
   mooseError("Lower dimensional element support not implemented for finite volume variables");
 }
 
+// Declare all the specializations, as the template specialization declaration below must know
 template <>
 ADReal MooseVariableFV<Real>::evaluateDot(const ElemArg & elem, const StateArg & state) const;
+template <>
+ADReal MooseVariableFV<Real>::evaluateDot(const FaceArg & elem_arg, const StateArg & state) const;
+template <>
+ADReal MooseVariableFV<Real>::evaluateDot(const ElemQpArg & elem_arg, const StateArg & state) const;
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class MooseVariableFV<Real>;

--- a/framework/include/variables/MooseVariableField.h
+++ b/framework/include/variables/MooseVariableField.h
@@ -399,3 +399,8 @@ protected:
   using MooseVariableField<OutputType>::_time_integrator;                                          \
   using MooseVariableField<OutputType>::_ad_real_dummy;                                            \
   using MooseVariableField<OutputType>::getSolution
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class MooseVariableField<Real>;
+extern template class MooseVariableField<RealVectorValue>;
+extern template class MooseVariableField<RealEigenVector>;

--- a/framework/include/variables/MooseVariableInterface.h
+++ b/framework/include/variables/MooseVariableInterface.h
@@ -235,3 +235,24 @@ protected:
 private:
   const MooseObject & _moose_object;
 };
+
+// Declare all the specializations, as the template specialization declaration below must know
+template <>
+const VectorVariableValue & MooseVariableInterface<RealVectorValue>::value();
+template <>
+const VectorVariableValue & MooseVariableInterface<RealVectorValue>::valueOld();
+template <>
+const VectorVariableValue & MooseVariableInterface<RealVectorValue>::valueOlder();
+template <>
+const VectorVariableValue & MooseVariableInterface<RealVectorValue>::dot();
+template <>
+const VectorVariableValue & MooseVariableInterface<RealVectorValue>::dotDot();
+template <>
+const VectorVariableValue & MooseVariableInterface<RealVectorValue>::dotOld();
+template <>
+const VectorVariableValue & MooseVariableInterface<RealVectorValue>::dotDotOld();
+
+// Prevent implicit instantiation in other translation units where these classes are used
+extern template class MooseVariableInterface<Real>;
+extern template class MooseVariableInterface<RealVectorValue>;
+extern template class MooseVariableInterface<RealEigenVector>;

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -486,7 +486,7 @@ AuxKernelTempl<ComputeValueType>::isMortar()
   return dynamic_cast<MortarNodalAuxKernelTempl<ComputeValueType> *>(this) != nullptr;
 }
 
-// Explicitly instantiates the two versions of the AuxKernelTempl class
+// Explicitly instantiates the three versions of the AuxKernelTempl class
 template class AuxKernelTempl<Real>;
 template class AuxKernelTempl<RealVectorValue>;
 template class AuxKernelTempl<RealEigenVector>;


### PR DESCRIPTION
 this requires providing the full declaration of the template in the header, including member function specializations
 
This can possibly reduce compile time & compilation memory cost, and does remove most of our visibility compilation warnings (all from the framework, I did not do modules)

refs #27462
It does not address the root cause so I am not closing the issue

thanks to Casey for the hint on the template specialization