### PR TITLE
Fixing typo in main installation page

### DIFF
--- a/modules/doc/content/getting_started/installation/index_content.md
+++ b/modules/doc/content/getting_started/installation/index_content.md
@@ -9,7 +9,7 @@ choice:
 - [Conda Pre-Built MOOSE](installation/moose_conda_binary.md) (Excellent for Training)
 - INL's HPC Cluster (access restrictions)
 
-  - [Developerment](installation/inl_hpc_install_moose.md)
+  - [Development](installation/inl_hpc_install_moose.md)
   - [Pre-Built MOOSE](installation/inl_hpc_prebuilt_moose.md) (Excellent for Training)
 
 - Optional packages:


### PR DESCRIPTION
## Reason

Typo was found in the installation landing page, this is a quick one-line fix. See #27731 for origin.

## Design

Simple markdown file line change.

## Impact

No impact other than more professional documentation.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
