### PR TITLE
Add capability to define multiple test spec file names in MooseDocs configurations

### DIFF
--- a/modules/doc/content/newsletter/2025/2025_01.md
+++ b/modules/doc/content/newsletter/2025/2025_01.md
@@ -15,7 +15,7 @@ for a complete description of all MOOSE changes.
 
 ## Bug Fixes and Minor Enhancements
 
-- MooseDocs SQA has the ability to check against two test specification files (i.e., `tests` as well
+- MooseDocs SQA has the ability to check against multiple test specification file names (for example, `tests` as well
   as `assessments`) when performing requirement reporting and checks, using the `specs:` parameter
   in `sqa_reports.yml`.
 

--- a/modules/doc/content/newsletter/2025/2025_01.md
+++ b/modules/doc/content/newsletter/2025/2025_01.md
@@ -15,4 +15,8 @@ for a complete description of all MOOSE changes.
 
 ## Bug Fixes and Minor Enhancements
 
+- MooseDocs SQA has the ability to check against two test specification files (i.e., `tests` as well
+  as `assessments`) when performing requirement reporting and checks, using the `specs:` parameter
+  in `sqa_reports.yml`.
+
 ## Conda Package Changes

--- a/modules/doc/training/content/sqa/training/lead/sqa_moosedocs.md
+++ b/modules/doc/training/content/sqa/training/lead/sqa_moosedocs.md
@@ -189,6 +189,22 @@ Requirements:
         include_non_testable: true
 ```
 
+Multiple test specifications files can be added (such as when `tests` and `assessments` are used as
+filenames for organization) by setting the `specs:` parameter:
+
+```
+Requirements:
+    blackbear:
+        directories:
+            - test/tests
+        specs:
+            - tests
+            - assessments
+        log_testable: WARNING
+        show_warning: false
+        include_non_testable: true
+```
+
 !---
 
 ### SQA Reports: Running

--- a/python/moosesqa/SQARequirementReport.py
+++ b/python/moosesqa/SQARequirementReport.py
@@ -50,10 +50,11 @@ class SQARequirementReport(SQAReport):
                 raise NotADirectoryError("Supplied directory does not exist: {}".format(d))
 
         # Build Requirement objects and remove directory based dict
-        req_dict = get_requirements_from_tests(directories, specs.split(), self.include_non_testable)
         requirements = []
-        for values in req_dict.values():
-            requirements += values
+        for s in specs:
+            req_dict = get_requirements_from_tests(directories, s.split(), self.include_non_testable)
+            for values in req_dict.values():
+                requirements += values
 
         # Populate the lists of tests for SQARequirementDiffReport
         self.test_names = set()

--- a/python/moosesqa/test/specs/spec_multiple
+++ b/python/moosesqa/test/specs/spec_multiple
@@ -1,0 +1,8 @@
+# For testing mooseutils.sqa tools in the case that multiple specs are provided.
+# This file is used in tandem with the spec_missing_req file in python/moosesqa/test/specs.
+[Tests]
+   [no_issue]
+     design = 'design.md'
+     requirement = 'all'
+   []
+[]

--- a/python/moosesqa/test/test_SQARequirementReport.py
+++ b/python/moosesqa/test/test_SQARequirementReport.py
@@ -28,7 +28,8 @@ class TestSQARequirementReport(unittest.TestCase):
     @mock.patch('mooseutils.colorText', side_effect=lambda t, c, **kwargs: '{}:{}'.format(c,t))
     def testOptions(self, *args):
 
-        reporter = SQARequirementReport(title='testing', specs='spec_missing_req',
+        # test single spec
+        reporter = SQARequirementReport(title='testing', specs=['spec_missing_req'],
                                         directories=['python/moosesqa/test/specs'])
         r = reporter.getReport()
         self.assertEqual(reporter.status, SQAReport.Status.ERROR)
@@ -38,6 +39,20 @@ class TestSQARequirementReport(unittest.TestCase):
         self.assertIn('log_empty_requirement: 1', r)
         self.assertIn('log_empty_design: 1', r)
         self.assertIn('log_empty_issues: 1',r )
+        self.assertIn('log_duplicate_requirement: 1', r)
+
+        # test multiple specs
+        reporter = SQARequirementReport(title='testing', specs=['spec_missing_req','spec_multiple'],
+                                        directories=['python/moosesqa/test/specs'])
+        r = reporter.getReport()
+        self.assertEqual(reporter.status, SQAReport.Status.ERROR)
+        self.assertIn('log_missing_requirement: 1', r)
+        self.assertIn('log_missing_design: 1', r)
+        self.assertIn('log_missing_issues: 2', r)
+        self.assertIn('log_empty_requirement: 1', r)
+        self.assertIn('log_empty_design: 1', r)
+        self.assertIn('log_empty_issues: 1',r )
+        self.assertIn('log_duplicate_requirement: 2', r)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #29713

This change fixes an issue that @gambka was experiencing when working with MooseDocs SQA by adding a new feature.