### PR TITLE
Switch to using LibmeshPetscCall wrapper macros

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1174,9 +1174,7 @@ MooseApp::executeExecutioner()
   // run the simulation
   if (_use_executor && _executor)
   {
-    auto ierr = Moose::PetscSupport::petscSetupOutput(_command_line.get());
-    LIBMESH_CHKERR(ierr);
-
+    LibmeshPetscCall(Moose::PetscSupport::petscSetupOutput(_command_line.get()));
     _executor->init();
     errorCheck();
     auto result = _executor->exec();
@@ -1185,8 +1183,7 @@ MooseApp::executeExecutioner()
   }
   else if (_executioner)
   {
-    auto ierr = Moose::PetscSupport::petscSetupOutput(_command_line.get());
-    LIBMESH_CHKERR(ierr);
+    LibmeshPetscCall(Moose::PetscSupport::petscSetupOutput(_command_line.get()));
     _executioner->init();
     errorCheck();
     _executioner->execute();

--- a/framework/src/base/MooseInit.C
+++ b/framework/src/base/MooseInit.C
@@ -42,8 +42,7 @@ RegisterSigHandler()
 MooseInit::MooseInit(int argc, char * argv[], MPI_Comm COMM_WORLD_IN)
   : LibMeshInit(argc, argv, COMM_WORLD_IN)
 {
-  auto ierr = PetscPopSignalHandler(); // get rid of PETSc error handler
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(COMM_WORLD_IN, PetscPopSignalHandler()); // get rid of PETSc error handler
 
 // Set the number of OpenMP threads to the same as the number of threads libMesh is going to use
 #ifdef LIBMESH_HAVE_OPENMP

--- a/framework/src/convergence/DefaultNonlinearConvergence.C
+++ b/framework/src/convergence/DefaultNonlinearConvergence.C
@@ -103,38 +103,32 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int iter)
 
   SNES snes = system.getSNES();
 
-  PetscErrorCode ierr;
-
   // ||u||
   PetscReal xnorm;
-  ierr = SNESGetSolutionNorm(snes, &xnorm);
-  CHKERRABORT(_fe_problem.comm().get(), ierr);
+  LibmeshPetscCallA(_fe_problem.comm().get(), SNESGetSolutionNorm(snes, &xnorm));
 
   // ||r||
   PetscReal fnorm;
-  ierr = SNESGetFunctionNorm(snes, &fnorm);
-  CHKERRABORT(_fe_problem.comm().get(), ierr);
+  LibmeshPetscCallA(_fe_problem.comm().get(), SNESGetFunctionNorm(snes, &fnorm));
 
   // ||du||
   PetscReal snorm;
-  ierr = SNESGetUpdateNorm(snes, &snorm);
-  CHKERRABORT(_fe_problem.comm().get(), ierr);
+  LibmeshPetscCallA(_fe_problem.comm().get(), SNESGetUpdateNorm(snes, &snorm));
 
   // Get current number of function evaluations done by SNES
   PetscInt nfuncs;
-  ierr = SNESGetNumberFunctionEvals(snes, &nfuncs);
-  CHKERRABORT(_fe_problem.comm().get(), ierr);
+  LibmeshPetscCallA(_fe_problem.comm().get(), SNESGetNumberFunctionEvals(snes, &nfuncs));
 
   // Get tolerances from SNES
   PetscReal abs_tol, rel_tol, rel_step_tol;
   PetscInt max_its, max_funcs;
-  ierr = SNESGetTolerances(snes, &abs_tol, &rel_tol, &rel_step_tol, &max_its, &max_funcs);
-  CHKERRABORT(_fe_problem.comm().get(), ierr);
+  LibmeshPetscCallA(
+      _fe_problem.comm().get(),
+      SNESGetTolerances(snes, &abs_tol, &rel_tol, &rel_step_tol, &max_its, &max_funcs));
 
 #if !PETSC_VERSION_LESS_THAN(3, 8, 4)
   PetscBool force_iteration = PETSC_FALSE;
-  ierr = SNESGetForceIteration(snes, &force_iteration);
-  CHKERRABORT(_fe_problem.comm().get(), ierr);
+  LibmeshPetscCallA(_fe_problem.comm().get(), SNESGetForceIteration(snes, &force_iteration));
 
   // if PETSc says to force iteration, then force at least one iteration
   if (force_iteration && !(_nl_forced_its))
@@ -143,8 +137,7 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int iter)
   // if specified here to force iteration, but PETSc doesn't know, tell it
   if (!force_iteration && (_nl_forced_its))
   {
-    ierr = SNESSetForceIteration(snes, PETSC_TRUE);
-    CHKERRABORT(_fe_problem.comm().get(), ierr);
+    LibmeshPetscCallA(_fe_problem.comm().get(), SNESSetForceIteration(snes, PETSC_TRUE));
   }
 #endif
 
@@ -152,8 +145,7 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int iter)
   // SNESSetFunctionDomainError() and SNESGetFunctionDomainError()
   // were added in different releases of PETSc.
   PetscBool domainerror;
-  ierr = SNESGetFunctionDomainError(snes, &domainerror);
-  CHKERRABORT(_fe_problem.comm().get(), ierr);
+  LibmeshPetscCallA(_fe_problem.comm().get(), SNESGetFunctionDomainError(snes, &domainerror));
   if (domainerror)
     status = MooseConvergenceStatus::DIVERGED;
 
@@ -240,9 +232,9 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int iter)
     MooseUtils::indentMessage(_app.name(), msg);
   if (msg.length() > 0)
 #if !PETSC_VERSION_LESS_THAN(3, 17, 0)
-    ierr = PetscInfo(snes, "%s", msg.c_str());
+    LibmeshPetscCallA(_fe_problem.comm().get(), PetscInfo(snes, "%s", msg.c_str()));
 #else
-    ierr = PetscInfo(snes, msg.c_str());
+    LibmeshPetscCallA(_fe_problem.comm().get(), PetscInfo(snes, msg.c_str()));
 #endif
 
   verboseOutput(oss);

--- a/framework/src/executioners/Eigenvalue.C
+++ b/framework/src/executioners/Eigenvalue.C
@@ -197,16 +197,13 @@ Eigenvalue::prepareSolverOptions()
   {
     // Master app has the default data base
     if (!_app.isUltimateMaster())
-    {
-      auto ierr = PetscOptionsPush(_eigen_problem.petscOptionsDatabase());
-      LIBMESH_CHKERR(ierr);
-    }
+      LibmeshPetscCall(PetscOptionsPush(_eigen_problem.petscOptionsDatabase()));
+
     Moose::SlepcSupport::slepcSetOptions(_eigen_problem, _pars);
+
     if (!_app.isUltimateMaster())
-    {
-      auto ierr = PetscOptionsPop();
-      LIBMESH_CHKERR(ierr);
-    }
+      LibmeshPetscCall(PetscOptionsPop());
+
     _eigen_problem.petscOptionsInserted() = true;
   }
 #endif

--- a/framework/src/outputs/PetscOutput.C
+++ b/framework/src/outputs/PetscOutput.C
@@ -238,17 +238,16 @@ PetscOutput::solveSetup()
   NonlinearSystemBase & nl = _problem_ptr->currentNonlinearSystem();
   SNES snes = nl.getSNES();
   KSP ksp;
-  auto ierr = SNESGetKSP(snes, &ksp);
-  CHKERRABORT(_communicator.get(), ierr);
+  LibmeshPetscCallA(_communicator.get(), SNESGetKSP(snes, &ksp));
 
   // Set the PETSc monitor functions (register the nonlinear callback so that linear outputs
   // get an updated nonlinear iteration number)
   // Not every Output should register its own DM monitor! Just register one each of nonlinear
   // and linear and dispatch all Outputs from there!
-  ierr = SNESMonitorSet(snes, petscNonlinearOutput, this, LIBMESH_PETSC_NULLPTR);
-  CHKERRABORT(_communicator.get(), ierr);
-  ierr = KSPMonitorSet(ksp, petscLinearOutput, this, LIBMESH_PETSC_NULLPTR);
-  CHKERRABORT(_communicator.get(), ierr);
+  LibmeshPetscCallA(_communicator.get(),
+                    SNESMonitorSet(snes, petscNonlinearOutput, this, LIBMESH_PETSC_NULLPTR));
+  LibmeshPetscCallA(_communicator.get(),
+                    KSPMonitorSet(ksp, petscLinearOutput, this, LIBMESH_PETSC_NULLPTR));
 }
 
 Real

--- a/framework/src/problems/EigenProblem.C
+++ b/framework/src/problems/EigenProblem.C
@@ -540,10 +540,7 @@ EigenProblem::solve(const unsigned int nl_sys_num)
 #if !PETSC_RELEASE_LESS_THAN(3, 12, 0)
   // Master has the default database
   if (!_app.isUltimateMaster())
-  {
-    auto ierr = PetscOptionsPush(_petsc_option_data_base);
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(PetscOptionsPush(_petsc_option_data_base));
 #endif
 
   setCurrentNonlinearSystem(nl_sys_num);
@@ -615,10 +612,7 @@ EigenProblem::solve(const unsigned int nl_sys_num)
 
 #if !PETSC_RELEASE_LESS_THAN(3, 12, 0)
   if (!_app.isUltimateMaster())
-  {
-    auto ierr = PetscOptionsPop();
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(PetscOptionsPop());
 #endif
 
   // sync solutions in displaced problem

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -587,10 +587,7 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
 #if !PETSC_RELEASE_LESS_THAN(3, 12, 0)
   // Main app should hold the default database to handle system petsc options
   if (!_app.isUltimateMaster())
-  {
-    auto ierr = PetscOptionsCreate(&_petsc_option_data_base);
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(PetscOptionsCreate(&_petsc_option_data_base));
 #endif
 
   if (!_solve)
@@ -6221,10 +6218,8 @@ FEProblemBase::solve(const unsigned int nl_sys_num)
   // Now this database will be the default
   // Each app should have only one database
   if (!_app.isUltimateMaster())
-  {
-    auto ierr = PetscOptionsPush(_petsc_option_data_base);
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(PetscOptionsPush(_petsc_option_data_base));
+
   // We did not add PETSc options to database yet
   if (!_is_petsc_options_inserted)
   {
@@ -6261,10 +6256,7 @@ FEProblemBase::solve(const unsigned int nl_sys_num)
 
 #if !PETSC_RELEASE_LESS_THAN(3, 12, 0)
   if (!_app.isUltimateMaster())
-  {
-    auto ierr = PetscOptionsPop();
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(PetscOptionsPop());
 #endif
 }
 
@@ -6378,17 +6370,14 @@ FEProblemBase::solveLinearSystem(const unsigned int linear_sys_num,
   solver_params._line_search = Moose::LineSearchType::LS_NONE;
 
 #if PETSC_RELEASE_LESS_THAN(3, 12, 0)
-  auto ierr = Moose::PetscSupport::petscSetOptions(
-      options, solver_params); // Make sure the PETSc options are setup for this app
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCall(Moose::PetscSupport::petscSetOptions(
+      options, solver_params)); // Make sure the PETSc options are setup for this app
 #else
   // Now this database will be the default
   // Each app should have only one database
   if (!_app.isUltimateMaster())
-  {
-    auto ierr = PetscOptionsPush(_petsc_option_data_base);
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(PetscOptionsPush(_petsc_option_data_base));
+
   // We did not add PETSc options to database yet
   if (!_is_petsc_options_inserted)
   {
@@ -6402,10 +6391,7 @@ FEProblemBase::solveLinearSystem(const unsigned int linear_sys_num,
 
 #if !PETSC_RELEASE_LESS_THAN(3, 12, 0)
   if (!_app.isUltimateMaster())
-  {
-    auto ierr = PetscOptionsPop();
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(PetscOptionsPop());
 #endif
 }
 

--- a/framework/src/restart/DataIO.C
+++ b/framework/src/restart/DataIO.C
@@ -728,16 +728,13 @@ void
 dataLoad(std::istream & stream, Vec & v, void * context)
 {
   PetscInt local_size;
-  auto ierr = VecGetLocalSize(v, &local_size);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(PETSC_COMM_WORLD, VecGetLocalSize(v, &local_size));
   PetscScalar * array;
-  ierr = VecGetArray(v, &array);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(PETSC_COMM_WORLD, VecGetArray(v, &array));
   for (PetscInt i = 0; i < local_size; i++)
     dataLoad(stream, array[i], context);
 
-  ierr = VecRestoreArray(v, &array);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(PETSC_COMM_WORLD, VecRestoreArray(v, &array));
 }
 
 template <>
@@ -745,14 +742,11 @@ void
 dataStore(std::ostream & stream, Vec & v, void * context)
 {
   PetscInt local_size;
-  auto ierr = VecGetLocalSize(v, &local_size);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(PETSC_COMM_WORLD, VecGetLocalSize(v, &local_size));
   PetscScalar * array;
-  ierr = VecGetArray(v, &array);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(PETSC_COMM_WORLD, VecGetArray(v, &array));
   for (PetscInt i = 0; i < local_size; i++)
     dataStore(stream, array[i], context);
 
-  ierr = VecRestoreArray(v, &array);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(PETSC_COMM_WORLD, VecRestoreArray(v, &array));
 }

--- a/framework/src/systems/LinearSystem.C
+++ b/framework/src/systems/LinearSystem.C
@@ -196,15 +196,12 @@ LinearSystem::computeLinearSystemInternal(const std::set<TagID> & vector_tags,
     // Necessary for speed
     if (auto petsc_matrix = dynamic_cast<PetscMatrix<Number> *>(&matrix))
     {
-      auto ierr = MatSetOption(petsc_matrix->mat(),
-                               MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
-                               PETSC_TRUE);
-      LIBMESH_CHKERR(ierr);
+      LibmeshPetscCall(MatSetOption(petsc_matrix->mat(),
+                                    MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
+                                    PETSC_TRUE));
       if (!_fe_problem.errorOnJacobianNonzeroReallocation())
-      {
-        ierr = MatSetOption(petsc_matrix->mat(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
-        LIBMESH_CHKERR(ierr);
-      }
+        LibmeshPetscCall(
+            MatSetOption(petsc_matrix->mat(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE));
     }
   }
 

--- a/framework/src/systems/NonlinearEigenSystem.C
+++ b/framework/src/systems/NonlinearEigenSystem.C
@@ -85,11 +85,9 @@ assemble_matrix(EquationSystems & es, const std::string & system_name)
                          eigen_nl.eigenMatrixTag());
 #if LIBMESH_HAVE_SLEPC
     if (p->negativeSignEigenKernel())
-    {
-      auto ierr =
-          MatScale(static_cast<PetscMatrix<Number> &>(eigen_system.get_matrix_B()).mat(), -1.0);
-      LIBMESH_CHKERR(ierr);
-    }
+      LibmeshPetscCallA(
+          p->comm().get(),
+          MatScale(static_cast<PetscMatrix<Number> &>(eigen_system.get_matrix_B()).mat(), -1.0));
 #endif
     return;
   }

--- a/framework/src/systems/NonlinearEigenSystem.C
+++ b/framework/src/systems/NonlinearEigenSystem.C
@@ -444,8 +444,7 @@ NonlinearEigenSystem::getSNES()
   if (_eigen_problem.isNonlinearEigenvalueSolver())
   {
     SNES snes = nullptr;
-    auto ierr = Moose::SlepcSupport::mooseSlepcEPSGetSNES(eps, &snes);
-    LIBMESH_CHKERR(ierr);
+    LibmeshPetscCall(Moose::SlepcSupport::mooseSlepcEPSGetSNES(eps, &snes));
     return snes;
   }
   else
@@ -531,8 +530,7 @@ NonlinearEigenSystem::attachPreconditioner(Preconditioner<Number> * precondition
   // We need to let PETSc know that
   if (_preconditioner)
   {
-    auto ierr = Moose::SlepcSupport::registerPCToPETSc();
-    LIBMESH_CHKERR(ierr);
+    LibmeshPetscCall(Moose::SlepcSupport::registerPCToPETSc());
     // Mark this, and then we can setup correct petsc options
     _eigen_problem.solverParams()._customized_pc_for_eigen = true;
     _eigen_problem.solverParams()._type = Moose::ST_JFNK;

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -230,10 +230,7 @@ NonlinearSystem::solve()
   checkInvalidSolution();
 
   if (_use_coloring_finite_difference)
-  {
-    auto ierr = MatFDColoringDestroy(&_fdcoloring);
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(MatFDColoringDestroy(&_fdcoloring));
 }
 
 void
@@ -293,12 +290,11 @@ NonlinearSystem::setupStandardFiniteDifferencedPreconditioner()
   PetscMatrix<Number> * petsc_mat =
       static_cast<PetscMatrix<Number> *>(&_nl_implicit_sys.get_system_matrix());
 
-  auto ierr = SNESSetJacobian(petsc_nonlinear_solver->snes(),
-                              petsc_mat->mat(),
-                              petsc_mat->mat(),
-                              SNESComputeJacobianDefault,
-                              nullptr);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCall(SNESSetJacobian(petsc_nonlinear_solver->snes(),
+                                   petsc_mat->mat(),
+                                   petsc_mat->mat(),
+                                   SNESComputeJacobianDefault,
+                                   nullptr));
 }
 
 void

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -321,44 +321,35 @@ NonlinearSystem::setupColoringFiniteDifferencedPreconditioner()
 
   petsc_mat->close();
 
-  auto ierr = (PetscErrorCode)0;
   ISColoring iscoloring;
 
   // PETSc 3.5.x
   MatColoring matcoloring;
-  ierr = MatColoringCreate(petsc_mat->mat(), &matcoloring);
-  CHKERRABORT(_communicator.get(), ierr);
-  ierr = MatColoringSetType(matcoloring, MATCOLORINGLF);
-  CHKERRABORT(_communicator.get(), ierr);
-  ierr = MatColoringSetFromOptions(matcoloring);
-  CHKERRABORT(_communicator.get(), ierr);
-  ierr = MatColoringApply(matcoloring, &iscoloring);
-  CHKERRABORT(_communicator.get(), ierr);
-  ierr = MatColoringDestroy(&matcoloring);
-  CHKERRABORT(_communicator.get(), ierr);
+  LibmeshPetscCallA(_communicator.get(), MatColoringCreate(petsc_mat->mat(), &matcoloring));
+  LibmeshPetscCallA(_communicator.get(), MatColoringSetType(matcoloring, MATCOLORINGLF));
+  LibmeshPetscCallA(_communicator.get(), MatColoringSetFromOptions(matcoloring));
+  LibmeshPetscCallA(_communicator.get(), MatColoringApply(matcoloring, &iscoloring));
+  LibmeshPetscCallA(_communicator.get(), MatColoringDestroy(&matcoloring));
 
-  ierr = MatFDColoringCreate(petsc_mat->mat(), iscoloring, &_fdcoloring);
-  CHKERRABORT(_communicator.get(), ierr);
-  ierr = MatFDColoringSetFromOptions(_fdcoloring);
-  CHKERRABORT(_communicator.get(), ierr);
+  LibmeshPetscCallA(_communicator.get(),
+                    MatFDColoringCreate(petsc_mat->mat(), iscoloring, &_fdcoloring));
+  LibmeshPetscCallA(_communicator.get(), MatFDColoringSetFromOptions(_fdcoloring));
   // clang-format off
-  ierr =MatFDColoringSetFunction(_fdcoloring,
-                           (PetscErrorCode(*)(void))(void (*)(void)) &
-                               libMesh::libmesh_petsc_snes_fd_residual,
-                           &petsc_nonlinear_solver);
-  CHKERRABORT(_communicator.get(), ierr);
+  LibmeshPetscCallA(_communicator.get(), MatFDColoringSetFunction(_fdcoloring,
+                                                                  (PetscErrorCode(*)(void))(void (*)(void)) &
+                                                                      libMesh::libmesh_petsc_snes_fd_residual,
+                                                                  &petsc_nonlinear_solver));
   // clang-format on
-  ierr = MatFDColoringSetUp(petsc_mat->mat(), iscoloring, _fdcoloring);
-  CHKERRABORT(_communicator.get(), ierr);
-  ierr = SNESSetJacobian(petsc_nonlinear_solver.snes(),
-                         petsc_mat->mat(),
-                         petsc_mat->mat(),
-                         SNESComputeJacobianDefaultColor,
-                         _fdcoloring);
-  CHKERRABORT(_communicator.get(), ierr);
+  LibmeshPetscCallA(_communicator.get(),
+                    MatFDColoringSetUp(petsc_mat->mat(), iscoloring, _fdcoloring));
+  LibmeshPetscCallA(_communicator.get(),
+                    SNESSetJacobian(petsc_nonlinear_solver.snes(),
+                                    petsc_mat->mat(),
+                                    petsc_mat->mat(),
+                                    SNESComputeJacobianDefaultColor,
+                                    _fdcoloring));
   // PETSc >=3.3.0
-  ierr = ISColoringDestroy(&iscoloring);
-  CHKERRABORT(_communicator.get(), ierr);
+  LibmeshPetscCallA(_communicator.get(), ISColoringDestroy(&iscoloring));
 }
 
 bool

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -1932,15 +1932,12 @@ NonlinearSystemBase::computeResidualAndJacobianInternal(const std::set<TagID> & 
     // Necessary for speed
     if (auto petsc_matrix = dynamic_cast<PetscMatrix<Number> *>(&jacobian))
     {
-      auto ierr = MatSetOption(petsc_matrix->mat(),
-                               MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
-                               PETSC_TRUE);
-      LIBMESH_CHKERR(ierr);
+      LibmeshPetscCall(MatSetOption(petsc_matrix->mat(),
+                                    MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
+                                    PETSC_TRUE));
       if (!_fe_problem.errorOnJacobianNonzeroReallocation())
-      {
-        ierr = MatSetOption(petsc_matrix->mat(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
-        LIBMESH_CHKERR(ierr);
-      }
+        LibmeshPetscCall(
+            MatSetOption(petsc_matrix->mat(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE));
     }
   }
 
@@ -2279,20 +2276,14 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
 
   auto & jacobian = getMatrix(systemMatrixTag());
 
-  auto ierr = (PetscErrorCode)0;
   if (!_fe_problem.errorOnJacobianNonzeroReallocation())
-  {
-    ierr = MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
-                        MAT_NEW_NONZERO_ALLOCATION_ERR,
-                        PETSC_FALSE);
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+                                  MAT_NEW_NONZERO_ALLOCATION_ERR,
+                                  PETSC_FALSE));
+
   if (_fe_problem.ignoreZerosInJacobian())
-  {
-    ierr = MatSetOption(
-        static_cast<PetscMatrix<Number> &>(jacobian).mat(), MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE);
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(MatSetOption(
+        static_cast<PetscMatrix<Number> &>(jacobian).mat(), MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE));
 
   std::vector<numeric_index_type> zero_rows;
 
@@ -2473,10 +2464,9 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
 
       if (constraints_applied)
       {
-        auto ierr = MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
-                                 MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
-                                 PETSC_TRUE);
-        LIBMESH_CHKERR(ierr);
+        LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+                                      MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
+                                      PETSC_TRUE));
 
         jacobian.close();
         jacobian.zero_rows(zero_rows, 0.0);
@@ -2493,10 +2483,9 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
 
     if (constraints_applied)
     {
-      auto ierr = MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
-                               MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
-                               PETSC_TRUE);
-      LIBMESH_CHKERR(ierr);
+      LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+                                    MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
+                                    PETSC_TRUE));
 
       jacobian.close();
       jacobian.zero_rows(zero_rows, 0.0);
@@ -2678,10 +2667,9 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
 
   if (constraints_applied)
   {
-    auto ierr = MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
-                             MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
-                             PETSC_TRUE);
-    LIBMESH_CHKERR(ierr);
+    LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+                                  MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
+                                  PETSC_TRUE));
 
     jacobian.close();
     jacobian.zero_rows(zero_rows, 0.0);
@@ -2784,15 +2772,12 @@ NonlinearSystemBase::computeJacobianInternal(const std::set<TagID> & tags)
     // Necessary for speed
     if (auto petsc_matrix = dynamic_cast<PetscMatrix<Number> *>(&jacobian))
     {
-      auto ierr = MatSetOption(petsc_matrix->mat(),
-                               MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
-                               PETSC_TRUE);
-      LIBMESH_CHKERR(ierr);
+      LibmeshPetscCall(MatSetOption(petsc_matrix->mat(),
+                                    MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
+                                    PETSC_TRUE));
       if (!_fe_problem.errorOnJacobianNonzeroReallocation())
-      {
-        ierr = MatSetOption(petsc_matrix->mat(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
-        LIBMESH_CHKERR(ierr);
-      }
+        LibmeshPetscCall(
+            MatSetOption(petsc_matrix->mat(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE));
     }
   }
 
@@ -3177,17 +3162,13 @@ NonlinearSystemBase::computeJacobianBlocks(std::vector<JacobianBlock *> & blocks
   {
     SparseMatrix<Number> & jacobian = blocks[i]->_jacobian;
 
-    auto ierr = MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
-                             MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
-                             PETSC_TRUE);
-    LIBMESH_CHKERR(ierr);
+    LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+                                  MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
+                                  PETSC_TRUE));
     if (!_fe_problem.errorOnJacobianNonzeroReallocation())
-    {
-      ierr = MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
-                          MAT_NEW_NONZERO_ALLOCATION_ERR,
-                          PETSC_TRUE);
-      LIBMESH_CHKERR(ierr);
-    }
+      LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+                                    MAT_NEW_NONZERO_ALLOCATION_ERR,
+                                    PETSC_TRUE));
 
     jacobian.zero();
   }
@@ -4087,8 +4068,5 @@ void
 NonlinearSystemBase::destroyColoring()
 {
   if (matrixFromColoring())
-  {
-    auto ierr = MatFDColoringDestroy(&_fdcoloring);
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(MatFDColoringDestroy(&_fdcoloring));
 }

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -129,13 +129,11 @@ DM_Moose::checkChildSize(DM child, const PetscInt child_size, const std::string 
 PetscErrorCode
 DMMooseValidityCheck(DM dm)
 {
-  PetscErrorCode ierr;
   PetscBool ismoose;
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(dm, DM_CLASSID, 1);
-  ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose));
   if (!ismoose)
     LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
                      PETSC_ERR_ARG_WRONG,
@@ -150,11 +148,8 @@ DMMooseGetContacts(DM dm,
                    std::vector<std::pair<std::string, std::string>> & contact_names,
                    std::vector<PetscBool> & displaced)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   DM_Moose * dmm = (DM_Moose *)dm->data;
   for (const auto & it : *(dmm->_contact_names))
   {
@@ -169,11 +164,8 @@ DMMooseGetUnContacts(DM dm,
                      std::vector<std::pair<std::string, std::string>> & uncontact_names,
                      std::vector<PetscBool> & displaced)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   DM_Moose * dmm = (DM_Moose *)dm->data;
   for (const auto & it : *(dmm->_uncontact_names))
   {
@@ -186,11 +178,8 @@ DMMooseGetUnContacts(DM dm,
 PetscErrorCode
 DMMooseGetSides(DM dm, std::vector<std::string> & side_names)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   DM_Moose * dmm = (DM_Moose *)dm->data;
   for (const auto & it : *(dmm->_side_ids))
     side_names.push_back(it.first);
@@ -200,11 +189,8 @@ DMMooseGetSides(DM dm, std::vector<std::string> & side_names)
 PetscErrorCode
 DMMooseGetUnSides(DM dm, std::vector<std::string> & side_names)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   DM_Moose * dmm = (DM_Moose *)dm->data;
   for (const auto & it : *(dmm->_unside_ids))
     side_names.push_back(it.first);
@@ -214,11 +200,8 @@ DMMooseGetUnSides(DM dm, std::vector<std::string> & side_names)
 PetscErrorCode
 DMMooseGetBlocks(DM dm, std::vector<std::string> & block_names)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   DM_Moose * dmm = (DM_Moose *)dm->data;
   for (const auto & it : *(dmm->_block_ids))
     block_names.push_back(it.first);
@@ -228,11 +211,8 @@ DMMooseGetBlocks(DM dm, std::vector<std::string> & block_names)
 PetscErrorCode
 DMMooseGetVariables(DM dm, std::vector<std::string> & var_names)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   DM_Moose * dmm = (DM_Moose *)(dm->data);
   for (const auto & it : *(dmm->_var_ids))
     var_names.push_back(it.first);
@@ -242,11 +222,8 @@ DMMooseGetVariables(DM dm, std::vector<std::string> & var_names)
 PetscErrorCode
 DMMooseSetNonlinearSystem(DM dm, NonlinearSystemBase & nl)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (dm->setupcalled)
     SETERRQ(((PetscObject)dm)->comm,
             PETSC_ERR_ARG_WRONGSTATE,
@@ -259,11 +236,8 @@ DMMooseSetNonlinearSystem(DM dm, NonlinearSystemBase & nl)
 PetscErrorCode
 DMMooseSetName(DM dm, const std::string & dm_name)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (dm->setupcalled)
     SETERRQ(((PetscObject)dm)->comm,
             PETSC_ERR_ARG_WRONGSTATE,
@@ -276,11 +250,8 @@ DMMooseSetName(DM dm, const std::string & dm_name)
 PetscErrorCode
 DMMooseSetParentDM(DM dm, DM_Moose * parent)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (dm->setupcalled)
     SETERRQ(((PetscObject)dm)->comm,
             PETSC_ERR_ARG_WRONGSTATE,
@@ -294,12 +265,10 @@ DMMooseSetParentDM(DM dm, DM_Moose * parent)
 PetscErrorCode
 DMMooseSetVariables(DM dm, const std::set<std::string> & vars)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)dm->data;
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (dmm->_vars)
@@ -325,12 +294,10 @@ DMMooseSetVariables(DM dm, const std::set<std::string> & vars)
 PetscErrorCode
 DMMooseSetBlocks(DM dm, const std::set<std::string> & blocks)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)dm->data;
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (dmm->_blocks)
@@ -342,12 +309,10 @@ DMMooseSetBlocks(DM dm, const std::set<std::string> & blocks)
 PetscErrorCode
 DMMooseSetSides(DM dm, const std::set<std::string> & sides)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)dm->data;
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (dmm->_sides)
@@ -359,12 +324,10 @@ DMMooseSetSides(DM dm, const std::set<std::string> & sides)
 PetscErrorCode
 DMMooseSetUnSides(DM dm, const std::set<std::string> & unsides)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)dm->data;
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (dmm->_unsides)
@@ -376,12 +339,10 @@ DMMooseSetUnSides(DM dm, const std::set<std::string> & unsides)
 PetscErrorCode
 DMMooseSetUnSideByVar(DM dm, const std::set<std::string> & unside_by_var)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)dm->data;
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (dmm->_unside_by_var)
@@ -395,12 +356,10 @@ DMMooseSetContacts(DM dm,
                    const std::vector<std::pair<std::string, std::string>> & contacts,
                    const std::vector<PetscBool> & displaced)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)dm->data;
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (contacts.size() != displaced.size())
@@ -427,12 +386,10 @@ DMMooseSetUnContacts(DM dm,
                      const std::vector<std::pair<std::string, std::string>> & uncontacts,
                      const std::vector<PetscBool> & displaced)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)dm->data;
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (uncontacts.size() != displaced.size())
@@ -458,11 +415,8 @@ DMMooseSetUnContacts(DM dm,
 PetscErrorCode
 DMMooseGetNonlinearSystem(DM dm, NonlinearSystemBase *& nl)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   DM_Moose * dmm = (DM_Moose *)(dm->data);
   nl = dmm->_nl;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -471,21 +425,16 @@ DMMooseGetNonlinearSystem(DM dm, NonlinearSystemBase *& nl)
 PetscErrorCode
 DMMooseSetSplitNames(DM dm, const std::vector<std::string> & split_names)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   DM_Moose * dmm = (DM_Moose *)(dm->data);
 
   if (dmm->_splits)
   {
     for (auto & it : *(dmm->_splits))
     {
-      ierr = DMDestroy(&(it.second._dm));
-      CHKERRQ(ierr);
-      ierr = ISDestroy(&(it.second._rembedding));
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(DMDestroy(&(it.second._dm)));
+      LibmeshPetscCallQ(ISDestroy(&(it.second._rembedding)));
     }
     delete dmm->_splits;
     dmm->_splits = LIBMESH_PETSC_NULLPTR;
@@ -512,11 +461,8 @@ DMMooseSetSplitNames(DM dm, const std::vector<std::string> & split_names)
 PetscErrorCode
 DMMooseGetSplitNames(DM dm, std::vector<std::string> & split_names)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   DM_Moose * dmm = (DM_Moose *)(dm->data);
   if (!dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "DM not set up");
@@ -536,7 +482,6 @@ static PetscErrorCode
 DMMooseGetEmbedding_Private(DM dm, IS * embedding)
 {
   DM_Moose * dmm = (DM_Moose *)dm->data;
-  PetscErrorCode ierr;
 
   PetscFunctionBegin;
   if (!embedding)
@@ -840,17 +785,15 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
                           unindices.end(),
                           std::inserter(dindices, dindices.end()));
       PetscInt * darray;
-      ierr = PetscMalloc(sizeof(PetscInt) * dindices.size(), &darray);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscMalloc(sizeof(PetscInt) * dindices.size(), &darray));
       dof_id_type i = 0;
       for (const auto & dof : dindices)
       {
         darray[i] = dof;
         ++i;
       }
-      ierr = ISCreateGeneral(
-          ((PetscObject)dm)->comm, dindices.size(), darray, PETSC_OWN_POINTER, &dmm->_embedding);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(ISCreateGeneral(
+          ((PetscObject)dm)->comm, dindices.size(), darray, PETSC_OWN_POINTER, &dmm->_embedding));
     }
     else
     {
@@ -860,16 +803,13 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
       Vec v;
       PetscInt low, high;
 
-      ierr = DMCreateGlobalVector(dm, &v);
-      CHKERRQ(ierr);
-      ierr = VecGetOwnershipRange(v, &low, &high);
-      CHKERRQ(ierr);
-      ierr = ISCreateStride(((PetscObject)dm)->comm, (high - low), low, 1, &dmm->_embedding);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(DMCreateGlobalVector(dm, &v));
+      LibmeshPetscCallQ(VecGetOwnershipRange(v, &low, &high));
+      LibmeshPetscCallQ(
+          ISCreateStride(((PetscObject)dm)->comm, (high - low), low, 1, &dmm->_embedding));
     }
   }
-  ierr = PetscObjectReference((PetscObject)(dmm->_embedding));
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscObjectReference((PetscObject)(dmm->_embedding)));
   *embedding = dmm->_embedding;
 
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -879,7 +819,6 @@ static PetscErrorCode
 DMCreateFieldDecomposition_Moose(
     DM dm, PetscInt * len, char *** namelist, IS ** islist, DM ** dmlist)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)(dm->data);
 
   PetscFunctionBegin;
@@ -891,20 +830,11 @@ DMCreateFieldDecomposition_Moose(
     PetscFunctionReturn(PETSC_SUCCESS);
   *len = dmm->_splitlocs->size();
   if (namelist)
-  {
-    ierr = PetscMalloc(*len * sizeof(char *), namelist);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(PetscMalloc(*len * sizeof(char *), namelist));
   if (islist)
-  {
-    ierr = PetscMalloc(*len * sizeof(IS), islist);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(PetscMalloc(*len * sizeof(IS), islist));
   if (dmlist)
-  {
-    ierr = PetscMalloc(*len * sizeof(DM), dmlist);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(PetscMalloc(*len * sizeof(DM), dmlist));
   for (const auto & dit : *(dmm->_splitlocs))
   {
     unsigned int d = dit.second;
@@ -912,61 +842,43 @@ DMCreateFieldDecomposition_Moose(
     DM_Moose::SplitInfo & dinfo = (*dmm->_splits)[dname];
     if (!dinfo._dm)
     {
-      ierr = DMCreateMoose(((PetscObject)dm)->comm, *dmm->_nl, dname, &dinfo._dm);
-      CHKERRQ(ierr);
-      ierr = PetscObjectSetOptionsPrefix((PetscObject)dinfo._dm, ((PetscObject)dm)->prefix);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(DMCreateMoose(((PetscObject)dm)->comm, *dmm->_nl, dname, &dinfo._dm));
+      LibmeshPetscCallQ(
+          PetscObjectSetOptionsPrefix((PetscObject)dinfo._dm, ((PetscObject)dm)->prefix));
       std::string suffix = std::string("fieldsplit_") + dname + "_";
-      ierr = PetscObjectAppendOptionsPrefix((PetscObject)dinfo._dm, suffix.c_str());
-      CHKERRQ(ierr);
-      ierr = DMMooseSetParentDM(dinfo._dm, dmm);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscObjectAppendOptionsPrefix((PetscObject)dinfo._dm, suffix.c_str()));
+      LibmeshPetscCallQ(DMMooseSetParentDM(dinfo._dm, dmm));
     }
-    ierr = DMSetFromOptions(dinfo._dm);
-    CHKERRQ(ierr);
-    ierr = DMSetUp(dinfo._dm);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(DMSetFromOptions(dinfo._dm));
+    LibmeshPetscCallQ(DMSetUp(dinfo._dm));
     if (namelist)
-    {
-      ierr = PetscStrallocpy(dname.c_str(), (*namelist) + d);
-      CHKERRQ(ierr);
-    }
+      LibmeshPetscCallQ(PetscStrallocpy(dname.c_str(), (*namelist) + d));
     if (islist)
     {
       if (!dinfo._rembedding)
       {
         IS dembedding, lembedding;
-        ierr = DMMooseGetEmbedding_Private(dinfo._dm, &dembedding);
-        CHKERRQ(ierr);
+        LibmeshPetscCallQ(DMMooseGetEmbedding_Private(dinfo._dm, &dembedding));
         if (dmm->_embedding)
         {
           // Create a relative embedding into the parent's index space.
-          ierr = ISEmbed(dembedding, dmm->_embedding, PETSC_TRUE, &lembedding);
-          CHKERRQ(ierr);
+          LibmeshPetscCallQ(ISEmbed(dembedding, dmm->_embedding, PETSC_TRUE, &lembedding));
           const PetscInt * lindices;
           PetscInt len, dlen, llen, *rindices, off, i;
-          ierr = ISGetLocalSize(dembedding, &dlen);
-          CHKERRQ(ierr);
-          ierr = ISGetLocalSize(lembedding, &llen);
-          CHKERRQ(ierr);
+          LibmeshPetscCallQ(ISGetLocalSize(dembedding, &dlen));
+          LibmeshPetscCallQ(ISGetLocalSize(lembedding, &llen));
           if (llen != dlen)
             LIBMESH_SETERRQ1(
                 ((PetscObject)dm)->comm, PETSC_ERR_PLIB, "Failed to embed split %u", d);
-          ierr = ISDestroy(&dembedding);
-          CHKERRQ(ierr);
+          LibmeshPetscCallQ(ISDestroy(&dembedding));
           // Convert local embedding to global (but still relative) embedding
-          ierr = PetscMalloc(llen * sizeof(PetscInt), &rindices);
-          CHKERRQ(ierr);
-          ierr = ISGetIndices(lembedding, &lindices);
-          CHKERRQ(ierr);
-          ierr = PetscMemcpy(rindices, lindices, llen * sizeof(PetscInt));
-          CHKERRQ(ierr);
-          ierr = ISDestroy(&lembedding);
-          CHKERRQ(ierr);
+          LibmeshPetscCallQ(PetscMalloc(llen * sizeof(PetscInt), &rindices));
+          LibmeshPetscCallQ(ISGetIndices(lembedding, &lindices));
+          LibmeshPetscCallQ(PetscMemcpy(rindices, lindices, llen * sizeof(PetscInt)));
+          LibmeshPetscCallQ(ISDestroy(&lembedding));
           // We could get the index offset from a corresponding global vector, but subDMs don't yet
           // have global vectors
-          ierr = ISGetLocalSize(dmm->_embedding, &len);
-          CHKERRQ(ierr);
+          LibmeshPetscCallQ(ISGetLocalSize(dmm->_embedding, &len));
 
           MPI_Scan(&len,
                    &off,
@@ -982,27 +894,23 @@ DMCreateFieldDecomposition_Moose(
           off -= len;
           for (i = 0; i < llen; ++i)
             rindices[i] += off;
-          ierr = ISCreateGeneral(
-              ((PetscObject)dm)->comm, llen, rindices, PETSC_OWN_POINTER, &(dinfo._rembedding));
-          CHKERRQ(ierr);
+          LibmeshPetscCallQ(ISCreateGeneral(
+              ((PetscObject)dm)->comm, llen, rindices, PETSC_OWN_POINTER, &(dinfo._rembedding)));
         }
         else
         {
           dinfo._rembedding = dembedding;
         }
       }
-      ierr = PetscObjectReference((PetscObject)(dinfo._rembedding));
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscObjectReference((PetscObject)(dinfo._rembedding)));
       (*islist)[d] = dinfo._rembedding;
       PetscInt is_size;
-      ierr = ISGetLocalSize(dinfo._rembedding, &is_size);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(ISGetLocalSize(dinfo._rembedding, &is_size));
       split_size_sum += is_size;
     }
     if (dmlist)
     {
-      ierr = PetscObjectReference((PetscObject)dinfo._dm);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscObjectReference((PetscObject)dinfo._dm));
       (*dmlist)[d] = dinfo._dm;
     }
   }
@@ -1023,30 +931,24 @@ static PetscErrorCode
 DMCreateDomainDecomposition_Moose(
     DM dm, PetscInt * len, char *** namelist, IS ** innerislist, IS ** outerislist, DM ** dmlist)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
   /* Use DMCreateFieldDecomposition_Moose() to obtain everything but outerislist, which is currently
    * LIBMESH_PETSC_NULLPTR. */
   if (outerislist)
     *outerislist = LIBMESH_PETSC_NULLPTR; /* FIX: allow mesh-based overlap. */
-  ierr = DMCreateFieldDecomposition_Moose(dm, len, namelist, innerislist, dmlist);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMCreateFieldDecomposition_Moose(dm, len, namelist, innerislist, dmlist));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 static PetscErrorCode
 DMMooseFunction(DM dm, Vec x, Vec r)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
   libmesh_assert(x);
   libmesh_assert(r);
 
   NonlinearSystemBase * nl = NULL;
-  ierr = DMMooseGetNonlinearSystem(dm, nl);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseGetNonlinearSystem(dm, nl));
   PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(nl->system().solution.get());
   PetscVector<Number> X_global(x, nl->comm()), R(r, nl->comm());
 
@@ -1111,23 +1013,19 @@ static PetscErrorCode
 SNESFunction_DMMoose(SNES, Vec x, Vec r, void * ctx)
 {
   DM dm = (DM)ctx;
-  PetscErrorCode ierr;
 
   PetscFunctionBegin;
-  ierr = DMMooseFunction(dm, x, r);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseFunction(dm, x, r));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 static PetscErrorCode
 DMMooseJacobian(DM dm, Vec x, Mat jac, Mat pc)
 {
-  PetscErrorCode ierr;
   NonlinearSystemBase * nl = NULL;
 
   PetscFunctionBegin;
-  ierr = DMMooseGetNonlinearSystem(dm, nl);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseGetNonlinearSystem(dm, nl));
 
   PetscMatrix<Number> the_pc(pc, nl->comm());
   PetscMatrix<Number> Jac(jac, nl->comm());
@@ -1205,31 +1103,25 @@ static PetscErrorCode
 SNESJacobian_DMMoose(SNES, Vec x, Mat jac, Mat pc, void * ctx)
 {
   DM dm = (DM)ctx;
-  PetscErrorCode ierr;
 
   PetscFunctionBegin;
-  ierr = DMMooseJacobian(dm, x, jac, pc);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseJacobian(dm, x, jac, pc));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 static PetscErrorCode
 DMVariableBounds_Moose(DM dm, Vec xl, Vec xu)
 {
-  PetscErrorCode ierr;
   NonlinearSystemBase * nl = NULL;
 
   PetscFunctionBegin;
-  ierr = DMMooseGetNonlinearSystem(dm, nl);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseGetNonlinearSystem(dm, nl));
 
   PetscVector<Number> XL(xl, nl->comm());
   PetscVector<Number> XU(xu, nl->comm());
 
-  ierr = VecSet(xl, PETSC_NINFINITY);
-  CHKERRQ(ierr);
-  ierr = VecSet(xu, PETSC_INFINITY);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(VecSet(xl, PETSC_NINFINITY));
+  LibmeshPetscCallQ(VecSet(xu, PETSC_INFINITY));
   if (nl->nonlinearSolver()->bounds != NULL)
     nl->nonlinearSolver()->bounds(XL, XU, nl->nonlinearSolver()->system());
   else if (nl->nonlinearSolver()->bounds_object != NULL)
@@ -1243,12 +1135,10 @@ DMVariableBounds_Moose(DM dm, Vec xl, Vec xu)
 static PetscErrorCode
 DMCreateGlobalVector_Moose(DM dm, Vec * x)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)(dm->data);
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
 
@@ -1261,31 +1151,20 @@ DMCreateGlobalVector_Moose(DM dm, Vec * x)
   if (dmm->_embedding)
   {
     PetscInt n;
-    ierr = VecCreate(((PetscObject)v)->comm, x);
-    CHKERRQ(ierr);
-    ierr = ISGetLocalSize(dmm->_embedding, &n);
-    CHKERRQ(ierr);
-    ierr = VecSetSizes(*x, n, PETSC_DETERMINE);
-    CHKERRQ(ierr);
-    ierr = VecSetType(*x, ((PetscObject)v)->type_name);
-    CHKERRQ(ierr);
-    ierr = VecSetFromOptions(*x);
-    CHKERRQ(ierr);
-    ierr = VecSetUp(*x);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(VecCreate(((PetscObject)v)->comm, x));
+    LibmeshPetscCallQ(ISGetLocalSize(dmm->_embedding, &n));
+    LibmeshPetscCallQ(VecSetSizes(*x, n, PETSC_DETERMINE));
+    LibmeshPetscCallQ(VecSetType(*x, ((PetscObject)v)->type_name));
+    LibmeshPetscCallQ(VecSetFromOptions(*x));
+    LibmeshPetscCallQ(VecSetUp(*x));
   }
   else
-  {
-    ierr = VecDuplicate(v, x);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(VecDuplicate(v, x));
 
 #if PETSC_RELEASE_LESS_THAN(3, 13, 0)
-  ierr = PetscObjectCompose((PetscObject)*x, "DM", (PetscObject)dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscObjectCompose((PetscObject)*x, "DM", (PetscObject)dm));
 #else
-  ierr = VecSetDM(*x, dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(VecSetDM(*x, dm));
 #endif
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1293,17 +1172,14 @@ DMCreateGlobalVector_Moose(DM dm, Vec * x)
 static PetscErrorCode
 DMCreateMatrix_Moose(DM dm, Mat * A)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)(dm->data);
   MatType type;
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
-  ierr = DMGetMatType(dm, &type);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMGetMatType(dm, &type));
 
   /*
    The simplest thing for now: compute the sparsity_pattern using dof_map and init the matrix using
@@ -1319,159 +1195,117 @@ DMCreateMatrix_Moose(DM dm, Mat * A)
   N = M;
   m = static_cast<PetscInt>(dof_map.n_dofs_on_processor(dmm->_nl->system().processor_id()));
   n = m;
-  ierr = PetscObjectGetComm((PetscObject)dm, &comm);
-  CHKERRQ(ierr);
-  ierr = MatCreate(comm, A);
-  CHKERRQ(ierr);
-  ierr = MatSetSizes(*A, m, n, M, N);
-  CHKERRQ(ierr);
-  ierr = MatSetType(*A, type);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscObjectGetComm((PetscObject)dm, &comm));
+  LibmeshPetscCallQ(MatCreate(comm, A));
+  LibmeshPetscCallQ(MatSetSizes(*A, m, n, M, N));
+  LibmeshPetscCallQ(MatSetType(*A, type));
   /* Set preallocation for the basic sparse matrix types (applies only if *A has the right type. */
   /* For now we ignore blocksize issues, since BAIJ doesn't play well with field decomposition by
    * variable. */
   const std::vector<numeric_index_type> & n_nz = dof_map.get_n_nz();
   const std::vector<numeric_index_type> & n_oz = dof_map.get_n_oz();
-  ierr = MatSeqAIJSetPreallocation(*A, 0, (PetscInt *)(n_nz.empty() ? NULL : &n_nz[0]));
-  CHKERRQ(ierr);
-  ierr = MatMPIAIJSetPreallocation(*A,
-                                   0,
-                                   (PetscInt *)(n_nz.empty() ? NULL : &n_nz[0]),
-                                   0,
-                                   (PetscInt *)(n_oz.empty() ? NULL : &n_oz[0]));
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(MatSeqAIJSetPreallocation(*A, 0, (PetscInt *)(n_nz.empty() ? NULL : &n_nz[0])));
+  LibmeshPetscCallQ(MatMPIAIJSetPreallocation(*A,
+                                              0,
+                                              (PetscInt *)(n_nz.empty() ? NULL : &n_nz[0]),
+                                              0,
+                                              (PetscInt *)(n_oz.empty() ? NULL : &n_oz[0])));
   /* TODO: set the prefix for *A and MatSetFromOptions(*A)? Might override the type and other
    * settings made here. */
-  ierr = MatSetUp(*A);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(MatSetUp(*A));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 static PetscErrorCode
 DMView_Moose(DM dm, PetscViewer viewer)
 {
-  PetscErrorCode ierr;
   PetscBool isascii;
   const char *name, *prefix;
   DM_Moose * dmm = (DM_Moose *)dm->data;
 
   PetscFunctionBegin;
-  ierr = PetscObjectTypeCompare((PetscObject)viewer, PETSCVIEWERASCII, &isascii);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)viewer, PETSCVIEWERASCII, &isascii));
   if (isascii)
   {
-    ierr = PetscObjectGetName((PetscObject)dm, &name);
-    CHKERRQ(ierr);
-    ierr = PetscObjectGetOptionsPrefix((PetscObject)dm, &prefix);
-    CHKERRQ(ierr);
-    ierr = PetscViewerASCIIPrintf(viewer, "DM Moose with name %s and prefix %s\n", name, prefix);
-    CHKERRQ(ierr);
-    ierr = PetscViewerASCIIPrintf(viewer, "variables:");
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscObjectGetName((PetscObject)dm, &name));
+    LibmeshPetscCallQ(PetscObjectGetOptionsPrefix((PetscObject)dm, &prefix));
+    LibmeshPetscCallQ(
+        PetscViewerASCIIPrintf(viewer, "DM Moose with name %s and prefix %s\n", name, prefix));
+    LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "variables:"));
     for (const auto & vit : *(dmm->_var_ids))
     {
-      ierr = PetscViewerASCIIPrintf(viewer, "(%s,%u) ", vit.first.c_str(), vit.second);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "(%s,%u) ", vit.first.c_str(), vit.second));
     }
-    ierr = PetscViewerASCIIPrintf(viewer, "\n");
-    CHKERRQ(ierr);
-    ierr = PetscViewerASCIIPrintf(viewer, "blocks:");
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "\n"));
+    LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "blocks:"));
     for (const auto & bit : *(dmm->_block_ids))
     {
-      ierr = PetscViewerASCIIPrintf(viewer, "(%s,%d) ", bit.first.c_str(), bit.second);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "(%s,%d) ", bit.first.c_str(), bit.second));
     }
-    ierr = PetscViewerASCIIPrintf(viewer, "\n");
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "\n"));
 
     if (dmm->_side_ids->size())
     {
-      ierr = PetscViewerASCIIPrintf(viewer, "sides:");
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "sides:"));
       for (const auto & sit : *(dmm->_side_ids))
       {
-        ierr = PetscViewerASCIIPrintf(viewer, "(%s,%d) ", sit.first.c_str(), sit.second);
-        CHKERRQ(ierr);
+        LibmeshPetscCallQ(
+            PetscViewerASCIIPrintf(viewer, "(%s,%d) ", sit.first.c_str(), sit.second));
       }
-      ierr = PetscViewerASCIIPrintf(viewer, "\n");
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "\n"));
     }
 
     if (dmm->_unside_ids->size())
     {
-      ierr = PetscViewerASCIIPrintf(viewer, "unsides:");
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "unsides:"));
       for (const auto & sit : *(dmm->_unside_ids))
       {
-        ierr = PetscViewerASCIIPrintf(viewer, "(%s,%d) ", sit.first.c_str(), sit.second);
-        CHKERRQ(ierr);
+        LibmeshPetscCallQ(
+            PetscViewerASCIIPrintf(viewer, "(%s,%d) ", sit.first.c_str(), sit.second));
       }
-      ierr = PetscViewerASCIIPrintf(viewer, "\n");
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "\n"));
     }
 
     if (dmm->_contact_names->size())
     {
-      ierr = PetscViewerASCIIPrintf(viewer, "contacts:");
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "contacts:"));
       for (const auto & cit : *(dmm->_contact_names))
       {
-        ierr = PetscViewerASCIIPrintf(
-            viewer, "(%s,%s,", cit.second.first.c_str(), cit.second.second.c_str());
-        CHKERRQ(ierr);
+        LibmeshPetscCallQ(PetscViewerASCIIPrintf(
+            viewer, "(%s,%s,", cit.second.first.c_str(), cit.second.second.c_str()));
         if ((*dmm->_contact_displaced)[cit.second])
-        {
-          ierr = PetscViewerASCIIPrintf(viewer, "displaced) ");
-          CHKERRQ(ierr);
-        }
+          LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "displaced) "));
         else
-        {
-          ierr = PetscViewerASCIIPrintf(viewer, "undisplaced) ");
-          CHKERRQ(ierr);
-        }
+          LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "undisplaced) "));
       }
-      ierr = PetscViewerASCIIPrintf(viewer, "\n");
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "\n"));
     }
 
     if (dmm->_uncontact_names->size())
     {
-      ierr = PetscViewerASCIIPrintf(viewer, "_uncontacts:");
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "_uncontacts:"));
       for (const auto & cit : *(dmm->_uncontact_names))
       {
-        ierr = PetscViewerASCIIPrintf(
-            viewer, "(%s,%s,", cit.second.first.c_str(), cit.second.second.c_str());
-        CHKERRQ(ierr);
+        LibmeshPetscCallQ(PetscViewerASCIIPrintf(
+            viewer, "(%s,%s,", cit.second.first.c_str(), cit.second.second.c_str()));
         if ((*dmm->_uncontact_displaced)[cit.second])
-        {
-          ierr = PetscViewerASCIIPrintf(viewer, "displaced) ");
-          CHKERRQ(ierr);
-        }
+          LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "displaced) "));
         else
-        {
-          ierr = PetscViewerASCIIPrintf(viewer, "undisplaced) ");
-          CHKERRQ(ierr);
-        }
+          LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "undisplaced) "));
       }
-      ierr = PetscViewerASCIIPrintf(viewer, "\n");
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "\n"));
     }
 
     if (dmm->_splitlocs && dmm->_splitlocs->size())
     {
-      ierr = PetscViewerASCIIPrintf(viewer, "Field decomposition:");
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "Field decomposition:"));
       // FIX: decompositions might have different sizes and components on different ranks.
       for (const auto & dit : *(dmm->_splitlocs))
       {
         std::string dname = dit.first;
-        ierr = PetscViewerASCIIPrintf(viewer, " %s", dname.c_str());
-        CHKERRQ(ierr);
+        LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, " %s", dname.c_str()));
       }
-      ierr = PetscViewerASCIIPrintf(viewer, "\n");
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "\n"));
     }
   }
   else
@@ -1483,12 +1317,10 @@ DMView_Moose(DM dm, PetscViewer viewer)
 static PetscErrorCode
 DMMooseGetMeshBlocks_Private(DM dm, std::set<subdomain_id_type> & blocks)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)(dm->data);
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
 
@@ -1506,12 +1338,10 @@ DMMooseGetMeshBlocks_Private(DM dm, std::set<subdomain_id_type> & blocks)
 static PetscErrorCode
 DMSetUp_Moose_Pre(DM dm)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)(dm->data);
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
 
@@ -1669,8 +1499,7 @@ DMSetUp_Moose_Pre(DM dm)
   dmm->_block_ids->clear();
   dmm->_block_names->clear();
   std::set<subdomain_id_type> blocks;
-  ierr = DMMooseGetMeshBlocks_Private(dm, blocks);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseGetMeshBlocks_Private(dm, blocks));
   if (blocks.empty())
     SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "No mesh blocks found.");
 
@@ -1757,37 +1586,29 @@ DMSetUp_Moose_Pre(DM dm)
     for (const auto & cit : *(dmm->_uncontact_names))
       name += "_primary_" + cit.second.first + "_secondary_" + cit.second.second;
   }
-  ierr = PetscObjectSetName((PetscObject)dm, name.c_str());
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscObjectSetName((PetscObject)dm, name.c_str()));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 PetscErrorCode
 DMMooseReset(DM dm)
 {
-  PetscErrorCode ierr;
   PetscBool ismoose;
   DM_Moose * dmm = (DM_Moose *)(dm->data);
 
   PetscFunctionBegin;
-  ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose));
   if (!ismoose)
     PetscFunctionReturn(PETSC_SUCCESS);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
-  ierr = ISDestroy(&dmm->_embedding);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(ISDestroy(&dmm->_embedding));
   for (auto & it : *(dmm->_splits))
   {
     DM_Moose::SplitInfo & split = it.second;
-    ierr = ISDestroy(&split._rembedding);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(ISDestroy(&split._rembedding));
     if (split._dm)
-    {
-      ierr = DMMooseReset(split._dm);
-      CHKERRQ(ierr);
-    }
+      LibmeshPetscCallQ(DMMooseReset(split._dm));
   }
   dm->setupcalled = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1796,12 +1617,10 @@ DMMooseReset(DM dm)
 static PetscErrorCode
 DMSetUp_Moose(DM dm)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)(dm->data);
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
   if (dmm->_print_embedding)
@@ -1809,33 +1628,23 @@ DMSetUp_Moose(DM dm)
     const char *name, *prefix;
     IS embedding;
 
-    ierr = PetscObjectGetName((PetscObject)dm, &name);
-    CHKERRQ(ierr);
-    ierr = PetscObjectGetOptionsPrefix((PetscObject)dm, &prefix);
-    CHKERRQ(ierr);
-    ierr = PetscViewerASCIIPrintf(PETSC_VIEWER_STDOUT_(((PetscObject)dm)->comm),
-                                  "DM Moose with name %s and prefix %s\n",
-                                  name,
-                                  prefix);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscObjectGetName((PetscObject)dm, &name));
+    LibmeshPetscCallQ(PetscObjectGetOptionsPrefix((PetscObject)dm, &prefix));
+    LibmeshPetscCallQ(PetscViewerASCIIPrintf(PETSC_VIEWER_STDOUT_(((PetscObject)dm)->comm),
+                                             "DM Moose with name %s and prefix %s\n",
+                                             name,
+                                             prefix));
     if (dmm->_all_vars && dmm->_all_blocks && dmm->_nosides && dmm->_nounsides &&
         dmm->_nocontacts && dmm->_nouncontacts)
-    {
-      ierr = PetscViewerASCIIPrintf(PETSC_VIEWER_STDOUT_(((PetscObject)dm)->comm),
-                                    "\thas a trivial embedding\n");
-      CHKERRQ(ierr);
-    }
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(PETSC_VIEWER_STDOUT_(((PetscObject)dm)->comm),
+                                               "\thas a trivial embedding\n"));
     else
     {
-      ierr = DMMooseGetEmbedding_Private(dm, &embedding);
-      CHKERRQ(ierr);
-      ierr = PetscViewerASCIIPrintf(PETSC_VIEWER_STDOUT_(((PetscObject)dm)->comm),
-                                    "\thas embedding defined by IS:\n");
-      CHKERRQ(ierr);
-      ierr = ISView(embedding, PETSC_VIEWER_STDOUT_(((PetscObject)dm)->comm));
-      CHKERRQ(ierr);
-      ierr = ISDestroy(&embedding);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(DMMooseGetEmbedding_Private(dm, &embedding));
+      LibmeshPetscCallQ(PetscViewerASCIIPrintf(PETSC_VIEWER_STDOUT_(((PetscObject)dm)->comm),
+                                               "\thas embedding defined by IS:\n"));
+      LibmeshPetscCallQ(ISView(embedding, PETSC_VIEWER_STDOUT_(((PetscObject)dm)->comm)));
+      LibmeshPetscCallQ(ISDestroy(&embedding));
     }
   }
   /*
@@ -1845,13 +1654,10 @@ DMSetUp_Moose(DM dm)
   if (dmm->_all_vars && dmm->_all_blocks && dmm->_nosides && dmm->_nounsides && dmm->_nocontacts &&
       dmm->_nouncontacts)
   {
-    ierr = DMSNESSetFunction(dm, SNESFunction_DMMoose, (void *)dm);
-    CHKERRQ(ierr);
-    ierr = DMSNESSetJacobian(dm, SNESJacobian_DMMoose, (void *)dm);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(DMSNESSetFunction(dm, SNESFunction_DMMoose, (void *)dm));
+    LibmeshPetscCallQ(DMSNESSetJacobian(dm, SNESJacobian_DMMoose, (void *)dm));
     if (dmm->_nl->nonlinearSolver()->bounds || dmm->_nl->nonlinearSolver()->bounds_object)
-      ierr = DMSetVariableBounds(dm, DMVariableBounds_Moose);
-    CHKERRQ(ierr);
+      LibmeshPetscCallQ(DMSetVariableBounds(dm, DMVariableBounds_Moose));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1867,12 +1673,10 @@ PetscErrorCode
 DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
 #endif
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm = (DM_Moose *)dm->data;
 
   PetscFunctionBegin;
-  ierr = DMMooseValidityCheck(dm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseValidityCheck(dm));
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
 // PETSc changed macro definitions in 3.18; the former correct usage
@@ -1881,130 +1685,98 @@ DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
 #if !PETSC_VERSION_LESS_THAN(3, 18, 0)
   PetscOptionsBegin(((PetscObject)dm)->comm, ((PetscObject)dm)->prefix, "DMMoose options", "DM");
 #else
-  ierr = PetscOptionsBegin(
-      ((PetscObject)dm)->comm, ((PetscObject)dm)->prefix, "DMMoose options", "DM");
+  LibmeshPetscCallQ(PetscOptionsBegin(
+      ((PetscObject)dm)->comm, ((PetscObject)dm)->prefix, "DMMoose options", "DM"));
 #endif
   std::string opt, help;
   PetscInt maxvars = dmm->_nl->system().get_dof_map().n_variables();
   char ** vars;
   std::set<std::string> varset;
   PetscInt nvars = maxvars;
-  ierr = PetscMalloc(maxvars * sizeof(char *), &vars);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscMalloc(maxvars * sizeof(char *), &vars));
   opt = "-dm_moose_vars";
   help = "Variables in DMMoose";
-  ierr = PetscOptionsStringArray(
-      opt.c_str(), help.c_str(), "DMMooseSetVars", vars, &nvars, LIBMESH_PETSC_NULLPTR);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscOptionsStringArray(
+      opt.c_str(), help.c_str(), "DMMooseSetVars", vars, &nvars, LIBMESH_PETSC_NULLPTR));
   for (PetscInt i = 0; i < nvars; ++i)
   {
     varset.insert(std::string(vars[i]));
-    ierr = PetscFree(vars[i]);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscFree(vars[i]));
   }
-  ierr = PetscFree(vars);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscFree(vars));
   if (varset.size())
-  {
-    ierr = DMMooseSetVariables(dm, varset);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(DMMooseSetVariables(dm, varset));
   //
   std::set<subdomain_id_type> meshblocks;
-  ierr = DMMooseGetMeshBlocks_Private(dm, meshblocks);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMMooseGetMeshBlocks_Private(dm, meshblocks));
   PetscInt maxblocks = meshblocks.size();
   char ** blocks;
-  ierr = PetscMalloc(maxblocks * sizeof(char *), &blocks);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscMalloc(maxblocks * sizeof(char *), &blocks));
   std::set<std::string> blockset;
   PetscInt nblocks = maxblocks;
   opt = "-dm_moose_blocks";
   help = "Blocks in DMMoose";
-  ierr = PetscOptionsStringArray(
-      opt.c_str(), help.c_str(), "DMMooseSetBlocks", blocks, &nblocks, LIBMESH_PETSC_NULLPTR);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscOptionsStringArray(
+      opt.c_str(), help.c_str(), "DMMooseSetBlocks", blocks, &nblocks, LIBMESH_PETSC_NULLPTR));
   for (PetscInt i = 0; i < nblocks; ++i)
   {
     blockset.insert(std::string(blocks[i]));
-    ierr = PetscFree(blocks[i]);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscFree(blocks[i]));
   }
-  ierr = PetscFree(blocks);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscFree(blocks));
   if (blockset.size())
-  {
-    ierr = DMMooseSetBlocks(dm, blockset);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(DMMooseSetBlocks(dm, blockset));
   PetscInt maxsides =
       dmm->_nl->system().get_mesh().get_boundary_info().get_global_boundary_ids().size();
   char ** sides;
-  ierr = PetscMalloc(maxsides * maxvars * sizeof(char *), &sides);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscMalloc(maxsides * maxvars * sizeof(char *), &sides));
   PetscInt nsides = maxsides;
   std::set<std::string> sideset;
 
   // Do sides
   opt = "-dm_moose_sides";
   help = "Sides to include in DMMoose";
-  ierr = PetscOptionsStringArray(
-      opt.c_str(), help.c_str(), "DMMooseSetSides", sides, &nsides, LIBMESH_PETSC_NULLPTR);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscOptionsStringArray(
+      opt.c_str(), help.c_str(), "DMMooseSetSides", sides, &nsides, LIBMESH_PETSC_NULLPTR));
   for (PetscInt i = 0; i < nsides; ++i)
   {
     sideset.insert(std::string(sides[i]));
-    ierr = PetscFree(sides[i]);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscFree(sides[i]));
   }
   if (sideset.size())
-  {
-    ierr = DMMooseSetSides(dm, sideset);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(DMMooseSetSides(dm, sideset));
 
   // Do unsides
   opt = "-dm_moose_unsides";
   help = "Sides to exclude from DMMoose";
   nsides = maxsides;
-  ierr = PetscOptionsStringArray(
-      opt.c_str(), help.c_str(), "DMMooseSetUnSides", sides, &nsides, LIBMESH_PETSC_NULLPTR);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscOptionsStringArray(
+      opt.c_str(), help.c_str(), "DMMooseSetUnSides", sides, &nsides, LIBMESH_PETSC_NULLPTR));
   sideset.clear();
   for (PetscInt i = 0; i < nsides; ++i)
   {
     sideset.insert(std::string(sides[i]));
-    ierr = PetscFree(sides[i]);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscFree(sides[i]));
   }
   if (sideset.size())
-  {
-    ierr = DMMooseSetUnSides(dm, sideset);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(DMMooseSetUnSides(dm, sideset));
 
   // Do unsides by var
   opt = "-dm_moose_unside_by_var";
   help = "Sides to exclude from DMMoose on a by-var basis";
   nsides = maxsides * maxvars;
-  ierr = PetscOptionsStringArray(
-      opt.c_str(), help.c_str(), "DMMooseSetUnSideByVar", sides, &nsides, LIBMESH_PETSC_NULLPTR);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscOptionsStringArray(
+      opt.c_str(), help.c_str(), "DMMooseSetUnSideByVar", sides, &nsides, LIBMESH_PETSC_NULLPTR));
   sideset.clear();
   for (PetscInt i = 0; i < nsides; ++i)
   {
     sideset.insert(std::string(sides[i]));
-    ierr = PetscFree(sides[i]);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscFree(sides[i]));
   }
   if (sideset.size())
-  {
-    ierr = DMMooseSetUnSideByVar(dm, sideset);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(DMMooseSetUnSideByVar(dm, sideset));
 
-  ierr = PetscFree(sides);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscFree(sides));
   PetscInt maxcontacts = dmm->_nl->feProblem().geomSearchData()._penetration_locators.size();
   std::shared_ptr<DisplacedProblem> displaced_problem = dmm->_nl->feProblem().getDisplacedProblem();
   if (displaced_problem)
@@ -2021,13 +1793,12 @@ DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
       "defining the contact surfaces"
       "\t-dm_moose_contact_<n>_displaced <bool> determines whether the contact is defined on "
       "the displaced mesh or not";
-  ierr = PetscOptionsInt(opt.c_str(),
-                         help.c_str(),
-                         "DMMooseSetContacts",
-                         ncontacts,
-                         &ncontacts,
-                         LIBMESH_PETSC_NULLPTR);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscOptionsInt(opt.c_str(),
+                                    help.c_str(),
+                                    "DMMooseSetContacts",
+                                    ncontacts,
+                                    &ncontacts,
+                                    LIBMESH_PETSC_NULLPTR));
   if (ncontacts > maxcontacts)
     LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
                      PETSC_ERR_ARG_SIZ,
@@ -2043,13 +1814,12 @@ DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
       std::ostringstream oopt, ohelp;
       oopt << "-dm_moose_contact_" << i;
       ohelp << "Primary and secondary for contact " << i;
-      ierr = PetscOptionsStringArray(oopt.str().c_str(),
-                                     ohelp.str().c_str(),
-                                     "DMMooseSetContacts",
-                                     primary_secondary,
-                                     &sz,
-                                     LIBMESH_PETSC_NULLPTR);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscOptionsStringArray(oopt.str().c_str(),
+                                                ohelp.str().c_str(),
+                                                "DMMooseSetContacts",
+                                                primary_secondary,
+                                                &sz,
+                                                LIBMESH_PETSC_NULLPTR));
       if (sz != 2)
         LIBMESH_SETERRQ2(
             ((PetscObject)dm)->comm,
@@ -2060,43 +1830,36 @@ DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
             sz);
       contacts.push_back(DM_Moose::ContactName(std::string(primary_secondary[0]),
                                                std::string(primary_secondary[1])));
-      ierr = PetscFree(primary_secondary[0]);
-      CHKERRQ(ierr);
-      ierr = PetscFree(primary_secondary[1]);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscFree(primary_secondary[0]));
+      LibmeshPetscCallQ(PetscFree(primary_secondary[1]));
     }
     {
       PetscBool displaced = PETSC_FALSE;
       std::ostringstream oopt, ohelp;
       oopt << "-dm_moose_contact_" << i << "_displaced";
       ohelp << "Whether contact " << i << " is determined using displaced mesh or not";
-      ierr = PetscOptionsBool(oopt.str().c_str(),
-                              ohelp.str().c_str(),
-                              "DMMooseSetContacts",
-                              PETSC_FALSE,
-                              &displaced,
-                              LIBMESH_PETSC_NULLPTR);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscOptionsBool(oopt.str().c_str(),
+                                         ohelp.str().c_str(),
+                                         "DMMooseSetContacts",
+                                         PETSC_FALSE,
+                                         &displaced,
+                                         LIBMESH_PETSC_NULLPTR));
       contact_displaced.push_back(displaced);
     }
   }
   if (contacts.size())
-  {
-    ierr = DMMooseSetContacts(dm, contacts, contact_displaced);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(DMMooseSetContacts(dm, contacts, contact_displaced));
   {
     std::ostringstream oopt, ohelp;
     PetscBool is_include_all_nodes;
     oopt << "-dm_moose_includeAllContactNodes";
     ohelp << "Whether to include all nodes on the contact surfaces into the subsolver";
-    ierr = PetscOptionsBool(oopt.str().c_str(),
-                            ohelp.str().c_str(),
-                            "",
-                            PETSC_FALSE,
-                            &is_include_all_nodes,
-                            LIBMESH_PETSC_NULLPTR);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscOptionsBool(oopt.str().c_str(),
+                                       ohelp.str().c_str(),
+                                       "",
+                                       PETSC_FALSE,
+                                       &is_include_all_nodes,
+                                       LIBMESH_PETSC_NULLPTR));
     dmm->_include_all_contact_nodes = is_include_all_nodes;
   }
   std::vector<DM_Moose::ContactName> uncontacts;
@@ -2109,13 +1872,12 @@ DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
       "defining the contact surfaces"
       "\t-dm_moose_contact_<n>_displaced <bool> determines whether the contact is defined on "
       "the displaced mesh or not";
-  ierr = PetscOptionsInt(opt.c_str(),
-                         help.c_str(),
-                         "DMMooseSetUnContacts",
-                         nuncontacts,
-                         &nuncontacts,
-                         LIBMESH_PETSC_NULLPTR);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscOptionsInt(opt.c_str(),
+                                    help.c_str(),
+                                    "DMMooseSetUnContacts",
+                                    nuncontacts,
+                                    &nuncontacts,
+                                    LIBMESH_PETSC_NULLPTR));
   if (nuncontacts > maxcontacts)
     LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
                      PETSC_ERR_ARG_SIZ,
@@ -2131,13 +1893,12 @@ DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
       std::ostringstream oopt, ohelp;
       oopt << "-dm_moose_uncontact_" << i;
       ohelp << "Primary and secondary for uncontact " << i;
-      ierr = PetscOptionsStringArray(oopt.str().c_str(),
-                                     ohelp.str().c_str(),
-                                     "DMMooseSetUnContacts",
-                                     primary_secondary,
-                                     &sz,
-                                     LIBMESH_PETSC_NULLPTR);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscOptionsStringArray(oopt.str().c_str(),
+                                                ohelp.str().c_str(),
+                                                "DMMooseSetUnContacts",
+                                                primary_secondary,
+                                                &sz,
+                                                LIBMESH_PETSC_NULLPTR));
       if (sz != 2)
         LIBMESH_SETERRQ2(
             ((PetscObject)dm)->comm,
@@ -2148,31 +1909,25 @@ DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
             sz);
       uncontacts.push_back(DM_Moose::ContactName(std::string(primary_secondary[0]),
                                                  std::string(primary_secondary[1])));
-      ierr = PetscFree(primary_secondary[0]);
-      CHKERRQ(ierr);
-      ierr = PetscFree(primary_secondary[1]);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscFree(primary_secondary[0]));
+      LibmeshPetscCallQ(PetscFree(primary_secondary[1]));
     }
     {
       PetscBool displaced = PETSC_FALSE;
       std::ostringstream oopt, ohelp;
       oopt << "-dm_moose_uncontact_" << i << "_displaced";
       ohelp << "Whether uncontact " << i << " is determined using displaced mesh or not";
-      ierr = PetscOptionsBool(oopt.str().c_str(),
-                              ohelp.str().c_str(),
-                              "DMMooseSetUnContact",
-                              PETSC_FALSE,
-                              &displaced,
-                              LIBMESH_PETSC_NULLPTR);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscOptionsBool(oopt.str().c_str(),
+                                         ohelp.str().c_str(),
+                                         "DMMooseSetUnContact",
+                                         PETSC_FALSE,
+                                         &displaced,
+                                         LIBMESH_PETSC_NULLPTR));
       uncontact_displaced.push_back(displaced);
     }
   }
   if (uncontacts.size())
-  {
-    ierr = DMMooseSetUnContacts(dm, uncontacts, uncontact_displaced);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(DMMooseSetUnContacts(dm, uncontacts, uncontact_displaced));
 
   PetscInt nsplits = 0;
   /* Insert the usage of -dm_moose_fieldsplit_names into this help message, since the following
@@ -2180,23 +1935,20 @@ DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
   const char * fdhelp = "Number of named fieldsplits defined by the DM.\n\
                 \tNames of fieldsplits are defined by -dm_moose_fieldsplit_names <splitname1> <splitname2> ...\n\
                 \tEach split can be configured with its own variables, blocks and sides, as any DMMoose";
-  ierr = PetscOptionsInt(
-      "-dm_moose_nfieldsplits", fdhelp, "DMMooseSetSplitNames", nsplits, &nsplits, NULL);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscOptionsInt(
+      "-dm_moose_nfieldsplits", fdhelp, "DMMooseSetSplitNames", nsplits, &nsplits, NULL));
   if (nsplits)
   {
     PetscInt nnsplits = nsplits;
     std::vector<std::string> split_names;
     char ** splitnames;
-    ierr = PetscMalloc(nsplits * sizeof(char *), &splitnames);
-    CHKERRQ(ierr);
-    ierr = PetscOptionsStringArray("-dm_moose_fieldsplit_names",
-                                   "Names of fieldsplits defined by the DM",
-                                   "DMMooseSetSplitNames",
-                                   splitnames,
-                                   &nnsplits,
-                                   LIBMESH_PETSC_NULLPTR);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscMalloc(nsplits * sizeof(char *), &splitnames));
+    LibmeshPetscCallQ(PetscOptionsStringArray("-dm_moose_fieldsplit_names",
+                                              "Names of fieldsplits defined by the DM",
+                                              "DMMooseSetSplitNames",
+                                              splitnames,
+                                              &nnsplits,
+                                              LIBMESH_PETSC_NULLPTR));
     if (!nnsplits)
     {
       for (PetscInt i = 0; i < nsplits; ++i)
@@ -2218,26 +1970,21 @@ DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
       for (PetscInt i = 0; i < nsplits; ++i)
       {
         split_names.push_back(std::string(splitnames[i]));
-        ierr = PetscFree(splitnames[i]);
-        CHKERRQ(ierr);
+        LibmeshPetscCallQ(PetscFree(splitnames[i]));
       }
     }
-    ierr = PetscFree(splitnames);
-    CHKERRQ(ierr);
-    ierr = DMMooseSetSplitNames(dm, split_names);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscFree(splitnames));
+    LibmeshPetscCallQ(DMMooseSetSplitNames(dm, split_names));
   }
-  ierr = PetscOptionsBool("-dm_moose_print_embedding",
-                          "Print IS embedding DM's dofs",
-                          "DMMoose",
-                          dmm->_print_embedding,
-                          &dmm->_print_embedding,
-                          LIBMESH_PETSC_NULLPTR);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscOptionsBool("-dm_moose_print_embedding",
+                                     "Print IS embedding DM's dofs",
+                                     "DMMoose",
+                                     dmm->_print_embedding,
+                                     &dmm->_print_embedding,
+                                     LIBMESH_PETSC_NULLPTR));
   PetscOptionsEnd();
-  ierr = DMSetUp_Moose_Pre(dm);
-  CHKERRQ(ierr); /* Need some preliminary set up because, strangely enough, DMView() is called in
-                    DMSetFromOptions(). */
+  LibmeshPetscCallQ(DMSetUp_Moose_Pre(dm)); /* Need some preliminary set up because, strangely
+                    enough, DMView() is called in DMSetFromOptions(). */
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2245,7 +1992,6 @@ static PetscErrorCode
 DMDestroy_Moose(DM dm)
 {
   DM_Moose * dmm = (DM_Moose *)(dm->data);
-  PetscErrorCode ierr;
 
   PetscFunctionBegin;
   delete dmm->_name;
@@ -2280,36 +2026,26 @@ DMDestroy_Moose(DM dm)
   {
     for (auto & sit : *(dmm->_splits))
     {
-      ierr = DMDestroy(&(sit.second._dm));
-      CHKERRQ(ierr);
-      ierr = ISDestroy(&(sit.second._rembedding));
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(DMDestroy(&(sit.second._dm)));
+      LibmeshPetscCallQ(ISDestroy(&(sit.second._rembedding)));
     }
     delete dmm->_splits;
   }
   if (dmm->_splitlocs)
     delete dmm->_splitlocs;
-  ierr = ISDestroy(&dmm->_embedding);
-  CHKERRQ(ierr);
-  ierr = PetscFree(dm->data);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(ISDestroy(&dmm->_embedding));
+  LibmeshPetscCallQ(PetscFree(dm->data));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 PetscErrorCode
 DMCreateMoose(MPI_Comm comm, NonlinearSystemBase & nl, const std::string & dm_name, DM * dm)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
-  ierr = DMCreate(comm, dm);
-  CHKERRQ(ierr);
-  ierr = DMSetType(*dm, DMMOOSE);
-  CHKERRQ(ierr);
-  ierr = DMMooseSetNonlinearSystem(*dm, nl);
-  CHKERRQ(ierr);
-  ierr = DMMooseSetName(*dm, dm_name);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(DMCreate(comm, dm));
+  LibmeshPetscCallQ(DMSetType(*dm, DMMOOSE));
+  LibmeshPetscCallQ(DMMooseSetNonlinearSystem(*dm, nl));
+  LibmeshPetscCallQ(DMMooseSetName(*dm, dm_name));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2317,17 +2053,14 @@ EXTERN_C_BEGIN
 PetscErrorCode
 DMCreate_Moose(DM dm)
 {
-  PetscErrorCode ierr;
   DM_Moose * dmm;
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(dm, DM_CLASSID, 1);
 #if PETSC_RELEASE_LESS_THAN(3, 18, 0)
-  ierr = PetscNewLog(dm, &dmm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscNewLog(dm, &dmm));
 #else // PetscNewLog was deprecated
-  ierr = PetscNew(&dmm);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscNew(&dmm));
 #endif
   dm->data = dmm;
 
@@ -2389,7 +2122,6 @@ SNESUpdateDMMoose(SNES snes, PetscInt iteration)
      sparsity pattern has changed.
      For now we are rebuilding the whole KSP, when necessary.
   */
-  PetscErrorCode ierr;
   DM dm;
   KSP ksp;
   const char * prefix;
@@ -2401,31 +2133,19 @@ SNESUpdateDMMoose(SNES snes, PetscInt iteration)
   {
     /* TODO: limit this only to situations when displaced (un)contact splits are present, as is
      * DisplacedProblem(). */
-    ierr = SNESGetDM(snes, &dm);
-    CHKERRQ(ierr);
-    ierr = DMMooseReset(dm);
-    CHKERRQ(ierr);
-    ierr = DMSetUp(dm);
-    CHKERRQ(ierr);
-    ierr = SNESGetKSP(snes, &ksp);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(SNESGetDM(snes, &dm));
+    LibmeshPetscCallQ(DMMooseReset(dm));
+    LibmeshPetscCallQ(DMSetUp(dm));
+    LibmeshPetscCallQ(SNESGetKSP(snes, &ksp));
     /* Should we rebuild the whole KSP? */
-    ierr = PetscObjectGetOptionsPrefix((PetscObject)ksp, &prefix);
-    CHKERRQ(ierr);
-    ierr = PetscObjectGetComm((PetscObject)ksp, &comm);
-    CHKERRQ(ierr);
-    ierr = PCCreate(comm, &pc);
-    CHKERRQ(ierr);
-    ierr = PCSetDM(pc, dm);
-    CHKERRQ(ierr);
-    ierr = PCSetOptionsPrefix(pc, prefix);
-    CHKERRQ(ierr);
-    ierr = PCSetFromOptions(pc);
-    CHKERRQ(ierr);
-    ierr = KSPSetPC(ksp, pc);
-    CHKERRQ(ierr);
-    ierr = PCDestroy(&pc);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(PetscObjectGetOptionsPrefix((PetscObject)ksp, &prefix));
+    LibmeshPetscCallQ(PetscObjectGetComm((PetscObject)ksp, &comm));
+    LibmeshPetscCallQ(PCCreate(comm, &pc));
+    LibmeshPetscCallQ(PCSetDM(pc, dm));
+    LibmeshPetscCallQ(PCSetOptionsPrefix(pc, prefix));
+    LibmeshPetscCallQ(PCSetFromOptions(pc));
+    LibmeshPetscCallQ(KSPSetPC(ksp, pc));
+    LibmeshPetscCallQ(PCDestroy(&pc));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -2434,13 +2154,11 @@ PetscErrorCode
 DMMooseRegisterAll()
 {
   static PetscBool DMMooseRegisterAllCalled = PETSC_FALSE;
-  PetscErrorCode ierr;
 
   PetscFunctionBegin;
   if (!DMMooseRegisterAllCalled)
   {
-    ierr = DMRegister(DMMOOSE, DMCreate_Moose);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(DMRegister(DMMOOSE, DMCreate_Moose));
     DMMooseRegisterAllCalled = PETSC_TRUE;
   }
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -65,16 +65,14 @@ void
 MooseVecView(NumericVector<Number> & vector)
 {
   PetscVector<Number> & petsc_vec = static_cast<PetscVector<Number> &>(vector);
-  auto ierr = VecView(petsc_vec.vec(), 0);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(vector.comm().get(), VecView(petsc_vec.vec(), 0));
 }
 
 void
 MooseMatView(SparseMatrix<Number> & mat)
 {
   PetscMatrix<Number> & petsc_mat = static_cast<PetscMatrix<Number> &>(mat);
-  auto ierr = MatView(petsc_mat.mat(), 0);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(mat.comm().get(), MatView(petsc_mat.mat(), 0));
 }
 
 void
@@ -82,8 +80,7 @@ MooseVecView(const NumericVector<Number> & vector)
 {
   PetscVector<Number> & petsc_vec =
       static_cast<PetscVector<Number> &>(const_cast<NumericVector<Number> &>(vector));
-  auto ierr = VecView(petsc_vec.vec(), 0);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(vector.comm().get(), VecView(petsc_vec.vec(), 0));
 }
 
 void
@@ -91,8 +88,7 @@ MooseMatView(const SparseMatrix<Number> & mat)
 {
   PetscMatrix<Number> & petsc_mat =
       static_cast<PetscMatrix<Number> &>(const_cast<SparseMatrix<Number> &>(mat));
-  auto ierr = MatView(petsc_mat.mat(), 0);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(mat.comm().get(), MatView(petsc_mat.mat(), 0));
 }
 
 namespace Moose

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -516,7 +516,6 @@ slepcSetOptions(EigenProblem & eigen_problem, const InputParameters & params)
 PetscErrorCode
 mooseEPSFormMatrices(EigenProblem & eigen_problem, EPS eps, Vec x, void * ctx)
 {
-  PetscErrorCode ierr;
   ST st;
   Mat A, B;
   PetscBool aisshell, bisshell;
@@ -535,16 +534,11 @@ mooseEPSFormMatrices(EigenProblem & eigen_problem, EPS eps, Vec x, void * ctx)
   auto & sys = eigen_nl.sys();
   SNES snes = eigen_nl.getSNES();
   // Rest ST state so that we can retrieve matrices
-  ierr = EPSGetST(eps, &st);
-  CHKERRQ(ierr);
-  ierr = STResetMatrixState(st);
-  CHKERRQ(ierr);
-  ierr = EPSGetOperators(eps, &A, &B);
-  CHKERRQ(ierr);
-  ierr = PetscObjectTypeCompare((PetscObject)A, MATSHELL, &aisshell);
-  CHKERRQ(ierr);
-  ierr = PetscObjectTypeCompare((PetscObject)B, MATSHELL, &bisshell);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(EPSGetST(eps, &st));
+  LibmeshPetscCallQ(STResetMatrixState(st));
+  LibmeshPetscCallQ(EPSGetOperators(eps, &A, &B));
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)A, MATSHELL, &aisshell));
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)B, MATSHELL, &bisshell));
   if (aisshell || bisshell)
   {
     SETERRQ(PetscObjectComm((PetscObject)eps),
@@ -698,7 +692,6 @@ moosePetscSNESFormMatricesTags(SNES /*snes*/,
 PetscErrorCode
 mooseSlepcEigenFormFunctionMFFD(void * ctx, Vec x, Vec r)
 {
-  PetscErrorCode ierr;
   PetscErrorCode (*func)(SNES, Vec, Vec, void *);
   void * fctx;
   PetscFunctionBegin;
@@ -709,15 +702,13 @@ mooseSlepcEigenFormFunctionMFFD(void * ctx, Vec x, Vec r)
 
   eigen_problem->onLinearSolver(true);
 
-  ierr = SNESGetFunction(snes, NULL, &func, &fctx);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(SNESGetFunction(snes, NULL, &func, &fctx));
   if (fctx != ctx)
   {
     SETERRQ(
         PetscObjectComm((PetscObject)snes), PETSC_ERR_ARG_INCOMP, "Contexts are not consistent \n");
   }
-  ierr = (*func)(snes, x, r, ctx);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ((*func)(snes, x, r, ctx));
 
   eigen_problem->onLinearSolver(false);
 
@@ -729,7 +720,6 @@ mooseSlepcEigenFormJacobianA(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
 {
   PetscBool jisshell, pisshell;
   PetscBool jismffd;
-  PetscErrorCode ierr;
 
   PetscFunctionBegin;
 
@@ -739,44 +729,34 @@ mooseSlepcEigenFormJacobianA(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
 
   // If both jacobian and preconditioning are shell matrices,
   // and then assemble them and return
-  ierr = PetscObjectTypeCompare((PetscObject)jac, MATSHELL, &jisshell);
-  CHKERRQ(ierr);
-  ierr = PetscObjectTypeCompare((PetscObject)jac, MATMFFD, &jismffd);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)jac, MATSHELL, &jisshell));
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)jac, MATMFFD, &jismffd));
 
   if (jismffd && eigen_problem->solverParams()._eigen_matrix_vector_mult)
   {
-    ierr = MatMFFDSetFunction(jac, Moose::SlepcSupport::mooseSlepcEigenFormFunctionMFFD, ctx);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(
+        MatMFFDSetFunction(jac, Moose::SlepcSupport::mooseSlepcEigenFormFunctionMFFD, ctx));
 
     EPS eps = eigen_nl.getEPS();
 
-    ierr = mooseEPSFormMatrices(*eigen_problem, eps, x, ctx);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(mooseEPSFormMatrices(*eigen_problem, eps, x, ctx));
 
     if (pc != jac)
     {
-      ierr = MatAssemblyBegin(jac, MAT_FINAL_ASSEMBLY);
-      CHKERRQ(ierr);
-      ierr = MatAssemblyEnd(jac, MAT_FINAL_ASSEMBLY);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(MatAssemblyBegin(jac, MAT_FINAL_ASSEMBLY));
+      LibmeshPetscCallQ(MatAssemblyEnd(jac, MAT_FINAL_ASSEMBLY));
     }
     PetscFunctionReturn(PETSC_SUCCESS);
   }
 
-  ierr = PetscObjectTypeCompare((PetscObject)pc, MATSHELL, &pisshell);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)pc, MATSHELL, &pisshell));
   if ((jisshell || jismffd) && pisshell)
   {
     // Just assemble matrices and return
-    ierr = MatAssemblyBegin(jac, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
-    ierr = MatAssemblyBegin(pc, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
-    ierr = MatAssemblyEnd(jac, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
-    ierr = MatAssemblyEnd(pc, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(MatAssemblyBegin(jac, MAT_FINAL_ASSEMBLY));
+    LibmeshPetscCallQ(MatAssemblyBegin(pc, MAT_FINAL_ASSEMBLY));
+    LibmeshPetscCallQ(MatAssemblyEnd(jac, MAT_FINAL_ASSEMBLY));
+    LibmeshPetscCallQ(MatAssemblyEnd(pc, MAT_FINAL_ASSEMBLY));
 
     PetscFunctionReturn(PETSC_SUCCESS);
   }
@@ -805,20 +785,16 @@ mooseSlepcEigenFormJacobianA(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
     {
       moosePetscSNESFormMatrixTag(
           snes, x, pc, sys.get_precond_matrix(), ctx, eigen_nl.precondMatrixTag());
-      ierr = MatAssemblyBegin(jac, MAT_FINAL_ASSEMBLY);
-      CHKERRQ(ierr);
-      ierr = MatAssemblyEnd(jac, MAT_FINAL_ASSEMBLY);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(MatAssemblyBegin(jac, MAT_FINAL_ASSEMBLY));
+      LibmeshPetscCallQ(MatAssemblyEnd(jac, MAT_FINAL_ASSEMBLY));
       PetscFunctionReturn(PETSC_SUCCESS);
     }
     if (!jisshell && !jismffd) // We need to form only Jacobian matrix
     {
       moosePetscSNESFormMatrixTag(
           snes, x, jac, sys.get_matrix_A(), ctx, eigen_nl.nonEigenMatrixTag());
-      ierr = MatAssemblyBegin(pc, MAT_FINAL_ASSEMBLY);
-      CHKERRQ(ierr);
-      ierr = MatAssemblyEnd(pc, MAT_FINAL_ASSEMBLY);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(MatAssemblyBegin(pc, MAT_FINAL_ASSEMBLY));
+      LibmeshPetscCallQ(MatAssemblyEnd(pc, MAT_FINAL_ASSEMBLY));
       PetscFunctionReturn(PETSC_SUCCESS);
     }
   }
@@ -830,7 +806,6 @@ mooseSlepcEigenFormJacobianB(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
 {
   PetscBool jshell, pshell;
   PetscBool jismffd;
-  PetscErrorCode ierr;
 
   PetscFunctionBegin;
 
@@ -840,23 +815,16 @@ mooseSlepcEigenFormJacobianB(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
 
   // If both jacobian and preconditioning are shell matrices,
   // and then assemble them and return
-  ierr = PetscObjectTypeCompare((PetscObject)jac, MATSHELL, &jshell);
-  CHKERRQ(ierr);
-  ierr = PetscObjectTypeCompare((PetscObject)jac, MATMFFD, &jismffd);
-  CHKERRQ(ierr);
-  ierr = PetscObjectTypeCompare((PetscObject)pc, MATSHELL, &pshell);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)jac, MATSHELL, &jshell));
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)jac, MATMFFD, &jismffd));
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)pc, MATSHELL, &pshell));
   if ((jshell || jismffd) && pshell)
   {
     // Just assemble matrices and return
-    ierr = MatAssemblyBegin(jac, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
-    ierr = MatAssemblyBegin(pc, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
-    ierr = MatAssemblyEnd(jac, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
-    ierr = MatAssemblyEnd(pc, MAT_FINAL_ASSEMBLY);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(MatAssemblyBegin(jac, MAT_FINAL_ASSEMBLY));
+    LibmeshPetscCallQ(MatAssemblyBegin(pc, MAT_FINAL_ASSEMBLY));
+    LibmeshPetscCallQ(MatAssemblyEnd(jac, MAT_FINAL_ASSEMBLY));
+    LibmeshPetscCallQ(MatAssemblyEnd(pc, MAT_FINAL_ASSEMBLY));
 
     PetscFunctionReturn(PETSC_SUCCESS);
   }
@@ -870,8 +838,7 @@ mooseSlepcEigenFormJacobianB(SNES snes, Vec x, Mat jac, Mat pc, void * ctx)
 
   if (eigen_problem->negativeSignEigenKernel())
   {
-    ierr = MatScale(pc, -1.);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(MatScale(pc, -1.));
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -887,8 +854,6 @@ moosePetscSNESFormFunction(SNES /*snes*/, Vec x, Vec r, void * ctx, TagID tag)
 PetscErrorCode
 mooseSlepcEigenFormFunctionA(SNES snes, Vec x, Vec r, void * ctx)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
 
   EigenProblem * eigen_problem = static_cast<EigenProblem *>(ctx);
@@ -901,19 +866,14 @@ mooseSlepcEigenFormFunctionA(SNES snes, Vec x, Vec r, void * ctx)
     Mat A;
     ST st;
 
-    ierr = mooseEPSFormMatrices(*eigen_problem, eps, x, ctx);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(mooseEPSFormMatrices(*eigen_problem, eps, x, ctx));
 
     // Rest ST state so that we can restrieve matrices
-    ierr = EPSGetST(eps, &st);
-    CHKERRQ(ierr);
-    ierr = STResetMatrixState(st);
-    CHKERRQ(ierr);
-    ierr = EPSGetOperators(eps, &A, NULL);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(EPSGetST(eps, &st));
+    LibmeshPetscCallQ(STResetMatrixState(st));
+    LibmeshPetscCallQ(EPSGetOperators(eps, &A, NULL));
 
-    ierr = MatMult(A, x, r);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(MatMult(A, x, r));
 
     PetscFunctionReturn(PETSC_SUCCESS);
   }
@@ -926,8 +886,6 @@ mooseSlepcEigenFormFunctionA(SNES snes, Vec x, Vec r, void * ctx)
 PetscErrorCode
 mooseSlepcEigenFormFunctionB(SNES snes, Vec x, Vec r, void * ctx)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
 
   EigenProblem * eigen_problem = static_cast<EigenProblem *>(ctx);
@@ -940,19 +898,14 @@ mooseSlepcEigenFormFunctionB(SNES snes, Vec x, Vec r, void * ctx)
     ST st;
     Mat B;
 
-    ierr = mooseEPSFormMatrices(*eigen_problem, eps, x, ctx);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(mooseEPSFormMatrices(*eigen_problem, eps, x, ctx));
 
     // Rest ST state so that we can restrieve matrices
-    ierr = EPSGetST(eps, &st);
-    CHKERRQ(ierr);
-    ierr = STResetMatrixState(st);
-    CHKERRQ(ierr);
-    ierr = EPSGetOperators(eps, NULL, &B);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(EPSGetST(eps, &st));
+    LibmeshPetscCallQ(STResetMatrixState(st));
+    LibmeshPetscCallQ(EPSGetOperators(eps, NULL, &B));
 
-    ierr = MatMult(B, x, r);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(MatMult(B, x, r));
 
     if (eigen_problem->bxNormProvided())
     {
@@ -966,8 +919,7 @@ mooseSlepcEigenFormFunctionB(SNES snes, Vec x, Vec r, void * ctx)
 
   if (eigen_problem->negativeSignEigenKernel())
   {
-    ierr = VecScale(r, -1.);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(VecScale(r, -1.));
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -976,8 +928,6 @@ mooseSlepcEigenFormFunctionB(SNES snes, Vec x, Vec r, void * ctx)
 PetscErrorCode
 mooseSlepcEigenFormFunctionAB(SNES /*snes*/, Vec x, Vec Ax, Vec Bx, void * ctx)
 {
-  PetscErrorCode ierr;
-
   PetscFunctionBegin;
 
   EigenProblem * eigen_problem = static_cast<EigenProblem *>(ctx);
@@ -992,28 +942,19 @@ mooseSlepcEigenFormFunctionAB(SNES /*snes*/, Vec x, Vec Ax, Vec Bx, void * ctx)
     ST st;
     Mat A, B;
 
-    ierr = mooseEPSFormMatrices(*eigen_problem, eps, x, ctx);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(mooseEPSFormMatrices(*eigen_problem, eps, x, ctx));
 
     // Rest ST state so that we can restrieve matrices
-    ierr = EPSGetST(eps, &st);
-    CHKERRQ(ierr);
-    ierr = STResetMatrixState(st);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(EPSGetST(eps, &st));
+    LibmeshPetscCallQ(STResetMatrixState(st));
 
-    ierr = EPSGetOperators(eps, &A, &B);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(EPSGetOperators(eps, &A, &B));
 
-    ierr = MatMult(A, x, Ax);
-    CHKERRQ(ierr);
-    ierr = MatMult(B, x, Bx);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(MatMult(A, x, Ax));
+    LibmeshPetscCallQ(MatMult(B, x, Bx));
 
     if (eigen_problem->negativeSignEigenKernel())
-    {
-      ierr = VecScale(Bx, -1.);
-      CHKERRQ(ierr);
-    }
+      LibmeshPetscCallQ(VecScale(Bx, -1.));
 
     if (eigen_problem->bxNormProvided())
     {
@@ -1047,10 +988,7 @@ mooseSlepcEigenFormFunctionAB(SNES /*snes*/, Vec x, Vec Ax, Vec Bx, void * ctx)
   }
 
   if (eigen_problem->negativeSignEigenKernel())
-  {
-    ierr = VecScale(Bx, -1.);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(VecScale(Bx, -1.));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1130,8 +1068,7 @@ mooseMatMult_Eigen(Mat mat, Vec x, Vec r)
 {
   PetscFunctionBegin;
   void * ctx = nullptr;
-  auto ierr = MatShellGetContext(mat, &ctx);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(MatShellGetContext(mat, &ctx));
 
   if (!ctx)
     mooseError("No context is set for shell matrix ");
@@ -1142,10 +1079,7 @@ mooseMatMult_Eigen(Mat mat, Vec x, Vec r)
   evaluateResidual(*eigen_problem, x, r, eigen_nl.eigenVectorTag());
 
   if (eigen_problem->negativeSignEigenKernel())
-  {
-    ierr = VecScale(r, -1.);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(VecScale(r, -1.));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1155,8 +1089,7 @@ mooseMatMult_NonEigen(Mat mat, Vec x, Vec r)
 {
   PetscFunctionBegin;
   void * ctx = nullptr;
-  auto ierr = MatShellGetContext(mat, &ctx);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(MatShellGetContext(mat, &ctx));
 
   if (!ctx)
     mooseError("No context is set for shell matrix ");
@@ -1184,11 +1117,9 @@ setOperationsForShellMat(EigenProblem & eigen_problem, Mat mat, bool eigen)
 PETSC_EXTERN PetscErrorCode
 registerPCToPETSc()
 {
-  PetscErrorCode ierr;
   PetscFunctionBegin;
 
-  ierr = PCRegister("moosepc", PCCreate_MoosePC);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PCRegister("moosepc", PCCreate_MoosePC));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1218,17 +1149,13 @@ PCDestroy_MoosePC(PC /*pc*/)
 PetscErrorCode
 PCView_MoosePC(PC /*pc*/, PetscViewer viewer)
 {
-  PetscErrorCode ierr;
   PetscBool iascii;
 
   PetscFunctionBegin;
-  ierr = PetscObjectTypeCompare((PetscObject)viewer, PETSCVIEWERASCII, &iascii);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)viewer, PETSCVIEWERASCII, &iascii));
   if (iascii)
-  {
-    ierr = PetscViewerASCIIPrintf(viewer, "  %s\n", "moosepc");
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(PetscViewerASCIIPrintf(viewer, "  %s\n", "moosepc"));
+
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1238,22 +1165,15 @@ PCApply_MoosePC(PC pc, Vec x, Vec y)
   void * ctx;
   Mat Amat, Pmat;
   PetscContainer container;
-  PetscErrorCode ierr;
 
   PetscFunctionBegin;
-  ierr = PCGetOperators(pc, &Amat, &Pmat);
-  CHKERRQ(ierr);
-  ierr = PetscObjectQuery((PetscObject)Pmat, "formFunctionCtx", (PetscObject *)&container);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PCGetOperators(pc, &Amat, &Pmat));
+  LibmeshPetscCallQ(
+      PetscObjectQuery((PetscObject)Pmat, "formFunctionCtx", (PetscObject *)&container));
   if (container)
-  {
-    ierr = PetscContainerGetPointer(container, &ctx);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(PetscContainerGetPointer(container, &ctx));
   else
-  {
     mooseError(" Can not find a context \n");
-  }
 
   EigenProblem * eigen_problem = static_cast<EigenProblem *>(ctx);
   NonlinearEigenSystem & nl_eigen = eigen_problem->getCurrentNonlinearEigenSystem();
@@ -1274,24 +1194,18 @@ PetscErrorCode
 PCSetUp_MoosePC(PC pc)
 {
   void * ctx;
-  PetscErrorCode ierr;
   Mat Amat, Pmat;
   PetscContainer container;
 
   PetscFunctionBegin;
-  ierr = PCGetOperators(pc, &Amat, &Pmat);
-  CHKERRQ(ierr);
-  ierr = PetscObjectQuery((PetscObject)Pmat, "formFunctionCtx", (PetscObject *)&container);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(PCGetOperators(pc, &Amat, &Pmat));
+  LibmeshPetscCallQ(
+      PetscObjectQuery((PetscObject)Pmat, "formFunctionCtx", (PetscObject *)&container));
   if (container)
-  {
-    ierr = PetscContainerGetPointer(container, &ctx);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(PetscContainerGetPointer(container, &ctx));
   else
-  {
     mooseError(" Can not find a context \n");
-  }
+
   EigenProblem * eigen_problem = static_cast<EigenProblem *>(ctx);
   NonlinearEigenSystem & nl_eigen = eigen_problem->getCurrentNonlinearEigenSystem();
   Preconditioner<Number> * preconditioner = nl_eigen.preconditioner();

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -1232,12 +1232,10 @@ mooseSlepcStoppingTest(EPS eps,
                        EPSConvergedReason * reason,
                        void * ctx)
 {
-  PetscErrorCode ierr;
   EigenProblem * eigen_problem = static_cast<EigenProblem *>(ctx);
 
   PetscFunctionBegin;
-  ierr = EPSStoppingBasic(eps, its, max_it, nconv, nev, reason, NULL);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(EPSStoppingBasic(eps, its, max_it, nconv, nev, reason, NULL));
 
   // If we do free power iteration, we need to mark the solver as converged.
   // It is because SLEPc does not offer a way to copy unconverged solution.
@@ -1256,24 +1254,20 @@ mooseSlepcStoppingTest(EPS eps,
 PetscErrorCode
 mooseSlepcEPSGetSNES(EPS eps, SNES * snes)
 {
-  PetscErrorCode ierr;
   PetscBool same, nonlinear;
 
   PetscFunctionBegin;
-  ierr = PetscObjectTypeCompare((PetscObject)eps, EPSPOWER, &same);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(PetscObjectTypeCompare((PetscObject)eps, EPSPOWER, &same));
 
   if (!same)
     mooseError("It is not eps power, and there is no snes");
 
-  ierr = EPSPowerGetNonlinear(eps, &nonlinear);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(EPSPowerGetNonlinear(eps, &nonlinear));
 
   if (!nonlinear)
     mooseError("It is not a nonlinear eigen solver");
 
-  ierr = EPSPowerGetSNES(eps, snes);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(EPSPowerGetSNES(eps, snes));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1281,21 +1275,17 @@ mooseSlepcEPSGetSNES(EPS eps, SNES * snes)
 PetscErrorCode
 mooseSlepcEPSSNESSetUpOptionPrefix(EPS eps)
 {
-  PetscErrorCode ierr;
   SNES snes;
   const char * prefix = nullptr;
 
   PetscFunctionBegin;
-  ierr = mooseSlepcEPSGetSNES(eps, &snes);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(mooseSlepcEPSGetSNES(eps, &snes));
   // There is an extra "eps_power" in snes that users do not like it.
   // Let us remove that from snes.
   // Retrieve option prefix from EPS
-  ierr = PetscObjectGetOptionsPrefix((PetscObject)eps, &prefix);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(PetscObjectGetOptionsPrefix((PetscObject)eps, &prefix));
   // Set option prefix to SNES
-  ierr = SNESSetOptionsPrefix(snes, prefix);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(SNESSetOptionsPrefix(snes, prefix));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1303,41 +1293,33 @@ mooseSlepcEPSSNESSetUpOptionPrefix(EPS eps)
 PetscErrorCode
 mooseSlepcEPSSNESSetCustomizePC(EPS eps)
 {
-  PetscErrorCode ierr;
   SNES snes;
   KSP ksp;
   PC pc;
 
   PetscFunctionBegin;
   // Get SNES from EPS
-  ierr = mooseSlepcEPSGetSNES(eps, &snes);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(mooseSlepcEPSGetSNES(eps, &snes));
   // Get KSP from SNES
-  ierr = SNESGetKSP(snes, &ksp);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(SNESGetKSP(snes, &ksp));
   // Get PC from KSP
-  ierr = KSPGetPC(ksp, &pc);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(KSPGetPC(ksp, &pc));
   // Set PC type
-  ierr = PCSetType(pc, "moosepc");
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(PCSetType(pc, "moosepc"));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 PetscErrorCode
 mooseSlepcEPSSNESKSPSetPCSide(FEProblemBase & problem, EPS eps)
 {
-  PetscErrorCode ierr;
   SNES snes;
   KSP ksp;
 
   PetscFunctionBegin;
   // Get SNES from EPS
-  ierr = mooseSlepcEPSGetSNES(eps, &snes);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(mooseSlepcEPSGetSNES(eps, &snes));
   // Get KSP from SNES
-  ierr = SNESGetKSP(snes, &ksp);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(SNESGetKSP(snes, &ksp));
 
   Moose::PetscSupport::petscSetDefaultPCSide(problem, ksp);
 
@@ -1356,7 +1338,6 @@ mooseSlepcEPSMonitor(EPS eps,
                      void * mctx)
 {
   ST st;
-  auto ierr = (PetscErrorCode)0;
   PetscScalar eigenr, eigeni;
 
   PetscFunctionBegin;
@@ -1364,13 +1345,11 @@ mooseSlepcEPSMonitor(EPS eps,
   auto & console = eigen_problem->console();
 
   auto inverse = eigen_problem->outputInverseEigenvalue();
-  ierr = EPSGetST(eps, &st);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(EPSGetST(eps, &st));
   eigenr = eigr[0];
   eigeni = eigi[0];
   // Make the eigenvalue consistent with shift type
-  ierr = STBackTransform(st, 1, &eigenr, &eigeni);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallQ(STBackTransform(st, 1, &eigenr, &eigeni));
 
   auto eigenvalue = inverse ? 1.0 / eigenr : eigenr;
 

--- a/modules/external_petsc_solver/include/petscsolver/PETScDiffusionFDM.h
+++ b/modules/external_petsc_solver/include/petscsolver/PETScDiffusionFDM.h
@@ -11,7 +11,7 @@
 
 #include "libmesh/libmesh.h"
 
-#include "libmesh/petsc_macro.h"
+#include "libmesh/petsc_solver_exception.h"
 #include <petscdm.h>
 #include <petscdmda.h>
 #include <petscts.h>

--- a/modules/external_petsc_solver/src/base/ExternalPetscSolverApp.C
+++ b/modules/external_petsc_solver/src/base/ExternalPetscSolverApp.C
@@ -40,8 +40,7 @@ ExternalPetscSolverApp::getPetscTS()
   if (!_ts)
   {
     // Create an external PETSc solver
-    auto ierr = PETScExternalSolverCreate(_comm->get(), &_ts);
-    LIBMESH_CHKERR(ierr);
+    LibmeshPetscCall(PETScExternalSolverCreate(_comm->get(), &_ts));
     _is_petsc_app = true;
   }
   return _ts;

--- a/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
+++ b/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
@@ -91,38 +91,36 @@ add_element_Quad4(DM da,
   // xp: number of processors in x direction
   // yp: number of processors in y direction
   PetscInt Mx, My, xp, yp;
-  auto ierr = DMDAGetInfo(da,
-                          PETSC_IGNORE,
-                          &Mx,
-                          &My,
-                          PETSC_IGNORE,
-                          &xp,
-                          &yp,
-                          PETSC_IGNORE,
-                          PETSC_IGNORE,
-                          PETSC_IGNORE,
-                          PETSC_IGNORE,
-                          PETSC_IGNORE,
-                          PETSC_IGNORE,
-                          PETSC_IGNORE);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(mesh.comm().get(),
+                    DMDAGetInfo(da,
+                                PETSC_IGNORE,
+                                &Mx,
+                                &My,
+                                PETSC_IGNORE,
+                                &xp,
+                                &yp,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE));
 
   const PetscInt *lx, *ly;
   PetscInt *lxo, *lyo;
   // PETSc-3.8.x or older use PetscDataType
 #if PETSC_VERSION_LESS_THAN(3, 9, 0)
-  ierr = DMGetWorkArray(da, xp + yp + 2, PETSC_INT, &lxo);
+  LibmeshPetscCallA(mesh.comm().get(), DMGetWorkArray(da, xp + yp + 2, PETSC_INT, &lxo));
 #else
   // PETSc-3.9.x or newer use MPI_DataType
-  ierr = DMGetWorkArray(da, xp + yp + 2, MPIU_INT, &lxo);
+  LibmeshPetscCallA(mesh.comm().get(), DMGetWorkArray(da, xp + yp + 2, MPIU_INT, &lxo));
 #endif
-  LIBMESH_CHKERR(ierr);
 
   // Gets the ranges of indices in the x, y and z direction that are owned by each process
   // Ranges here are different from what we have in Mat and Vec.
   // It means how many points each processor holds
-  ierr = DMDAGetOwnershipRanges(da, &lx, &ly, NULL);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(mesh.comm().get(), DMDAGetOwnershipRanges(da, &lx, &ly, NULL));
   lxo[0] = 0;
   for (PetscInt i = 0; i < xp; i++)
     lxo[i + 1] = lxo[i] + lx[i];
@@ -137,31 +135,26 @@ add_element_Quad4(DM da,
   // Finds integer in a sorted array of integers
   // Loc:  the location if found, otherwise -(slot+1)
   // where slot is the place the value would go
-  ierr = PetscFindInt(i, xp + 1, lxo, &xpid);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(mesh.comm().get(), PetscFindInt(i, xp + 1, lxo, &xpid));
 
   xpid = xpid < 0 ? -xpid - 1 - 1 : xpid;
 
-  ierr = PetscFindInt(i + 1, xp + 1, lxo, &xpidplus);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(mesh.comm().get(), PetscFindInt(i + 1, xp + 1, lxo, &xpidplus));
 
   xpidplus = xpidplus < 0 ? -xpidplus - 1 - 1 : xpidplus;
 
-  ierr = PetscFindInt(j, yp + 1, lyo, &ypid);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(mesh.comm().get(), PetscFindInt(j, yp + 1, lyo, &ypid));
 
   ypid = ypid < 0 ? -ypid - 1 - 1 : ypid;
 
-  ierr = PetscFindInt(j + 1, yp + 1, lyo, &ypidplus);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(mesh.comm().get(), PetscFindInt(j + 1, yp + 1, lyo, &ypidplus));
 
   ypidplus = ypidplus < 0 ? -ypidplus - 1 - 1 : ypidplus;
 #if PETSC_VERSION_LESS_THAN(3, 9, 0)
-  ierr = DMRestoreWorkArray(da, xp + yp + 2, PETSC_INT, &lxo);
+  LibmeshPetscCallA(mesh.comm().get(), DMRestoreWorkArray(da, xp + yp + 2, PETSC_INT, &lxo));
 #else
-  ierr = DMRestoreWorkArray(da, xp + yp + 2, MPIU_INT, &lxo);
+  LibmeshPetscCallA(mesh.comm().get(), DMRestoreWorkArray(da, xp + yp + 2, MPIU_INT, &lxo));
 #endif
-  LIBMESH_CHKERR(ierr);
 
   // Bottom Left
   auto node0_ptr = mesh.add_point(Point(static_cast<Real>(i) / nx, static_cast<Real>(j) / ny, 0),
@@ -347,23 +340,23 @@ build_cube_Quad4(UnstructuredMesh & mesh, DM da)
   PetscInt xs, ys, xm, ym, Mx, My, xp, yp;
 
   /* Get local grid boundaries */
-  auto ierr = DMDAGetCorners(da, &xs, &ys, PETSC_IGNORE, &xm, &ym, PETSC_IGNORE);
-  LIBMESH_CHKERR(ierr);
-  ierr = DMDAGetInfo(da,
-                     PETSC_IGNORE,
-                     &Mx,
-                     &My,
-                     PETSC_IGNORE,
-                     &xp,
-                     &yp,
-                     PETSC_IGNORE,
-                     PETSC_IGNORE,
-                     PETSC_IGNORE,
-                     PETSC_IGNORE,
-                     PETSC_IGNORE,
-                     PETSC_IGNORE,
-                     PETSC_IGNORE);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCallA(mesh.comm().get(),
+                    DMDAGetCorners(da, &xs, &ys, PETSC_IGNORE, &xm, &ym, PETSC_IGNORE));
+  LibmeshPetscCallA(mesh.comm().get(),
+                    DMDAGetInfo(da,
+                                PETSC_IGNORE,
+                                &Mx,
+                                &My,
+                                PETSC_IGNORE,
+                                &xp,
+                                &yp,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE,
+                                PETSC_IGNORE));
 
   for (PetscInt j = ys; j < ys + ym; j++)
     for (PetscInt i = xs; i < xs + xm; i++)

--- a/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
+++ b/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
@@ -49,11 +49,8 @@ PETScDMDAMesh::PETScDMDAMesh(const InputParameters & parameters) : MooseMesh(par
   ExternalPetscSolverApp * petsc_app = dynamic_cast<ExternalPetscSolverApp *>(&_app);
 
   if (petsc_app && petsc_app->getPetscTS())
-  {
     // Retrieve mesh from TS
-    auto ierr = TSGetDM(petsc_app->getPetscTS(), &_dmda);
-    LIBMESH_CHKERR(ierr);
-  }
+    LibmeshPetscCall(TSGetDM(petsc_app->getPetscTS(), &_dmda));
   else
     mooseError(" PETSc external solver TS does not exist or this is not a petsc external solver");
 }

--- a/modules/external_petsc_solver/src/timesteppers/ExternalPetscTimeStepper.C
+++ b/modules/external_petsc_solver/src/timesteppers/ExternalPetscTimeStepper.C
@@ -36,8 +36,7 @@ ExternalPetscTimeStepper::computeInitialDT()
 {
   // Query the time step size of PETSc solver
   PetscReal dt;
-  auto ierr = TSGetTimeStep(_external_petsc_problem.getPetscTS(), &dt);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCall(TSGetTimeStep(_external_petsc_problem.getPetscTS(), &dt));
   return dt;
 }
 
@@ -46,7 +45,6 @@ ExternalPetscTimeStepper::computeDT()
 {
   // Query the time step size of PETSc solver
   PetscReal dt;
-  auto ierr = TSGetTimeStep(_external_petsc_problem.getPetscTS(), &dt);
-  LIBMESH_CHKERR(ierr);
+  LibmeshPetscCall(TSGetTimeStep(_external_petsc_problem.getPetscTS(), &dt));
   return dt;
 }

--- a/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolatorSegregated.C
+++ b/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolatorSegregated.C
@@ -423,7 +423,7 @@ INSFVRhieChowInterpolatorSegregated::computeHbyA(bool verbose)
     // Now we set the diagonal of our system matrix to 0 so we can create H*u
     // TODO: Add a function for this in libmesh
     *working_vector_petsc = 0.0;
-    LIBMESH_CHKERR(MatDiagonalSet(mmat->mat(), working_vector_petsc->vec(), INSERT_VALUES));
+    LibmeshPetscCall(MatDiagonalSet(mmat->mat(), working_vector_petsc->vec(), INSERT_VALUES));
 
     if (verbose)
     {

--- a/modules/navier_stokes/src/userobjects/RhieChowMassFlux.C
+++ b/modules/navier_stokes/src/userobjects/RhieChowMassFlux.C
@@ -518,7 +518,7 @@ RhieChowMassFlux::computeHbyA(bool verbose)
     // Now we set the diagonal of our system matrix to 0 so we can create H*u
     // TODO: Add a function for this in libmesh
     *working_vector_petsc = 0.0;
-    LIBMESH_CHKERR(MatDiagonalSet(mmat->mat(), working_vector_petsc->vec(), INSERT_VALUES));
+    LibmeshPetscCall(MatDiagonalSet(mmat->mat(), working_vector_petsc->vec(), INSERT_VALUES));
 
     if (verbose)
     {

--- a/modules/optimization/src/executioners/AdjointSolve.C
+++ b/modules/optimization/src/executioners/AdjointSolve.C
@@ -159,12 +159,12 @@ AdjointSolve::applyNodalBCs(SparseMatrix<Number> & matrix,
     auto petsc_solution = dynamic_cast<const PetscVector<Number> *>(&solution);
     auto petsc_rhs = dynamic_cast<PetscVector<Number> *>(&rhs);
     if (petsc_matrix && petsc_solution && petsc_rhs)
-      LIBMESH_CHKERR(MatZeroRowsColumns(petsc_matrix->mat(),
-                                        cast_int<PetscInt>(nbc_dofs.size()),
-                                        numeric_petsc_cast(nbc_dofs.data()),
-                                        1.0,
-                                        petsc_solution->vec(),
-                                        petsc_rhs->vec()));
+      LibmeshPetscCall(MatZeroRowsColumns(petsc_matrix->mat(),
+                                          cast_int<PetscInt>(nbc_dofs.size()),
+                                          numeric_petsc_cast(nbc_dofs.data()),
+                                          1.0,
+                                          petsc_solution->vec(),
+                                          petsc_rhs->vec()));
     else
       mooseError("Using PETSc matrices and vectors is required for applying homogenized boundary "
                  "conditions.");

--- a/modules/optimization/src/executioners/OptimizeSolve.C
+++ b/modules/optimization/src/executioners/OptimizeSolve.C
@@ -84,84 +84,76 @@ OptimizeSolve::solve()
 PetscErrorCode
 OptimizeSolve::taoSolve()
 {
-  // Petsc error code to be checked after each petsc call
-  auto ierr = (PetscErrorCode)0;
-
   PetscFunctionBegin;
   // Initialize tao object
-  ierr = TaoCreate(_my_comm.get(), &_tao);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(TaoCreate(_my_comm.get(), &_tao));
 
 #if PETSC_RELEASE_LESS_THAN(3, 21, 0)
-  ierr = TaoSetMonitor(_tao, monitor, this, nullptr);
+  LibmeshPetscCallQ(TaoSetMonitor(_tao, monitor, this, nullptr));
 #else
-  ierr = TaoMonitorSet(_tao, monitor, this, nullptr);
+  LibmeshPetscCallQ(TaoMonitorSet(_tao, monitor, this, nullptr));
 #endif
-  CHKERRQ(ierr);
 
   switch (_tao_solver_enum)
   {
     case TaoSolverEnum::NEWTON_TRUST_REGION:
-      ierr = TaoSetType(_tao, TAONTR);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAONTR));
       break;
     case TaoSolverEnum::BOUNDED_NEWTON_TRUST_REGION:
-      ierr = TaoSetType(_tao, TAOBNTR);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOBNTR));
       break;
     case TaoSolverEnum::BOUNDED_CONJUGATE_GRADIENT:
-      ierr = TaoSetType(_tao, TAOBNCG);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOBNCG));
       break;
     case TaoSolverEnum::NEWTON_LINE_SEARCH:
-      ierr = TaoSetType(_tao, TAONLS);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAONLS));
       break;
     case TaoSolverEnum::BOUNDED_NEWTON_LINE_SEARCH:
-      ierr = TaoSetType(_tao, TAOBNLS);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOBNLS));
       break;
     case TaoSolverEnum::BOUNDED_QUASI_NEWTON_TRUST_REGION:
-      ierr = TaoSetType(_tao, TAOBQNKTR);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOBQNKTR));
       break;
     case TaoSolverEnum::NEWTON_TRUST_LINE:
-      ierr = TaoSetType(_tao, TAONTL);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAONTL));
       break;
     case TaoSolverEnum::BOUNDED_NEWTON_TRUST_LINE:
-      ierr = TaoSetType(_tao, TAOBNTL);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOBNTL));
       break;
     case TaoSolverEnum::QUASI_NEWTON:
-      ierr = TaoSetType(_tao, TAOLMVM);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOLMVM));
       break;
     case TaoSolverEnum::BOUNDED_QUASI_NEWTON:
-      ierr = TaoSetType(_tao, TAOBLMVM);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOBLMVM));
       break;
 
     case TaoSolverEnum::NELDER_MEAD:
-      ierr = TaoSetType(_tao, TAONM);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAONM));
       break;
 
     case TaoSolverEnum::BOUNDED_QUASI_NEWTON_LINE_SEARCH:
-      ierr = TaoSetType(_tao, TAOBQNLS);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOBQNLS));
       break;
     case TaoSolverEnum::ORTHANT_QUASI_NEWTON:
-      ierr = TaoSetType(_tao, TAOOWLQN);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOOWLQN));
       break;
     case TaoSolverEnum::GRADIENT_PROJECTION_CONJUGATE_GRADIENT:
-      ierr = TaoSetType(_tao, TAOGPCG);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOGPCG));
       break;
     case TaoSolverEnum::BUNDLE_RISK_MIN:
-      ierr = TaoSetType(_tao, TAOBMRM);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOBMRM));
       break;
     case TaoSolverEnum::AUGMENTED_LAGRANGIAN_MULTIPLIER_METHOD:
 #if !PETSC_VERSION_LESS_THAN(3, 15, 0)
-      ierr = TaoSetType(_tao, TAOALMM);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(TaoSetType(_tao, TAOALMM));
       // Need to cancel monitors for ALMM, if not there is a segfault at MOOSE destruction. Setup
       // default constraint monitor.
 #if PETSC_RELEASE_GREATER_EQUALS(3, 21, 0)
-      ierr = TaoMonitorCancel(_tao);
+      LibmeshPetscCallQ(TaoMonitorCancel(_tao));
 #else
-      ierr = TaoCancelMonitors(_tao);
+      LibmeshPetscCallQ(TaoCancelMonitors(_tao));
 #endif
-      CHKERRQ(ierr);
-      ierr = PetscOptionsSetValue(NULL, "-tao_cmonitor", NULL);
-      CHKERRQ(ierr);
+      LibmeshPetscCallQ(PetscOptionsSetValue(NULL, "-tao_cmonitor", NULL));
       break;
 #else
       mooseError("ALMM is only compatible with PETSc versions above 3.14. ");
@@ -171,58 +163,48 @@ OptimizeSolve::taoSolve()
       mooseError("Invalid Tao solve type");
   }
 
-  CHKERRQ(ierr);
-
   // Set objective and gradient functions
 #if !PETSC_VERSION_LESS_THAN(3, 17, 0)
-  ierr = TaoSetObjective(_tao, objectiveFunctionWrapper, this);
+  LibmeshPetscCallQ(TaoSetObjective(_tao, objectiveFunctionWrapper, this));
 #else
-  ierr = TaoSetObjectiveRoutine(_tao, objectiveFunctionWrapper, this);
+  LibmeshPetscCallQ(TaoSetObjectiveRoutine(_tao, objectiveFunctionWrapper, this));
 #endif
-  CHKERRQ(ierr);
 #if !PETSC_VERSION_LESS_THAN(3, 17, 0)
-  ierr = TaoSetObjectiveAndGradient(_tao, NULL, objectiveAndGradientFunctionWrapper, this);
+  LibmeshPetscCallQ(
+      TaoSetObjectiveAndGradient(_tao, NULL, objectiveAndGradientFunctionWrapper, this));
 #else
-  ierr = TaoSetObjectiveAndGradientRoutine(_tao, objectiveAndGradientFunctionWrapper, this);
+  LibmeshPetscCallQ(
+      TaoSetObjectiveAndGradientRoutine(_tao, objectiveAndGradientFunctionWrapper, this));
 #endif
-  CHKERRQ(ierr);
 
   // Set matrix-free version of the Hessian function
-  ierr = MatCreateShell(_my_comm.get(), _ndof, _ndof, _ndof, _ndof, this, &_hessian);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(MatCreateShell(_my_comm.get(), _ndof, _ndof, _ndof, _ndof, this, &_hessian));
   // Link matrix-free Hessian to Tao
 #if !PETSC_VERSION_LESS_THAN(3, 17, 0)
-  ierr = TaoSetHessian(_tao, _hessian, _hessian, hessianFunctionWrapper, this);
+  LibmeshPetscCallQ(TaoSetHessian(_tao, _hessian, _hessian, hessianFunctionWrapper, this));
 #else
-  ierr = TaoSetHessianRoutine(_tao, _hessian, _hessian, hessianFunctionWrapper, this);
+  LibmeshPetscCallQ(TaoSetHessianRoutine(_tao, _hessian, _hessian, hessianFunctionWrapper, this));
 #endif
-  CHKERRQ(ierr);
 
   // Set initial guess
 #if !PETSC_VERSION_LESS_THAN(3, 17, 0)
-  ierr = TaoSetSolution(_tao, _parameters->vec());
+  LibmeshPetscCallQ(TaoSetSolution(_tao, _parameters->vec()));
 #else
-  ierr = TaoSetInitialVector(_tao, _parameters->vec());
+  LibmeshPetscCallQ(TaoSetInitialVector(_tao, _parameters->vec()));
 #endif
-  CHKERRQ(ierr);
 
   // Set TAO petsc options
-  ierr = TaoSetFromOptions(_tao);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(TaoSetFromOptions(_tao));
 
   // save nonTAO PETSC options to reset before every call to execute()
   _petsc_options = _problem.getPetscOptions();
   _solver_params = _problem.solverParams();
 
   // Set bounds for bounded optimization
-  ierr = TaoSetVariableBoundsRoutine(_tao, variableBoundsWrapper, this);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(TaoSetVariableBoundsRoutine(_tao, variableBoundsWrapper, this));
 
   if (_tao_solver_enum == TaoSolverEnum::AUGMENTED_LAGRANGIAN_MULTIPLIER_METHOD)
-  {
-    ierr = taoALCreate();
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(taoALCreate());
 
   // Backup multiapps so transient problems start with the same initial condition
   _problem.backupMultiApps(OptimizationAppTypes::EXEC_FORWARD);
@@ -230,29 +212,20 @@ OptimizeSolve::taoSolve()
   _problem.backupMultiApps(OptimizationAppTypes::EXEC_HOMOGENEOUS_FORWARD);
 
   // Solve optimization
-  ierr = TaoSolve(_tao);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(TaoSolve(_tao));
 
   // Print solve statistics
   if (getParam<bool>("verbose"))
-  {
-    ierr = TaoView(_tao, PETSC_VIEWER_STDOUT_WORLD);
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(TaoView(_tao, PETSC_VIEWER_STDOUT_WORLD));
 
-  ierr = TaoDestroy(&_tao);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(TaoDestroy(&_tao));
 
-  ierr = MatDestroy(&_hessian);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(MatDestroy(&_hessian));
 
   if (_tao_solver_enum == TaoSolverEnum::AUGMENTED_LAGRANGIAN_MULTIPLIER_METHOD)
-  {
-    ierr = taoALDestroy();
-    CHKERRQ(ierr);
-  }
+    LibmeshPetscCallQ(taoALDestroy());
 
-  return ierr;
+  PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 void
@@ -341,8 +314,7 @@ OptimizeSolve::monitor(Tao tao, void * ctx)
   PetscReal f, gnorm, cnorm, xdiff;
 
   PetscFunctionBegin;
-  auto ierr = TaoGetSolutionStatus(tao, &its, &f, &gnorm, &cnorm, &xdiff, &reason);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(TaoGetSolutionStatus(tao, &its, &f, &gnorm, &cnorm, &xdiff, &reason));
 
   auto * solver = static_cast<OptimizeSolve *>(ctx);
   solver->setTaoSolutionStatus((double)f, (int)its, (double)gnorm, (double)cnorm, (double)xdiff);
@@ -388,10 +360,8 @@ OptimizeSolve::hessianFunctionWrapper(
   PetscFunctionBegin;
   // Define Hessian-vector multiplication routine
   auto * solver = static_cast<OptimizeSolve *>(ctx);
-  PetscErrorCode ierr = MatShellSetOperation(
-      solver->_hessian, MATOP_MULT, (void (*)(void))OptimizeSolve::applyHessianWrapper);
-
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(MatShellSetOperation(
+      solver->_hessian, MATOP_MULT, (void (*)(void))OptimizeSolve::applyHessianWrapper));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -401,8 +371,7 @@ OptimizeSolve::applyHessianWrapper(Mat H, Vec s, Vec Hs)
   void * ctx;
 
   PetscFunctionBegin;
-  auto ierr = MatShellGetContext(H, &ctx);
-  CHKERRQ(ierr);
+  LibmeshPetscCallQ(MatShellGetContext(H, &ctx));
 
   auto * solver = static_cast<OptimizeSolve *>(ctx);
   libMesh::PetscVector<Number> sbar(s, solver->_my_comm);
@@ -416,8 +385,8 @@ OptimizeSolve::variableBoundsWrapper(Tao tao, Vec /*xl*/, Vec /*xu*/, void * ctx
   PetscFunctionBegin;
   auto * solver = static_cast<OptimizeSolve *>(ctx);
 
-  PetscErrorCode ierr = solver->variableBounds(tao);
-  return ierr;
+  LibmeshPetscCallQ(solver->variableBounds(tao));
+  PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 Real
@@ -514,9 +483,8 @@ OptimizeSolve::variableBounds(Tao tao)
     xu.set(i, _obj_function->getUpperBound(i));
   }
   // set upper and lower bounds in tao solver
-  PetscErrorCode ierr;
-  ierr = TaoSetVariableBounds(tao, xl.vec(), xu.vec());
-  return ierr;
+  LibmeshPetscCallQ(TaoSetVariableBounds(tao, xl.vec(), xu.vec()));
+  PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 PetscErrorCode
@@ -578,75 +546,57 @@ OptimizeSolve::inequalityGradientFunctionWrapper(
 PetscErrorCode
 OptimizeSolve::taoALCreate()
 {
-  auto ierr = (PetscErrorCode)0;
-
   PetscFunctionBegin;
   if (_obj_function->getNumEqCons())
   {
     // Create equality vector
-    ierr = VecCreate(_my_comm.get(), &_ce);
-    CHKERRQ(ierr);
-    ierr = VecSetSizes(_ce, _obj_function->getNumEqCons(), _obj_function->getNumEqCons());
-    CHKERRQ(ierr);
-    ierr = VecSetFromOptions(_ce);
-    CHKERRQ(ierr);
-    ierr = VecSetUp(_ce);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(VecCreate(_my_comm.get(), &_ce));
+    LibmeshPetscCallQ(
+        VecSetSizes(_ce, _obj_function->getNumEqCons(), _obj_function->getNumEqCons()));
+    LibmeshPetscCallQ(VecSetFromOptions(_ce));
+    LibmeshPetscCallQ(VecSetUp(_ce));
 
     // Set equality jacobian matrix
-    ierr = MatCreate(_my_comm.get(), &_gradient_e);
-    CHKERRQ(ierr);
-    ierr = MatSetSizes(
-        _gradient_e, _obj_function->getNumEqCons(), _ndof, _obj_function->getNumEqCons(), _ndof);
-    CHKERRQ(ierr);
-    ierr = MatSetFromOptions(_gradient_e);
-    CHKERRQ(ierr);
-    ierr = MatSetUp(_gradient_e);
+    LibmeshPetscCallQ(MatCreate(_my_comm.get(), &_gradient_e));
+    LibmeshPetscCallQ(MatSetSizes(
+        _gradient_e, _obj_function->getNumEqCons(), _ndof, _obj_function->getNumEqCons(), _ndof));
+    LibmeshPetscCallQ(MatSetFromOptions(_gradient_e));
+    LibmeshPetscCallQ(MatSetUp(_gradient_e));
 
     // Set the Equality Constraints
-    ierr = TaoSetEqualityConstraintsRoutine(_tao, _ce, equalityFunctionWrapper, this);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(TaoSetEqualityConstraintsRoutine(_tao, _ce, equalityFunctionWrapper, this));
 
     // Set the Equality Constraints Jacobian
-    ierr = TaoSetJacobianEqualityRoutine(
-        _tao, _gradient_e, _gradient_e, equalityGradientFunctionWrapper, this);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(TaoSetJacobianEqualityRoutine(
+        _tao, _gradient_e, _gradient_e, equalityGradientFunctionWrapper, this));
   }
 
   if (_obj_function->getNumInEqCons())
   {
     // Create inequality vector
-    ierr = VecCreate(_my_comm.get(), &_ci);
-    CHKERRQ(ierr);
-    ierr = VecSetSizes(_ci, _obj_function->getNumInEqCons(), _obj_function->getNumInEqCons());
-    CHKERRQ(ierr);
-    ierr = VecSetFromOptions(_ci);
-    CHKERRQ(ierr);
-    ierr = VecSetUp(_ci);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(VecCreate(_my_comm.get(), &_ci));
+    LibmeshPetscCallQ(
+        VecSetSizes(_ci, _obj_function->getNumInEqCons(), _obj_function->getNumInEqCons()));
+    LibmeshPetscCallQ(VecSetFromOptions(_ci));
+    LibmeshPetscCallQ(VecSetUp(_ci));
 
     // Set inequality jacobian matrix
-    ierr = MatCreate(_my_comm.get(), &_gradient_i);
-    CHKERRQ(ierr);
-    ierr = MatSetSizes(_gradient_i,
-                       _obj_function->getNumInEqCons(),
-                       _ndof,
-                       _obj_function->getNumInEqCons(),
-                       _ndof);
-    CHKERRQ(ierr);
-    ierr = MatSetFromOptions(_gradient_i);
-    CHKERRQ(ierr);
-    ierr = MatSetUp(_gradient_i);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(MatCreate(_my_comm.get(), &_gradient_i));
+    LibmeshPetscCallQ(MatSetSizes(_gradient_i,
+                                  _obj_function->getNumInEqCons(),
+                                  _ndof,
+                                  _obj_function->getNumInEqCons(),
+                                  _ndof));
+    LibmeshPetscCallQ(MatSetFromOptions(_gradient_i));
+    LibmeshPetscCallQ(MatSetUp(_gradient_i));
 
     // Set the Inequality constraints
-    ierr = TaoSetInequalityConstraintsRoutine(_tao, _ci, inequalityFunctionWrapper, this);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(
+        TaoSetInequalityConstraintsRoutine(_tao, _ci, inequalityFunctionWrapper, this));
 
     // Set the Inequality constraints Jacobian
-    ierr = TaoSetJacobianInequalityRoutine(
-        _tao, _gradient_i, _gradient_i, inequalityGradientFunctionWrapper, this);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(TaoSetJacobianInequalityRoutine(
+        _tao, _gradient_i, _gradient_i, inequalityGradientFunctionWrapper, this));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -654,23 +604,16 @@ OptimizeSolve::taoALCreate()
 PetscErrorCode
 OptimizeSolve::taoALDestroy()
 {
-  auto ierr = (PetscErrorCode)0;
-
   PetscFunctionBegin;
   if (_obj_function->getNumEqCons())
   {
-    ierr = VecDestroy(&_ce);
-    CHKERRQ(ierr);
-    ierr = MatDestroy(&_gradient_e);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(VecDestroy(&_ce));
+    LibmeshPetscCallQ(MatDestroy(&_gradient_e));
   }
   if (_obj_function->getNumInEqCons())
   {
-    ierr = VecDestroy(&_ci);
-    CHKERRQ(ierr);
-
-    ierr = MatDestroy(&_gradient_i);
-    CHKERRQ(ierr);
+    LibmeshPetscCallQ(VecDestroy(&_ci));
+    LibmeshPetscCallQ(MatDestroy(&_gradient_i));
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/modules/stochastic_tools/src/utils/POD.C
+++ b/modules/stochastic_tools/src/utils/POD.C
@@ -71,14 +71,17 @@ POD::computePOD(const VariableName & vname,
   _communicator.max(snapshot_size);
 
   // Generally snapshot matrices are dense.
-  LIBMESH_CHKERR(MatCreateDense(
-      _communicator.get(), local_rows, PETSC_DECIDE, global_rows, snapshot_size, NULL, &mat));
+  LibmeshPetscCallA(
+      _communicator.get(),
+      MatCreateDense(
+          _communicator.get(), local_rows, PETSC_DECIDE, global_rows, snapshot_size, NULL, &mat));
 
   // Check where the local rows begin in the matrix, we use these to convert from local to
   // global indices
   dof_id_type local_beg = 0;
   dof_id_type local_end = 0;
-  LIBMESH_CHKERR(
+  LibmeshPetscCallA(
+      _communicator.get(),
       MatGetOwnershipRange(mat, numeric_petsc_cast(&local_beg), numeric_petsc_cast(&local_end)));
 
   unsigned int counter = 0;
@@ -95,61 +98,67 @@ POD::computePOD(const VariableName & vname,
         std::iota(std::begin(columns), std::end(columns), 0);
 
         // Set the rows in the "sparse" matrix
-        LIBMESH_CHKERR(MatSetValues(mat,
-                                    1,
-                                    rows.data(),
-                                    snapshot_size,
-                                    columns.data(),
-                                    snap.get_values().data(),
-                                    INSERT_VALUES));
+        LibmeshPetscCallA(_communicator.get(),
+                          MatSetValues(mat,
+                                       1,
+                                       rows.data(),
+                                       snapshot_size,
+                                       columns.data(),
+                                       snap.get_values().data(),
+                                       INSERT_VALUES));
       }
     }
 
   // Assemble the matrix
-  LIBMESH_CHKERR(MatAssemblyBegin(mat, MAT_FINAL_ASSEMBLY));
-  LIBMESH_CHKERR(MatAssemblyEnd(mat, MAT_FINAL_ASSEMBLY));
+  LibmeshPetscCallA(_communicator.get(), MatAssemblyBegin(mat, MAT_FINAL_ASSEMBLY));
+  LibmeshPetscCallA(_communicator.get(), MatAssemblyEnd(mat, MAT_FINAL_ASSEMBLY));
 
   SVD svd;
-  LIBMESH_CHKERR(SVDCreate(_communicator.get(), &svd));
+  LibmeshPetscCallA(_communicator.get(), SVDCreate(_communicator.get(), &svd));
   // Now we set the operators for our SVD objects
-  LIBMESH_CHKERR(SVDSetOperators(svd, mat, NULL));
+  LibmeshPetscCallA(_communicator.get(), SVDSetOperators(svd, mat, NULL));
 
   // Set the parallel operation mode to "DISTRIBUTED", default is "REDUNDANT"
   DS ds;
-  LIBMESH_CHKERR(SVDGetDS(svd, &ds));
-  LIBMESH_CHKERR(DSSetParallel(ds, DS_PARALLEL_DISTRIBUTED));
+  LibmeshPetscCallA(_communicator.get(), SVDGetDS(svd, &ds));
+  LibmeshPetscCallA(_communicator.get(), DSSetParallel(ds, DS_PARALLEL_DISTRIBUTED));
 
   // We want the Lanczos method, might give the choice to the user
   // at some point
-  LIBMESH_CHKERR(SVDSetType(svd, SVDTRLANCZOS));
+  LibmeshPetscCallA(_communicator.get(), SVDSetType(svd, SVDTRLANCZOS));
 
   // Default is the transpose is explicitly created. This method is less efficient
   // computationally but better for storage
-  LIBMESH_CHKERR(SVDSetImplicitTranspose(svd, PETSC_TRUE));
+  LibmeshPetscCallA(_communicator.get(), SVDSetImplicitTranspose(svd, PETSC_TRUE));
 
-  LIBMESH_CHKERR(PetscOptionsInsertString(NULL, _extra_slepc_options.c_str()));
+  LibmeshPetscCallA(_communicator.get(),
+                    PetscOptionsInsertString(NULL, _extra_slepc_options.c_str()));
 
   // Set the subspace size for the Lanczos method, we take twice as many
   // basis vectors as the requested number of POD modes. This guarantees in most of the case the
   // convergence of the singular triplets.
-  LIBMESH_CHKERR(SVDSetDimensions(
-      svd, num_modes, std::min(2 * num_modes, global_rows), std::min(2 * num_modes, global_rows)));
+  LibmeshPetscCallA(_communicator.get(),
+                    SVDSetDimensions(svd,
+                                     num_modes,
+                                     std::min(2 * num_modes, global_rows),
+                                     std::min(2 * num_modes, global_rows)));
 
   // Gives the user the ability to override any option set before the solve.
-  LIBMESH_CHKERR(SVDSetFromOptions(svd));
+  LibmeshPetscCallA(_communicator.get(), SVDSetFromOptions(svd));
 
   // Compute the singular value triplets
-  LIBMESH_CHKERR(SVDSolve(svd));
+  LibmeshPetscCallA(_communicator.get(), SVDSolve(svd));
 
   // Check how many singular triplets converged
   PetscInt nconv;
-  LIBMESH_CHKERR(SVDGetConverged(svd, &nconv));
+  LibmeshPetscCallA(_communicator.get(), SVDGetConverged(svd, &nconv));
 
   // We start extracting the basis functions and the singular values.
 
   // Find the local size needed for u
   dof_id_type local_snapsize = 0;
-  LIBMESH_CHKERR(MatGetLocalSize(mat, NULL, numeric_petsc_cast(&local_snapsize)));
+  LibmeshPetscCallA(_communicator.get(),
+                    MatGetLocalSize(mat, NULL, numeric_petsc_cast(&local_snapsize)));
 
   PetscVector<Real> u(_communicator);
   u.init(snapshot_size, local_snapsize, false, PARALLEL);
@@ -164,7 +173,8 @@ POD::computePOD(const VariableName & vname,
   singular_values.resize(nconv);
   // Fetch the singular value triplet and immediately save the singular value
   for (PetscInt j = 0; j < nconv; ++j)
-    LIBMESH_CHKERR(SVDGetSingularTriplet(svd, j, &singular_values[j], NULL, NULL));
+    LibmeshPetscCallA(_communicator.get(),
+                      SVDGetSingularTriplet(svd, j, &singular_values[j], NULL, NULL));
 
   // Determine how many modes we need
   unsigned int num_requested_modes = determineNumberOfModes(singular_values, num_modes, energy);
@@ -174,12 +184,12 @@ POD::computePOD(const VariableName & vname,
   right_basis_functions.resize(num_requested_modes);
   for (PetscInt j = 0; j < cast_int<PetscInt>(num_requested_modes); ++j)
   {
-    LIBMESH_CHKERR(SVDGetSingularTriplet(svd, j, NULL, v.vec(), u.vec()));
+    LibmeshPetscCallA(_communicator.get(), SVDGetSingularTriplet(svd, j, NULL, v.vec(), u.vec()));
     u.localize(left_basis_functions[j].get_values());
     v.localize(right_basis_functions[j].get_values());
   }
-  LIBMESH_CHKERR(MatDestroy(&mat));
-  LIBMESH_CHKERR(SVDDestroy(&svd));
+  LibmeshPetscCallA(_communicator.get(), MatDestroy(&mat));
+  LibmeshPetscCallA(_communicator.get(), SVDDestroy(&svd));
 #else
   // These variables would otherwise be unused
   libmesh_ignore(vname);


### PR DESCRIPTION
Hi @lindsayad,

## Reason and Design
Same as that of libMesh/libmesh#3973.
Shortens the code and allows exception throwing.

~I'm missing `LIBMESH_CHKERR`, I'll do that in another PR, I suspect this will be enough for a few CI problems already.~

Cheers,
-N