### PR TITLE
Convert to relative path if needed

### DIFF
--- a/scripts/tests/test_versioner.py
+++ b/scripts/tests/test_versioner.py
@@ -105,6 +105,11 @@ class Test(unittest.TestCase):
             Versioner.git_file('foo', 'HEAD')
         self.assertIn('Failed to load', str(e.exception))
 
+        out_of_repo_path = os.path.join(MOOSE_DIR, '..', 'out_of_repo')
+        with self.assertRaises(Exception) as e:
+            Versioner.git_file(out_of_repo_path, 'HEAD')
+        self.assertEqual(f'Supplied path {out_of_repo_path} is not in {MOOSE_DIR}', str(e.exception))
+
     def testGetApp(self):
         app_name, git_root, git_hash = Versioner.get_app()
         self.assertEqual('moose', app_name)

--- a/scripts/versioner.py
+++ b/scripts/versioner.py
@@ -172,8 +172,12 @@ class Versioner:
     @staticmethod
     def git_file(file, commit, repo_dir=MOOSE_DIR, allow_missing=False):
         """ gets the contents of a file at a given git commit """
-        repo_dir = repo_dir.rstrip(os.sep)
-        file = file.replace(repo_dir, '.')
+        if os.path.isabs(file):
+            relative = os.path.relpath(file, MOOSE_DIR)
+            if relative.startswith('..'):
+                raise Exception(f'Supplied path {file} is not in {MOOSE_DIR}')
+            file = relative
+
         command = ['git', 'show', f'{commit}:{file}']
         process = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                  cwd=repo_dir, check=False)


### PR DESCRIPTION
Turns out when operating as a submodule we ended up with strange paths being interpreted when performing `git show HEAD:../moose/to/file`. And git does not like leaving root repo area.

Instead, always operate using full absolute (real) paths to files, and when it comes time to performing `git show`, convert these locations to relative paths without leaving the root repo.

Closes #28633

