### PR TITLE
Skip --dump tests for valgrind

### DIFF
--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -1186,5 +1186,7 @@
 
     requirement = 'The system shall report a helpful error when the dump parameter does not match any valid parameters'
     issues = '#26714'
+    # See #29735
+    valgrind = none
   []
 []


### PR DESCRIPTION
These are memory intensive and commonly time out for valgrind

Closes #29735
