### PR TITLE
Fix for skipped sync timesteps in exodus files

### DIFF
--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -307,8 +307,11 @@ Output::onInterval()
   }
 
   // If sync times are not skipped, return true if the current time is a sync_time
-  if (_sync_times.find(_time) != _sync_times.end())
-    output = true;
+  for (const auto _sync_time : _sync_times)
+  {
+    if (std::abs(_sync_time - _time) < _t_tol)
+      output = true;
+  }
 
   // check if enough simulation time has passed between outputs
   if (_time > _last_output_simulation_time &&


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
- This ensures that `sync_times` works as intended
## Design
<!--A concise description (design) of the enhancement.-->
- Because of floating point errors the simulation time did would be off from `_sync_time` by less than 1e-15
- Replaced find function with a difference comparison between `_sync_time`, `_time`, and `_t_tol`
## Impact
<!--Will the enhancement change existing APIs or add something new?-->
- Fixes issues with sync time outputs

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
closes #28722