### PR TITLE
Optionally skip initial adaptivity projections

### DIFF
--- a/framework/include/base/Adaptivity.h
+++ b/framework/include/base/Adaptivity.h
@@ -219,6 +219,22 @@ public:
   void setInitialMarkerVariableName(std::string marker_field);
 
   /**
+   * Sets whether or not to project initial marker values onto the
+   * initial refined mesh.
+   *
+   * Currently defaults to true for backwards compatibility, but
+   * setting this to false can obviate the requirement for *any*
+   * initial projection steps, thereby saving memory and CPU time.
+   *
+   * @param project_initial_marker Whether to project the initial
+   * marker onto the initial refined mesh.
+   */
+  void setProjectInitialMarker(bool project_initial_marker)
+  {
+    _project_initial_marker = project_initial_marker;
+  }
+
+  /**
    * Set the maximum refinement level (for the new Adaptivity system).
    */
   void setMaxHLevel(unsigned int level) { _max_h_level = level; }
@@ -302,6 +318,9 @@ protected:
 
   /// Name of the initial marker variable if using the new adaptivity system
   std::string _initial_marker_variable_name;
+
+  /// Whether or not to project initial marker onto refined mesh
+  bool _project_initial_marker;
 
   /// The maximum number of refinement levels
   unsigned int _max_h_level;

--- a/framework/src/actions/SetAdaptivityOptionsAction.C
+++ b/framework/src/actions/SetAdaptivityOptionsAction.C
@@ -67,7 +67,7 @@ SetAdaptivityOptionsAction::validParams()
       "initial_marker",
       "The name of the Marker to use to adapt the mesh during initial refinement.");
   params.addParam<bool>("project_initial_marker",
-                        true,
+                        false,
                         "Whether to project initial Marker values onto the refined mesh.");
   params.addParamNamesToGroup("initial_steps initial_marker project_initial_marker",
                               "Initial Adaptivity");

--- a/framework/src/actions/SetAdaptivityOptionsAction.C
+++ b/framework/src/actions/SetAdaptivityOptionsAction.C
@@ -66,7 +66,11 @@ SetAdaptivityOptionsAction::validParams()
   params.addParam<MarkerName>(
       "initial_marker",
       "The name of the Marker to use to adapt the mesh during initial refinement.");
-  params.addParamNamesToGroup("initial_steps initial_marker", "Initial Adaptivity");
+  params.addParam<bool>("project_initial_marker",
+                        true,
+                        "Whether to project initial Marker values onto the refined mesh.");
+  params.addParamNamesToGroup("initial_steps initial_marker project_initial_marker",
+                              "Initial Adaptivity");
   return params;
 }
 
@@ -153,6 +157,7 @@ SetAdaptivityOptionsAction::act()
 
     adapt.setTimeActive(getParam<Real>("start_time"), getParam<Real>("stop_time"));
     adapt.setInterval(getParam<unsigned int>("interval"));
+    adapt.setProjectInitialMarker(getParam<bool>("project_initial_marker"));
 
     adapt.setRecomputeMarkersFlag(getParam<bool>("recompute_markers_during_cycles"));
     if (getParam<bool>("switch_h_to_p_refinement"))

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -259,7 +259,62 @@ Adaptivity::adaptMesh(std::string marker_name /*=std::string()*/)
 bool
 Adaptivity::initialAdaptMesh()
 {
-  return adaptMesh(_initial_marker_variable_name);
+  // This is an initial adaptivity step.  We're going to be projecting
+  // any initial conditions onto the fine mesh from their source, so
+  // we don't need to project them from the coarse mesh; that would be
+  // inaccurate if we trusted it and it's redundant since we don't.
+
+  // libMesh doesn't currently provide an API to turn projections on
+  // and off with a single switch, so we'll manually disable
+  // projections on every vector, then afterward reenable the ones we
+  // disabled.
+  //
+  // The catch is that we can only safely disable projections if
+  // project_initial_marker has been switched to false, because we
+  // don't know if the user code wants to look at adaptivity marker
+  // variables on the new mesh.
+  std::tuple<EquationSystems *,
+             std::vector<std::pair<unsigned int, std::string>>,
+             std::vector<unsigned int>>
+      main, disp;
+  if (!_project_initial_marker)
+  {
+    std::get<0>(main) = &_fe_problem.es();
+    std::get<0>(disp) = _displaced_problem ? &_displaced_problem->es() : nullptr;
+    for (auto [es, vecs, solns] : {main, disp})
+      if (es)
+        for (auto s : make_range(es->n_systems()))
+        {
+          System & sys = es->get_system(s);
+          if (sys.project_solution_on_reinit())
+          {
+            solns.push_back(s);
+            sys.project_solution_on_reinit() = false;
+          }
+          for (auto v : make_range(sys.n_vectors()))
+          {
+            const std::string & vecname = sys.vector_name(v);
+            if (sys.vector_preservation(vecname))
+            {
+              vecs.emplace_back(s, vecname);
+              sys.set_vector_preservation(vecname, false);
+            }
+          }
+        }
+  }
+
+  const bool returnval = adaptMesh(_initial_marker_variable_name);
+
+  for (auto [es, vecs, solns] : {main, disp})
+    if (es)
+    {
+      for (const auto s : solns)
+        es->get_system(s).project_solution_on_reinit() = true;
+      for (const auto & [s, vecname] : vecs)
+        es->get_system(s).set_vector_preservation(vecname, true);
+    }
+
+  return returnval;
 }
 
 void

--- a/modules/contact/test/tests/adaptivity/contact_initial_adaptivity.i
+++ b/modules/contact/test/tests/adaptivity/contact_initial_adaptivity.i
@@ -104,6 +104,10 @@
   steps = 0
   marker = box
   max_h_level = 2
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   initial_steps = 2
   [./Markers]
     [./box]

--- a/modules/contact/test/tests/verification/patch_tests/automatic_patch_update/iteration_adaptivity_parallel.i
+++ b/modules/contact/test/tests/verification/patch_tests/automatic_patch_update/iteration_adaptivity_parallel.i
@@ -50,6 +50,10 @@
 
 [Adaptivity]
   initial_marker = box
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   initial_steps = 1
   max_h_level = 1
   [Markers]

--- a/modules/contact/test/tests/verification/patch_tests/automatic_patch_update/iteration_adaptivity_parallel_node_face.i
+++ b/modules/contact/test/tests/verification/patch_tests/automatic_patch_update/iteration_adaptivity_parallel_node_face.i
@@ -50,6 +50,10 @@
 
 [Adaptivity]
   initial_marker = box
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   initial_steps = 1
   max_h_level = 1
   [Markers]

--- a/modules/geochemistry/test/tests/nodal_void_volume/nodal_void_volume_adaptive.i
+++ b/modules/geochemistry/test/tests/nodal_void_volume/nodal_void_volume_adaptive.i
@@ -10,6 +10,10 @@
 
 [Adaptivity]
   initial_marker = u_marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   marker = u_marker
   max_h_level = 1
   [Markers]

--- a/modules/level_set/test/tests/functions/olsson_bubble/olsson_bubble.i
+++ b/modules/level_set/test/tests/functions/olsson_bubble/olsson_bubble.i
@@ -7,6 +7,10 @@
 
 [Adaptivity]
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   initial_steps = 2
   max_h_level = 2
   [./Markers]

--- a/modules/phase_field/examples/anisotropic_interfaces/GrandPotentialPlanarGrowth.i
+++ b/modules/phase_field/examples/anisotropic_interfaces/GrandPotentialPlanarGrowth.i
@@ -274,6 +274,10 @@
  initial_steps = 3
  max_h_level = 3
  initial_marker = err_eta
+
+ # backwards compatibility for exodiffs after #25067
+ project_initial_marker = true
+
  marker = err_bnds
 [./Markers]
    [./err_eta]

--- a/modules/phase_field/examples/anisotropic_interfaces/GrandPotentialSolidification.i
+++ b/modules/phase_field/examples/anisotropic_interfaces/GrandPotentialSolidification.i
@@ -284,6 +284,10 @@
  initial_steps = 5
  max_h_level = 3
  initial_marker = err_eta
+
+ # backwards compatibility for exodiffs after #25067
+ project_initial_marker = true
+
  marker = err_bnds
 [./Markers]
    [./err_eta]

--- a/modules/phase_field/examples/anisotropic_interfaces/GrandPotentialTwophaseAnisotropy.i
+++ b/modules/phase_field/examples/anisotropic_interfaces/GrandPotentialTwophaseAnisotropy.i
@@ -280,6 +280,10 @@
  initial_steps = 5
  max_h_level = 3
  initial_marker = err_eta
+
+ # backwards compatibility for exodiffs after #25067
+ project_initial_marker = true
+
  marker = err_bnds
 [./Markers]
    [./err_eta]

--- a/modules/porous_flow/examples/lava_lamp/1phase_convection.i
+++ b/modules/porous_flow/examples/lava_lamp/1phase_convection.i
@@ -19,6 +19,10 @@
   max_h_level = 2
   marker = marker
   initial_marker = initial
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   initial_steps = 2
   [Indicators]
     [indicator]

--- a/modules/porous_flow/examples/lava_lamp/2phase_convection.i
+++ b/modules/porous_flow/examples/lava_lamp/2phase_convection.i
@@ -23,6 +23,10 @@
   max_h_level = 2
   marker = marker
   initial_marker = initial
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   initial_steps = 2
   [Indicators]
     [indicator]

--- a/modules/porous_flow/test/tests/flux_limited_TVD_advection/fltvd_1D_adaptivity.i
+++ b/modules/porous_flow/test/tests/flux_limited_TVD_advection/fltvd_1D_adaptivity.i
@@ -11,6 +11,10 @@
 [Adaptivity]
   initial_steps = 1
   initial_marker = tracer_marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   marker = tracer_marker
   max_h_level = 1
   [Markers]

--- a/modules/porous_flow/test/tests/flux_limited_TVD_pflow/pffltvd_1D_adaptivity.i
+++ b/modules/porous_flow/test/tests/flux_limited_TVD_pflow/pffltvd_1D_adaptivity.i
@@ -11,6 +11,10 @@
 [Adaptivity]
   initial_steps = 1
   initial_marker = tracer_marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   marker = tracer_marker
   max_h_level = 1
   [Markers]

--- a/modules/porous_flow/test/tests/recover/pffltvd.i
+++ b/modules/porous_flow/test/tests/recover/pffltvd.i
@@ -21,6 +21,10 @@
 [Adaptivity]
   initial_steps = 1
   initial_marker = tracer_marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   marker = tracer_marker
   max_h_level = 1
   [Markers]

--- a/modules/ray_tracing/test/tests/traceray/adaptivity/adaptivity_1d.i
+++ b/modules/ray_tracing/test/tests/traceray/adaptivity/adaptivity_1d.i
@@ -48,6 +48,10 @@
   steps = 1
   marker = marker
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 2
   [Indicators/indicator]
     type = GradientJumpIndicator

--- a/modules/ray_tracing/test/tests/traceray/adaptivity/adaptivity_2d.i
+++ b/modules/ray_tracing/test/tests/traceray/adaptivity/adaptivity_2d.i
@@ -49,6 +49,10 @@
   steps = 1
   marker = marker
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 2
   [Indicators/indicator]
     type = GradientJumpIndicator

--- a/modules/ray_tracing/test/tests/traceray/adaptivity/adaptivity_3d.i
+++ b/modules/ray_tracing/test/tests/traceray/adaptivity/adaptivity_3d.i
@@ -50,6 +50,10 @@
   steps = 1
   marker = marker
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 2
   [Indicators/indicator]
     type = GradientJumpIndicator

--- a/modules/ray_tracing/test/tests/userobjects/cone_ray_study/cone_ray_study.i
+++ b/modules/ray_tracing/test/tests/userobjects/cone_ray_study/cone_ray_study.i
@@ -79,6 +79,10 @@
   steps = 0 # 6 for pretty pictures
   marker = marker
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 6
   [Indicators/indicator]
     type = GradientJumpIndicator

--- a/modules/ray_tracing/test/tests/userobjects/cone_ray_study/cone_ray_study_3d.i
+++ b/modules/ray_tracing/test/tests/userobjects/cone_ray_study/cone_ray_study_3d.i
@@ -80,6 +80,10 @@
   steps = 0 # 6 for pretty pictures
   marker = marker
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 6
   [Indicators/indicator]
     type = GradientJumpIndicator

--- a/modules/solid_mechanics/examples/piston/piston_params.i
+++ b/modules/solid_mechanics/examples/piston/piston_params.i
@@ -21,6 +21,10 @@
   max_h_level = 3
   cycles_per_step = 1
   initial_marker = uniform
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   marker = errorFraction
   [Markers]
     [uniform]

--- a/test/tests/adaptivity/cycles_per_step/cycles_per_step.i
+++ b/test/tests/adaptivity/cycles_per_step/cycles_per_step.i
@@ -51,6 +51,10 @@
   cycles_per_step = 2
   marker = marker
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 2
   [Indicators/indicator]
     type = GradientJumpIndicator

--- a/test/tests/adaptivity/cycles_per_step/test.i
+++ b/test/tests/adaptivity/cycles_per_step/test.i
@@ -51,6 +51,10 @@
   steps = 1
   marker = marker
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 2
   [./Indicators]
     [./indicator]

--- a/test/tests/adaptivity/initial_adapt/initial_adapt.i
+++ b/test/tests/adaptivity/initial_adapt/initial_adapt.i
@@ -63,6 +63,10 @@
   marker = box
   max_h_level = 2
   initial_steps = 2
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [./Markers]
     [./box]
       bottom_left = '0.3 0.3 0'

--- a/test/tests/adaptivity/initial_marker/initial_marker.i
+++ b/test/tests/adaptivity/initial_marker/initial_marker.i
@@ -64,6 +64,10 @@
   max_h_level = 2
   initial_steps = 4
   initial_marker = initial_box
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [./Markers]
     [./box]
       bottom_left = '0.3 0.3 0'

--- a/test/tests/adaptivity/scalar/scalar_adaptivity.i
+++ b/test/tests/adaptivity/scalar/scalar_adaptivity.i
@@ -68,6 +68,10 @@
   initial_steps = 2
   max_h_level = 2
   marker = EFM
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [Markers]
     [EFM]
       type = ErrorFractionMarker

--- a/test/tests/adaptivity/steady/steady.i
+++ b/test/tests/adaptivity/steady/steady.i
@@ -46,6 +46,10 @@
 
 [Adaptivity]
   initial_marker = uniform
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   initial_steps = 1
   [Markers/uniform]
     type = UniformMarker

--- a/test/tests/functions/image_function/image.i
+++ b/test/tests/functions/image_function/image.i
@@ -10,6 +10,10 @@
   max_h_level = 5
   initial_steps = 5
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [Indicators]
     [indicator]
       type = GradientJumpIndicator

--- a/test/tests/functions/image_function/threshold_adapt.i
+++ b/test/tests/functions/image_function/threshold_adapt.i
@@ -45,6 +45,10 @@
   max_h_level = 5
   initial_steps = 5
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [Indicators]
     [indicator]
       type = GradientJumpIndicator

--- a/test/tests/functions/image_function/threshold_adapt_parallel.i
+++ b/test/tests/functions/image_function/threshold_adapt_parallel.i
@@ -46,6 +46,10 @@
   max_h_level = 5
   initial_steps = 5
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [Indicators]
     [indicator]
       type = GradientJumpIndicator

--- a/test/tests/fvkernels/fv_adapt/steady-adapt.i
+++ b/test/tests/fvkernels/fv_adapt/steady-adapt.i
@@ -76,6 +76,10 @@
 [Adaptivity]
   marker = box
   initial_steps = 1
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [Markers]
     [box]
       bottom_left = '0.5 0 0'

--- a/test/tests/fvkernels/fv_adapt/transient-adapt.i
+++ b/test/tests/fvkernels/fv_adapt/transient-adapt.i
@@ -96,6 +96,10 @@
 [Adaptivity]
   marker = box
   initial_steps = 1
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [Markers]
     [box]
       bottom_left = '0.3 0.3 0'

--- a/test/tests/globalparams/global_param/suppress_check.i
+++ b/test/tests/globalparams/global_param/suppress_check.i
@@ -42,6 +42,10 @@
     []
   []
   initial_marker = boundary
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   initial_steps = 1
 []
 

--- a/test/tests/kernels/diffusion_with_hanging_node/simple_diffusion.i
+++ b/test/tests/kernels/diffusion_with_hanging_node/simple_diffusion.i
@@ -59,6 +59,9 @@
   max_h_level = 1
   initial_steps = 1
 
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [./Markers]
     [./box]
       type = BoxMarker

--- a/test/tests/kernels/hfem/tests
+++ b/test/tests/kernels/hfem/tests
@@ -88,7 +88,7 @@
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with displaced meshes.'
     mumps = true
   []
-  [robin_adpatation]
+  [robin_adaptation]
     type = 'RunException'
     input = 'robin_adapt.i'
     expect_err = 'HFEM does not support mesh adaptivity currently'

--- a/test/tests/markers/block_restricted/marker_block.i
+++ b/test/tests/markers/block_restricted/marker_block.i
@@ -26,6 +26,10 @@
 [Adaptivity]
   initial_steps = 2
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [./Markers]
     [./marker]
       type = UniformMarker

--- a/test/tests/markers/boundary_marker/adjacent.i
+++ b/test/tests/markers/boundary_marker/adjacent.i
@@ -51,6 +51,10 @@
     []
   []
   initial_marker = boundary
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   initial_steps = 2
 []
 

--- a/test/tests/markers/boundary_marker/distance.i
+++ b/test/tests/markers/boundary_marker/distance.i
@@ -52,6 +52,10 @@
     []
   []
   initial_marker = boundary
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   initial_steps = 1
 []
 

--- a/test/tests/markers/boundary_marker/multiple.i
+++ b/test/tests/markers/boundary_marker/multiple.i
@@ -27,6 +27,10 @@
     []
   []
   initial_marker = boundary
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   initial_steps = 3
 []
 

--- a/test/tests/markers/two_circle_marker/two_circle_marker.i
+++ b/test/tests/markers/two_circle_marker/two_circle_marker.i
@@ -43,6 +43,10 @@
 [Adaptivity]
   initial_steps = 1
   initial_marker = two_circle_marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   cycles_per_step = 1
   marker = two_circle_marker
   max_h_level = 1

--- a/test/tests/markers/two_circle_marker/two_circle_marker_coarsen.i
+++ b/test/tests/markers/two_circle_marker/two_circle_marker_coarsen.i
@@ -43,6 +43,10 @@
 [Adaptivity]
   initial_steps = 1
   initial_marker = two_circle_marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   cycles_per_step = 1
   marker = two_circle_marker
   max_h_level = 1

--- a/test/tests/markers/two_circle_marker/two_circle_marker_gaussian_ic.i
+++ b/test/tests/markers/two_circle_marker/two_circle_marker_gaussian_ic.i
@@ -60,6 +60,10 @@
 [Adaptivity]
   initial_steps = 1
   initial_marker = two_circle_marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   cycles_per_step = 1
   marker = two_circle_marker
   max_h_level = 1

--- a/test/tests/meshgenerators/distributed_rectilinear/dmg_displaced_mesh/adaptivity.i
+++ b/test/tests/meshgenerators/distributed_rectilinear/dmg_displaced_mesh/adaptivity.i
@@ -101,6 +101,10 @@
   steps = 1
   marker = marker
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 2
   [./Indicators]
     [./indicator]

--- a/test/tests/meshgenerators/distributed_rectilinear/dmg_displaced_mesh/pbc_adaptivity.i
+++ b/test/tests/meshgenerators/distributed_rectilinear/dmg_displaced_mesh/pbc_adaptivity.i
@@ -134,6 +134,10 @@
   steps = 1
   marker = marker
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 2
   [./Indicators]
     [./indicator]

--- a/test/tests/meshgenerators/distributed_rectilinear/generator/distributed_rectilinear_mesh_generator_adaptivity.i
+++ b/test/tests/meshgenerators/distributed_rectilinear/generator/distributed_rectilinear_mesh_generator_adaptivity.i
@@ -53,6 +53,10 @@
   steps = 1
   marker = marker
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 2
   [./Indicators]
     [./indicator]

--- a/test/tests/meshmodifiers/element_subdomain_modifier/adaptivity_moving_boundary.i
+++ b/test/tests/meshmodifiers/element_subdomain_modifier/adaptivity_moving_boundary.i
@@ -67,6 +67,10 @@
   steps = 1
   marker = 'marker'
   initial_marker = 'marker'
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 1
   [Indicators]
     [indicator]

--- a/test/tests/meshmodifiers/element_subdomain_modifier/adaptivity_moving_boundary_3d.i
+++ b/test/tests/meshmodifiers/element_subdomain_modifier/adaptivity_moving_boundary_3d.i
@@ -75,6 +75,10 @@
   steps = 1
   marker = 'marker'
   initial_marker = 'marker'
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 1
   [Indicators/indicator]
     type = GradientJumpIndicator

--- a/test/tests/meshmodifiers/element_subdomain_modifier/amr_bc.i
+++ b/test/tests/meshmodifiers/element_subdomain_modifier/amr_bc.i
@@ -63,6 +63,10 @@
   steps = 1
   marker = 'marker'
   initial_marker = 'marker'
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 1
   [Indicators/indicator]
     type = GradientJumpIndicator

--- a/test/tests/outputs/debug/show_execution_adaptivity.i
+++ b/test/tests/outputs/debug/show_execution_adaptivity.i
@@ -55,6 +55,10 @@
   cycles_per_step = 2
   marker = marker
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   max_h_level = 2
   [Indicators/indicator]
     type = GradientJumpIndicator

--- a/test/tests/outputs/dofmap/simple_transient.i
+++ b/test/tests/outputs/dofmap/simple_transient.i
@@ -50,6 +50,10 @@
   marker = marker
   initial_steps = 1
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [./Markers]
     [./marker]
       type = UniformMarker

--- a/test/tests/outputs/json/distributed/distributed.i
+++ b/test/tests/outputs/json/distributed/distributed.i
@@ -9,6 +9,10 @@
 
 [Adaptivity]
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [Markers/marker]
     type = BoxMarker
     bottom_left = '0 0 0'

--- a/test/tests/outputs/oversample/ex02_adapt.i
+++ b/test/tests/outputs/oversample/ex02_adapt.i
@@ -50,6 +50,10 @@
   marker = marker
   steps = 2
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [./Indicators]
     [./indicator]
       type = GradientJumpIndicator

--- a/test/tests/postprocessors/num_adaptivity_cycles/num_adaptivity_cycles.i
+++ b/test/tests/postprocessors/num_adaptivity_cycles/num_adaptivity_cycles.i
@@ -64,6 +64,10 @@
   max_h_level = 2
   initial_steps = 4
   initial_marker = initial_box
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [./Markers]
     [./box]
       bottom_left = '0.3 0.3 0'

--- a/test/tests/postprocessors/num_adaptivity_cycles/num_adaptivity_cycles_toggle_adaptivity.i
+++ b/test/tests/postprocessors/num_adaptivity_cycles/num_adaptivity_cycles_toggle_adaptivity.i
@@ -64,6 +64,10 @@
   max_h_level = 2
   initial_steps = 4
   initial_marker = initial_box
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [./Markers]
     [./box]
       bottom_left = '0.3 0.3 0'

--- a/test/tests/postprocessors/num_adaptivity_cycles/num_adaptivity_cycles_toggle_adaptivity_wait.i
+++ b/test/tests/postprocessors/num_adaptivity_cycles/num_adaptivity_cycles_toggle_adaptivity_wait.i
@@ -64,6 +64,10 @@
   max_h_level = 2
   initial_steps = 4
   initial_marker = initial_box
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [./Markers]
     [./box]
       bottom_left = '0.3 0.3 0'

--- a/test/tests/reporters/mesh_info/mesh_info.i
+++ b/test/tests/reporters/mesh_info/mesh_info.i
@@ -18,6 +18,10 @@
 
 [Adaptivity]
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   [Markers/marker]
     type = BoxMarker
     bottom_left = '0 0 0'

--- a/test/tests/userobjects/toggle_mesh_adaptivity/toggle_mesh_adaptivity_gaussian_ic.i
+++ b/test/tests/userobjects/toggle_mesh_adaptivity/toggle_mesh_adaptivity_gaussian_ic.i
@@ -60,6 +60,10 @@
 [Adaptivity]
   initial_steps = 1
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   cycles_per_step = 1
   marker = marker
   max_h_level = 2

--- a/test/tests/userobjects/toggle_mesh_adaptivity/toggle_mesh_adaptivity_gaussian_ic_stop_time.i
+++ b/test/tests/userobjects/toggle_mesh_adaptivity/toggle_mesh_adaptivity_gaussian_ic_stop_time.i
@@ -60,6 +60,10 @@
 [Adaptivity]
   initial_steps = 1
   initial_marker = marker
+
+  # backwards compatibility for exodiffs after #25067
+  project_initial_marker = true
+
   cycles_per_step = 1
   marker = marker
   max_h_level = 2


### PR DESCRIPTION
I let #25067 drop after finding more hassle than I'd expected plus another workaround to the initial problem, but we've got other users hitting the same unnecessary projections of initial zeroed data, so maybe it's time to again try not making that our default behavior.

## Reason
MOOSE does projections of initial data even when that data is zero and projections are unnecessarily expensive.

## Design
Disable initial projections by default, unless specified otherwise by user input files.

## Impact
Last time I tried this there were dozens of CI input files that needed projections done specifically because an exodiff was looking for the projected values of an initial adaptivity marker.  We'll see how bad things are this time.  Perhaps the right thing to do is to add an option to the exodiff tests to just not test those marker aux variables.