### PR TITLE
Add more logging from periodic BCs

### DIFF
--- a/framework/src/actions/AddPeriodicBCAction.C
+++ b/framework/src/actions/AddPeriodicBCAction.C
@@ -92,7 +92,12 @@ AddPeriodicBCAction::setPeriodicVars(PeriodicBoundaryBase & p,
     {
       unsigned int var_num = nl.getVariable(0, var_name).number();
       p.set_variable(var_num);
-      _mesh->addPeriodicVariable(var_num, p.myboundary, p.pairedboundary);
+      // Only try to add periodic information to meshes which currently support them
+      if (_mesh->isRegularOrthogonal())
+        _mesh->addPeriodicVariable(var_num, p.myboundary, p.pairedboundary);
+      else
+        mooseInfoRepeated("Periodicity information for variable '" + var_name +
+                          "' will only be stored in the system's DoF map, not on the MooseMesh");
     }
   }
 }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2110,6 +2110,7 @@ MooseMesh::addPeriodicVariable(unsigned int var_num, BoundaryID primary, Boundar
 
   _half_range = Point(dimensionWidth(0) / 2.0, dimensionWidth(1) / 2.0, dimensionWidth(2) / 2.0);
 
+  bool component_found = false;
   for (unsigned int component = 0; component < dimension(); ++component)
   {
     const std::pair<BoundaryID, BoundaryID> * boundary_ids = getPairedBoundaryMapping(component);
@@ -2117,8 +2118,20 @@ MooseMesh::addPeriodicVariable(unsigned int var_num, BoundaryID primary, Boundar
     if (boundary_ids != nullptr &&
         ((boundary_ids->first == primary && boundary_ids->second == secondary) ||
          (boundary_ids->first == secondary && boundary_ids->second == primary)))
+    {
       _periodic_dim[var_num][component] = true;
+      component_found = true;
+    }
   }
+  if (!component_found)
+    mooseWarning("Could not find a match between boundary '",
+                 getBoundaryName(primary),
+                 "' and '",
+                 getBoundaryName(secondary),
+                 "' to set periodic boundary conditions for variable (index:",
+                 var_num,
+                 ") in either the X, Y or Z direction. The periodic dimension of the mesh for this "
+                 "variable will not be stored.");
 }
 
 bool

--- a/test/tests/bcs/periodic/periodic_bc_test.i
+++ b/test/tests/bcs/periodic/periodic_bc_test.i
@@ -1,13 +1,22 @@
 [Mesh]
-  type = GeneratedMesh
-  dim = 2
-  nx = 50
-  ny = 50
-  nz = 0
-  xmax = 40
-  ymax = 40
-  zmax = 0
-  elem_type = QUAD4
+  inactive = 'rotation'
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 50
+    ny = 50
+    nz = 0
+    xmax = 40
+    ymax = 40
+    zmax = 0
+    elem_type = QUAD4
+  []
+  [rotation]
+    type = TransformGenerator
+    input = gmg
+    transform = "ROTATE"
+    vector_value = '45 0 0'
+  []
 []
 
 [Variables]

--- a/test/tests/bcs/periodic/tests
+++ b/test/tests/bcs/periodic/tests
@@ -53,6 +53,8 @@
     exodiff = 'orthogonal_pbc_on_square_out.e'
     use_old_floor = true
     requirement = "The system shall support periodic boundary conditions on orthogonal boundaries with transforms defined as functions."
+    # Mesh is orthogonal but the periodic boundaries are not facing each other
+    allow_warnings = true
   []
 
   [parallel_pbc_using_trans_test]
@@ -189,7 +191,14 @@
       expect_err = "Boundary 'abs' does not exist in the mesh"
       input = 'all_periodic_trans.i'
       cli_args = "BCs/Periodic/x/secondary='abs'"
-      detail = 'the secondary boundary of a periodic boundary condition does not exist on the mesh.'
+      detail = 'the secondary boundary of a periodic boundary condition does not exist on the mesh,'
+    []
+    [not_matching_translation]
+      type = RunException
+      expect_err = "Could not find a match between boundary"
+      input = 'periodic_bc_test.i'
+      cli_args = "BCs/Periodic/x/secondary='left'"
+      detail = 'the primary and secondary boundaries on an orthogonal mesh do not match when applying a X,Y or Z translation.'
     []
   []
 []


### PR DESCRIPTION
refs #22496 

I cant do much more than this at this point. We literally have a test that enforces that objects can retrieve periodic information from a mooseMesh that is not orthogonal and therefore does NOT store periodic information (only supported for orthogonal meshes in MooseMesh). 
It's the phase field objects which I guess want to be able to work on non-orthogonal meshes. IMO it's not proper. They should check if the MooseMesh supports storing periodic information before trying to retrieve it and worse, use it

what I have here will give valuable hints that many objects that are relying on the MooseMesh for periodicity information are not getting it because it's not detected as orthogonal