### PR TITLE
Make sure symlinks are set up

### DIFF
--- a/modules/solid_mechanics/contrib/neml2.mk
+++ b/modules/solid_mechanics/contrib/neml2.mk
@@ -78,6 +78,12 @@ NEML2_SRC            := $(shell find $(NEML2_SRC_DIRS) -name "*.cxx")
 NEML2_OBJ            := $(patsubst %.cxx,%.$(obj-suffix),$(NEML2_SRC))
 NEML2_LIB            := $(NEML2_DIR)/libNEML2-$(METHOD).la
 
+ifeq ($(MOOSE_HEADER_SYMLINKS),true)
+$(NEML2_OBJ): $(moose_config_symlink) | moose_header_symlinks
+else
+$(NEML2_OBJ): $(moose_config)
+endif
+
 $(NEML2_LIB): $(NEML2_OBJ)
 	@echo "Linking Library "$@"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=link --quiet \


### PR DESCRIPTION
App-hosted NEML2 models should be able to include files from MOOSE (e.g. to access the `Registry` and the DataFile system). This patch makes sure that the `header_symlinks` are set up befor tryin to build NEML2 objects. This fixes a build error, where during a first-time build MOOSE includes would not be found.

Fixes #27438