### PR TITLE
Libmesh update 20241120

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2024.11.20" %}
+{% set version = "2024.12.02" %}
 
 package:
   name: moose-libmesh

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,8 +4,8 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 2 %}
-{% set version = "2024.10.17" %}
+{% set build = 0 %}
+{% set version = "2024.11.20" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2024.10.17 mpich_2
-  - moose-libmesh 2024.10.17 openmpi_2
+  - moose-libmesh 2024.11.20 mpich_0
+  - moose-libmesh 2024.11.20 openmpi_0
 
 moose_wasp:
   - moose-wasp 2024.11.13

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2024.11.20 mpich_0
-  - moose-libmesh 2024.11.20 openmpi_0
+  - moose-libmesh 2024.12.02 mpich_0
+  - moose-libmesh 2024.12.02 openmpi_0
 
 moose_wasp:
   - moose-wasp 2024.11.13

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.11.15" %}
+{% set version = "2024.11.20" %}
 
 package:
   name: moose-dev

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2024.11.20" %}
+{% set version = "2024.12.02" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2024.11.20
+  - moose-dev 2024.12.02
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2024.11.15
+  - moose-dev 2024.11.20
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=5483644b60cc538a4b54d312f28835bd94107627
+ARG LIBMESH_REV=8aa40d295a479374e419f442440c4799100f11a9
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=8aa40d295a479374e419f442440c4799100f11a9
+ARG LIBMESH_REV=6ef7d4395794104f48dae1fd48e64077207188e8
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/modules/doc/content/newsletter/2024/2024_11.md
+++ b/modules/doc/content/newsletter/2024/2024_11.md
@@ -39,16 +39,25 @@ for a complete description of all MOOSE changes.
   incomplete basis that would deliver suboptimal convergence.
 - Use more accurate projections when decimating solutions on `H_DIV`
   finite elements for visualization output.
+- Optimizations to `SparseMatrix::read_matlab()`
 - Added `--with-xdr-libdir` option to `configure`, making it possible
   to build libMesh with XDR support using more types of third-party
   library installations.
 - Better `configure --help` entries for NetCDF options
+- `configure` now autodetects the Fortran compiler from PETSc where
+  possible
 - Fixes for `make check` NetCDF tests when combining older NetCDF with
   newer HDF5
 - Support for distributed-and-unprepared meshes in `all_tri()`
 - Compatibility fixes for PETSc 3.23
 - Support for adding a prefix when querying a
   `PetscNonlinearSolver::snes()` that might have yet to be initialized
+- Added `NumericVector::set_type()`, deprecated older `type()` setter
+  that returned a writeable reference.  This will eventually make more
+  flexible changes to vector type possible.
+- Fixes for libMesh-based error reporting without a `LibMeshInit`
+  object active.  This corrected a regression in the error handling of
+  the libMesh `fparser-parse` utility.
 - Fixes in Reduced Basis EIM code
 
 ## PETSc-level Changes

--- a/modules/doc/content/newsletter/2024/2024_11.md
+++ b/modules/doc/content/newsletter/2024/2024_11.md
@@ -9,6 +9,48 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2024.11.20` Update
+
+- Added `MeshBase::elem_orders()`, `MeshBase::max_nodal_order()`, etc.
+  APIs.  This will soon allow middleware code to do additional sanity
+  checking of user variable order choices, or to automatically choose
+  an isoparametric variable order when appropriate.
+- Added triangularization and tetrahedralization support to `meshtool`
+  app.
+- Added the ability to condense out "element-internal" degrees of
+  freedom when building algebraic systems.  This gives smaller
+  algebraic systems to solve, without "bubble function" coefficients
+  in continuous FEM methods or internal degrees of freedom in HDG
+  methods.
+- Added `NonManifoldGhostingFunctor` class, which can be used to give
+  reliable distributed-mesh connectivity on meshes where multiple edge
+  elements meet at the same point and/or multiple face elements meet
+  along the same edge.
+- Added `SidesToElemMap` class, for caching that "reverse connectivity"
+  in classes like the `NonManifoldGhostingFunctor` that use it.
+- Generalized `MeshFunction::find_element()` allowing evaluation of a
+  `MeshFunction` on algebraically-ghosted elements when a `GHOSTED`
+  vector is in use.
+- Added `SimplexRefiner` class, which currently supports refinement of
+  simplicial (edge, triangle, and/or tetrahedral) meshes via edge
+  bisection.
+- Exit with error when asked to evaluate `L2_HIERARCHIC` bases of
+  polynomial degree `p=0`.  Previously this case was returning an
+  incomplete basis that would deliver suboptimal convergence.
+- Use more accurate projections when decimating solutions on `H_DIV`
+  finite elements for visualization output.
+- Added `--with-xdr-libdir` option to `configure`, making it possible
+  to build libMesh with XDR support using more types of third-party
+  library installations.
+- Better `configure --help` entries for NetCDF options
+- Fixes for `make check` NetCDF tests when combining older NetCDF with
+  newer HDF5
+- Support for distributed-and-unprepared meshes in `all_tri()`
+- Compatibility fixes for PETSc 3.23
+- Support for adding a prefix when querying a
+  `PetscNonlinearSolver::snes()` that might have yet to be initialized
+- Fixes in Reduced Basis EIM code
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -383,3 +383,10 @@ cece3f711bd9c235af31c9d5a4c54e292400ecc1: #29074
   libmesh: eeed62e
   wasp: 0b6b0db
   moose-dev: 3b2f25a
+2a8169df2c9203ce86f81514317a6e9a0ea2cc05: #29110
+  tools: 2844df4
+  mpi: e7edc35
+  petsc: c8dc37c
+  libmesh: d060615
+  wasp: 0b6b0db
+  moose-dev: a1e01c7


### PR DESCRIPTION
The first commit here is cherry-picked from #28954 to try to avoid conflicts there later.

Update libMesh submodule:
    
- Added `MeshBase::elem_orders()`, `MeshBase::max_nodal_order()`, etc. APIs.  This will soon allow middleware code to do additional sanity checking of user variable order choices, or to automatically choose an isoparametric variable order when appropriate.
- Added triangularization and tetrahedralization support to `meshtool` app.
- Added the ability to condense out "element-internal" degrees of freedom when building algebraic systems.  This gives smaller algebraic systems to solve, without "bubble function" coefficients in continuous FEM methods or internal degrees of freedom in HDG methods.
- Added `NonManifoldGhostingFunctor` class, which can be used to give reliable distributed-mesh connectivity on meshes where multiple edge elements meet at the same point and/or multiple face elements meet along the same edge.
- Added `SidesToElemMap` class, for caching that "reverse connectivity" in classes like the `NonManifoldGhostingFunctor` that use it.
- Generalized `MeshFunction::find_element()` allowing evaluation of a `MeshFunction` on algebraically-ghosted elements when a `GHOSTED` vector is in use.
- Added `SimplexRefiner` class, which currently supports refinement of simplicial (edge, triangle, and/or tetrahedral) meshes via edge bisection.
- Exit with error when asked to evaluate `L2_HIERARCHIC` bases of polynomial degree `p=0`.  Previously this case was returning an incomplete basis that would deliver suboptimal convergence.
- Use more accurate projections when decimating solutions on `H_DIV` finite elements for visualization output.
- Added `--with-xdr-libdir` option to `configure`, making it possible to build libMesh with XDR support using more types of third-party library installations.
- Better `configure --help` entries for NetCDF options
- Fixes for `make check` NetCDF tests when combining older NetCDF with newer HDF5
- Support for distributed-and-unprepared meshes in `all_tri()`
- Compatibility fixes for PETSc 3.23
- Support for adding a prefix when querying a `PetscNonlinearSolver::snes()` that might have yet to be initialized
- Fixes in Reduced Basis EIM code