### PR TITLE
Fix SideIntegralPostprocessor error with FV variables and distributed mesh.

### DIFF
--- a/framework/src/postprocessors/SideIntegralPostprocessor.C
+++ b/framework/src/postprocessors/SideIntegralPostprocessor.C
@@ -28,7 +28,7 @@ SideIntegralPostprocessor::initialSetup()
 {
   SidePostprocessor::initialSetup();
 
-  if (!_qp_integration && _mesh.allFaceInfo().size() == 0)
+  if (!_qp_integration && _mesh.isFiniteVolumeInfoDirty())
     errorNoFaceInfo();
 }
 


### PR DESCRIPTION
closes #28919 
