### PR TITLE
rename [Modules/TensorMechanics] in tests and examples

### DIFF
--- a/modules/combined/examples/optimization/2d_mbb.i
+++ b/modules/combined/examples/optimization/2d_mbb.i
@@ -61,7 +61,7 @@ power = 2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/2d_mbb_pde.i
+++ b/modules/combined/examples/optimization/2d_mbb_pde.i
@@ -83,7 +83,7 @@ power = 2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/2d_mbb_pde_amr.i
+++ b/modules/combined/examples/optimization/2d_mbb_pde_amr.i
@@ -94,7 +94,7 @@ power = 2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/3d_mbb.i
+++ b/modules/combined/examples/optimization/3d_mbb.i
@@ -98,7 +98,7 @@ power = 2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/helmholtz_multimat_nostrip.i
+++ b/modules/combined/examples/optimization/helmholtz_multimat_nostrip.i
@@ -166,7 +166,7 @@ Et = 1.0 # w
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/helmholtz_multimat_strip.i
+++ b/modules/combined/examples/optimization/helmholtz_multimat_strip.i
@@ -196,7 +196,7 @@ Et = 1.0 # w
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/multi-load/single_main.i
+++ b/modules/combined/examples/optimization/multi-load/single_main.i
@@ -86,7 +86,7 @@ Emin = 1.0e-6
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/multi-load/single_subapp_one.i
+++ b/modules/combined/examples/optimization/multi-load/single_subapp_one.i
@@ -84,7 +84,7 @@ Emin = 1.0e-6
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/multi-load/single_subapp_two.i
+++ b/modules/combined/examples/optimization/multi-load/single_subapp_two.i
@@ -84,7 +84,7 @@ Emin = 1.0e-6
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/multi-load/square_main.i
+++ b/modules/combined/examples/optimization/multi-load/square_main.i
@@ -101,7 +101,7 @@ Emin = 1.0e-6
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/multi-load/square_subapp_one.i
+++ b/modules/combined/examples/optimization/multi-load/square_subapp_one.i
@@ -84,7 +84,7 @@ Emin = 1.0e-6
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/multi-load/square_subapp_two.i
+++ b/modules/combined/examples/optimization/multi-load/square_subapp_two.i
@@ -83,7 +83,7 @@ Emin = 1.0e-6
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/thermomechanical/structural_sub.i
+++ b/modules/combined/examples/optimization/thermomechanical/structural_sub.i
@@ -76,7 +76,7 @@ rho1 = 1.0
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/thermomechanical/thermal_sub.i
+++ b/modules/combined/examples/optimization/thermomechanical/thermal_sub.i
@@ -120,7 +120,7 @@ TC1 = 1.0
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/thermomechanical/thermomechanical_main.i
+++ b/modules/combined/examples/optimization/thermomechanical/thermomechanical_main.i
@@ -92,7 +92,7 @@ E1 = 1.0
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/optimization/three_materials.i
+++ b/modules/combined/examples/optimization/three_materials.i
@@ -91,7 +91,7 @@ C3 = 1.0
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/examples/phase_field-mechanics/LandauPhaseTrans.i
+++ b/modules/combined/examples/phase_field-mechanics/LandauPhaseTrans.i
@@ -38,7 +38,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     generate_output = 'stress_xx stress_yy'

--- a/modules/combined/examples/phase_field-mechanics/SimplePhaseTrans.i
+++ b/modules/combined/examples/phase_field-mechanics/SimplePhaseTrans.i
@@ -39,7 +39,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     generate_output = 'stress_xx stress_yy'

--- a/modules/combined/examples/phase_field-mechanics/interface_stress.i
+++ b/modules/combined/examples/phase_field-mechanics/interface_stress.i
@@ -32,7 +32,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     generate_output = 'hydrostatic_stress stress_xx'

--- a/modules/combined/examples/publications/rapid_dev/fig7b.i
+++ b/modules/combined/examples/publications/rapid_dev/fig7b.i
@@ -89,7 +89,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/all]
+[Physics/SolidMechanics/QuasiStatic/all]
   add_variables = true
   eigenstrain_names = eigenstrain
 []

--- a/modules/combined/examples/publications/rapid_dev/fig8.i
+++ b/modules/combined/examples/publications/rapid_dev/fig8.i
@@ -126,16 +126,10 @@ PR=2
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
-      [./all]
-        add_variables = true
-        strain = SMALL
-        eigenstrain_names = eigenstrain
-      [../]
-    [../]
-  [../]
+[Physics/SolidMechanics/QuasiStatic/all]
+  add_variables = true
+  strain = SMALL
+  eigenstrain_names = eigenstrain
 []
 
 [Kernels]

--- a/modules/combined/examples/xfem/xfem_mechanics_prescribed_growth.i
+++ b/modules/combined/examples/xfem/xfem_mechanics_prescribed_growth.i
@@ -34,7 +34,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     planar_formulation = plane_strain

--- a/modules/combined/examples/xfem/xfem_thermomechanics_stress_growth.i
+++ b/modules/combined/examples/xfem/xfem_thermomechanics_stress_growth.i
@@ -57,7 +57,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     planar_formulation = plane_strain

--- a/modules/combined/test/tests/ad_cavity_pressure/negative_volume.i
+++ b/modules/combined/test/tests/ad_cavity_pressure/negative_volume.i
@@ -37,7 +37,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     strain = FINITE
     add_variables = true

--- a/modules/combined/test/tests/adaptive_timestepping/adapt_tstep_function_change.i
+++ b/modules/combined/test/tests/adaptive_timestepping/adapt_tstep_function_change.i
@@ -39,7 +39,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     volumetric_locking_correction = true

--- a/modules/combined/test/tests/adaptive_timestepping/adapt_tstep_function_change_restart1.i
+++ b/modules/combined/test/tests/adaptive_timestepping/adapt_tstep_function_change_restart1.i
@@ -39,7 +39,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     incremental = true

--- a/modules/combined/test/tests/adaptive_timestepping/adapt_tstep_function_change_restart2.i
+++ b/modules/combined/test/tests/adaptive_timestepping/adapt_tstep_function_change_restart2.i
@@ -38,7 +38,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     volumetric_locking_correction = true

--- a/modules/combined/test/tests/adaptive_timestepping/adapt_tstep_function_force_step.i
+++ b/modules/combined/test/tests/adaptive_timestepping/adapt_tstep_function_force_step.i
@@ -41,7 +41,7 @@
 []
 
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     incremental = true

--- a/modules/combined/test/tests/additive_manufacturing/check_element_addition_by_variable.i
+++ b/modules/combined/test/tests/additive_manufacturing/check_element_addition_by_variable.i
@@ -44,7 +44,7 @@
   block = '1 2'
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     # strain = FINITE
     add_variables = true

--- a/modules/combined/test/tests/axisymmetric_2d3d_solution_function/2d.i
+++ b/modules/combined/test/tests/axisymmetric_2d3d_solution_function/2d.i
@@ -54,7 +54,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     volumetric_locking_correction = true
     add_variables = true

--- a/modules/combined/test/tests/axisymmetric_2d3d_solution_function/3dy.i
+++ b/modules/combined/test/tests/axisymmetric_2d3d_solution_function/3dy.i
@@ -60,7 +60,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     volumetric_locking_correction = true
     add_variables  = true

--- a/modules/combined/test/tests/beam_eigenstrain_transfer/subapp1_uo_transfer.i
+++ b/modules/combined/test/tests/beam_eigenstrain_transfer/subapp1_uo_transfer.i
@@ -31,9 +31,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./all]
         strain = SMALL
         incremental = true

--- a/modules/combined/test/tests/beam_eigenstrain_transfer/subapp2_uo_transfer.i
+++ b/modules/combined/test/tests/beam_eigenstrain_transfer/subapp2_uo_transfer.i
@@ -39,9 +39,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./all]
         strain = SMALL
         incremental = true

--- a/modules/combined/test/tests/beam_eigenstrain_transfer/subapp_err_2.i
+++ b/modules/combined/test/tests/beam_eigenstrain_transfer/subapp_err_2.i
@@ -31,9 +31,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./all]
         strain = SMALL
         incremental = true

--- a/modules/combined/test/tests/beam_eigenstrain_transfer/subapp_err_3.i
+++ b/modules/combined/test/tests/beam_eigenstrain_transfer/subapp_err_3.i
@@ -31,9 +31,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./all]
         strain = SMALL
         incremental = true

--- a/modules/combined/test/tests/beam_eigenstrain_transfer/subapp_err_4.i
+++ b/modules/combined/test/tests/beam_eigenstrain_transfer/subapp_err_4.i
@@ -31,9 +31,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./all]
         strain = SMALL
         incremental = true

--- a/modules/combined/test/tests/break_mesh_interface_contact/break_mesh_interface_contact.i
+++ b/modules/combined/test/tests/break_mesh_interface_contact/break_mesh_interface_contact.i
@@ -51,7 +51,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   generate_output = 'stress_xx stress_yy strain_xx strain_yy'
   add_variables = true
   strain = FINITE

--- a/modules/combined/test/tests/cavity_pressure/negative_volume.i
+++ b/modules/combined/test/tests/cavity_pressure/negative_volume.i
@@ -37,7 +37,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     strain = FINITE
     add_variables = true

--- a/modules/combined/test/tests/combined_plasticity_temperature/ad_plasticity_temperature_dep_yield.i
+++ b/modules/combined/test/tests/combined_plasticity_temperature/ad_plasticity_temperature_dep_yield.i
@@ -41,7 +41,7 @@
   displacements = 'disp_x disp_y disp_z'
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     incremental = true

--- a/modules/combined/test/tests/combined_plasticity_temperature/plasticity_temperature_dep_yield.i
+++ b/modules/combined/test/tests/combined_plasticity_temperature/plasticity_temperature_dep_yield.i
@@ -41,7 +41,7 @@
   displacements = 'disp_x disp_y disp_z'
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     incremental = true

--- a/modules/combined/test/tests/elastic_patch/ad_elastic_patch_plane_strain.i
+++ b/modules/combined/test/tests/elastic_patch/ad_elastic_patch_plane_strain.i
@@ -26,7 +26,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = SMALL
   incremental = true
   planar_formulation = PLANE_STRAIN

--- a/modules/combined/test/tests/elastic_patch/ad_elastic_patch_rspherical.i
+++ b/modules/combined/test/tests/elastic_patch/ad_elastic_patch_rspherical.i
@@ -29,7 +29,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = SMALL
   incremental = true
   add_variables = true

--- a/modules/combined/test/tests/elastic_patch/ad_elastic_patch_rz.i
+++ b/modules/combined/test/tests/elastic_patch/ad_elastic_patch_rz.i
@@ -25,7 +25,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = SMALL
   incremental = true
   add_variables = true

--- a/modules/combined/test/tests/elastic_patch/ad_elastic_patch_rz_nonlinear.i
+++ b/modules/combined/test/tests/elastic_patch/ad_elastic_patch_rz_nonlinear.i
@@ -40,7 +40,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = FINITE
   decomposition_method = EigenSolution
   add_variables = true

--- a/modules/combined/test/tests/elastic_patch/elastic_patch_plane_strain.i
+++ b/modules/combined/test/tests/elastic_patch/elastic_patch_plane_strain.i
@@ -26,7 +26,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = SMALL
   incremental = true
   planar_formulation = PLANE_STRAIN

--- a/modules/combined/test/tests/elastic_patch/elastic_patch_rspherical.i
+++ b/modules/combined/test/tests/elastic_patch/elastic_patch_rspherical.i
@@ -26,7 +26,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = SMALL
   incremental = true
   add_variables = true

--- a/modules/combined/test/tests/elastic_patch/elastic_patch_rz.i
+++ b/modules/combined/test/tests/elastic_patch/elastic_patch_rz.i
@@ -25,7 +25,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = SMALL
   incremental = true
   add_variables = true

--- a/modules/combined/test/tests/elastic_patch/elastic_patch_rz_nonlinear.i
+++ b/modules/combined/test/tests/elastic_patch/elastic_patch_rz_nonlinear.i
@@ -40,7 +40,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = FINITE
   decomposition_method = EigenSolution
   add_variables = true

--- a/modules/combined/test/tests/elastic_thermal_patch/ad_elastic_thermal_weak_plane_stress_jacobian.i
+++ b/modules/combined/test/tests/elastic_thermal_patch/ad_elastic_thermal_weak_plane_stress_jacobian.i
@@ -24,7 +24,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./plane_stress]
     planar_formulation = WEAK_PLANE_STRESS
     strain = SMALL

--- a/modules/combined/test/tests/elastic_thermal_patch/elastic_thermal_jacobian_rz_smp.i
+++ b/modules/combined/test/tests/elastic_thermal_patch/elastic_thermal_jacobian_rz_smp.i
@@ -44,9 +44,9 @@
   [../]
 []
 
-[Modules]
-    [TensorMechanics]
-        [Master]
+[Physics]
+    [SolidMechanics]
+        [QuasiStatic]
             displacements = 'disp_x disp_y'
             [All]
                 displacements = 'disp_x disp_y'

--- a/modules/combined/test/tests/elastic_thermal_patch/elastic_thermal_patch.i
+++ b/modules/combined/test/tests/elastic_thermal_patch/elastic_thermal_patch.i
@@ -106,7 +106,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   add_variables = true
   strain = FINITE
   eigenstrain_names = eigenstrain

--- a/modules/combined/test/tests/elastic_thermal_patch/elastic_thermal_patch_rz.i
+++ b/modules/combined/test/tests/elastic_thermal_patch/elastic_thermal_patch_rz.i
@@ -77,7 +77,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   add_variables = true
   strain = SMALL
   incremental = true

--- a/modules/combined/test/tests/elastic_thermal_patch/elastic_thermal_patch_rz_smp.i
+++ b/modules/combined/test/tests/elastic_thermal_patch/elastic_thermal_patch_rz_smp.i
@@ -82,9 +82,9 @@
   [../]
 []
 
-[Modules]
-    [TensorMechanics]
-        [Master]
+[Physics]
+    [SolidMechanics]
+        [QuasiStatic]
             displacements = 'disp_x disp_y'
             [All]
                 displacements = 'disp_x disp_y'

--- a/modules/combined/test/tests/fdp_geometric_coupling/fdp_geometric_coupling.i
+++ b/modules/combined/test/tests/fdp_geometric_coupling/fdp_geometric_coupling.i
@@ -34,7 +34,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./block1]
     block = 1
     volumetric_locking_correction = true

--- a/modules/combined/test/tests/gap_heat_transfer_convex/gap_heat_transfer_convex.i
+++ b/modules/combined/test/tests/gap_heat_transfer_convex/gap_heat_transfer_convex.i
@@ -44,7 +44,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   volumetric_locking_correction = true
   strain = FINITE
   eigenstrain_names = eigenstrain

--- a/modules/combined/test/tests/gap_heat_transfer_convex/gap_heat_transfer_convex_gap_offsets.i
+++ b/modules/combined/test/tests/gap_heat_transfer_convex/gap_heat_transfer_convex_gap_offsets.i
@@ -79,7 +79,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   volumetric_locking_correction = true
   strain = FINITE
   eigenstrain_names = eigenstrain

--- a/modules/combined/test/tests/gap_heat_transfer_jac/two_blocks.i
+++ b/modules/combined/test/tests/gap_heat_transfer_jac/two_blocks.i
@@ -31,7 +31,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     add_variables = true

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d-rz/finite.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d-rz/finite.i
@@ -104,7 +104,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx strain_yy strain_zz'
     block = 'plank block'

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d-rz/finite_action.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d-rz/finite_action.i
@@ -79,7 +79,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx strain_yy strain_zz'
     block = 'plank block'

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d-rz/finite_action_al.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d-rz/finite_action_al.i
@@ -99,7 +99,7 @@ name = 'finite_al'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '
                       'strain_yy strain_zz'

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/closed_gap_thermomechanical_mortar_contact.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/closed_gap_thermomechanical_mortar_contact.i
@@ -65,8 +65,8 @@
   []
 []
 
-[Modules]
-  [TensorMechanics/Master]
+[Physics]
+  [SolidMechanics/QuasiStatic]
     [steel]
       strain = FINITE
       add_variables = false

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/finite.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/finite.i
@@ -103,7 +103,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx strain_yy strain_zz'
     block = 'plank block'

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/finite_action.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/finite_action.i
@@ -78,7 +78,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx strain_yy strain_zz'
     block = 'plank block'

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/finite_action_rr.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/finite_action_rr.i
@@ -85,7 +85,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx strain_yy strain_zz'
     block = 'plank block'

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/finite_rr.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/finite_rr.i
@@ -110,7 +110,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx strain_yy strain_zz'
     block = 'plank block'

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/varied_pressure_thermomechanical_mortar.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d/varied_pressure_thermomechanical_mortar.i
@@ -65,8 +65,8 @@
   []
 []
 
-[Modules]
-  [TensorMechanics/Master]
+[Physics]
+  [SolidMechanics/QuasiStatic]
     [steel]
       strain = FINITE
       add_variables = false

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/small-2d-rz/small.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/small-2d-rz/small.i
@@ -107,7 +107,7 @@ name = 'small'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx strain_yy strain_zz'
     block = 'plank block'

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/small-2d/closed_gap_pressure_dependent_thermal_contact.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/small-2d/closed_gap_pressure_dependent_thermal_contact.i
@@ -84,8 +84,8 @@
   []
 []
 
-[Modules]
-  [TensorMechanics/Master]
+[Physics]
+  [SolidMechanics/QuasiStatic]
     [steel]
       strain = SMALL
       add_variables = false

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/small-2d/multi_component_mortar_thermal_conduction.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/small-2d/multi_component_mortar_thermal_conduction.i
@@ -65,8 +65,8 @@
   []
 []
 
-[Modules]
-  [TensorMechanics/Master]
+[Physics]
+  [SolidMechanics/QuasiStatic]
     [steel]
       strain = SMALL
       add_variables = false

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/small-2d/open_gap_pressure_dependent.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/small-2d/open_gap_pressure_dependent.i
@@ -64,8 +64,8 @@
   []
 []
 
-[Modules]
-  [TensorMechanics/Master]
+[Physics]
+  [SolidMechanics/QuasiStatic]
     [steel]
       strain = SMALL
       add_variables = false

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/small-2d/small.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/small-2d/small.i
@@ -103,7 +103,7 @@ name = 'small'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx strain_yy strain_zz'
     block = 'plank block'

--- a/modules/combined/test/tests/generalized_plane_strain_tm_contact/generalized_plane_strain_tm_contact.i
+++ b/modules/combined/test/tests/generalized_plane_strain_tm_contact/generalized_plane_strain_tm_contact.i
@@ -78,8 +78,8 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
+[Physics]
+  [./SolidMechanics]
     [./GeneralizedPlaneStrain]
       [./gps]
         use_displaced_mesh = true

--- a/modules/combined/test/tests/generalized_plane_strain_tm_contact/out_of_plane_pressure.i
+++ b/modules/combined/test/tests/generalized_plane_strain_tm_contact/out_of_plane_pressure.i
@@ -87,8 +87,8 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
+[Physics]
+  [./SolidMechanics]
     [./GeneralizedPlaneStrain]
       [./gps]
         displacements = 'disp_x disp_y'

--- a/modules/combined/test/tests/gravity/gravity.i
+++ b/modules/combined/test/tests/gravity/gravity.i
@@ -48,7 +48,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   volumetric_locking_correction = true
   strain = FINITE
   add_variables = true

--- a/modules/combined/test/tests/gravity/gravity_hex20.i
+++ b/modules/combined/test/tests/gravity/gravity_hex20.i
@@ -50,7 +50,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = FINITE
   add_variables = true
   generate_output = 'stress_xx'

--- a/modules/combined/test/tests/gravity/gravity_qp_select.i
+++ b/modules/combined/test/tests/gravity/gravity_qp_select.i
@@ -99,7 +99,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = FINITE
   #incremental = true
   add_variables = true

--- a/modules/combined/test/tests/gravity/gravity_rz.i
+++ b/modules/combined/test/tests/gravity/gravity_rz.i
@@ -48,7 +48,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   volumetric_locking_correction = true
   strain = FINITE
   add_variables = true

--- a/modules/combined/test/tests/gravity/gravity_rz_quad8.i
+++ b/modules/combined/test/tests/gravity/gravity_rz_quad8.i
@@ -50,7 +50,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = FINITE
   add_variables = true
   generate_output = 'stress_xx stress_yy stress_xy'

--- a/modules/combined/test/tests/internal_volume/hex20.i
+++ b/modules/combined/test/tests/internal_volume/hex20.i
@@ -42,7 +42,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     incremental = true
     strain = FINITE

--- a/modules/combined/test/tests/internal_volume/hex8.i
+++ b/modules/combined/test/tests/internal_volume/hex8.i
@@ -57,7 +57,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     volumetric_locking_correction = true
     incremental = true

--- a/modules/combined/test/tests/internal_volume/rspherical.i
+++ b/modules/combined/test/tests/internal_volume/rspherical.i
@@ -37,7 +37,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     incremental = true
     strain = FINITE

--- a/modules/combined/test/tests/internal_volume/rz.i
+++ b/modules/combined/test/tests/internal_volume/rz.i
@@ -41,7 +41,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     volumetric_locking_correction = true
     incremental = true

--- a/modules/combined/test/tests/internal_volume/rz_cone.i
+++ b/modules/combined/test/tests/internal_volume/rz_cone.i
@@ -40,7 +40,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     volumetric_locking_correction = true
     incremental = true

--- a/modules/combined/test/tests/internal_volume/rz_displaced.i
+++ b/modules/combined/test/tests/internal_volume/rz_displaced.i
@@ -74,7 +74,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     volumetric_locking_correction = false
     decomposition_method = EigenSolution

--- a/modules/combined/test/tests/internal_volume/rz_displaced_quad8.i
+++ b/modules/combined/test/tests/internal_volume/rz_displaced_quad8.i
@@ -71,7 +71,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     volumetric_locking_correction = false
     decomposition_method = EigenSolution

--- a/modules/combined/test/tests/internal_volume/rz_quad8.i
+++ b/modules/combined/test/tests/internal_volume/rz_quad8.i
@@ -42,7 +42,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     incremental = true
     strain = FINITE

--- a/modules/combined/test/tests/j2_plasticity_vs_LSH/j2_hard1_mod.i
+++ b/modules/combined/test/tests/j2_plasticity_vs_LSH/j2_hard1_mod.i
@@ -26,7 +26,7 @@
   zmax = 0.5
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/combined/test/tests/linear_elasticity/applied_strain.i
+++ b/modules/combined/test/tests/linear_elasticity/applied_strain.i
@@ -17,7 +17,7 @@
   elem_type = QUAD4
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = SMALL
   eigenstrain_names = eigenstrain
   add_variables = true

--- a/modules/combined/test/tests/linear_elasticity/extra_stress.i
+++ b/modules/combined/test/tests/linear_elasticity/extra_stress.i
@@ -12,7 +12,7 @@
   elem_type = QUAD4
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   add_variables = true
   generate_output = 'stress_xx stress_xy stress_yy stress_zz strain_xx strain_xy strain_yy'
 []

--- a/modules/combined/test/tests/linear_elasticity/linear_anisotropic_material.i
+++ b/modules/combined/test/tests/linear_elasticity/linear_anisotropic_material.i
@@ -25,7 +25,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = SMALL
   incremental = true
   add_variables = true

--- a/modules/combined/test/tests/linear_elasticity/linear_elastic_material.i
+++ b/modules/combined/test/tests/linear_elasticity/linear_elastic_material.i
@@ -25,7 +25,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = SMALL
   add_variables = true
   generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'

--- a/modules/combined/test/tests/linear_elasticity/tensor.i
+++ b/modules/combined/test/tests/linear_elasticity/tensor.i
@@ -116,7 +116,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = SMALL
   add_variables = true
   generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'

--- a/modules/combined/test/tests/linear_elasticity/thermal_expansion.i
+++ b/modules/combined/test/tests/linear_elasticity/thermal_expansion.i
@@ -22,7 +22,7 @@
   elem_type = QUAD4
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   strain = SMALL
   eigenstrain_names = eigenstrain
   add_variables = true

--- a/modules/combined/test/tests/misc/re_init_face.i
+++ b/modules/combined/test/tests/misc/re_init_face.i
@@ -11,7 +11,7 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     use_automatic_differentiation = false
     strain = FINITE

--- a/modules/combined/test/tests/nodal_patch_recovery/npr_with_lower_domains.i
+++ b/modules/combined/test/tests/nodal_patch_recovery/npr_with_lower_domains.i
@@ -160,7 +160,7 @@ order = FIRST
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_zz vonmises_stress hydrostatic_stress strain_xx strain_yy strain_zz'
     block = 'plank block'

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mbb.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mbb.i
@@ -51,7 +51,7 @@ power = 2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mbb_pde.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mbb_pde.i
@@ -73,7 +73,7 @@ power = 3
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mbb_pde_amr.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mbb_pde_amr.i
@@ -84,7 +84,7 @@ power = 3
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mmb_2material.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mmb_2material.i
@@ -67,7 +67,7 @@ rho2 = 1.0
     min = '${fparse vol_frac-0.15}'
   []
 []
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mmb_2material_cost.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mmb_2material_cost.i
@@ -63,7 +63,7 @@ C2 = 1.0
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mmb_2material_cost_initial.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mmb_2material_cost_initial.i
@@ -82,7 +82,7 @@ C2 = 1.0
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/3d_mbb.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/3d_mbb.i
@@ -87,7 +87,7 @@ power = 3
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/paper_three_materials_test.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/paper_three_materials_test.i
@@ -91,7 +91,7 @@ C3 = 1.0
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/thermal_test.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/thermal_test.i
@@ -121,7 +121,7 @@ TC1 = 1.0
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/three_materials_thermal.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/three_materials_thermal.i
@@ -131,7 +131,7 @@ TC3 = 1.0
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/optimization_density_update/top_opt_2d.i
+++ b/modules/combined/test/tests/optimization/optimization_density_update/top_opt_2d.i
@@ -53,7 +53,7 @@ power = 2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/optimization_density_update/top_opt_2d_pde_filter.i
+++ b/modules/combined/test/tests/optimization/optimization_density_update/top_opt_2d_pde_filter.i
@@ -67,7 +67,7 @@ power = 2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/optimization_density_update/top_opt_3d.i
+++ b/modules/combined/test/tests/optimization/optimization_density_update/top_opt_3d.i
@@ -46,7 +46,7 @@ power = 2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/optimization/optimization_density_update/top_opt_3d_pde_filter.i
+++ b/modules/combined/test/tests/optimization/optimization_density_update/top_opt_3d_pde_filter.i
@@ -70,7 +70,7 @@ power = 2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = SMALL
     add_variables = true

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_aniso.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_aniso.i
@@ -20,9 +20,9 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./All]
         add_variables = true
         strain = SMALL
@@ -31,6 +31,8 @@
       [../]
     [../]
   [../]
+[]
+[Modules]
   [./PhaseField]
     [./Nonconserved]
       [./c]

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_aniso_cleavage_plane.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_aniso_cleavage_plane.i
@@ -26,9 +26,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./All]
         add_variables = true
         strain = SMALL

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_aniso_hist_false.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_aniso_hist_false.i
@@ -20,9 +20,9 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./All]
         add_variables = true
         strain = SMALL
@@ -31,6 +31,8 @@
       [../]
     [../]
   [../]
+[]
+[Modules]
   [./PhaseField]
     [./Nonconserved]
       [./c]

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_computeCrackedStress_finitestrain_elastic.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_computeCrackedStress_finitestrain_elastic.i
@@ -27,9 +27,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./All]
         add_variables = true
         strain = FINITE
@@ -39,6 +39,8 @@
       [../]
     [../]
   [../]
+[]
+[Modules]
   [./PhaseField]
     [./Nonconserved]
       [./c]

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_computeCrackedStress_finitestrain_plastic.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_computeCrackedStress_finitestrain_plastic.i
@@ -39,9 +39,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./All]
         add_variables = true
         strain = FINITE
@@ -51,6 +51,8 @@
       [../]
     [../]
   [../]
+[]
+[Modules]
   [./PhaseField]
     [./Nonconserved]
       [./c]

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_computeCrackedStress_smallstrain.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_computeCrackedStress_smallstrain.i
@@ -27,9 +27,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./All]
         add_variables = true
         strain = SMALL
@@ -39,6 +39,8 @@
       [../]
     [../]
   [../]
+[]
+[Modules]
   [./PhaseField]
     [./Nonconserved]
       [./c]

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_iso.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_iso.i
@@ -30,8 +30,10 @@
       [../]
     [../]
   [../]
-  [./TensorMechanics]
-    [./Master]
+[]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./mech]
         add_variables = true
         strain = SMALL

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_iso_with_pressure.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_iso_with_pressure.i
@@ -30,8 +30,10 @@
       [../]
     [../]
   [../]
-  [./TensorMechanics]
-    [./Master]
+[]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./mech]
         add_variables = true
         strain = SMALL

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_iso_wo_time.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_iso_wo_time.i
@@ -20,9 +20,9 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./mech]
         add_variables = true
         strain = SMALL

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_linear_fracture_energy.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_linear_fracture_energy.i
@@ -30,8 +30,10 @@
       [../]
     [../]
   [../]
-  [./TensorMechanics]
-    [./Master]
+[]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./mech]
         add_variables = true
         strain = SMALL

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_no_split.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_no_split.i
@@ -30,8 +30,10 @@
       [../]
     [../]
   [../]
-  [./TensorMechanics]
-    [./Master]
+[]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./mech]
         add_variables = true
         strain = SMALL

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_vi_solver.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_vi_solver.i
@@ -24,8 +24,10 @@
       [../]
     [../]
   [../]
-  [./TensorMechanics]
-    [./Master]
+[]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./mech]
         add_variables = true
         strain = SMALL

--- a/modules/combined/test/tests/phase_field_fracture/crack2d_vol_dev.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_vol_dev.i
@@ -30,8 +30,10 @@
       [../]
     [../]
   [../]
-  [./TensorMechanics]
-    [./Master]
+[]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./mech]
         add_variables = true
         strain = SMALL

--- a/modules/combined/test/tests/phase_field_fracture/void2d_iso.i
+++ b/modules/combined/test/tests/phase_field_fracture/void2d_iso.i
@@ -7,9 +7,9 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./All]
         add_variables = true
         strain = SMALL
@@ -17,6 +17,8 @@
       [../]
     [../]
   [../]
+[]
+[Modules]
   [./PhaseField]
     [./Nonconserved]
       [./c]

--- a/modules/combined/test/tests/phase_field_fracture_viscoplastic/crack2d.i
+++ b/modules/combined/test/tests/phase_field_fracture_viscoplastic/crack2d.i
@@ -8,9 +8,9 @@
   volumetric_locking_correction = true
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [./SolidMechanics]
+    [./QuasiStatic]
       [./All]
         add_variables = true
         strain = Finite
@@ -19,6 +19,8 @@
       [../]
     [../]
   [../]
+[]
+[Modules]
   [./PhaseField]
     [./Nonconserved]
       [./c]

--- a/modules/combined/test/tests/power_law_hardening/ADPowerLawHardening.i
+++ b/modules/combined/test/tests/power_law_hardening/ADPowerLawHardening.i
@@ -33,7 +33,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = SMALL

--- a/modules/combined/test/tests/power_law_hardening/PowerLawHardening.i
+++ b/modules/combined/test/tests/power_law_hardening/PowerLawHardening.i
@@ -33,7 +33,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = SMALL

--- a/modules/combined/test/tests/reference_residual/group_variables.i
+++ b/modules/combined/test/tests/reference_residual/group_variables.i
@@ -101,8 +101,8 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
+[Physics]
+  [./SolidMechanics]
     [./GeneralizedPlaneStrain]
       [./gps1]
         use_displaced_mesh = true

--- a/modules/combined/test/tests/reference_residual/reference_residual.i
+++ b/modules/combined/test/tests/reference_residual/reference_residual.i
@@ -49,7 +49,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     volumetric_locking_correction = true
     incremental = true

--- a/modules/combined/test/tests/reference_residual/reference_residual_perfgraph.i
+++ b/modules/combined/test/tests/reference_residual/reference_residual_perfgraph.i
@@ -49,7 +49,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     volumetric_locking_correction = true
     incremental = true

--- a/modules/combined/test/tests/restart-transient-from-ss-with-stateful/sub_ss.i
+++ b/modules/combined/test/tests/restart-transient-from-ss-with-stateful/sub_ss.i
@@ -38,7 +38,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   # FINITE strain when strain is large, i.e., visible movement.
   # SMALL strain when things are stressed, but may not move.
   [./fuel]

--- a/modules/combined/test/tests/restart-transient-from-ss-with-stateful/sub_tr.i
+++ b/modules/combined/test/tests/restart-transient-from-ss-with-stateful/sub_tr.i
@@ -38,7 +38,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   # FINITE strain when strain is large, i.e., visible movement.
   # SMALL strain when things are stressed, but may not move.
   [./fuel]

--- a/modules/combined/test/tests/stateful_mortar_constraints/stateful_mortar_npr.i
+++ b/modules/combined/test/tests/stateful_mortar_constraints/stateful_mortar_npr.i
@@ -159,7 +159,7 @@ order = FIRST
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_zz vonmises_stress hydrostatic_stress strain_xx strain_yy strain_zz'
     block = 'plank block'

--- a/modules/combined/test/tests/surface_tension_KKS/surface_tension_KKS.i
+++ b/modules/combined/test/tests/surface_tension_KKS/surface_tension_KKS.i
@@ -112,7 +112,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     generate_output = 'hydrostatic_stress stress_xx stress_yy stress_zz'

--- a/modules/combined/test/tests/surface_tension_KKS/surface_tension_VDWgas.i
+++ b/modules/combined/test/tests/surface_tension_KKS/surface_tension_VDWgas.i
@@ -122,7 +122,7 @@
 
 
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     generate_output = 'hydrostatic_stress stress_xx stress_yy stress_zz'

--- a/modules/combined/test/tests/thermal_elastic/ad-thermal_elastic.i
+++ b/modules/combined/test/tests/thermal_elastic/ad-thermal_elastic.i
@@ -93,7 +93,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_xz stress_yz'

--- a/modules/combined/test/tests/thermal_elastic/thermal_elastic.i
+++ b/modules/combined/test/tests/thermal_elastic/thermal_elastic.i
@@ -93,7 +93,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_xz stress_yz'

--- a/modules/combined/test/tests/thermal_strain/thermal_strain.i
+++ b/modules/combined/test/tests/thermal_strain/thermal_strain.i
@@ -39,7 +39,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   add_variables = true
   strain = SMALL
   incremental = true

--- a/modules/combined/test/tests/umat/gap_heat_transfer_umat.i
+++ b/modules/combined/test/tests/umat/gap_heat_transfer_umat.i
@@ -48,7 +48,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/All]
+[Physics/SolidMechanics/QuasiStatic/All]
   volumetric_locking_correction = true
   strain = FINITE
   generate_output = 'strain_yy stress_yy'

--- a/modules/combined/tutorials/introduction/thermal_mechanical_contact/thermomech_cont_step01.i
+++ b/modules/combined/tutorials/introduction/thermal_mechanical_contact/thermomech_cont_step01.i
@@ -67,7 +67,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/combined/tutorials/introduction/thermal_mechanical_contact/thermomech_cont_step02.i
+++ b/modules/combined/tutorials/introduction/thermal_mechanical_contact/thermomech_cont_step02.i
@@ -104,7 +104,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/examples/2d_indenter/indenter_rz_fine.i
+++ b/modules/contact/examples/2d_indenter/indenter_rz_fine.i
@@ -53,7 +53,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     block = '1 2'

--- a/modules/contact/examples/2d_indenter/indenter_rz_nodeface_friction.i
+++ b/modules/contact/examples/2d_indenter/indenter_rz_nodeface_friction.i
@@ -46,7 +46,7 @@
   [saved_y]
   []
 []
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/examples/3d_berkovich/indenter_berkovich_friction.i
+++ b/modules/contact/examples/3d_berkovich/indenter_berkovich_friction.i
@@ -38,7 +38,7 @@
 []
 
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d-action.i
+++ b/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d-action.i
@@ -118,7 +118,7 @@ offset = 0.00
   allow_renumbering = false
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d-al.i
+++ b/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d-al.i
@@ -196,7 +196,7 @@ offset = 0.00
 
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d-function.i
+++ b/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d-function.i
@@ -206,7 +206,7 @@ offset = 0.00
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d-penalty.i
+++ b/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d-penalty.i
@@ -192,7 +192,7 @@ offset = 0.00
 
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d.i
+++ b/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d.i
@@ -196,7 +196,7 @@ offset = 0.00
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d_pg.i
+++ b/modules/contact/test/tests/3d-mortar-contact/frictional-mortar-3d_pg.i
@@ -200,7 +200,7 @@ offset = 0.00
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/3d-mortar-contact/frictionless-mortar-3d-penalty.i
+++ b/modules/contact/test/tests/3d-mortar-contact/frictionless-mortar-3d-penalty.i
@@ -153,7 +153,7 @@ offset = 0.00
 
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/3d-mortar-contact/half_sphere_nodal_geometry.i
+++ b/modules/contact/test/tests/3d-mortar-contact/half_sphere_nodal_geometry.i
@@ -113,7 +113,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/adaptivity/contact_initial_adaptivity.i
+++ b/modules/contact/test/tests/adaptivity/contact_initial_adaptivity.i
@@ -27,7 +27,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/bouncing-block-contact/ping-ponging/kinematic-ping-pong.i
+++ b/modules/contact/test/tests/bouncing-block-contact/ping-ponging/kinematic-ping-pong.i
@@ -25,7 +25,7 @@ offset = 1e-2
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = false
     use_automatic_differentiation = true

--- a/modules/contact/test/tests/bouncing-block-contact/ping-ponging/mortar-no-ping-pong_weighted.i
+++ b/modules/contact/test/tests/bouncing-block-contact/ping-ponging/mortar-no-ping-pong_weighted.i
@@ -28,7 +28,7 @@ offset = 1e-2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = false
     use_automatic_differentiation = true

--- a/modules/contact/test/tests/bouncing-block-contact/ping-ponging/ranfs-ping-pong.i
+++ b/modules/contact/test/tests/bouncing-block-contact/ping-ponging/ranfs-ping-pong.i
@@ -25,7 +25,7 @@ offset = 1e-2
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = false
     use_automatic_differentiation = true

--- a/modules/contact/test/tests/catch_release/catch_release.i
+++ b/modules/contact/test/tests/catch_release/catch_release.i
@@ -16,7 +16,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/cohesive_zone_model/bilinear_mixed.i
+++ b/modules/contact/test/tests/cohesive_zone_model/bilinear_mixed.i
@@ -45,9 +45,9 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules]
-  [TensorMechanics]
-    [Master]
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
       generate_output = 'stress_yy stress_xy strain_xy'
       [all]
         strain = FINITE

--- a/modules/contact/test/tests/cohesive_zone_model/bilinear_mixed_compare.i
+++ b/modules/contact/test/tests/cohesive_zone_model/bilinear_mixed_compare.i
@@ -80,9 +80,9 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules]
-  [TensorMechanics]
-    [Master]
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
       generate_output = 'stress_yy vonmises_stress stress_xy'
       [all]
         strain = FINITE

--- a/modules/contact/test/tests/cohesive_zone_model/bilinear_mixed_mortar_only_czm.i
+++ b/modules/contact/test/tests/cohesive_zone_model/bilinear_mixed_mortar_only_czm.i
@@ -81,9 +81,9 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules]
-  [TensorMechanics]
-    [Master]
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
       generate_output = 'stress_yy'
       [all]
         strain = FINITE

--- a/modules/contact/test/tests/cohesive_zone_model/mortar_czm.i
+++ b/modules/contact/test/tests/cohesive_zone_model/mortar_czm.i
@@ -68,9 +68,9 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules]
-  [TensorMechanics]
-    [Master]
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
       generate_output = 'stress_yy'
       [all]
         strain = FINITE

--- a/modules/contact/test/tests/cohesive_zone_model/mortar_czm_analysis.i
+++ b/modules/contact/test/tests/cohesive_zone_model/mortar_czm_analysis.i
@@ -67,9 +67,9 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules]
-  [TensorMechanics]
-    [Master]
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
       generate_output = 'stress_yy'
       [all]
         strain = FINITE

--- a/modules/contact/test/tests/dual_mortar/dm_mechanical_contact.i
+++ b/modules/contact/test/tests/dual_mortar/dm_mechanical_contact.i
@@ -55,7 +55,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/dual_mortar/dm_mechanical_contact_precon.i
+++ b/modules/contact/test/tests/dual_mortar/dm_mechanical_contact_precon.i
@@ -55,7 +55,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/fieldsplit/2blocks3d.i
+++ b/modules/contact/test/tests/fieldsplit/2blocks3d.i
@@ -12,7 +12,7 @@
   error_on_jacobian_nonzero_reallocation = true
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/fieldsplit/frictional_mortar_FS.i
+++ b/modules/contact/test/tests/fieldsplit/frictional_mortar_FS.i
@@ -18,7 +18,7 @@ refine = 1
   uniform_refine = ${refine}
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/fieldsplit/frictionless_mortar_FS.i
+++ b/modules/contact/test/tests/fieldsplit/frictionless_mortar_FS.i
@@ -18,7 +18,7 @@ refine = 1
   uniform_refine = ${refine}
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/frictional/single_point_2d/single_point_2d.i
+++ b/modules/contact/test/tests/frictional/single_point_2d/single_point_2d.i
@@ -35,7 +35,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/frictional/single_point_2d/single_point_2d_predictor.i
+++ b/modules/contact/test/tests/frictional/single_point_2d/single_point_2d_predictor.i
@@ -35,7 +35,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/frictional/single_point_2d/single_point_2d_tp.i
+++ b/modules/contact/test/tests/frictional/single_point_2d/single_point_2d_tp.i
@@ -35,7 +35,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/frictional/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d.i
+++ b/modules/contact/test/tests/frictional/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d.i
@@ -41,7 +41,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/frictional/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d_tp.i
+++ b/modules/contact/test/tests/frictional/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d_tp.i
@@ -41,7 +41,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/hertz_spherical/hertz_contact.i
+++ b/modules/contact/test/tests/hertz_spherical/hertz_contact.i
@@ -57,7 +57,7 @@
   [] # AuxVariables
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = SMALL

--- a/modules/contact/test/tests/hertz_spherical/hertz_contact_hex20.i
+++ b/modules/contact/test/tests/hertz_spherical/hertz_contact_hex20.i
@@ -118,7 +118,7 @@
 
 [] # AuxVariables
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = SMALL

--- a/modules/contact/test/tests/hertz_spherical/hertz_contact_hex27.i
+++ b/modules/contact/test/tests/hertz_spherical/hertz_contact_hex27.i
@@ -104,7 +104,7 @@
 
 [] # AuxVariables
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = SMALL

--- a/modules/contact/test/tests/hertz_spherical/hertz_contact_rz.i
+++ b/modules/contact/test/tests/hertz_spherical/hertz_contact_rz.i
@@ -109,7 +109,7 @@
 
 [] # AuxVariables
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = SMALL

--- a/modules/contact/test/tests/hertz_spherical/hertz_contact_rz_quad8.i
+++ b/modules/contact/test/tests/hertz_spherical/hertz_contact_rz_quad8.i
@@ -104,7 +104,7 @@
 
 [] # AuxVariables
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = SMALL

--- a/modules/contact/test/tests/incremental_slip/incremental_slip.i
+++ b/modules/contact/test/tests/incremental_slip/incremental_slip.i
@@ -7,7 +7,7 @@
   displacements = 'disp_x disp_y disp_z'
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/kinematic-and-scaling/bouncing-block-kinematic.i
+++ b/modules/contact/test/tests/kinematic-and-scaling/bouncing-block-kinematic.i
@@ -25,7 +25,7 @@ offset = 1e-2
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = false
     use_automatic_differentiation = true

--- a/modules/contact/test/tests/mechanical_constraint/frictionless_kinematic.i
+++ b/modules/contact/test/tests/mechanical_constraint/frictionless_kinematic.i
@@ -27,7 +27,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/mechanical_constraint/frictionless_kinematic_gap_offsets.i
+++ b/modules/contact/test/tests/mechanical_constraint/frictionless_kinematic_gap_offsets.i
@@ -33,7 +33,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/mechanical_constraint/frictionless_penalty.i
+++ b/modules/contact/test/tests/mechanical_constraint/frictionless_penalty.i
@@ -27,7 +27,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/mechanical_constraint/glued_kinematic.i
+++ b/modules/contact/test/tests/mechanical_constraint/glued_kinematic.i
@@ -27,7 +27,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/mechanical_constraint/glued_penalty.i
+++ b/modules/contact/test/tests/mechanical_constraint/glued_penalty.i
@@ -27,7 +27,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/mortar_aux_kernels/block-dynamics-aux-fretting-wear-test-action.i
+++ b/modules/contact/test/tests/mortar_aux_kernels/block-dynamics-aux-fretting-wear-test-action.i
@@ -40,7 +40,7 @@ offset = -0.045
   []
 []
 
-[Modules/TensorMechanics/DynamicMaster]
+[Physics/SolidMechanics/Dynamic]
   [all]
     hht_alpha = 0.0
     newmark_beta = 0.25

--- a/modules/contact/test/tests/mortar_aux_kernels/frictional-mortar-3d-status.i
+++ b/modules/contact/test/tests/mortar_aux_kernels/frictional-mortar-3d-status.i
@@ -211,7 +211,7 @@ offset = 0.00
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/mortar_aux_kernels/pressure-aux-friction.i
+++ b/modules/contact/test/tests/mortar_aux_kernels/pressure-aux-friction.i
@@ -119,7 +119,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/mortar_aux_kernels/pressure-aux-frictionless.i
+++ b/modules/contact/test/tests/mortar_aux_kernels/pressure-aux-frictionless.i
@@ -115,7 +115,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/mortar_cartesian_lms/cylinder_friction_cartesian.i
+++ b/modules/contact/test/tests/mortar_cartesian_lms/cylinder_friction_cartesian.i
@@ -84,7 +84,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     incremental = false
     save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/mortar_cartesian_lms/cylinder_friction_cartesian_pg.i
+++ b/modules/contact/test/tests/mortar_cartesian_lms/cylinder_friction_cartesian_pg.i
@@ -91,7 +91,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     incremental = false
     save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/mortar_cartesian_lms/cylinder_friction_cartesian_vcp.i
+++ b/modules/contact/test/tests/mortar_cartesian_lms/cylinder_friction_cartesian_vcp.i
@@ -84,7 +84,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     incremental = false
     save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/mortar_cartesian_lms/two_block_1st_order_constraint_lm_xy.i
+++ b/modules/contact/test/tests/mortar_cartesian_lms/two_block_1st_order_constraint_lm_xy.i
@@ -103,7 +103,7 @@ velocity = 0.1
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/mortar_cartesian_lms/two_block_1st_order_constraint_lm_xy_friction.i
+++ b/modules/contact/test/tests/mortar_cartesian_lms/two_block_1st_order_constraint_lm_xy_friction.i
@@ -140,7 +140,7 @@ refine = 3
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/mortar_cartesian_lms/two_block_1st_order_constraint_lm_xy_friction_pg.i
+++ b/modules/contact/test/tests/mortar_cartesian_lms/two_block_1st_order_constraint_lm_xy_friction_pg.i
@@ -144,7 +144,7 @@ refine = 3
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/mortar_cartesian_lms/two_block_1st_order_constraint_lm_xy_friction_vcp.i
+++ b/modules/contact/test/tests/mortar_cartesian_lms/two_block_1st_order_constraint_lm_xy_friction_vcp.i
@@ -140,7 +140,7 @@ refine = 3
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/mortar_dynamics/block-dynamics-friction-creep.i
+++ b/modules/contact/test/tests/mortar_dynamics/block-dynamics-friction-creep.i
@@ -73,7 +73,7 @@ offset = -0.095
   []
 []
 
-[Modules/TensorMechanics/DynamicMaster]
+[Physics/SolidMechanics/Dynamic]
   [all]
     add_variables = true
     alpha = 0.0

--- a/modules/contact/test/tests/mortar_dynamics/frictional-mortar-3d-dynamics-light-function.i
+++ b/modules/contact/test/tests/mortar_dynamics/frictional-mortar-3d-dynamics-light-function.i
@@ -205,7 +205,7 @@
   []
 []
 
-[Modules/TensorMechanics/DynamicMaster]
+[Physics/SolidMechanics/Dynamic]
   [all]
     add_variables = true
     hht_alpha = 0.0

--- a/modules/contact/test/tests/mortar_dynamics/frictional-mortar-3d-dynamics-light.i
+++ b/modules/contact/test/tests/mortar_dynamics/frictional-mortar-3d-dynamics-light.i
@@ -196,7 +196,7 @@ offset = 0.00
   []
 []
 
-[Modules/TensorMechanics/DynamicMaster]
+[Physics/SolidMechanics/Dynamic]
   [all]
     add_variables = true
     hht_alpha = 0.0

--- a/modules/contact/test/tests/mortar_dynamics/frictional-mortar-3d-dynamics.i
+++ b/modules/contact/test/tests/mortar_dynamics/frictional-mortar-3d-dynamics.i
@@ -196,7 +196,7 @@ offset = 0.00
   []
 []
 
-[Modules/TensorMechanics/DynamicMaster]
+[Physics/SolidMechanics/Dynamic]
   [all]
     add_variables = true
     hht_alpha = 0.0

--- a/modules/contact/test/tests/mortar_dynamics/frictional-mortar-3d.i
+++ b/modules/contact/test/tests/mortar_dynamics/frictional-mortar-3d.i
@@ -196,7 +196,7 @@ offset = 0.00
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/mortar_restart/frictional_bouncing_block_action_restart_1.i
+++ b/modules/contact/test/tests/mortar_restart/frictional_bouncing_block_action_restart_1.i
@@ -33,7 +33,7 @@ offset = 1e-2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     generate_output = 'stress_xx stress_yy'

--- a/modules/contact/test/tests/mortar_restart/frictional_bouncing_block_action_restart_2.i
+++ b/modules/contact/test/tests/mortar_restart/frictional_bouncing_block_action_restart_2.i
@@ -43,7 +43,7 @@ offset = 1e-2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     generate_output = 'stress_xx stress_yy'

--- a/modules/contact/test/tests/mortar_tm/2d/ad_frictional/finite.i
+++ b/modules/contact/test/tests/mortar_tm/2d/ad_frictional/finite.i
@@ -73,7 +73,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2d/ad_frictional/finite_rr.i
+++ b/modules/contact/test/tests/mortar_tm/2d/ad_frictional/finite_rr.i
@@ -79,7 +79,7 @@ name = 'finite_rr'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2d/ad_frictional/finite_stiff.i
+++ b/modules/contact/test/tests/mortar_tm/2d/ad_frictional/finite_stiff.i
@@ -73,7 +73,7 @@ name = 'finite_stiff'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_fir/finite.i
+++ b/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_fir/finite.i
@@ -73,7 +73,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_fir/finite_rr.i
+++ b/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_fir/finite_rr.i
@@ -79,7 +79,7 @@ name = 'finite_rr'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_fir/small.i
+++ b/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_fir/small.i
@@ -73,7 +73,7 @@ name = 'small'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '
                       'strain_yy strain_zz'

--- a/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_sec/finite.i
+++ b/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_sec/finite.i
@@ -73,7 +73,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_sec/finite_rr.i
+++ b/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_sec/finite_rr.i
@@ -79,7 +79,7 @@ name = 'finite_rr'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_sec/small.i
+++ b/modules/contact/test/tests/mortar_tm/2d/ad_frictionless_sec/small.i
@@ -73,7 +73,7 @@ name = 'small'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '
                       'strain_yy strain_zz'

--- a/modules/contact/test/tests/mortar_tm/2d/frictionless_first/finite.i
+++ b/modules/contact/test/tests/mortar_tm/2d/frictionless_first/finite.i
@@ -73,7 +73,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2d/frictionless_first/finite_rr.i
+++ b/modules/contact/test/tests/mortar_tm/2d/frictionless_first/finite_rr.i
@@ -79,7 +79,7 @@ name = 'finite_rr'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2d/frictionless_first/small.i
+++ b/modules/contact/test/tests/mortar_tm/2d/frictionless_first/small.i
@@ -73,7 +73,7 @@ name = 'small'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '
                       'strain_yy strain_zz'

--- a/modules/contact/test/tests/mortar_tm/2d/frictionless_second/finite.i
+++ b/modules/contact/test/tests/mortar_tm/2d/frictionless_second/finite.i
@@ -73,7 +73,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2d/frictionless_second/finite_rr.i
+++ b/modules/contact/test/tests/mortar_tm/2d/frictionless_second/finite_rr.i
@@ -79,7 +79,7 @@ name = 'finite_rr'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2d/frictionless_second/small.i
+++ b/modules/contact/test/tests/mortar_tm/2d/frictionless_second/small.i
@@ -73,7 +73,7 @@ name = 'small'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [action]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '
                       'strain_yy strain_zz'

--- a/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_first/finite.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_first/finite.i
@@ -77,7 +77,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     use_automatic_differentiation = true
     strain = FINITE

--- a/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_first/finite_rr.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_first/finite_rr.i
@@ -83,7 +83,7 @@ name = 'finite_rr'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     use_automatic_differentiation = true
     strain = FINITE

--- a/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_first/small.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_first/small.i
@@ -77,7 +77,7 @@ name = 'small'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     use_automatic_differentiation = true
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_second/finite.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_second/finite.i
@@ -77,7 +77,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     use_automatic_differentiation = true
     strain = FINITE

--- a/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_second/finite_rr.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_second/finite_rr.i
@@ -83,7 +83,7 @@ name = 'finite_rr'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     use_automatic_differentiation = true
     strain = FINITE

--- a/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_second/small.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_second/small.i
@@ -77,7 +77,7 @@ name = 'small'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     use_automatic_differentiation = true
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2drz/frictionless_first/finite.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/frictionless_first/finite.i
@@ -77,7 +77,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2drz/frictionless_first/finite_rr.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/frictionless_first/finite_rr.i
@@ -83,7 +83,7 @@ name = 'finite_rr'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2drz/frictionless_first/small.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/frictionless_first/small.i
@@ -77,7 +77,7 @@ name = 'small'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '
                       'strain_yy strain_zz'

--- a/modules/contact/test/tests/mortar_tm/2drz/frictionless_second/finite.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/frictionless_second/finite.i
@@ -77,7 +77,7 @@ name = 'finite'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2drz/frictionless_second/finite_rr.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/frictionless_second/finite_rr.i
@@ -83,7 +83,7 @@ name = 'finite_rr'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     strain = FINITE
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '

--- a/modules/contact/test/tests/mortar_tm/2drz/frictionless_second/small.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/frictionless_second/small.i
@@ -77,7 +77,7 @@ name = 'small'
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [block]
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress hydrostatic_stress strain_xx '
                       'strain_yy strain_zz'

--- a/modules/contact/test/tests/mortar_tm/horizontal_blocks_mortar_TM.i
+++ b/modules/contact/test/tests/mortar_tm/horizontal_blocks_mortar_TM.i
@@ -55,7 +55,7 @@ offset = 0.01
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/multiple_contact_pairs/multiple_pairs.i
+++ b/modules/contact/test/tests/multiple_contact_pairs/multiple_pairs.i
@@ -9,7 +9,7 @@ offset = 1e-2
   file = multiple_pairs.e
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/multiple_contact_pairs/multiple_pairs_mortar.i
+++ b/modules/contact/test/tests/multiple_contact_pairs/multiple_pairs_mortar.i
@@ -12,7 +12,7 @@ offset = 1e-2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/multiple_contact_pairs/multiple_pairs_mortar_friction.i
+++ b/modules/contact/test/tests/multiple_contact_pairs/multiple_pairs_mortar_friction.i
@@ -12,7 +12,7 @@ offset = 1e-2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/multiple_contact_pairs/three_hexagons_coarse.i
+++ b/modules/contact/test/tests/multiple_contact_pairs/three_hexagons_coarse.i
@@ -28,7 +28,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/multiple_contact_pairs/three_hexagons_coarse_automatic_pair.i
+++ b/modules/contact/test/tests/multiple_contact_pairs/three_hexagons_coarse_automatic_pair.i
@@ -28,7 +28,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/multiple_contact_pairs/three_hexagons_coarse_various_actions.i
+++ b/modules/contact/test/tests/multiple_contact_pairs/three_hexagons_coarse_various_actions.i
@@ -28,7 +28,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/nodal_area/nodal_area_Hex20.i
+++ b/modules/contact/test/tests/nodal_area/nodal_area_Hex20.i
@@ -33,7 +33,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     incremental = true
     save_in = 'react_x react_y react_z'

--- a/modules/contact/test/tests/nodal_area/nodal_area_Hex20_3.i
+++ b/modules/contact/test/tests/nodal_area/nodal_area_Hex20_3.i
@@ -33,7 +33,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     incremental = true
     save_in = 'react_x react_y react_z'

--- a/modules/contact/test/tests/nodal_area/nodal_area_Hex27.i
+++ b/modules/contact/test/tests/nodal_area/nodal_area_Hex27.i
@@ -33,7 +33,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     incremental = true
     save_in = 'react_x react_y react_z'

--- a/modules/contact/test/tests/non-singular-frictional-mortar/frictional-mortar.i
+++ b/modules/contact/test/tests/non-singular-frictional-mortar/frictional-mortar.i
@@ -18,7 +18,7 @@ refine = 1
   uniform_refine =  ${refine}
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/normalized_penalty/normalized_penalty.i
+++ b/modules/contact/test/tests/normalized_penalty/normalized_penalty.i
@@ -28,7 +28,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/normalized_penalty/normalized_penalty_Q8.i
+++ b/modules/contact/test/tests/normalized_penalty/normalized_penalty_Q8.i
@@ -27,7 +27,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/normalized_penalty/normalized_penalty_kin.i
+++ b/modules/contact/test/tests/normalized_penalty/normalized_penalty_kin.i
@@ -28,7 +28,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/normalized_penalty/normalized_penalty_kin_Q8.i
+++ b/modules/contact/test/tests/normalized_penalty/normalized_penalty_kin_Q8.i
@@ -28,7 +28,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_adaptivity.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_adaptivity.i
@@ -61,7 +61,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/all]
+[Physics/SolidMechanics/QuasiStatic/all]
   strain = FINITE
   add_variables = true
   extra_vector_tags = 'ref'

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al.i
@@ -68,7 +68,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/all]
+[Physics/SolidMechanics/QuasiStatic/all]
   strain = FINITE
   add_variables = true
   save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action.i
@@ -50,7 +50,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/all]
+[Physics/SolidMechanics/QuasiStatic/all]
   strain = FINITE
   add_variables = true
   save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg.i
@@ -51,7 +51,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/all]
+[Physics/SolidMechanics/QuasiStatic/all]
   strain = FINITE
   add_variables = true
   save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg_bussetta_simple.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg_bussetta_simple.i
@@ -51,7 +51,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/all]
+[Physics/SolidMechanics/QuasiStatic/all]
   strain = FINITE
   add_variables = true
   save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg_tight.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg_tight.i
@@ -53,7 +53,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/all]
+[Physics/SolidMechanics/QuasiStatic/all]
   strain = FINITE
   add_variables = true
   save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_tight_slip.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_tight_slip.i
@@ -69,7 +69,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/all]
+[Physics/SolidMechanics/QuasiStatic/all]
   strain = FINITE
   add_variables = true
   save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_normal_al.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_normal_al.i
@@ -62,7 +62,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/all]
+[Physics/SolidMechanics/QuasiStatic/all]
   strain = FINITE
   add_variables = true
   save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_normal_al_backup.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_normal_al_backup.i
@@ -65,7 +65,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/all]
+[Physics/SolidMechanics/QuasiStatic/all]
   strain = FINITE
   add_variables = true
   save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_normal_al_test_nochange.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_normal_al_test_nochange.i
@@ -69,7 +69,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master/all]
+[Physics/SolidMechanics/QuasiStatic/all]
   strain = FINITE
   add_variables = true
   save_in = 'saved_x saved_y'

--- a/modules/contact/test/tests/pdass_problems/frictional_bouncing_block.i
+++ b/modules/contact/test/tests/pdass_problems/frictional_bouncing_block.i
@@ -38,7 +38,7 @@ offset = 1e-2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     generate_output = 'stress_xx stress_yy'

--- a/modules/contact/test/tests/pdass_problems/frictional_bouncing_block_action.i
+++ b/modules/contact/test/tests/pdass_problems/frictional_bouncing_block_action.i
@@ -38,7 +38,7 @@ offset = 1e-2
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     generate_output = 'stress_xx stress_yy'

--- a/modules/contact/test/tests/pressure/pressureAugLag.i
+++ b/modules/contact/test/tests/pressure/pressureAugLag.i
@@ -12,7 +12,7 @@
   maximum_lagrangian_update_iterations = 200
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/pressure/pressurePenalty.i
+++ b/modules/contact/test/tests/pressure/pressurePenalty.i
@@ -9,7 +9,7 @@
 []
 
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/pressure/pressurePenalty_mechanical_constraint.i
+++ b/modules/contact/test/tests/pressure/pressurePenalty_mechanical_constraint.i
@@ -8,7 +8,7 @@
   file = pressure.e
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = SMALL

--- a/modules/contact/test/tests/ranfs-and-scaling/bouncing-block-ranfs.i
+++ b/modules/contact/test/tests/ranfs-and-scaling/bouncing-block-ranfs.i
@@ -25,7 +25,7 @@ offset = 1e-2
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = false
     use_automatic_differentiation = true

--- a/modules/contact/test/tests/ring_contact/ring_contact.i
+++ b/modules/contact/test/tests/ring_contact/ring_contact.i
@@ -22,7 +22,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/simple_contact/merged.i
+++ b/modules/contact/test/tests/simple_contact/merged.i
@@ -7,7 +7,7 @@
   file = merged.e
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     incremental = true

--- a/modules/contact/test/tests/simple_contact/simple_contact_rspherical.i
+++ b/modules/contact/test/tests/simple_contact/simple_contact_rspherical.i
@@ -31,7 +31,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/simple_contact/simple_contact_rz_test.i
+++ b/modules/contact/test/tests/simple_contact/simple_contact_rz_test.i
@@ -33,7 +33,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     incremental = true

--- a/modules/contact/test/tests/simple_contact/simple_contact_test.i
+++ b/modules/contact/test/tests/simple_contact/simple_contact_test.i
@@ -13,7 +13,7 @@
   displacements = 'disp_x disp_y disp_z'
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/simple_contact/simple_contact_test2.i
+++ b/modules/contact/test/tests/simple_contact/simple_contact_test2.i
@@ -7,7 +7,7 @@
   displacements = 'disp_x disp_y disp_z'
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/simple_contact/two_block_compress/two_equal_blocks_compress_2d.i
+++ b/modules/contact/test/tests/simple_contact/two_block_compress/two_equal_blocks_compress_2d.i
@@ -78,7 +78,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/simple_contact/two_block_compress/two_equal_blocks_compress_2d_pg.i
+++ b/modules/contact/test/tests/simple_contact/two_block_compress/two_equal_blocks_compress_2d_pg.i
@@ -85,7 +85,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/simple_contact/two_block_compress/two_equal_blocks_compress_3d.i
+++ b/modules/contact/test/tests/simple_contact/two_block_compress/two_equal_blocks_compress_3d.i
@@ -91,7 +91,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/simple_contact/two_block_compress/two_equal_blocks_compress_3d_pg.i
+++ b/modules/contact/test/tests/simple_contact/two_block_compress/two_equal_blocks_compress_3d_pg.i
@@ -98,7 +98,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/sliding_block/edge_dropping/two_equal_blocks_slide_2d.i
+++ b/modules/contact/test/tests/sliding_block/edge_dropping/two_equal_blocks_slide_2d.i
@@ -78,7 +78,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/sliding_block/edge_dropping/two_equal_blocks_slide_3d.i
+++ b/modules/contact/test/tests/sliding_block/edge_dropping/two_equal_blocks_slide_3d.i
@@ -91,7 +91,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     incremental = true

--- a/modules/contact/test/tests/sliding_block/in_and_out/frictional_02_penalty.i
+++ b/modules/contact/test/tests/sliding_block/in_and_out/frictional_02_penalty.i
@@ -44,7 +44,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/sliding_block/in_and_out/frictional_04_penalty.i
+++ b/modules/contact/test/tests/sliding_block/in_and_out/frictional_04_penalty.i
@@ -44,7 +44,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/sliding_block/in_and_out/frictionless_kinematic.i
+++ b/modules/contact/test/tests/sliding_block/in_and_out/frictionless_kinematic.i
@@ -44,7 +44,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/sliding_block/in_and_out/frictionless_lm.i
+++ b/modules/contact/test/tests/sliding_block/in_and_out/frictionless_lm.i
@@ -11,7 +11,7 @@
   volumetric_locking_correction = false
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/sliding_block/in_and_out/frictionless_penalty.i
+++ b/modules/contact/test/tests/sliding_block/in_and_out/frictionless_penalty.i
@@ -44,7 +44,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/sliding_block/in_and_out/frictionless_penalty_contact_line_search.i
+++ b/modules/contact/test/tests/sliding_block/in_and_out/frictionless_penalty_contact_line_search.i
@@ -44,7 +44,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/sliding_block/sliding/frictional_02_aug.i
+++ b/modules/contact/test/tests/sliding_block/sliding/frictional_02_aug.i
@@ -52,7 +52,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/sliding_block/sliding/frictional_02_penalty.i
+++ b/modules/contact/test/tests/sliding_block/sliding/frictional_02_penalty.i
@@ -38,7 +38,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/sliding_block/sliding/frictional_04_penalty.i
+++ b/modules/contact/test/tests/sliding_block/sliding/frictional_04_penalty.i
@@ -38,7 +38,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/sliding_block/sliding/frictionless_aug.i
+++ b/modules/contact/test/tests/sliding_block/sliding/frictionless_aug.i
@@ -44,7 +44,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/sliding_block/sliding/frictionless_kinematic.i
+++ b/modules/contact/test/tests/sliding_block/sliding/frictionless_kinematic.i
@@ -38,7 +38,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/sliding_block/sliding/frictionless_penalty.i
+++ b/modules/contact/test/tests/sliding_block/sliding/frictionless_penalty.i
@@ -38,7 +38,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/tan-pen-and-scaling/bouncing-block-tan-pen.i
+++ b/modules/contact/test/tests/tan-pen-and-scaling/bouncing-block-tan-pen.i
@@ -25,7 +25,7 @@ offset = 1e-2
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = false
     use_automatic_differentiation = true

--- a/modules/contact/test/tests/tension_release/4ElemTensionRelease.i
+++ b/modules/contact/test/tests/tension_release/4ElemTensionRelease.i
@@ -15,7 +15,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/tension_release/4ElemTensionRelease_mechanical_constraint.i
+++ b/modules/contact/test/tests/tension_release/4ElemTensionRelease_mechanical_constraint.i
@@ -16,7 +16,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = SMALL

--- a/modules/contact/test/tests/tension_release/8ElemTensionRelease.i
+++ b/modules/contact/test/tests/tension_release/8ElemTensionRelease.i
@@ -26,7 +26,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/test/tests/verification/patch_tests/automatic_patch_update/iteration_adaptivity_parallel.i
+++ b/modules/contact/test/tests/verification/patch_tests/automatic_patch_update/iteration_adaptivity_parallel.i
@@ -72,7 +72,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [cube1_mechanics]
     strain = FINITE
     block = 'cube1 cube2'

--- a/modules/contact/test/tests/verification/patch_tests/automatic_patch_update/iteration_adaptivity_parallel_node_face.i
+++ b/modules/contact/test/tests/verification/patch_tests/automatic_patch_update/iteration_adaptivity_parallel_node_face.i
@@ -72,7 +72,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [cube1_mechanics]
     strain = FINITE
     block = 'cube1 cube2'

--- a/modules/contact/tutorials/introduction/step01.i
+++ b/modules/contact/tutorials/introduction/step01.i
@@ -39,7 +39,7 @@
   patch_update_strategy = iteration
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/contact/tutorials/introduction/step02.i
+++ b/modules/contact/tutorials/introduction/step02.i
@@ -40,7 +40,7 @@
   patch_update_strategy = iteration
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = true
     strain = FINITE

--- a/modules/fsi/test/tests/2d-finite-strain-steady/thermal-me.i
+++ b/modules/fsi/test/tests/2d-finite-strain-steady/thermal-me.i
@@ -195,7 +195,7 @@ alpha_fluid = 2e-4 # thermal expansion coefficient of fluid used in INSADBoussin
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   strain = FINITE
   material_output_order = FIRST
   generate_output = 'vonmises_stress stress_xx stress_yy stress_zz strain_xx strain_yy strain_zz'

--- a/modules/fsi/test/tests/2d-small-strain-transient/ad-fsi-flat-channel.i
+++ b/modules/fsi/test/tests/2d-small-strain-transient/ad-fsi-flat-channel.i
@@ -172,7 +172,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [solid_domain]
     strain = SMALL
     incremental = false

--- a/modules/fsi/test/tests/2d-small-strain-transient/fsi_flat_channel.i
+++ b/modules/fsi/test/tests/2d-small-strain-transient/fsi_flat_channel.i
@@ -217,7 +217,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./solid_domain]
     strain = SMALL
     incremental = false

--- a/modules/solid_mechanics/test/tests/ad_anisotropic_creep/ad_aniso_creep_x_3d_anisoElasticity.i
+++ b/modules/solid_mechanics/test/tests/ad_anisotropic_creep/ad_aniso_creep_x_3d_anisoElasticity.i
@@ -133,7 +133,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     generate_output = 'elastic_strain_xx stress_xx'

--- a/modules/solid_mechanics/test/tests/ad_anisotropic_creep/ad_aniso_creep_x_3d_shear.i
+++ b/modules/solid_mechanics/test/tests/ad_anisotropic_creep/ad_aniso_creep_x_3d_shear.i
@@ -93,8 +93,8 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
-  [all]
+[Physics/SolidMechanics/QuasiStatic]
+  [./all]
     strain = FINITE
     generate_output = 'elastic_strain_xy stress_xy'
     use_automatic_differentiation = true

--- a/modules/solid_mechanics/test/tests/ad_anisotropic_creep/ad_aniso_creep_xy_3d_anisoElasticity.i
+++ b/modules/solid_mechanics/test/tests/ad_anisotropic_creep/ad_aniso_creep_xy_3d_anisoElasticity.i
@@ -143,7 +143,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     generate_output = 'elastic_strain_xx stress_xx elastic_strain_yy stress_yy elastic_strain_zz stress_zz'

--- a/modules/solid_mechanics/test/tests/ad_anisotropic_creep/ad_aniso_creep_xy_3d_shear.i
+++ b/modules/solid_mechanics/test/tests/ad_anisotropic_creep/ad_aniso_creep_xy_3d_shear.i
@@ -107,7 +107,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     strain = FINITE
     generate_output = 'elastic_strain_xy stress_xy elastic_strain_zy stress_zy'

--- a/modules/xfem/test/tests/bimaterials/glued_ad_bimaterials_2d.i
+++ b/modules/xfem/test/tests/bimaterials/glued_ad_bimaterials_2d.i
@@ -104,7 +104,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
     use_automatic_differentiation = true

--- a/modules/xfem/test/tests/bimaterials/inclusion_ad_bimaterials_2d.i
+++ b/modules/xfem/test/tests/bimaterials/inclusion_ad_bimaterials_2d.i
@@ -81,7 +81,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
     use_automatic_differentiation = true

--- a/modules/xfem/test/tests/corner_nodes_cut/corner_edge_cut.i
+++ b/modules/xfem/test/tests/corner_nodes_cut/corner_edge_cut.i
@@ -44,7 +44,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
   [../]

--- a/modules/xfem/test/tests/corner_nodes_cut/corner_node_cut.i
+++ b/modules/xfem/test/tests/corner_nodes_cut/corner_node_cut.i
@@ -38,7 +38,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
   [../]

--- a/modules/xfem/test/tests/corner_nodes_cut/corner_node_cut_twice.i
+++ b/modules/xfem/test/tests/corner_nodes_cut/corner_node_cut_twice.i
@@ -38,7 +38,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
   [../]

--- a/modules/xfem/test/tests/corner_nodes_cut/notch.i
+++ b/modules/xfem/test/tests/corner_nodes_cut/notch.i
@@ -30,7 +30,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
   [../]

--- a/modules/xfem/test/tests/high_order_elements/square_branch_2d.i
+++ b/modules/xfem/test/tests/high_order_elements/square_branch_2d.i
@@ -37,7 +37,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
   [../]

--- a/modules/xfem/test/tests/high_order_elements/tests
+++ b/modules/xfem/test/tests/high_order_elements/tests
@@ -85,7 +85,7 @@
     type = Exodiff
     input = square_branch_2d.i
     exodiff = 'square_branch_quad8_2d_out.e square_branch_quad8_2d_out.e-s002 square_branch_quad8_2d_out.e-s003'
-    cli_args = 'Modules/TensorMechanics/Master/all/planar_formulation=PLANE_STRAIN Mesh/elem_type=QUAD8 Outputs/file_base=square_branch_quad8_2d_out'
+    cli_args = 'Physics/SolidMechanics/QuasiStatic/all/planar_formulation=PLANE_STRAIN Mesh/elem_type=QUAD8 Outputs/file_base=square_branch_quad8_2d_out'
     map = false
     unique_id = true
     requirement = 'The XFEM module shall permit modeling of branching of discontinuities represented with XFEM by sequentially cutting second-order elements in 2D using QUAD8 elements.'

--- a/modules/xfem/test/tests/init_solution_propagation/init_solution_propagation.i
+++ b/modules/xfem/test/tests/init_solution_propagation/init_solution_propagation.i
@@ -61,7 +61,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     add_variables = true

--- a/modules/xfem/test/tests/mechanical_constraint/glued_penalty.i
+++ b/modules/xfem/test/tests/mechanical_constraint/glued_penalty.i
@@ -30,7 +30,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     planar_formulation = plane_strain

--- a/modules/xfem/test/tests/moment_fitting/solid_mechanics_moment_fitting.i
+++ b/modules/xfem/test/tests/moment_fitting/solid_mechanics_moment_fitting.i
@@ -47,7 +47,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
   [../]

--- a/modules/xfem/test/tests/moving_interface/cut_mesh_2d.i
+++ b/modules/xfem/test/tests/moving_interface/cut_mesh_2d.i
@@ -60,7 +60,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   displacements = 'disp_x disp_y'
   [all]
     strain = SMALL

--- a/modules/xfem/test/tests/moving_interface/cut_mesh_3d.i
+++ b/modules/xfem/test/tests/moving_interface/cut_mesh_3d.i
@@ -58,7 +58,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   displacements = 'disp_x disp_y disp_z'
   [all]
     strain = SMALL

--- a/modules/xfem/test/tests/moving_interface/moving_ad_bimaterial.i
+++ b/modules/xfem/test/tests/moving_interface/moving_ad_bimaterial.i
@@ -98,7 +98,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
     use_automatic_differentiation = true

--- a/modules/xfem/test/tests/pressure_bc/2d_pressure_displaced_mesh.i
+++ b/modules/xfem/test/tests/pressure_bc/2d_pressure_displaced_mesh.i
@@ -36,7 +36,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     add_variables = true

--- a/modules/xfem/test/tests/pressure_bc/edge_2d_pressure.i
+++ b/modules/xfem/test/tests/pressure_bc/edge_2d_pressure.i
@@ -36,7 +36,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
     generate_output = 'stress_xx stress_yy'

--- a/modules/xfem/test/tests/pressure_bc/edge_3d_pressure.i
+++ b/modules/xfem/test/tests/pressure_bc/edge_3d_pressure.i
@@ -44,7 +44,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     add_variables = true

--- a/modules/xfem/test/tests/pressure_bc/inclined_edge_2d_pressure.i
+++ b/modules/xfem/test/tests/pressure_bc/inclined_edge_2d_pressure.i
@@ -36,7 +36,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
     generate_output = 'stress_xx stress_yy'

--- a/modules/xfem/test/tests/solid_mechanics_basic/crack_propagation_2d.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/crack_propagation_2d.i
@@ -39,7 +39,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     planar_formulation = plane_strain

--- a/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d.i
@@ -57,7 +57,7 @@
   incremental = true
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     add_variables = true

--- a/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d_fatigue.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d_fatigue.i
@@ -84,7 +84,7 @@
   incremental = true
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     add_variables = true

--- a/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d_mhs.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d_mhs.i
@@ -57,7 +57,7 @@
   incremental = true
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     add_variables = true

--- a/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d_propagation.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d_propagation.i
@@ -57,7 +57,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     add_variables = true

--- a/modules/xfem/test/tests/solid_mechanics_basic/elliptical_crack.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/elliptical_crack.i
@@ -35,7 +35,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     add_variables = true

--- a/modules/xfem/test/tests/solid_mechanics_basic/penny_crack.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/penny_crack.i
@@ -48,7 +48,7 @@
   incremental = true
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     add_variables = true

--- a/modules/xfem/test/tests/solid_mechanics_basic/penny_crack_cfp.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/penny_crack_cfp.i
@@ -54,7 +54,7 @@
   incremental = true
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     add_variables = true

--- a/modules/xfem/test/tests/solid_mechanics_basic/square_branch_quad_2d.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/square_branch_quad_2d.i
@@ -35,7 +35,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
     planar_formulation = PLANE_STRAIN

--- a/modules/xfem/test/tests/solid_mechanics_basic/square_branch_tri_2d.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/square_branch_tri_2d.i
@@ -35,7 +35,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = SMALL
     planar_formulation = PLANE_STRAIN

--- a/modules/xfem/test/tests/solid_mechanics_basic/test.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/test.i
@@ -32,7 +32,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   displacements = 'disp_x disp_y'
   [./all]
     strain = FINITE

--- a/modules/xfem/test/tests/solid_mechanics_basic/test_crack_counter.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/test_crack_counter.i
@@ -56,7 +56,7 @@
   [../]
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [./all]
     strain = FINITE
     planar_formulation = plane_strain


### PR DESCRIPTION
Probably not the most sophisticated PR: Just renaming Modules\TensorMechanis to Physics\SolidMechanics in some tests and examples. 

closes #28696