### PR TITLE
Add cmd line arg to suppress header output

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -247,8 +247,10 @@ MooseApp::validParams()
       "Continue the calculation. Without <file base>, the most recent recovery file will be used");
   params.setGlobalCommandLineParam("recover");
 
-  params.addCommandLineParam<bool>(
-      "suppress_header", "--suppress-header", false, "Flag to print the App header");
+  params.addCommandLineParam<bool>("suppress_header",
+                                   "--suppress-header",
+                                   false,
+                                   "Disables the output of the application header.");
   params.setGlobalCommandLineParam("suppress_header");
 
   params.addCommandLineParam<bool>(

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -248,6 +248,10 @@ MooseApp::validParams()
   params.setGlobalCommandLineParam("recover");
 
   params.addCommandLineParam<bool>(
+      "suppress_header", "--suppress-header", false, "Flag to print the App header");
+  params.setGlobalCommandLineParam("suppress_header");
+
+  params.addCommandLineParam<bool>(
       "test_checkpoint_half_transient",
       "--test-checkpoint-half-transient",
       "Run half of a transient with checkpoints enabled; used by the TestHarness");
@@ -730,13 +734,8 @@ MooseApp::setupOptions()
   TIME_SECTION("setupOptions", 5, "Setting Up Options");
 
   // Print the header, this is as early as possible
-  auto hdr = header();
-  if (hdr.length() != 0)
-  {
-    if (multiAppLevel() > 0)
-      MooseUtils::indentMessage(_name, hdr);
-    Moose::out << hdr << std::endl;
-  }
+  if (header().length() && !getParam<bool>("suppress_header"))
+    _console << header() << std::endl;
 
   if (getParam<bool>("error_unused"))
     setCheckUnusedFlag(true);

--- a/test/include/base/MooseTestApp.h
+++ b/test/include/base/MooseTestApp.h
@@ -25,4 +25,6 @@ public:
 
   static void registerAll(Factory & f, ActionFactory & af, Syntax & s, bool use_test_objs = false);
   static void registerApps();
+
+  virtual std::string header() const override;
 };

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -52,6 +52,9 @@ MooseTestApp::validParams()
       "--test-check-legacy-params",
       "Check for legacy parameter construction with CheckLegacyParamsAction; for testing");
 
+  params.addCommandLineParam<std::string>(
+      "append_header", "--append-header <header>", "", "String to print at top of console output");
+
   params.set<bool>("automatic_automatic_scaling") = false;
   params.set<bool>("use_legacy_material_output") = false;
   params.set<bool>("use_legacy_initial_residual_evaluation_behavior") = false;
@@ -139,6 +142,12 @@ void
 MooseTestApp::registerApps()
 {
   registerApp(MooseTestApp);
+}
+
+std::string
+MooseTestApp::header() const
+{
+  return getParam<std::string>("append_header");
 }
 
 extern "C" void

--- a/test/tests/misc/header/parent.i
+++ b/test/tests/misc/header/parent.i
@@ -1,0 +1,26 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 0
+[]
+
+[Outputs]
+  color = false
+[]
+
+[MultiApps]
+  [sub]
+    type = TransientMultiApp
+    app_type = MooseTestApp
+    input_files = sub.i
+    cli_args = --append-header=sub
+  []
+[]

--- a/test/tests/misc/header/sub.i
+++ b/test/tests/misc/header/sub.i
@@ -1,0 +1,26 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 0
+[]
+
+[Outputs]
+  color = false
+[]
+
+[MultiApps]
+  [sub]
+    type = TransientMultiApp
+    app_type = MooseTestApp
+    input_files = subsub.i
+    cli_args = --append-header=subsub
+  []
+[]

--- a/test/tests/misc/header/subsub.i
+++ b/test/tests/misc/header/subsub.i
@@ -1,0 +1,17 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 0
+[]
+
+[Outputs]
+  color = false
+[]

--- a/test/tests/misc/header/tests
+++ b/test/tests/misc/header/tests
@@ -1,0 +1,23 @@
+[Tests]
+  issues = '#1832'
+  design = 'syntax/MultiApps/index.md'
+
+  [g]
+    requirement = "The system shall be able to print a header for multi-level sub-applications:"
+    [header_on]
+      type = 'RunApp'
+      input = 'parent.i'
+      expect_out = 'parent\nsub0: sub\nsub0_sub0: subsub'
+      detail = "custom for each parent and sub-applications;"
+      cli_args = '--append-header=parent'
+    []
+    [header_off]
+      type = 'RunApp'
+      input = 'parent.i'
+      prereq = g/header_on
+      cli_args = '--append-header=parent --suppress-header'
+      absent_out = 'parent\nsub0: sub\nsub0_sub0: subsub'
+      detail = "and suppress the all parent and sub-applications."
+    []
+  []
+[]


### PR DESCRIPTION
Combined #29663 into this. Changed the header output stream to `_console`, and added command line arg to suppress header output. Added command line arg to `MooseTestApp` to optionally print a header to allow testing.

Closes #29662
