### PR TITLE
Valgrind fix for variables not properly initialized in RGMB ControlDrumMeshGenerator

### DIFF
--- a/modules/reactor/src/meshgenerators/ControlDrumMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/ControlDrumMeshGenerator.C
@@ -203,8 +203,9 @@ ControlDrumMeshGenerator::ControlDrumMeshGenerator(const InputParameters & param
   // Define azimuthal angles explicitly based on num_azimuthal_sectors and manually add pad start
   // angle and end angle if they are not contained within these angle intervals
   std::vector<Real> azimuthal_angles;
-  const auto custom_start_angle = _pad_start_angle;
-  const auto custom_end_angle = (_pad_end_angle > 360) ? _pad_end_angle - 360. : _pad_end_angle;
+  const auto custom_start_angle = _has_pad_region ? _pad_start_angle : 0.;
+  const auto custom_end_angle =
+      _has_pad_region ? ((_pad_end_angle > 360) ? _pad_end_angle - 360. : _pad_end_angle) : 0.;
   for (unsigned int i = 0; i < num_sectors; ++i)
   {
     Real current_azim_angle = (Real)i * 360. / (Real)num_sectors;


### PR DESCRIPTION


<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->

refs #29762 