### PR TITLE
Minor optimizations on MooseVariableData

### DIFF
--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -581,7 +581,7 @@ struct IsADType<MetaPhysicL::DualNumber<T, Args...>>
  * error with constexpr-based if conditions. The templating delays the triggering
  * of the static assertion until the template is instantiated.
  */
-template <class T>
+template <class... Ts>
 constexpr std::false_type always_false{};
 
 } // namespace Moose

--- a/framework/include/variables/MooseVariableData.h
+++ b/framework/include/variables/MooseVariableData.h
@@ -461,6 +461,15 @@ private:
   void assignADNodalValue(const ADReal & value, const unsigned int & component);
   void fetchADNodalValues();
 
+  /**
+   * Internal method for computeValues() and computeMonomialValues()
+   *
+   * Monomial is a template parameter so that we get compile time optimization
+   * for monomial vs non-monomial
+   */
+  template <bool monomial>
+  void computeValuesInternal();
+
   const libMesh::FEType & _fe_type;
 
   const unsigned int _var_num;

--- a/framework/include/variables/MooseVariableData.h
+++ b/framework/include/variables/MooseVariableData.h
@@ -554,19 +554,19 @@ private:
   FieldVariableValue _u_dot;
 
   /// u_dotdot (second time derivative)
-  FieldVariableValue _u_dotdot, _u_dotdot_bak;
+  FieldVariableValue _u_dotdot;
 
   /// u_dot_old (time derivative)
-  FieldVariableValue _u_dot_old, _u_dot_old_bak;
+  FieldVariableValue _u_dot_old;
 
   /// u_dotdot_old (second time derivative)
-  FieldVariableValue _u_dotdot_old, _u_dotdot_old_bak;
+  FieldVariableValue _u_dotdot_old;
 
   /// derivative of u_dot wrt u
   VariableValue _du_dot_du;
 
   /// derivative of u_dotdot wrt u
-  VariableValue _du_dotdot_du, _du_dotdot_du_bak;
+  VariableValue _du_dotdot_du;
 
   /// The current qrule. This has to be a reference because the current qrule will be constantly
   /// changing. If we initialized this to point to one qrule, then in the next calculation we would

--- a/framework/include/variables/MooseVariableDataFV.h
+++ b/framework/include/variables/MooseVariableDataFV.h
@@ -373,19 +373,19 @@ private:
   FieldVariableValue _u_dot;
 
   /// u_dotdot (second time derivative)
-  FieldVariableValue _u_dotdot, _u_dotdot_bak;
+  FieldVariableValue _u_dotdot;
 
   /// u_dot_old (time derivative)
-  FieldVariableValue _u_dot_old, _u_dot_old_bak;
+  FieldVariableValue _u_dot_old;
 
   /// u_dotdot_old (second time derivative)
-  FieldVariableValue _u_dotdot_old, _u_dotdot_old_bak;
+  FieldVariableValue _u_dotdot_old;
 
   /// derivative of u_dot wrt u
   VariableValue _du_dot_du;
 
   /// derivative of u_dotdot wrt u
-  VariableValue _du_dotdot_du, _du_dotdot_du_bak;
+  VariableValue _du_dotdot_du;
 
   /// Pointer to time integrator
   const TimeIntegrator * const _time_integrator;

--- a/framework/src/variables/MooseVariableConstMonomial.C
+++ b/framework/src/variables/MooseVariableConstMonomial.C
@@ -42,50 +42,26 @@ void
 MooseVariableConstMonomial::computeElemValues()
 {
   _element_data->setGeometry(Moose::Volume);
-
-  // We have not optimized AD calculations for const monomials yet, so we fall back on the
-  // non-optimized routine
-  if (_element_data->needsAD())
-    _element_data->computeValues();
-  else
-    _element_data->computeMonomialValues();
+  _element_data->computeMonomialValues();
 }
 
 void
 MooseVariableConstMonomial::computeElemValuesFace()
 {
   _element_data->setGeometry(Moose::Face);
-
-  // We have not optimized AD calculations for const monomials yet, so we fall back on the
-  // non-optimized routine
-  if (_element_data->needsAD())
-    _element_data->computeValues();
-  else
-    _element_data->computeMonomialValues();
+  _element_data->computeMonomialValues();
 }
 
 void
 MooseVariableConstMonomial::computeNeighborValues()
 {
   _neighbor_data->setGeometry(Moose::Volume);
-
-  // We have not optimized AD calculations for const monomials yet, so we fall back on the
-  // non-optimized routine
-  if (_neighbor_data->needsAD())
-    _neighbor_data->computeValues();
-  else
-    _neighbor_data->computeMonomialValues();
+  _neighbor_data->computeMonomialValues();
 }
 
 void
 MooseVariableConstMonomial::computeNeighborValuesFace()
 {
   _neighbor_data->setGeometry(Moose::Face);
-
-  // We have not optimized AD calculations for const monomials yet, so we fall back on the
-  // non-optimized routine
-  if (_neighbor_data->needsAD())
-    _neighbor_data->computeValues();
-  else
-    _neighbor_data->computeMonomialValues();
+  _neighbor_data->computeMonomialValues();
 }

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -428,27 +428,21 @@ MooseVariableData<OutputType>::computeValues()
   unsigned int nqp = _current_qrule->n_points();
   auto && active_coupleable_matrix_tags = _subproblem.getActiveFEVariableCoupleableMatrixTags(_tid);
 
-  bool second_required =
-      _need_second || _need_second_old || _need_second_older || _need_second_previous_nl;
-  bool curl_required = _need_curl || _need_curl_old;
-  bool div_required = _need_div || _need_div_old;
-
-  if (second_required)
-    mooseAssert(_current_second_phi,
-                "We're requiring a second calculation but have not set a second shape function!");
-  if (curl_required)
-    mooseAssert(_current_curl_phi,
-                "We're requiring a curl calculation but have not set a curl shape function!");
-  if (div_required)
-    mooseAssert(_current_div_phi,
-                "We're requiring a divergence calculation but have not set a div shape function!");
+  mooseAssert(
+      !(_need_second || _need_second_old || _need_second_older || _need_second_previous_nl) ||
+          _current_second_phi,
+      "We're requiring a second calculation but have not set a second shape function!");
+  mooseAssert(!(_need_curl || _need_curl_old) || _current_curl_phi,
+              "We're requiring a curl calculation but have not set a curl shape function!");
+  mooseAssert(!(_need_div || _need_div_old) || _current_div_phi,
+              "We're requiring a divergence calculation but have not set a div shape function!");
 
   // Curl
   if (_need_curl)
   {
     _curl_u.resize(nqp);
     for (unsigned int i = 0; i < nqp; ++i)
-      _curl_u[i] = 0;
+      _curl_u[i] = 0.;
     for (unsigned int i = 0; i < num_dofs; i++)
       for (unsigned int qp = 0; qp < nqp; qp++)
         _curl_u[qp] += (*_current_curl_phi)[i][qp] * _vector_tags_dof_u[_solution_tag][i];
@@ -457,7 +451,7 @@ MooseVariableData<OutputType>::computeValues()
   {
     _curl_u_old.resize(nqp);
     for (unsigned int i = 0; i < nqp; ++i)
-      _curl_u_old[i] = 0;
+      _curl_u_old[i] = 0.;
     for (unsigned int i = 0; i < num_dofs; i++)
       for (unsigned int qp = 0; qp < nqp; qp++)
         _curl_u_old[qp] += (*_current_curl_phi)[i][qp] * _vector_tags_dof_u[_old_solution_tag][i];
@@ -468,7 +462,7 @@ MooseVariableData<OutputType>::computeValues()
   {
     _div_u.resize(nqp);
     for (unsigned int i = 0; i < nqp; ++i)
-      _div_u[i] = 0;
+      _div_u[i] = 0.;
     for (unsigned int i = 0; i < num_dofs; i++)
       for (unsigned int qp = 0; qp < nqp; qp++)
         _div_u[qp] += (*_current_div_phi)[i][qp] * _vector_tags_dof_u[_solution_tag][i];
@@ -477,7 +471,7 @@ MooseVariableData<OutputType>::computeValues()
   {
     _div_u_old.resize(nqp);
     for (unsigned int i = 0; i < nqp; ++i)
-      _div_u_old[i] = 0;
+      _div_u_old[i] = 0.;
     for (unsigned int i = 0; i < num_dofs; i++)
       for (unsigned int qp = 0; qp < nqp; qp++)
         _div_u_old[qp] += (*_current_div_phi)[i][qp] * _vector_tags_dof_u[_old_solution_tag][i];
@@ -488,7 +482,7 @@ MooseVariableData<OutputType>::computeValues()
   {
     _second_u.resize(nqp);
     for (unsigned int i = 0; i < nqp; ++i)
-      _second_u[i] = 0;
+      _second_u[i] = 0.;
     for (unsigned int i = 0; i < num_dofs; i++)
       for (unsigned int qp = 0; qp < nqp; qp++)
         _second_u[qp].add_scaled((*_current_second_phi)[i][qp],
@@ -510,7 +504,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _second_u_old.resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _second_u_old[i] = 0;
+        _second_u_old[i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _second_u_old[qp].add_scaled((*_current_second_phi)[i][qp],
@@ -521,7 +515,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _second_u_older.resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _second_u_older[i] = 0;
+        _second_u_older[i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _second_u_older[qp].add_scaled((*_current_second_phi)[i][qp],
@@ -535,7 +529,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _vector_tag_u[tag].resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _vector_tag_u[tag][i] = 0;
+        _vector_tag_u[tag][i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _vector_tag_u[tag][qp] += (*_current_phi)[i][qp] * _vector_tags_dof_u[tag][i];
@@ -544,7 +538,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _vector_tag_grad[tag].resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _vector_tag_grad[tag][i] = 0;
+        _vector_tag_grad[tag][i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _vector_tag_grad[tag][qp].add_scaled((*_current_grad_phi)[i][qp],
@@ -557,7 +551,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _matrix_tag_u[tag].resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _matrix_tag_u[tag][i] = 0;
+        _matrix_tag_u[tag][i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _matrix_tag_u[tag][qp] += (*_current_phi)[i][qp] * _matrix_tags_dof_u[tag][i];
@@ -569,7 +563,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _u_dot.resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _u_dot[i] = 0;
+        _u_dot[i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _u_dot[qp] += (*_current_phi)[i][qp] * _dof_values_dot[i];
@@ -579,7 +573,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _u_dotdot.resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _u_dotdot[i] = 0;
+        _u_dotdot[i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _u_dotdot[qp] += (*_current_phi)[i][qp] * _dof_values_dotdot[i];
@@ -589,7 +583,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _u_dot_old.resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _u_dot_old[i] = 0;
+        _u_dot_old[i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _u_dot_old[qp] += (*_current_phi)[i][qp] * _dof_values_dot_old[i];
@@ -599,7 +593,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _u_dotdot_old.resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _u_dotdot_old[i] = 0;
+        _u_dotdot_old[i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _u_dotdot_old[qp] += (*_current_phi)[i][qp] * _dof_values_dotdot_old[i];
@@ -609,7 +603,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _du_dot_du.resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _du_dot_du[i] = 0;
+        _du_dot_du[i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _du_dot_du[qp] = _dof_du_dot_du[i];
@@ -619,7 +613,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _du_dotdot_du.resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _du_dotdot_du[i] = 0;
+        _du_dotdot_du[i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _du_dotdot_du[qp] = _dof_du_dotdot_du[i];
@@ -629,7 +623,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _grad_u_dot.resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _grad_u_dot[i] = 0;
+        _grad_u_dot[i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _grad_u_dot[qp].add_scaled((*_current_grad_phi)[i][qp], _dof_values_dot[i]);
@@ -639,7 +633,7 @@ MooseVariableData<OutputType>::computeValues()
     {
       _grad_u_dotdot.resize(nqp);
       for (unsigned int i = 0; i < nqp; ++i)
-        _grad_u_dotdot[i] = 0;
+        _grad_u_dotdot[i] = 0.;
       for (unsigned int i = 0; i < num_dofs; i++)
         for (unsigned int qp = 0; qp < nqp; qp++)
           _grad_u_dotdot[qp].add_scaled((*_current_grad_phi)[i][qp], _dof_values_dotdot[i]);
@@ -794,10 +788,10 @@ MooseVariableData<RealEigenVector>::computeValues()
         _u_dotdot_old[i].setZero(_count);
 
       if (_need_du_dot_du)
-        _du_dot_du[i] = 0;
+        _du_dot_du[i] = 0.;
 
       if (_need_du_dotdot_du)
-        _du_dotdot_du[i] = 0;
+        _du_dotdot_du[i] = 0.;
 
       if (_need_grad_dot)
         _grad_u_dot[i].setZero(_count, LIBMESH_DIM);
@@ -1001,10 +995,10 @@ MooseVariableData<OutputType>::computeMonomialValues()
   }
 
   const dof_id_type & idx = _dof_indices[0];
-  Real u_dot = 0;
-  Real u_dotdot = 0;
-  Real u_dot_old = 0;
-  Real u_dotdot_old = 0;
+  Real u_dot = 0.;
+  Real u_dotdot = 0.;
+  Real u_dot_old = 0.;
+  Real u_dotdot_old = 0.;
   const Real & du_dot_du = _sys.duDotDu(_var_num);
   const Real & du_dotdot_du = _sys.duDotDotDu();
 
@@ -1142,7 +1136,7 @@ MooseVariableData<OutputType>::computeAD(const unsigned int num_dofs, const unsi
 {
   // Have to do this because upon construction this won't initialize any of the derivatives
   // (because DualNumber::do_derivatives is false at that time).
-  _ad_zero = 0;
+  _ad_zero = 0.;
 
   _ad_dof_values.resize(num_dofs);
   if (_need_ad_u)
@@ -1489,8 +1483,9 @@ MooseVariableData<RealEigenVector>::addSolution(NumericVector<Number> & sol,
   unsigned int p = 0;
   for (unsigned int j = 0; j < _count; ++j)
   {
-    unsigned int inc = (isNodal() ? j : j * _dof_indices.size());
-    for (unsigned int i = 0; i < _dof_indices.size(); ++i)
+    const auto num_dofs = _dof_indices.size();
+    unsigned int inc = (isNodal() ? j : j * num_dofs);
+    for (unsigned int i = 0; i < num_dofs; ++i)
       sol.add(_dof_indices[i] + inc, v(p++));
   }
 }
@@ -1581,7 +1576,7 @@ MooseVariableData<OutputType>::computeIncrementAtQps(const NumericVector<Number>
   unsigned int num_dofs = _dof_indices.size();
   for (unsigned int qp = 0; qp < nqp; qp++)
   {
-    _increment[qp] = 0;
+    _increment[qp] = 0.;
     for (unsigned int i = 0; i < num_dofs; i++)
       _increment[qp] += (*_phi)[i][qp] * increment_vec(_dof_indices[i]);
   }
@@ -1801,7 +1796,7 @@ MooseVariableData<OutputType>::fetchADNodalValues()
       }
       // Executing something with a time derivative at initial should not put a NaN
       else if (_time_integrator && !_time_integrator->dt())
-        _ad_dofs_dot[i] = 0;
+        _ad_dofs_dot[i] = 0.;
       else
         mooseError("AD nodal time derivatives not implemented for variables without a time "
                    "integrator (auxiliary variables)");
@@ -1894,11 +1889,12 @@ MooseVariableData<OutputType>::reinitAux()
 
       fetchDoFValues();
 
+      const auto num_dofs = _dof_indices.size();
       for (auto & dof_u : _vector_tags_dof_u)
-        dof_u.resize(_dof_indices.size());
+        dof_u.resize(num_dofs);
 
       for (auto & dof_u : _matrix_tags_dof_u)
-        dof_u.resize(_dof_indices.size());
+        dof_u.resize(num_dofs);
 
       _has_dof_indices = true;
     }
@@ -1927,7 +1923,7 @@ MooseVariableData<OutputType>::reinitNodes(const std::vector<dof_id_type> & node
     }
   }
 
-  if (_dof_indices.size() > 0)
+  if (!_dof_indices.empty())
     _has_dof_indices = true;
   else
     _has_dof_indices = false;

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -475,6 +475,9 @@ MooseVariableData<OutputType>::computeValuesInternal()
   // Helper for filling values
   const auto fill = [this, &nqp, &num_dofs](auto & dest, const auto & phi, const auto & vector)
   {
+    if constexpr (monomial)
+      libmesh_ignore(num_dofs);
+
     // Deduce OutputType
     constexpr bool is_real = std::is_same_v<OutputType, Real>;
     constexpr bool is_real_vector = std::is_same_v<OutputType, RealVectorValue>;
@@ -483,7 +486,7 @@ MooseVariableData<OutputType>::computeValuesInternal()
 
     // this is only used in the RealEigenVector case to get this->_count
     if constexpr (!is_eigen)
-      (void)this;
+      libmesh_ignore(this);
 
     // Deduce type of value within dest MooseArray
     using dest_array_type = typename std::remove_reference_t<decltype(dest)>::value_type;
@@ -496,7 +499,7 @@ MooseVariableData<OutputType>::computeValuesInternal()
     const auto set_zero = [this, &dest](const auto qp)
     {
       if constexpr (!is_eigen)
-        (void)this;
+        libmesh_ignore(this);
 
       if constexpr (is_real || is_real_vector)
         dest[qp] = 0;
@@ -516,7 +519,7 @@ MooseVariableData<OutputType>::computeValuesInternal()
     };
 
     // Accumulates a value
-    const auto accumulate = [this, &dest, &phi, &vector](const auto i, const auto qp)
+    const auto accumulate = [&dest, &phi, &vector](const auto i, const auto qp)
     {
       if constexpr (is_real || is_real_vector || (is_eigen && is_output))
       {

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -479,6 +479,9 @@ MooseVariableData<OutputType>::computeValues()
     constexpr bool is_eigen = std::is_same_v<OutputType, RealEigenVector>;
     mooseAssert(is_real || is_real_vector || is_eigen, "Unsupported type");
 
+    if constexpr (!is_eigen)
+      (void)this;
+
     // Output type
     using T = typename std::remove_reference_t<decltype(dest)>::value_type;
     constexpr bool is_output = std::is_same_v<T, OutputType>;

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -563,13 +563,6 @@ MooseVariableData<OutputType>::computeValues()
   if (_need_second_previous_nl)
     fill(
         _second_u_previous_nl, *_current_second_phi, _vector_tags_dof_u[_previous_nl_solution_tag]);
-  if (is_transient)
-  {
-    if (_need_second_old)
-      fill(_second_u_old, *_current_second_phi, _vector_tags_dof_u[_old_solution_tag]);
-    if (_need_second_older)
-      fill(_second_u_older, *_current_second_phi, _vector_tags_dof_u[_older_solution_tag]);
-  }
 
   // Vector tags
   for (auto tag : _required_vector_tags)
@@ -585,18 +578,19 @@ MooseVariableData<OutputType>::computeValues()
     if (_need_matrix_tag_u[tag])
       fill(_matrix_tag_u[tag], *_current_phi, _matrix_tags_dof_u[tag]);
 
-  // Derivatives
+  // Derivatives and old values
   if (is_transient)
   {
+    if (_need_second_old)
+      fill(_second_u_old, *_current_second_phi, _vector_tags_dof_u[_old_solution_tag]);
+    if (_need_second_older)
+      fill(_second_u_older, *_current_second_phi, _vector_tags_dof_u[_older_solution_tag]);
     if (_need_u_dot)
       fill(_u_dot, *_current_phi, _dof_values_dot);
-
     if (_need_u_dotdot)
       fill(_u_dotdot, *_current_phi, _dof_values_dotdot);
-
     if (_need_u_dot_old)
       fill(_u_dot_old, *_current_phi, _dof_values_dot_old);
-
     if (_need_u_dotdot_old)
       fill(_u_dotdot_old, *_current_phi, _dof_values_dotdot_old);
 
@@ -609,7 +603,6 @@ MooseVariableData<OutputType>::computeValues()
         for (unsigned int qp = 0; qp < nqp; qp++)
           _du_dot_du[qp] = _dof_du_dot_du[i];
     }
-
     if (_need_du_dotdot_du)
     {
       _du_dotdot_du.resize(nqp);
@@ -620,7 +613,6 @@ MooseVariableData<OutputType>::computeValues()
           _du_dotdot_du[qp] = _dof_du_dotdot_du[i];
     }
 
-    // Derivative gradients
     if (_need_grad_dot)
       fill(_grad_u_dot, *_current_grad_phi, _dof_values_dot);
     if (_need_grad_dotdot)

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -542,6 +542,8 @@ MooseVariableData<OutputType>::computeValues()
           else
             static_assert(Moose::always_false<T>, "Unsupported type");
         }
+        else
+          static_assert(Moose::always_false<OutputType>, "Unsupported type");
       }
   };
 

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -487,6 +487,7 @@ MooseVariableData<OutputType>::computeValues()
     constexpr bool is_output = std::is_same_v<T, OutputType>;
     constexpr bool is_gradient = std::is_same_v<T, OutputGradient>;
     constexpr bool is_second = std::is_same_v<T, OutputSecond>;
+    constexpr bool is_divergence = std::is_same_v<T, OutputDivergence>;
 
     dest.resize(nqp);
     for (unsigned int qp = 0; qp < nqp; ++qp)
@@ -513,7 +514,7 @@ MooseVariableData<OutputType>::computeValues()
       {
         if constexpr (is_real || is_real_vector || (is_eigen && is_output))
         {
-          if constexpr (is_output)
+          if constexpr (is_output || is_divergence)
             dest[qp] += phi[i][qp] * vector[i];
           else if constexpr (is_gradient || is_second)
             dest[qp].add_scaled(phi[i][qp], vector[i]);

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -507,7 +507,7 @@ MooseVariableData<OutputType>::computeValues()
         else if constexpr (is_second)
           dest[qp].setZero(this->_count, LIBMESH_DIM * LIBMESH_DIM);
         else
-          static_assert(Moose::always_false<T>, "Unsupported type");
+          static_assert(Moose::always_false<dest_array_type>, "Unsupported type");
       }
       else
         static_assert(Moose::always_false<OutputType>, "Unsupported type");
@@ -524,7 +524,7 @@ MooseVariableData<OutputType>::computeValues()
           else if constexpr (is_gradient || is_second)
             dest[qp].add_scaled(phi[i][qp], vector[i]);
           else
-            static_assert(Moose::always_false<T>, "Unsupported type");
+            static_assert(Moose::always_false<dest_array_type>, "Unsupported type");
         }
         else if constexpr (is_eigen)
         {
@@ -540,7 +540,7 @@ MooseVariableData<OutputType>::computeValues()
                 dest[qp].col(d++) += phi[i][qp](d1, d2) * vector[i];
           }
           else
-            static_assert(Moose::always_false<T>, "Unsupported type");
+            static_assert(Moose::always_false<dest_array_type>, "Unsupported type");
         }
         else
           static_assert(Moose::always_false<OutputType>, "Unsupported type");

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -514,10 +514,10 @@ MooseVariableData<OutputType>::computeValuesInternal()
         else if constexpr (is_second)
           dest[qp].setZero(this->_count, LIBMESH_DIM * LIBMESH_DIM);
         else
-          static_assert(Moose::always_false<dest_array_type>, "Unsupported type");
+          static_assert(Moose::always_false<OutputType, dest_array_type>, "Unsupported type");
       }
       else
-        static_assert(Moose::always_false<OutputType>, "Unsupported type");
+        static_assert(Moose::always_false<OutputType, dest_array_type>, "Unsupported type");
     };
 
     // Accumulates a value
@@ -530,7 +530,7 @@ MooseVariableData<OutputType>::computeValuesInternal()
         else if constexpr (is_gradient || is_second)
           dest[qp].add_scaled(phi[i][qp], dof_values[i]);
         else
-          static_assert(Moose::always_false<dest_array_type>, "Unsupported type");
+          static_assert(Moose::always_false<OutputType, dest_array_type>, "Unsupported type");
       }
       else if constexpr (is_eigen)
       {
@@ -546,10 +546,10 @@ MooseVariableData<OutputType>::computeValuesInternal()
               dest[qp].col(d++) += phi[i][qp](d1, d2) * dof_values[i];
         }
         else
-          static_assert(Moose::always_false<dest_array_type>, "Unsupported type");
+          static_assert(Moose::always_false<OutputType, dest_array_type>, "Unsupported type");
       }
       else
-        static_assert(Moose::always_false<OutputType>, "Unsupported type");
+        static_assert(Moose::always_false<OutputType, dest_array_type>, "Unsupported type");
     };
 
     dest.resize(nqp);

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -560,7 +560,7 @@ MooseVariableData<OutputType>::computeValuesInternal()
       mooseAssert(num_dofs == 1, "Should have only one dof");
       set_zero(0);
       accumulate(0, 0);
-      for (unsigned int qp = 0; qp < nqp; ++qp)
+      for (unsigned int qp = 1; qp < nqp; ++qp)
         dest[qp] = dest[0];
     }
     // Non monomial case

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -1306,13 +1306,13 @@ MooseVariableData<OutputType>::setDofValue(const OutputData & value, unsigned in
   _has_dof_values = true;
 
   auto & u = _vector_tag_u[_solution_tag];
-  for (unsigned int qp = 0; qp < u.size(); qp++)
-  {
-    u[qp] = (*_phi)[0][qp] * dof_values[0];
-
-    for (unsigned int i = 1; i < dof_values.size(); i++)
+  const auto nqps = u.size();
+  const auto ndofs = dof_values.size();
+  for (unsigned int qp = 0; qp < nqps; qp++)
+    u[qp] *= 0.;
+  for (unsigned int qp = 0; qp < nqps; qp++)
+    for (unsigned int i = 0; i < ndofs; i++)
       u[qp] += (*_phi)[i][qp] * dof_values[i];
-  }
 }
 
 template <typename OutputType>
@@ -1326,12 +1326,13 @@ MooseVariableData<OutputType>::setDofValues(const DenseVector<OutputData> & valu
   _has_dof_values = true;
 
   auto & u = _vector_tag_u[_solution_tag];
-  for (unsigned int qp = 0; qp < u.size(); qp++)
-  {
-    u[qp] = (*_phi)[0][qp] * dof_values[0];
-    for (unsigned int i = 1; i < dof_values.size(); i++)
+  const auto nqps = u.size();
+  const auto ndofs = dof_values.size();
+  for (unsigned int qp = 0; qp < nqps; qp++)
+    u[qp] *= 0.;
+  for (unsigned int qp = 0; qp < nqps; qp++)
+    for (unsigned int i = 0; i < ndofs; i++)
       u[qp] += (*_phi)[i][qp] * dof_values[i];
-  }
 }
 
 template <typename OutputType>
@@ -1669,10 +1670,11 @@ MooseVariableData<RealEigenVector>::computeIncrementAtNode(
   else
   {
     unsigned int n = 0;
+    const auto n_dof_indices = _dof_indices.size();
     for (unsigned int j = 0; j < _count; j++)
     {
       _increment[0](j) = increment_vec(_dof_indices[0] + n);
-      n += _dof_indices.size();
+      n += n_dof_indices;
     }
   }
 }

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -494,6 +494,8 @@ MooseVariableData<OutputType>::computeValuesInternal()
     constexpr bool is_gradient = std::is_same_v<dest_array_type, OutputGradient>;
     constexpr bool is_second = std::is_same_v<dest_array_type, OutputSecond>;
     constexpr bool is_divergence = std::is_same_v<dest_array_type, OutputDivergence>;
+    static_assert(is_output || is_gradient || is_second || is_divergence,
+                  "Unsupported destination array type");
 
     // Sets a value to zero at a quadrature point
     const auto set_zero = [this, &dest](const auto qp)

--- a/framework/src/variables/MooseVariableDataFV.C
+++ b/framework/src/variables/MooseVariableDataFV.C
@@ -468,28 +468,28 @@ MooseVariableDataFV<OutputType>::computeValues()
     if (second_required)
     {
       if (_need_second)
-        _second_u[qp] = 0;
+        _second_u[qp] = 0.;
 
       if (_need_second_previous_nl)
-        _second_u_previous_nl[qp] = 0;
+        _second_u_previous_nl[qp] = 0.;
 
       if (is_transient)
       {
         if (_need_second_old)
-          _second_u_old[qp] = 0;
+          _second_u_old[qp] = 0.;
 
         if (_need_second_older)
-          _second_u_older[qp] = 0;
+          _second_u_older[qp] = 0.;
       }
     }
 
     if (curl_required)
     {
       if (_need_curl)
-        _curl_u[qp] = 0;
+        _curl_u[qp] = 0.;
 
       if (is_transient && _need_curl_old)
-        _curl_u_old[qp] = 0;
+        _curl_u_old[qp] = 0.;
     }
 
     for (auto tag : _required_vector_tags)


### PR DESCRIPTION
locally (M1 max) I observed 8% speedup on simple_diffusion.i with -r 7.
I am hoping someone can reproduce so we can merge this. 
I doubt the test suite will show a consistent improvement but let's see with this PR's run