### PR TITLE
Various mixture-related fluid properties improvements

### DIFF
--- a/modules/fluid_properties/include/fluidproperties/IdealRealGasMixtureFluidProperties.h
+++ b/modules/fluid_properties/include/fluidproperties/IdealRealGasMixtureFluidProperties.h
@@ -18,6 +18,34 @@
 class SinglePhaseFluidProperties;
 
 /**
+ * Overrides the value and derivative methods for a property from some arguments
+ */
+#define override_property(want, prop1, prop2)                                                      \
+  virtual Real want##_from_##prop1##_##prop2(Real prop1, Real prop2, const std::vector<Real> & x)  \
+      const override;                                                                              \
+  virtual void want##_from_##prop1##_##prop2(Real prop1,                                           \
+                                             Real prop2,                                           \
+                                             const std::vector<Real> & x,                          \
+                                             Real & want,                                          \
+                                             Real & d##want##_d##prop1,                            \
+                                             Real & d##want##_d##prop2,                            \
+                                             std::vector<Real> & dp_dx) const override
+
+/**
+ * Declares the value and derivative methods for a property from some arguments
+ */
+#define declare_property(want, prop1, prop2)                                                       \
+  virtual Real want##_from_##prop1##_##prop2(Real prop1, Real prop2, const std::vector<Real> & x)  \
+      const;                                                                                       \
+  virtual void want##_from_##prop1##_##prop2(Real prop1,                                           \
+                                             Real prop2,                                           \
+                                             const std::vector<Real> & x,                          \
+                                             Real & want,                                          \
+                                             Real & d##want##_d##prop1,                            \
+                                             Real & d##want##_d##prop2,                            \
+                                             std::vector<Real> & dp_dx) const
+
+/**
  * Class for fluid properties of an arbitrary vapor mixture
  *
  *
@@ -36,525 +64,29 @@ public:
    */
   virtual unsigned int getNumberOfSecondaryVapors() const override { return _n_secondary_vapors; }
 
-  /**
-   * Pressure from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume
-   * @param[in] e   specific internal energy
-   * @param[in] x   vapor mass fraction values
-   * @return        pressure
-   */
-  virtual Real p_from_v_e(Real v, Real e, const std::vector<Real> & x) const override;
+  override_property(p, v, e);
+  override_property(T, v, e);
+  override_property(c, v, e);
+  override_property(rho, p, T);
+  override_property(e, p, T);
+  override_property(s, p, T);
+  override_property(c, p, T);
+  override_property(cp, p, T);
+  override_property(cv, p, T);
+  override_property(mu, p, T);
+  override_property(k, p, T);
+  override_property(e, p, rho);
 
-  /**
-   * Pressure and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume
-   * @param[in] e   specific internal energy
-   * @param[in] x   vapor mass fraction values
-   * @param[out] p       pressure
-   * @param[out] dp_dv   derivative of pressure w.r.t. specific volume
-   * @param[out] dp_de   derivative of pressure w.r.t. specific internal energy
-   * @param[out] dp_dx   derivative of pressure w.r.t. vapor mass fraction values
-   */
-  virtual void p_from_v_e(Real v,
-                          Real e,
-                          const std::vector<Real> & x,
-                          Real & p,
-                          Real & dp_dv,
-                          Real & dp_de,
-                          std::vector<Real> & dp_dx) const override;
-
-  /**
-   * Temperature from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume
-   * @param[in] e   specific internal energy
-   * @param[in] x   vapor mass fraction values
-   * @return        temperature
-   */
-  virtual Real T_from_v_e(Real v, Real e, const std::vector<Real> & x) const override;
-
-  /**
-   * Temperature and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume
-   * @param[in] e   specific internal energy
-   * @param[in] x   vapor mass fraction values
-   * @param[out] T       temperature
-   * @param[out] dT_dv   derivative of temperature w.r.t. specific volume
-   * @param[out] dT_de   derivative of temperature w.r.t. specific internal energy
-   * @param[out] dT_dx   derivative of temperature w.r.t. vapor mass fraction values
-   */
-  virtual void T_from_v_e(Real v,
-                          Real e,
-                          const std::vector<Real> & x,
-                          Real & T,
-                          Real & dT_dv,
-                          Real & dT_de,
-                          std::vector<Real> & dT_dx) const override;
-
-  /**
-   * Speed of sound from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume
-   * @param[in] e   specific internal energy
-   * @param[in] x   vapor mass fraction values
-   * @return        speed of sound
-   */
-  virtual Real c_from_v_e(Real v, Real e, const std::vector<Real> & x) const override;
-
-  /**
-   * Speed of sound and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume
-   * @param[in] e   specific internal energy
-   * @param[in] x   vapor mass fraction values
-   * @param[out] c       Speed of sound
-   * @param[out] dc_dv   derivative of temperature w.r.t. specific volume
-   * @param[out] dc_de   derivative of temperature w.r.t. specific internal energy
-   * @param[out] dc_dx   derivative of temperature w.r.t. vapor mass fraction values
-   */
-  virtual void c_from_v_e(Real v,
-                          Real e,
-                          const std::vector<Real> & x,
-                          Real & c,
-                          Real & dc_dv,
-                          Real & dc_de,
-                          std::vector<Real> & dc_dx) const override;
-
-  /**
-   * Density from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @return        density
-   */
-  virtual Real rho_from_p_T(Real p, Real T, const std::vector<Real> & x) const override;
-
-  /**
-   * Density and its derivatives from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @param[out] rho       density
-   * @param[out] drho_dp   derivative of density w.r.t. pressure
-   * @param[out] drho_dT   derivative of density w.r.t. temperature
-   * @param[out] drho_dx   derivative of density w.r.t. vapor mass fraction values
-   */
-  virtual void rho_from_p_T(Real p,
-                            Real T,
-                            const std::vector<Real> & x,
-                            Real & rho,
-                            Real & drho_dp,
-                            Real & drho_dT,
-                            std::vector<Real> & drho_dx) const override;
-
-  /**
-   * Specific internal energy from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @return        specific internal energy
-   */
-  virtual Real e_from_p_T(Real p, Real T, const std::vector<Real> & x) const override;
-
-  /**
-   * Specific internal energy and its derivatives from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @param[out] e       specific internal energy
-   * @param[out] de_dp   derivative of specific internal energy w.r.t. pressure
-   * @param[out] de_dT   derivative of specific internal energy w.r.t. temperature
-   * @param[out] de_dx   derivative of specific internal energy w.r.t. vapor mass fraction values
-   */
-  virtual void e_from_p_T(Real p,
-                          Real T,
-                          const std::vector<Real> & x,
-                          Real & e,
-                          Real & de_dp,
-                          Real & de_dT,
-                          std::vector<Real> & de_dx) const override;
-
-  /**
-   * Speed of sound from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @return        speed of sound
-   */
-  virtual Real c_from_p_T(Real p, Real T, const std::vector<Real> & x) const override;
-
-  /**
-   * Speed of sound and its derivatives from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @param[out] c       speed of sound
-   * @param[out] dc_dp   derivative of speed of sound w.r.t. pressure
-   * @param[out] dc_dT   derivative of speed of sound w.r.t. temperature
-   * @param[out] dc_dx   derivative of speed of sound w.r.t. vapor mass fraction values
-   */
-  virtual void c_from_p_T(Real p,
-                          Real T,
-                          const std::vector<Real> & x,
-                          Real & c,
-                          Real & dc_dp,
-                          Real & dc_dT,
-                          std::vector<Real> & dc_dx) const override;
-
-  /**
-   * Isobaric heat capacity from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @return        isobaric heat capacity
-   */
-  virtual Real cp_from_p_T(Real p, Real T, const std::vector<Real> & x) const override;
-  virtual void cp_from_p_T(Real p,
-                           Real T,
-                           const std::vector<Real> & x,
-                           Real & cp,
-                           Real & dcp_dp,
-                           Real & dcp_dT,
-                           std::vector<Real> & dcp_dx) const override;
-
-  /**
-   * Isochoric heat capacity from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @return        isochoric heat capacity
-   */
-  virtual Real cv_from_p_T(Real p, Real T, const std::vector<Real> & x) const override;
-  virtual void cv_from_p_T(Real p,
-                           Real T,
-                           const std::vector<Real> & x,
-                           Real & cv,
-                           Real & dcv_dp,
-                           Real & dcv_dT,
-                           std::vector<Real> & dcv_dx) const override;
-
-  /**
-   * Dynamic viscosity from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @return        dynamic viscosity
-   */
-  virtual Real mu_from_p_T(Real p, Real T, const std::vector<Real> & x) const override;
-  virtual void mu_from_p_T(Real p,
-                           Real T,
-                           const std::vector<Real> & x,
-                           Real & mu,
-                           Real & dmu_dp,
-                           Real & dmu_dT,
-                           std::vector<Real> & dmu_dx) const override;
-
-  /**
-   * Thermal conductivity from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @return        thermal conductivity
-   */
-  virtual Real k_from_p_T(Real p, Real T, const std::vector<Real> & x) const override;
-  virtual void k_from_p_T(Real p,
-                          Real T,
-                          const std::vector<Real> & x,
-                          Real & k,
-                          Real & dk_dp,
-                          Real & dk_dT,
-                          std::vector<Real> & dk_dx) const override;
-  /**
-   * Specific volume from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @return        specific volume
-   */
-  virtual Real v_from_p_T(Real p, Real T, const std::vector<Real> & x) const;
-
-  /**
-   * Specific volume and its derivatives from pressure and temperature
-   *
-   * @param[in] p   pressure
-   * @param[in] T   temperature
-   * @param[in] x   vapor mass fraction values
-   * @param[out] v       specific volume
-   * @param[out] dv_dp   derivative of specific volume w.r.t. pressure
-   * @param[out] dv_dT   derivative of specific volume w.r.t. temperature
-   * @param[out] dv_dx   derivative of specific volume w.r.t. vapor mass fraction values
-   */
-  virtual void v_from_p_T(Real p,
-                          Real T,
-                          const std::vector<Real> & x,
-                          Real & v,
-                          Real & dv_dp,
-                          Real & dv_dT,
-                          std::vector<Real> & dv_dx) const;
-
-  /**
-   * Specific internal energy from pressure and density
-   *
-   * @param[in] p   pressure
-   * @param[in] rho density
-   * @param[in] x   vapor mass fraction values
-   * @return        specific internal energy
-   */
-  virtual Real e_from_p_rho(Real p, Real rho, const std::vector<Real> & x) const override;
-
-  /**
-   * Specific internal energy and its derivatives from pressure and density
-   *
-   * @param[in] p   pressure
-   * @param[in] rho density
-   * @param[in] x   vapor mass fraction values
-   * @param[out] e       specific internal energy
-   * @param[out] de_dp   derivative of specific internal energy w.r.t. pressure
-   * @param[out] de_drho derivative of specific internal energy w.r.t. density
-   * @param[out] de_dx   derivative of specific internal energy w.r.t. vapor mass fraction values
-   */
-  virtual void e_from_p_rho(Real p,
-                            Real rho,
-                            const std::vector<Real> & x,
-                            Real & e,
-                            Real & de_dp,
-                            Real & de_drho,
-                            std::vector<Real> & de_dx) const override;
-
-  /**
-   * Pressure and temperature from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume
-   * @param[in] e   specific internal energy
-   * @param[in] x   vapor mass fraction values
-   * @param[out] p  pressure
-   * @param[out] T  temperature
-   */
-  void p_T_from_v_e(Real v, Real e, const std::vector<Real> & x, Real & p, Real & T) const;
-
-  /**
-   * Pressure and temperature from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume
-   * @param[in] e   specific internal energy
-   * @param[in] x   vapor mass fraction values
-   * @param[out] p       pressure
-   * @param[out] dp_dv   derivative of pressure w.r.t. specific volume
-   * @param[out] dp_de   derivative of pressure w.r.t. specific internal energy
-   * @param[out] dp_dx   derivative of pressure w.r.t. vapor mass fraction values
-   * @param[out] T       temperature
-   * @param[out] dT_dv   derivative of temperature w.r.t. specific volume
-   * @param[out] dT_de   derivative of temperature w.r.t. specific internal energy
-   * @param[out] dT_dx   derivative of temperature w.r.t. vapor mass fraction values
-   */
-  void p_T_from_v_e(Real v,
-                    Real e,
-                    const std::vector<Real> & x,
-                    Real & p,
-                    Real & dp_dv,
-                    Real & dp_de,
-                    std::vector<Real> & dp_dx,
-                    Real & T,
-                    Real & dT_dv,
-                    Real & dT_de,
-                    std::vector<Real> & dT_dx) const;
-
-  /**
-   * Temperature from pressure and specific volume
-   *
-   * @param[in] p   pressure
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @return        temperature
-   */
-  Real T_from_p_v(Real p, Real v, const std::vector<Real> & x) const;
-
-  /**
-   * Temperature and its derivatives from pressure and specific volume
-   *
-   * @param[in] p   pressure
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @param[out] T       temperature
-   * @param[out] dT_dp   derivative of temperature w.r.t. pressure
-   * @param[out] dT_dv   derivative of temperature w.r.t. specific volume
-   * @param[out] dT_dx   derivative of temperature w.r.t. vapor mass fraction values
-   */
-  void T_from_p_v(Real p,
-                  Real v,
-                  const std::vector<Real> & x,
-                  Real & T,
-                  Real & dT_dp,
-                  Real & dT_dv,
-                  std::vector<Real> & dT_dx) const;
-
-  /**
-   * Pressure from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @return        pressure
-   */
-  Real p_from_T_v(Real T, Real v, const std::vector<Real> & x) const;
-
-  /**
-   * Pressure and its derivatives from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @param[out] p       pressure
-   * @param[out] dp_dT   derivative of pressure w.r.t. temperature
-   * @param[out] dp_dv   derivative of pressure w.r.t. specific volume
-   */
-  void p_from_T_v(
-      Real T, Real v, const std::vector<Real> & x, Real & p, Real & dp_dT, Real & dp_dv) const;
-
-  /**
-   * Pressure and its derivatives from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @param[out] p       pressure
-   * @param[out] dp_dT   derivative of pressure w.r.t. temperature
-   * @param[out] dp_dv   derivative of pressure w.r.t. specific volume
-   * @param[out] dp_dx   derivative of pressure w.r.t. vapor mass fraction values
-   */
-  void p_from_T_v(Real T,
-                  Real v,
-                  const std::vector<Real> & x,
-                  Real & p,
-                  Real & dp_dT,
-                  Real & dp_dv,
-                  std::vector<Real> & dp_dx) const;
-
-  /**
-   * Specific internal energy from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @return        specific internal energy
-   */
-  Real e_from_T_v(Real T, Real v, const std::vector<Real> & x) const;
-
-  /**
-   * Specific internal energy and its derivatives from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @param[out] e       specific internal energy
-   * @param[out] de_dT   derivative of specific internal energy w.r.t. temperature
-   * @param[out] de_dv   derivative of specific internal energy w.r.t. specific volume
-   * @param[out] de_dx   derivative of specific internal energy w.r.t. vapor mass fraction values
-   */
-  void e_from_T_v(Real T,
-                  Real v,
-                  const std::vector<Real> & x,
-                  Real & e,
-                  Real & de_dT,
-                  Real & de_dv,
-                  std::vector<Real> & de_dx) const;
-
-  /**
-   * Specific entropy and its derivatives from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @param[out] s       specific entropy
-   * @param[out] ds_dT   derivative of specific entropy w.r.t. temperature
-   * @param[out] ds_dv   derivative of specific entropy w.r.t. specific volume
-   * @param[out] ds_dx   derivative of specific entropy w.r.t. vapor mass fraction values
-   */
-  void s_from_T_v(
-      Real T, Real v, const std::vector<Real> & x, Real & s, Real & ds_dT, Real & ds_dv) const;
-
-  /**
-   * Speed of sound from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @return        speed of sound
-   */
-  Real c_from_T_v(Real T, Real v, const std::vector<Real> & x) const;
-
-  /**
-   * Speed of sound and its derivatives from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @param[out] c       speed of sound
-   * @param[out] dc_dT   derivative of speed of sound w.r.t. temperature
-   * @param[out] dc_dv   derivative of speed of sound w.r.t. specific volume
-   * @param[out] dc_dx   derivative of speed of sound w.r.t. vapor mass fraction values
-   */
-  void c_from_T_v(Real T,
-                  Real v,
-                  const std::vector<Real> & x,
-                  Real & c,
-                  Real & dc_dT,
-                  Real & dc_dv,
-                  std::vector<Real> & dc_dx) const;
-
-  /**
-   * Isobaric heat capacity from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @return        isobaric heat capacity
-   */
-  Real cp_from_T_v(Real T, Real v, const std::vector<Real> & x) const;
-
-  /**
-   * Isochoric heat capacity from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @return        isochoric heat capacity
-   */
-  Real cv_from_T_v(Real T, Real v, const std::vector<Real> & x) const;
-
-  /**
-   * Dynamic viscosity from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @return        dynamic viscosity
-   */
-  Real mu_from_T_v(Real T, Real v, const std::vector<Real> & x) const;
-
-  /**
-   * Thermal conductivity from temperature and specific volume
-   *
-   * @param[in] T   temperature
-   * @param[in] v   specific volume
-   * @param[in] x   vapor mass fraction values
-   * @return        thermal conductivity
-   */
-  Real k_from_T_v(Real T, Real v, const std::vector<Real> & x) const;
+  declare_property(v, p, T);
+  declare_property(T, p, v);
+  declare_property(p, T, v);
+  declare_property(e, T, v);
+  declare_property(s, T, v);
+  declare_property(c, T, v);
+  declare_property(cp, T, v);
+  declare_property(cv, T, v);
+  declare_property(mu, T, v);
+  declare_property(k, T, v);
 
   /**
    * Mass fraction of primary (condensable) component at saturation from pressure and temperature

--- a/modules/fluid_properties/include/fluidproperties/IdealRealGasMixtureFluidProperties.h
+++ b/modules/fluid_properties/include/fluidproperties/IdealRealGasMixtureFluidProperties.h
@@ -58,6 +58,18 @@ public:
   IdealRealGasMixtureFluidProperties(const InputParameters & parameters);
 
   /**
+   * Gets the primary component single-phase fluid properties
+   */
+  const SinglePhaseFluidProperties & getPrimaryFluidProperties() const;
+
+  /**
+   * Gets a secondary component single-phase fluid properties
+   *
+   * @param[in] i  Index of the secondary fluid properties (0 is first secondary)
+   */
+  const SinglePhaseFluidProperties & getSecondaryFluidProperties(unsigned int i = 0) const;
+
+  /**
    * Number of secondary vapors (non-condensable components)
    *
    * @return number of secondary vapors

--- a/modules/fluid_properties/include/fluidproperties/VaporMixtureFluidProperties.h
+++ b/modules/fluid_properties/include/fluidproperties/VaporMixtureFluidProperties.h
@@ -116,6 +116,7 @@ public:
   propfunc(c, v, e)
   propfunc(rho, p, T)
   propfunc(e, p, T)
+  propfunc(s, p, T)
   propfunc(c, p, T)
   propfunc(cp, p, T)
   propfunc(cv, p, T)

--- a/modules/fluid_properties/include/fluidproperties/VaporMixtureFluidProperties.h
+++ b/modules/fluid_properties/include/fluidproperties/VaporMixtureFluidProperties.h
@@ -48,8 +48,7 @@
                                              ADReal & d##want##d2,                                 \
                                              std::vector<ADReal> & d##want##dx) const              \
   {                                                                                                \
-    fluidPropError(                                                                                \
-        name(), ": ", __PRETTY_FUNCTION__, " derivative derivatives not  implemented.");           \
+    imperfectJacobianMessage(__PRETTY_FUNCTION__, " derivative derivatives not  implemented.");    \
     Real dummy, tmp1, tmp2;                                                                        \
     std::vector<Real> x_raw(x.size(), 0);                                                          \
     std::vector<Real> tmp3(x.size(), 0);                                                           \
@@ -81,7 +80,7 @@
                                              Real & d##want##d2,                                   \
                                              std::vector<Real> & d##want##dx) const                \
   {                                                                                                \
-    fluidPropError(name(), ": ", __PRETTY_FUNCTION__, " derivatives not implemented.");            \
+    imperfectJacobianMessage(__PRETTY_FUNCTION__, " derivatives not implemented.");                \
     d##want##d1 = 0;                                                                               \
     d##want##d2 = 0;                                                                               \
     std::fill(d##want##dx.begin(), d##want##dx.end(), 0.);                                         \
@@ -166,9 +165,9 @@ public:
   std::vector<Real> massFractionsFromMolarFractions(const std::vector<Real> & molar_fractions,
                                                     const std::vector<Real> & molar_masses) const;
 
-private:
+protected:
   template <typename... Args>
-  void fluidPropError(Args... args) const
+  void imperfectJacobianMessage(Args... args) const
   {
     if (_allow_imperfect_jacobians)
       mooseDoOnce(mooseWarning(std::forward<Args>(args)...));

--- a/modules/fluid_properties/include/userobjects/FluidPropertiesInterrogator.h
+++ b/modules/fluid_properties/include/userobjects/FluidPropertiesInterrogator.h
@@ -173,6 +173,8 @@ protected:
   const bool _has_2phase;
   /// flag that user provided 2-phase NCG fluid properties
   const bool _has_2phase_ncg;
+  /// flag that user provided 2-phase NCG partial pressure fluid properties
+  const bool _has_2phase_ncg_partial_pressure;
 
   /// pointer to liquid fluid properties object (if provided 2-phase object)
   const SinglePhaseFluidProperties * const _fp_liquid;

--- a/modules/fluid_properties/include/utils/BrentsMethod.h
+++ b/modules/fluid_properties/include/utils/BrentsMethod.h
@@ -16,6 +16,13 @@
 // C++ includes
 #include <functional>
 
+/**
+ * Brent's method is used to find the root of a function f(x), i.e., find
+ * x such that f(x) = 0.
+ *
+ * First, brackets x1 and x2 are found such that f(x) changes sign between
+ * x1 and x2, implying that there is a root between the points.
+ */
 namespace BrentsMethod
 {
 /**

--- a/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
@@ -248,9 +248,9 @@ define_from_p_T_using_T_v(k)
 
 define_from_v_e_using_T_v(p)
 define_from_v_e_using_T_v(c)
-    // clang-format on
 
-    InputParameters IdealRealGasMixtureFluidProperties::validParams()
+InputParameters IdealRealGasMixtureFluidProperties::validParams()
+// clang-format on
 {
   InputParameters params = VaporMixtureFluidProperties::validParams();
   params += NaNInterface::validParams();

--- a/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
@@ -136,7 +136,7 @@ registerMooseObject("FluidPropertiesApp", IdealRealGasMixtureFluidProperties);
       {                                                                                            \
         if (j == i)                                                                                \
           continue;                                                                                \
-        const Real dxj_dxi = -x[j] / (1. - x[i]);                                                  \
+        const Real dxj_dxi = 0;                                                                    \
         dy_dx[i] += dxj_dxi * y_sec[j] - x[j] * dy_dv_sec[j] * v / (x[j] * x[j]) * dxj_dxi;        \
       }                                                                                            \
       const Real dx_primary_dxi = -x_primary / (1. - x[i]);                                        \
@@ -274,6 +274,13 @@ IdealRealGasMixtureFluidProperties::IdealRealGasMixtureFluidProperties(
   _fp_secondary.resize(_n_secondary_vapors);
   for (unsigned int i = 0; i < _n_secondary_vapors; i++)
     _fp_secondary[i] = &getUserObjectByName<SinglePhaseFluidProperties>(_fp_secondary_names[i]);
+
+  // The derivatives w.r.t. secondary mass fractions need to be tested for mixtures
+  // of 3 or more gases. See the comment in p_from_T_v about dxj_dxi. This also
+  // appears in the define_mass_specific_prop_from_T_v macro.
+  if (_n_secondary_vapors > 1)
+    mooseError(
+        "IdealRealGasMixtureFluidProperties has not been tested for mixtures of 3 or more gases.");
 }
 
 const SinglePhaseFluidProperties &
@@ -562,7 +569,11 @@ IdealRealGasMixtureFluidProperties::p_from_T_v(Real T,
     {
       if (j == i)
         continue;
-      dxj_dxi = -x[j] / (1. - x[i]);
+      // Note: this was previously as follows, but we were unable to understand
+      // why and this is not currently tested (requires 3 or more components in
+      // the mixture):
+      // dxj_dxi = -x[j] / (1. - x[i]);
+      dxj_dxi = 0;
       dp_dx[i] += -dp_dv_sec[j] * v / (x[j] * x[j]) * dxj_dxi;
     }
     dp_dx[i] += -dp_dv_primary * v / (x_primary * x_primary) * (-x_primary / (1. - x[i]));

--- a/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
@@ -136,6 +136,11 @@ registerMooseObject("FluidPropertiesApp", IdealRealGasMixtureFluidProperties);
       {                                                                                            \
         if (j == i)                                                                                \
           continue;                                                                                \
+        if (_n_secondary_vapors > 1)                                                               \
+          imperfectJacobianMessage(                                                                \
+              "The mass fraction derivatives in the following "                                    \
+              "function have not been tested for mixtures of 3 or more components:\n\n",           \
+              __PRETTY_FUNCTION__);                                                                \
         const Real dxj_dxi = 0;                                                                    \
         dy_dx[i] += dxj_dxi * y_sec[j] - x[j] * dy_dv_sec[j] * v / (x[j] * x[j]) * dxj_dxi;        \
       }                                                                                            \
@@ -277,13 +282,6 @@ IdealRealGasMixtureFluidProperties::IdealRealGasMixtureFluidProperties(
   _fp_secondary.resize(_n_secondary_vapors);
   for (unsigned int i = 0; i < _n_secondary_vapors; i++)
     _fp_secondary[i] = &getUserObjectByName<SinglePhaseFluidProperties>(_fp_secondary_names[i]);
-
-  // The derivatives w.r.t. secondary mass fractions need to be tested for mixtures
-  // of 3 or more gases. See the comment in p_from_T_v about dxj_dxi. This also
-  // appears in the define_mass_specific_prop_from_T_v macro.
-  if (_n_secondary_vapors > 1)
-    mooseError(
-        "IdealRealGasMixtureFluidProperties has not been tested for mixtures of 3 or more gases.");
 }
 
 const SinglePhaseFluidProperties &
@@ -576,6 +574,11 @@ IdealRealGasMixtureFluidProperties::p_from_T_v(Real T,
       // why and this is not currently tested (requires 3 or more components in
       // the mixture):
       // dxj_dxi = -x[j] / (1. - x[i]);
+      if (_n_secondary_vapors > 1)
+        imperfectJacobianMessage(
+            "The mass fraction derivatives in the following "
+            "function have not been tested for mixtures of 3 or more components:\n\n",
+            __PRETTY_FUNCTION__);
       dxj_dxi = 0;
       dp_dx[i] += -dp_dv_sec[j] * v / (x[j] * x[j]) * dxj_dxi;
     }

--- a/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
@@ -198,6 +198,9 @@ registerMooseObject("FluidPropertiesApp", IdealRealGasMixtureFluidProperties);
     const Real yp = _fp_primary->prop##_from_v_e(vp, ep);                                          \
     y = x_primary * M_star / M_primary * yp;                                                       \
                                                                                                    \
+    mooseDoOnce(mooseWarning("The temperature and specific volume derivatives in the following "   \
+                             "function are currently neglected:\n\n",                              \
+                             __PRETTY_FUNCTION__));                                                \
     dy_dT = 0;                                                                                     \
     dy_dv = 0;                                                                                     \
                                                                                                    \
@@ -684,6 +687,9 @@ IdealRealGasMixtureFluidProperties::cp_from_T_v(Real T,
 
   // Neglect these for now. These require higher-order derivatives, so a finite
   // difference should probably be used, as for sound speed.
+  mooseDoOnce(mooseWarning("The temperature and specific volume derivatives in the following "
+                           "function are currently neglected:\n\n",
+                           __PRETTY_FUNCTION__));
   dcp_dT = 0;
   dcp_dv = 0;
 
@@ -724,6 +730,9 @@ IdealRealGasMixtureFluidProperties::cv_from_T_v(Real T,
 
   // Neglect these for now. These require higher-order derivatives, so a finite
   // difference should probably be used, as for sound speed.
+  mooseDoOnce(mooseWarning("The temperature and specific volume derivatives in the following "
+                           "function are currently neglected:\n\n",
+                           __PRETTY_FUNCTION__));
   dcv_dT = 0;
   dcv_dv = 0;
 

--- a/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
@@ -198,9 +198,9 @@ registerMooseObject("FluidPropertiesApp", IdealRealGasMixtureFluidProperties);
     const Real yp = _fp_primary->prop##_from_v_e(vp, ep);                                          \
     y = x_primary * M_star / M_primary * yp;                                                       \
                                                                                                    \
-    mooseDoOnce(mooseWarning("The temperature and specific volume derivatives in the following "   \
+    imperfectJacobianMessage("The temperature and specific volume derivatives in the following "   \
                              "function are currently neglected:\n\n",                              \
-                             __PRETTY_FUNCTION__));                                                \
+                             __PRETTY_FUNCTION__);                                                 \
     dy_dT = 0;                                                                                     \
     dy_dv = 0;                                                                                     \
                                                                                                    \
@@ -687,9 +687,9 @@ IdealRealGasMixtureFluidProperties::cp_from_T_v(Real T,
 
   // Neglect these for now. These require higher-order derivatives, so a finite
   // difference should probably be used, as for sound speed.
-  mooseDoOnce(mooseWarning("The temperature and specific volume derivatives in the following "
+  imperfectJacobianMessage("The temperature and specific volume derivatives in the following "
                            "function are currently neglected:\n\n",
-                           __PRETTY_FUNCTION__));
+                           __PRETTY_FUNCTION__);
   dcp_dT = 0;
   dcp_dv = 0;
 
@@ -730,9 +730,9 @@ IdealRealGasMixtureFluidProperties::cv_from_T_v(Real T,
 
   // Neglect these for now. These require higher-order derivatives, so a finite
   // difference should probably be used, as for sound speed.
-  mooseDoOnce(mooseWarning("The temperature and specific volume derivatives in the following "
+  imperfectJacobianMessage("The temperature and specific volume derivatives in the following "
                            "function are currently neglected:\n\n",
-                           __PRETTY_FUNCTION__));
+                           __PRETTY_FUNCTION__);
   dcv_dT = 0;
   dcv_dv = 0;
 

--- a/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
@@ -265,6 +265,19 @@ IdealRealGasMixtureFluidProperties::IdealRealGasMixtureFluidProperties(
     _fp_secondary[i] = &getUserObjectByName<SinglePhaseFluidProperties>(_fp_secondary_names[i]);
 }
 
+const SinglePhaseFluidProperties &
+IdealRealGasMixtureFluidProperties::getPrimaryFluidProperties() const
+{
+  return *_fp_primary;
+}
+
+const SinglePhaseFluidProperties &
+IdealRealGasMixtureFluidProperties::getSecondaryFluidProperties(unsigned int i) const
+{
+  mooseAssert(i < getNumberOfSecondaryVapors(), "Requested secondary index too high.");
+  return *_fp_secondary[i];
+}
+
 Real
 IdealRealGasMixtureFluidProperties::T_from_v_e(Real v, Real e, const std::vector<Real> & x) const
 {

--- a/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/IdealRealGasMixtureFluidProperties.C
@@ -14,8 +14,224 @@
 
 registerMooseObject("FluidPropertiesApp", IdealRealGasMixtureFluidProperties);
 
-InputParameters
-IdealRealGasMixtureFluidProperties::validParams()
+/**
+ * Defines the value and derivative methods from (v,e) for a property y
+ * using T(v,e) and y(T,v).
+ */
+#define define_from_v_e_using_T_v(prop)                                                            \
+  Real IdealRealGasMixtureFluidProperties::prop##_from_v_e(                                        \
+      Real v, Real e, const std::vector<Real> & x) const                                           \
+  {                                                                                                \
+    const Real T = T_from_v_e(v, e, x);                                                            \
+    return prop##_from_T_v(T, v, x);                                                               \
+  }                                                                                                \
+                                                                                                   \
+  void IdealRealGasMixtureFluidProperties::prop##_from_v_e(Real v,                                 \
+                                                           Real e,                                 \
+                                                           const std::vector<Real> & x,            \
+                                                           Real & y,                               \
+                                                           Real & dy_dv,                           \
+                                                           Real & dy_de,                           \
+                                                           std::vector<Real> & dy_dx) const        \
+  {                                                                                                \
+    Real T, dT_dv, dT_de;                                                                          \
+    std::vector<Real> dT_dx(_n_secondary_vapors);                                                  \
+    T_from_v_e(v, e, x, T, dT_dv, dT_de, dT_dx);                                                   \
+                                                                                                   \
+    Real dy_dT_v, dy_dv_T;                                                                         \
+    std::vector<Real> dy_dx_Tv;                                                                    \
+    prop##_from_T_v(T, v, x, y, dy_dT_v, dy_dv_T, dy_dx_Tv);                                       \
+                                                                                                   \
+    dy_dv = dy_dv_T + dy_dT_v * dT_dv;                                                             \
+    dy_de = dy_dT_v * dT_de;                                                                       \
+    dy_dx.resize(_n_secondary_vapors);                                                             \
+    for (unsigned int i = 0; i < _n_secondary_vapors; i++)                                         \
+      dy_dx[i] = dy_dx_Tv[i] + dy_dT_v * dT_dx[i];                                                 \
+  }
+
+/**
+ * Defines the value and derivative methods from (p,T) for a property y
+ * using v(p,T) and y(T,v).
+ */
+#define define_from_p_T_using_T_v(prop)                                                            \
+  Real IdealRealGasMixtureFluidProperties::prop##_from_p_T(                                        \
+      Real p, Real T, const std::vector<Real> & x) const                                           \
+  {                                                                                                \
+    const Real v = v_from_p_T(p, T, x);                                                            \
+    return prop##_from_T_v(T, v, x);                                                               \
+  }                                                                                                \
+                                                                                                   \
+  void IdealRealGasMixtureFluidProperties::prop##_from_p_T(Real p,                                 \
+                                                           Real T,                                 \
+                                                           const std::vector<Real> & x,            \
+                                                           Real & y,                               \
+                                                           Real & dy_dp,                           \
+                                                           Real & dy_dT,                           \
+                                                           std::vector<Real> & dy_dx) const        \
+  {                                                                                                \
+    Real v, dv_dp, dv_dT;                                                                          \
+    std::vector<Real> dv_dx;                                                                       \
+    v_from_p_T(p, T, x, v, dv_dp, dv_dT, dv_dx);                                                   \
+                                                                                                   \
+    Real dy_dT_v, dy_dv_T;                                                                         \
+    std::vector<Real> dy_dx_Tv;                                                                    \
+    prop##_from_T_v(T, v, x, y, dy_dT_v, dy_dv_T, dy_dx_Tv);                                       \
+                                                                                                   \
+    dy_dp = dy_dv_T * dv_dp;                                                                       \
+    dy_dT = dy_dT_v + dy_dv_T * dv_dT;                                                             \
+    dy_dx.resize(_n_secondary_vapors);                                                             \
+    for (unsigned int i = 0; i < _n_secondary_vapors; i++)                                         \
+      dy_dx[i] = dy_dx_Tv[i] + dy_dv_T * dv_dx[i];                                                 \
+  }
+
+/**
+ * Defines the value and derivative methods from (T,v) for a mass-specific property y
+ */
+#define define_mass_specific_prop_from_T_v(prop)                                                   \
+  Real IdealRealGasMixtureFluidProperties::prop##_from_T_v(                                        \
+      Real T, Real v, const std::vector<Real> & x) const                                           \
+  {                                                                                                \
+    const Real x_primary = primaryMassFraction(x);                                                 \
+    Real y = x_primary * _fp_primary->prop##_from_T_v(T, v / x_primary);                           \
+                                                                                                   \
+    for (unsigned int i = 0; i < _n_secondary_vapors; i++)                                         \
+      y += x[i] * _fp_secondary[i]->prop##_from_T_v(T, v / x[i]);                                  \
+                                                                                                   \
+    return y;                                                                                      \
+  }                                                                                                \
+                                                                                                   \
+  void IdealRealGasMixtureFluidProperties::prop##_from_T_v(Real T,                                 \
+                                                           Real v,                                 \
+                                                           const std::vector<Real> & x,            \
+                                                           Real & y,                               \
+                                                           Real & dy_dT,                           \
+                                                           Real & dy_dv,                           \
+                                                           std::vector<Real> & dy_dx) const        \
+  {                                                                                                \
+    const Real x_primary = primaryMassFraction(x);                                                 \
+                                                                                                   \
+    Real y_primary, dy_dT_primary, dy_dv_primary;                                                  \
+    _fp_primary->prop##_from_T_v(T, v / x_primary, y_primary, dy_dT_primary, dy_dv_primary);       \
+    y = x_primary * y_primary;                                                                     \
+    dy_dT = x_primary * dy_dT_primary;                                                             \
+    dy_dv = dy_dv_primary;                                                                         \
+                                                                                                   \
+    Real dy_dT_sec;                                                                                \
+    std::vector<Real> y_sec(_n_secondary_vapors), dy_dv_sec(_n_secondary_vapors);                  \
+    for (unsigned int i = 0; i < _n_secondary_vapors; i++)                                         \
+    {                                                                                              \
+      _fp_secondary[i]->prop##_from_T_v(T, v / x[i], y_sec[i], dy_dT_sec, dy_dv_sec[i]);           \
+      y += x[i] * y_sec[i];                                                                        \
+      dy_dT += x[i] * dy_dT_sec;                                                                   \
+      dy_dv += dy_dv_sec[i];                                                                       \
+    }                                                                                              \
+                                                                                                   \
+    dy_dx.resize(_n_secondary_vapors);                                                             \
+    for (unsigned int i = 0; i < _n_secondary_vapors; i++)                                         \
+    {                                                                                              \
+      dy_dx[i] = y_sec[i] - x[i] * dy_dv_sec[i] * v / (x[i] * x[i]);                               \
+      for (unsigned int j = 0; j < _n_secondary_vapors; j++)                                       \
+      {                                                                                            \
+        if (j == i)                                                                                \
+          continue;                                                                                \
+        const Real dxj_dxi = -x[j] / (1. - x[i]);                                                  \
+        dy_dx[i] += dxj_dxi * y_sec[j] - x[j] * dy_dv_sec[j] * v / (x[j] * x[j]) * dxj_dxi;        \
+      }                                                                                            \
+      const Real dx_primary_dxi = -x_primary / (1. - x[i]);                                        \
+      dy_dx[i] += dx_primary_dxi * y_primary -                                                     \
+                  x_primary * dy_dv_primary * v / (x_primary * x_primary) * dx_primary_dxi;        \
+    }                                                                                              \
+  }
+
+/**
+ * Defines the value and derivative methods from (T,v) for a transport property y
+ */
+#define define_transport_prop_from_T_v(prop)                                                       \
+  Real IdealRealGasMixtureFluidProperties::prop##_from_T_v(                                        \
+      Real T, Real v, const std::vector<Real> & x) const                                           \
+  {                                                                                                \
+    const Real x_primary = primaryMassFraction(x);                                                 \
+    Real M_primary = _fp_primary->molarMass();                                                     \
+                                                                                                   \
+    Real sum = x_primary / M_primary;                                                              \
+    for (unsigned int i = 0; i < _n_secondary_vapors; i++)                                         \
+      sum += x[i] / _fp_secondary[i]->molarMass();                                                 \
+    const Real M_star = 1. / sum;                                                                  \
+                                                                                                   \
+    const Real vp = v / x_primary;                                                                 \
+    const Real ep = _fp_primary->e_from_T_v(T, vp);                                                \
+    const Real yp = _fp_primary->prop##_from_v_e(vp, ep);                                          \
+    Real y = x_primary * M_star / M_primary * yp;                                                  \
+                                                                                                   \
+    for (unsigned int i = 0; i < _n_secondary_vapors; i++)                                         \
+    {                                                                                              \
+      const Real vi = v / x[i];                                                                    \
+      const Real ei = _fp_secondary[i]->e_from_T_v(T, vp);                                         \
+      const Real Mi = _fp_secondary[i]->molarMass();                                               \
+      const Real yi = _fp_secondary[i]->prop##_from_v_e(vi, ei);                                   \
+      y += x[i] * M_star / Mi * yi;                                                                \
+    }                                                                                              \
+                                                                                                   \
+    return y;                                                                                      \
+  }                                                                                                \
+                                                                                                   \
+  void IdealRealGasMixtureFluidProperties::prop##_from_T_v(Real T,                                 \
+                                                           Real v,                                 \
+                                                           const std::vector<Real> & x,            \
+                                                           Real & y,                               \
+                                                           Real & dy_dT,                           \
+                                                           Real & dy_dv,                           \
+                                                           std::vector<Real> & dy_dx) const        \
+  {                                                                                                \
+    const Real x_primary = primaryMassFraction(x);                                                 \
+    Real M_primary = _fp_primary->molarMass();                                                     \
+                                                                                                   \
+    Real sum = x_primary / M_primary;                                                              \
+    for (unsigned int i = 0; i < _n_secondary_vapors; i++)                                         \
+      sum += x[i] / _fp_secondary[i]->molarMass();                                                 \
+    const Real M_star = 1. / sum;                                                                  \
+                                                                                                   \
+    const Real vp = v / x_primary;                                                                 \
+    const Real ep = _fp_primary->e_from_T_v(T, vp);                                                \
+    const Real yp = _fp_primary->prop##_from_v_e(vp, ep);                                          \
+    y = x_primary * M_star / M_primary * yp;                                                       \
+                                                                                                   \
+    dy_dT = 0;                                                                                     \
+    dy_dv = 0;                                                                                     \
+                                                                                                   \
+    Real sum_yj = 0;                                                                               \
+    dy_dx.resize(_n_secondary_vapors);                                                             \
+    for (unsigned int i = 0; i < _n_secondary_vapors; i++)                                         \
+    {                                                                                              \
+      const Real vi = v / x[i];                                                                    \
+      const Real ei = _fp_secondary[i]->e_from_T_v(T, vi);                                         \
+      const Real Mi = _fp_secondary[i]->molarMass();                                               \
+      const Real yi = _fp_secondary[i]->prop##_from_v_e(vi, ei);                                   \
+      y += x[i] * M_star / Mi * yi;                                                                \
+      dy_dx[i] = -M_star / M_primary * yp -                                                        \
+                 x_primary * (1 / Mi - 1 / M_primary) * M_star * M_star / M_primary * yp +         \
+                 M_star / Mi * yi;                                                                 \
+      sum_yj += x[i] * yi / Mi;                                                                    \
+    }                                                                                              \
+                                                                                                   \
+    for (unsigned int i = 0; i < _n_secondary_vapors; i++)                                         \
+    {                                                                                              \
+      const Real Mi = _fp_secondary[i]->molarMass();                                               \
+      dy_dx[i] += -M_star * M_star * (1 / Mi - 1 / M_primary) * sum_yj;                            \
+    }                                                                                              \
+  }
+
+define_mass_specific_prop_from_T_v(e) define_mass_specific_prop_from_T_v(s)
+
+    define_transport_prop_from_T_v(mu) define_transport_prop_from_T_v(k)
+
+        define_from_p_T_using_T_v(e) define_from_p_T_using_T_v(s) define_from_p_T_using_T_v(c)
+            define_from_p_T_using_T_v(cp) define_from_p_T_using_T_v(cv)
+                define_from_p_T_using_T_v(mu) define_from_p_T_using_T_v(k)
+
+                    define_from_v_e_using_T_v(p) define_from_v_e_using_T_v(c)
+
+                        InputParameters IdealRealGasMixtureFluidProperties::validParams()
 {
   InputParameters params = VaporMixtureFluidProperties::validParams();
   params += NaNInterface::validParams();
@@ -50,35 +266,29 @@ IdealRealGasMixtureFluidProperties::IdealRealGasMixtureFluidProperties(
 }
 
 Real
-IdealRealGasMixtureFluidProperties::p_from_v_e(Real v, Real e, const std::vector<Real> & x) const
-{
-  Real p, T;
-  p_T_from_v_e(v, e, x, p, T);
-
-  return p;
-}
-
-void
-IdealRealGasMixtureFluidProperties::p_from_v_e(Real v,
-                                               Real e,
-                                               const std::vector<Real> & x,
-                                               Real & p,
-                                               Real & dp_dv,
-                                               Real & dp_de,
-                                               std::vector<Real> & dp_dx) const
-{
-  Real T, dT_dv, dT_de;
-  std::vector<Real> dT_dx(_n_secondary_vapors);
-  p_T_from_v_e(v, e, x, p, dp_dv, dp_de, dp_dx, T, dT_dv, dT_de, dT_dx);
-}
-
-Real
 IdealRealGasMixtureFluidProperties::T_from_v_e(Real v, Real e, const std::vector<Real> & x) const
 {
-  Real p, T;
-  p_T_from_v_e(v, e, x, p, T);
+  Real v_primary = v / primaryMassFraction(x);
+  static const Real vc = 1. / _fp_primary->criticalDensity();
+  static const Real ec = _fp_primary->criticalInternalEnergy();
 
-  return T;
+  // Initial estimate of a bracketing interval for the temperature
+  Real lower_temperature, upper_temperature;
+  if (v_primary > vc)
+  {
+    Real e_sat_primary = _fp_primary->e_spndl_from_v(v_primary);
+    lower_temperature = _fp_primary->T_from_v_e(v_primary, e_sat_primary);
+  }
+  else
+    lower_temperature = _fp_primary->T_from_v_e(v_primary, ec);
+
+  upper_temperature = _T_mix_max;
+
+  // Use BrentsMethod to find temperature
+  auto energy_diff = [&v, &e, &x, this](Real T) { return this->e_from_T_v(T, v, x) - e; };
+
+  BrentsMethod::bracket(energy_diff, lower_temperature, upper_temperature);
+  return BrentsMethod::root(energy_diff, lower_temperature, upper_temperature);
 }
 
 void
@@ -90,50 +300,17 @@ IdealRealGasMixtureFluidProperties::T_from_v_e(Real v,
                                                Real & dT_de,
                                                std::vector<Real> & dT_dx) const
 {
-  Real p, dp_dv, dp_de;
-  std::vector<Real> dp_dx(_n_secondary_vapors);
-  p_T_from_v_e(v, e, x, p, dp_dv, dp_de, dp_dx, T, dT_dv, dT_de, dT_dx);
-}
+  T = T_from_v_e(v, e, x);
 
-Real
-IdealRealGasMixtureFluidProperties::c_from_v_e(Real v, Real e, const std::vector<Real> & x) const
-{
-  Real p, T;
-  p_T_from_v_e(v, e, x, p, T);
-  return c_from_T_v(T, v, x);
-}
-
-void
-IdealRealGasMixtureFluidProperties::c_from_v_e(Real v,
-                                               Real e,
-                                               const std::vector<Real> & x,
-                                               Real & c,
-                                               Real & dc_dv,
-                                               Real & dc_de,
-                                               std::vector<Real> & dc_dx) const
-{
-  Real p, T;
-  p_T_from_v_e(v, e, x, p, T);
-
-  // sound of speed and derivatives
-  Real dc_dT_v, dc_dv_T;
-  std::vector<Real> dc_dx_Tv;
-  c_from_T_v(T, v, x, c, dc_dT_v, dc_dv_T, dc_dx_Tv);
-
-  // internal energy and derivatives
   Real e_unused, de_dT_v, de_dv_T;
   std::vector<Real> de_dx_Tv;
   e_from_T_v(T, v, x, e_unused, de_dT_v, de_dv_T, de_dx_Tv);
 
-  // Compute derivatives using the following rules:
-  dc_dv = dc_dv_T - dc_dT_v * de_dv_T / de_dT_v;
-  dc_de = dc_dT_v / de_dT_v;
-
-  // Derivatives with respect to mass fractions:
+  dT_dv = -de_dv_T / de_dT_v;
+  dT_de = 1.0 / de_dT_v;
+  dT_dx.resize(_n_secondary_vapors);
   for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    dc_dx[i] = dc_dx_Tv[i] - dc_dT_v * de_dx_Tv[i] / de_dT_v;
-  }
+    dT_dx[i] = -de_dx_Tv[i] / de_dT_v;
 }
 
 Real
@@ -197,9 +374,7 @@ IdealRealGasMixtureFluidProperties::v_from_p_T(Real p, Real T, const std::vector
   auto pressure_diff = [&T, &p, &x, this](Real v) { return this->p_from_T_v(T, v, x) - p; };
 
   BrentsMethod::bracket(pressure_diff, lower_spec_volume, upper_spec_volume);
-  Real v = BrentsMethod::root(pressure_diff, lower_spec_volume, upper_spec_volume);
-
-  return v;
+  return BrentsMethod::root(pressure_diff, lower_spec_volume, upper_spec_volume);
 }
 
 void
@@ -211,348 +386,17 @@ IdealRealGasMixtureFluidProperties::v_from_p_T(Real p,
                                                Real & dv_dT,
                                                std::vector<Real> & dv_dx) const
 {
+  v = v_from_p_T(p, T, x);
+
   Real p_unused, dp_dT, dp_dv;
   std::vector<Real> dp_dx;
-  dp_dx.resize(_n_secondary_vapors);
-
-  v = v_from_p_T(p, T, x);
   p_from_T_v(T, v, x, p_unused, dp_dT, dp_dv, dp_dx);
 
   dv_dp = 1. / dp_dv;
   dv_dT = -dp_dT / dp_dv;
-
   dv_dx.resize(_n_secondary_vapors);
   for (unsigned int i = 0; i < _n_secondary_vapors; i++)
     dv_dx[i] = -dp_dx[i] / dp_dv;
-}
-
-Real
-IdealRealGasMixtureFluidProperties::e_from_p_T(Real p, Real T, const std::vector<Real> & x) const
-{
-  Real v = v_from_p_T(p, T, x);
-  return e_from_T_v(T, v, x);
-}
-
-void
-IdealRealGasMixtureFluidProperties::e_from_p_T(Real p,
-                                               Real T,
-                                               const std::vector<Real> & x,
-                                               Real & e,
-                                               Real & de_dp,
-                                               Real & de_dT,
-                                               std::vector<Real> & de_dx) const
-{
-  Real v, de_dT_v, de_dv_T, p_unused, dp_dT_v, dp_dv_T;
-  std::vector<Real> de_dx_Tv, dp_dx_Tv;
-  de_dx_Tv.resize(_n_secondary_vapors);
-  dp_dx_Tv.resize(_n_secondary_vapors);
-
-  v = v_from_p_T(p, T, x);
-  e_from_T_v(T, v, x, e, de_dT_v, de_dv_T, de_dx_Tv);
-  p_from_T_v(T, v, x, p_unused, dp_dT_v, dp_dv_T, dp_dx_Tv);
-
-  de_dp = de_dv_T / dp_dv_T;
-  de_dT = de_dT_v - de_dv_T * dp_dT_v / dp_dv_T;
-
-  de_dx.resize(_n_secondary_vapors);
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-    de_dx[i] = -(de_dv_T - de_dx_Tv[i] * dp_dv_T / dp_dx_Tv[i]) * dp_dx_Tv[i] / dp_dv_T;
-}
-
-Real
-IdealRealGasMixtureFluidProperties::c_from_p_T(Real p, Real T, const std::vector<Real> & x) const
-{
-  Real v;
-  Real p_unused, dp_dT, dp_dv;
-  Real s, ds_dT, ds_dv;
-
-  v = v_from_p_T(p, T, x);
-  p_from_T_v(T, v, x, p_unused, dp_dT, dp_dv);
-  s_from_T_v(T, v, x, s, ds_dT, ds_dv);
-
-  Real dp_dv_s = dp_dv - dp_dT * ds_dv / ds_dT;
-
-  if (dp_dv_s >= 0)
-    mooseWarning("c_from_p_T(), dp_dv_s = ", dp_dv_s, ". Should be negative.");
-  return v * std::sqrt(-dp_dv_s);
-}
-
-void
-IdealRealGasMixtureFluidProperties::c_from_p_T(Real p,
-                                               Real T,
-                                               const std::vector<Real> & x,
-                                               Real & c,
-                                               Real & dc_dp,
-                                               Real & dc_dT,
-                                               std::vector<Real> & dc_dx) const
-{
-  Real p_perturbed, T_perturbed, c_perturbed;
-
-  c = c_from_p_T(p, T, x);
-  // For derived properties, we would need higher order derivatives;
-  // therefore, numerical derivatives are used here
-  Real dp = p * 1.e-6;
-  p_perturbed = p + dp;
-  c_perturbed = c_from_p_T(p_perturbed, T, x);
-  dc_dp = (c_perturbed - c) / (dp);
-
-  Real dT = 1.e-6;
-  T_perturbed = T + dT;
-  c_perturbed = c_from_p_T(p, T_perturbed, x);
-  dc_dT = (c_perturbed - c) / (dT);
-
-  dc_dx.resize(_n_secondary_vapors);
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    Real c_perturbed;
-    std::vector<Real> x_perturbed(x);
-    Real dx_i = 1e-6;
-    for (unsigned int j = 0; j < _n_secondary_vapors; j++)
-    {
-      if (j != i)
-        x_perturbed[j] =
-            x[j] * (1.0 - (x[i] + dx_i)) / (1.0 - x[i]); // recalculate new mass fractions
-    }
-    x_perturbed[i] += dx_i;
-    c_perturbed = c_from_p_T(p, T, x_perturbed);
-    dc_dx[i] = ((c_perturbed - c) / dx_i);
-  }
-}
-
-Real
-IdealRealGasMixtureFluidProperties::cp_from_p_T(Real p, Real T, const std::vector<Real> & x) const
-{
-  Real p_unused, dp_dT, dp_dv;
-  Real h, dh_dT, dh_dv;
-
-  Real v = v_from_p_T(p, T, x);
-  p_from_T_v(T, v, x, p_unused, dp_dT, dp_dv);
-
-  const Real x_primary = primaryMassFraction(x);
-
-  _fp_primary->h_from_T_v(T, v / x_primary, h, dh_dT, dh_dv);
-  Real cp = x_primary * (dh_dT - dh_dv * dp_dT / dp_dv);
-
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    _fp_secondary[i]->h_from_T_v(T, v / x[i], h, dh_dT, dh_dv);
-    cp += x[i] * (dh_dT - dh_dv * dp_dT / dp_dv);
-  }
-
-  return cp;
-}
-void
-IdealRealGasMixtureFluidProperties::cp_from_p_T(Real p,
-                                                Real T,
-                                                const std::vector<Real> & x,
-                                                Real & cp,
-                                                Real & dcp_dp,
-                                                Real & dcp_dT,
-                                                std::vector<Real> & dcp_dx) const
-{
-  Real p_unused, dp_dT, dp_dv;
-  Real h, dh_dT, dh_dv;
-
-  Real v = v_from_p_T(p, T, x);
-  p_from_T_v(T, v, x, p_unused, dp_dT, dp_dv);
-
-  const Real x_primary = primaryMassFraction(x);
-
-  _fp_primary->h_from_T_v(T, v / x_primary, h, dh_dT, dh_dv);
-  const Real cp_xp = (dh_dT - dh_dv * dp_dT / dp_dv);
-  cp = x_primary * cp_xp;
-  dcp_dT = 0;
-  dcp_dp = 0;
-
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    _fp_secondary[i]->h_from_T_v(T, v / x[i], h, dh_dT, dh_dv);
-    cp += x[i] * (dh_dT - dh_dv * dp_dT / dp_dv);
-    dcp_dx[i] = (dh_dT - dh_dv * dp_dT / dp_dv) - cp_xp;
-  }
-}
-
-Real
-IdealRealGasMixtureFluidProperties::cv_from_p_T(Real p, Real T, const std::vector<Real> & x) const
-{
-  Real v = v_from_p_T(p, T, x);
-
-  const Real x_primary = primaryMassFraction(x);
-  Real cv = x_primary * _fp_primary->cv_from_T_v(T, v / x_primary);
-
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-    cv += x[i] * _fp_secondary[i]->cv_from_T_v(T, v / x[i]);
-
-  return cv;
-}
-void
-IdealRealGasMixtureFluidProperties::cv_from_p_T(Real p,
-                                                Real T,
-                                                const std::vector<Real> & x,
-                                                Real & cv,
-                                                Real & dcv_dp,
-                                                Real & dcv_dT,
-                                                std::vector<Real> & dcv_dx) const
-
-{
-  Real v = v_from_p_T(p, T, x);
-
-  const Real x_primary = primaryMassFraction(x);
-  const Real cv_xp = _fp_primary->cv_from_T_v(T, v / x_primary);
-  cv = x_primary * cv_xp;
-  dcv_dT = 0;
-  dcv_dp = 0;
-
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    cv += x[i] * _fp_secondary[i]->cv_from_T_v(T, v / x[i]);
-    dcv_dx[i] = _fp_secondary[i]->cv_from_T_v(T, v / x[i]) - cv_xp;
-  }
-}
-Real
-IdealRealGasMixtureFluidProperties::mu_from_p_T(Real p, Real T, const std::vector<Real> & x) const
-{
-  Real v = v_from_p_T(p, T, x);
-
-  const Real x_primary = primaryMassFraction(x);
-  Real M_primary = _fp_primary->molarMass();
-
-  Real sum = x_primary / M_primary;
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-    sum += x[i] / _fp_secondary[i]->molarMass();
-  Real M_star = 1. / sum;
-
-  Real vp = v / x_primary;
-  Real ep = _fp_primary->e_from_T_v(T, vp);
-  Real mu = x_primary * M_star / M_primary * _fp_primary->mu_from_v_e(vp, ep);
-
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    Real vi = v / x[i];
-    Real ei = _fp_secondary[i]->e_from_T_v(T, vi);
-    Real Mi = _fp_secondary[i]->molarMass();
-    mu += x[i] * M_star / Mi * _fp_secondary[i]->mu_from_v_e(vi, ei);
-  }
-
-  return mu;
-}
-void
-IdealRealGasMixtureFluidProperties::mu_from_p_T(Real p,
-                                                Real T,
-                                                const std::vector<Real> & x,
-                                                Real & mu,
-                                                Real & dmu_dp,
-                                                Real & dmu_dT,
-                                                std::vector<Real> & dmu_dx) const
-{
-  Real v = v_from_p_T(p, T, x);
-
-  const Real x_primary = primaryMassFraction(x);
-  Real M_primary = _fp_primary->molarMass();
-
-  Real sum = x_primary / M_primary;
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-    sum += x[i] / _fp_secondary[i]->molarMass();
-  Real M_star = 1. / sum;
-
-  Real vp = v / x_primary;
-  Real ep = _fp_primary->e_from_T_v(T, vp);
-  Real mup = _fp_primary->mu_from_v_e(vp, ep);
-  mu = x_primary * M_star / M_primary * mup;
-  dmu_dT = 0;
-  dmu_dp = 0;
-
-  Real sum_muj = 0;
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    const Real vi = v / x[i];
-    const Real ei = _fp_secondary[i]->e_from_T_v(T, vi);
-    const Real Mi = _fp_secondary[i]->molarMass();
-    const Real mui = _fp_secondary[i]->mu_from_v_e(vi, ei);
-    mu += x[i] * M_star / Mi * mui;
-    dmu_dx[i] = -M_star / M_primary * mup -
-                x_primary * (1 / Mi - 1 / M_primary) * M_star * M_star / M_primary * mup +
-                M_star / Mi * mui;
-    sum_muj += x[i] * mui / Mi;
-  }
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    const Real Mi = _fp_secondary[i]->molarMass();
-    dmu_dx[i] += -M_star * M_star * (1 / Mi - 1 / M_primary) * sum_muj;
-  }
-}
-
-Real
-IdealRealGasMixtureFluidProperties::k_from_p_T(Real p, Real T, const std::vector<Real> & x) const
-{
-  Real v = v_from_p_T(p, T, x);
-
-  const Real x_primary = primaryMassFraction(x);
-  Real M_primary = _fp_primary->molarMass();
-
-  Real sum = x_primary / M_primary;
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-    sum += x[i] / _fp_secondary[i]->molarMass();
-  Real M_star = 1. / sum;
-
-  Real vp = v / x_primary;
-  Real ep = _fp_primary->e_from_T_v(T, vp);
-  Real k = x_primary * M_star / M_primary * _fp_primary->k_from_v_e(vp, ep);
-
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    Real vi = v / x[i];
-    Real ei = _fp_secondary[i]->e_from_T_v(T, vi);
-    Real Mi = _fp_secondary[i]->molarMass();
-    k += x[i] * M_star / Mi * _fp_secondary[i]->k_from_v_e(vi, ei);
-  }
-
-  return k;
-}
-void
-IdealRealGasMixtureFluidProperties::k_from_p_T(Real p,
-                                               Real T,
-                                               const std::vector<Real> & x,
-                                               Real & k,
-                                               Real & dk_dp,
-                                               Real & dk_dT,
-                                               std::vector<Real> & dk_dx) const
-{
-  Real v = v_from_p_T(p, T, x);
-
-  const Real x_primary = primaryMassFraction(x);
-  Real M_primary = _fp_primary->molarMass();
-
-  Real sum = x_primary / M_primary;
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-    sum += x[i] / _fp_secondary[i]->molarMass();
-  Real M_star = 1. / sum;
-
-  Real vp = v / x_primary;
-  Real ep = _fp_primary->e_from_T_v(T, vp);
-  const Real kp = _fp_primary->k_from_v_e(vp, ep);
-  k = x_primary * M_star / M_primary * kp;
-  dk_dp = 0;
-  dk_dT = 0;
-
-  Real sum_kj = 0;
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    Real vi = v / x[i];
-    Real ei = _fp_secondary[i]->e_from_T_v(T, vi);
-    Real Mi = _fp_secondary[i]->molarMass();
-    Real ki = _fp_secondary[i]->k_from_v_e(vi, ei);
-    k += x[i] * M_star / Mi * ki;
-    dk_dx[i] = -M_star / M_primary * kp -
-               x_primary * (1 / Mi - 1 / M_primary) * M_star * M_star / M_primary * kp +
-               M_star / Mi * ki;
-    sum_kj += x[i] * ki / Mi;
-  }
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    Real Mi = _fp_secondary[i]->molarMass();
-    dk_dx[i] += -M_star * M_star * (1 / Mi - 1 / M_primary) * sum_kj;
-  }
 }
 
 Real
@@ -594,74 +438,6 @@ IdealRealGasMixtureFluidProperties::e_from_p_rho(Real p,
   }
 }
 
-void
-IdealRealGasMixtureFluidProperties::p_T_from_v_e(
-    Real v, Real e, const std::vector<Real> & x, Real & p, Real & T) const
-{
-  Real v_primary = v / primaryMassFraction(x);
-  static const Real vc = 1. / _fp_primary->criticalDensity();
-  static const Real ec = _fp_primary->criticalInternalEnergy();
-
-  // Initial estimate of a bracketing interval for the temperature
-  Real lower_temperature, upper_temperature;
-  if (v_primary > vc)
-  {
-    Real e_sat_primary = _fp_primary->e_spndl_from_v(v_primary);
-    lower_temperature = _fp_primary->T_from_v_e(v_primary, e_sat_primary);
-  }
-  else
-    lower_temperature = _fp_primary->T_from_v_e(v_primary, ec);
-
-  upper_temperature = _T_mix_max;
-
-  // Use BrentsMethod to find temperature
-  auto energy_diff = [&v, &e, &x, this](Real T) { return this->e_from_T_v(T, v, x) - e; };
-
-  BrentsMethod::bracket(energy_diff, lower_temperature, upper_temperature);
-  T = BrentsMethod::root(energy_diff, lower_temperature, upper_temperature);
-
-  p = p_from_T_v(T, v, x);
-}
-
-void
-IdealRealGasMixtureFluidProperties::p_T_from_v_e(Real v,
-                                                 Real e,
-                                                 const std::vector<Real> & x,
-                                                 Real & p,
-                                                 Real & dp_dv,
-                                                 Real & dp_de,
-                                                 std::vector<Real> & dp_dx,
-                                                 Real & T,
-                                                 Real & dT_dv,
-                                                 Real & dT_de,
-                                                 std::vector<Real> & dT_dx) const
-{
-  p_T_from_v_e(v, e, x, p, T);
-
-  // pressure and derivatives
-  Real p_unused, dp_dT_v, dp_dv_T;
-  std::vector<Real> dp_dx_Tv;
-  p_from_T_v(T, v, x, p_unused, dp_dT_v, dp_dv_T, dp_dx_Tv);
-
-  // internal energy and derivatives
-  Real e_unused, de_dT_v, de_dv_T;
-  std::vector<Real> de_dx_Tv;
-  e_from_T_v(T, v, x, e_unused, de_dT_v, de_dv_T, de_dx_Tv);
-
-  // Compute derivatives using the following rules:
-  dp_dv = dp_dv_T - dp_dT_v * de_dv_T / de_dT_v;
-  dp_de = dp_dT_v / de_dT_v;
-  dT_dv = -de_dv_T / de_dT_v;
-  dT_de = 1. / de_dT_v;
-
-  // Derivatives with respect to mass fractions:
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    dT_dx[i] = -de_dx_Tv[i] / de_dT_v;
-    dp_dx[i] = dp_dx_Tv[i] + dp_dT_v * dT_dx[i];
-  }
-}
-
 Real
 IdealRealGasMixtureFluidProperties::T_from_p_v(Real p, Real v, const std::vector<Real> & x) const
 {
@@ -685,9 +461,7 @@ IdealRealGasMixtureFluidProperties::T_from_p_v(Real p, Real v, const std::vector
   auto pressure_diff = [&p, &v, &x, this](Real T) { return this->p_from_T_v(T, v, x) - p; };
 
   BrentsMethod::bracket(pressure_diff, lower_temperature, upper_temperature);
-  Real T = BrentsMethod::root(pressure_diff, lower_temperature, upper_temperature);
-
-  return T;
+  return BrentsMethod::root(pressure_diff, lower_temperature, upper_temperature);
 }
 
 void
@@ -712,9 +486,7 @@ IdealRealGasMixtureFluidProperties::T_from_p_v(Real p,
 
   // Derivatives with respect to mass fractions:
   for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
     dT_dx[i] = -dp_dx_Tv[i] / dp_dT_v;
-  }
 }
 
 Real
@@ -730,30 +502,6 @@ IdealRealGasMixtureFluidProperties::p_from_T_v(Real T, Real v, const std::vector
 }
 
 void
-IdealRealGasMixtureFluidProperties::p_from_T_v(
-    Real T, Real v, const std::vector<Real> & x, Real & p, Real & dp_dT, Real & dp_dv) const
-{
-  Real p_primary, dp_dT_primary, dp_dv_primary;
-  Real p_sec, dp_dT_sec, dp_dv_sec;
-
-  const Real x_primary = primaryMassFraction(x);
-
-  _fp_primary->p_from_T_v(T, v / x_primary, p_primary, dp_dT_primary, dp_dv_primary);
-  p = p_primary;
-  dp_dT = dp_dT_primary;
-  dp_dv = dp_dv_primary / x_primary;
-
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    _fp_secondary[i]->p_from_T_v(T, v / x[i], p_sec, dp_dT_sec, dp_dv_sec);
-
-    p += p_sec;
-    dp_dT += dp_dT_sec;
-    dp_dv += dp_dv_sec / x[i];
-  }
-}
-
-void
 IdealRealGasMixtureFluidProperties::p_from_T_v(Real T,
                                                Real v,
                                                const std::vector<Real> & x,
@@ -762,30 +510,27 @@ IdealRealGasMixtureFluidProperties::p_from_T_v(Real T,
                                                Real & dp_dv,
                                                std::vector<Real> & dp_dx) const
 {
-  Real p_primary, dp_dT_primary, dp_dv_primary;
-  Real p_sec, dp_dT_sec, dxj_dxi;
-  std::vector<Real> dp_dv_sec;
-
   const Real x_primary = primaryMassFraction(x);
-  dp_dx.resize(_n_secondary_vapors);
-  dp_dv_sec.resize(_n_secondary_vapors);
 
+  Real p_primary, dp_dT_primary, dp_dv_primary;
   _fp_primary->p_from_T_v(T, v / x_primary, p_primary, dp_dT_primary, dp_dv_primary);
   p = p_primary;
   dp_dT = dp_dT_primary;
   dp_dv = dp_dv_primary / x_primary;
 
   // get the partial pressures and their derivatives first
+  Real p_sec, dp_dT_sec, dxj_dxi;
+  std::vector<Real> dp_dv_sec(_n_secondary_vapors);
   for (unsigned int i = 0; i < _n_secondary_vapors; i++)
   {
     _fp_secondary[i]->p_from_T_v(T, v / x[i], p_sec, dp_dT_sec, dp_dv_sec[i]);
-
     p += p_sec;
     dp_dT += dp_dT_sec;
     dp_dv += dp_dv_sec[i] / x[i];
   }
 
   // get the composition dependent derivatives of the secondary vapors
+  dp_dx.resize(_n_secondary_vapors);
   for (unsigned int i = 0; i < _n_secondary_vapors; i++)
   {
     dp_dx[i] = -dp_dv_sec[i] * v / (x[i] * x[i]);
@@ -801,104 +546,20 @@ IdealRealGasMixtureFluidProperties::p_from_T_v(Real T,
 }
 
 Real
-IdealRealGasMixtureFluidProperties::e_from_T_v(Real T, Real v, const std::vector<Real> & x) const
-{
-  const Real x_primary = primaryMassFraction(x);
-  Real e = x_primary * _fp_primary->e_from_T_v(T, v / x_primary);
-
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-    e += x[i] * _fp_secondary[i]->e_from_T_v(T, v / x[i]);
-
-  return e;
-}
-
-void
-IdealRealGasMixtureFluidProperties::e_from_T_v(Real T,
-                                               Real v,
-                                               const std::vector<Real> & x,
-                                               Real & e,
-                                               Real & de_dT,
-                                               Real & de_dv,
-                                               std::vector<Real> & de_dx) const
-{
-  Real e_primary, de_dT_primary, de_dv_primary;
-  Real de_dT_sec, dxj_dxi, dx_primary_dxi;
-  std::vector<Real> e_sec, de_dv_sec;
-
-  const Real x_primary = primaryMassFraction(x);
-  de_dx.resize(_n_secondary_vapors);
-  e_sec.resize(_n_secondary_vapors);
-  de_dv_sec.resize(_n_secondary_vapors);
-
-  _fp_primary->e_from_T_v(T, v / x_primary, e_primary, de_dT_primary, de_dv_primary);
-  e = x_primary * e_primary;
-  de_dT = x_primary * de_dT_primary;
-  de_dv = de_dv_primary;
-
-  // get the partial pressures and their derivatives first
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    _fp_secondary[i]->e_from_T_v(T, v / x[i], e_sec[i], de_dT_sec, de_dv_sec[i]);
-
-    e += x[i] * e_sec[i];
-    de_dT += x[i] * de_dT_sec;
-    de_dv += de_dv_sec[i];
-  }
-
-  // get the composition dependent derivatives of the secondary vapors
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    de_dx[i] = e_sec[i] - x[i] * de_dv_sec[i] * v / (x[i] * x[i]);
-    for (unsigned int j = 0; j < _n_secondary_vapors; j++)
-    {
-      if (j == i)
-        continue;
-      dxj_dxi = -x[j] / (1. - x[i]);
-      de_dx[i] += dxj_dxi * e_sec[j] - x[j] * de_dv_sec[j] * v / (x[j] * x[j]) * dxj_dxi;
-    }
-    dx_primary_dxi = -x_primary / (1. - x[i]);
-    de_dx[i] += dx_primary_dxi * e_primary -
-                x_primary * de_dv_primary * v / (x_primary * x_primary) * dx_primary_dxi;
-  }
-}
-
-void
-IdealRealGasMixtureFluidProperties::s_from_T_v(
-    Real T, Real v, const std::vector<Real> & x, Real & s, Real & ds_dT, Real & ds_dv) const
-{
-  Real s_primary, ds_dT_primary, ds_dv_primary;
-  Real s_sec, ds_dT_sec, ds_dv_sec;
-
-  const Real x_primary = primaryMassFraction(x);
-
-  _fp_primary->s_from_T_v(T, v / x_primary, s_primary, ds_dT_primary, ds_dv_primary);
-  s = x_primary * s_primary;
-  ds_dT = x_primary * ds_dT_primary;
-  ds_dv = ds_dv_primary;
-
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    _fp_secondary[i]->s_from_T_v(T, v / x[i], s_sec, ds_dT_sec, ds_dv_sec);
-
-    s += x[i] * s_sec;
-    ds_dT += x[i] * ds_dT_sec;
-    ds_dv += ds_dv_sec;
-  }
-}
-
-Real
 IdealRealGasMixtureFluidProperties::c_from_T_v(Real T, Real v, const std::vector<Real> & x) const
 {
   Real p, dp_dT, dp_dv;
+  std::vector<Real> dp_dx;
+  p_from_T_v(T, v, x, p, dp_dT, dp_dv, dp_dx);
+
   Real s, ds_dT, ds_dv;
+  std::vector<Real> ds_dx;
+  s_from_T_v(T, v, x, s, ds_dT, ds_dv, ds_dx);
 
-  p_from_T_v(T, v, x, p, dp_dT, dp_dv);
-  s_from_T_v(T, v, x, s, ds_dT, ds_dv);
-
-  Real dp_dv_s = dp_dv - dp_dT * ds_dv / ds_dT;
+  const Real dp_dv_s = dp_dv - dp_dT * ds_dv / ds_dT;
 
   if (dp_dv_s >= 0)
-    mooseWarning("c_from_T_v(), dp_dv_s = ", dp_dv_s, ". Should be negative.");
+    mooseWarning("c_from_T_v(): dp_dv_s = ", dp_dv_s, ". Should be negative.");
   return v * std::sqrt(-dp_dv_s);
 }
 
@@ -911,27 +572,25 @@ IdealRealGasMixtureFluidProperties::c_from_T_v(Real T,
                                                Real & dc_dv,
                                                std::vector<Real> & dc_dx) const
 {
-  Real T_perturbed, v_perturbed, c_perturbed;
-
   c = c_from_T_v(T, v, x);
+
   // For derived properties, we would need higher order derivatives;
   // therefore, numerical derivatives are used here.
-  Real dT = 1.e-6;
-  T_perturbed = T + dT;
-  c_perturbed = c_from_T_v(T_perturbed, v, x);
-  dc_dT = (c_perturbed - c) / (dT);
+  const Real dT = 1.e-6;
+  const Real T_perturbed = T + dT;
+  Real c_perturbed = c_from_T_v(T_perturbed, v, x);
+  dc_dT = (c_perturbed - c) / dT;
 
-  Real dv = v * 1.e-6;
-  v_perturbed = v + dv;
+  const Real dv = v * 1.e-6;
+  const Real v_perturbed = v + dv;
   c_perturbed = c_from_T_v(T, v_perturbed, x);
-  dc_dv = (c_perturbed - c) / (dv);
+  dc_dv = (c_perturbed - c) / dv;
 
   dc_dx.resize(_n_secondary_vapors);
   for (unsigned int i = 0; i < _n_secondary_vapors; i++)
   {
-    Real c_perturbed;
     std::vector<Real> x_perturbed(x);
-    Real dx_i = 1e-6;
+    const Real dx_i = 1e-6;
     for (unsigned int j = 0; j < _n_secondary_vapors; j++)
     {
       if (j != i)
@@ -947,23 +606,60 @@ IdealRealGasMixtureFluidProperties::c_from_T_v(Real T,
 Real
 IdealRealGasMixtureFluidProperties::cp_from_T_v(Real T, Real v, const std::vector<Real> & x) const
 {
-  Real p, dp_dT, dp_dv;
-  Real h, dh_dT, dh_dv;
-
-  p_from_T_v(T, v, x, p, dp_dT, dp_dv);
-
   const Real x_primary = primaryMassFraction(x);
 
+  Real p, dp_dT, dp_dv;
+  std::vector<Real> dp_dx;
+  p_from_T_v(T, v, x, p, dp_dT, dp_dv, dp_dx);
+
+  Real h, dh_dT, dh_dv;
   _fp_primary->h_from_T_v(T, v / x_primary, h, dh_dT, dh_dv);
-  Real cp = x_primary * (dh_dT - dh_dv * dp_dT / dp_dv);
+  const Real cp_primary = dh_dT - dh_dv * dp_dT / dp_dv;
+  Real cp = x_primary * cp_primary;
 
   for (unsigned int i = 0; i < _n_secondary_vapors; i++)
   {
     _fp_secondary[i]->h_from_T_v(T, v / x[i], h, dh_dT, dh_dv);
-    cp += x[i] * (dh_dT - dh_dv * dp_dT / dp_dv);
+    const Real cp_sec = dh_dT - dh_dv * dp_dT / dp_dv;
+    cp += x[i] * cp_sec;
   }
 
   return cp;
+}
+
+void
+IdealRealGasMixtureFluidProperties::cp_from_T_v(Real T,
+                                                Real v,
+                                                const std::vector<Real> & x,
+                                                Real & cp,
+                                                Real & dcp_dT,
+                                                Real & dcp_dv,
+                                                std::vector<Real> & dcp_dx) const
+{
+  const Real x_primary = primaryMassFraction(x);
+
+  Real p, dp_dT, dp_dv;
+  std::vector<Real> dp_dx;
+  p_from_T_v(T, v, x, p, dp_dT, dp_dv, dp_dx);
+
+  Real h, dh_dT, dh_dv;
+  _fp_primary->h_from_T_v(T, v / x_primary, h, dh_dT, dh_dv);
+  const Real cp_primary = dh_dT - dh_dv * dp_dT / dp_dv;
+  cp = x_primary * cp_primary;
+
+  // Neglect these for now. These require higher-order derivatives, so a finite
+  // difference should probably be used, as for sound speed.
+  dcp_dT = 0;
+  dcp_dv = 0;
+
+  dcp_dx.resize(_n_secondary_vapors);
+  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
+  {
+    _fp_secondary[i]->h_from_T_v(T, v / x[i], h, dh_dT, dh_dv);
+    const Real cp_sec = dh_dT - dh_dv * dp_dT / dp_dv;
+    cp += x[i] * cp_sec;
+    dcp_dx[i] = cp_sec - cp_primary;
+  }
 }
 
 Real
@@ -978,56 +674,31 @@ IdealRealGasMixtureFluidProperties::cv_from_T_v(Real T, Real v, const std::vecto
   return cv;
 }
 
-Real
-IdealRealGasMixtureFluidProperties::mu_from_T_v(Real T, Real v, const std::vector<Real> & x) const
+void
+IdealRealGasMixtureFluidProperties::cv_from_T_v(Real T,
+                                                Real v,
+                                                const std::vector<Real> & x,
+                                                Real & cv,
+                                                Real & dcv_dT,
+                                                Real & dcv_dv,
+                                                std::vector<Real> & dcv_dx) const
 {
   const Real x_primary = primaryMassFraction(x);
-  Real M_primary = _fp_primary->molarMass();
+  const Real cv_primary = _fp_primary->cv_from_T_v(T, v / x_primary);
+  cv = x_primary * cv_primary;
 
-  Real sum = x_primary / M_primary;
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-    sum += x[i] / _fp_secondary[i]->molarMass();
-  Real M_star = 1. / sum;
+  // Neglect these for now. These require higher-order derivatives, so a finite
+  // difference should probably be used, as for sound speed.
+  dcv_dT = 0;
+  dcv_dv = 0;
 
-  Real vp = v / x_primary;
-  Real ep = _fp_primary->e_from_T_v(T, vp);
-  Real mu = x_primary * M_star / M_primary * _fp_primary->mu_from_v_e(vp, ep);
-
+  dcv_dx.resize(_n_secondary_vapors);
   for (unsigned int i = 0; i < _n_secondary_vapors; i++)
   {
-    Real vi = v / x[i];
-    Real ei = _fp_secondary[i]->e_from_T_v(T, vp);
-    Real Mi = _fp_secondary[i]->molarMass();
-    mu += x[i] * M_star / Mi * _fp_secondary[i]->mu_from_v_e(vi, ei);
+    const Real cv_sec = _fp_secondary[i]->cv_from_T_v(T, v / x[i]);
+    cv += x[i] * cv_sec;
+    dcv_dx[i] = cv_sec - cv_primary;
   }
-
-  return mu;
-}
-
-Real
-IdealRealGasMixtureFluidProperties::k_from_T_v(Real T, Real v, const std::vector<Real> & x) const
-{
-  const Real x_primary = primaryMassFraction(x);
-  Real M_primary = _fp_primary->molarMass();
-
-  Real sum = x_primary / M_primary;
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-    sum += x[i] / _fp_secondary[i]->molarMass();
-  Real M_star = 1. / sum;
-
-  Real vp = v / x_primary;
-  Real ep = _fp_primary->e_from_T_v(T, vp);
-  Real k = x_primary * M_star / M_primary * _fp_primary->k_from_v_e(vp, ep);
-
-  for (unsigned int i = 0; i < _n_secondary_vapors; i++)
-  {
-    Real vi = v / x[i];
-    Real ei = _fp_secondary[i]->e_from_T_v(T, vp);
-    Real Mi = _fp_secondary[i]->molarMass();
-    k += x[i] * M_star / Mi * _fp_secondary[i]->k_from_v_e(vi, ei);
-  }
-
-  return k;
 }
 
 Real
@@ -1038,7 +709,7 @@ IdealRealGasMixtureFluidProperties::xs_prim_from_p_T(Real p,
   Real T_c = _fp_primary->criticalTemperature();
   Real xs;
   if (T > T_c)
-    // return 1. to indicate that no water would condense for
+    // return 1. to indicate that the primary fluid will not condense for
     // given (p,T)
     xs = 1.;
   else
@@ -1046,7 +717,7 @@ IdealRealGasMixtureFluidProperties::xs_prim_from_p_T(Real p,
     Real pp_sat = _fp_primary->pp_sat_from_p_T(p, T);
     if (pp_sat < 0.)
     {
-      // return 1. to indicate that no water would condense for
+      // return 1. to indicate that the primary fluid will not condense for
       // given (p,T)
       xs = 1.;
       return xs;

--- a/modules/fluid_properties/src/fluidproperties/SinglePhaseFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/SinglePhaseFluidProperties.C
@@ -309,13 +309,13 @@ SinglePhaseFluidProperties::criticalTemperature() const
 Real
 SinglePhaseFluidProperties::criticalDensity() const
 {
-  mooseError(__PRETTY_FUNCTION__, " not implemented.");
+  return rho_from_p_T(criticalPressure(), criticalTemperature());
 }
 
 Real
 SinglePhaseFluidProperties::criticalInternalEnergy() const
 {
-  mooseError(__PRETTY_FUNCTION__, " not implemented.");
+  return e_from_p_rho(criticalPressure(), criticalDensity());
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/FluidPropertiesInterrogator.C
+++ b/modules/fluid_properties/src/userobjects/FluidPropertiesInterrogator.C
@@ -478,22 +478,6 @@ FluidPropertiesInterrogator::computeVaporMixture(bool throw_error_if_no_match)
     params.set<Real>("cv") = cv;
     params.set<Real>("k") = k;
 
-    const auto x_ncg = params.get<std::vector<Real>>("x_ncg");
-    for (unsigned int i = 0; i < x_ncg.size(); i++)
-      outputProperty("Mass fraction " + std::to_string(i), x_ncg[i], "-");
-    outputProperty("Pressure", params.get<Real>("p"), "Pa");
-    outputProperty("Temperature", params.get<Real>("T"), "K");
-    outputProperty("Density", params.get<Real>("rho"), "kg/m^3");
-    outputProperty("Specific volume", params.get<Real>("v"), "m^3/kg");
-    outputProperty("Specific internal energy", params.get<Real>("e"), "J/kg");
-    outputProperty("Specific enthalpy", params.get<Real>("h"), "J/kg");
-    _console << std::endl;
-    outputProperty("Sound speed", params.get<Real>("c"), "m/s");
-    outputProperty("Dynamic viscosity", params.get<Real>("mu"), "Pa-s");
-    outputProperty("Specific heat at constant pressure", params.get<Real>("cp"), "J/(kg-K)");
-    outputProperty("Specific heat at constant volume", params.get<Real>("cv"), "J/(kg-K)");
-    outputProperty("Thermal conductivity", params.get<Real>("k"), "W/(m-K)");
-
     if (isParamValid("vel") || specified["rho,rhou,rhoE,x_ncg"])
     {
       const Real h = e + p / rho;

--- a/modules/fluid_properties/src/userobjects/FluidPropertiesInterrogator.C
+++ b/modules/fluid_properties/src/userobjects/FluidPropertiesInterrogator.C
@@ -459,6 +459,7 @@ FluidPropertiesInterrogator::computeVaporMixture(bool throw_error_if_no_match)
 
     const Real v = 1.0 / rho;
     const Real h = e + p / rho;
+    const Real s = _fp_vapor_mixture->s_from_p_T(p, T, x_ncg);
     const Real c = _fp_vapor_mixture->c_from_p_T(p, T, x_ncg);
     const Real mu = _fp_vapor_mixture->mu_from_p_T(p, T, x_ncg);
     const Real cp = _fp_vapor_mixture->cp_from_p_T(p, T, x_ncg);
@@ -472,6 +473,7 @@ FluidPropertiesInterrogator::computeVaporMixture(bool throw_error_if_no_match)
     params.set<Real>("e") = e;
     params.set<Real>("v") = v;
     params.set<Real>("h") = h;
+    params.set<Real>("s") = s;
     params.set<Real>("c") = c;
     params.set<Real>("mu") = mu;
     params.set<Real>("cp") = cp;
@@ -537,7 +539,7 @@ void
 FluidPropertiesInterrogator::buildJSONVaporMixture(nlohmann::json & json,
                                                    const InputParameters & params)
 {
-  for (auto p : {"p", "T", "rho", "e", "v", "h", "c", "mu", "cp", "cv", "k"})
+  for (auto p : {"p", "T", "rho", "e", "v", "h", "s", "c", "mu", "cp", "cv", "k"})
     if (params.have_parameter<Real>(p))
       json["static"][p] = params.get<Real>(p);
 
@@ -764,6 +766,7 @@ FluidPropertiesInterrogator::outputVaporMixtureStaticProperties(const InputParam
   outputProperty("Specific volume", params.get<Real>("v"), "m^3/kg");
   outputProperty("Specific internal energy", params.get<Real>("e"), "J/kg");
   outputProperty("Specific enthalpy", params.get<Real>("h"), "J/kg");
+  outputProperty("Specific entropy", params.get<Real>("s"), "J/kg");
   _console << std::endl;
   outputProperty("Sound speed", params.get<Real>("c"), "m/s");
   outputProperty("Dynamic viscosity", params.get<Real>("mu"), "Pa-s");

--- a/modules/fluid_properties/src/utils/BrentsMethod.C
+++ b/modules/fluid_properties/src/utils/BrentsMethod.C
@@ -37,8 +37,10 @@ bracket(std::function<Real(Real)> const & f, Real & x1, Real & x2)
     std::stringstream debug_ss;
     while (f1 * f2 > 0.0)
     {
+#ifdef DEBUG
       debug_ss << "  iteration " << iter << ": (x1,x2) = (" << x1 << "," << x2 << "), (f1,f2) = ("
                << f1 << "," << f2 << ")\n";
+#endif
       if (std::abs(f1) < std::abs(f2))
       {
         x1 += factor * (x1 - x2);
@@ -55,7 +57,7 @@ bracket(std::function<Real(Real)> const & f, Real & x1, Real & x2)
       iter++;
       if (iter >= n)
         throw MooseException("No bracketing interval found by BrentsMethod::bracket after " +
-                             Moose::stringify(n) + " iterations:\n" + debug_ss.str());
+                             Moose::stringify(n) + " iterations.\n" + debug_ss.str());
     }
   }
 }
@@ -77,8 +79,10 @@ root(std::function<Real(Real)> const & f, Real x1, Real x2, Real tol)
   std::stringstream debug_ss;
   for (unsigned int i = 1; i <= iter_max; ++i)
   {
+#ifdef DEBUG
     debug_ss << "  iteration " << i << ": dx = " << xm << ", x = " << b << ", f(x) = " << fb
              << "\n";
+#endif
     if (fb * fc > 0.0)
     {
       // Rename a,b and c and adjust bounding interval d
@@ -160,7 +164,7 @@ root(std::function<Real(Real)> const & f, Real x1, Real x2, Real tol)
     fb = f(b);
   }
 
-  throw MooseException("Maximum number of iterations exceeded in BrentsMethod::root:\n" +
+  throw MooseException("Maximum number of iterations exceeded in BrentsMethod::root.\n" +
                        debug_ss.str());
   return 0.0; // Should never get here
 }

--- a/modules/fluid_properties/src/utils/BrentsMethod.C
+++ b/modules/fluid_properties/src/utils/BrentsMethod.C
@@ -34,8 +34,11 @@ bracket(std::function<Real(Real)> const & f, Real & x1, Real & x2)
   if (f1 * f2 > 0.0)
   {
     unsigned int iter = 0;
+    std::stringstream debug_ss;
     while (f1 * f2 > 0.0)
     {
+      debug_ss << "  iteration " << iter << ": (x1,x2) = (" << x1 << "," << x2 << "), (f1,f2) = ("
+               << f1 << "," << f2 << ")\n";
       if (std::abs(f1) < std::abs(f2))
       {
         x1 += factor * (x1 - x2);
@@ -52,7 +55,7 @@ bracket(std::function<Real(Real)> const & f, Real & x1, Real & x2)
       iter++;
       if (iter >= n)
         throw MooseException("No bracketing interval found by BrentsMethod::bracket after " +
-                             Moose::stringify(n) + " iterations");
+                             Moose::stringify(n) + " iterations:\n" + debug_ss.str());
     }
   }
 }
@@ -63,7 +66,7 @@ root(std::function<Real(Real)> const & f, Real x1, Real x2, Real tol)
   Real a = x1, b = x2, c = x2, d = 0.0, e = 0.0, min1, min2;
   Real fa = f(a);
   Real fb = f(b);
-  Real fc, p, q, r, s, tol1, xm;
+  Real fc, p, q, r, s, tol1, xm = 0;
   unsigned int iter_max = 100;
   Real eps = 1.0e-12;
 
@@ -71,8 +74,11 @@ root(std::function<Real(Real)> const & f, Real x1, Real x2, Real tol)
     throw MooseException("Root must be bracketed in BrentsMethod::root");
 
   fc = fb;
+  std::stringstream debug_ss;
   for (unsigned int i = 1; i <= iter_max; ++i)
   {
+    debug_ss << "  iteration " << i << ": dx = " << xm << ", x = " << b << ", f(x) = " << fb
+             << "\n";
     if (fb * fc > 0.0)
     {
       // Rename a,b and c and adjust bounding interval d
@@ -154,7 +160,8 @@ root(std::function<Real(Real)> const & f, Real x1, Real x2, Real tol)
     fb = f(b);
   }
 
-  throw MooseException("Maximum number of iterations exceeded in BrentsMethod::root");
+  throw MooseException("Maximum number of iterations exceeded in BrentsMethod::root:\n" +
+                       debug_ss.str());
   return 0.0; // Should never get here
 }
 } // namespace BrentsMethod

--- a/modules/fluid_properties/test/include/utils/FluidPropertiesTestUtils.h
+++ b/modules/fluid_properties/test/include/utils/FluidPropertiesTestUtils.h
@@ -28,7 +28,7 @@
 // difference approximation
 #define REL_TOL_DERIVATIVE 1e-6
 
-// Macro for computing relative error
+// Macro for performing relative error test
 #define REL_TEST(value, ref_value, tol)                                                            \
   if (std::abs(ref_value) < 1e-15)                                                                 \
     ABS_TEST(value, ref_value, tol);                                                               \
@@ -36,6 +36,15 @@
     EXPECT_LE(std::abs(((MetaPhysicL::raw_value(value)) - (MetaPhysicL::raw_value(ref_value))) /   \
                        (MetaPhysicL::raw_value(ref_value))),                                       \
               tol);
+
+// Macro for performing relative or absolute error test
+#define REL_ABS_TEST(value, ref_value, rel_tol, abs_tol)                                           \
+  if (std::abs(ref_value - value) < abs_tol)                                                       \
+    EXPECT_TRUE(true);                                                                             \
+  else                                                                                             \
+    EXPECT_LE(std::abs(((MetaPhysicL::raw_value(value)) - (MetaPhysicL::raw_value(ref_value))) /   \
+                       (MetaPhysicL::raw_value(ref_value))),                                       \
+              rel_tol);
 
 // Macro for computing absolute error
 #define ABS_TEST(value, ref_value, tol)                                                            \

--- a/modules/fluid_properties/test/include/utils/VaporMixtureFluidPropertiesUtils.h
+++ b/modules/fluid_properties/test/include/utils/VaporMixtureFluidPropertiesUtils.h
@@ -12,8 +12,9 @@
 #include "SinglePhaseFluidPropertiesTestUtils.h"
 
 // Macro for performing a derivative test
-#define VAPOR_MIX_DERIV_TEST(f, a, b, x, tol)                                                      \
+#define VAPOR_MIX_DERIV_TEST(f, a, b, x, rel_tol)                                                  \
   {                                                                                                \
+    const Real abs_tol = 1e-10;                                                                    \
     const Real da = REL_PERTURBATION * a;                                                          \
     const Real db = REL_PERTURBATION * b;                                                          \
     std::vector<Real> dx(x.size());                                                                \
@@ -33,9 +34,9 @@
     Real f_value, df_da, df_db;                                                                    \
     std::vector<Real> df_dx(x.size());                                                             \
     f(a, b, x, f_value, df_da, df_db, df_dx);                                                      \
-    REL_TEST(f(a, b, x), f_value, REL_TOL_CONSISTENCY);                                            \
-    REL_TEST(df_da, df_da_fd, tol);                                                                \
-    REL_TEST(df_db, df_db_fd, tol);                                                                \
+    REL_ABS_TEST(f(a, b, x), f_value, REL_TOL_CONSISTENCY, abs_tol);                               \
+    REL_ABS_TEST(df_da, df_da_fd, rel_tol, abs_tol);                                               \
+    REL_ABS_TEST(df_db, df_db_fd, rel_tol, abs_tol);                                               \
     for (unsigned int i = 0; i < x.size(); ++i)                                                    \
-      REL_TEST(df_dx[i], df_dx_fd[i], tol);                                                        \
+      REL_ABS_TEST(df_dx[i], df_dx_fd[i], rel_tol, abs_tol);                                       \
   }

--- a/modules/fluid_properties/test/tests/fp_interrogator/tests
+++ b/modules/fluid_properties/test/tests/fp_interrogator/tests
@@ -329,6 +329,7 @@ Density:                                   0.8972309616  kg/m\^3
 Specific volume:                            1.114540227  m\^3/kg
 Specific internal energy:              1.0334658129e\+06  J/kg
 Specific enthalpy:                     1.1449198356e\+06  J/kg
+Specific entropy:                      1.4838960040e\+04  J/kg
 
 Sound speed:                                351.3883482  m/s
 Dynamic viscosity:                     1.8230000000e-05  Pa-s
@@ -374,7 +375,7 @@ Thermal conductivity:                           0.02568  W/\(m-K\)'
                  '"k":0.[0-9]+,"mu":1.823e-05,"p":100000.0,"rho":0.[0-9]+,"s":2486.[0-9]+,'
                  '"v":1.[0-9]+}},"vapor-mixture":{"static":{"T":372.[0-9]+,"c":351.[0-9]+,'
                  '"cp":3071.[0-9]+,"cv":2772.[0-9]+,"e":1033465.[0-9]+,"h":1144919.[0-9]+,'
-                 '"k":0.[0-9]+,"mu":1.[0-9]+e-05,"p":100000.0,"rho":0.[0-9]+,"v":1.[0-9]+}}}'
+                 '"k":0.[0-9]+,"mu":1.[0-9]+e-05,"p":100000.0,"rho":0.[0-9]+,"s":14838.[0-9]+,"v":1.[0-9]+}}}'
 
     requirement = "The fluid properties interrogator shall output two-phase "
       "and static-state, single-phase fluid properties for (p, T) input with "
@@ -399,6 +400,7 @@ Density:                                    1.187005237  kg/m\^3
 Specific volume:                           0.8424562661  m\^3/kg
 Specific internal energy:              2.4771659033e\+06  J/kg
 Specific enthalpy:                     3.2387829780e\+06  J/kg
+Specific entropy:                           5966.595696  J/kg
 
 Sound speed:                                997.8878004  m/s
 Dynamic viscosity:                     1.8230000000e-05  Pa-s
@@ -422,7 +424,7 @@ Thermal conductivity:                           0.02568  W/\(m-K\)'
     threading = '!pthreads'
     expect_out = '{"static":{"T":2547.[0-9]+,"c":997.[0-9]+,"cp":1271.[0-9]+,'
                  '"cv":972.[0-9]+,"e":2477165.[0-9]+,"h":3238782.[0-9]+,"k":0.[0-9]+,'
-                 '"mu":1.[0-9]+e-05,"p":904043.[0-9]+,"rho":1.[0-9]+,"v":0.[0-9]+}}'
+                 '"mu":1.[0-9]+e-05,"p":904043.[0-9]+,"rho":1.[0-9]+,"s":5966.[0-9]+,"v":0.[0-9]+}}'
 
     requirement = "The fluid properties interrogator shall output static-state, "
       "single-phase fluid properties for (rho, e) input with a vapor mixture "

--- a/modules/fluid_properties/unit/include/IdealRealGasMixtureFluidPropertiesTest.h
+++ b/modules/fluid_properties/unit/include/IdealRealGasMixtureFluidPropertiesTest.h
@@ -69,6 +69,7 @@ protected:
       InputParameters params = _factory.getValidParams(class_name);
       params.set<UserObjectName>("fp_primary") = fp_steam_name;
       params.set<std::vector<UserObjectName>>("fp_secondary") = {fp_nitrogen_name};
+      params.set<bool>("allow_imperfect_jacobians") = true;
       _fe_problem->addUserObject(class_name, fp_mix_name, params);
       _fp_mix = &_fe_problem->getUserObject<IdealRealGasMixtureFluidProperties>(fp_mix_name);
     }

--- a/modules/fluid_properties/unit/include/TestSinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/unit/include/TestSinglePhaseFluidProperties.h
@@ -53,6 +53,9 @@ public:
   virtual void
   k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const override;
 
+  virtual Real criticalPressure() const override { return _p_crit; }
+  virtual Real criticalTemperature() const override { return _T_crit; }
+
 protected:
   const Real _drho_dp;
   const Real _drho_dT;
@@ -70,6 +73,8 @@ protected:
   const Real _dcp_de;
   const Real _dk_dv;
   const Real _dk_de;
+  const Real _p_crit;
+  const Real _T_crit;
 };
 
 #pragma GCC diagnostic pop

--- a/modules/fluid_properties/unit/src/IdealRealGasMixtureFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/IdealRealGasMixtureFluidPropertiesTest.C
@@ -13,6 +13,8 @@
 
 TEST_F(IdealRealGasMixtureFluidPropertiesTest, test)
 {
+  Moose::_throw_on_warning = false;
+
   Real T = 400.;
   Real p = 100000.;
   std::vector<Real> x = {0.9};

--- a/modules/fluid_properties/unit/src/IdealRealGasMixtureFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/IdealRealGasMixtureFluidPropertiesTest.C
@@ -18,93 +18,104 @@ TEST_F(IdealRealGasMixtureFluidPropertiesTest, test)
   std::vector<Real> x = {0.9};
 
   // pure fluids
-  Real rho_nitrogen = _fp_nitrogen->rho_from_p_T(p, T);
-  Real rho_steam = _fp_steam->rho_from_p_T(p, T);
-  REL_TEST(rho_nitrogen, 0.84228968026683726, REL_TOL_CONSISTENCY);
-  REL_TEST(rho_steam, 0.61493738819320221, REL_TOL_CONSISTENCY);
+  const Real rho_nitrogen = _fp_nitrogen->rho_from_p_T(p, T);
+  const Real rho_steam = _fp_steam->rho_from_p_T(p, T);
+  REL_TEST(rho_nitrogen, 0.84228968026683726, REL_TOL_SAVED_VALUE);
+  REL_TEST(rho_steam, 0.61493738819320221, REL_TOL_SAVED_VALUE);
 
-  // mixture properties
-  Real rho_mix = _fp_mix->rho_from_p_T(p, T, x);
-  Real v_mix = _fp_mix->v_from_p_T(p, T, x);
-  Real e_mix = _fp_mix->e_from_p_T(p, T, x);
-  Real c_mix = _fp_mix->c_from_p_T(p, T, x);
-  Real cp_mix = _fp_mix->cp_from_p_T(p, T, x);
-  Real cv_mix = _fp_mix->cv_from_p_T(p, T, x);
-  Real mu_mix = _fp_mix->mu_from_p_T(p, T, x);
-  Real k_mix = _fp_mix->k_from_p_T(p, T, x);
-  REL_TEST(rho_mix, 0.88183704292782583, REL_TOL_CONSISTENCY);
-  REL_TEST(v_mix, 1.1339963636363655, REL_TOL_CONSISTENCY);
-  REL_TEST(e_mix, 523068.96363636368, REL_TOL_CONSISTENCY);
-  REL_TEST(c_mix, 418.49693534182865, REL_TOL_CONSISTENCY);
-  REL_TEST(cp_mix, 1083.6715000000002, REL_TOL_CONSISTENCY);
-  REL_TEST(cv_mix, 771.82250000000022, REL_TOL_CONSISTENCY);
-  REL_TEST(mu_mix, 2.08926978862e-5, REL_TOL_CONSISTENCY);
-  REL_TEST(k_mix, 0.0319250086968, REL_TOL_CONSISTENCY);
-
-  // check inverse functions of (v,e)
-  Real p_mix = _fp_mix->p_from_v_e(v_mix, e_mix, x);
-  Real T_mix = _fp_mix->T_from_v_e(v_mix, e_mix, x);
-  REL_TEST(p_mix, p, REL_TOL_CONSISTENCY);
-  REL_TEST(T_mix, T, REL_TOL_CONSISTENCY);
-
-  // check T(p,v) and its derivatives
-  REL_TEST(T, _fp_mix->T_from_p_v(p, v_mix, x), REL_TOL_CONSISTENCY);
-  VAPOR_MIX_DERIV_TEST(_fp_mix->T_from_p_v, p, v_mix, x, REL_TOL_DERIVATIVE);
-
-  // check e(p,rho) and its derivatives
-  REL_TEST(e_mix, _fp_mix->e_from_p_rho(p, rho_mix, x), REL_TOL_CONSISTENCY);
-  VAPOR_MIX_DERIV_TEST(_fp_mix->e_from_p_rho, p, rho_mix, x, REL_TOL_DERIVATIVE);
-
-  //////////////////////////////////////////////////////////////////////////////
-  // note that the VAPOR_MIX_DERIV_TEST works for binary mixtures only (for now)
-  //////////////////////////////////////////////////////////////////////////////
-
-  // check analytical derivatives from (p,T)
+  // rho(p,T)
+  const Real rho_mix = _fp_mix->rho_from_p_T(p, T, x);
+  REL_TEST(rho_mix, 0.88183704292782583, REL_TOL_SAVED_VALUE);
   VAPOR_MIX_DERIV_TEST(_fp_mix->rho_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
+
+  // v(p,T)
+  const Real v_mix = _fp_mix->v_from_p_T(p, T, x);
+  REL_TEST(v_mix, 1.1339963636363655, REL_TOL_SAVED_VALUE);
   VAPOR_MIX_DERIV_TEST(_fp_mix->v_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
-  // the following test fails since the pertubation in VAPOR_MIX_DERIV_TEST
-  // is too small if v(p,T) is iterated within e_from_p_T
-  // VAPOR_MIX_DERIV_TEST(_fp_mix->e_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
-  Real e, de_dp, de_dT;
-  std::vector<Real> de_dx;
-  de_dx.resize(_fp_mix->getNumberOfSecondaryVapors());
-  _fp_mix->e_from_p_T(p, T, x, e, de_dp, de_dT, de_dx);
-  Real dp = p * 1.e-5;
-  Real p1 = _fp_mix->e_from_p_T(p - dp, T, x);
-  Real p2 = _fp_mix->e_from_p_T(p + dp, T, x);
-  Real de_dp_num = (p2 - p1) / (2.0 * dp);
-  REL_TEST(de_dp, de_dp_num, REL_TOL_DERIVATIVE);
 
-  // check analytical derivatives from (v,e)
-  VAPOR_MIX_DERIV_TEST(_fp_mix->p_from_v_e, v_mix, e_mix, x, REL_TOL_DERIVATIVE);
-  VAPOR_MIX_DERIV_TEST(_fp_mix->T_from_v_e, v_mix, e_mix, x, REL_TOL_DERIVATIVE);
-
-  // check analytical derivatives from (T,v)
-  VAPOR_MIX_DERIV_TEST(_fp_mix->p_from_T_v, T, v_mix, x, REL_TOL_DERIVATIVE);
+  /// e(p,T)
+  const Real e_mix = _fp_mix->e_from_p_T(p, T, x);
+  REL_TEST(e_mix, 523068.96363636368, REL_TOL_SAVED_VALUE);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->e_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
+  // e(p,rho)
+  REL_TEST(_fp_mix->e_from_p_rho(p, rho_mix, x), e_mix, REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->e_from_p_rho, p, rho_mix, x, REL_TOL_DERIVATIVE);
+  // e(T,v)
+  REL_TEST(_fp_mix->e_from_T_v(T, v_mix, x), e_mix, REL_TOL_CONSISTENCY);
   VAPOR_MIX_DERIV_TEST(_fp_mix->e_from_T_v, T, v_mix, x, REL_TOL_DERIVATIVE);
 
-  // state-of-the-art mixture model comparison
+  // p(v,e)
+  REL_TEST(_fp_mix->p_from_v_e(v_mix, e_mix, x), p, REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->p_from_v_e, v_mix, e_mix, x, REL_TOL_DERIVATIVE);
+  // p(T,v)
+  REL_TEST(_fp_mix->p_from_T_v(T, v_mix, x), p, REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->p_from_T_v, T, v_mix, x, REL_TOL_DERIVATIVE);
+
+  // T(v,e)
+  REL_TEST(_fp_mix->T_from_v_e(v_mix, e_mix, x), T, REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->T_from_v_e, v_mix, e_mix, x, REL_TOL_DERIVATIVE);
+  // T(p,v)
+  REL_TEST(_fp_mix->T_from_p_v(p, v_mix, x), T, REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->T_from_p_v, p, v_mix, x, REL_TOL_DERIVATIVE);
+
+  // c(p,T)
+  const Real c_mix = _fp_mix->c_from_p_T(p, T, x);
+  REL_TEST(c_mix, 418.49693534182865, REL_TOL_SAVED_VALUE);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->c_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
+  // c(v,e)
+  REL_TEST(_fp_mix->c_from_v_e(v_mix, e_mix, x), c_mix, REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->c_from_v_e, v_mix, e_mix, x, REL_TOL_DERIVATIVE);
+
+  /// s(p,T)
+  const Real s_mix = _fp_mix->s_from_p_T(p, T, x);
+  REL_TEST(s_mix, 700.961535541455, REL_TOL_SAVED_VALUE);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->s_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
+  // s(T,v)
+  REL_TEST(_fp_mix->s_from_T_v(T, v_mix, x), s_mix, REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->s_from_T_v, T, v_mix, x, REL_TOL_DERIVATIVE);
+
+  // cp(p,T)
+  const Real cp_mix = _fp_mix->cp_from_p_T(p, T, x);
+  REL_TEST(cp_mix, 1083.6715000000002, REL_TOL_SAVED_VALUE);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->cp_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
+  // cp(T,v)
+  REL_TEST(_fp_mix->cp_from_T_v(T, v_mix, x), cp_mix, REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->cp_from_T_v, T, v_mix, x, REL_TOL_DERIVATIVE);
+
+  // cv(p,T)
+  const Real cv_mix = _fp_mix->cv_from_p_T(p, T, x);
+  REL_TEST(cv_mix, 771.82250000000022, REL_TOL_SAVED_VALUE);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->cv_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
+  // cv(T,v)
+  REL_TEST(_fp_mix->cv_from_T_v(T, v_mix, x), cv_mix, REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->cv_from_T_v, T, v_mix, x, REL_TOL_DERIVATIVE);
+
+  // mu(p,T)
+  const Real mu_mix = _fp_mix->mu_from_p_T(p, T, x);
+  REL_TEST(mu_mix, 2.089269788624648e-05, REL_TOL_SAVED_VALUE);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->mu_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
+  // mu(T,v)
+  REL_TEST(_fp_mix->mu_from_T_v(T, v_mix, x), mu_mix, REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->mu_from_T_v, T, v_mix, x, REL_TOL_DERIVATIVE);
+
+  // k(p,T)
+  const Real k_mix = _fp_mix->k_from_p_T(p, T, x);
+  REL_TEST(k_mix, 0.0319250086967551, REL_TOL_SAVED_VALUE);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->k_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
+  // k(T,v)
+  REL_TEST(_fp_mix->k_from_T_v(T, v_mix, x), k_mix, REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->k_from_T_v, T, v_mix, x, REL_TOL_DERIVATIVE);
+
+  // Compare calculations with a state-of-the-art mixture model. Note these are
+  // not expected to be exactly the same, so very loose tolerances must be used.
+  // mu and k are not available in the state-of-the-art mixture model.
   T = 360.;
   p = 100000.;
   x[0] = 0.5;
-  rho_mix = _fp_mix->rho_from_p_T(p, T, x); // 0.7362935
-  v_mix = _fp_mix->v_from_p_T(p, T, x);     // 1.3581540
-  e_mix = _fp_mix->e_from_p_T(p, T, x);     // 1380586.9
-  c_mix = _fp_mix->c_from_p_T(p, T, x);     // 428.1928
-  cp_mix = _fp_mix->cp_from_p_T(p, T, x);   // 1479.7114
-  cv_mix = _fp_mix->cv_from_p_T(p, T, x);   // 1090.5912
-  // these quantities cannot be calculated with the state-of-the-art mixture model
-  // mu_mix = _fp_mix->mu_from_p_T(p, T, x);
-  // k_mix = _fp_mix->k_from_p_T(p, T, x);
-
-  REL_TEST(rho_mix, 0.7362935, 0.115554);
-  REL_TEST(v_mix, 1.3581540, 0.103585);
-  REL_TEST(e_mix, 1380586.9, 0.023648);
-  REL_TEST(c_mix, 428.1928, 0.017535);
-  REL_TEST(cp_mix, 1479.7114, 0.146444);
-  VAPOR_MIX_DERIV_TEST(_fp_mix->cp_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
-  REL_TEST(cv_mix, 1090.5912, 0.183001);
-  VAPOR_MIX_DERIV_TEST(_fp_mix->cv_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
-  VAPOR_MIX_DERIV_TEST(_fp_mix->mu_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
-  VAPOR_MIX_DERIV_TEST(_fp_mix->k_from_p_T, p, T, x, REL_TOL_DERIVATIVE);
+  REL_TEST(_fp_mix->rho_from_p_T(p, T, x), 0.7362935, 0.115554);
+  REL_TEST(_fp_mix->v_from_p_T(p, T, x), 1.3581540, 0.103585);
+  REL_TEST(_fp_mix->e_from_p_T(p, T, x), 1380586.9, 0.023648);
+  REL_TEST(_fp_mix->c_from_p_T(p, T, x), 428.1928, 0.017535);
+  REL_TEST(_fp_mix->cp_from_p_T(p, T, x), 1479.7114, 0.146444);
+  REL_TEST(_fp_mix->cv_from_p_T(p, T, x), 1090.5912, 0.183001);
 }

--- a/modules/fluid_properties/unit/src/IdealRealGasMixtureFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/IdealRealGasMixtureFluidPropertiesTest.C
@@ -13,6 +13,8 @@
 
 TEST_F(IdealRealGasMixtureFluidPropertiesTest, test)
 {
+  // save this setting so that it can be restored later
+  const bool original_throw_on_warning = Moose::_throw_on_warning;
   Moose::_throw_on_warning = false;
 
   Real T = 400.;
@@ -120,4 +122,7 @@ TEST_F(IdealRealGasMixtureFluidPropertiesTest, test)
   REL_TEST(_fp_mix->c_from_p_T(p, T, x), 428.1928, 0.017535);
   REL_TEST(_fp_mix->cp_from_p_T(p, T, x), 1479.7114, 0.146444);
   REL_TEST(_fp_mix->cv_from_p_T(p, T, x), 1090.5912, 0.183001);
+
+  // restore original setting
+  Moose::_throw_on_warning = original_throw_on_warning;
 }

--- a/modules/fluid_properties/unit/src/SinglePhaseFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/SinglePhaseFluidPropertiesTest.C
@@ -51,4 +51,10 @@ TEST_F(SinglePhaseFluidPropertiesTest, testAll)
 
   REL_TEST(_fp->k_from_p_T(p, T), _fp->k_from_v_e(v, e), REL_TOL_CONSISTENCY);
   DERIV_TEST(_fp->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
+
+  const Real rho_crit = 40.0;
+  REL_TEST(_fp->criticalDensity(), rho_crit, REL_TOL_CONSISTENCY);
+
+  const Real e_crit = 220.0;
+  REL_TEST(_fp->criticalInternalEnergy(), e_crit, REL_TOL_CONSISTENCY);
 }

--- a/modules/fluid_properties/unit/src/TestSinglePhaseFluidProperties.C
+++ b/modules/fluid_properties/unit/src/TestSinglePhaseFluidProperties.C
@@ -36,7 +36,9 @@ TestSinglePhaseFluidProperties::TestSinglePhaseFluidProperties(const InputParame
     _dcp_dv(14.0),
     _dcp_de(15.0),
     _dk_dv(16.0),
-    _dk_de(17.0)
+    _dk_de(17.0),
+    _p_crit(5.0),
+    _T_crit(10.0)
 {
 }
 


### PR DESCRIPTION
This PR does the following, in support of the upcoming THM gas mixture flow channel:

- Added default implementations for `SinglePhaseFluidProperties::criticalDensity()` and `criticalInternalEnergy()` by evaluating respective methods with `criticalPressure()` and `criticalTemperature()`.
- Closes #29656
- Stopped outputting vapor mixture properties twice in `FluidPropertiesInterrogator`
- Added debug information to the solve-failed exception in `BrentsMethod` (iteration history)
- Added `REL_ABS_TEST` macro to `FluidPropertiesTestUtils`
- Added s(p,T) to `VaporMixtureFluidProperties` and interrogator
- Cleaned `IdealRealGasMixtureFluidProperties` and overhauled its testing

Note that I will not be using `IdealRealGasMixtureFluidProperties` in my upcoming gas mixture flow model - I'll have another PR with a simplified class: `IdealGasMixtureFluidProperties`, which assumes ideal gases. I'm sorry for the excessive cleanup commit.
