### PR TITLE
Copy out-of-directory symlinks during install

### DIFF
--- a/conda/moose/run_test.sh
+++ b/conda/moose/run_test.sh
@@ -4,7 +4,7 @@ set -e
 if [[ $(uname) == 'Darwin' ]] && [[ $(uname -m) == 'x86_64' ]]; then
     exit 0
 fi
-combined-opt --copy-inputs framework
-cd combined/framework
-combined-opt --run -j 4 --re=kernels/simple_diffusion
+moose_test-opt --copy-inputs tests
+cd moose_test/tests
+moose_test-opt --run -j 4 --re=kernels/simple_diffusion
 exit 0

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -513,25 +513,14 @@ $(copy_input_targets):
 	@$(eval kv := $(subst ->, ,$(subst target_$(APPLICATION_NAME)_,,$@)))
 	@$(eval source_dir := $(word 1, $(kv)))
 	@$(eval dest_dir := $(if $(word 2, $(kv)),$(word 2, $(kv)),$(source_dir)))
-	@echo "Installing inputs from directory \"$(source_dir)\" into $(dest_dir)"
-	@rm -rf $(share_install_dir)/$(dest_dir)
-	@mkdir -p $(share_install_dir)/$(dest_dir)
+	@$(eval dest_dir_full := $(share_install_dir)/$(dest_dir))
 	@$(eval abs_source_dir := $(realpath $(APPLICATION_DIR)/$(source_dir)))
-	@if [ "$(abs_source_dir)" != "" ]; \
-	then \
-		cp -R $(abs_source_dir)/ $(share_install_dir)/$(dest_dir); \
-	else \
-		(echo "ERROR: Source directory $(APPLICATION_DIR)/$(source_dir) does not exist!"; exit 1) \
-	fi;
-	@if [ -e $(APPLICATION_DIR)/testroot ]; \
-	then \
-		cp -f $(APPLICATION_DIR)/testroot $(share_install_dir)/$(dest_dir)/; \
-	elif [ -e $(source_dir)/testroot ]; \
-	then \
-		cp -f $(source_dir)/testroot $(share_install_dir)/$(dest_dir)/; \
-	else \
-		echo "app_name = $(APPLICATION_NAME)" > $(share_install_dir)/$(dest_dir)/testroot; \
-	fi; \
+	@echo "Installing tests $(dest_dir_full)"
+	@APPLICATION_DIR="$(APPLICATION_DIR)" \
+	 APPLICATION_NAME="$(APPLICATION_NAME)" \
+	 SOURCE_DIR="$(abs_source_dir)" \
+	 DEST_DIR="$(dest_dir_full)" \
+	 $(FRAMEWORK_DIR)/scripts/install_copy_inputs.sh
 
 # Install target for a single .la library archive and the associated .so/.dylib library
 install_lib_from_archive_%: %

--- a/framework/scripts/install_copy_inputs.sh
+++ b/framework/scripts/install_copy_inputs.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+for var in APPLICATION_DIR APPLICATION_NAME SOURCE_DIR DEST_DIR; do
+  if [ -z "${!var}" ]; then
+    echo "$var not set"
+    exit 1
+  fi
+done
+
+if [ ! -d "$SOURCE_DIR" ]; then
+  echo "ERROR: Source directory ${SOURCE_DIR} does not exist"
+  exit 1
+fi
+rm -rf "$DEST_DIR"
+mkdir -p "$DEST_DIR"
+
+# Gets the path of one relative to another; needed because
+# realpath --relative-to doesn't exist on mac
+function relpath() {
+  python -c "import os.path; print(os.path.relpath('$1', '$2'))";
+}
+
+# Find symlinks in the source. Done separately like this so that
+# we can support files with spaces from find
+links=()
+while IFS=  read -r -d $'\0' link; do
+  links+=("$link")
+done < <(find "$SOURCE_DIR" -type l -print0)
+
+# The root of the repository; we don't allow for "unsafely" resolving
+# any symlinks that are out of the repository
+repo_root=$(cd "$APPLICATION_DIR"; git rev-parse --show-toplevel)
+
+# Filter symlinks for those broken or out of the application
+rsync_args=()
+for link in "${links[@]}"; do
+  skip=
+  # Links that resolve within directories that do not exist will fail this,
+  # which is fine for now (they already didn't work). Relaive links
+  # that point within the same directory (when the source doesn't exist)
+  # will work.
+  if ! source="$(readlink -f "$link")"; then
+    skip="link is broken"
+  else
+    source_relative_to_app="$(relpath "$source" "$repo_root")"
+    if [[ "$source_relative_to_app" == ..* ]]; then
+      skip="resolves outside of ${repo_root}"
+    fi
+  fi
+  if [ -n "$skip" ]; then
+    echo "WARNING: Skipping ${link}; ${skip}"
+    link_relative_to_source="$(relpath "$link" "$SOURCE_DIR")"
+    rsync_args+=("--exclude" "$link_relative_to_source")
+  fi
+done
+
+# Rely on --copy-unsafe-links to copy the content that cannot be accessed
+# in the new directory
+rsync -aq --copy-unsafe-links "${rsync_args[@]}" "$SOURCE_DIR/" "$DEST_DIR"
+
+# Setup the testroot
+if [ -e "${APPLICATION_DIR}/testroot" ]; then
+  cp -f "${APPLICATION_DIR}/testroot" "${DEST_DIR}/"
+elif [ -e "${SOURCE_DIR}/testroot" ]; then
+  cp -f "${SOURCE_DIR}/testroot" "${DEST_DIR}/"
+else
+  echo "app_name = ${APPLICATION_NAME}" > "${DEST_DIR}/testroot";
+fi

--- a/modules/combined/combined_installable_dirs.mk
+++ b/modules/combined/combined_installable_dirs.mk
@@ -1,4 +1,4 @@
 # We need to separate out declaring INSTALLABLE_DIRS for combined because
 # it needs to be used in both modules/Makefile and modules/combined/Makefile
-INSTALLABLE_MODULE_DIRS := $(shell find $(MOOSE_DIR)/modules -maxdepth 1 -mindepth 1 -type d -not -name doc -not -name module_loader -not -name heat_conduction)
-INSTALLABLE_DIRS        := $(foreach module,$(INSTALLABLE_MODULE_DIRS),../$(shell basename $(module))/test/tests->$(shell basename $(module))) ../../test/tests->framework ../../tutorials/tutorial04_meshing/app/test/tests->reactor_tutorial
+INSTALLABLE_MODULE_DIRS := $(shell find $(MOOSE_DIR)/modules -maxdepth 1 -mindepth 1 -type d -not -name doc -not -name module_loader -not -name heat_conduction -not -name tensor_mechanics)
+INSTALLABLE_DIRS        := $(foreach module,$(INSTALLABLE_MODULE_DIRS),../$(shell basename $(module))/test/tests->$(shell basename $(module))) ../../tutorials/tutorial04_meshing/app/test/tests->reactor_tutorial

--- a/modules/reactor/test/tests/meshgenerators/peripheral_ring_mesh_generator/input_mesh_invalid_bdry_2.e
+++ b/modules/reactor/test/tests/meshgenerators/peripheral_ring_mesh_generator/input_mesh_invalid_bdry_2.e
@@ -1,1 +1,0 @@
-../polygon_concentric_circle_mesh_generator/poly_2d_back_only.e

--- a/modules/reactor/test/tests/meshgenerators/peripheral_ring_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/peripheral_ring_mesh_generator/tests
@@ -130,7 +130,7 @@
     type = 'RunException'
     input = 'core_ring.i'
     cli_args = 'Mesh/pr/input_mesh_external_boundary=10001
-                Mesh/fmg/file=input_mesh_invalid_bdry_2.e
+                Mesh/fmg/file=input_sim.e
                 Mesh/inactive=tg
                 --mesh-only'
     expect_err = 'This mesh generator does not work for the provided external boundary as it is not a closed loop.'

--- a/test/tests/meshdivisions/depletion_id_in.e
+++ b/test/tests/meshdivisions/depletion_id_in.e
@@ -1,1 +1,1 @@
-../../../modules/reactor/test/tests/meshgenerators/reporting_id/depletion_id/depletion_id_in.e
+../positions/depletion_id_in.e


### PR DESCRIPTION
Closes #29171

Relies on rsync to do the copy, with the `--copy-unsafe-links` which will copy full files instead of links for links that no longer resolve. Could do it more manually, but this is cleaner. The "unsafe" links are checked. We could do this without rsync, but it's a bit more complex. And seeing that we require it in the installed environment, I'm fine with requiring it in the install environment.

Resolves the issue of symlinks that point out of one installed test directory into another.