### PR TITLE
Deleted deprecated closures member

### DIFF
--- a/modules/thermal_hydraulics/include/components/FlowChannelBase.h
+++ b/modules/thermal_hydraulics/include/components/FlowChannelBase.h
@@ -182,11 +182,6 @@ public:
    *
    * @return The closures object(s)
    */
-  std::shared_ptr<ClosuresBase> getClosures() const
-  {
-    mooseDeprecated("getClosures() is deprecated. Use getClosuresObjects() instead.");
-    return _closures;
-  }
   std::vector<std::shared_ptr<ClosuresBase>> getClosuresObjects() const
   {
     return _closures_objects;
@@ -221,7 +216,6 @@ protected:
   FunctionName _area_function;
 
   /// Closures object(s)
-  std::shared_ptr<ClosuresBase> _closures;
   std::vector<std::shared_ptr<ClosuresBase>> _closures_objects;
 
   const bool & _pipe_pars_transferred;

--- a/modules/thermal_hydraulics/include/components/HeatTransferBase.h
+++ b/modules/thermal_hydraulics/include/components/HeatTransferBase.h
@@ -94,7 +94,6 @@ protected:
   const bool _P_hf_provided;
 
   /// Used closures object(s)
-  std::shared_ptr<ClosuresBase> _closures;
   std::vector<std::shared_ptr<ClosuresBase>> _closures_objects;
 
   /// heated perimeter name

--- a/modules/thermal_hydraulics/src/components/FlowChannelBase.C
+++ b/modules/thermal_hydraulics/src/components/FlowChannelBase.C
@@ -171,9 +171,6 @@ FlowChannelBase::init()
     const auto & closures_names = getParam<std::vector<std::string>>("closures");
     for (const auto & closures_name : closures_names)
       _closures_objects.push_back(getTHMProblem().getClosures(closures_name));
-    // _closures should be removed after transition:
-    if (_closures_objects.size() >= 1)
-      _closures = _closures_objects[0];
   }
 }
 

--- a/modules/thermal_hydraulics/src/components/HeatTransferBase.C
+++ b/modules/thermal_hydraulics/src/components/HeatTransferBase.C
@@ -56,7 +56,6 @@ HeatTransferBase::init()
     _model_type = flow_channel.getFlowModelID();
     _fp_name = flow_channel.getFluidPropertiesName();
     _A_fn_name = flow_channel.getAreaFunctionName();
-    _closures = flow_channel.getClosures();
     _closures_objects = flow_channel.getClosuresObjects();
   }
 }


### PR DESCRIPTION
This is a cleanup task for #29594. THM-based applications need to transition to stop using the deprecated singular closures data member.

This will fail at first because application updates are coming in; invalidating after those update should fix.

- [x] Sockeye fix: https://github.inl.gov/ncrc/sockeye/pull/812
- [x] RELAP-7 fix: https://github.inl.gov/ncrc/relap-7/pull/2585
- [x] Update Sabertooth
- [x] Update DireWolf
- [x] Update BlueCRAB


