### PR TITLE
Add a clean error on adding components with a regular / mesh generated mesh

### DIFF
--- a/modules/thermal_hydraulics/src/actions/AddComponentAction.C
+++ b/modules/thermal_hydraulics/src/actions/AddComponentAction.C
@@ -9,6 +9,7 @@
 
 #include "AddComponentAction.h"
 #include "THMProblem.h"
+#include "THMMesh.h"
 
 registerMooseAction("ThermalHydraulicsApp", AddComponentAction, "THM:add_component");
 
@@ -29,6 +30,12 @@ AddComponentAction::AddComponentAction(const InputParameters & params)
 void
 AddComponentAction::act()
 {
+  // Error if using an unsupported mesh type, as most components cannot handle working with a
+  // regular MooseMesh instead of a THM mesh
+  if (!dynamic_cast<THMMesh *>(_mesh.get()))
+    mooseError("The Components block cannot be used to add a Component in conjunction with the "
+               "Mesh block at this time");
+
   if (!_group)
   {
     THMProblem * thm_problem = dynamic_cast<THMProblem *>(_problem.get());

--- a/modules/thermal_hydraulics/test/tests/misc/mesh_block_interaction/test.i
+++ b/modules/thermal_hydraulics/test/tests/misc/mesh_block_interaction/test.i
@@ -1,0 +1,54 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.1
+  []
+  [time]
+    type = TimeDerivative
+    variable = u
+  []
+[]
+
+[Components]
+  [inlet]
+    type = InletMassFlowRateTemperature1Phase
+    input = 'iwst_pipe_1:in'
+    m_dot = 1
+    T = 100
+  []
+
+  [iwst_pipe_1]
+    type = FlowChannel1Phase
+    position = '0 0 0'
+    orientation = '0 1 0'
+    length = 10
+    n_elems = 15
+    A = 1
+    D_h = 1
+  []
+
+  [outlet]
+    type = Outlet1Phase
+    input = 'iwst_pipe_1:out'
+    p = 1e5
+  []
+[]
+
+[Executioner]
+  type = Transient
+  dt = 0.1
+  num_steps = 10
+  abort_on_solve_fail = true
+[]

--- a/modules/thermal_hydraulics/test/tests/misc/mesh_block_interaction/tests
+++ b/modules/thermal_hydraulics/test/tests/misc/mesh_block_interaction/tests
@@ -1,0 +1,10 @@
+[Tests]
+  issues = '#29667'
+  design = 'THMMesh.md'
+  [no_components_and_mesh]
+    type = 'RunException'
+    input = 'test.i'
+    requirement = 'The system shall error if using both a regular mesh, usually created in the Mesh syntax, and components, usually created in the Components syntax.'
+    expect_err = "The Components block cannot be used to add a Component in conjunction with the Mesh block at this time"
+  []
+[]


### PR DESCRIPTION
I feel like I have done this before (and given up?). We ll see what tests fail. 

closes #29667
