### PR TITLE
Added parameter size match check to DiscreteLineSegmentInterface

### DIFF
--- a/modules/thermal_hydraulics/src/interfaces/DiscreteLineSegmentInterface.C
+++ b/modules/thermal_hydraulics/src/interfaces/DiscreteLineSegmentInterface.C
@@ -50,6 +50,9 @@ DiscreteLineSegmentInterface::DiscreteLineSegmentInterface(const MooseObject * m
 {
   std::partial_sum(_lengths.begin(), _lengths.end(), _section_end.begin());
 
+  if (_lengths.size() != _n_elems.size())
+    mooseError("The parameters 'length' and 'n_elems' must have the same number of entries.");
+
   // Compute the axial coordinates of the centers of each element
   unsigned int k_section_begin = 0;
   Real x_begin = 0.0;

--- a/modules/thermal_hydraulics/test/tests/interfaces/discrete_line_segment_interface/tests
+++ b/modules/thermal_hydraulics/test/tests/interfaces/discrete_line_segment_interface/tests
@@ -62,11 +62,20 @@
     [compute_axial_coordinate_invalid_axial_coord]
       type = RunException
       input = 'discrete_line_segment_interface.i'
-      cli_args = "AuxKernels/testvar_aux/length=5.0"
-      expect_err = "testvar_aux: The point \(x,y,z\)=\(.*\) has an invalid axial coordinate \(.*\). Valid axial coordinates are in the range \(0,5\)."
+      cli_args = "AuxKernels/testvar_aux/length='1 2 3'"
+      expect_err = "testvar_aux: The point \(x,y,z\)=\(.*\) has an invalid axial coordinate \(.*\). Valid axial coordinates are in the range \(0,6\)."
       allow_test_objects = true
 
       detail = 'if an invalid axial coordinate is provided.'
+    []
+    [length_n_elems_size_mismatch]
+      type = RunException
+      input = 'discrete_line_segment_interface.i'
+      cli_args = "AuxKernels/testvar_aux/length=10.0"
+      expect_err = "The parameters 'length' and 'n_elems' must have the same number of entries"
+      allow_test_objects = true
+
+      detail = 'if the number of lengths and element counts do not match.'
     []
   []
 []


### PR DESCRIPTION
I found that we were not checking that parameter sizes were consistent, leading to segmentation faults in the constructor.