### PR TITLE
Make porous flow doc links unique

### DIFF
--- a/modules/porous_flow/doc/content/modules/porous_flow/boundaries.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/boundaries.md
@@ -108,7 +108,7 @@ A similar equation holds for temperature (but in PorousFlow
 simulations the heat is sometimes supplied by the fluid, in which case
 the appropriate equation to use for the heat may be the above equation
 multiplied by the enthalpy).  Here $k_{nn}$ is the permeability of the
-region between the model and the imaginary environment 
+region between the model and the imaginary environment
 (which can also be thought of as the permeability of the adjacent element),
 $k_{\mathrm{r}}$ is the relative permeability in this region, $\rho$
 and $\mu$ are the fluid density and viscosity.  The environment
@@ -123,23 +123,23 @@ almost zero and does nothing.
 
 ### Numerical Implementation
 
-The [`PorousFlowSink`](PorousFlowSink.md) is implemented in a fairly general way 
-that allows for flexibility in setting combinations of pressure and temperature boundary conditions. Due to its implementation, 
+The [`PorousFlowSink`](PorousFlowSink.md) is implemented in a fairly general way
+that allows for flexibility in setting combinations of pressure and temperature boundary conditions. Due to its implementation,
 it is difficult to draw a perfect analogy to the physical flux. Nevertheless,
 [eq:fix_pp_bc] may be implemented in a number of ways, and one of the most
 common involves a [`PorousFlowPiecewiseLinearSink`](PorousFlowPiecewiseLinearSink.md)
 that follows the format of [eq:s_f_g] using $f(x,t)=C$ and $g(P-P_{\mathrm{e}})$ as a
-piecewise linear function between ordered pairs of `pt_vals` (on the x-axis) and 
-`multiplier` (on the y-axis). An example of the function $g$ is shown in the figure below. It accepts $P-P_{\mathrm{e}}$ as an input and returns 
+piecewise linear function between ordered pairs of `pt_vals` (on the x-axis) and
+`multiplier` (on the y-axis). An example of the function $g$ is shown in the figure below. It accepts $P-P_{\mathrm{e}}$ as an input and returns
 a value that ends up multiplying $C$ to give a flux (as in [eq:s_f_g]). $C$ can be thought of as the conductance and is specified with `flux_function = C`. Its numerical value is discussed below. $P_{\mathrm{e}}$ can be specified using an AuxVariable or set to a constant value using `PT_shift = Pe`.
 
 
 !media piecewiselinear_g_function.png style=width:50%;margin-left:10px caption=Depiction of $g(P-P_{\mathrm{e}})$ for PorousFlowPiecewiseLinearSink. The function accepts $P-P_{\mathrm{e}}$ as an input (i.e. the difference between a specified environment pressure and the pressure on the boundary element) and returns a value that multiplies $C$ to give the flux out of the domain. id=PiecewiseLinear_g_Function
 
-To set a Dirichlet boundary condition $P = P_{\mathrm{e}}$, either $C$ or the slope of $g$ should be very large. 
+To set a Dirichlet boundary condition $P = P_{\mathrm{e}}$, either $C$ or the slope of $g$ should be very large.
 It is usually convenient to make the slope of $g$ equal to 1 by setting `pt_vals = '-1E9 1E9'` and `multipliers = '-1E9 1E9'`, and then $C$ can be selected appropriately.
 The range for `pt_vals` should be sufficiently large that the simulation always occupies the region between the values specified (`-1E9 1E9` is a typical choice because porepressures encountered in many simulations are $O(10^6)$).
-This ensures good convergence, and if in doubt set the `pt_vals` at a higher value than you expect. 
+This ensures good convergence, and if in doubt set the `pt_vals` at a higher value than you expect.
 If $P - P_{\mathrm{e}}$ falls outside of the range defined in `pt_vals`, then the slope of $g = 0$. This can be useful to set a boundary condition that will only allow for outflow (e.g. by using  `pt_vals = '0 1E9'`, `multipliers = '0 1E9'`).`
 
 The numerical value of the conductance, $C$, is
@@ -152,11 +152,11 @@ true`, and then $C = 1/L$.  This has three advantages: (1) the MOOSE
 input file is simpler; (2) MOOSE automatically chooses the correct
 mobility and relative permeability to use; (3) these parameters are
 appropriate to the model so it reduces the potential for difficult
-numerical situations occurring. 
+numerical situations occurring.
 
-Also note, if $C \times g$ is too large, the boundary residual will be much larger than residuals within the domain. This results in poor convergence. 
+Also note, if $C \times g$ is too large, the boundary residual will be much larger than residuals within the domain. This results in poor convergence.
 
-So what value should be assigned to $C$? In the example below, $C = 10^{-5}$, $\rho \sim 10^3$ kg/m$^3$, $k = 10^{-15}$ m$^2$, $k_r = 1$, and $\mu \sim 10^{-3}$ Pa-s. Therefore $L \sim 10^{-4}$ m. This value of $L$ is small enough to ensure that the Dirichlet boundary condition is satisfied. If $C$ is increased to $10^{-2}$, $L \sim 10^{-7}$ m, and the simulation has difficulty converging. If $C = 10^{-11}$, $L\sim10^2$ m, and the boundary acts like a source of fluid from a distant reservoir (i.e. it no longer acts like a Dirichlet boundary condition). 
+So what value should be assigned to $C$? In the example below, $C = 10^{-5}$, $\rho \sim 10^3$ kg/m$^3$, $k = 10^{-15}$ m$^2$, $k_r = 1$, and $\mu \sim 10^{-3}$ Pa-s. Therefore $L \sim 10^{-4}$ m. This value of $L$ is small enough to ensure that the Dirichlet boundary condition is satisfied. If $C$ is increased to $10^{-2}$, $L \sim 10^{-7}$ m, and the simulation has difficulty converging. If $C = 10^{-11}$, $L\sim10^2$ m, and the boundary acts like a source of fluid from a distant reservoir (i.e. it no longer acts like a Dirichlet boundary condition).
 The value of $C$ is simply $1/L$ if `use_mobility = true` and `use_relperm = true`.
 
 !listing modules/porous_flow/test/tests/sinks/PorousFlowPiecewiseLinearSink_BC_eg1.i start=[BCs] end=[Postprocessors]
@@ -331,7 +331,7 @@ Inclusion of a BC for $u$ in a MOOSE input file will specify something about the
 
 ### The PorousFlow mass flux
 
-The [governing equation](governing_equations.md) for mass conservation of fluid species $\kappa$ is
+The [governing equation](porous_flow/governing_equations.md) for mass conservation of fluid species $\kappa$ is
 \begin{equation}
 0 = \frac{\partial M^{\kappa}}{\partial t} + M^{\kappa}\nabla\cdot{\mathbf
   v}_{s} + \nabla\cdot \mathbf{F}^{\kappa} + \Lambda M^{\kappa} - \phi I_{\mathrm{chem}} - q^{\kappa} \ .
@@ -339,7 +339,7 @@ The [governing equation](governing_equations.md) for mass conservation of fluid 
 The standard [PorousFlow nomenclature](/porous_flow/nomenclature.md) as been used here.  The weak form is
 \begin{equation}
 \label{eqn.pf.mass.flux.weak}
-0 = \int_{\Omega}\psi \dot{M}^{\kappa} + \int_{\Omega}\psi \left( M^{\kappa}\nabla\cdot{\mathbf v}_{s} + \Lambda M^{\kappa} - \phi I_{\mathrm{chem}} - q^{\kappa} \right) - \int_{\Omega}\nabla\psi\cdot \mathbf{F}^{\kappa} + \int_{\partial\Omega}\psi {\mathbf n}\cdot \mathbf{F}^{\kappa} 
+0 = \int_{\Omega}\psi \dot{M}^{\kappa} + \int_{\Omega}\psi \left( M^{\kappa}\nabla\cdot{\mathbf v}_{s} + \Lambda M^{\kappa} - \phi I_{\mathrm{chem}} - q^{\kappa} \right) - \int_{\Omega}\nabla\psi\cdot \mathbf{F}^{\kappa} + \int_{\partial\Omega}\psi {\mathbf n}\cdot \mathbf{F}^{\kappa}
 \end{equation}
 The flux of species $\kappa$ out through an arbitrary area $A$ is
 \begin{equation}
@@ -362,7 +362,7 @@ Inclusion of a BC for porepressure or mass fraction in a MOOSE input file will s
 
 ### The PorousFlow heat flux
 
-The [governing equation](governing_equations.md) for heat-energy conservation is
+The [governing equation](porous_flow/governing_equations.md) for heat-energy conservation is
 \begin{equation}
 0 = \frac{\partial\mathcal{E}}{\partial t} + \mathcal{E}\nabla\cdot{\mathbf
   v}_{s} + \nabla\cdot \mathbf{F}^{T} -

--- a/modules/porous_flow/doc/content/modules/porous_flow/groundwater_models.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/groundwater_models.md
@@ -166,7 +166,7 @@ These equations are sometimes used to model unsaturated flow (as in unconfined a
 
 ### Presentation 1
 
-Groundwater flow is often modelled by the [equation](governing_equations.md)
+Groundwater flow is often modelled by the [equation](porous_flow/governing_equations.md)
 \begin{equation}
 \label{eqn.full.sat}
 \frac{\partial}{\partial t}(\phi \rho) = \sum_{i=1}^{3} \sum_{j=1}^{3}\nabla_{i} \left[\rho \frac{k_{ij}}{\mu} \left(\nabla_{j} P - \rho g_{j}\right) \right]\ .

--- a/modules/porous_flow/doc/content/modules/porous_flow/hysteresis.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/hysteresis.md
@@ -26,7 +26,7 @@ The order is computed by the [PorousFlowHysteresisOrder](PorousFlowHysteresisOrd
 
 ## Capillary curves
 
-All capillary curves are based on the [van Genuchten](capillary_pressure.md) curve
+All capillary curves are based on the [van Genuchten](porous_flow/capillary_pressure.md) curve
 \begin{equation}
 \label{vg.cap.eqn}
 P_{c}(S_{l}) = \frac{1}{\alpha} \left( S_{\mathrm{eff}}^{n/(1-n)} - 1\right)^{1/n} \ ,
@@ -217,7 +217,7 @@ Assuming the relative permeability values are constant outside the well-defined 
 
 [!citet](doughty2008) recommends extending and modifying the curves in the following ways.
 
-1. There is no hysteresis in the region $S_{l} < S_{l, r}$: the drying curves equal the wetting curves in this region, and if $\mathrm{TP}_{0} < S_{l, r}$ then $\mathrm{TP}_{0} = S_{l, r}$ is used in the wetting curves. 
+1. There is no hysteresis in the region $S_{l} < S_{l, r}$: the drying curves equal the wetting curves in this region, and if $\mathrm{TP}_{0} < S_{l, r}$ then $\mathrm{TP}_{0} = S_{l, r}$ is used in the wetting curves.
 
 2. The gas relative permeability is extended to the region $S_{l} < S_{l, r}$ so that $k_{r, g}(0) = 1$.   Two types of extension are possible in MOOSE.  Both are cubic functions satisfying $k_{r, g}(0) = 1$, $k_{r, g}(S_{l, r}) = k_{r, g}^{max}$ and $k'_{r, g}(0) = 0$:
 

--- a/modules/porous_flow/doc/content/modules/porous_flow/kt.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/kt.md
@@ -72,7 +72,7 @@ Clicking on the links in the above table will provide you with more examples.  F
 !alert note
 For multi-phase situations you will need an advective flux calculator for each phase and each component, unless the phases are immiscible (each component exists in one phase only).
 
-For example, in the case of 2 phases with 2 components, each potentially existing in both phases, there are 2 PorousFlow [governing equations](governing_equations.md): one for each component.  The equation for fluid component zero contains contributions from both phase 0 and phase 1.  The equation for fluid component one contains contributions from both phase 0 and phase 1.  So the Kernels will look like
+For example, in the case of 2 phases with 2 components, each potentially existing in both phases, there are 2 PorousFlow [governing equations](porous_flow/governing_equations.md): one for each component.  The equation for fluid component zero contains contributions from both phase 0 and phase 1.  The equation for fluid component one contains contributions from both phase 0 and phase 1.  So the Kernels will look like
 
 !listing modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_2phasePS_KT.i start=Kernels
 

--- a/modules/porous_flow/doc/content/modules/porous_flow/material_laws.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/material_laws.md
@@ -3,7 +3,7 @@
 Several important material properties and constitutive equations are implemented in PorousFlow.
 Detailed descriptions of these are provided in the following:
 
-- [Capillary pressure](capillary_pressure.md)
+- [Capillary pressure](porous_flow/capillary_pressure.md)
 - [Relative permeability](relative_permeability.md)
 - [Permeability](porous_flow/permeability.md)
 - [Porosity](/porous_flow/porosity.md)

--- a/modules/porous_flow/doc/content/modules/porous_flow/natural_convection.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/natural_convection.md
@@ -2,7 +2,7 @@
 
 ## Problem statement
 
-This example is based on the Elder problem [!cite](Elder1967TransientCI), see [!citet](Oldenburg1995OnTD). The natural convection of water in a 2D porous tank heated on one part of the bottom is modelled. The schematic is demonstrated in [schematicFig]. The experiment details are elaborated in the referred paper so will not be shown here to avoid repetition. The governing equations and associated `Kernels` that describe this problem are provided in detail [here](governing_equations.md).
+This example is based on the Elder problem [!cite](Elder1967TransientCI), see [!citet](Oldenburg1995OnTD). The natural convection of water in a 2D porous tank heated on one part of the bottom is modelled. The schematic is demonstrated in [schematicFig]. The experiment details are elaborated in the referred paper so will not be shown here to avoid repetition. The governing equations and associated `Kernels` that describe this problem are provided in detail [here](porous_flow/governing_equations.md).
 
 
 !table id=datatable caption=Parameters of the problem [!citep](Oldenburg1995OnTD).

--- a/modules/porous_flow/doc/content/modules/porous_flow/sinks.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/sinks.md
@@ -91,7 +91,7 @@ where the polyline coordinates and weighting are defined in the following [Const
 
 !listing modules/porous_flow/test/tests/dirackernels/pls02reporter.i block=Reporters
 
-Reporter input provides an easy way to control polyline sink point locations from a [Sampler](Samplers/index.md) multi-app.  
+Reporter input provides an easy way to control polyline sink point locations from a [Sampler](Samplers/index.md) multi-app.
 It is an error to supply both plaint text file and reporter input for the point data.
 
 Rather than manually specifying each point via the separate points file or reporter, the second input format allows the
@@ -378,7 +378,7 @@ Each of these record the total fluid flux (kg) injected by or produced by the bo
 
 ### Reproducing the steady-state 2D analytical solution
 
-The PorousFlow fluid equation (see [governing equations](governing_equations.md)) for a fully-saturated medium with $\rho \propto
+The PorousFlow fluid equation (see [governing equations](porous_flow/governing_equations.md)) for a fully-saturated medium with $\rho \propto
 \exp(P/B)$ and large constant bulk modulus $B$ becomes Darcy's equation
 \begin{equation}
 \frac{\partial}{\partial t}\rho =  \nabla_{i}\alpha_{ij}\nabla_{j}\rho

--- a/modules/porous_flow/doc/content/modules/porous_flow/solute_tracer_transport.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/solute_tracer_transport.md
@@ -60,7 +60,7 @@ Then, we need to declare what type of unknown we are solving. This can be done i
 
 ### Kernel declaration
 
-This section describes the physics we need to solve. To do so, some kernels are declared. In MOOSE, the required kernels depend on the terms in the governing equations. For this problem, six kernels were declared. To have a better understanding, users are recommended to visit [this page](governing_equations.md). The code block is shown below with the first three kernels associated with equation 1  and the remain associated with equation 2.
+This section describes the physics we need to solve. To do so, some kernels are declared. In MOOSE, the required kernels depend on the terms in the governing equations. For this problem, six kernels were declared. To have a better understanding, users are recommended to visit [this page](porous_flow/governing_equations.md). The code block is shown below with the first three kernels associated with equation 1  and the remain associated with equation 2.
 
 !listing modules/porous_flow/examples/solute_tracer_transport/solute_tracer_transport.i start=[Kernels] end=[FluidProperties]
 

--- a/modules/porous_flow/doc/content/modules/porous_flow/tests/dirackernels/dirackernels_tests.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/tests/dirackernels/dirackernels_tests.md
@@ -37,7 +37,7 @@ MOOSE produces the expected result:
 
 ## Theis tests
 
-In the fully-saturated, isothermal case with no mechanical coupling and constant, large fluid bulk modulus, the [fluid flow equations](governing_equations.md) reduce to the form conventionally used in groundwater flow:
+In the fully-saturated, isothermal case with no mechanical coupling and constant, large fluid bulk modulus, the [fluid flow equations](porous_flow/governing_equations.md) reduce to the form conventionally used in groundwater flow:
 \begin{equation}
 S_{s}\frac{\partial H}{\partial t} = \nabla_{i}\left(K_{ij}\nabla_{j} H \right) \ ,
 \end{equation}
@@ -72,7 +72,7 @@ Flow from a source in a radial 1D problem admits a similarity solution, where th
 
 [fig:theis_similarity_fig] shows the comparison of
 similarity solutions calculated with either fixed radial distance or fixed time. In this case, good agreement
-is observed between the two results for both liquid pressure and gas saturation. 
+is observed between the two results for both liquid pressure and gas saturation.
 
 !media dirackernels/theis3_similarity_fig.png style=width:90%;margin-left:10px caption=Results of the 2-phase radial injection simulation. id=fig:theis_similarity_fig
 

--- a/modules/porous_flow/doc/content/modules/porous_flow/tests/plastic_heating/plastic_heating_tests.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/tests/plastic_heating/plastic_heating_tests.md
@@ -1,6 +1,6 @@
 # Heat energy produced by plastic deformation
 
-In [PorousFlow](governing_equations.md), it is assumed that plastic deformation causes a heat energy-density rate
+In [PorousFlow](porous_flow/governing_equations.md), it is assumed that plastic deformation causes a heat energy-density rate
 (J.m$^{-3}$.s$^{-1}$) of
 \begin{equation}
 c (1-\phi) \sigma_{ij}\epsilon^{\mathrm{plastic}}_{ij} \ ,
@@ -9,7 +9,7 @@ where $c$ is a coefficient (s$^{-1}$), $\phi$ is the porosity,
 $\sigma$ is the stress, and $\epsilon^{\mathrm{plastic}}$ is the
 plastic strain.  This is implemented in the [PorousFlowPlasticHeatEnergy Kernel](PorousFlowPlasticHeatEnergy.md)
 
-In the set of simple tests described below, the porous skeleton contains no fluid, and no heat flow is considered, so the heat energy 
+In the set of simple tests described below, the porous skeleton contains no fluid, and no heat flow is considered, so the heat energy
 released simply heats up the porous skeleton:
 \begin{equation}
 \frac{\partial}{\partial t} (1 - \phi)c_{R}\rho_{R} T = c (1-\phi)

--- a/modules/porous_flow/doc/content/modules/porous_flow/tests/pressure_pulse/pressure_pulse_tests.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/tests/pressure_pulse/pressure_pulse_tests.md
@@ -6,7 +6,7 @@ gravity and without sources is just Darcy's equation
 \frac{\partial}{\partial t}\phi\rho = \nabla_{i}\left(\frac{\rho
   \kappa_{ij}}{\mu} \nabla_{j}P \right) \ ,
 \end{equation}
-with notation described in [the governing equations](governing_equations.md).  Using $\rho \propto
+with notation described in [the governing equations](porous_flow/governing_equations.md).  Using $\rho \propto
 \exp(P/K)$, where $K$ is the fluid bulk modulus, Darcy's equation
 becomes
 \begin{equation}

--- a/modules/porous_flow/doc/content/modules/porous_flow/tutorial_01.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/tutorial_01.md
@@ -50,7 +50,7 @@ In these equations
 - $\alpha_{f}$ is the volumetric thermal expansion coefficient of the fluid (units K$^{-1}$)
 
 The [derivation](PorousFlowFullySaturatedMassTimeDerivative.md) of [eq:basicthm] from
-the [full PorousFlow equations](governing_equations.md) assumes that $M$ and $A$ are constant.
+the [full PorousFlow equations](porous_flow/governing_equations.md) assumes that $M$ and $A$ are constant.
 
 In this tutorial page we will be solving fluid flow only, so the
 $\dot{\epsilon}_{v}$ and $\dot{T}$ in Eq. [eq:basicthm] are ignored (set to zero).

--- a/modules/porous_flow/doc/content/source/actions/PorousFlowFullySaturated.md
+++ b/modules/porous_flow/doc/content/source/actions/PorousFlowFullySaturated.md
@@ -61,7 +61,7 @@ The `Action` does *not* add Kernels to model the following effects
 
 ## Heat equation
 
-The [heat equation](governing_equations.md) is associated with the temperature variable, and is only included if the `coupling_type` includes "Thermo".
+The [heat equation](porous_flow/governing_equations.md) is associated with the temperature variable, and is only included if the `coupling_type` includes "Thermo".
 \begin{equation}
 \label{eq:heat_cons}
 0 = \frac{\partial}{\partial t}\left( (1 - \phi)\rho_{R}C_{R}T + \phi\rho\mathcal{E} \right) + \left( (1 - \phi)\rho_{R}C_{R}T + \phi\rho\mathcal{E} \right)\nabla\cdot{\mathbf
@@ -83,7 +83,7 @@ To represent the term $\nabla_{i}\left(h\rho \frac{k_{ij}}{\mu} (\nabla_{j}P - \
 
 ## Solid-mechanics equations
 
-The [static conservation of momentum equation](governing_equations.md) is associated with the displacement variables, and is only included if the `coupling_type` includes "Mechanical":
+The [static conservation of momentum equation](porous_flow/governing_equations.md) is associated with the displacement variables, and is only included if the `coupling_type` includes "Mechanical":
 \begin{equation}
 \label{eq:cons_mom}
 0 = \nabla_{i}\sigma_{ij}^{\mathrm{eff}} - \alpha_{B}\nabla_{j} P - \rho_{\mathrm{undrained}} g_{j} \ .

--- a/modules/porous_flow/doc/content/source/bcs/PorousFlowOutflowBC.md
+++ b/modules/porous_flow/doc/content/source/bcs/PorousFlowOutflowBC.md
@@ -21,7 +21,7 @@ This BC is fully upwinded, so can be used in conjunction with the [PorousFlowAdv
 
 ### Fluid flow
 
-To allow a fluid species, $\kappa$, to flow freely out of the model, the [governing equations](governing_equations.md) imply that
+To allow a fluid species, $\kappa$, to flow freely out of the model, the [governing equations](porous_flow/governing_equations.md) imply that
 \begin{equation}
 \mathbf{F} = \sum_{\beta}\chi_{\beta}^{\kappa}\mathbf{F}_{\beta}^{\mathrm{advective}} + \mathbf{F}^{\kappa}_{\mathrm{diffusion+dispersion}} \ ,
 \end{equation}
@@ -40,7 +40,7 @@ Input-file syntax for this type of boundary condition requires specifying:
 
 ### Heat flow
 
-To allow heat energy to flow freely out of the model, the [governing equations](governing_equations.md) imply that
+To allow heat energy to flow freely out of the model, the [governing equations](porous_flow/governing_equations.md) imply that
 \begin{equation}
 \mathbf{F} = -\lambda \nabla T + \sum_{\beta}h_{\beta}\mathbf{F}_{\beta} = -\lambda \nabla T - \sum_{\beta}h_{\beta}\rho_{\beta}\frac{k\,k_{\mathrm{r,}\beta}}{\mu_{\beta}}(\nabla
 P_{\beta} - \rho_{\beta} \mathbf{g}) \ .

--- a/modules/porous_flow/doc/content/source/kernels/PorousFlowFullySaturatedMassTimeDerivative.md
+++ b/modules/porous_flow/doc/content/source/kernels/PorousFlowFullySaturatedMassTimeDerivative.md
@@ -3,7 +3,7 @@
 !syntax description /Kernels/PorousFlowFullySaturatedMassTimeDerivative
 
 Consider a fully-saturated, single-phase, single-component fluid in a
-THM simulation.  The time-derivative terms from the [fluid governing equation](governing_equations.md) are
+THM simulation.  The time-derivative terms from the [fluid governing equation](porous_flow/governing_equations.md) are
 \begin{equation}
 \frac{\partial}{\partial t} \phi \rho + \phi\rho\dot{\epsilon}_{v} \ ,
 \end{equation}
@@ -55,7 +55,7 @@ comparison with analytical and numerical solutions of poro-mechanics.
 - $(\rho)(\dot{P}/M + \alpha_{B}\dot{\epsilon}_{v})$ for HM problems;
 - $(\rho)(\dot{P}/M + \alpha_{B}\dot{\epsilon}_{v} - A\dot{T})$ for THM problems.
 
-The `PorousFlowFullySaturatedMassTimeDerivative` Kernel does not employ lumping, which is largely unnecessary in this single-phase, single-component situation.  This means only ``quad-point'' Materials are needed.  In fact, when using all the FullySaturated flow Kernels (see [governing equations](governing_equations.md)) standard Materials evaluated at the quadpoints are needed, which saves on computation time and input-file length.
+The `PorousFlowFullySaturatedMassTimeDerivative` Kernel does not employ lumping, which is largely unnecessary in this single-phase, single-component situation.  This means only ``quad-point'' Materials are needed.  In fact, when using all the FullySaturated flow Kernels (see [governing equations](porous_flow/governing_equations.md)) standard Materials evaluated at the quadpoints are needed, which saves on computation time and input-file length.
 
 In each case, the initial pre-multiplication by $\rho$ is optional
 (indicated by the parentheses around $\rho$).

--- a/modules/porous_flow/doc/content/source/materials/PorousFlow1PhaseP.md
+++ b/modules/porous_flow/doc/content/source/materials/PorousFlow1PhaseP.md
@@ -2,7 +2,7 @@
 
 !syntax description /Materials/PorousFlow1PhaseP
 
-Given the porepressure, this Material computes the saturation for 1-phase fluid simulations.  See [capillary pressure](capillary_pressure.md) for further details.
+Given the porepressure, this Material computes the saturation for 1-phase fluid simulations.  See [capillary pressure](porous_flow/capillary_pressure.md) for further details.
 
 !syntax parameters /Materials/PorousFlow1PhaseP
 

--- a/modules/porous_flow/doc/content/source/materials/PorousFlow2PhasePP.md
+++ b/modules/porous_flow/doc/content/source/materials/PorousFlow2PhasePP.md
@@ -2,7 +2,7 @@
 
 !syntax description /Materials/PorousFlow2PhasePP
 
-Given the liquid and gas porepressures, this Material computes the liquid and gas saturations for 2-phase fluid simulations.  See [capillary pressure](capillary_pressure.md) for further details.
+Given the liquid and gas porepressures, this Material computes the liquid and gas saturations for 2-phase fluid simulations.  See [capillary pressure](porous_flow/capillary_pressure.md) for further details.
 
 !syntax parameters /Materials/PorousFlow2PhasePP
 


### PR DESCRIPTION
Some page names are the same as in Sockeye, which is a problem for including Sockeye documentation in BlueCrab.

This is needed for https://github.inl.gov/ncrc/blue_crab/pull/312.
