### PR TITLE
Add some checks in reactor module for bad subdomain / boundaries inputs

### DIFF
--- a/modules/reactor/src/meshgenerators/AzimuthalBlockSplitGenerator.C
+++ b/modules/reactor/src/meshgenerators/AzimuthalBlockSplitGenerator.C
@@ -117,7 +117,9 @@ AzimuthalBlockSplitGenerator::generate()
   for (unsigned int i = 0; i < _old_block_ids.size(); i++)
     if (_old_block_ids[i] == Moose::INVALID_BLOCK_ID || !mesh_blocks.count(_old_block_ids[i]))
       paramError("old_blocks",
-                 "This parameter contains blocks that do not exist in the input mesh.");
+                 "This parameter contains blocks that do not exist in the input mesh. Error "
+                 "triggered by block: " +
+                     getParam<std::vector<SubdomainName>>("old_blocks")[i]);
 
   if (std::find(_old_block_ids.begin(),
                 _old_block_ids.end(),

--- a/modules/reactor/src/meshgenerators/DepletionIDGenerator.C
+++ b/modules/reactor/src/meshgenerators/DepletionIDGenerator.C
@@ -27,7 +27,7 @@ DepletionIDGenerator::validParams()
   params.addParam<std::vector<ExtraElementIDName>>(
       "exclude_id_name", "Extra ID names that need to be excluded in the depletion ID generation");
   params.addParam<std::vector<std::vector<dof_id_type>>>(
-      "exclude_id_value", "Extra ID values correponding to names defined in `exclude_id_name`");
+      "exclude_id_value", "Extra ID values corresponding to names defined in `exclude_id_name`");
   params.addClassDescription("This DepletionIDGenerator source code is to assign depletion IDs for "
                              "elements on a mesh based on material and other extra element IDs.");
   return params;

--- a/modules/reactor/src/meshgenerators/PatternedPolygonPeripheralModifierBase.C
+++ b/modules/reactor/src/meshgenerators/PatternedPolygonPeripheralModifierBase.C
@@ -85,6 +85,9 @@ PatternedPolygonPeripheralModifierBase::generate()
   // Load boundary information
   _input_mesh_external_bid =
       MooseMeshUtils::getBoundaryID(_input_mesh_external_boundary, *input_mesh);
+  if (_input_mesh_external_bid == Moose::INVALID_BOUNDARY_ID)
+    paramError("input_mesh_external_boundary",
+               "External boundary does not exist in the input mesh");
   std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> side_list =
       input_mesh->get_boundary_info().build_side_list();
   input_mesh->get_boundary_info().build_node_list_from_side_list();

--- a/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
@@ -162,6 +162,9 @@ PeripheralRingMeshGenerator::generate()
 
   _input_mesh_external_bid =
       MooseMeshUtils::getBoundaryID(_input_mesh_external_boundary, *input_mesh);
+  if (!MooseMeshUtils::hasBoundaryName(*input_mesh, _input_mesh_external_boundary))
+    paramError("input_mesh_external_boundary",
+               "External boundary does not exist in the input mesh");
   // We check the element types of input mesh's external boundary here.
   // We support both linear and quadratic sides (i.e., EDGE2 and EDGE3), but we cannot support mixed
   // sides

--- a/modules/reactor/src/meshgenerators/SubdomainExtraElementIDGenerator.C
+++ b/modules/reactor/src/meshgenerators/SubdomainExtraElementIDGenerator.C
@@ -54,6 +54,11 @@ SubdomainExtraElementIDGenerator::generate()
   // construct a map from the subdomain ID to the index in 'subdomains'
   auto subdomain_ids = MooseMeshUtils::getSubdomainIDs(*mesh, _subdomain_names);
 
+  // check that all subdomains are present
+  for (const auto & name : _subdomain_names)
+    if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
+      paramError("subdomains", "Subdomain " + name + " does not exist in the mesh");
+
   // check to make sure no duplicated subdomain ids
   std::set<SubdomainID> unique_subdomain_ids;
   for (const auto & id : subdomain_ids)

--- a/modules/reactor/test/tests/meshgenerators/peripheral_ring_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/peripheral_ring_mesh_generator/tests
@@ -173,4 +173,15 @@
     requirement ='The system shall throw an error if the given external boundary is actually an internal boundary of the input mesh.'
     mesh_mode = 'REPLICATED'
   []
+  [err_non_existing_boundary]
+    type = 'RunException'
+    input = 'core_ring.i'
+    cli_args = 'Mesh/fmg/file=input_mesh_err.e
+                Mesh/pr/input_mesh_external_boundary=12345
+                Mesh/inactive=tg
+                --mesh-only'
+    expect_err = 'External boundary does not exist in the input mesh'
+    requirement ='The system shall throw an error if the given external boundary does not exist in the input mesh.'
+    mesh_mode = 'REPLICATED'
+  []
 []

--- a/modules/reactor/test/tests/meshgenerators/revolve_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/revolve_generator/tests
@@ -70,10 +70,10 @@
     [simple_tri_270]
       type = 'Exodiff'
       input = 'simple_revolve.i'
-      cli_args = '--mesh-only simple_revolve_tri_270.e 
-                  Mesh/rg/revolving_angles=270.0 
-                  Mesh/rg/start_boundary=123 
-                  Mesh/rg/end_boundary=456 
+      cli_args = '--mesh-only simple_revolve_tri_270.e
+                  Mesh/rg/revolving_angles=270.0
+                  Mesh/rg/start_boundary=123
+                  Mesh/rg/end_boundary=456
                   Mesh/rg/preserve_volumes=true'
       exodiff = 'simple_revolve_tri_270.e'
       recover = false
@@ -82,8 +82,8 @@
     [simple_tri_-270]
       type = 'Exodiff'
       input = 'simple_revolve.i'
-      cli_args = '--mesh-only simple_revolve_tri_-270.e 
-                  Mesh/rg/revolving_angles=270.0 
+      cli_args = '--mesh-only simple_revolve_tri_-270.e
+                  Mesh/rg/revolving_angles=270.0
                   Mesh/rg/clockwise=false'
       exodiff = 'simple_revolve_tri_-270.e'
       recover = false
@@ -92,7 +92,7 @@
     [simple_tri_vol_preserve]
       type = 'Exodiff'
       input = 'simple_revolve.i'
-      cli_args = '--mesh-only simple_revolve_tri_vp.e 
+      cli_args = '--mesh-only simple_revolve_tri_vp.e
                   Mesh/rg/preserve_volumes=true'
       exodiff = 'simple_revolve_tri_vp.e'
       recover = false
@@ -101,8 +101,8 @@
     [simple_tri_on_axis_1]
       type = 'Exodiff'
       input = 'simple_revolve.i'
-      cli_args = '--mesh-only simple_revolve_tri_oa.e 
-                  Mesh/rg/axis_point="0.0 1.15470053838 0.0" 
+      cli_args = '--mesh-only simple_revolve_tri_oa.e
+                  Mesh/rg/axis_point="0.0 1.15470053838 0.0"
                   Mesh/rg/axis_direction="1.0 0.0 0.0"'
       exodiff = 'simple_revolve_tri_oa.e'
       recover = false
@@ -111,8 +111,8 @@
     [simple_tri_on_axis_2]
       type = 'Exodiff'
       input = 'simple_revolve.i'
-      cli_args = '--mesh-only simple_revolve_tri_oa_2.e 
-                  Mesh/rg/axis_point="-1.0 0.0 0.0" 
+      cli_args = '--mesh-only simple_revolve_tri_oa_2.e
+                  Mesh/rg/axis_point="-1.0 0.0 0.0"
                   Mesh/rg/axis_direction="0.0 1.0 0.0"'
       exodiff = 'simple_revolve_tri_oa_2.e'
       recover = false
@@ -121,7 +121,7 @@
     [simple_quad]
       type = 'Exodiff'
       input = 'simple_revolve.i'
-      cli_args = '--mesh-only simple_revolve_quad.e 
+      cli_args = '--mesh-only simple_revolve_quad.e
                   Mesh/shg/element_type=QUAD'
       exodiff = 'simple_revolve_quad.e'
       recover = false
@@ -130,9 +130,9 @@
     [simple_quad_on_axis_1]
       type = 'Exodiff'
       input = 'simple_revolve.i'
-      cli_args = '--mesh-only simple_revolve_quad_oa.e 
-                  Mesh/rg/axis_point="0.0 1.15470053838 0.0" 
-                  Mesh/rg/axis_direction="1.0 0.0 0.0" 
+      cli_args = '--mesh-only simple_revolve_quad_oa.e
+                  Mesh/rg/axis_point="0.0 1.15470053838 0.0"
+                  Mesh/rg/axis_direction="1.0 0.0 0.0"
                   Mesh/shg/element_type=QUAD'
       exodiff = 'simple_revolve_quad_oa.e'
       recover = false
@@ -141,9 +141,9 @@
     [simple_quad_on_axis_2]
       type = 'Exodiff'
       input = 'simple_revolve.i'
-      cli_args = '--mesh-only simple_revolve_quad_oa_2.e 
-                  Mesh/rg/axis_point="-1.0 0.0 0.0" 
-                  Mesh/rg/axis_direction="0.0 1.0 0.0" 
+      cli_args = '--mesh-only simple_revolve_quad_oa_2.e
+                  Mesh/rg/axis_point="-1.0 0.0 0.0"
+                  Mesh/rg/axis_direction="0.0 1.0 0.0"
                   Mesh/shg/element_type=QUAD'
       exodiff = 'simple_revolve_quad_oa_2.e'
       recover = false
@@ -152,10 +152,10 @@
     [simple_hybrid]
       type = 'Exodiff'
       input = 'simple_revolve.i'
-      cli_args = '--mesh-only simple_revolve_hybrid.e 
-                  Mesh/shg/element_type=HYBRID 
-                  Mesh/shg/block_id="100 200" 
-                  Mesh/shg/block_name="block_tri block_quad" 
+      cli_args = '--mesh-only simple_revolve_hybrid.e
+                  Mesh/shg/element_type=HYBRID
+                  Mesh/shg/block_id="100 200"
+                  Mesh/shg/block_name="block_tri block_quad"
                   Mesh/shg/radial_intervals=2'
       exodiff = 'simple_revolve_hybrid.e'
       recover = false
@@ -172,7 +172,7 @@
     [multi_tri_partial]
       type = 'Exodiff'
       input = 'multi_revolve.i'
-      cli_args = '--mesh-only multi_revolve_tri_partial.e 
+      cli_args = '--mesh-only multi_revolve_tri_partial.e
                   Mesh/rg/revolving_angles="120 180"'
       exodiff = 'multi_revolve_tri_partial.e'
       recover = false
@@ -196,7 +196,7 @@
     [revolve_1d_single]
       type = 'Exodiff'
       input = 'revolve_1d.i'
-      cli_args = '--mesh-only revolve_1d_s_in.e 
+      cli_args = '--mesh-only revolve_1d_s_in.e
                   Mesh/gmg/nx=1'
       exodiff = 'revolve_1d_s_in.e'
       recover = false
@@ -231,7 +231,7 @@
     [err_3d_input]
       type = 'RunException'
       input = 'revolve_2d.i'
-      cli_args = '--mesh-only err_revolve_2d.e 
+      cli_args = '--mesh-only err_revolve_2d.e
                   Mesh/gmg/dim=3'
       expect_err = 'This mesh generator only works for 1D and 2D input meshes.'
       detail = "if input mesh has an inappropriate dimension."
@@ -239,7 +239,7 @@
     [err_1d_nonverticle]
       type = 'RunException'
       input = 'revolve_1d.i'
-      cli_args = '--mesh-only err_revolve_1d.e 
+      cli_args = '--mesh-only err_revolve_1d.e
                   Mesh/rg/axis_direction="-1.0 1.0 0.0"'
       expect_err = 'The 1D input mesh is not perpendicular to the rotation axis'
       detail = "if input 1D mesh is not perpendicular to the rotation axis."
@@ -247,7 +247,7 @@
     [err_input_centroid_on_axis]
       type = 'RunException'
       input = 'revolve_1d.i'
-      cli_args = '--mesh-only err_revolve_1d.e 
+      cli_args = '--mesh-only err_revolve_1d.e
                   Mesh/rg/axis_point="0.5 0.0 0.0"'
       expect_err = 'The input mesh is either across the axis or overlapped with the axis'
       detail = "if the input 1D mesh has its centroid overlapped with the rotation axis."
@@ -255,7 +255,7 @@
     [err_1d_input_across_axis]
       type = 'RunException'
       input = 'revolve_1d.i'
-      cli_args = '--mesh-only err_revolve_1d.e 
+      cli_args = '--mesh-only err_revolve_1d.e
                   Mesh/rg/axis_point="0.3 0.0 0.0"'
       expect_err = 'The input mesh is across the axis'
       detail = "if the input 1D mesh is across the rotation axis."
@@ -263,7 +263,7 @@
     [err_2d_input_across_axis]
       type = 'RunException'
       input = 'revolve_2d.i'
-      cli_args = '--mesh-only err_revolve_2d.e 
+      cli_args = '--mesh-only err_revolve_2d.e
                   Mesh/rg/axis_point="0.3 0.0 0.0"'
       expect_err = 'The input mesh is across the axis'
       detail = "if the input 2D mesh is across the rotation axis."
@@ -271,10 +271,18 @@
     [err_input_off_plane]
       type = 'RunException'
       input = 'revolve_1d.i'
-      cli_args = '--mesh-only err_revolve_1d.e 
+      cli_args = '--mesh-only err_revolve_1d.e
                   Mesh/rg/axis_point="0.0 0.0 1.0"'
       expect_err = 'The input mesh is not in the same plane with the rotation axis'
       detail = "the input 1D mesh is not coplanar to the rotation axis."
     []
-  []  
+    [err_bad_block_swap]
+      type = 'RunException'
+      input = 'multi_revolve.i'
+      cli_args = "--mesh-only bad_swap.e
+                  Mesh/rg/subdomain_swaps=' ;13021 300 13021 400'"
+      expect_err = 'Source subdomain 13021 was not found in the mesh'
+      detail = "the source subdomain for a subdomain swap does not exist in the mesh."
+    []
+  []
 []

--- a/modules/reactor/test/tests/meshgenerators/subdomain_extra_element_id_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/subdomain_extra_element_id_generator/tests
@@ -26,6 +26,13 @@
       expect_err = 'Cannot have subdomain with ID 1 listed more than once!'
       detail = 'a subdomain is listed more than once when assigning extra element IDs'
     []
+    [non_existing_subdomain]
+      type = RunException
+      input = 'subdomain_elem_ids_test.i'
+      cli_args = "Mesh/subdomain_ids/subdomains='1234 sub1 2 sub3'"
+      expect_err = 'Subdomain 1234 does not exist in the mesh'
+      detail = 'a subdomain listed by the user does not exist in the mesh'
+    []
     [diff_size1]
       type = RunException
       input = 'subdomain_elem_ids_test.i'


### PR DESCRIPTION
refs #22117 

there are still some swap checks we could add for RevolveGenerator
and we could start adding more checks for extra element ids. this is a step in the right direction