### PR TITLE
Fix (sub)subapp command line args

### DIFF
--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -57,7 +57,8 @@ outputFrameworkInformation(const MooseApp & app)
   oss << "\n";
 
   const auto & cl = std::as_const(*app.commandLine());
-  const auto cl_range = as_range(std::next(cl.getEntries().begin()), cl.getEntries().end());
+  const auto cl_range =
+      as_range(std::next(cl.getEntries().begin(), app.multiAppLevel() == 0), cl.getEntries().end());
 
   std::stringstream args_oss;
   for (const auto & entry : cl_range)

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -57,6 +57,7 @@ outputFrameworkInformation(const MooseApp & app)
   oss << "\n";
 
   const auto & cl = std::as_const(*app.commandLine());
+  // We skip the 0th argument of the main app, i.e., the name used to invoke the program
   const auto cl_range =
       as_range(std::next(cl.getEntries().begin(), app.multiAppLevel() == 0), cl.getEntries().end());
 

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -211,6 +211,8 @@ CommandLine::initSubAppCommandLine(const std::string & multiapp_name,
     subapp_args.push_back(MooseUtils::removeExtraWhitespace(arg));
 
   // Pull out all of the arguments that are relevant to this multiapp from the parent
+  // Note that the 0th argument of the main app, i.e., the name used to invoke the program,
+  // is neither a global entry nor a subapp entry and, as such, won't be passed on
   for (auto & entry : as_range(getEntries().begin(), getEntries().end()))
     if (entry.global || (entry.subapp_name && (*entry.subapp_name == multiapp_name ||
                                                *entry.subapp_name == subapp_name)))

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -211,7 +211,7 @@ CommandLine::initSubAppCommandLine(const std::string & multiapp_name,
     subapp_args.push_back(MooseUtils::removeExtraWhitespace(arg));
 
   // Pull out all of the arguments that are relevant to this multiapp from the parent
-  for (auto & entry : as_range(std::next(getEntries().begin()), getEntries().end()))
+  for (auto & entry : as_range(getEntries().begin(), getEntries().end()))
     if (entry.global || (entry.subapp_name && (*entry.subapp_name == multiapp_name ||
                                                *entry.subapp_name == subapp_name)))
     {

--- a/unit/src/CommandLineTest.C
+++ b/unit/src/CommandLineTest.C
@@ -480,7 +480,9 @@ TEST(CommandLineTest, initSubAppCommandLine)
   const auto test = [](const std::vector<std::string> & args,
                        const std::string & multiapp_name,
                        const std::string & subapp_name,
-                       const std::vector<std::string> & expected_args)
+                       const std::string & subsubapp_name,
+                       const std::vector<std::string> & expected_args,
+                       const std::vector<std::string> & subexpected_args)
   {
     InputParameters params = emptyInputParameters();
     params.addCommandLineParam<bool>("global", "--global", "Doc1");
@@ -498,6 +500,13 @@ TEST(CommandLineTest, initSubAppCommandLine)
     const auto subapp_cl =
         cl.initSubAppCommandLine(multiapp_name, subapp_name, std::vector<std::string>());
     ASSERT_EQ(expected_args, subapp_cl->getArguments());
+
+    subapp_cl->parse();
+    subapp_cl->populateCommandLineParams(params);
+
+    const auto subsubapp_cl =
+        subapp_cl->initSubAppCommandLine(multiapp_name, subsubapp_name, std::vector<std::string>());
+    ASSERT_EQ(subexpected_args, subsubapp_cl->getArguments());
   };
 
   test({"--global",
@@ -511,8 +520,10 @@ TEST(CommandLineTest, initSubAppCommandLine)
         "sub1:Kernels/active=foo"},
        "sub",
        "sub0",
-       {"--global", "some/value=123", "App/foo=bar", ":Foo/bar=baz", "subsub0:val=5"});
-  test({"--unused", "--another_global"}, "sub", "sub1", {});
+       "subsub0",
+       {"--global", "some/value=123", "App/foo=bar", ":Foo/bar=baz", "subsub0:val=5"},
+       {"--global", ":Foo/bar=baz", "val=5"});
+  test({"--unused", "--another_global"}, "sub", "sub1", "subsub1", {}, {});
 }
 
 TEST(CommandLineTest, requiredParameter)


### PR DESCRIPTION
Hi Logan (@loganharbour),

Fixes a couple of bugs introduced in 4f72723 of #26878:

1) In `initSubAppCommandLine()`, the use of `std::next()` meant we were losing an argument with each spawned subapp. This is okay for the first subapp because it only skipped the executable invocation (which I think was the reason it was there? - but note this is unnecessary because for that entry, `global == false`) but then meant that if the subapp created a further subapp, the latter would lose an argument.
2) Similarly, when printing in `outputFrameworkInformation`, the use of `std::next()` meant we weren't printing the entire argument list. We now only skip with `std::next()` on the main app, so we don't print the executable invocation line.

Cheers,
-Nuno