### PR TITLE
New error when two different ICs are specified

### DIFF
--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -56,6 +56,7 @@ AddVariableAction::validParams()
                                      "Specifies a scaling factor to apply to this variable");
   params.addParam<std::vector<Real>>("initial_condition",
                                      "Specifies a constant initial condition for this variable");
+  params.addParam<std::string>("initial_from_file_var", "Initial from file");
   return params;
 }
 
@@ -131,6 +132,12 @@ AddVariableAction::init()
     mooseError("Both the MooseVariable* and Add*VariableAction parameters objects have had the "
                "`scaling` parameter set, and they are different values. I don't know how you "
                "achieved this, but you need to rectify it.");
+
+  if (_pars.isParamSetByUser("initial_condition") &&
+      _pars.isParamSetByUser("initial_from_file_var"))
+    mooseError("Two initial conditions have been provided for the variable ",
+               name(),
+               ". One from the user and one from the restart input file.");
 
   _moose_object_pars.applySpecificParameters(_pars, {"order", "family", "scaling"});
 

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -19,6 +19,7 @@
 #include "MooseEigenSystem.h"
 #include "MooseObjectAction.h"
 #include "MooseMesh.h"
+#include "CopyNodalVarsAction.h"
 
 #include "libmesh/libmesh.h"
 #include "libmesh/exodusII_io.h"
@@ -56,7 +57,7 @@ AddVariableAction::validParams()
                                      "Specifies a scaling factor to apply to this variable");
   params.addParam<std::vector<Real>>("initial_condition",
                                      "Specifies a constant initial condition for this variable");
-  params.addParam<std::string>("initial_from_file_var", "Initial from file");
+  params.transferParam<std::string>(CopyNodalVarsAction::validParams(), "initial_from_file_var");
   return params;
 }
 
@@ -135,9 +136,11 @@ AddVariableAction::init()
 
   if (_pars.isParamSetByUser("initial_condition") &&
       _pars.isParamSetByUser("initial_from_file_var"))
-    mooseError("Two initial conditions have been provided for the variable ",
+    paramError("initial_condition",
+               "Two initial conditions have been provided for the variable ",
                name(),
-               ". One from the user and one from the restart input file.");
+               " using the 'initial_condition' and 'initial_from_file_var' parameters. Please "
+               "remove one of them.");
 
   _moose_object_pars.applySpecificParameters(_pars, {"order", "family", "scaling"});
 

--- a/test/tests/restart/restart_diffusion/tests
+++ b/test/tests/restart/restart_diffusion/tests
@@ -105,7 +105,10 @@
     type = 'RunException'
     input = 'exodus_refined_restart_2_test.i'
     expect_err = 'Initial conditions have been specified during an Exodus restart'
-    cli_args = 'Variables/u/initial_condition=3 Problem/allow_initial_conditions_with_restart=false'
+    cli_args = "ICs/ic_over_restart/type=ConstantIC
+                ICs/ic_over_restart/variable=u
+                ICs/ic_over_restart/value=1
+                Problem/allow_initial_conditions_with_restart=false"
     issues = "#21423"
     requirement = "The system shall issue a useful error message stating that initial conditions "
                   "should not be used when restarting."

--- a/test/tests/restart/scalar-var/part3.i
+++ b/test/tests/restart/scalar-var/part3.i
@@ -1,0 +1,50 @@
+[Mesh]
+  [fmg]
+    type = FileMeshGenerator
+    file = part1_out.e
+    use_for_exodus_restart = true
+  []
+[]
+
+[Variables]
+  [v]
+    family = MONOMIAL
+    order = CONSTANT
+    fv = true
+    initial_from_file_var = v
+    initial_condition = 0
+  []
+  [lambda]
+    family = SCALAR
+    order = FIRST
+    initial_from_file_var = lambda
+  []
+[]
+
+[FVKernels]
+  [advection]
+    type = FVElementalAdvection
+    variable = v
+    velocity = '1 0 0'
+  []
+  [lambda]
+    type = FVScalarLagrangeMultiplier
+    variable = v
+    lambda = lambda
+    phi0 = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+  petsc_options_iname = '-snes_max_it'
+  petsc_options_value = '0'
+  nl_abs_tol = 1e-10
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    execute_on = 'final'
+  []
+[]

--- a/test/tests/restart/scalar-var/tests
+++ b/test/tests/restart/scalar-var/tests
@@ -21,6 +21,7 @@
       type = 'RunException'
       input = part3.i
       expect_err = 'Two initial conditions have been provided for the variable v using the \'initial_condition\' and \'initial_from_file_var\' parameters. Please remove one of them.'
+      detail = 'run restart input with two initial conditions'
     []
   []
 []

--- a/test/tests/restart/scalar-var/tests
+++ b/test/tests/restart/scalar-var/tests
@@ -20,7 +20,7 @@
       prereq = 'restarting/part1'
       type = 'RunException'
       input = part3.i
-      expect_err = 'Two initial conditions have been provided for the variable v. One from the user and one from the restart input file.'
+      expect_err = 'Two initial conditions have been provided for the variable v using the \'initial_condition\' and \'initial_from_file_var\' parameters. Please remove one of them.'
     []
   []
 []

--- a/test/tests/restart/scalar-var/tests
+++ b/test/tests/restart/scalar-var/tests
@@ -16,5 +16,11 @@
       exodiff = part2_out.e
       detail = 'run restart input'
     []
+    [part3]
+      prereq = 'restarting/part1'
+      type = 'RunException'
+      input = part3.i
+      expect_err = 'Two initial conditions have been provided for the variable v. One from the user and one from the restart input file.'
+    []
   []
 []


### PR DESCRIPTION
-Error thrown if an initial_condition parameter is provided along with an initial_from_file_var parameter for the same variable.

closes #20944

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
This added error check will make debugging input files easier.

## Design
<!--A concise description (design) of the enhancement.-->
Previously an error was only thrown if two initial_condition parameters were supplied for the same variable. Now an error is also thrown if an initial_from_file_var is also provided.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
