### PR TITLE
Modified error message to be more accurate.

### DIFF
--- a/framework/src/parser/Builder.C
+++ b/framework/src/parser/Builder.C
@@ -1780,9 +1780,11 @@ Builder::setScalarComponentParameter(const std::string & full_name,
     _errmsg += hit::errormsg(root()->find(full_name),
                              "wrong number of values in scalar component parameter ",
                              full_name,
-                             ": size ",
+                             ": ",
+                             short_name,
+                             " was given ",
                              vec.size(),
-                             " is not a multiple of ",
+                             " components but should have ",
                              LIBMESH_DIM) +
                "\n";
     return;


### PR DESCRIPTION
closes #28961

## Reason
This error message prints if the number of values passed to a scalar component variable does not match with LIBMESH_DIM. However, the error message stated that the number of values passed was not a factor LIBMESH_DIM.

## Design
This just modifies the error message to make the issue clearer to the user.

## Impact
Users should have an easier time debugging their input files.
