### PR TITLE
Removed redeclaration of _name attribute from MooseApp

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1132,9 +1132,6 @@ protected:
    */
   void errorCheck();
 
-  /// The name of this object
-  const std::string _name;
-
   /// Parameters of this object
   InputParameters _pars;
 


### PR DESCRIPTION
MooseApp is derived from MooseBase. MooseBase has an attribute called _name, which described the name of the object. MooseApp erroneously redeclares this attribute and does not initialize it. Thus, when a MooseApp or more derived class tries to access _name, it defaults to the empty MooseApp::_name instead of the desired MooseBase::_name. MooseBase::_name is still accessible without using the namespace operator through the name() method because the name() method is not erroneously redeclare in MooseApp. This commit removes the erroneous redeclaration of MooseApp::_name. Closes #29670.