### PR TITLE
Restricted convergence test to 4 processes

### DIFF
--- a/test/tests/convergence/default_nonlinear_convergence/default_nonlinear_convergence.i
+++ b/test/tests/convergence/default_nonlinear_convergence/default_nonlinear_convergence.i
@@ -35,9 +35,8 @@
 [Convergence]
   [res_conv]
     type = DefaultNonlinearConvergence
-    # With default tolerances, the solve takes 2 iterations, but with this
-    # value, the solve takes only 1:
-    nl_abs_tol = 1e-5
+    # With this, convergence should occur immediately (zero iterations)
+    nl_abs_tol = 1e15
   []
 []
 

--- a/test/tests/convergence/default_nonlinear_convergence/gold/default_nonlinear_convergence_out.csv
+++ b/test/tests/convergence/default_nonlinear_convergence/gold/default_nonlinear_convergence_out.csv
@@ -1,2 +1,2 @@
 time,num_nl_its
-2,1
+2,0


### PR DESCRIPTION
This fixes the sweep testing failures caused by https://github.com/idaholab/moose/pull/28848.
