### PR TITLE
Make October 2024 news public

### DIFF
--- a/modules/doc/content/newsletter/2024/2024_10.md
+++ b/modules/doc/content/newsletter/2024/2024_10.md
@@ -1,10 +1,5 @@
 # MOOSE Newsletter (October 2024)
 
-!alert! construction title=In Progress
-This MOOSE Newsletter edition is in progress. Please check back in November 2024
-for a complete description of all MOOSE changes.
-!alert-end!
-
 ## MOOSE Improvements
 
 ### New System: Convergence

--- a/modules/doc/content/newsletter/2024/2024_10.md
+++ b/modules/doc/content/newsletter/2024/2024_10.md
@@ -44,8 +44,7 @@ pyramid into 2 tetrahedra, each prism into 3 tets, and each cube into
 
 ### Ability to set multiple time integrators
 
-For simulations using multiple equations, notably in the context of solving multiple nonlinear
-systems, there is now the option to use different time integration methods for each equation.
+For simulations using multiple variables/equations, there is now the option to use different time integration methods for each variable/equation.
 
 ### New tests scheduler for High Performance Computing
 

--- a/modules/doc/content/newsletter/2024/2024_10.md
+++ b/modules/doc/content/newsletter/2024/2024_10.md
@@ -12,6 +12,38 @@ to add new capability is [PostprocessorConvergence.md], which allows a post-proc
 to be compared to a tolerance to determine convergence. This post-processor
 should be executed on the new `execute_on` option, `NONLINEAR_CONVERGENCE`.
 
+### Standardization of Physics initialization
+
+For all `Physics` classes deriving from `PhysicsBase`, the variable initialization behavior has been standardized.
+Variables should be initialized using, in order of priority:
+
+- user-specified initialization input parameters, which should always be obeyed
+- from an exodus file, with the `initialize_variables_from_mesh_file` parameter, if no user specified values for a variable are requested
+- from the checkpoint file specified to the `Problem` for the restart
+- from the default value of the initialization parameters, if and only if none of the previous conditions apply
+
+### Direct Nodeset generation
+
+In MOOSE, we often forego the concepts of nodesets and sidesets to simply use the term "boundary", which refers
+to one or the other depending on the objects at hand. For example, a Dirichlet boundary condition for a Lagrange variable
+will use a nodeset for its boundary parameter, while a postprocessor computing the diffusive flux with a monomial variable
+will use a sideset for its boundary parameter. As such, we focused our mesh generation effort to be able to easily create sidesets,
+and the nodesets can be easily generated from these sidesets.
+
+However, for the specific need of generating 1D nodesets within a 3D mesh, we needed to be able to generate nodesets directly.
+The [ParsedGenerateNodeset.md] joins the roster of mesh generators for that purpose. It offers much of the flexibility of
+the [ParsedGenerateSideset.md] and their design are very similar.
+
+## MOOSE Modules changes
+
+### Navier Stokes: Skewness correction changes
+
+The gradient of the pressure, both corrected and uncorrected, that are used in Rhie-Chow interpolation are now both
+using skewness correction when skewness correction has been specified for the pressure variable.
+
+Skewness-corrected gradients are now computed using the Least-Squares method rather than Green Gauss.
+With these two modifications, oscillations on skewed meshes in simulations with volumetric body forces are no longer present.
+
 ## libMesh-level Changes
 
 ### `2024.10.17` Update
@@ -48,6 +80,12 @@ should be executed on the new `execute_on` option, `NONLINEAR_CONVERGENCE`.
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements
+
+- The [GenericFunctorTimeDerivativeMaterial.md] was added to be able to create time-derivative functor material properties of other functors.
+- The [ParsedAux.md] can now directly leverage Real and ADReal-valued material properties, without first converting them to auxiliary variables.
+- Block-restriction of indicators in adaptivity is now fully supported. Previously only markers could be block restricted, while indicators had to
+  cover the whole domain.
+- The [Coupleable.md] interface now supports an additional routine for retrieving the time derivative of nodal and DoF values with automatic differentiation.
 
 ## Conda Package Changes
 

--- a/modules/doc/content/newsletter/2024/2024_10.md
+++ b/modules/doc/content/newsletter/2024/2024_10.md
@@ -102,8 +102,6 @@ other variables is much reduced, and performance was greatly improved.
 - Improvements and fixes in Reduced Basis code, particularly the
   Empirical Interpolation Method classes.
 
-## PETSc-level Changes
-
 ## Bug Fixes and Minor Enhancements
 
 - The [GenericFunctorTimeDerivativeMaterial.md] was added to be able to create time-derivative functor material properties of other functors.

--- a/modules/doc/content/newsletter/2024/2024_10.md
+++ b/modules/doc/content/newsletter/2024/2024_10.md
@@ -22,20 +22,20 @@ should be executed on the new `execute_on` option, `NONLINEAR_CONVERGENCE`.
   creating high-quality volume meshes from arbitrary STL files is
   still a work in progress.
 - Support for higher-order (up to quintic) vector-valued FE bases in
-  the Nédélec (first kind) and Ravier-Thomas FE families.
+  the Nédélec (first kind) and Raviart-Thomas FE families.
 - Better handling for odd IsoGeometric Analysis extraction operators,
   and better error handling for broken IGA operators.
 - Better unit test coverage for NodeElem; fixes to NodeElem
   methods which should be no-op but instead threw errors.
 - Unit test coverage for fifth-order `MONOMIAL` elements.  So far
   new tests have not uncovered any problems, but based on user
-  reports of convergence issues we recommend limiting `MONOMIAL`
+  reports of convergence issues, we recommend limiting `MONOMIAL`
   variables to fourth-order.
-- Fixes for condensed eigensolve support after mesh reinit
+- Fixes for condensed eigensolve support after mesh reinit.
 - Fixes for caching of FE data on sides of meshes with non-uniform
-  p-refinement levels
+  p-refinement levels.
 - Minor fixes for compiler complaints from `nvc++` and
-  `clang++ -fsanitize`
+  `clang++ -fsanitize`.
 - Properly register `--keep-cout` and `--drop-cerr` warnings with
   PETSc to avoid "options you set that were not used" false positives.
 - Better error messages when tetrahedralizing a non-watertight input
@@ -45,7 +45,6 @@ should be executed on the new `execute_on` option, `NONLINEAR_CONVERGENCE`.
 - Improvements and fixes in Reduced Basis code, particularly the
   Empirical Interpolation Method classes.
 
-
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements
@@ -53,9 +52,9 @@ should be executed on the new `execute_on` option, `NONLINEAR_CONVERGENCE`.
 ## Conda Package Changes
 
 - `moose-mpi`, our lowest level package, has been updated to allow users wishing to
-  build their own PETSc, libMesh, WASP to do so without needing to install any
+  build their own PETSc, libMesh, and WASP to do so without needing to install any
   additional Conda packages.
 - HDF5 has been downgraded to solve issue: [Floating Point Exception, #28350](https://github.com/idaholab/moose/issues/28350)
 - The minimum MacOS build SDK has been bumped to MacOS Big Sur (11.3). Users of
   MacOS versions older than this may run into issues building and running MOOSE,
-  MOOSE dependencies, or other   MOOSE-based applications.
+  MOOSE dependencies, or other MOOSE-based applications.

--- a/modules/doc/content/newsletter/2024/2024_10.md
+++ b/modules/doc/content/newsletter/2024/2024_10.md
@@ -34,6 +34,24 @@ However, for the specific need of generating 1D nodesets within a 3D mesh, we ne
 The [ParsedGenerateNodeset.md] joins the roster of mesh generators for that purpose. It offers much of the flexibility of
 the [ParsedGenerateSideset.md] and their design are very similar.
 
+### Mesh conversion to all simplices (triangles and tets)
+
+The [ElementsToSimplicesConverter.md] was created as a mesh generator. An input mesh will be modified
+to replace each non-simplex mesh element with a set of simplices
+connecting the same nodes.  Each quad is split into 2 triangles, each
+pyramid into 2 tetrahedra, each prism into 3 tets, and each cube into
+6 tets.
+
+### Ability to set multiple time integrators
+
+For simulations using multiple equations, notably in the context of solving multiple nonlinear
+systems, there is now the option to use different time integration methods for each equation.
+
+### New tests scheduler for High Performance Computing
+
+A new scheduler was added to the MOOSE test suite to be able to leverage HPC platforms for
+continuous integration.
+
 ## MOOSE Modules changes
 
 ### Navier Stokes: Skewness correction changes
@@ -43,6 +61,13 @@ using skewness correction when skewness correction has been specified for the pr
 
 Skewness-corrected gradients are now computed using the Least-Squares method rather than Green Gauss.
 With these two modifications, oscillations on skewed meshes in simulations with volumetric body forces are no longer present.
+
+## Thermal hydraulics: use of field variables on node elements for Junctions
+
+For cases with large numbers of Junctions, it was observed that performance was severely degraded.
+This was explained by the use of scalar variables, which are intended to have a global coupling
+to other fields. By instead using field variables on node elements, the expected coupling to
+other variables is much reduced, and performance was greatly improved.
 
 ## libMesh-level Changes
 
@@ -86,6 +111,15 @@ With these two modifications, oscillations on skewed meshes in simulations with 
 - Block-restriction of indicators in adaptivity is now fully supported. Previously only markers could be block restricted, while indicators had to
   cover the whole domain.
 - The [Coupleable.md] interface now supports an additional routine for retrieving the time derivative of nodal and DoF values with automatic differentiation.
+- A diagnostics for "waterproofness" of sidesets, e.g. covering the entire external boundary of the mesh, was added to the [MeshDiagnosticsGenerator.md].
+- A new execution flag `NONLINEAR_CONVERGENCE` was added for executing objects right before evaluating the residual in nonlinear iterations and assessing convergence.
+- A new `timeIntegral()` routine was added to Functions to compute the integral from time `t1` to `t2` at point `p`. The routine must be implemented for every Function requiring it.
+- A `FunctorMaterial` was added to compute the time derivatives of other functors. This facilitates the creation of complex expressions directly from the input file.
+- The [AverageVariableChange.md] postprocessor was added to compute the change over time steps of a variable. This is part of a larger effort to provide greater flexibility in setting convergence criteria.
+- `FluidProperties` can now return exceptions when a `NaN` is encountered, using the [NaNInterface.md]. Previously, only ignoring, returning an error or a warning were possible.
+- The [JSONFileReader.md] was templated to be able to read JSON files with leaves of strings rather than Reals.
+- Verification and validation document lists can now be placed in the top level of `[Tests]` specifications.
+- The [SideFVFluxBCIntegral.md] was added to be able to postprocess the fluxes of a `FVFluxBC` directly rather than re-implementing the flux computation in a postprocessor.
 
 ## Conda Package Changes
 

--- a/modules/doc/content/newsletter/2024/2024_11.md
+++ b/modules/doc/content/newsletter/2024/2024_11.md
@@ -1,0 +1,16 @@
+# MOOSE Newsletter (November 2024)
+
+!alert! construction title=In Progress
+This MOOSE Newsletter edition is in progress. Please check back in December 2024
+for a complete description of all MOOSE changes.
+!alert-end!
+
+## MOOSE Improvements
+
+## libMesh-level Changes
+
+## PETSc-level Changes
+
+## Bug Fixes and Minor Enhancements
+
+## Conda Package Changes

--- a/modules/doc/content/newsletter/index.md
+++ b/modules/doc/content/newsletter/index.md
@@ -6,6 +6,7 @@ monthly to the [MOOSE discussion forum](contact_us.md) as well as provided below
 
 ## 2024
 
+- [October, 2024](2024_10.md)
 - [September, 2024](2024_09.md)
 - [August, 2024](2024_08.md)
 - [July, 2024](2024_07.md)


### PR DESCRIPTION
Adds November 2024 template and also makes a few small adjustments to grammar, whitespaces, etc. 

@idaholab/moose-ccb Please add your contributions, as well as those that you have reviewed or been affiliated with, if those are not in the news already. Thanks!

Refs #11447
