### PR TITLE
Use syntax for variable name in new apps registerSyntax to have constistency with syntax registration macro

### DIFF
--- a/stork/src/base/StorkApp.C.app
+++ b/stork/src/base/StorkApp.C.app
@@ -21,9 +21,9 @@ StorkApp::StorkApp(InputParameters parameters) : MooseApp(parameters)
 StorkApp::~StorkApp() {}
 
 void
-StorkApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
+StorkApp::registerAll(Factory & f, ActionFactory & af, Syntax & syntax)
 {
-  ModulesApp::registerAllObjects<StorkApp>(f, af, s);
+  ModulesApp::registerAllObjects<StorkApp>(f, af, syntax);
   Registry::registerObjectsTo(f, {"StorkApp"});
   Registry::registerActionsTo(af, {"StorkApp"});
 


### PR DESCRIPTION

closes #28830
