### PR TITLE
Fixup a couple of inconsistencies in EM module SQA

### DIFF
--- a/modules/doc/sqa_reports.yml
+++ b/modules/doc/sqa_reports.yml
@@ -36,6 +36,10 @@ Applications:
         app_types:
             - ElectromagneticsApp
         content_directory: modules/electromagnetics/doc/content
+        remove:
+            - framework/doc/remove.yml
+        unregister:
+            - framework/doc/unregister.yml
 
     external_petsc_solver:
         exe_directory: modules/combined

--- a/modules/electromagnetics/doc/content/modules/electromagnetics/sqa/index.md
+++ b/modules/electromagnetics/doc/content/modules/electromagnetics/sqa/index.md
@@ -1,1 +1,4 @@
 !template load file=sqa/app_index.md.template app=Electromagnetics category=electromagnetics
+
+!template item key=sqa-report
+!sqa report category={{category}}


### PR DESCRIPTION
Refs #15968

This didn't effect usability or functionality, but the landing page for the EM module SQA was incorrect since its addition. The remove/unregister yaml files were also missing for the EM module in the main SQA reports configuration file. 