### PR TITLE
Add a debug option for controls

### DIFF
--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -41,6 +41,9 @@ SetupDebugAction::validParams()
       "show_material_props",
       false,
       "Print out the material properties supplied for each block, face, neighbor, and/or sideset");
+  params.addParam<bool>("show_controllable",
+                        false,
+                        "Print out the controllable parameters from all input parameters");
   params.addParam<bool>("show_mesh_meta_data", false, "Print out the available mesh meta data");
   params.addParam<bool>(
       "show_reporters", false, "Print out information about the declared and requested Reporters");
@@ -165,5 +168,13 @@ SetupDebugAction::act()
     auto params = _factory.getValidParams(type);
     params.set<MultiMooseEnum>("scope") = block_restriction_scope;
     _problem->addOutput(type, "_moose_block_restriction_debug_output", params);
+  }
+
+  // Controllable output
+  if (getParam<bool>("show_controllable"))
+  {
+    const std::string type = "ControlOutput";
+    auto params = _factory.getValidParams(type);
+    _problem->addOutput(type, "_moose_controllable_debug_output", params);
   }
 }

--- a/test/tests/controls/output/tests
+++ b/test/tests/controls/output/tests
@@ -7,6 +7,13 @@
     expect_out = "Controls:.*Active Controls:.*Active Controls:"
     requirement = "The Control system shall include a means to output information regarding the controlled parameters."
   [../]
+  [debug_syntax]
+    type = RunApp
+    input = controllable.i
+    cli_args = "Debug/show_controllable=true Outputs/active=''"
+    expect_out = "Active Objects:"
+    requirement = "The system shall include a means to output information regarding the controlled parameters, accessible through the Debug syntax."
+  [../]
   [./clear]
     type = RunApp
     input = controllable_clear.i
@@ -21,7 +28,6 @@
     expect_out = "Controls:.*Active Controls:"
     absent_out = "Controls:.*Active Controls:.*Active Controls:"
     requirement = "The system shall include a command line flag for displaying controllable parameter information."
-
   [../]
   [./active]
     type = RunApp

--- a/test/tests/controls/output/tests
+++ b/test/tests/controls/output/tests
@@ -12,7 +12,7 @@
     input = controllable.i
     cli_args = "Debug/show_controllable=true Outputs/active=''"
     expect_out = "Active Objects:"
-    requirement = "The system shall include a means to output information regarding the controlled parameters, accessible through the Debug syntax."
+    requirement = "The system shall include a means to output information regarding the controlled parameters, accessible through dedicated debugging syntax."
   [../]
   [./clear]
     type = RunApp


### PR DESCRIPTION
 refs #29604

in a second phase we could create a dedicated action instead so it can output during the Action phase (e.g. before the controls run and crash if you misspelled a controlled parameter)