### PR TITLE
Water tight sideset check

### DIFF
--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -60,7 +60,7 @@ private:
 
   /// whether to check that sidesets are consistently oriented using neighbor subdomains
   const MooseEnum _check_sidesets_orientation;
-  //// whether to check that each side is assigned to a sideset
+  //// whether to check that each external side is assigned to a sideset
   const MooseEnum _check_watertight_sidesets;
   /// whether to check element volumes
   const MooseEnum _check_element_volumes;

--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -31,6 +31,8 @@ protected:
 private:
   /// Routine to check sideset orientation near subdomains
   void checkSidesetsOrientation(const std::unique_ptr<MeshBase> & mesh) const;
+  //// Routine to check is mesh is fully covered in sidesets
+  void checkWaterTightSidesets(const std::unique_ptr<MeshBase> & mesh) const;
   /// Routine to check the element volumes
   void checkElementVolumes(const std::unique_ptr<MeshBase> & mesh) const;
   /// Routine to check the element types in each subdomain
@@ -58,6 +60,8 @@ private:
 
   /// whether to check that sidesets are consistently oriented using neighbor subdomains
   const MooseEnum _check_sidesets_orientation;
+  //// whether to check that each side is assigned to a sideset
+  const MooseEnum _check_watertight_sidesets;
   /// whether to check element volumes
   const MooseEnum _check_element_volumes;
   /// minimum size for element volume to be counted as a tiny element

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -41,10 +41,9 @@ MeshDiagnosticsGenerator::validParams()
       chk_option,
       "whether to check that sidesets are consistently oriented using neighbor subdomains. If a "
       "sideset is inconsistently oriented within a subdomain, this will not be detected");
-  params.addParam<MooseEnum>(
-      "check_for_watertight_sidesets",
-      chk_option,
-      "whether to check for sides that are not assigned to any sidesets");
+  params.addParam<MooseEnum>("check_for_watertight_sidesets",
+                             chk_option,
+                             "whether to check for sides that are not assigned to any sidesets");
   params.addParam<MooseEnum>(
       "examine_element_volumes", chk_option, "whether to examine volume of the elements");
   params.addParam<Real>("minimum_element_volumes", 1e-16, "minimum size for element volume");
@@ -103,10 +102,10 @@ MeshDiagnosticsGenerator::MeshDiagnosticsGenerator(const InputParameters & param
     paramError("examine_non_conformality",
                "You must set this parameter to true to trigger mesh conformality check");
   if (_check_sidesets_orientation == "NO_CHECK" && _check_watertight_sidesets == "NO_CHECK" &&
-      _check_element_volumes == "NO_CHECK" &&
-      _check_element_types == "NO_CHECK" && _check_element_overlap == "NO_CHECK" &&
-      _check_non_planar_sides == "NO_CHECK" && _check_non_conformal_mesh == "NO_CHECK" &&
-      _check_adaptivity_non_conformality == "NO_CHECK" && _check_local_jacobian == "NO_CHECK")
+      _check_element_volumes == "NO_CHECK" && _check_element_types == "NO_CHECK" &&
+      _check_element_overlap == "NO_CHECK" && _check_non_planar_sides == "NO_CHECK" &&
+      _check_non_conformal_mesh == "NO_CHECK" && _check_adaptivity_non_conformality == "NO_CHECK" &&
+      _check_local_jacobian == "NO_CHECK")
     mooseError("You need to turn on at least one diagnostic. Did you misspell a parameter?");
 }
 
@@ -162,7 +161,7 @@ MeshDiagnosticsGenerator::checkSidesetsOrientation(const std::unique_ptr<MeshBas
   auto side_set = boundary_info.get_side_boundary_ids();
   boundary_info.build_node_list_from_side_list();
   auto nodeset_map = boundary_info.get_nodeset_map();
-  //auto & num_sides = mesh->n_sides();
+  // auto & num_sides = mesh->n_sides();
   for (const auto bid : boundary_info.get_boundary_ids())
   {
     // This check only looks at subdomains on both sides of the sideset
@@ -306,35 +305,39 @@ MeshDiagnosticsGenerator::checkWaterTightSidesets(const std::unique_ptr<MeshBase
       // Check if side is external
       if (elem->neighbor_ptr(i) == nullptr)
       {
-	// If external check if that side had a sideset 
+        // If external check if that side had a sideset
         auto side_itr = sideset_map.equal_range(elem);
-	bool has_boundary = false;
-	for (auto itr = side_itr.first; itr != side_itr.second; itr++)
-	{
-	  if (itr->second.first == i)
-	  {  
+        bool has_boundary = false;
+        for (auto itr = side_itr.first; itr != side_itr.second; itr++)
+        {
+          if (itr->second.first == i)
+          {
             has_boundary = true;
-	  }
-	}
+          }
+        }
         if (!has_boundary)
-	{
-	  // This side does not have a sideset!!!
+        {
+          // This side does not have a sideset!!!
           std::string message;
-	  if (mesh->mesh_dimension() == 3)
-	    message = "Element " + std::to_string(elem->id()) + " contains an external face which has not been assigned to a sideset";
+          if (mesh->mesh_dimension() == 3)
+            message = "Element " + std::to_string(elem->id()) +
+                      " contains an external face which has not been assigned to a sideset";
           else
-	    message = "Element " + std::to_string(elem->id()) + " contains an external edge which has not been assigned to a sideset";
-	  _console << message << std::endl;
-	  num_faces_without_sideset++;
-	}
+            message = "Element " + std::to_string(elem->id()) +
+                      " contains an external edge which has not been assigned to a sideset";
+          _console << message << std::endl;
+          num_faces_without_sideset++;
+        }
       }
-    }  
+    }
   }
   std::string message;
   if (mesh->mesh_dimension() == 3)
-    message = "Number of external element faces that have not been assigned to a sideset: " + std::to_string(num_faces_without_sideset);
+    message = "Number of external element faces that have not been assigned to a sideset: " +
+              std::to_string(num_faces_without_sideset);
   else
-    message = "Number of external element edges that have not been assigned to a sideset: " + std::to_string(num_faces_without_sideset);
+    message = "Number of external element edges that have not been assigned to a sideset: " +
+              std::to_string(num_faces_without_sideset);
   diagnosticsLog(message, _check_watertight_sidesets, num_faces_without_sideset);
 }
 

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -281,7 +281,7 @@ MeshDiagnosticsGenerator::checkWaterTightSidesets(const std::unique_ptr<MeshBase
   /*
   Algorithm Overview:
   1) Loop through all elements
-  2) For each element loop through all it's sides
+  2) For each element loop through all its sides
   3) If it has no neighbors it's an external side
   4) If external check if it's part of a sideset
   */
@@ -304,24 +304,23 @@ MeshDiagnosticsGenerator::checkWaterTightSidesets(const std::unique_ptr<MeshBase
         auto side_range = sideset_map.equal_range(elem);
         bool has_boundary = false;
         for (const auto & itr : as_range(side_range))
-        {
           if (itr.second.first == i)
-          {
             has_boundary = true;
-          }
-        }
         if (!has_boundary)
         {
           // This side does not have a sideset!!!
           std::string message;
-          if (mesh->mesh_dimension() == 3)
-            message = "Element " + std::to_string(elem->id()) +
-                      " contains an external face which has not been assigned to a sideset";
-          else
-            message = "Element " + std::to_string(elem->id()) +
-                      " contains an external edge which has not been assigned to a sideset";
-          _console << message << std::endl;
-          num_faces_without_sideset++;
+          if (num_faces_without_sideset < _num_outputs)
+          {
+            if (mesh->mesh_dimension() == 3)
+              message = "Element " + std::to_string(elem->id()) +
+                        " contains an external face which has not been assigned to a sideset";
+            else
+              message = "Element " + std::to_string(elem->id()) +
+                        " contains an external edge which has not been assigned to a sideset";
+            _console << message << std::endl;
+            num_faces_without_sideset++;
+          }
         }
       }
     }

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/2D_missing_sideset.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/2D_missing_sideset.i
@@ -1,0 +1,22 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 2
+    ny = 2
+  []
+  [deletion]
+    type = BoundaryDeletionGenerator
+    input = gmg
+    boundary_names = 'right'
+  []
+  [diag]
+    type = MeshDiagnosticsGenerator
+    input = deletion
+    check_for_watertight_sidesets = INFO
+  []
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/3D_missing_sideset.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/3D_missing_sideset.i
@@ -1,0 +1,23 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 2
+    ny = 2
+    nz = 2
+  []
+  [deletion]
+    type = BoundaryDeletionGenerator
+    input = gmg
+    boundary_names = 'right'
+  []
+  [diag]
+    type = MeshDiagnosticsGenerator
+    input = deletion
+    check_for_watertight_sidesets = INFO
+  []
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/all_at_once.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/all_at_once.i
@@ -14,6 +14,7 @@
     examine_non_conformality = WARNING
     examine_nonplanar_sides = INFO
     examine_sidesets_orientation = WARNING
+    check_for_watertight_sidesets = WARNING
     search_for_adaptivity_nonconformality = WARNING
     check_local_jacobian = WARNING
   []

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/tests
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/tests
@@ -29,6 +29,22 @@
       expect_out = 'Sideset bad_one \(4\) has two neighboring sides with a very large angle'
       detail = 'inconsistently oriented sidesets between two neighbor sides within the sideset,'
     []
+    [2D_watertight_sidesets]
+      type = 'RunApp'
+      input = '2D_missing_sideset.i'
+      cli_args = '--mesh-only'
+      mesh_mode = 'replicated'
+      expect_out = 'Number of external element edges that have not been assigned to a sideset: 2'
+      detail = '2D meshed square missing a sideset on one side'
+    []
+    [3D_Watertight_sidesets]
+      type = 'RunApp'
+      input = '3D_missing_sideset.i'
+      cli_args = '--mesh-only'
+      mesh_mode = 'replicated'
+      expect_out = 'Number of external element faces that have not been assigned to a sideset: 4'
+      detail = '3D meshed cube missing a sideset on one side'
+    []
     [overlap]
       type = 'RunApp'
       input = 'node_based_test.i'

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/tests
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/tests
@@ -252,6 +252,7 @@
                   Mesh/diag/examine_non_conformality=NO_CHECK
                   Mesh/diag/examine_nonplanar_sides=NO_CHECK
                   Mesh/diag/examine_sidesets_orientation=NO_CHECK
+                  Mesh/diag/check_for_watertight_sidesets=NO_CHECK
                   Mesh/diag/search_for_adaptivity_nonconformality=NO_CHECK
                   Mesh/diag/check_local_jacobian=NO_CHECK --mesh-only"
       detail = 'a diagnostics object is created but no diagnostics are requested.'


### PR DESCRIPTION
refs #25278

## Reason
This makes it easier for users to find issues with their meshes.

## Design
In the mesh block of an input file users can add check_for_watertight_sidesets = '...'. This check loops through all elements, finds the external faces/edges, and then checks if each one is part of a sideset. If not it prints our which elements have faces/edges missing sidesets. This only works for 2D and 3D meshes right now. For 2D it checks all external edges, and for 3D is checks all external faces.

## Impact
Adds a watertight sideset check to Mesh Diagnostics 