### PR TITLE
Find non matching edges

### DIFF
--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -86,6 +86,8 @@ private:
   const Real _non_conformality_tol;
   //// whether to check for intersecting edges
   const MooseEnum _check_non_matching_edges;
+  //// tolerance for detecting when edges intersect
+  const Real _non_matching_edge_tol;
   /// whether to check for the adaptivity of non-conformal meshes
   const MooseEnum _check_adaptivity_non_conformality;
   /// whether to check for negative jacobians in the domain

--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -49,7 +49,7 @@ private:
   void checkNonConformalMeshFromAdaptivity(const std::unique_ptr<MeshBase> & mesh) const;
   /// Routine to check whether the Jacobians (elem and side) are not negative
   void checkLocalJacobians(const std::unique_ptr<MeshBase> & mesh) const;
-  //// Routing to check for non matching edges
+  //// Routine to check for non matching edges
   void checkNonMatchingEdges(const std::unique_ptr<MeshBase> & mesh) const;
 
   /**

--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -49,6 +49,8 @@ private:
   void checkNonConformalMeshFromAdaptivity(const std::unique_ptr<MeshBase> & mesh) const;
   /// Routine to check whether the Jacobians (elem and side) are not negative
   void checkLocalJacobians(const std::unique_ptr<MeshBase> & mesh) const;
+  //// Routing to check for non matching edges
+  void checkNonMatchingEdges(const std::unique_ptr<MeshBase> & mesh) const;
 
   /**
    * Utility routine to output the final diagnostics level in the desired mode
@@ -82,6 +84,8 @@ private:
   const MooseEnum _check_non_conformal_mesh;
   /// tolerance for detecting when meshes are not conformal
   const Real _non_conformality_tol;
+  //// whether to check for intersecting edges
+  const MooseEnum _check_non_matching_edges;
   /// whether to check for the adaptivity of non-conformal meshes
   const MooseEnum _check_adaptivity_non_conformality;
   /// whether to check for negative jacobians in the domain

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -25,7 +25,7 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
                            const Real conformality_tol,
                            unsigned int & num_nonconformal_nodes);
 
-bool checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
+bool checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                       const std::unique_ptr<Elem> & edge2,
                       std::vector<double> & intersection_coords,
                       const Real insersection_tol);

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -26,7 +26,7 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
                            unsigned int & num_nonconformal_nodes);
 
 bool checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
-                                const std::unique_ptr<Elem> & edge2,
+                                const std::unique_ptr<const Elem> & edge2,
                                 Point & intersection_point,
                                 const Real intersection_tol);
 }

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -27,5 +27,6 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
 
 bool checkEdgeOverlap(const std::unique_ptr<Elem> & edge1, 
                       const std::unique_ptr<Elem> & edge2,
-                      const ConsoleStream & console);
+                      const ConsoleStream & console,
+                      const Real insersection_tol);
 }

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -25,7 +25,7 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
                            const Real conformality_tol,
                            unsigned int & num_nonconformal_nodes);
 
-bool checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
+bool checkFirstOrderEdgeOverlap(const std::unique_ptr<const Elem> & edge1,
                                 const std::unique_ptr<const Elem> & edge2,
                                 Point & intersection_point,
                                 const Real intersection_tol);

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -24,4 +24,8 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
                            const unsigned int num_outputs,
                            const Real conformality_tol,
                            unsigned int & num_nonconformal_nodes);
+
+bool checkEdgeOverlap(const std::unique_ptr<Elem> & edge1, 
+                      const std::unique_ptr<Elem> & edge2,
+                      double tol);
 }

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -26,7 +26,7 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
                            unsigned int & num_nonconformal_nodes);
 
 bool checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
-                      const std::unique_ptr<Elem> & edge2,
-                      std::vector<double> & intersection_coords,
-                      const Real insersection_tol);
+                                const std::unique_ptr<Elem> & edge2,
+                                std::vector<double> & intersection_coords,
+                                const Real insersection_tol);
 }

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -25,7 +25,7 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
                            const Real conformality_tol,
                            unsigned int & num_nonconformal_nodes);
 
-bool checkEdgeOverlap(const std::unique_ptr<Elem> & edge1, 
+bool checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                       const std::unique_ptr<Elem> & edge2,
                       const ConsoleStream & console,
                       const Real insersection_tol);

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -25,8 +25,8 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
                            const Real conformality_tol,
                            unsigned int & num_nonconformal_nodes);
 
-bool checkFirstOrderEdgeOverlap(const std::unique_ptr<const Elem> & edge1,
-                                const std::unique_ptr<const Elem> & edge2,
+bool checkFirstOrderEdgeOverlap(const Elem & edge1,
+                                const Elem & edge2,
                                 Point & intersection_point,
                                 const Real intersection_tol);
 }

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -27,6 +27,6 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
 
 bool checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                                 const std::unique_ptr<Elem> & edge2,
-                                std::vector<double> & intersection_coords,
-                                const Real insersection_tol);
+                                Point & intersection_point,
+                                const Real intersection_tol);
 }

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -27,5 +27,5 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
 
 bool checkEdgeOverlap(const std::unique_ptr<Elem> & edge1, 
                       const std::unique_ptr<Elem> & edge2,
-                      double tol);
+                      const ConsoleStream & console);
 }

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -27,6 +27,6 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
 
 bool checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                       const std::unique_ptr<Elem> & edge2,
-                      std::vector<double> &intersection_coords,
+                      std::vector<double> & intersection_coords,
                       const Real insersection_tol);
 }

--- a/framework/include/utils/MeshBaseDiagnosticsUtils.h
+++ b/framework/include/utils/MeshBaseDiagnosticsUtils.h
@@ -27,6 +27,6 @@ void checkNonConformalMesh(const std::unique_ptr<libMesh::MeshBase> & mesh,
 
 bool checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                       const std::unique_ptr<Elem> & edge2,
-                      const ConsoleStream & console,
+                      std::vector<double> &intersection_coords,
                       const Real insersection_tol);
 }

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1431,8 +1431,7 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
     bounding_box_map.insert({elem, boundingBox});
   }
 
-  std::unique_ptr<PointLocatorBase> point_locator =
-      mesh->sub_point_locator(); // PointLocatorBase::build(TREE_ELEMENTS, *mesh);
+  std::unique_ptr<PointLocatorBase> point_locator = mesh->sub_point_locator();
   std::set<std::array<dof_id_type, 4>> overlapping_edges_nodes;
   for (const auto elem : mesh->active_element_ptr_range())
   {
@@ -1494,7 +1493,7 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
           // Now compare edge with other_edge
           Point intersection_coords;
           bool overlap = MeshBaseDiagnosticsUtils::checkFirstOrderEdgeOverlap(
-              edge, other_edge, intersection_coords, _non_matching_edge_tol);
+              *edge, *other_edge, intersection_coords, _non_matching_edge_tol);
           if (overlap)
           {
             // Add the nodes that make up the 2 edges to the vector overlapping_edges_nodes

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -65,8 +65,8 @@ MeshDiagnosticsGenerator::validParams()
                              chk_option,
                              "whether to examine the conformality of elements in the mesh");
   params.addParam<MooseEnum>("examine_non_matching_edges",
-                              chk_option,
-                              "Whether to check if there are any intersecting edges");
+                             chk_option,
+                             "Whether to check if there are any intersecting edges");
   params.addParam<Real>("intersection_tol", TOLERANCE, "tolerence for intersecting edges");
   params.addParam<Real>("nonconformal_tol", TOLERANCE, "tolerance for element non-conformality");
   params.addParam<MooseEnum>(
@@ -1418,9 +1418,10 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
       d)Have check to make sure the same pair of edges are not being tested twice for overlap
     3)Overlap check
       a)Shortest line that connects both lines is perpendicular to both lines
-      b)A good overview of the math for finding intersecting lines can be found here->paulbourke.net/geometry/pointlineplane/
+      b)A good overview of the math for finding intersecting lines can be found
+    here->paulbourke.net/geometry/pointlineplane/
   */
-  if(mesh->mesh_dimension() != 3)
+  if (mesh->mesh_dimension() != 3)
     mooseError("The edge intersection algorithm only works with 3D meshes");
   if (!mesh->is_serial())
     mooseError("Only serialized/replicated meshes are supported");
@@ -1433,15 +1434,16 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
       elem_edges[i] = elem->build_edge_ptr(i);
     for (auto other_elem : mesh->active_element_ptr_range())
     {
-      //If they're the same element then there's no need to check for overlap
+      // If they're the same element then there's no need to check for overlap
       if (elem == other_elem)
       {
         continue;
       }
-      //Get bounding boxes for both elements. If the bounding boxes don't intersect then no edges will either
+      // Get bounding boxes for both elements. If the bounding boxes don't intersect then no edges
+      // will either
       auto boundingBox1 = elem->loose_bounding_box();
       auto boundingBox2 = other_elem->loose_bounding_box();
-      if(!(boundingBox1.intersects(boundingBox2)))
+      if (!(boundingBox1.intersects(boundingBox2)))
       {
         continue;
       }
@@ -1458,16 +1460,17 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
           auto n2 = *node_list1[1];
           auto n3 = *node_list2[0];
           auto n4 = *node_list2[1];
-          //Check if the edges have already been added to our check_edges list
-          if (std::find(checked_edges.begin(), checked_edges.end(), n1) !=checked_edges.end() &&
-            std::find(checked_edges.begin(), checked_edges.end(), n2) !=checked_edges.end() &&
-            std::find(checked_edges.begin(), checked_edges.end(), n3) !=checked_edges.end() &&
-            std::find(checked_edges.begin(), checked_edges.end(), n4) !=checked_edges.end())
+          // Check if the edges have already been added to our check_edges list
+          if (std::find(checked_edges.begin(), checked_edges.end(), n1) != checked_edges.end() &&
+              std::find(checked_edges.begin(), checked_edges.end(), n2) != checked_edges.end() &&
+              std::find(checked_edges.begin(), checked_edges.end(), n3) != checked_edges.end() &&
+              std::find(checked_edges.begin(), checked_edges.end(), n4) != checked_edges.end())
           {
             continue;
           }
           // Now compare edge with other_edge
-          bool overlap = MeshBaseDiagnosticsUtils::checkEdgeOverlap(edge, other_edge, _console, _non_matching_edge_tol);
+          bool overlap = MeshBaseDiagnosticsUtils::checkEdgeOverlap(
+              edge, other_edge, _console, _non_matching_edge_tol);
           if (overlap)
           {
             // Add the nodes that make up the 2 edges to the vector checked_edges
@@ -1475,13 +1478,15 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
             checked_edges.push_back(n2);
             checked_edges.push_back(n3);
             checked_edges.push_back(n4);
-            num_intersecting_edges+=2;
+            num_intersecting_edges += 2;
           }
         }
       }
     }
   }
-  diagnosticsLog("Number of intersecting edges: " + Moose::stringify(num_intersecting_edges), _check_non_matching_edges, num_intersecting_edges);
+  diagnosticsLog("Number of intersecting edges: " + Moose::stringify(num_intersecting_edges),
+                 _check_non_matching_edges,
+                 num_intersecting_edges);
 }
 
 void

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -20,6 +20,7 @@
 #include "libmesh/cell_tet4.h"
 #include "libmesh/face_quad4.h"
 #include "libmesh/cell_hex8.h"
+#include "libmesh/string_to_enum.h"
 
 registerMooseObject("MooseApp", MeshDiagnosticsGenerator);
 

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1507,9 +1507,9 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
               std::string x_coord = std::to_string(intersection_coords(0));
               std::string y_coord = std::to_string(intersection_coords(1));
               std::string z_coord = std::to_string(intersection_coords(2));
-              std::string message = "Intersecting edges found between elements " + elem_id + " and " +
-                                    other_elem_id + " near point (" + x_coord + ", " + y_coord +
-                                    ", " + z_coord + ")";
+              std::string message = "Intersecting edges found between elements " + elem_id +
+                                    " and " + other_elem_id + " near point (" + x_coord + ", " +
+                                    y_coord + ", " + z_coord + ")";
               _console << message << std::endl;
             }
           }

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1431,7 +1431,8 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
     bounding_box_map.insert({elem, boundingBox});
   }
 
-  std::unique_ptr<PointLocatorBase> point_locator = PointLocatorBase::build(TREE_ELEMENTS, *mesh);
+  std::unique_ptr<PointLocatorBase> point_locator =
+      mesh->sub_point_locator(); // PointLocatorBase::build(TREE_ELEMENTS, *mesh);
   std::set<std::array<dof_id_type, 4>> overlapping_edges_nodes;
   for (const auto elem : mesh->active_element_ptr_range())
   {
@@ -1443,7 +1444,7 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
       (*point_locator)(elem->point(i), candidate_elems);
       nearby_elems.insert(candidate_elems.begin(), candidate_elems.end());
     }
-    std::vector<std::unique_ptr<Elem>> elem_edges(elem->n_edges());
+    std::vector<std::unique_ptr<const Elem>> elem_edges(elem->n_edges());
     for (auto i : elem->edge_index_range())
       elem_edges[i] = elem->build_edge_ptr(i);
     for (const auto other_elem : nearby_elems)

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1426,7 +1426,7 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
   if (!mesh->is_serial())
     mooseError("Only serialized/replicated meshes are supported");
   unsigned int num_intersecting_edges = 0;
-  std::set<Node> checked_edges_nodes;
+  std::set<Node> overlapping_edges_nodes;
   for (const auto elem : mesh->active_element_ptr_range())
   {
     std::vector<std::unique_ptr<Elem>> elem_edges(elem->n_edges());
@@ -1459,8 +1459,8 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
           const Node * n4 = other_edge->get_nodes()[1];
 
           // Check if the edges have already been added to our check_edges list
-          if (checked_edges_nodes.count(*n1) && checked_edges_nodes.count(*n2) &&
-              checked_edges_nodes.count(*n3) && checked_edges_nodes.count(*n4))
+          if (overlapping_edges_nodes.count(*n1) && overlapping_edges_nodes.count(*n2) &&
+              overlapping_edges_nodes.count(*n3) && overlapping_edges_nodes.count(*n4))
           {
             continue;
           }
@@ -1486,11 +1486,11 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
               edge, other_edge, intersection_coords, _non_matching_edge_tol);
           if (overlap)
           {
-            // Add the nodes that make up the 2 edges to the vector checked_edges_nodes
-            checked_edges_nodes.insert(*n1);
-            checked_edges_nodes.insert(*n2);
-            checked_edges_nodes.insert(*n3);
-            checked_edges_nodes.insert(*n4);
+            // Add the nodes that make up the 2 edges to the vector overlapping_edges_nodes
+            overlapping_edges_nodes.insert(*n1);
+            overlapping_edges_nodes.insert(*n2);
+            overlapping_edges_nodes.insert(*n3);
+            overlapping_edges_nodes.insert(*n4);
             num_intersecting_edges += 2;
 
             // Print error message

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1468,24 +1468,17 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
           // Check element/edge type
           if (edge->type() != EDGE2)
           {
-            std::string element_message =
-                "Edge of type " + Utility::enum_to_string(edge->type()) + " was found in cell " +
-                std::to_string(elem->id()) + " which is of type " +
-                Utility::enum_to_string(elem->type()) + '\n' +
-                "The edge intersection check only works for EDGE2 elements";
-            _console << element_message << std::endl;
+            std::string element_message = "Edge of type " + Utility::enum_to_string(edge->type()) +
+                                          " was found in cell " + std::to_string(elem->id()) +
+                                          " which is of type " +
+                                          Utility::enum_to_string(elem->type()) + '\n' +
+                                          "The edge intersection check only works for EDGE2 "
+                                          "elements.\nThis message will not be output again";
+            mooseDoOnce(_console << element_message << std::endl);
             continue;
           }
           if (other_edge->type() != EDGE2)
-          {
-            std::string element_message =
-                "Edge of type " + Utility::enum_to_string(other_edge->type()) +
-                " was found in cell " + std::to_string(other_elem->id()) + " which is of type " +
-                Utility::enum_to_string(other_elem->type()) + '\n' +
-                "The edge intersection check only works for EDGE2 elements";
-            _console << element_message << std::endl;
             continue;
-          }
 
           // Now compare edge with other_edge
           std::vector<double> intersection_coords(3);

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1432,7 +1432,7 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
     std::vector<std::unique_ptr<Elem>> elem_edges(elem->n_edges());
     for (auto i : elem->edge_index_range())
       elem_edges[i] = elem->build_edge_ptr(i);
-    for (auto other_elem : mesh->active_element_ptr_range())
+    for (const auto other_elem : mesh->active_element_ptr_range())
     {
       // If they're the same element then there's no need to check for overlap
       if (elem == other_elem)
@@ -1440,8 +1440,8 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
 
       // Get bounding boxes for both elements. If the bounding boxes don't intersect then no edges
       // will either
-      auto boundingBox1 = elem->loose_bounding_box();
-      auto boundingBox2 = other_elem->loose_bounding_box();
+      const auto boundingBox1 = elem->loose_bounding_box();
+      const auto boundingBox2 = other_elem->loose_bounding_box();
       if (!(boundingBox1.intersects(boundingBox2)))
         continue;
 
@@ -1467,7 +1467,7 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
 
           // Now compare edge with other_edge
           std::vector<double> intersection_coords(3);
-          bool overlap = MeshBaseDiagnosticsUtils::checkEdgeOverlap(
+          bool overlap = MeshBaseDiagnosticsUtils::checkFirstOrderEdgeOverlap(
               edge, other_edge, intersection_coords, _non_matching_edge_tol);
           if (overlap)
           {
@@ -1493,7 +1493,7 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
       }
     }
   }
-  diagnosticsLog("Number of intersecting edges: " + Moose::stringify(num_intersecting_edges),
+  diagnosticsLog("Number of intersecting element edges: " + Moose::stringify(num_intersecting_edges),
                  _check_non_matching_edges,
                  num_intersecting_edges);
 }

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1437,7 +1437,7 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
       // If they're the same element then there's no need to check for overlap
       if (elem == other_elem)
         continue;
-      
+
       // Get bounding boxes for both elements. If the bounding boxes don't intersect then no edges
       // will either
       auto boundingBox1 = elem->loose_bounding_box();
@@ -1459,10 +1459,8 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
           const Node * n4 = other_edge->get_nodes()[1];
 
           // Check if the edges have already been added to our check_edges list
-          if (checked_edges_nodes.count(*n1) &&
-              checked_edges_nodes.count(*n2) &&
-              checked_edges_nodes.count(*n3) &&
-              checked_edges_nodes.count(*n4))
+          if (checked_edges_nodes.count(*n1) && checked_edges_nodes.count(*n2) &&
+              checked_edges_nodes.count(*n3) && checked_edges_nodes.count(*n4))
           {
             continue;
           }
@@ -1486,7 +1484,9 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
             std::string x_coord = std::to_string(intersection_coords[0]);
             std::string y_coord = std::to_string(intersection_coords[1]);
             std::string z_coord = std::to_string(intersection_coords[2]);
-            std::string message = "Intersecting edges found between elements " + elem_id + " and " + other_elem_id + " near point (" + x_coord + ", " + y_coord + ", " + z_coord + ")";
+            std::string message = "Intersecting edges found between elements " + elem_id + " and " +
+                                  other_elem_id + " near point (" + x_coord + ", " + y_coord +
+                                  ", " + z_coord + ")";
             _console << message << std::endl;
           }
         }

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1428,13 +1428,14 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
     mooseError("Only serialized/replicated meshes are supported");
   unsigned int num_intersecting_edges = 0;
 
-  // Create map of element to bounding box to avoing reinitializing the same bounding box multiple times
+  // Create map of element to bounding box to avoing reinitializing the same bounding box multiple
+  // times
   std::unordered_map<Elem *, BoundingBox> bounding_box_map;
   for (const auto elem : mesh->active_element_ptr_range())
   {
     const auto boundingBox = elem->loose_bounding_box();
     bounding_box_map.insert({elem, boundingBox});
-  } 
+  }
 
   std::set<std::array<dof_id_type, 4>> overlapping_edges_nodes;
   for (const auto elem : mesh->active_element_ptr_range())

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1466,7 +1466,7 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
           }
 
           //Check element/edge type 
-          if (edge->type() != 0)
+          if (edge->type() != EDGE2)
           {
             std::string element_message = "Edge of type " + Utility::enum_to_string(edge->type()) + " was found in cell " + std::to_string(elem->id()) + 
                                           " which is of type " + Utility::enum_to_string(elem->type()) + '\n' + 
@@ -1474,7 +1474,7 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
             _console << element_message << std::endl;
             continue;
           }
-          if (other_edge->type() != 0)
+          if (other_edge->type() != EDGE2)
           {
             std::string element_message = "Edge of type " + Utility::enum_to_string(other_edge->type()) + " was found in cell " + std::to_string(other_elem->id()) + 
                                           " which is of type " + Utility::enum_to_string(other_elem->type()) + '\n' + 

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1493,7 +1493,8 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
       }
     }
   }
-  diagnosticsLog("Number of intersecting element edges: " + Moose::stringify(num_intersecting_edges),
+  diagnosticsLog("Number of intersecting element edges: " +
+                     Moose::stringify(num_intersecting_edges),
                  _check_non_matching_edges,
                  num_intersecting_edges);
 }

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -115,18 +115,11 @@ MeshDiagnosticsGenerator::MeshDiagnosticsGenerator(const InputParameters & param
     paramError("examine_non_conformality",
                "You must set this parameter to true to trigger mesh conformality check");
   if (_check_sidesets_orientation == "NO_CHECK" && _check_watertight_sidesets == "NO_CHECK" &&
-<<<<<<< HEAD
       _check_watertight_nodesets == "NO_CHECK" && _check_element_volumes == "NO_CHECK" &&
       _check_element_types == "NO_CHECK" && _check_element_overlap == "NO_CHECK" &&
       _check_non_planar_sides == "NO_CHECK" && _check_non_conformal_mesh == "NO_CHECK" &&
-      _check_adaptivity_non_conformality == "NO_CHECK" && _check_local_jacobian == "NO_CHECK")
-=======
-      _check_watertight_nodesets == "NO_CHECK" && _check_element_volumes == "NO_CHECK" && 
-      _check_element_types == "NO_CHECK" && _check_element_overlap == "NO_CHECK" && 
-      _check_non_planar_sides == "NO_CHECK" && _check_non_conformal_mesh == "NO_CHECK" && 
-      _check_adaptivity_non_conformality == "NO_CHECK" && _check_local_jacobian == "NO_CHECK" && 
+      _check_adaptivity_non_conformality == "NO_CHECK" && _check_local_jacobian == "NO_CHECK" &&
       _check_non_matching_edges == "NO_CHECK")
->>>>>>> a759b2e1ae (Basic outline for checkNonMatchingEdges)
     mooseError("You need to turn on at least one diagnostic. Did you misspell a parameter?");
 }
 

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1465,6 +1465,24 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
             continue;
           }
 
+          //Check element/edge type 
+          if (edge->type() != 0)
+          {
+            std::string element_message = "Edge of type " + Utility::enum_to_string(edge->type()) + " was found in cell " + std::to_string(elem->id()) + 
+                                          " which is of type " + Utility::enum_to_string(elem->type()) + '\n' + 
+                                          "The edge intersection check only works for EDGE2 elements";
+            _console << element_message << std::endl;
+            continue;
+          }
+          if (other_edge->type() != 0)
+          {
+            std::string element_message = "Edge of type " + Utility::enum_to_string(other_edge->type()) + " was found in cell " + std::to_string(other_elem->id()) + 
+                                          " which is of type " + Utility::enum_to_string(other_elem->type()) + '\n' + 
+                                          "The edge intersection check only works for EDGE2 elements";
+            _console << element_message << std::endl;
+            continue;
+          }
+
           // Now compare edge with other_edge
           std::vector<double> intersection_coords(3);
           bool overlap = MeshBaseDiagnosticsUtils::checkFirstOrderEdgeOverlap(

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1423,68 +1423,58 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
   */
   unsigned int num_intersecting_edges = 0;
   std::vector<Node> checked_edges;
-  //unsigned int num_elem_check = 0;
   for (auto elem : mesh->active_element_ptr_range())
   {
     std::vector<std::unique_ptr<Elem>> elem_edges(elem->n_edges());
-    //num_elem_check++;
     for (auto i : elem->edge_index_range())
       elem_edges[i] = elem->build_edge_ptr(i);
     for (auto other_elem : mesh->active_element_ptr_range())
     {
+      //If they're the same element then there's no need to check for overlap
+      if (elem == other_elem)
+      {
+        continue;
+      }
+      //Get bounding boxes for both elements. If the bounding boxes don't intersect then no edges will either
+      auto boundingBox1 = elem->loose_bounding_box();
+      auto boundingBox2 = other_elem->loose_bounding_box();
+      if(!(boundingBox1.intersects(boundingBox2)))
+      {
+        continue;
+      }
       std::vector<std::unique_ptr<Elem>> other_edges(other_elem->n_edges());
-      //num_elem_check++;
       for (auto j : other_elem->edge_index_range())
         other_edges[j] = other_elem->build_edge_ptr(j);
       for (auto & edge : elem_edges)
       {
         for (auto & other_edge : other_edges)
         {
+          const auto node_list1 = edge->get_nodes();
+          const auto node_list2 = other_edge->get_nodes();
+          auto n1 = *node_list1[0];
+          auto n2 = *node_list1[1];
+          auto n3 = *node_list2[0];
+          auto n4 = *node_list2[1];
+          //Check if the edges have already been added to our check_edges list
+          if (std::find(checked_edges.begin(), checked_edges.end(), n1) !=checked_edges.end() &&
+            std::find(checked_edges.begin(), checked_edges.end(), n2) !=checked_edges.end() &&
+            std::find(checked_edges.begin(), checked_edges.end(), n3) !=checked_edges.end() &&
+            std::find(checked_edges.begin(), checked_edges.end(), n4) !=checked_edges.end())
+          {
+            continue;
+          }
           // Now compare edge with other_edge
-          double tol = 0.000001;
-          bool overlap = MeshBaseDiagnosticsUtils::checkEdgeOverlap(edge, other_edge, tol);
+          bool overlap = MeshBaseDiagnosticsUtils::checkEdgeOverlap(edge, other_edge, _console);
           if (overlap)
           {
-            const auto node_list1 = edge->get_nodes();
-            const auto node_list2 = other_edge->get_nodes();
-            auto n1 = *node_list1[0];
-            auto n2 = *node_list1[1];
-            auto n3 = *node_list2[0];
-            auto n4 = *node_list2[1];
-            if(std::find(checked_edges.begin(), checked_edges.end(), n1) !=checked_edges.end() &&
-              std::find(checked_edges.begin(), checked_edges.end(), n2) !=checked_edges.end() &&
-              std::find(checked_edges.begin(), checked_edges.end(), n3) !=checked_edges.end() &&
-              std::find(checked_edges.begin(), checked_edges.end(), n4) !=checked_edges.end())
-            {
-              continue;
-            }
+            // Add the nodes that make up the 2 edges to the vector checked_edges
             checked_edges.push_back(n1);
             checked_edges.push_back(n2);
             checked_edges.push_back(n3);
             checked_edges.push_back(n4);
             num_intersecting_edges+=2;
-            //const Point * const p = n;
-  	        auto x1 = n1.operator()(0);
-	          auto y1 = n1.operator()(1);
-	          auto z1 = n1.operator()(2);
-            auto x2 = n2.operator()(0);
-	          auto y2 = n2.operator()(1);
-	          auto z2 = n2.operator()(2);
-            
-            std::string x_coord = std::to_string((x1+x2)/2);
-            std::string y_coord = std::to_string((y1+y2)/2);
-            std::string z_coord = std::to_string((z1+z2)/2);
-
-            std::string message = "Non-matching edges found near (" + x_coord + ", " + y_coord + ", " + z_coord + ")";
-            _console << message << std::endl;
           }
         }
-        /*for (const auto other_i : other_elem->edge_index_range())
-        {
-          const auto other_edge = other_elem->build_edge_ptr();
-          // you now have edge, and other_edge
-        }
-        */
       }
     }
   }

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1427,7 +1427,7 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
   if (!mesh->is_serial())
     mooseError("Only serialized/replicated meshes are supported");
   unsigned int num_intersecting_edges = 0;
-  std::set<Node> overlapping_edges_nodes;
+  std::set<dof_id_type> overlapping_edges_nodes;
   for (const auto elem : mesh->active_element_ptr_range())
   {
     std::vector<std::unique_ptr<Elem>> elem_edges(elem->n_edges());
@@ -1460,8 +1460,8 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
           const Node * n4 = other_edge->get_nodes()[1];
 
           // Check if the edges have already been added to our check_edges list
-          if (overlapping_edges_nodes.count(*n1) && overlapping_edges_nodes.count(*n2) &&
-              overlapping_edges_nodes.count(*n3) && overlapping_edges_nodes.count(*n4))
+          if (overlapping_edges_nodes.count(n1->id()) && overlapping_edges_nodes.count(n2->id()) &&
+              overlapping_edges_nodes.count(n3->id()) && overlapping_edges_nodes.count(n4->id()))
           {
             continue;
           }
@@ -1488,10 +1488,10 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
           if (overlap)
           {
             // Add the nodes that make up the 2 edges to the vector overlapping_edges_nodes
-            overlapping_edges_nodes.insert(*n1);
-            overlapping_edges_nodes.insert(*n2);
-            overlapping_edges_nodes.insert(*n3);
-            overlapping_edges_nodes.insert(*n4);
+            overlapping_edges_nodes.insert(n1->id());
+            overlapping_edges_nodes.insert(n2->id());
+            overlapping_edges_nodes.insert(n3->id());
+            overlapping_edges_nodes.insert(n4->id());
             num_intersecting_edges += 2;
 
             // Print error message

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1465,20 +1465,24 @@ MeshDiagnosticsGenerator::checkNonMatchingEdges(const std::unique_ptr<MeshBase> 
             continue;
           }
 
-          //Check element/edge type 
+          // Check element/edge type
           if (edge->type() != EDGE2)
           {
-            std::string element_message = "Edge of type " + Utility::enum_to_string(edge->type()) + " was found in cell " + std::to_string(elem->id()) + 
-                                          " which is of type " + Utility::enum_to_string(elem->type()) + '\n' + 
-                                          "The edge intersection check only works for EDGE2 elements";
+            std::string element_message =
+                "Edge of type " + Utility::enum_to_string(edge->type()) + " was found in cell " +
+                std::to_string(elem->id()) + " which is of type " +
+                Utility::enum_to_string(elem->type()) + '\n' +
+                "The edge intersection check only works for EDGE2 elements";
             _console << element_message << std::endl;
             continue;
           }
           if (other_edge->type() != EDGE2)
           {
-            std::string element_message = "Edge of type " + Utility::enum_to_string(other_edge->type()) + " was found in cell " + std::to_string(other_elem->id()) + 
-                                          " which is of type " + Utility::enum_to_string(other_elem->type()) + '\n' + 
-                                          "The edge intersection check only works for EDGE2 elements";
+            std::string element_message =
+                "Edge of type " + Utility::enum_to_string(other_edge->type()) +
+                " was found in cell " + std::to_string(other_elem->id()) + " which is of type " +
+                Utility::enum_to_string(other_elem->type()) + '\n' +
+                "The edge intersection check only works for EDGE2 elements";
             _console << element_message << std::endl;
             continue;
           }

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -16,6 +16,7 @@
 #include "libmesh/node.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/point_locator_base.h"
+#include "libmesh/utility.h"
 
 namespace MeshBaseDiagnosticsUtils
 {

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -93,11 +93,11 @@ checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
     is close enough to 0 return true The shortest line between the two edges will be perpendicular
     to both.
   */
-  const auto d1343 = (p1-p3)*(p4-p3);
-  const auto d4321 = (p4-p3)*(p2-p1);
-  const auto d1321 = (p1-p3)*(p2-p1);
-  const auto d4343 = (p4-p3)*(p4-p3);
-  const auto d2121 = (p2-p1)*(p2-p1);
+  const auto d1343 = (p1 - p3) * (p4 - p3);
+  const auto d4321 = (p4 - p3) * (p2 - p1);
+  const auto d1321 = (p1 - p3) * (p2 - p1);
+  const auto d4343 = (p4 - p3) * (p4 - p3);
+  const auto d2121 = (p2 - p1) * (p2 - p1);
 
   const auto denominator = d2121 * d4343 - d4321 * d4321;
   const auto numerator = d1343 * d4321 - d1321 * d4343;

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -70,14 +70,14 @@ checkNonConformalMesh(const std::unique_ptr<MeshBase> & mesh,
 
 bool
 checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
-                 const std::unique_ptr<Elem> & edge2,
-                 std::vector<double> & intersection_coords,
-                 const Real intersection_tol)
+                           const std::unique_ptr<Elem> & edge2,
+                           std::vector<double> & intersection_coords,
+                           const Real intersection_tol)
 {
-  //check that the two elements are of type EDGE2
-  mooseAssert(edge1->side_type(*(edge1->side_index_range()).end())==0,
+  // check that the two elements are of type EDGE2
+  mooseAssert(edge1->side_type(*(edge1->side_index_range()).end()) == 0,
               "Elements must be of type EDGE2");
-  mooseAssert(edge2->side_type(*(edge2->side_index_range()).end())==0,
+  mooseAssert(edge2->side_type(*(edge2->side_index_range()).end()) == 0,
               "Elements must be of type EDGE2");
   // Get nodes from the two edges
   const Node * const n1 = edge1->get_nodes()[0];
@@ -108,11 +108,16 @@ checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
     is close enough to 0 return true The shortest line between the two edges will be perpendicular
     to both.
   */
-  const auto d1343 = (n1x - n3x) * (n4x - n3x) + (n1y - n3y) * (n4y - n3y) + (n1z - n3z) * (n4z - n3z);
-  const auto d4321 = (n4x - n3x) * (n2x - n1x) + (n4y - n3y) * (n2y - n1y) + (n4z - n3z) * (n2z - n1z);
-  const auto d1321 = (n1x - n3x) * (n2x - n1x) + (n1y - n3y) * (n2y - n1y) + (n1z - n3z) * (n2z - n1z);
-  const auto d4343 = (n4x - n3x) * (n4x - n3x) + (n4y - n3y) * (n4y - n3y) + (n4z - n3z) * (n4z - n3z);
-  const auto d2121 = (n2x - n1x) * (n2x - n1x) + (n2y - n1y) * (n2y - n1y) + (n2z - n1z) * (n2z - n1z);
+  const auto d1343 =
+      (n1x - n3x) * (n4x - n3x) + (n1y - n3y) * (n4y - n3y) + (n1z - n3z) * (n4z - n3z);
+  const auto d4321 =
+      (n4x - n3x) * (n2x - n1x) + (n4y - n3y) * (n2y - n1y) + (n4z - n3z) * (n2z - n1z);
+  const auto d1321 =
+      (n1x - n3x) * (n2x - n1x) + (n1y - n3y) * (n2y - n1y) + (n1z - n3z) * (n2z - n1z);
+  const auto d4343 =
+      (n4x - n3x) * (n4x - n3x) + (n4y - n3y) * (n4y - n3y) + (n4z - n3z) * (n4z - n3z);
+  const auto d2121 =
+      (n2x - n1x) * (n2x - n1x) + (n2y - n1y) * (n2y - n1y) + (n2z - n1z) * (n2z - n1z);
 
   const auto denominator = d2121 * d4343 - d4321 * d4321;
   const auto numerator = d1343 * d4321 - d1321 * d4343;
@@ -141,8 +146,8 @@ checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
     return false;
 
   // Calculate distance between these two nodes
-  const auto distance =
-      std::sqrt(Utility::pow<2>(nax - nbx) + Utility::pow<2>(nay - nby) + Utility::pow<2>(naz - nbz));
+  const auto distance = std::sqrt(Utility::pow<2>(nax - nbx) + Utility::pow<2>(nay - nby) +
+                                  Utility::pow<2>(naz - nbz));
   if (distance < intersection_tol)
   {
     intersection_coords[0] = nax;

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -70,7 +70,7 @@ checkNonConformalMesh(const std::unique_ptr<MeshBase> & mesh,
 
 bool
 checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
-                           const std::unique_ptr<Elem> & edge2,
+                           const std::unique_ptr<const Elem> & edge2,
                            Point & intersection_point,
                            const Real intersection_tol)
 {

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -69,32 +69,37 @@ checkNonConformalMesh(const std::unique_ptr<MeshBase> & mesh,
 }
 
 bool
-checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
+checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                  const std::unique_ptr<Elem> & edge2,
                  std::vector<double> & intersection_coords,
                  const Real intersection_tol)
 {
+  //check that the two elements are of type EDGE2
+  mooseAssert(edge1->side_type(*(edge1->side_index_range()).end())==0,
+              "Elements must be of type EDGE2");
+  mooseAssert(edge2->side_type(*(edge2->side_index_range()).end())==0,
+              "Elements must be of type EDGE2");
   // Get nodes from the two edges
-  const Node * n1 = edge1->get_nodes()[0];
-  const Node * n2 = edge1->get_nodes()[1];
-  const Node * n3 = edge2->get_nodes()[0];
-  const Node * n4 = edge2->get_nodes()[1];
+  const Node * const n1 = edge1->get_nodes()[0];
+  const Node * const n2 = edge1->get_nodes()[1];
+  const Node * const n3 = edge2->get_nodes()[0];
+  const Node * const n4 = edge2->get_nodes()[1];
 
   // get x,y,z coordinates for each node
-  auto n1x = n1->operator()(0);
-  auto n1y = n1->operator()(1);
-  auto n1z = n1->operator()(2);
-  auto n2x = n2->operator()(0);
-  auto n2y = n2->operator()(1);
-  auto n2z = n2->operator()(2);
-  auto n3x = n3->operator()(0);
-  auto n3y = n3->operator()(1);
-  auto n3z = n3->operator()(2);
-  auto n4x = n4->operator()(0);
-  auto n4y = n4->operator()(1);
-  auto n4z = n4->operator()(2);
+  const auto n1x = n1->operator()(0);
+  const auto n1y = n1->operator()(1);
+  const auto n1z = n1->operator()(2);
+  const auto n2x = n2->operator()(0);
+  const auto n2y = n2->operator()(1);
+  const auto n2z = n2->operator()(2);
+  const auto n3x = n3->operator()(0);
+  const auto n3y = n3->operator()(1);
+  const auto n3z = n3->operator()(2);
+  const auto n4x = n4->operator()(0);
+  const auto n4y = n4->operator()(1);
+  const auto n4z = n4->operator()(2);
 
-  // Check that none of these points are the same
+  // Check that the two edges are not sharing a node
   if (n1->id() == n3->id() || n1->id() == n4->id() || n2->id() == n3->id() || n2->id() == n4->id())
     return false;
 
@@ -103,30 +108,30 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
     is close enough to 0 return true The shortest line between the two edges will be perpendicular
     to both.
   */
-  auto d1343 = (n1x - n3x) * (n4x - n3x) + (n1y - n3y) * (n4y - n3y) + (n1z - n3z) * (n4z - n3z);
-  auto d4321 = (n4x - n3x) * (n2x - n1x) + (n4y - n3y) * (n2y - n1y) + (n4z - n3z) * (n2z - n1z);
-  auto d1321 = (n1x - n3x) * (n2x - n1x) + (n1y - n3y) * (n2y - n1y) + (n1z - n3z) * (n2z - n1z);
-  auto d4343 = (n4x - n3x) * (n4x - n3x) + (n4y - n3y) * (n4y - n3y) + (n4z - n3z) * (n4z - n3z);
-  auto d2121 = (n2x - n1x) * (n2x - n1x) + (n2y - n1y) * (n2y - n1y) + (n2z - n1z) * (n2z - n1z);
+  const auto d1343 = (n1x - n3x) * (n4x - n3x) + (n1y - n3y) * (n4y - n3y) + (n1z - n3z) * (n4z - n3z);
+  const auto d4321 = (n4x - n3x) * (n2x - n1x) + (n4y - n3y) * (n2y - n1y) + (n4z - n3z) * (n2z - n1z);
+  const auto d1321 = (n1x - n3x) * (n2x - n1x) + (n1y - n3y) * (n2y - n1y) + (n1z - n3z) * (n2z - n1z);
+  const auto d4343 = (n4x - n3x) * (n4x - n3x) + (n4y - n3y) * (n4y - n3y) + (n4z - n3z) * (n4z - n3z);
+  const auto d2121 = (n2x - n1x) * (n2x - n1x) + (n2y - n1y) * (n2y - n1y) + (n2z - n1z) * (n2z - n1z);
 
-  auto denominator = d2121 * d4343 - d4321 * d4321;
-  auto numerator = d1343 * d4321 - d1321 * d4343;
+  const auto denominator = d2121 * d4343 - d4321 * d4321;
+  const auto numerator = d1343 * d4321 - d1321 * d4343;
 
   if (std::fabs(denominator) < intersection_tol)
     // This indicates that the two lines are parallel so they don't intersect
     return false;
 
-  auto mua = numerator / denominator;
-  auto mub = (d1343 + (mua * d4321)) / d4343;
+  const auto mua = numerator / denominator;
+  const auto mub = (d1343 + (mua * d4321)) / d4343;
 
   // Use these values to solve for the two points that define the shortest line segment
-  auto nax = n1x + mua * (n2x - n1x);
-  auto nay = n1y + mua * (n2y - n1y);
-  auto naz = n1z + mua * (n2z - n1z);
+  const auto nax = n1x + mua * (n2x - n1x);
+  const auto nay = n1y + mua * (n2y - n1y);
+  const auto naz = n1z + mua * (n2z - n1z);
 
-  auto nbx = n3x + mub * (n4x - n3x);
-  auto nby = n3y + mub * (n4y - n3y);
-  auto nbz = n3z + mub * (n4z - n3z);
+  const auto nbx = n3x + mub * (n4x - n3x);
+  const auto nby = n3y + mub * (n4y - n3y);
+  const auto nbz = n3z + mub * (n4z - n3z);
 
   // This method assume the two lines are infinite. This check to make sure na and nb are part of
   // their respective line segments
@@ -136,8 +141,8 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
     return false;
 
   // Calculate distance between these two nodes
-  double distance =
-      std::sqrt(std::pow(nax - nbx, 2) + std::pow(nay - nby, 2) + std::pow(naz - nbz, 2));
+  const auto distance =
+      std::sqrt(Utility::pow<2>(nax - nbx) + Utility::pow<2>(nay - nby) + Utility::pow<2>(naz - nbz));
   if (distance < intersection_tol)
   {
     intersection_coords[0] = nax;

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -75,10 +75,8 @@ checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                            const Real intersection_tol)
 {
   // check that the two elements are of type EDGE2
-  mooseAssert(edge1->type() == 0,
-              "Elements must be of type EDGE2");
-  mooseAssert(edge2->type() == 0,
-              "Elements must be of type EDGE2");
+  mooseAssert(edge1->type() == 0, "Elements must be of type EDGE2");
+  mooseAssert(edge2->type() == 0, "Elements must be of type EDGE2");
   // Get nodes from the two edges
   const Node * const n1 = edge1->get_nodes()[0];
   const Node * const n2 = edge1->get_nodes()[1];

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -16,7 +16,6 @@
 #include "libmesh/node.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/point_locator_base.h"
-#include "libmesh/utility.h"
 
 namespace MeshBaseDiagnosticsUtils
 {

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -75,8 +75,8 @@ checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                            const Real intersection_tol)
 {
   // check that the two elements are of type EDGE2
-  mooseAssert(edge1->type() == 0, "Elements must be of type EDGE2");
-  mooseAssert(edge2->type() == 0, "Elements must be of type EDGE2");
+  mooseAssert(edge1->type() == EDGE2, "Elements must be of type EDGE2");
+  mooseAssert(edge2->type() == EDGE2, "Elements must be of type EDGE2");
   // Get nodes from the two edges
   const Node * const n1 = edge1->get_nodes()[0];
   const Node * const n2 = edge1->get_nodes()[1];

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -67,4 +67,99 @@ checkNonConformalMesh(const std::unique_ptr<MeshBase> & mesh,
   }
   pl->unset_close_to_point_tol();
 }
+
+bool
+checkEdgeOverlap(const std::unique_ptr<Elem> & edge1, 
+                 const std::unique_ptr<Elem> & edge2,
+                 double tol)
+{
+  //get node array from two edges
+  const auto & node_list1 = edge1->get_nodes();
+  const auto & node_list2 = edge2->get_nodes();
+
+  //make sure two edges are not the same and don't share any nodes edge before checking for overlap
+  auto & n1 = (*node_list1)[0];
+  auto & n2 = (*node_list1)[-1];
+  auto & n3 = (*node_list2)[0];
+  auto & n4 = (*node_list2)[-1];
+  //auto num_nodes = node_list1->size();
+  //const Point *p1, *p2, *p3, *p4;
+  //const Point * const p1 = n1;
+  //const Point * const p2 = n2;
+  //const Point * const p3 = n3;
+  //const Point * const p4 = n4;
+
+  auto n1x = n1.operator()(0);
+  auto n1y = n1.operator()(1);
+  auto n1z = n1.operator()(2);
+  auto n2x = n2.operator()(0);
+  auto n2y = n2.operator()(1);
+  auto n2z = n2.operator()(2);
+  auto n3x = n3.operator()(0);
+  auto n3y = n3.operator()(1);
+  auto n3z = n3.operator()(2);
+  auto n4x = n4.operator()(0);
+  auto n4y = n4.operator()(1);
+  auto n4z = n4.operator()(2);
+
+  if(std::abs(n1x-n3x)<tol && std::abs(n1y-n3y)<tol && std::abs(n1z-n3z)<tol) 
+    return false;
+  if(std::abs(n2x-n4x)<tol && std::abs(n2y-n4y)<tol && std::abs(n2z-n4z)<tol)
+    return false;
+  if(std::abs(n1x-n4x)<tol && std::abs(n1y-n4y)<tol && std::abs(n1z-n4z)<tol) 
+    return false;
+  if(std::abs(n2x-n3x)<tol && std::abs(n2y-n3y)<tol && std::abs(n2z-n3z)<tol)
+    return false;
+
+  /*
+  if((n1x == n4x && n1y == n4y && n1z == n4z) && (n2x == n3x && n2y == n3y && n1z == n3z))
+  {
+    //Then these are the same edge so this test doen't apply
+    return false;
+  }
+  */
+
+  //There's a chance that they overlap. Find shortest line that connects two edges and if its length is close enough to 0 return true
+  double n13x, n13y, n13z, n21x, n21y, n21z, n43x, n43y, n43z;
+  double d1343, d4321, d1321, d4343, d2121, numerator, denominator, mua, mub;
+
+  n13x = n1x - n3x;
+  n13y = n1y - n3y;
+  n13z = n1z - n3z;
+  n21x = n2x - n1x;
+  n21y = n2y - n1y;
+  n21z = n2z - n1z;
+  n43x = n4x - n3x;
+  n43y = n4y - n3y;
+  n43z = n4z - n3z;
+
+  d1343 = n13x * n43x + n13y * n43y + n13z * n43z;
+  d4321 = n43x * n21x + n43y * n21y + n43z * n21z;
+  d1321 = n13x * n21x + n13y * n21y + n13z * n21z;
+  d4343 = n43x * n43x + n43y * n43y + n43z * n43z;
+  d2121 = n21x * n21x + n21y * n21y + n21z * n21z;
+
+  denominator = d2121 * d4343 - d4321 * d4321;
+  numerator = d1343 * d4321 - d1321 * d4343;
+
+  mua = numerator/denominator;
+  mub = (d1343 + (mua * d4321)) / d4343;
+
+  //Use these values to solve for the two poits that define the shortest line segment
+  double nax, nay, naz, nbx, nby, nbz;
+  nax = n1x + mua * n21x;
+  nay = n1y + mua * n21y;
+  naz = n1z + mua * n21z;
+
+  nbx = n3x + mub * n43x;
+  nby = n3y + mub * n43y;
+  nbz = n3z + mub * n43z;
+
+  //Calculate distance between these two nodes
+  double distance = std::sqrt(std::pow(nax - nbx, 2) + std::pow(nay - nby, 2) + std::pow(naz - nbz, 2));
+  if (distance < tol)
+    return true;
+  else
+    return false;
+}
 }

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -69,22 +69,22 @@ checkNonConformalMesh(const std::unique_ptr<MeshBase> & mesh,
 }
 
 bool
-checkEdgeOverlap(const std::unique_ptr<Elem> & edge1, 
+checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                  const std::unique_ptr<Elem> & edge2,
                  const ConsoleStream & console,
                  const Real intersection_tol)
 {
-  //get node array from two edges
+  // get node array from two edges
   const auto node_list1 = edge1->get_nodes();
   const auto node_list2 = edge2->get_nodes();
 
-  //make sure two edges are not the same and don't share any nodes edge before checking for overlap
+  // make sure two edges are not the same and don't share any nodes edge before checking for overlap
   auto n1 = *node_list1[0];
   auto n2 = *node_list1[1];
   auto n3 = *node_list2[0];
   auto n4 = *node_list2[1];
 
-  //get x,y,z coordinates for each point
+  // get x,y,z coordinates for each point
   auto n1x = n1.operator()(0);
   auto n1y = n1.operator()(1);
   auto n1z = n1.operator()(2);
@@ -98,16 +98,21 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
   auto n4y = n4.operator()(1);
   auto n4z = n4.operator()(2);
 
-  //Check that none of these points are the same
-  if(((std::fabs(n1x - n3x)<intersection_tol) && (std::fabs(n1y - n3y)<intersection_tol) && (std::fabs(n1z - n3z)<intersection_tol)) ||
-    ((std::fabs(n2x-n4x)<intersection_tol) && (std::fabs(n2y-n4y)<intersection_tol) && (std::fabs(n2z-n4z)<intersection_tol)) ||
-    ((std::fabs(n1x-n4x)<intersection_tol) && (std::fabs(n1y-n4y)<intersection_tol) && (std::fabs(n1z-n4z)<intersection_tol)) ||
-    ((std::fabs(n2x-n3x)<intersection_tol) && (std::fabs(n2y-n3y)<intersection_tol) && (std::fabs(n2z-n3z)<intersection_tol)))
+  // Check that none of these points are the same
+  if (((std::fabs(n1x - n3x) < intersection_tol) && (std::fabs(n1y - n3y) < intersection_tol) &&
+       (std::fabs(n1z - n3z) < intersection_tol)) ||
+      ((std::fabs(n2x - n4x) < intersection_tol) && (std::fabs(n2y - n4y) < intersection_tol) &&
+       (std::fabs(n2z - n4z) < intersection_tol)) ||
+      ((std::fabs(n1x - n4x) < intersection_tol) && (std::fabs(n1y - n4y) < intersection_tol) &&
+       (std::fabs(n1z - n4z) < intersection_tol)) ||
+      ((std::fabs(n2x - n3x) < intersection_tol) && (std::fabs(n2y - n3y) < intersection_tol) &&
+       (std::fabs(n2z - n3z) < intersection_tol)))
     return false;
 
   /*
-    There's a chance that they overlap. Find shortest line that connects two edges and if its length is close enough to 0 return true
-    The shortest line between the two edges will be perpendicular to both.
+    There's a chance that they overlap. Find shortest line that connects two edges and if its length
+    is close enough to 0 return true The shortest line between the two edges will be perpendicular
+    to both.
   */
   auto d1343 = (n1x - n3x) * (n4x - n3x) + (n1y - n3y) * (n4y - n3y) + (n1z - n3z) * (n4z - n3z);
   auto d4321 = (n4x - n3x) * (n2x - n1x) + (n4y - n3y) * (n2y - n1y) + (n4z - n3z) * (n2z - n1z);
@@ -118,15 +123,15 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
   auto denominator = d2121 * d4343 - d4321 * d4321;
   auto numerator = d1343 * d4321 - d1321 * d4343;
 
-  if(std::fabs(denominator) < intersection_tol)
+  if (std::fabs(denominator) < intersection_tol)
   {
-    //This indicates that the intersecting line is vertical so they don't intersect
+    // This indicates that the intersecting line is vertical so they don't intersect
     return false;
   }
-  auto mua = numerator/denominator;
+  auto mua = numerator / denominator;
   auto mub = (d1343 + (mua * d4321)) / d4343;
 
-  //Use these values to solve for the two poits that define the shortest line segment
+  // Use these values to solve for the two poits that define the shortest line segment
   auto nax = n1x + mua * (n2x - n1x);
   auto nay = n1y + mua * (n2y - n1y);
   auto naz = n1z + mua * (n2z - n1z);
@@ -135,29 +140,30 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
   auto nby = n3y + mub * (n4y - n3y);
   auto nbz = n3z + mub * (n4z - n3z);
 
-  //This method assume the two lines are infinite. This check to make sure na and nb are part of their respective line segments
-  if((nax < std::min(n1x, n2x)) || (nax > std::max(n1x, n2x)) ||
-     (nay < std::min(n1y, n2y)) || (nay > std::max(n1y, n2y)) ||
-     (naz < std::min(n1z, n2z)) || (naz > std::max(n1z, n2z)))
+  // This method assume the two lines are infinite. This check to make sure na and nb are part of
+  // their respective line segments
+  if ((nax < std::min(n1x, n2x)) || (nax > std::max(n1x, n2x)) || (nay < std::min(n1y, n2y)) ||
+      (nay > std::max(n1y, n2y)) || (naz < std::min(n1z, n2z)) || (naz > std::max(n1z, n2z)))
   {
     return false;
   }
 
-  if((nbx < std::min(n3x, n4x)) || (nax > std::max(n3x, n4x)) ||
-     (nby < std::min(n3y, n4y)) || (nay > std::max(n3y, n4y)) ||
-     (nbz < std::min(n3z, n4z)) || (naz > std::max(n3z, n4z)))
+  if ((nbx < std::min(n3x, n4x)) || (nax > std::max(n3x, n4x)) || (nby < std::min(n3y, n4y)) ||
+      (nay > std::max(n3y, n4y)) || (nbz < std::min(n3z, n4z)) || (naz > std::max(n3z, n4z)))
   {
     return false;
   }
 
-  //Calculate distance between these two nodes
-  double distance = std::sqrt(std::pow(nax - nbx, 2) + std::pow(nay - nby, 2) + std::pow(naz - nbz, 2));
+  // Calculate distance between these two nodes
+  double distance =
+      std::sqrt(std::pow(nax - nbx, 2) + std::pow(nay - nby, 2) + std::pow(naz - nbz, 2));
   if (distance < intersection_tol)
   {
     std::string x_coord = std::to_string(nax);
     std::string y_coord = std::to_string(nay);
     std::string z_coord = std::to_string(naz);
-    std::string message = "Non-matching edges found near (" + x_coord + ", " + y_coord + ", " + z_coord + ")";
+    std::string message =
+        "Non-matching edges found near (" + x_coord + ", " + y_coord + ", " + z_coord + ")";
     console << message << std::endl;
     return true;
   }

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -69,7 +69,7 @@ checkNonConformalMesh(const std::unique_ptr<MeshBase> & mesh,
 }
 
 bool
-checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
+checkFirstOrderEdgeOverlap(const std::unique_ptr<const Elem> & edge1,
                            const std::unique_ptr<const Elem> & edge2,
                            Point & intersection_point,
                            const Real intersection_tol)

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -75,9 +75,9 @@ checkFirstOrderEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                            const Real intersection_tol)
 {
   // check that the two elements are of type EDGE2
-  mooseAssert(edge1->side_type(*(edge1->side_index_range()).end()) == 0,
+  mooseAssert(edge1->type() == 0,
               "Elements must be of type EDGE2");
-  mooseAssert(edge2->side_type(*(edge2->side_index_range()).end()) == 0,
+  mooseAssert(edge2->type() == 0,
               "Elements must be of type EDGE2");
   // Get nodes from the two edges
   const Node * const n1 = edge1->get_nodes()[0];

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -74,14 +74,19 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                  double tol)
 {
   //get node array from two edges
-  const auto & node_list1 = edge1->get_nodes();
-  const auto & node_list2 = edge2->get_nodes();
+  const auto node_list1 = edge1->get_nodes();
+  const auto node_list2 = edge2->get_nodes();
 
   //make sure two edges are not the same and don't share any nodes edge before checking for overlap
-  auto & n1 = (*node_list1)[0];
-  auto & n2 = (*node_list1)[-1];
-  auto & n3 = (*node_list2)[0];
-  auto & n4 = (*node_list2)[-1];
+  auto n1 = *node_list1[0];
+  auto n2 = *node_list1[1];
+  auto n3 = *node_list2[0];
+  auto n4 = *node_list2[1];
+  //auto size1 = sizeof(*node_list1);
+  //auto size2 = std::size(*node_list1);
+  //if(size1 < 3){
+    //return false;
+  //}
   //auto num_nodes = node_list1->size();
   //const Point *p1, *p2, *p3, *p4;
   //const Point * const p1 = n1;
@@ -89,27 +94,48 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
   //const Point * const p3 = n3;
   //const Point * const p4 = n4;
 
-  auto n1x = n1.operator()(0);
-  auto n1y = n1.operator()(1);
-  auto n1z = n1.operator()(2);
-  auto n2x = n2.operator()(0);
-  auto n2y = n2.operator()(1);
-  auto n2z = n2.operator()(2);
-  auto n3x = n3.operator()(0);
-  auto n3y = n3.operator()(1);
-  auto n3z = n3.operator()(2);
-  auto n4x = n4.operator()(0);
-  auto n4y = n4.operator()(1);
-  auto n4z = n4.operator()(2);
+  double n1x = 1.0*(n1.operator()(0));
+  double n1y = 1.0*(n1.operator()(1));
+  double n1z = 1.0*(n1.operator()(2));
+  double n2x = 1.0*(n2.operator()(0));
+  double n2y = 1.0*(n2.operator()(1));
+  double n2z = 1.0*(n2.operator()(2));
+  double n3x = 1.0*(n3.operator()(0));
+  double n3y = 1.0*(n3.operator()(1));
+  double n3z = 1.0*(n3.operator()(2));
+  double n4x = 1.0*(n4.operator()(0));
+  double n4y = 1.0*(n4.operator()(1));
+  double n4z = 1.0*(n4.operator()(2));
 
-  if(std::abs(n1x-n3x)<tol && std::abs(n1y-n3y)<tol && std::abs(n1z-n3z)<tol) 
+  //double n13x, n13y, n13z, n21x, n21y, n21z, n43x, n43y, n43z;
+  double n13x = n1x - n3x;
+  double n13y = n1y - n3y;
+  double n13z = n1z - n3z;
+  double n21x = n2x - n1x;
+  double n21y = n2y - n1y;
+  double n21z = n2z - n1z;
+  double n43x = n4x - n3x;
+  double n43y = n4y - n3y;
+  double n43z = n4z - n3z;
+
+  //double n13xfabs = std::fabs(n13x);
+  //double n13xabs = std::abs(n13x);
+  if((std::fabs(n1x - n3x)<tol) && (std::fabs(n1y - n3y)<tol) && (std::fabs(n1z - n3z)<tol))
+  { 
     return false;
-  if(std::abs(n2x-n4x)<tol && std::abs(n2y-n4y)<tol && std::abs(n2z-n4z)<tol)
+  }
+  else if((std::fabs(n2x-n4x)<tol) && (std::fabs(n2y-n4y)<tol) && (std::fabs(n2z-n4z)<tol))
+  { 
     return false;
-  if(std::abs(n1x-n4x)<tol && std::abs(n1y-n4y)<tol && std::abs(n1z-n4z)<tol) 
+  }
+  else if((std::fabs(n1x-n4x)<tol) && (std::fabs(n1y-n4y)<tol) && (std::fabs(n1z-n4z)<tol)) 
+  {
     return false;
-  if(std::abs(n2x-n3x)<tol && std::abs(n2y-n3y)<tol && std::abs(n2z-n3z)<tol)
+  }
+  else if((std::fabs(n2x-n3x)<tol) && (std::fabs(n2y-n3y)<tol) && (std::fabs(n2z-n3z)<tol))
+  {
     return false;
+  }
 
   /*
   if((n1x == n4x && n1y == n4y && n1z == n4z) && (n2x == n3x && n2y == n3y && n1z == n3z))
@@ -120,18 +146,7 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
   */
 
   //There's a chance that they overlap. Find shortest line that connects two edges and if its length is close enough to 0 return true
-  double n13x, n13y, n13z, n21x, n21y, n21z, n43x, n43y, n43z;
   double d1343, d4321, d1321, d4343, d2121, numerator, denominator, mua, mub;
-
-  n13x = n1x - n3x;
-  n13y = n1y - n3y;
-  n13z = n1z - n3z;
-  n21x = n2x - n1x;
-  n21y = n2y - n1y;
-  n21z = n2z - n1z;
-  n43x = n4x - n3x;
-  n43y = n4y - n3y;
-  n43z = n4z - n3z;
 
   d1343 = n13x * n43x + n13y * n43y + n13z * n43z;
   d4321 = n43x * n21x + n43y * n21y + n43z * n21z;
@@ -142,6 +157,11 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
   denominator = d2121 * d4343 - d4321 * d4321;
   numerator = d1343 * d4321 - d1321 * d4343;
 
+  if(std::fabs(denominator) < tol)
+  {
+    //This indicates that the intersecting line is vertical so they don't intersect
+    return false;
+  }
   mua = numerator/denominator;
   mub = (d1343 + (mua * d4321)) / d4343;
 
@@ -154,6 +174,21 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
   nbx = n3x + mub * n43x;
   nby = n3y + mub * n43y;
   nbz = n3z + mub * n43z;
+
+  //This method assume the two lines are infinite. This check to make sure na and nb are part of their respective line segments
+  if((nax < std::min(n1x, n2x)) || (nax > std::max(n1x, n2x)) ||
+     (nay < std::min(n1y, n2y)) || (nay > std::max(n1y, n2y)) ||
+     (naz < std::min(n1z, n2z)) || (naz > std::max(n1z, n2z)))
+  {
+    return false;
+  }
+
+  if((nbx < std::min(n3x, n4x)) || (nax > std::max(n3x, n4x)) ||
+     (nby < std::min(n3y, n4y)) || (nay > std::max(n3y, n4y)) ||
+     (nbz < std::min(n3z, n4z)) || (naz > std::max(n3z, n4z)))
+  {
+    return false;
+  }
 
   //Calculate distance between these two nodes
   double distance = std::sqrt(std::pow(nax - nbx, 2) + std::pow(nay - nby, 2) + std::pow(naz - nbz, 2));

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -71,7 +71,7 @@ checkNonConformalMesh(const std::unique_ptr<MeshBase> & mesh,
 bool
 checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
                  const std::unique_ptr<Elem> & edge2,
-                 std::vector<double> &intersection_coords,
+                 std::vector<double> & intersection_coords,
                  const Real intersection_tol)
 {
   // Get nodes from the two edges
@@ -95,8 +95,7 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
   auto n4z = n4->operator()(2);
 
   // Check that none of these points are the same
-  if (n1->id() == n3->id() || n1->id() == n4->id() ||
-      n2->id() == n3->id() || n2->id() == n4->id())
+  if (n1->id() == n3->id() || n1->id() == n4->id() || n2->id() == n3->id() || n2->id() == n4->id())
     return false;
 
   /*
@@ -135,7 +134,7 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
     return false;
   if (mub < 0 || mub > 1)
     return false;
-  
+
   // Calculate distance between these two nodes
   double distance =
       std::sqrt(std::pow(nax - nbx, 2) + std::pow(nay - nby, 2) + std::pow(naz - nbz, 2));

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -69,19 +69,19 @@ checkNonConformalMesh(const std::unique_ptr<MeshBase> & mesh,
 }
 
 bool
-checkFirstOrderEdgeOverlap(const std::unique_ptr<const Elem> & edge1,
-                           const std::unique_ptr<const Elem> & edge2,
+checkFirstOrderEdgeOverlap(const Elem & edge1,
+                           const Elem & edge2,
                            Point & intersection_point,
                            const Real intersection_tol)
 {
   // check that the two elements are of type EDGE2
-  mooseAssert(edge1->type() == EDGE2, "Elements must be of type EDGE2");
-  mooseAssert(edge2->type() == EDGE2, "Elements must be of type EDGE2");
+  mooseAssert(edge1.type() == EDGE2, "Elements must be of type EDGE2");
+  mooseAssert(edge2.type() == EDGE2, "Elements must be of type EDGE2");
   // Get nodes from the two edges
-  const Point & p1 = edge1->point(0);
-  const Point & p2 = edge1->point(1);
-  const Point & p3 = edge2->point(0);
-  const Point & p4 = edge2->point(1);
+  const Point & p1 = edge1.point(0);
+  const Point & p2 = edge1.point(1);
+  const Point & p3 = edge2.point(0);
+  const Point & p4 = edge2.point(1);
 
   // Check that the two edges are not sharing a node
   if (p1 == p3 || p1 == p4 || p2 == p3 || p2 == p4)

--- a/framework/src/utils/MeshBaseDiagnosticsUtils.C
+++ b/framework/src/utils/MeshBaseDiagnosticsUtils.C
@@ -71,7 +71,7 @@ checkNonConformalMesh(const std::unique_ptr<MeshBase> & mesh,
 bool
 checkEdgeOverlap(const std::unique_ptr<Elem> & edge1, 
                  const std::unique_ptr<Elem> & edge2,
-                 double tol)
+                 const ConsoleStream & console)
 {
   //get node array from two edges
   const auto node_list1 = edge1->get_nodes();
@@ -82,68 +82,40 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
   auto n2 = *node_list1[1];
   auto n3 = *node_list2[0];
   auto n4 = *node_list2[1];
-  //auto size1 = sizeof(*node_list1);
-  //auto size2 = std::size(*node_list1);
-  //if(size1 < 3){
-    //return false;
-  //}
-  //auto num_nodes = node_list1->size();
-  //const Point *p1, *p2, *p3, *p4;
-  //const Point * const p1 = n1;
-  //const Point * const p2 = n2;
-  //const Point * const p3 = n3;
-  //const Point * const p4 = n4;
 
-  double n1x = 1.0*(n1.operator()(0));
-  double n1y = 1.0*(n1.operator()(1));
-  double n1z = 1.0*(n1.operator()(2));
-  double n2x = 1.0*(n2.operator()(0));
-  double n2y = 1.0*(n2.operator()(1));
-  double n2z = 1.0*(n2.operator()(2));
-  double n3x = 1.0*(n3.operator()(0));
-  double n3y = 1.0*(n3.operator()(1));
-  double n3z = 1.0*(n3.operator()(2));
-  double n4x = 1.0*(n4.operator()(0));
-  double n4y = 1.0*(n4.operator()(1));
-  double n4z = 1.0*(n4.operator()(2));
+  auto n1x = 1.0*(n1.operator()(0));
+  auto n1y = 1.0*(n1.operator()(1));
+  auto n1z = 1.0*(n1.operator()(2));
+  auto n2x = 1.0*(n2.operator()(0));
+  auto n2y = 1.0*(n2.operator()(1));
+  auto n2z = 1.0*(n2.operator()(2));
+  auto n3x = 1.0*(n3.operator()(0));
+  auto n3y = 1.0*(n3.operator()(1));
+  auto n3z = 1.0*(n3.operator()(2));
+  auto n4x = 1.0*(n4.operator()(0));
+  auto n4y = 1.0*(n4.operator()(1));
+  auto n4z = 1.0*(n4.operator()(2));
 
+  //Tolerance should be based on edge length. Here it is arbitrarily set to 1/1000th of the average of the two edge lengths
+  auto edge1Length = std::sqrt(std::pow(n1x - n2x, 2) + std::pow(n1y - n2y, 2) + std::pow(n1z - n2z, 2));
+  auto edge2Length = std::sqrt(std::pow(n3x - n4x, 2) + std::pow(n3y - n4y, 2) + std::pow(n3z - n4z, 2));
+  auto tol = ((edge1Length + edge2Length)/2)/1000;
   //double n13x, n13y, n13z, n21x, n21y, n21z, n43x, n43y, n43z;
-  double n13x = n1x - n3x;
-  double n13y = n1y - n3y;
-  double n13z = n1z - n3z;
-  double n21x = n2x - n1x;
-  double n21y = n2y - n1y;
-  double n21z = n2z - n1z;
-  double n43x = n4x - n3x;
-  double n43y = n4y - n3y;
-  double n43z = n4z - n3z;
+  auto n13x = n1x - n3x;
+  auto n13y = n1y - n3y;
+  auto n13z = n1z - n3z;
+  auto n21x = n2x - n1x;
+  auto n21y = n2y - n1y;
+  auto n21z = n2z - n1z;
+  auto n43x = n4x - n3x;
+  auto n43y = n4y - n3y;
+  auto n43z = n4z - n3z;
 
-  //double n13xfabs = std::fabs(n13x);
-  //double n13xabs = std::abs(n13x);
-  if((std::fabs(n1x - n3x)<tol) && (std::fabs(n1y - n3y)<tol) && (std::fabs(n1z - n3z)<tol))
-  { 
+  if(((std::fabs(n1x - n3x)<tol) && (std::fabs(n1y - n3y)<tol) && (std::fabs(n1z - n3z)<tol)) ||
+    ((std::fabs(n2x-n4x)<tol) && (std::fabs(n2y-n4y)<tol) && (std::fabs(n2z-n4z)<tol)) ||
+    ((std::fabs(n1x-n4x)<tol) && (std::fabs(n1y-n4y)<tol) && (std::fabs(n1z-n4z)<tol)) ||
+    ((std::fabs(n2x-n3x)<tol) && (std::fabs(n2y-n3y)<tol) && (std::fabs(n2z-n3z)<tol)))
     return false;
-  }
-  else if((std::fabs(n2x-n4x)<tol) && (std::fabs(n2y-n4y)<tol) && (std::fabs(n2z-n4z)<tol))
-  { 
-    return false;
-  }
-  else if((std::fabs(n1x-n4x)<tol) && (std::fabs(n1y-n4y)<tol) && (std::fabs(n1z-n4z)<tol)) 
-  {
-    return false;
-  }
-  else if((std::fabs(n2x-n3x)<tol) && (std::fabs(n2y-n3y)<tol) && (std::fabs(n2z-n3z)<tol))
-  {
-    return false;
-  }
-
-  /*
-  if((n1x == n4x && n1y == n4y && n1z == n4z) && (n2x == n3x && n2y == n3y && n1z == n3z))
-  {
-    //Then these are the same edge so this test doen't apply
-    return false;
-  }
-  */
 
   //There's a chance that they overlap. Find shortest line that connects two edges and if its length is close enough to 0 return true
   double d1343, d4321, d1321, d4343, d2121, numerator, denominator, mua, mub;
@@ -193,7 +165,14 @@ checkEdgeOverlap(const std::unique_ptr<Elem> & edge1,
   //Calculate distance between these two nodes
   double distance = std::sqrt(std::pow(nax - nbx, 2) + std::pow(nay - nby, 2) + std::pow(naz - nbz, 2));
   if (distance < tol)
+  {
+    std::string x_coord = std::to_string(nax);
+    std::string y_coord = std::to_string(nay);
+    std::string z_coord = std::to_string(naz);
+    std::string message = "Non-matching edges found near (" + x_coord + ", " + y_coord + ", " + z_coord + ")";
+    console << message << std::endl;
     return true;
+  }
   else
     return false;
 }

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/all_at_once.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/all_at_once.i
@@ -15,7 +15,7 @@
     examine_nonplanar_sides = INFO
     examine_sidesets_orientation = WARNING
     check_for_watertight_sidesets = WARNING
-    check_for_watertight_nodesets = WARNING    
+    check_for_watertight_nodesets = WARNING
     examine_non_matching_edges = WARNING
     search_for_adaptivity_nonconformality = WARNING
     check_local_jacobian = WARNING

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/all_at_once.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/all_at_once.i
@@ -15,7 +15,8 @@
     examine_nonplanar_sides = INFO
     examine_sidesets_orientation = WARNING
     check_for_watertight_sidesets = WARNING
-    check_for_watertight_nodesets = WARNING
+    check_for_watertight_nodesets = WARNING    
+    examine_non_matching_edges = WARNING
     search_for_adaptivity_nonconformality = WARNING
     check_local_jacobian = WARNING
   []

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/intersecting_edge_test.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/intersecting_edge_test.i
@@ -1,0 +1,66 @@
+[Mesh]
+  [gmg1]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 2
+    ny = 2
+    nz = 2
+    xmin = -0.5
+    xmax = 0.5
+    ymin = -0.5
+    ymax = 0.5
+    zmin = -1.5
+    zmax = -0.5
+  []
+  [gmg2]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 2
+    ny = 2
+    nz = 2
+    xmin = -0.5
+    xmax = 0.5
+    ymin = -0.5
+    ymax = 0.5
+    zmin = -0.5
+    zmax = 0.5
+  []
+  [block_1]
+    type = ParsedSubdomainMeshGenerator
+    input = gmg1
+    combinatorial_geometry = 'z < -0.5'
+    block_id = 1
+  []
+  [block_2]
+    type = ParsedSubdomainMeshGenerator
+    input = gmg2
+    combinatorial_geometry = 'z > 0.5'
+    block_id = 2
+  []
+  [convert1]
+    type = ElementsToTetrahedronsConverter
+    input = 'block_1'
+  []
+  [convert2]
+    type = ElementsToTetrahedronsConverter
+    input = 'block_2'
+  []
+  [rotate]
+    type = TransformGenerator
+    input = convert2
+    transform = 'rotate'
+    vector_value = '180 0 0'
+  []
+  [cmbn]
+    type = CombinerGenerator
+    inputs = 'convert1 rotate'
+  []
+  [diag]
+    type = MeshDiagnosticsGenerator
+    input = cmbn
+    examine_non_matching_edges = INFO
+  []
+[]
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/intersecting_edge_test.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/intersecting_edge_test.i
@@ -51,13 +51,14 @@
     transform = 'rotate'
     vector_value = '180 0 0'
   []
-  [cmbn]
-    type = CombinerGenerator
+  [stitch]
+    type = StitchedMeshGenerator
     inputs = 'convert1 rotate'
+    stitch_boundaries_pairs = 'front back'
   []
   [diag]
     type = MeshDiagnosticsGenerator
-    input = cmbn
+    input = stitch
     examine_non_matching_edges = INFO
   []
 []

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/tests
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/tests
@@ -13,6 +13,13 @@
       expect_out = 'Number of non-conformal nodes: 3'
       detail = 'element overlapping,'
     []
+    [intersecting_edges]
+      type = RunApp
+      input = 'intersecting_edge_test.i'
+      cli_args = '--mesh-only'
+      mesh_mode = replicated
+      expect_out = 'Number of intersecting edges: 4'
+    []
     [inconsistent_sidesets]
       type = RunApp
       input = 'consistent_domains.i'
@@ -269,7 +276,8 @@
                   Mesh/diag/examine_nonplanar_sides=NO_CHECK
                   Mesh/diag/examine_sidesets_orientation=NO_CHECK
                   Mesh/diag/check_for_watertight_sidesets=NO_CHECK
-                  Mesh/diag/check_for_watertight_nodesets=NO_CHECK
+                  Mesh/diag/check_for_watertight_nodesets=NO_CHECK   
+                  Mesh/diag/examine_non_matching_edges=NO_CHECK
                   Mesh/diag/search_for_adaptivity_nonconformality=NO_CHECK
                   Mesh/diag/check_local_jacobian=NO_CHECK --mesh-only"
       detail = 'a diagnostics object is created but no diagnostics are requested.'

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/tests
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/tests
@@ -18,7 +18,7 @@
       input = 'intersecting_edge_test.i'
       cli_args = '--mesh-only'
       mesh_mode = replicated
-      expect_out = 'Number of intersecting edges: 4'
+      expect_out = 'Number of intersecting element edges: 4'
       detail = 'edges intersecting'
     []
     [inconsistent_sidesets]

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/tests
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/tests
@@ -19,6 +19,7 @@
       cli_args = '--mesh-only'
       mesh_mode = replicated
       expect_out = 'Number of intersecting edges: 4'
+      detail = 'edges intersecting'
     []
     [inconsistent_sidesets]
       type = RunApp


### PR DESCRIPTION
## Reason
It is possible for non-matching edges to be created when using MOOSE's convert hexahedral to tetrahedral tool. This adds a new mesh diagnostic tool that can check for non-matching/intersecting edges.

## Design
The function compares each element to nearby elements. If they are close to each other, then the edges from each are checked for overlap. To check for overlap the shortest line that connects the two edges is calculated. If that line's length is less than the user specified tolerance then it's counted as overlapping and info about the location of the intersection is printed, along with the total number of intersecting edge pairs.

## Impact
Users can now include examine_non_matching_edges = INFO/WARNING/NO_CHECK as a mesh diagnostics option. Users can also specify overlap tolerance by including intersection_tol but this is not necessary.

closes #26596 
