### PR TITLE
Fixing typos in MooseDocs documentation.

### DIFF
--- a/python/MooseDocs/base/components.py
+++ b/python/MooseDocs/base/components.py
@@ -79,7 +79,7 @@ class ReaderComponent(Component, mixins.ReaderObject):
         settings = dict()
         settings['style'] = (None, "The style settings that are passed to rendered HTML tag.")
         settings['class'] = (None, "The class settings to be passed to rendered HTML tag.")
-        settings['id'] = (None, "The class settings to be passed to the rendered tag.")
+        settings['id'] = (None, "Identifier to link against this object.")
         return settings
 
     def __init__(self):

--- a/python/doc/content/python/MooseDocs/extensions/acronym.md
+++ b/python/doc/content/python/MooseDocs/extensions/acronym.md
@@ -2,7 +2,7 @@
 
 The acronym extension provides a convenient way to defined acronyms that may be used throughout all
 documentation pages. On each page the full text and acronym definition will be displayed the first
-time is used, as shown in [acronym-example].
+time it is used, as shown in [acronym-example].
 
 !alert note
 When viewing on the website a tooltip is created for the acronyms, the

--- a/python/doc/content/python/MooseDocs/extensions/alert.md
+++ b/python/doc/content/python/MooseDocs/extensions/alert.md
@@ -49,7 +49,7 @@ Do not do this, *it is bad*, umk.
 ## Block Alert
 
 The previous examples show the inline version (see [/core.md#core-inline]) of the
-alert command. Since, this command was built using the [command.md] there also exists a
+alert command. Since this command was built using the [command.md] there also exists a
 block version, which is demonstrated in [alert-example-block].
 
 !devel! example id=alert-example-block

--- a/python/doc/content/python/MooseDocs/extensions/appsyntax.md
+++ b/python/doc/content/python/MooseDocs/extensions/appsyntax.md
@@ -28,7 +28,7 @@ description of the object. To display this text the `!syntax description` comman
 the MOOSE input file syntax for the object as in [appsyntax-description].
 
 !devel! example id=appsyntax-description caption=Example use of the `!syntax description` command.
-!syntax description /Mesh/FileMesh style=color:green;
+!syntax description /Mesh/FileMesh
 !devel-end!
 
 !listing framework/src/mesh/FileMesh.C start=template

--- a/python/doc/content/python/MooseDocs/extensions/appsyntax.md
+++ b/python/doc/content/python/MooseDocs/extensions/appsyntax.md
@@ -28,7 +28,7 @@ description of the object. To display this text the `!syntax description` comman
 the MOOSE input file syntax for the object as in [appsyntax-description].
 
 !devel! example id=appsyntax-description caption=Example use of the `!syntax description` command.
-!syntax description /Mesh/FileMesh style=color:green
+!syntax description /Mesh/FileMesh style=color:green;
 !devel-end!
 
 !listing framework/src/mesh/FileMesh.C start=template
@@ -57,8 +57,8 @@ command are shown in [appsyntax-parameters-settings].
 ## Input Files (`!syntax inputs`) id=inputs
 
 In many cases it is useful to know where in the examples, tutorials, or tests an object is utilized
-in an input file. Therefore, `inputs` sub-command is defined. [appsyntax-inputs-example] lists
-all the input files that use include the ConstantDamper object and [appsyntax-inputs-settings]
+in an input file. Therefore, the `inputs` sub-command is defined. [appsyntax-inputs-example] lists
+all the input files that include the ConstantDamper object and [appsyntax-inputs-settings]
 provides the available settings for the `inputs` command.
 
 !devel settings module=MooseDocs.extensions.appsyntax

--- a/python/doc/content/python/MooseDocs/extensions/core.md
+++ b/python/doc/content/python/MooseDocs/extensions/core.md
@@ -13,7 +13,7 @@ italics are two examples of inline items.
 
 !alert note title=MooseDown is a restricted version of [markdown].
 To unify content and to create a fast parser a strict, limited set of markdown is being used to
-define the MooseDocs syntax. The following sections detail the syntax that comprise the syntax.
+define the MooseDocs syntax. The following sections detail the syntax.
 
 ## Settings id=settings
 
@@ -24,22 +24,22 @@ However, the settings are applied in a uniform manner. Foremost, the key and val
 an equal (`=`) sign +without spaces+ surrounding. The value may contain spaces, with the space after
 the equal sign being the exception.
 
-If syntax has settings the key-value pairs, the default value (if any), and a short description
+If syntax has settings then the key-value pairs, the default value (if any), and a short description
 will be provided in a table. For example, [code-settings] lists the available settings
 for the fenced code blocks discussed in the [#fenced-code] section.
 
 !devel example id=settings-example
-               caption=Example use of settings within [#links], settings are key-value pairs that
+               caption=Example use of settings within [#links]. Settings are key-value pairs that
                        are specified with a separating equal sign (no spaces exist on either side).
 [google](https://www.google.com style=color:teal;)
 
 ## Block Syntax id=core-block
 
-Block level content, as the name suggest, are blocks of text. In all cases, blocks must
+Block level content, as the name suggests, are blocks of text. In all cases, blocks must
 begin and end with empty lines (with the exception of the start and end of the file). This
 restriction allows for special characters such as the hash (`#`) to be used at the start
 of a line without conflicting with heading creation (see [#headings]). Additionally, this
-allows content and settings to be spanned across multiple lines.
+allows content and settings to span multiple lines.
 
 ### Code id=fenced-code
 
@@ -71,7 +71,7 @@ as shown in [quote-nested-example].
 > This is a quotation.
 
 !devel example caption=Nested content in block quotes. id=quote-nested-example
-> Quotations begin with the `<` character and may
+> Quotations begin with the `>` character and may
 > contain any valid markdown content, include quotes and code as shown here.
 >
 > > This begins another quotation, which also contains a fenced code block.
@@ -94,8 +94,8 @@ to define a heading:
 1. the hash(es) must +not+ be preceded by a space.
 
 
-Settings, as listed in [heading-settings], are be applied after the heading title text and as shown in
-[heading-standard] headings may also span multiple lines as shown in [heading-multiline].
+Settings, as listed in [heading-settings], are applied after the heading title text as shown in
+[heading-standard]. Headings may also span multiple lines as shown in [heading-multiline].
 
 !devel! example caption=Basic use of all six heading levels. id=heading-basic-example
 # Level One
@@ -164,7 +164,7 @@ item by two spaces, as shown in [unordered-nested-example].
 !devel-end!
 
 As mentioned above, lists can contain lists, which can contain lists, etc. A sub-list, which is a
-list in a list, is created by creating by indenting with at the level of the list item which is
+list in a list, is created by indenting at the level of the list item within which it
 should contained. Since lists are block items, it must be begin and end with empty lines. And, since
 this is a list it also follows the aforementioned rules for list continuation.
 [unordered-sublist-example] demonstrates the syntax for creating nested lists.
@@ -195,8 +195,8 @@ this is a list it also follows the aforementioned rules for list continuation.
 
 ### Ordered List
 
-A numbered list work nearly identical to unordered lists (see [#unordered]), but start with a
-numbered followed by a period and a single space. The number used for the first item in the list
+A numbered list works nearly identically to unordered lists (see [#unordered]), but starting with a
+number followed by a period and a single space. The number used for the first item in the list
 will be the number used for the start of the list, see [ordered-example].
 
 !devel! example id=ordered-example caption=Example of ordered lists with a starting number and a second with nested content.
@@ -230,7 +230,7 @@ You can create shortcuts to common items: [foo].
 
 ## Inline Content id=core-inline
 
-Inline content comprises of formatting, as the name suggest, that occurs within lines of text.
+Inline content comprises formatting, as the name suggests, that occurs within lines of text.
 Examples include inline code and text formatting such as +bold+.
 
 ### Monospace (Inline Code) id=monospace
@@ -288,7 +288,7 @@ syntax. The available settings for links is include in [link-settings].
 ### Shortcut links id=shortcut-link
 
 Links to shortcuts use the typical [markdown] syntax of a key enclosed in square brackets (`[key]`),
-where the key references a shortcut, which are defined as detailed in the [#shortcuts] section, refer
+where the key references a shortcut, which are defined in the [#shortcuts] section. Refer
 to [shortcut-example] for a demonstration of shortcut and shortcut link use.
 
 In addition to linking to [#shortcuts] created directly, the same syntax is used to reference
@@ -326,7 +326,7 @@ this.
 
 ### Escape Characters
 
-In some cases the use of characters such as a bracket of exclamation are needed in a context that
+In some cases the use of characters such as a bracket or exclamation are needed in a context that
 is recognized as special markdown syntax. In this case, the character should be escaped, using the
 `\` character, as in the following examples.
 

--- a/python/doc/content/python/MooseDocs/extensions/core.md
+++ b/python/doc/content/python/MooseDocs/extensions/core.md
@@ -165,7 +165,7 @@ item by two spaces, as shown in [unordered-nested-example].
 
 As mentioned above, lists can contain lists, which can contain lists, etc. A sub-list, which is a
 list in a list, is created by indenting at the level of the list item within which it
-should contained. Since lists are block items, it must be begin and end with empty lines. And, since
+should be contained. Since lists are block items, it must be begin and end with empty lines. And, since
 this is a list it also follows the aforementioned rules for list continuation.
 [unordered-sublist-example] demonstrates the syntax for creating nested lists.
 

--- a/python/doc/content/python/MooseDocs/extensions/datetime.md
+++ b/python/doc/content/python/MooseDocs/extensions/datetime.md
@@ -13,7 +13,7 @@ for date and time operations. This extension is based on the
 
 The "today" sub-command inserts the date when the execution of the documentation build occurs, by
 calling the python `datetime.date.today()` function, as demonstrated in [datetime-today-example].
-The available settings for the this command are provided in [datetime-today-settings].
+The available settings for this command are provided in [datetime-today-settings].
 
 !devel settings module=MooseDocs.extensions.datetime
                 object=TodayCommand

--- a/python/doc/content/python/MooseDocs/extensions/gallery.md
+++ b/python/doc/content/python/MooseDocs/extensions/gallery.md
@@ -1,7 +1,7 @@
 # Gallery Extension
 
-The gallery extension provides a mechanism for creating "cards" using the 'card' command and
-allow for these items to be organized in to a gallery with the 'gallery' command. The
+The gallery extension provides a mechanism for creating "cards" using the `!card` command and
+allows for these items to be organized into a gallery with the `!gallery` command. The
 available configuration items for the extension are listed below, in [gallery-config].
 
 !devel settings module=MooseDocs.extensions.gallery
@@ -12,8 +12,8 @@ available configuration items for the extension are listed below, in [gallery-co
 ## Cards
 
 In general, a gallery is composed of cards; however, the 'card' command works as a stand
-alone command. The name card is derived from the [materialize](https://materializecss.com/cards.html)
-framework, which MOOSEDocs relies for creating website content. The settings for the
+alone command. The name "card" is derived from the [materialize](https://materializecss.com/cards.html)
+framework, which MOOSEDocs relies on for creating website content. The settings for the
 card command are listed in [card-settings].
 
 !devel! example id=gallery-example-card

--- a/python/doc/content/python/MooseDocs/extensions/graph.md
+++ b/python/doc/content/python/MooseDocs/extensions/graph.md
@@ -9,14 +9,14 @@ sections. [plotly-ext-config] lists the configuration options for the extension.
                 id=plotly-ext-config
                 caption=Available configuration options for the `PlotlyExtension` object.
 
-The syntax for the support chart types is defined in a manner that allows for all [plotly]
+The syntax for the supported chart types is defined in a manner that allows for all [plotly]
 settings to be available for defining the data as well as the chart layout. For a complete list
 of available options refer to the [reference manual](https://plot.ly/javascript/reference).
 
 
 ## Scatter and Line Plots
 
-[Scatter and line](https://plot.ly/javascript/line-and-scatter/) plots are create with the
+[Scatter and line](https://plot.ly/javascript/line-and-scatter/) plots are created with the
 `scatter` sub-command. As shown in the [plotly] documentation the plot command accepts
 a single JSON data structure that contains the data and settings for each line. For simplicity
 and to remain consistent with the library this same data structure is used within MooseDocs,

--- a/python/doc/content/python/MooseDocs/extensions/ifelse.md
+++ b/python/doc/content/python/MooseDocs/extensions/ifelse.md
@@ -13,9 +13,9 @@ following sections demonstrate the use of the commands.
 
 The "modules" configuration item provides a list of python modules to search when calling
 conditional functions. The default behavior of the module is equivalent to adding the following
-the "modules" item.
+to the "modules" item.
 
-!listing
+!listing language=yaml
 MooseDocs.extensions.ifelse:
     modules:
         - MooseDocs.extensions.ifelse
@@ -72,8 +72,8 @@ The complete list of settings available for the "if" command are provided in [if
 
 Creating `if`-`elif`-`else` statements is accomplished by using an `if` command followed by any
 number of `elif` commands and then a final (optional) `else` command. It is important to understand
-that the implementation actually uses separate [commands](command.md). As such, each command the
-`if`, `elif`, and/or the `else` can use the inline or block version of the command definition. The
+that the implementation actually uses separate [commands](command.md). As such, each command (the
+`if`, `elif`, and/or the `else`) can use the inline or block version of the command definition. The
 extension will enforce that commands occur in the expected order.
 
 !devel! example id=if-elif-else caption=A `if elif else` statement that mixes the command

--- a/python/doc/content/python/MooseDocs/extensions/include.md
+++ b/python/doc/content/python/MooseDocs/extensions/include.md
@@ -4,7 +4,7 @@ A primary driver behind developing the MooseDocs system was to create a single s
 for all documentation and allow the same piece of text to be reused in multiple locations and in
 multiple formats. Therefore, it is possible to include markdown within markdown using the
 `!include` command.  The available
-setting for the `!include` command is given in [include-settings].
+settings for the `!include` command is given in [include-settings].
 
 !devel settings id=include-settings
                 caption=Settings for the `!include` command.

--- a/python/doc/content/python/MooseDocs/extensions/katex.md
+++ b/python/doc/content/python/MooseDocs/extensions/katex.md
@@ -20,7 +20,7 @@ as shown in [katex-numbered].
 !devel! example id=katex-numbered
                 caption=Example of syntax for creating numbered equations with [KaTeX].
 \begin{equation}
-\label{line-eq}
+\label{line-eq2}
 y = a\cdot x + b
 \end{equation}
 !devel-end!

--- a/python/doc/content/python/MooseDocs/extensions/katex.md
+++ b/python/doc/content/python/MooseDocs/extensions/katex.md
@@ -19,11 +19,21 @@ as shown in [katex-numbered].
 
 !devel! example id=katex-numbered
                 caption=Example of syntax for creating numbered equations with [KaTeX].
+\begin{equation}
+\label{line-eq}
+y = a\cdot x + b
+\end{equation}
+!devel-end!
+
+Equation blocks can also be created with `!equation`, as shown in [katex-numbered-2].
+
+!devel! example id=katex-numbered-2
+                caption=Example of syntax for creating numbered equations with [KaTeX].
 !equation id=line-eq
 y = a\cdot x + b
 !devel-end!
 
-To include a non-numbered equation, simply exclude the "id" in the command, as shown in
+To include a non-numbered equation, simply exclude the `\label` or "id" in the command, as shown in
 [katex-no-number].
 
 !devel! example id=katex-no-number
@@ -63,13 +73,13 @@ Inline equations can use traditional LaTeX syntax, i.e., the content is wrapped 
 the inline `!eq` command, as shown in [katex-inline].
 
 !devel example id=katex-inline caption=Example of an inline LaTeX equation.
-This $y=2\phi$ is inline and so it this: [!eq](\phi=\beta^2).
+This $y=2\phi$ is inline and so is this: [!eq](\phi=\beta^2).
 
 ## Macros
 
-It is possible to define macros within extension configuration. This is done using the
+It is possible to define macros within the extension configuration. This is done using the
 'macros' configuration parameter (see [katex-extension-config]). For example, the main configuration
-file for contains the following allowing for equation in [katex-macro] to be defined.
+file contains the following, allowing for equation in [katex-macro] to be defined.
 
 !listing modules/doc/config.yml start=MooseDocs.extensions.katex end=MooseDocs.extensions.appsyntax
 

--- a/python/doc/content/python/MooseDocs/extensions/listing.md
+++ b/python/doc/content/python/MooseDocs/extensions/listing.md
@@ -6,14 +6,14 @@ includes the ability to parse MOOSE input files and separate out blocks. The mai
 copying code or input syntax into the documentation to avoid out-of-date content.
 
 The extension provides the `!listing` command (see [command.md]), which allows for numbered captions
-to be applied, the [extensions/floats.md] provides additional details. The following table list the
+to be applied, the [extensions/floats.md] provides additional details. The following table lists the
 available configure options for the extension.
 
 !devel settings module=MooseDocs.extensions.listing object=ListingExtension
 
 The `!listing` command has the capability to include text from local content and arbitrary files
-(such as source code).  files. There is a wide range of settings that are available to specialize how
-the code is imported.  The complete list of available of settings are provided in [moose-listing] and
+(such as source code) files. There is a wide range of settings that are available to specialize how
+the code is imported.  The complete list of available settings are provided in [moose-listing] and
 the sections below provide various examples of using some of these settings.
 
 ## Local Listing Content
@@ -25,9 +25,10 @@ to how content is defined. The available settings for this command are given in
 
 !devel! example id=example-listing-local caption=Example listing with content from local markdown.
 !listing id=local caption=A function for adding 42. language=cpp
-double add_forty_two(const double y);
-y += 42;
-return y;
+double add_forty_two(const double y) {
+  y += 42;
+  return y;
+}
 !devel-end!
 
 !devel settings module=MooseDocs.extensions.listing
@@ -38,17 +39,17 @@ return y;
 ## File Content
 
 You can include complete files from the repository. For example, the following creates the code
-listing in [example-listing-complete].
+listing in [example-listing-complete]. The available settings for this command are given in
+[moose-listing].
+
+!devel! example id=example-listing-complete caption=Example for showing a complete file.
+!listing framework/src/kernels/Diffusion.C
+!devel-end!
 
 !devel settings module=MooseDocs.extensions.listing
                 object=FileListingCommand
                 id=moose-listing
                 caption=Settings available when capturing text from a file with the `listing` command.
-
-
-!devel! example id=example-listing-complete caption=Example for showing a complete file.
-!listing framework/src/kernels/Diffusion.C
-!devel-end!
 
 ### Regular Expression Match
 

--- a/python/doc/content/python/MooseDocs/extensions/listing.md
+++ b/python/doc/content/python/MooseDocs/extensions/listing.md
@@ -12,7 +12,7 @@ available configure options for the extension.
 !devel settings module=MooseDocs.extensions.listing object=ListingExtension
 
 The `!listing` command has the capability to include text from local content and arbitrary files
-(such as source code) files. There is a wide range of settings that are available to specialize how
+(such as source code files). There is a wide range of settings that are available to specialize how
 the code is imported.  The complete list of available settings are provided in [moose-listing] and
 the sections below provide various examples of using some of these settings.
 

--- a/python/doc/content/python/MooseDocs/extensions/media.md
+++ b/python/doc/content/python/MooseDocs/extensions/media.md
@@ -4,7 +4,6 @@ The media extension provides the `!media` markdown command for adding images and
 throughout MooseDocs content, the `!media` command can optionally create a numbered
 [extensions/floats.md] by specifying the "id" setting. A caption may be include by using the
 "caption" setting.
-
 The configuration options for the media extension are listed in [config-media-ext].
 
 !devel settings id=config-media-ext
@@ -14,9 +13,9 @@ The configuration options for the media extension are listed in [config-media-ex
 
 ## Images
 
-The media extension supports including the standard html image extensions: png, gif, jpg, jpeg,
-and svg. Images are added using the !media command followed by the filename, as shown in
-[example-media]. [image-settings] includes the list of available settings for media command for
+The media extension supports including the standard HTML image extensions: png, gif, jpg, jpeg,
+and svg. Images are added using the `!media` command followed by the filename, as shown in
+[example-media]. [image-settings] includes the list of available settings for the media command for
 images.
 
 !alert note

--- a/python/doc/content/python/MooseDocs/extensions/sqa.md
+++ b/python/doc/content/python/MooseDocs/extensions/sqa.md
@@ -1,10 +1,10 @@
 # Software Quality Assurance Extension
 
-The [!ac](SQA) extension is design to aid in tracking documentation for satisfying the NQA-1 standard for
+The [!ac](SQA) extension is designed to aid in tracking documentation for satisfying the NQA-1 standard for
 software quality. It is simply a tool to aid MOOSE-based software projects for being sure that all
 the necessary information exists to meet this standard. The first section details the use of
 templates for building software quality documentation, the second explains the extension level
-configuration, and the final section briefly discuss each of the available extension commands and
+configuration, and the final section briefly discusses each of the available extension commands and
 the intended purpose. For a working example please refer to the
 [MOOSE SQA](sqa/index.md exact=True optional=True) documentation.
 
@@ -88,7 +88,7 @@ they follow the framework versions of the [framework_cci.md] and [framework_scs.
 
 The available general SQA templates are listed below. Unlike the MOOSE-based application or module
 versions above, a landing page template does not exist and there is no naming convention required for
-loading these templates. These templates based on the [!ac](INL) templates and are stand-alone to
+loading these templates. These templates are based on the [!ac](INL) templates and are stand-alone to
 aid in creating SQA documentation for unique non-MOOSE applications. They are also used for the
 framework documents on which all MOOSE-based applications depend.
 
@@ -134,7 +134,7 @@ applications should specify this option with the correct repository as the defau
 [example-repo-config] sets the default URL. This example also demonstrates how to add
 additional URLs (i.e., pika) to the list of available URLs.
 
-!listing caption=Example use of "repos" configuration option. id=example-repo-config
+!listing caption=Example use of "repos" configuration option. id=example-repo-config language=yaml
 MooseDocs.extensions.sqa:
     repos:
         default: https://github.com/idaholab/mastodon
@@ -175,7 +175,7 @@ dictionary used for this option. These sub-options are detailed as follows.
 - `reports`: Options for SQA report generation, see [python/moosesqa/index.md] for additional
   details.
 
-!listing caption=Example use of "categories" configuration option. id=example-categories-config
+!listing caption=Example use of "categories" configuration option. id=example-categories-config language=yaml
 MooseDocs.extensions.sqa:
     categories:
         framework:
@@ -203,7 +203,7 @@ configuration option (see [#categories-config]). When listed this group is used 
 the requirements. The "requirement-groups" allows the group name to
 be modified. For example, [example-req-groups] demonstrates the use of this option.
 
-!listing caption=Example use of "requirement-groups" configuration option. id=example-req-groups
+!listing caption=Example use of "requirement-groups" configuration option. id=example-req-groups language=yaml
 MooseDocs.extensions.sqa:
     requirement-groups:
         dgkernels: DGKernel Objects
@@ -211,7 +211,7 @@ MooseDocs.extensions.sqa:
 
 ### +`reports`+
 
-This option provides information for generating of an application level set of SQA reports; please
+This option provides information for generating an application level set of SQA reports; please
 refer to [python/moosesqa/index.md] for additional details.
 
 ### +`default_collection`+

--- a/python/doc/content/python/MooseDocs/extensions/table.md
+++ b/python/doc/content/python/MooseDocs/extensions/table.md
@@ -1,6 +1,6 @@
 # Table Extension
 
-The table extension provides a means for defining table using traditional markdown syntax, as
+The table extension provides a means for defining tables using traditional markdown syntax, as
 shown in [example-basic]. It also adds the ability to create numbered and captioned tables
 as in [example-caption].
 

--- a/python/doc/content/python/MooseDocs/extensions/tag.md
+++ b/python/doc/content/python/MooseDocs/extensions/tag.md
@@ -23,9 +23,8 @@ development team.
 An example of the usage of extension settings from [tagging-config] in a configuration file is shown
 below.
 
-```
+```yaml
 Extensions:
-    ...
     MooseDocs.extensions.tagging:
         active: True
         js_file: tagging.js

--- a/python/doc/content/python/MooseDocs/extensions/template.md
+++ b/python/doc/content/python/MooseDocs/extensions/template.md
@@ -8,7 +8,7 @@ markdown files, using two methods:
 - +Key/value pairs+: Simple substitution of key/value pairs via a syntax `{{keyname}}`.
 - +Fields+: Substitution of entire blocks of markdown text/input.
 
-The commands associated the template extension are the following:
+The commands associated with the template extension are the following:
 
 - `template load`: Loads a template file. This is required to use any templates.
 - `template field`: Declares a template "field" that must be defined with the `template item` command.

--- a/python/doc/content/python/MooseDocs/index.md
+++ b/python/doc/content/python/MooseDocs/index.md
@@ -12,7 +12,7 @@ features tailored to documenting MOOSE code:
 - C++ [`MooseObject`](MooseObject.md) descriptions and input parameters tables may be automatically generated from
   applications (see [/appsyntax.md]).
 - Cross-referencing links to examples and source code may be created (see [/autolink.md]).
-- Dynamic source code listings allow source to displayed without duplication and update
+- Dynamic source code listings allow source to be displayed without duplication and update
   automatically with code changes (see [/listing.md]).
 
 The single-source markdown files may be converted into various media forms, including web-sites (like

--- a/python/doc/content/python/MooseDocs/specification.md
+++ b/python/doc/content/python/MooseDocs/specification.md
@@ -12,7 +12,7 @@ is a proposed standard. However, this specification is syntactically loose. For 
 defining lists the spacing can be misleading;
 [Example 273](http://spec.commonmark.org/0.28/#example-273) and
 [Example 268](http://spec.commonmark.org/0.28/#example-268) shows that some poorly defined behavior
-still exists and it is stated that the associated rule "should prevent most spurious list captures,"
+still exists. It is stated in the specification that the associated rule "should prevent most spurious list captures,"
 which is inadequate for a language.
 
 Additionally, most parsers of this specification do not support custom extensions or adding them is

--- a/python/doc/content/python/MooseDocs/specification.md
+++ b/python/doc/content/python/MooseDocs/specification.md
@@ -9,14 +9,14 @@ As a short-hand [HTML] format, [markdown] is ubiquitous, especially among softwa
 However, no standard exists and the original implementation was incomplete. Currently, there are
 myriad implementations---often deemed "flavors"---of Markdown. [CommonMark](http://commonmark.org/)
 is a proposed standard. However, this specification is syntactically loose. For example, when
-defining lists the spacing is can be misleading, see
+defining lists the spacing can be misleading;
 [Example 273](http://spec.commonmark.org/0.28/#example-273) and
 [Example 268](http://spec.commonmark.org/0.28/#example-268) shows that some poorly defined behavior
 still exists and it is stated that the associated rule "should prevent most spurious list captures,"
 which is inadequate for a language.
 
 Additionally, most parsers of this specification do not support custom extensions or adding them is
-difficulty, from a user perspective, because the parsing strategy used is complex and context
+difficult, from a user perspective, because the parsing strategy used is complex and context
 dependent.
 
 Originally, MooseDocs used the [markdown](http://pythonhosted.org/Markdown/) python package, which
@@ -25,7 +25,7 @@ found. The main problems, with respect to MooseDocs, was the parsing speed, the 
 and the complexity of adding extensions (i.e., there are too many extension formats). The lack of an
 [AST] limited the ability to convert the supplied markdown to other formats (e.g., LaTeX).
 
-For these reasons, among others not mentioned here, yet another markdown flavor was born. MOOSE
+For these reasons, among others not mentioned here, yet another markdown flavor was born, MOOSE
 flavored Markdown ("MooseDown"). The so called MooseDown language is designed to be strict with
 respect to format as well as easily extendable so that MOOSE-based applications can customize the
 system to meet their documentation needs. The strictness allows for a simple parsing strategy to be
@@ -33,10 +33,10 @@ used and promotes uniformity among the MooseDown files.
 
 ## MooseDocs Extensions
 
-The MooseDocs systems works using extensions, thus allowing for arbitrary languages and syntax
+The MooseDocs systems work using extensions, thus allowing for arbitrary languages and syntax
 to be supported. The MooseDown language is defined using the extensions listed in the following
 tables. [user-ext] provides a list of extensions that are useful for those writing documentation and
-[devel-ext] include extension information for developers for new extensions.
+[devel-ext] includes extension information for developers of new extensions.
 
 
 !table id=user-ext caption=List of extensions useful for writing "MooseDown".


### PR DESCRIPTION
Closes #29647
