### PR TITLE
Added diagnostic check for watertight nodesets

### DIFF
--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -33,6 +33,8 @@ private:
   void checkSidesetsOrientation(const std::unique_ptr<MeshBase> & mesh) const;
   //// Routine to check is mesh is fully covered in sidesets
   void checkWaterTightSidesets(const std::unique_ptr<MeshBase> & mesh) const;
+  //// Routine to check is mesh is fully covered in nodesets
+  void checkWatertightNodesets(const std::unique_ptr<MeshBase> & mesh) const;
   /// Routine to check the element volumes
   void checkElementVolumes(const std::unique_ptr<MeshBase> & mesh) const;
   /// Routine to check the element types in each subdomain
@@ -62,6 +64,8 @@ private:
   const MooseEnum _check_sidesets_orientation;
   //// whether to check that each external side is assigned to a sideset
   const MooseEnum _check_watertight_sidesets;
+  //// whether to check that each external node is assigned to a nodeset
+  const MooseEnum _check_watertight_nodesets;
   /// whether to check element volumes
   const MooseEnum _check_element_volumes;
   /// minimum size for element volume to be counted as a tiny element

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -46,6 +46,10 @@ MeshDiagnosticsGenerator::validParams()
       chk_option,
       "whether to check for external sides that are not assigned to any sidesets");
   params.addParam<MooseEnum>(
+      "check_for_watertight_nodesets",
+      chk_option,
+      "whether to check for external nodes that are not assigned to any nodeset");
+  params.addParam<MooseEnum>(
       "examine_element_volumes", chk_option, "whether to examine volume of the elements");
   params.addParam<Real>("minimum_element_volumes", 1e-16, "minimum size for element volume");
   params.addParam<Real>("maximum_element_volumes", 1e16, "Maximum size for element volume");
@@ -80,6 +84,7 @@ MeshDiagnosticsGenerator::MeshDiagnosticsGenerator(const InputParameters & param
     _input(getMesh("input")),
     _check_sidesets_orientation(getParam<MooseEnum>("examine_sidesets_orientation")),
     _check_watertight_sidesets(getParam<MooseEnum>("check_for_watertight_sidesets")),
+    _check_watertight_nodesets(getParam<MooseEnum>("check_for_watertight_nodesets")),
     _check_element_volumes(getParam<MooseEnum>("examine_element_volumes")),
     _min_volume(getParam<Real>("minimum_element_volumes")),
     _max_volume(getParam<Real>("maximum_element_volumes")),
@@ -103,10 +108,10 @@ MeshDiagnosticsGenerator::MeshDiagnosticsGenerator(const InputParameters & param
     paramError("examine_non_conformality",
                "You must set this parameter to true to trigger mesh conformality check");
   if (_check_sidesets_orientation == "NO_CHECK" && _check_watertight_sidesets == "NO_CHECK" &&
-      _check_element_volumes == "NO_CHECK" && _check_element_types == "NO_CHECK" &&
-      _check_element_overlap == "NO_CHECK" && _check_non_planar_sides == "NO_CHECK" &&
-      _check_non_conformal_mesh == "NO_CHECK" && _check_adaptivity_non_conformality == "NO_CHECK" &&
-      _check_local_jacobian == "NO_CHECK")
+      _check_watertight_nodesets == "NO_CHECK" && _check_element_volumes == "NO_CHECK" && 
+      _check_element_types == "NO_CHECK" && _check_element_overlap == "NO_CHECK" && 
+      _check_non_planar_sides == "NO_CHECK" && _check_non_conformal_mesh == "NO_CHECK" 
+      && _check_adaptivity_non_conformality == "NO_CHECK" && _check_local_jacobian == "NO_CHECK")
     mooseError("You need to turn on at least one diagnostic. Did you misspell a parameter?");
 }
 
@@ -128,6 +133,9 @@ MeshDiagnosticsGenerator::generate()
 
   if (_check_watertight_sidesets != "NO_CHECK")
     checkWaterTightSidesets(mesh);
+
+  if (_check_watertight_nodesets != "NO_CHECK")
+    checkWatertightNodesets(mesh);
 
   if (_check_element_volumes != "NO_CHECK")
     checkElementVolumes(mesh);
@@ -333,6 +341,63 @@ MeshDiagnosticsGenerator::checkWaterTightSidesets(const std::unique_ptr<MeshBase
     message = "Number of external element edges that have not been assigned to a sideset: " +
               std::to_string(num_faces_without_sideset);
   diagnosticsLog(message, _check_watertight_sidesets, num_faces_without_sideset);
+}
+
+void 
+MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase> & mesh) const
+{
+  /*
+  Diagnostic Overview:
+  1) Mesh precheck
+  2) Loop through all elements
+  3) Loop through all sides of that element
+  4) If side is external loop through its nodes
+  5) If node is not associated with any nodeset add to list
+  6) Print out node id
+  */  
+  if (mesh->mesh_dimension() < 2)
+    mooseError("The nodeset check only works for 2D and 3D meshes");
+  auto & boundary_info = mesh->get_boundary_info();
+  boundary_info.build_side_list();
+  const auto nodeset_map = boundary_info.get_nodeset_map();
+  unsigned int num_nodes_without_nodeset = 0;
+  std::set<Node> checked_nodes;
+
+  for (const auto elem : mesh->active_element_ptr_range())
+  {
+    for (auto i : elem->side_index_range())
+    {
+      // Check if side is external
+      if (elem->neighbor_ptr(i) == nullptr)
+      {
+        // Side is externa, now check nodes
+        auto side = elem->side_ptr(i);
+        const auto & node_list = side->get_nodes();
+        for (unsigned int j = 0; j < side->n_nodes(); j++)
+        {
+          const auto node = node_list[j];
+          if (checked_nodes.count(*node))
+            continue;
+          //if node is not part of nodeset map add it to list of bad nodes
+          if(nodeset_map.count(node) == 0)
+          {
+            // This node does not have a nodeset!!!
+            num_nodes_without_nodeset++;
+            checked_nodes.insert(*node);
+            std::string message;
+            if (num_nodes_without_nodeset < _num_outputs)
+            {
+              message = "Node " + std::to_string(node->id()) + " is external, but has not been assigned to a nodeset";
+              _console << message << std::endl;
+            }  
+          }
+        }
+      }
+    }
+  }
+  std::string message;
+  message = "Number of external nodes that have not been assigned to a nodeset: " + std::to_string(num_nodes_without_nodeset);
+  diagnosticsLog(message, _check_watertight_nodesets, num_nodes_without_nodeset);
 }
 
 void

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -358,8 +358,6 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
   if (mesh->mesh_dimension() < 2)
     mooseError("The nodeset check only works for 2D and 3D meshes");
   auto & boundary_info = mesh->get_boundary_info();
-  boundary_info.build_side_list();
-  const auto nodeset_map = boundary_info.get_nodeset_map();
   unsigned int num_nodes_without_nodeset = 0;
   std::set<dof_id_type> checked_nodes_id;
 
@@ -378,8 +376,8 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
           const auto node = node_list[j];
           if (checked_nodes_id.count(node->id()))
             continue;
-          // if node is not part of nodeset map add it to list of bad nodes
-          if (nodeset_map.count(node) == 0)
+          // if node has no nodeset, add it to list of bad nodes
+          if (boundary_info.n_boundary_ids(node) == 0)
           {
             // This node does not have a nodeset!!!
             num_nodes_without_nodeset++;

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -387,8 +387,9 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
             std::string message;
             if (num_nodes_without_nodeset < _num_outputs)
             {
-              message = "Node " + std::to_string(node->id()) +
-                        " is on an external boundary of the mesh, but has not been assigned to a nodeset";
+              message =
+                  "Node " + std::to_string(node->id()) +
+                  " is on an external boundary of the mesh, but has not been assigned to a nodeset";
               _console << message << std::endl;
             }
           }

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -108,10 +108,10 @@ MeshDiagnosticsGenerator::MeshDiagnosticsGenerator(const InputParameters & param
     paramError("examine_non_conformality",
                "You must set this parameter to true to trigger mesh conformality check");
   if (_check_sidesets_orientation == "NO_CHECK" && _check_watertight_sidesets == "NO_CHECK" &&
-      _check_watertight_nodesets == "NO_CHECK" && _check_element_volumes == "NO_CHECK" && 
-      _check_element_types == "NO_CHECK" && _check_element_overlap == "NO_CHECK" && 
-      _check_non_planar_sides == "NO_CHECK" && _check_non_conformal_mesh == "NO_CHECK" 
-      && _check_adaptivity_non_conformality == "NO_CHECK" && _check_local_jacobian == "NO_CHECK")
+      _check_watertight_nodesets == "NO_CHECK" && _check_element_volumes == "NO_CHECK" &&
+      _check_element_types == "NO_CHECK" && _check_element_overlap == "NO_CHECK" &&
+      _check_non_planar_sides == "NO_CHECK" && _check_non_conformal_mesh == "NO_CHECK" &&
+      _check_adaptivity_non_conformality == "NO_CHECK" && _check_local_jacobian == "NO_CHECK")
     mooseError("You need to turn on at least one diagnostic. Did you misspell a parameter?");
 }
 
@@ -343,7 +343,7 @@ MeshDiagnosticsGenerator::checkWaterTightSidesets(const std::unique_ptr<MeshBase
   diagnosticsLog(message, _check_watertight_sidesets, num_faces_without_sideset);
 }
 
-void 
+void
 MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase> & mesh) const
 {
   /*
@@ -354,7 +354,7 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
   4) If side is external loop through its nodes
   5) If node is not associated with any nodeset add to list
   6) Print out node id
-  */  
+  */
   if (mesh->mesh_dimension() < 2)
     mooseError("The nodeset check only works for 2D and 3D meshes");
   auto & boundary_info = mesh->get_boundary_info();
@@ -378,8 +378,8 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
           const auto node = node_list[j];
           if (checked_nodes.count(*node))
             continue;
-          //if node is not part of nodeset map add it to list of bad nodes
-          if(nodeset_map.count(node) == 0)
+          // if node is not part of nodeset map add it to list of bad nodes
+          if (nodeset_map.count(node) == 0)
           {
             // This node does not have a nodeset!!!
             num_nodes_without_nodeset++;
@@ -387,16 +387,18 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
             std::string message;
             if (num_nodes_without_nodeset < _num_outputs)
             {
-              message = "Node " + std::to_string(node->id()) + " is external, but has not been assigned to a nodeset";
+              message = "Node " + std::to_string(node->id()) +
+                        " is external, but has not been assigned to a nodeset";
               _console << message << std::endl;
-            }  
+            }
           }
         }
       }
     }
   }
   std::string message;
-  message = "Number of external nodes that have not been assigned to a nodeset: " + std::to_string(num_nodes_without_nodeset);
+  message = "Number of external nodes that have not been assigned to a nodeset: " +
+            std::to_string(num_nodes_without_nodeset);
   diagnosticsLog(message, _check_watertight_nodesets, num_nodes_without_nodeset);
 }
 

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -365,12 +365,12 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
 
   for (const auto elem : mesh->active_element_ptr_range())
   {
-    for (auto i : elem->side_index_range())
+    for (const auto i : elem->side_index_range())
     {
       // Check if side is external
       if (elem->neighbor_ptr(i) == nullptr)
       {
-        // Side is externa, now check nodes
+        // Side is external, now check nodes
         auto side = elem->side_ptr(i);
         const auto & node_list = side->get_nodes();
         for (unsigned int j = 0; j < side->n_nodes(); j++)
@@ -388,7 +388,7 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
             if (num_nodes_without_nodeset < _num_outputs)
             {
               message = "Node " + std::to_string(node->id()) +
-                        " is external, but has not been assigned to a nodeset";
+                        " is on an external boundary of the mesh, but has not been assigned to a nodeset";
               _console << message << std::endl;
             }
           }

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -361,7 +361,7 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
   boundary_info.build_side_list();
   const auto nodeset_map = boundary_info.get_nodeset_map();
   unsigned int num_nodes_without_nodeset = 0;
-  std::set<Node> checked_nodes;
+  std::set<dof_id_type> checked_nodes_id;
 
   for (const auto elem : mesh->active_element_ptr_range())
   {
@@ -376,14 +376,14 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
         for (unsigned int j = 0; j < side->n_nodes(); j++)
         {
           const auto node = node_list[j];
-          if (checked_nodes.count(*node))
+          if (checked_nodes_id.count(node->id()))
             continue;
           // if node is not part of nodeset map add it to list of bad nodes
           if (nodeset_map.count(node) == 0)
           {
             // This node does not have a nodeset!!!
             num_nodes_without_nodeset++;
-            checked_nodes.insert(*node);
+            checked_nodes_id.insert(node->id());
             std::string message;
             if (num_nodes_without_nodeset < _num_outputs)
             {

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/2D_missing_nodeset.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/2D_missing_nodeset.i
@@ -1,0 +1,22 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 2
+    ny = 2
+  []
+  [deletion]
+    type = BoundaryDeletionGenerator
+    input = gmg
+    boundary_names = 'right'
+  []
+  [diag]
+    type = MeshDiagnosticsGenerator
+    input = deletion
+    check_for_watertight_nodesets = INFO
+  []
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/3D_missing_nodeset.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/3D_missing_nodeset.i
@@ -1,0 +1,23 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 2
+    ny = 2
+    nz = 2
+  []
+  [deletion]
+    type = BoundaryDeletionGenerator
+    input = gmg
+    boundary_names = 'right'
+  []
+  [diag]
+    type = MeshDiagnosticsGenerator
+    input = deletion
+    check_for_watertight_nodesets = INFO
+  []
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/all_at_once.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/all_at_once.i
@@ -15,6 +15,7 @@
     examine_nonplanar_sides = INFO
     examine_sidesets_orientation = WARNING
     check_for_watertight_sidesets = WARNING
+    check_for_watertight_nodesets = WARNING
     search_for_adaptivity_nonconformality = WARNING
     check_local_jacobian = WARNING
   []

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/tests
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/tests
@@ -45,6 +45,22 @@
       expect_out = 'Number of external element faces that have not been assigned to a sideset: 4'
       detail = '3D meshed cube missing a sideset on one side'
     []
+    [2D_watertight_nodesets]
+      type = 'RunApp'
+      input = '2D_missing_nodeset.i'
+      cli_args = '--mesh-only'
+      mesh_mode = 'replicated'
+      expect_out = 'Number of external nodes that have not been assigned to a nodeset: 1'
+      detail = '2D meshed square missing a nodeset on one side'
+    []
+    [3D_watertight_nodesets]
+      type = 'RunApp'
+      input = '3D_missing_nodeset.i'
+      cli_args = '--mesh-only'
+      mesh_mode = 'replicated'
+      expect_out = 'Number of external nodes that have not been assigned to a nodeset: 1'
+      detail = '3D meshed cube missing a nodeset on one side'
+    []
     [overlap]
       type = 'RunApp'
       input = 'node_based_test.i'
@@ -253,6 +269,7 @@
                   Mesh/diag/examine_nonplanar_sides=NO_CHECK
                   Mesh/diag/examine_sidesets_orientation=NO_CHECK
                   Mesh/diag/check_for_watertight_sidesets=NO_CHECK
+                  Mesh/diag/check_for_watertight_nodesets=NO_CHECK
                   Mesh/diag/search_for_adaptivity_nonconformality=NO_CHECK
                   Mesh/diag/check_local_jacobian=NO_CHECK --mesh-only"
       detail = 'a diagnostics object is created but no diagnostics are requested.'

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/tests
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/tests
@@ -51,7 +51,7 @@
       cli_args = '--mesh-only'
       mesh_mode = 'replicated'
       expect_out = 'Number of external nodes that have not been assigned to a nodeset: 1'
-      detail = '2D meshed square missing a nodeset on one side'
+      detail = '2D meshed square with one external node that does not belong to a nodeset'
     []
     [3D_watertight_nodesets]
       type = 'RunApp'
@@ -59,7 +59,7 @@
       cli_args = '--mesh-only'
       mesh_mode = 'replicated'
       expect_out = 'Number of external nodes that have not been assigned to a nodeset: 1'
-      detail = '3D meshed cube missing a nodeset on one side'
+      detail = '3D meshed cube with one external node that does not belong to a nodeset'
     []
     [overlap]
       type = 'RunApp'


### PR DESCRIPTION
-Loops through all elements and sides
-If side is external it checks if all its nodes are assigned to a nodeset

closes #28822

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
Adds new diagnostic tool for users

## Design
<!--A concise description (design) of the enhancement.-->
If feature it turned on, it loops through each element, then the element's sides. If the sides are external it checks each node to ensure it's been assigned to a nodeset. If not, the node id is printed for reference.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
Adds watertight nodeset check to Mesh Diagnostics 

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
