### PR TITLE
Revert "Fix find_moose_executable utility"

### DIFF
--- a/python/mooseutils/mooseutils.py
+++ b/python/mooseutils/mooseutils.py
@@ -139,7 +139,7 @@ def find_moose_executable(loc, **kwargs):
             exe_name = os.path.join(loc, name + '-' + method)
             if os.path.isfile(exe_name):
                 exe = exe_name
-                break
+            break
 
     # Returns the executable or error code
     if (exe is None) and show_error:


### PR DESCRIPTION
Reverts idaholab/moose#29589

@nmnobre we messed up on this one. `scripts/versioner.yaml` (see [here](https://github.com/idaholab/moose/blob/90a2914a0fee19ee10456baae3400b3354d510a3/scripts/versioner.yaml#L62)) defines the dependencies for each of our released packages. You modified a file here that modifies the `moose-dev` package without bumping the version for `moose-dev`. Whoops.

We actually can't get this in right now because version bumps are currently unsupported due to some changes in conda.

@milljm let's add this commit to #29104.