### PR TITLE
Header output

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -730,13 +730,7 @@ MooseApp::setupOptions()
   TIME_SECTION("setupOptions", 5, "Setting Up Options");
 
   // Print the header, this is as early as possible
-  auto hdr = header();
-  if (hdr.length() != 0)
-  {
-    if (multiAppLevel() > 0)
-      MooseUtils::indentMessage(_name, hdr);
-    Moose::out << hdr << std::endl;
-  }
+  _console << header() << std::endl;
 
   if (getParam<bool>("error_unused"))
     setCheckUnusedFlag(true);

--- a/test/include/base/MooseTestApp.h
+++ b/test/include/base/MooseTestApp.h
@@ -25,4 +25,6 @@ public:
 
   static void registerAll(Factory & f, ActionFactory & af, Syntax & s, bool use_test_objs = false);
   static void registerApps();
+
+  virtual std::string header() const override;
 };

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -141,6 +141,12 @@ MooseTestApp::registerApps()
   registerApp(MooseTestApp);
 }
 
+std::string
+MooseTestApp::header() const
+{
+  return std::string("MOOSE Test App\n");
+}
+
 extern "C" void
 MooseTestApp__registerAll(Factory & f, ActionFactory & af, Syntax & s)
 {

--- a/test/tests/multiapps/multilevel/dt_from_parent_parent.i
+++ b/test/tests/multiapps/multilevel/dt_from_parent_parent.i
@@ -6,30 +6,30 @@
 []
 
 [Variables]
-  [./u]
-  [../]
+  [u]
+  []
 []
 
 [Kernels]
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = left
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = DirichletBC
     variable = u
     boundary = right
     value = 1
-  [../]
+  []
 []
 
 [Executioner]
@@ -45,17 +45,18 @@
 
 [Outputs]
   exodus = true
-  [./out]
+  color = false
+  [out]
     type = Console
     output_file = true
-  [../]
+  []
 []
 
 [MultiApps]
-  [./sub]
+  [sub]
     type = TransientMultiApp
     app_type = MooseTestApp
     positions = '0 0 0 0.5 0.5 0'
     input_files = dt_from_parent_sub.i
-  [../]
+  []
 []

--- a/test/tests/multiapps/multilevel/tests
+++ b/test/tests/multiapps/multilevel/tests
@@ -38,4 +38,11 @@
 
     requirement = "The system shall support writing screen output from multi-level sub-applications to a file."
   []
+
+  [header_check]
+    type = 'RunApp'
+    input = 'dt_from_parent_parent.i'
+    prereq = group/dt_from_parent
+    expect_out = 'MOOSE Test App\n\nsub0: MOOSE Test App\nsub0: \nsub0_sub0: MOOSE Test App'
+  []
 []

--- a/test/tests/multiapps/multilevel/tests
+++ b/test/tests/multiapps/multilevel/tests
@@ -28,6 +28,13 @@
 
       detail = "where the sub-application controls the time step for the parent application,"
     []
+    [header_check]
+      type = 'RunApp'
+      input = 'dt_from_parent_parent.i'
+      prereq = group/dt_from_parent
+      expect_out = 'MOOSE Test App\n\nsub0: MOOSE Test App\nsub0: \nsub0_sub0: MOOSE Test App'
+      detail = "and append the subapp number to the header"
+    []
   []
 
   [console_to_file]
@@ -37,12 +44,5 @@
     prereq = 'group/time_dt_from_parent'
 
     requirement = "The system shall support writing screen output from multi-level sub-applications to a file."
-  []
-
-  [header_check]
-    type = 'RunApp'
-    input = 'dt_from_parent_parent.i'
-    prereq = group/dt_from_parent
-    expect_out = 'MOOSE Test App\n\nsub0: MOOSE Test App\nsub0: \nsub0_sub0: MOOSE Test App'
   []
 []


### PR DESCRIPTION
Changes header output to `_console` stream. In order to test this, I needed an app to actually have a header out output. I added one to the `MooseTestApp`, hopefully that is okay.

ref #29662
