### PR TITLE
Add valgrind suppression for netgen singleton leak

### DIFF
--- a/python/TestHarness/suppressions/errors.supp
+++ b/python/TestHarness/suppressions/errors.supp
@@ -250,3 +250,10 @@
    fun:*torch*autograd*
    ...
 }
+{
+   netgen_singleton_taskmanager_leak
+   Memcheck:Leak
+   ...
+   fun:*TaskManager*
+   ...
+}


### PR DESCRIPTION
This fixes a valgrind failure triggered by #28298

Refs #28297
