### PR TITLE
Added parameters for watertight sideset and nodeset diagnostic check

### DIFF
--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -35,10 +35,10 @@ private:
   void checkWatertightSidesets(const std::unique_ptr<MeshBase> & mesh) const;
   //// Routine to check is mesh is fully covered in nodesets
   void checkWatertightNodesets(const std::unique_ptr<MeshBase> & mesh) const;
-  /// Helper function that finds the intersection of the _watertight_boundaries vector and the provided one
+  /// Helper function that finds the intersection between the given vectors
   std::vector<boundary_id_type>
-  findBoundaryOverlap(std::vector<boundary_id_type>,
-                      std::vector<boundary_id_type> boundary_ids) const;
+  findBoundaryOverlap(const std::vector<boundary_id_type> & watertight_boundaries,
+                      std::vector<boundary_id_type> & boundary_ids) const;
   /// Routine to check the element volumes
   void checkElementVolumes(const std::unique_ptr<MeshBase> & mesh) const;
   /// Routine to check the element types in each subdomain
@@ -73,7 +73,7 @@ private:
   /// whether to check that each external node is assigned to a nodeset
   const MooseEnum _check_watertight_nodesets;
   /// boundaries to be checked in watertight checks
-  const std::vector<BoundaryID> _watertight_boundaries;
+  std::vector<BoundaryID> _watertight_boundaries;
   /// whether to check element volumes
   const MooseEnum _check_element_volumes;
   /// minimum size for element volume to be counted as a tiny element

--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -66,13 +66,18 @@ private:
    */
   void diagnosticsLog(std::string msg, const MooseEnum & log_level, bool problem_detected) const;
 
+  /// Convert bounday names to IDs and sort
+  std::vector<BoundaryID> prepareBoundaries(const std::unique_ptr<MeshBase> & mesh) const;
+
   /// whether to check that sidesets are consistently oriented using neighbor subdomains
   const MooseEnum _check_sidesets_orientation;
   /// whether to check that each external side is assigned to a sideset
   const MooseEnum _check_watertight_sidesets;
   /// whether to check that each external node is assigned to a nodeset
   const MooseEnum _check_watertight_nodesets;
-  /// boundaries to be checked in watertight checks
+  /// Names of boundaries to be checked in watertight checks
+  std::vector<BoundaryName> _watertight_boundary_names;
+  /// IDs of boundaries to be checked in watertight checks
   std::vector<BoundaryID> _watertight_boundaries;
   /// whether to check element volumes
   const MooseEnum _check_element_volumes;

--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -66,9 +66,6 @@ private:
    */
   void diagnosticsLog(std::string msg, const MooseEnum & log_level, bool problem_detected) const;
 
-  /// Convert bounday names to IDs and sort
-  std::vector<BoundaryID> prepareBoundaries(const std::unique_ptr<MeshBase> & mesh) const;
-
   /// whether to check that sidesets are consistently oriented using neighbor subdomains
   const MooseEnum _check_sidesets_orientation;
   /// whether to check that each external side is assigned to a sideset

--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -32,9 +32,11 @@ private:
   /// Routine to check sideset orientation near subdomains
   void checkSidesetsOrientation(const std::unique_ptr<MeshBase> & mesh) const;
   //// Routine to check is mesh is fully covered in sidesets
-  void checkWaterTightSidesets(const std::unique_ptr<MeshBase> & mesh) const;
+  void checkWatertightSidesets(const std::unique_ptr<MeshBase> & mesh) const;
   //// Routine to check is mesh is fully covered in nodesets
   void checkWatertightNodesets(const std::unique_ptr<MeshBase> & mesh) const;
+  /// Helper function that finds the intersection of the _watertight_boundaries vector and the provided one
+  std::vector<boundary_id_type> findBoundaryOverlap(std::vector<boundary_id_type>, std::vector<boundary_id_type> boundary_ids) const;
   /// Routine to check the element volumes
   void checkElementVolumes(const std::unique_ptr<MeshBase> & mesh) const;
   /// Routine to check the element types in each subdomain
@@ -64,10 +66,12 @@ private:
 
   /// whether to check that sidesets are consistently oriented using neighbor subdomains
   const MooseEnum _check_sidesets_orientation;
-  //// whether to check that each external side is assigned to a sideset
+  /// whether to check that each external side is assigned to a sideset
   const MooseEnum _check_watertight_sidesets;
-  //// whether to check that each external node is assigned to a nodeset
+  /// whether to check that each external node is assigned to a nodeset
   const MooseEnum _check_watertight_nodesets;
+  /// boundaries to be checked in watertight checks
+  const std::vector<BoundaryID> _watertight_boundaries;
   /// whether to check element volumes
   const MooseEnum _check_element_volumes;
   /// minimum size for element volume to be counted as a tiny element

--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -36,7 +36,9 @@ private:
   //// Routine to check is mesh is fully covered in nodesets
   void checkWatertightNodesets(const std::unique_ptr<MeshBase> & mesh) const;
   /// Helper function that finds the intersection of the _watertight_boundaries vector and the provided one
-  std::vector<boundary_id_type> findBoundaryOverlap(std::vector<boundary_id_type>, std::vector<boundary_id_type> boundary_ids) const;
+  std::vector<boundary_id_type>
+  findBoundaryOverlap(std::vector<boundary_id_type>,
+                      std::vector<boundary_id_type> boundary_ids) const;
   /// Routine to check the element volumes
   void checkElementVolumes(const std::unique_ptr<MeshBase> & mesh) const;
   /// Routine to check the element types in each subdomain

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -52,9 +52,7 @@ MeshDiagnosticsGenerator::validParams()
       chk_option,
       "whether to check for external nodes that are not assigned to any nodeset");
   params.addParam<std::vector<BoundaryID>>(
-       "boundaries_to_check",
-       {},
-       "IDs of boundaries to be checked for watertight checks");
+      "boundaries_to_check", {}, "IDs of boundaries to be checked for watertight checks");
   params.addParam<MooseEnum>(
       "examine_element_volumes", chk_option, "whether to examine volume of the elements");
   params.addParam<Real>("minimum_element_volumes", 1e-16, "minimum size for element volume");
@@ -331,13 +329,14 @@ MeshDiagnosticsGenerator::checkWatertightSidesets(const std::unique_ptr<MeshBase
       {
         // If external get the boundary ids associated with this side
         std::vector<boundary_id_type> boundary_ids;
-        //boundary_info.boundary_ids(elem, i, boundary_ids);
+        // boundary_info.boundary_ids(elem, i, boundary_ids);
         auto side_range = sideset_map.equal_range(elem);
         for (const auto & itr : as_range(side_range))
           if (itr.second.first == i)
             boundary_ids.push_back(i);
         // get intersection of boundary_ids and _watertight_boundaries
-        std::vector<boundary_id_type> intersections = findBoundaryOverlap(boundary_copy, boundary_ids);
+        std::vector<boundary_id_type> intersections =
+            findBoundaryOverlap(boundary_copy, boundary_ids);
         if (boundary_ids.empty())
         {
           // This side does not have a sideset!!!
@@ -356,20 +355,23 @@ MeshDiagnosticsGenerator::checkWatertightSidesets(const std::unique_ptr<MeshBase
         }
         else if (!_watertight_boundaries.empty() && intersections.empty())
         {
-          // This means that at least 1 boundary was specified, and that this side was not assigned to it
+          // This means that at least 1 boundary was specified, and that this side was not assigned
+          // to it
           std::string message;
           if (num_faces_without_sideset < _num_outputs)
           {
             if (mesh->mesh_dimension() == 3)
-                message = "Element " + std::to_string(elem->id()) +
-                          " contains an external face which has not been assigned to one of the specified sidesets";
+              message = "Element " + std::to_string(elem->id()) +
+                        " contains an external face which has not been assigned to one of the "
+                        "specified sidesets";
             else
               message = "Element " + std::to_string(elem->id()) +
-                        " contains an external edge which has not been assigned to one of the specified sidesets";
-              _console << message << std::endl;
-              num_faces_without_sideset++;
+                        " contains an external edge which has not been assigned to one of the "
+                        "specified sidesets";
+            _console << message << std::endl;
+            num_faces_without_sideset++;
           }
-        } 
+        }
       }
     }
   }
@@ -423,7 +425,8 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
           // get vector of node's boundaries (in most cases it will only have one)
           std::vector<boundary_id_type> boundary_ids;
           boundary_info.boundary_ids(node, boundary_ids);
-          std::vector<boundary_id_type> intersection = findBoundaryOverlap(boundary_copy, boundary_ids);
+          std::vector<boundary_id_type> intersection =
+              findBoundaryOverlap(boundary_copy, boundary_ids);
           // if node has no nodeset, add it to list of bad nodes
           if (boundary_info.n_boundary_ids(node) == 0)
           {
@@ -441,15 +444,16 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
           }
           else if (!_watertight_boundaries.empty() && intersection.empty())
           {
-            // This indicates that at least one boundary was specified, and it does not match with any 
+            // This indicates that at least one boundary was specified, and it does not match with
+            // any
             num_nodes_without_nodeset++;
             checked_nodes_id.insert(node->id());
             std::string message;
             if (num_nodes_without_nodeset < _num_outputs)
             {
-              message =
-                  "Node " + std::to_string(node->id()) +
-                  " is on an external boundary of the mesh, but has not been assigned to one of the specified nodesets";
+              message = "Node " + std::to_string(node->id()) +
+                        " is on an external boundary of the mesh, but has not been assigned to one "
+                        "of the specified nodesets";
               _console << message << std::endl;
             }
           }
@@ -464,13 +468,18 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
 }
 
 std::vector<boundary_id_type>
-MeshDiagnosticsGenerator::findBoundaryOverlap(std::vector<boundary_id_type> boundary_copy, std::vector<boundary_id_type> boundary_ids) const
+MeshDiagnosticsGenerator::findBoundaryOverlap(std::vector<boundary_id_type> boundary_copy,
+                                              std::vector<boundary_id_type> boundary_ids) const
 {
   // Both vectors must be sorted first
   // Returns their intersection (elements that they share)
   std::sort(boundary_ids.begin(), boundary_ids.end());
   std::vector<boundary_id_type> boundary_intersection;
-  std::set_intersection(boundary_copy.begin(), boundary_copy.end(), boundary_ids.begin(), boundary_ids.end(), std::back_inserter(boundary_intersection));
+  std::set_intersection(boundary_copy.begin(),
+                        boundary_copy.end(),
+                        boundary_ids.begin(),
+                        boundary_ids.end(),
+                        std::back_inserter(boundary_intersection));
   return boundary_intersection;
 }
 

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -52,7 +52,10 @@ MeshDiagnosticsGenerator::validParams()
       chk_option,
       "whether to check for external nodes that are not assigned to any nodeset");
   params.addParam<std::vector<BoundaryID>>(
-      "boundaries_to_check", {}, "Names boundaries that should form a watertight envelope around the mesh. Defaults to all the boundaries combined.");
+      "boundaries_to_check",
+      {},
+      "Names boundaries that should form a watertight envelope around the mesh. Defaults to all "
+      "the boundaries combined.");
   params.addParam<MooseEnum>(
       "examine_element_volumes", chk_option, "whether to examine volume of the elements");
   params.addParam<Real>("minimum_element_volumes", 1e-16, "minimum size for element volume");
@@ -466,8 +469,9 @@ MeshDiagnosticsGenerator::checkWatertightNodesets(const std::unique_ptr<MeshBase
 }
 
 std::vector<boundary_id_type>
-MeshDiagnosticsGenerator::findBoundaryOverlap(const std::vector<boundary_id_type> & watertight_boundaries,
-                                              std::vector<boundary_id_type> & boundary_ids) const
+MeshDiagnosticsGenerator::findBoundaryOverlap(
+    const std::vector<boundary_id_type> & watertight_boundaries,
+    std::vector<boundary_id_type> & boundary_ids) const
 {
   // Only the boundary_ids vector is sorted here. watertight_boundaries has to be sorted beforehand
   // Returns their intersection (elements that they share)


### PR DESCRIPTION
-Diagnostics can now take an additional vector parameter _watertight_boundaries 
-Users can use it to input a list of sidesets/nodesets 
-If supplied the diagnostic check functionality changes 
-It will instead check if an external side/node is assigned to one of the provided boundary ids 
-The error message for these instances is worded differently to reflect what the diagnostic check is looking for 
-The t in checkWaterTightSidesets is now lowercase because it was bothering me and to match checkWatertightNodesets

closes #29077

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
To provide users with more mesh debugging tools

## Design
<!--A concise description (design) of the enhancement.-->
Users  can supply a list of boundary ids. If supplied this diagnostic check looks for sides/nodes that are external and that are not assigned to one of the prescribed boundaries.
## Impact
<!--Will the enhancement change existing APIs or add something new?-->
This modifies the checkWatertightSideset and checkWatertightNodeset diagnostic tools. If no list of boundary ids is supplied however, then they behave the same as they did before.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
