### PR TITLE
Dont try to run tests using the XDR format when libmesh was built without it

### DIFF
--- a/modules/doc/content/citing.md
+++ b/modules/doc/content/citing.md
@@ -202,6 +202,26 @@ This paper gives an overview of the MOOSE Thermal Hydraulics module (THM):
 }
 ```
 
+
+### Fluid properties
+
+The following document summarizes the main capabilities available in the Fluid Properties module:
+
+```
+@article{GIUDICELLI2025109407,
+title = {The MOOSE fluid properties module},
+journal = {Computer Physics Communications},
+volume = {307},
+pages = {109407},
+year = {2025},
+issn = {0010-4655},
+doi = {https://doi.org/10.1016/j.cpc.2024.109407},
+url = {https://www.sciencedirect.com/science/article/pii/S0010465524003308},
+author = {Guillaume Giudicelli and Christopher Green and Joshua Hansel and David Andrs and April Novak and Sebastian Schunert and Benjamin Spaude and Steven Isaacs and Matthias Kunick and Robert Salko and Shane Henderson and Lise Charlot and Alexander Lindsay},
+keywords = {Modeling & simulation, Fluid properties, MOOSE}
+}
+```
+
 ### Peridynamics
 
 The following papers document the formulations used in the MOOSE Peridynamics module.

--- a/test/tests/auxkernels/solution_aux/tests
+++ b/test/tests/auxkernels/solution_aux/tests
@@ -168,6 +168,7 @@
       input = 'aux_nonlinear_solution.i'
       exodiff = 'aux_nonlinear_solution_out.e'
       detail = "from a simulation using"
+      xdr = true
     []
 
     [from_xda]

--- a/test/tests/mesh/checkpoint/tests
+++ b/test/tests/mesh/checkpoint/tests
@@ -1,7 +1,7 @@
 [Tests]
   design = 'splitting.md'
   issues = '#8472 #7752 #11004'
-  [./test_2_generate_split]
+  [test_2_generate_split]
     type = 'RunApp'
     input = 'checkpoint_split.i'
     cli_args = '--split-mesh 2 --split-file checkpoint_split_in'
@@ -9,8 +9,9 @@
     requirement = 'The system shall generate pre-split mesh files using a standard input file combined with command line arguments.'
     recover = false
     mesh_mode = 'REPLICATED'
-  [../]
-  [./test_2]
+    xdr = true
+  []
+  [test_2]
     prereq = 'test_2_generate_split'
     type = 'Exodiff'
     input = 'checkpoint_split.i'
@@ -20,8 +21,8 @@
     min_parallel = 2
 
     requirement = 'The system shall use pre-split mesh files using a standard input file combined with command line arguments.'
-  [../]
-  [./test_2a_generate_split]
+  []
+  [test_2a_generate_split]
     type = 'RunApp'
     input = 'checkpoint_split.i'
     cli_args = '--split-mesh 2 --split-file checkpoint_split_in.cpr'
@@ -29,8 +30,8 @@
     requirement = 'The system shall generate pre-split binary mesh files using a standard input file combined with command line arguments.'
     recover = false
     mesh_mode = 'REPLICATED'
-  [../]
-  [./test_2a]
+  []
+  [test_2a]
     prereq = 'test_2a_generate_split'
     type = 'Exodiff'
     input = 'checkpoint_split.i'
@@ -40,5 +41,5 @@
     min_parallel = 2
 
     requirement = 'The system shall use pre-split binary mesh files using a standard input file combined with command line arguments.'
-  [../]
+  []
 []

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -146,6 +146,7 @@
     design = 'XDA.md'
     issues = '#2243'
     requirement = 'The system shall support XDR output.'
+    xdr = true
   []
 
   [json_full]

--- a/test/tests/outputs/xda/tests
+++ b/test/tests/outputs/xda/tests
@@ -18,6 +18,7 @@
       check_files = 'xdr_out_0000.xdr xdr_out_0000_mesh.xdr xdr_out_0001.xdr xdr_out_0001_mesh.xdr'
 
       detail = 'in XDR (binary) format.'
+      xdr = true
     []
   []
 []

--- a/test/tests/outputs/xda_xdr/tests
+++ b/test/tests/outputs/xda_xdr/tests
@@ -2,12 +2,13 @@
   issues = '#1927'
   design = 'outputs/XDA.md'
 
-  [./both_xda_and_xdr]
+  [both_xda_and_xdr]
     # Test that setting xda = true and xdr = true works.
     type = CheckFiles
     input = xda_xdr.i
     check_files = 'xda_xdr_out_0000.xda xda_xdr_out_0000.xdr xda_xdr_out_0000_mesh.xdr xda_xdr_out_0000_mesh.xda'
 
     requirement = "The system shall support simultaneous output of the ASCII and binary forms of the libMesh native format."
-  [../]
+    xdr = true
+  []
 []

--- a/test/tests/postprocessors/num_elems/tests
+++ b/test/tests/postprocessors/num_elems/tests
@@ -1,5 +1,5 @@
 [Tests]
-  [./test]
+  [test]
     type = 'CSVDiff'
     input = 'num_elems.i'
     csvdiff = 'num_elems_out.csv'
@@ -8,12 +8,13 @@
                    (active or total) in the simulation.'
     design = '/NumElements.md'
     issues = '#2094 #8421'
-  [../]
+  []
 
-  [./test_split]
+  [test_split]
     type = 'CSVDiff'
     input = 'num_elems.i'
     cli_args = '--use-split --split-file generated.cpr Outputs/file_base=num_elems_split_out'
+    xdr = true
 
     min_parallel = 4
     max_parallel = 4
@@ -24,5 +25,5 @@
                    (active or total) in the simulation when using distributed (pre-split) mesh.'
     design = '/NumElements.md'
     issues = '#2094 #8421'
-  [../]
+  []
 []

--- a/test/tests/postprocessors/num_nodes/tests
+++ b/test/tests/postprocessors/num_nodes/tests
@@ -1,5 +1,5 @@
 [Tests]
-  [./test]
+  [test]
     type = 'CSVDiff'
     input = 'num_nodes.i'
     csvdiff = 'num_nodes_out.csv'
@@ -8,12 +8,13 @@
                    (replicated or distributed) in the simulation.'
     design = '/NumNodes.md'
     issues = '#2094'
-  [../]
+  []
 
-  [./test_split]
+  [test_split]
     type = 'CSVDiff'
     input = 'num_nodes.i'
     cli_args = '--use-split --split-file generated.cpr Outputs/file_base=num_nodes_split_out'
+    xdr = true
 
     min_parallel = 4
     max_parallel = 4
@@ -24,5 +25,5 @@
                    in the simulation when using distributed (pre-split) mesh.'
     design = '/NumNodes.md'
     issues = '#2094 #8421'
-  [../]
+  []
 []


### PR DESCRIPTION
refs #26682 
fixes failures found in #28906 

I think the error message is clear enough for someone USING xdr when they built without support for it that we dont need to make their test suite fail as well. But I could be wrong. 
In which case we could keep only 1 failing test?