### PR TITLE
Display unit for input param only if it is type Real or std::vector<Real>

### DIFF
--- a/python/MooseDocs/extensions/appsyntax.py
+++ b/python/MooseDocs/extensions/appsyntax.py
@@ -768,14 +768,16 @@ class RenderParameterToken(components.RenderComponent):
         html.Tag(p, 'span', string='C++ Type:')
         html.String(p, content=cpp_type, escape=True)
 
-        if cpp_type == "double" or cpp_type == "std::vector<double>":
-            doc_unit = param['doc_unit']
+        doc_unit = param['doc_unit']
+        # Only display a unit if specified or if the type is likely to have a unit
+        if doc_unit or "double" in cpp_type:
             p = html.Tag(body, 'p', class_='moose-parameter-description-doc-unit')
             html.Tag(p, 'span', string='Unit:')
-            if not doc_unit:
-                html.String(p, content='(no unit assumed)')
-            else:
+            # If a unit was specified, always display it
+            if doc_unit:
                 html.String(p, content=doc_unit)
+            else:
+                html.String(p, content='(no unit assumed)')
 
         if param['options']:
             p = html.Tag(body, 'p', class_='moose-parameter-description-options')

--- a/python/MooseDocs/extensions/appsyntax.py
+++ b/python/MooseDocs/extensions/appsyntax.py
@@ -770,7 +770,7 @@ class RenderParameterToken(components.RenderComponent):
 
         doc_unit = param['doc_unit']
         # Only display a unit if specified or if the type is likely to have a unit
-        if doc_unit or "double" in cpp_type:
+        if doc_unit or "double" in cpp_type or "Variable" in cpp_type or "Postprocessor" in cpp_type or "Funct" in cpp_type or "MaterialProperty" in cpp_type:
             p = html.Tag(body, 'p', class_='moose-parameter-description-doc-unit')
             html.Tag(p, 'span', string='Unit:')
             # If a unit was specified, always display it

--- a/python/MooseDocs/extensions/appsyntax.py
+++ b/python/MooseDocs/extensions/appsyntax.py
@@ -768,13 +768,14 @@ class RenderParameterToken(components.RenderComponent):
         html.Tag(p, 'span', string='C++ Type:')
         html.String(p, content=cpp_type, escape=True)
 
-        doc_unit = param['doc_unit']
-        p = html.Tag(body, 'p', class_='moose-parameter-description-doc-unit')
-        html.Tag(p, 'span', string='Unit:')
-        if not doc_unit:
-            html.String(p, content='(no unit assumed)')
-        else:
-            html.String(p, content=doc_unit)
+        if cpp_type == "double" or cpp_type == "std::vector<double>":
+            doc_unit = param['doc_unit']
+            p = html.Tag(body, 'p', class_='moose-parameter-description-doc-unit')
+            html.Tag(p, 'span', string='Unit:')
+            if not doc_unit:
+                html.String(p, content='(no unit assumed)')
+            else:
+                html.String(p, content=doc_unit)
 
         if param['options']:
             p = html.Tag(body, 'p', class_='moose-parameter-description-options')

--- a/python/MooseDocs/test/extensions/test_appsyntax.py
+++ b/python/MooseDocs/test/extensions/test_appsyntax.py
@@ -169,7 +169,6 @@ class TestParameters(AppSyntaxTestCase):
         self.assertLatexArg(res(1), 2, 'Bracket')
         self.assertIn('The name of the variable', res(1,0)['content'])
 
-
 class TestParam(AppSyntaxTestCase):
     TEXT = "[!param](/Kernels/Diffusion/variable)"
 
@@ -225,6 +224,21 @@ class TestParam(AppSyntaxTestCase):
         message = ast(0,0)['message']
         self.assertIn("Unable to locate the parameter '/Kernels/Diffusion/foobar', did you mean:", message)
         self.assertIn('    /Kernels/Diffusion/', message)
+
+    def testUnit(self):
+        all_types_showing_no_unit = ["double", "VariableValue", "FunctionName", "PostprocessorName", "FunctorName", "MaterialPropertyName"]
+        example_parameters = ["/BCs/DirichletBC/value", "/Kernels/Diffusion/variable", "/BCs/FunctionDirichletBC/function", "/BCs/PostprocessorDirichletBC/postprocessor",
+                              "/BCs/FunctorDirichletBC/functor", "/AuxKernels/MaterialRealAux/property"]
+
+        for i, tested_type in enumerate(all_types_showing_no_unit):
+            _, res = self.execute("[!param](" + example_parameters[i] + ")", renderer=base.MaterializeRenderer())
+            # Show (no unit assumed) as a parameter of that type could require one
+            self.assertHTMLTag(res(1, 0, 2), 'p', size=2, class_='moose-parameter-description-doc-unit')
+            self.assertIn(u"(no unit assumed)", res(1, 0, 2, 1)['content'])
+
+        # BoundaryName not in the show "no unit assumed" list
+        _, res = self.execute("[!param](/BCs/DirichletBC/boundary)", renderer=base.MaterializeRenderer())
+        self.assertNotIn(u"(no unit assumed)", res(1, 0, 2, 1)['content'])
 
 class TestChildren(AppSyntaxTestCase):
     TEXT = "!syntax children /Kernels/Diffusion"


### PR DESCRIPTION
Refs #27352 and #29115.

