### PR TITLE
remove unecessary gold file of raleigh-bernard test

### DIFF
--- a/modules/navier_stokes/test/tests/finite_volume/two_phase/mixture_model/gold/rayleigh-bernard-two-phase_CSV.csv
+++ b/modules/navier_stokes/test/tests/finite_volume/two_phase/mixture_model/gold/rayleigh-bernard-two-phase_CSV.csv
@@ -1,2 +1,0 @@
-time,average_void,max_drag_coefficient,max_x_slip_velocity,max_x_velocity,max_y_slip_velocity,max_y_velocity,min_x_velocity,min_y_velocity
-100000000,0.63164526969771,1.0944684774357,0.0034920207171246,0.064928198698841,0.0032870680232468,0.083763786666914,-0.064928198698841,-0.095198974217213


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

In #28707, Raleigh-Bernard test is changed from CSVDiff to RunApp due to multiple solutions available for the problem. The csv gold file is not needed. This PR is created to clean up.
