### PR TITLE
Turn off legacy initial residual evaluation behavior for darcy flow tutorial

### DIFF
--- a/tutorials/darcy_thermo_mech/step01_diffusion/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/src/base/DarcyThermoMechApp.C
@@ -22,6 +22,7 @@ DarcyThermoMechApp::validParams()
 
   params.set<bool>("automatic_automatic_scaling") = false;
   params.set<bool>("use_legacy_material_output") = false;
+  params.set<bool>("use_legacy_initial_residual_evaluation_behavior") = false;
 
   return params;
 }

--- a/tutorials/darcy_thermo_mech/step11_action/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step11_action/src/base/DarcyThermoMechApp.C
@@ -22,6 +22,7 @@ DarcyThermoMechApp::validParams()
 
   params.set<bool>("automatic_automatic_scaling") = false;
   params.set<bool>("use_legacy_material_output") = false;
+  params.set<bool>("use_legacy_initial_residual_evaluation_behavior") = false;
 
   return params;
 }


### PR DESCRIPTION
This PR sets the `use_legacy_initial_residual_evaluation_behavior` parameter in `DarcyThermoMechApp.C` to `false` for the darcy thermo mech tutorial.

This removes legacy warnings and pre-SMO residual output that confuses users and workshop attendees (as seen in the UIUC Workshop this week). 

Refs #23472
