### PR TITLE
libMesh submodule update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 1 %}
+{% set build = 0 %}
 {% set version = "2024.10.17" %}
 
 package:

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 1 %}
-{% set version = "2024.08.30" %}
+{% set version = "2024.10.17" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2024.10.17 mpich_1
-  - moose-libmesh 2024.10.17 openmpi_1
+  - moose-libmesh 2024.10.17 mpich_0
+  - moose-libmesh 2024.10.17 openmpi_0
 
 moose_wasp:
   - moose-wasp 2024.05.08

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2024.08.30 mpich_1
-  - moose-libmesh 2024.08.30 openmpi_1
+  - moose-libmesh 2024.10.17 mpich_1
+  - moose-libmesh 2024.10.17 openmpi_1
 
 moose_wasp:
   - moose-wasp 2024.05.08

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.10.01" %}
+{% set version = "2024.10.17" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2024.10.01
+  - moose-dev 2024.10.17
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=80e8b6c591a704cd426fb50f8cc05d97994b2241
+ARG LIBMESH_REV=5483644b60cc538a4b54d312f28835bd94107627
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/modules/doc/content/newsletter/2024/2024_10.md
+++ b/modules/doc/content/newsletter/2024/2024_10.md
@@ -9,6 +9,38 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2024.10.17` Update
+
+- Support for reading (the surface triangulations defined by) STL
+  files.  This combined with our recent tetrahedralization support
+  also allows for creating volume meshes from STL files; however,
+  creating high-quality volume meshes from arbitrary STL files is
+  still a work in progress.
+- Support for higher-order (up to quintic) vector-valued FE bases in
+  the Nédélec (first kind) and Ravier-Thomas FE families.
+- Better handling for odd IsoGeometric Analysis extraction operators,
+  and better error handling for broken IGA operators.
+- Better unit test coverage for NodeElem; fixes to NodeElem
+  methods which should be no-op but instead threw errors.
+- Unit test coverage for fifth-order `MONOMIAL` elements.  So far
+  new tests have not uncovered any problems, but based on user
+  reports of convergence issues we recommend limiting `MONOMIAL`
+  variables to fourth-order.
+- Fixes for condensed eigensolve support after mesh reinit
+- Fixes for caching of FE data on sides of meshes with non-uniform
+  p-refinement levels
+- Minor fixes for compiler complaints from `nvc++` and
+  `clang++ -fsanitize`
+- Properly register `--keep-cout` and `--drop-cerr` warnings with
+  PETSc to avoid "options you set that were not used" false positives.
+- Better error messages when tetrahedralizing a non-watertight input
+  boundary mesh.
+- Refactoring in AbaqusIO, to enable subclasses in MOOSE code with
+  experimental support for more advanced file features.
+- Improvements and fixes in Reduced Basis code, particularly the
+  Empirical Interpolation Method classes.
+
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -355,3 +355,10 @@ b9c32bf26ef2dc29535a2494fb64c7736bcd0d13: #28717
   libmesh: 0e90306
   moose-dev: 28a1964
   wasp: 33b8e6b
+1de06170ee9d9f633f569393a939b773d84efc74: #28880
+  tools: 27f74e0
+  mpi: 765e804
+  petsc: acb1bfc
+  libmesh: 4aafc7b
+  moose-dev: f3bb17f
+  wasp: 33b8e6b


### PR DESCRIPTION
- Support for reading (the surface triangulations defined by) STL files.  This combined with our recent tetrahedralization support also allows for creating volume meshes from STL files; however, creating high-quality volume meshes from arbitrary STL files is still a work in progress.
- Support for higher-order (up to quintic) vector-valued FE bases in the Nédélec (first kind) and Ravier-Thomas FE families.
- Better handling for odd IsoGeometric Analysis extraction operators, and better error handling for broken IGA operators.
- Better unit test coverage for NodeElem; fixes to NodeElem methods which should be no-op but instead threw errors.
- Unit test coverage for fifth-order `MONOMIAL` elements.  So far new tests have not uncovered any problems, but based on user reports of convergence issues we recommend limiting `MONOMIAL` variables to fourth-order.
- Fixes for condensed eigensolve support after mesh reinit
- Fixes for caching of FE data on sides of meshes with non-uniform p-refinement levels
- Minor fixes for compiler complaints from `nvc++` and `clang++ -fsanitize`
- Properly register `--keep-cout` and `--drop-cerr` warnings with PETSc to avoid "options you set that were not used" false positives.
- Better error messages when tetrahedralizing a non-watertight input boundary mesh.
- Refactoring in AbaqusIO, to enable subclasses in MOOSE code with experimental support for more advanced file features.
- Improvements and fixes in Reduced Basis code, particularly the Empirical Interpolation Method classes.