### PR TITLE
RunCommand job_slot control

### DIFF
--- a/python/TestHarness/testers/RunCommand.py
+++ b/python/TestHarness/testers/RunCommand.py
@@ -16,11 +16,18 @@ class RunCommand(Tester):
         params = Tester.validParams()
         params.addRequiredParam('command',      "The command line to execute for this test.")
         params.addParam('test_name',          "The name of the test - populated automatically")
+        params.addParam('job_slots',    1, "Inform the TestHarness how many cores this job is"
+                                           " expected to consume")
         return params
 
     def __init__(self, name, params):
         Tester.__init__(self, name, params)
         self.command = params['command']
+
+    def getSlots(self, options) ->int:
+        """ return param job slots, default to 1 if 0 is provided """
+        # insure zero can't be used
+        return max(1, int(self.specs['job_slots']))
 
     def getCommand(self, options):
         # Create the command line string to run

--- a/python/TestHarness/tests/test_Allocations.py
+++ b/python/TestHarness/tests/test_Allocations.py
@@ -101,3 +101,24 @@ class TestHarnessTester(TestHarnessTestCase):
         self.assertNotIn('MAX_CPUS', output)
         self.assertNotIn('OVERSIZED', output)
         self.assertRegex(output, 'tests/test_harness.allocation_test.*OK')
+
+    def testRunCommand(self):
+        """
+        RunCommand [insufficient slots] SKIP / OK check
+        """
+        output = self.runTests('--no-color', '-i', 'allocation_runcommand', '-j 2').decode('utf-8')
+        self.assertNotIn('OVERSIZED', output)
+        # -j 2 forces job_slots = 3, test to be skipped.
+        self.assertRegex(output, 'tests/test_harness.3_slots.*? \[INSUFFICIENT SLOTS\] SKIP')
+        # -j 2 allows job_slots = 2, test to pass without displaying oversized caveat
+        self.assertNotIn('OVERSIZED', output)
+        self.assertRegex(output, 'tests/test_harness.2_slots.*? OK')
+
+    def testRunCommandOversized(self):
+        """
+        RunCommand [OVERSIZED] caveat check
+        """
+        output = self.runTests('--no-color', '-i', 'allocation_runcommand').decode('utf-8')
+        # both tests should run and pass, but while alerting the user of being oversized
+        self.assertRegex(output, 'tests/test_harness.2_slots.*? \[OVERSIZED\] OK')
+        self.assertRegex(output, 'tests/test_harness.3_slots.*? \[OVERSIZED\] OK')

--- a/test/tests/test_harness/allocation_runcommand
+++ b/test/tests/test_harness/allocation_runcommand
@@ -1,0 +1,12 @@
+[Tests]
+  [./2_slots]
+    type = RunCommand
+    command = "true"
+    job_slots = 2
+  [../]
+  [./3_slots]
+    type = RunCommand
+    command = "true"
+    job_slots = 3
+  [../]
+[]


### PR DESCRIPTION
Seems simple enough. We already have a `getSlots` method, should be able to use that.

Closes #28900

