### PR TITLE
Add a missing communication for interior and boundary lower-d blocks

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1419,6 +1419,8 @@ MooseMesh::cacheInfo()
       _block_node_list[node.id()].insert(elem->subdomain_id());
     }
   }
+  _communicator.set_union(_lower_d_interior_blocks);
+  _communicator.set_union(_lower_d_boundary_blocks);
 
   for (const auto & elem : mesh.active_local_element_ptr_range())
   {


### PR DESCRIPTION
Closes #29166. This is follow-up fix for PR #29144.
