### PR TITLE
Improve pre-SMO residual console formatting

### DIFF
--- a/framework/include/outputs/ConsoleUtils.h
+++ b/framework/include/outputs/ConsoleUtils.h
@@ -83,6 +83,11 @@ std::string outputOutputInformation(MooseApp & app);
 std::string outputSystemInformationHelper(System & system);
 
 /**
+ * Output the information about pre-SMO residual evaluation
+ */
+std::string outputPreSMOResidualInformation();
+
+/**
  * Output the legacy flag information
  */
 std::string outputLegacyInformation(MooseApp & app);

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -745,6 +745,14 @@ Console::outputSystemInformation()
   if (_system_info_flags.isValueSet("output"))
     _console << ConsoleUtils::outputOutputInformation(_app);
 
+  if (!_app.getParam<bool>("use_legacy_initial_residual_evaluation_behavior"))
+    for (const auto i : make_range(_problem_ptr->numNonlinearSystems()))
+      if (_problem_ptr->getNonlinearSystemBase(i).usePreSMOResidual())
+      {
+        _console << ConsoleUtils::outputPreSMOResidualInformation();
+        break;
+      }
+
   // Output the legacy flags, these cannot be turned off so they become annoying to people.
   _console << ConsoleUtils::outputLegacyInformation(_app);
 

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -398,6 +398,23 @@ outputOutputInformation(MooseApp & app)
 }
 
 std::string
+outputPreSMOResidualInformation()
+{
+  std::stringstream oss;
+  oss << std::left;
+
+  oss << COLOR_BLUE;
+  oss << "Executioner/use_pre_smo_residual is set to true. The pre-SMO residual will be evaluated "
+         "at the beginning of each time step before executing objects that could modify the "
+         "solution, such as preset BCs, predictors, correctors, constraints, and certain user "
+         "objects. The pre-SMO residuals will be prefixed with * and will be used in the relative "
+         "convergence check.\n";
+  oss << COLOR_DEFAULT;
+
+  return oss.str();
+}
+
+std::string
 outputLegacyInformation(MooseApp & app)
 {
   std::stringstream oss;

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -22,6 +22,7 @@
 #include "HDGPrimalSolutionUpdateThread.h"
 #include "HDGKernel.h"
 #include "AuxiliarySystem.h"
+#include "Console.h"
 
 #include "libmesh/nonlinear_solver.h"
 #include "libmesh/petsc_nonlinear_solver.h"
@@ -175,7 +176,10 @@ NonlinearSystem::solve()
     _computing_pre_smo_residual = false;
     _nl_implicit_sys.rhs->close();
     _pre_smo_residual = _nl_implicit_sys.rhs->l2_norm();
-    _console << "Pre-SMO residual: " << _pre_smo_residual << std::endl;
+    _console << " * Nonlinear |R| = "
+             << Console::outputNorm(std::numeric_limits<Real>::max(), _pre_smo_residual)
+             << " (Before preset BCs, predictors, correctors, and constraints)\n";
+    _console << std::flush;
   }
 
   const bool presolve_succeeded = preSolve();


### PR DESCRIPTION
This PR makes two changes to the pre-SMO residual console output:
1. Reword to say "(before solution modification)" which hopefully is easier to understand.
2. Use the same printing format as the other residual outputs.

close #29195
