### PR TITLE
Added error check to prevent segfault

### DIFF
--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -297,6 +297,8 @@ public:
    */
   bool isTaskComplete(const std::string & task) const;
 
+  std::string getFinalTask() { return _final_task; }
+
 protected:
   /**
    * This method auto-builds all Actions that needs to be built and adds them to ActionWarehouse.

--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -297,8 +297,6 @@ public:
    */
   bool isTaskComplete(const std::string & task) const;
 
-  std::string getFinalTask() { return _final_task; }
-
 protected:
   /**
    * This method auto-builds all Actions that needs to be built and adds them to ActionWarehouse.

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1251,7 +1251,8 @@ protected:
 
   /// Indicates whether warnings or errors are displayed when overridden parameters are detected
   bool _error_overridden;
-  std::string _ready_to_exit;
+  /// Indicates if simulation is ready to exit, and keeps track of which param caused it to exit
+  std::string _early_exit_param;
   /// The exit code
   int _exit_code;
 

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1251,7 +1251,7 @@ protected:
 
   /// Indicates whether warnings or errors are displayed when overridden parameters are detected
   bool _error_overridden;
-  bool _ready_to_exit;
+  std::string _ready_to_exit;
   /// The exit code
   int _exit_code;
 

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1253,6 +1253,7 @@ protected:
   bool _error_overridden;
   /// Indicates if simulation is ready to exit, and keeps track of which param caused it to exit
   std::string _early_exit_param;
+  bool _ready_to_exit;
   /// The exit code
   int _exit_code;
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -428,6 +428,7 @@ MooseApp::MooseApp(InputParameters parameters)
     _factory(*this),
     _error_overridden(false),
     _early_exit_param(""),
+    _ready_to_exit(false),
     _exit_code(0),
     _initial_from_file(false),
     _distributed_mesh_on_command_line(false),
@@ -815,12 +816,14 @@ MooseApp::setupOptions()
   {
     Moose::out << getPrintableVersion() << std::endl;
     _early_exit_param = "--version";
+    _ready_to_exit = true;
     return;
   }
   else if (getParam<bool>("help"))
   {
     _command_line->printUsage();
     _early_exit_param = "--help";
+    _ready_to_exit = true;
   }
   else if (getParam<bool>("dump") || isParamSetByUser("dump_search"))
   {
@@ -844,6 +847,7 @@ MooseApp::setupOptions()
       Moose::out << "\n### START DUMP DATA ###\n"
                  << formatter.toString(tree.getRoot()) << "\n### END DUMP DATA ###" << std::endl;
       _early_exit_param = "--dump";
+      _ready_to_exit = true;
     }
     else
       mooseError("Search parameter '", search, "' was not found in the registered syntax.");
@@ -868,6 +872,7 @@ MooseApp::setupOptions()
                    << act->_file << "\n";
     }
     _early_exit_param = "--registry";
+    _ready_to_exit = true;
   }
   else if (getParam<bool>("registry_hit"))
   {
@@ -913,6 +918,7 @@ MooseApp::setupOptions()
 
     Moose::out << "\n### END REGISTRY DATA ###\n";
     _early_exit_param = "--registry_hit";
+    _ready_to_exit = true;
   }
   else if (getParam<bool>("definition"))
   {
@@ -924,6 +930,7 @@ MooseApp::setupOptions()
     Moose::out << "%-START-SON-DEFINITION-%\n"
                << formatter.toString(tree.getRoot()) << "\n%-END-SON-DEFINITION-%\n";
     _early_exit_param = "--definition";
+    _ready_to_exit = true;
   }
   else if (getParam<bool>("yaml") || isParamSetByUser("yaml_search"))
   {
@@ -935,6 +942,7 @@ MooseApp::setupOptions()
     _builder.buildFullTree(search);
 
     _early_exit_param = "--yaml";
+    _ready_to_exit = true;
   }
   else if (getParam<bool>("json") || isParamSetByUser("json_search"))
   {
@@ -947,6 +955,7 @@ MooseApp::setupOptions()
 
     Moose::out << "**START JSON DATA**\n" << tree.getRoot().dump(2) << "\n**END JSON DATA**\n";
     _early_exit_param = "--json";
+    _ready_to_exit = true;
   }
   else if (getParam<bool>("syntax"))
   {
@@ -958,6 +967,7 @@ MooseApp::setupOptions()
       Moose::out << it.first << "\n";
     Moose::out << "**END SYNTAX DATA**\n" << std::endl;
     _early_exit_param = "--syntax";
+    _ready_to_exit = true;
   }
   else if (getParam<bool>("show_type"))
   {
@@ -965,6 +975,7 @@ MooseApp::setupOptions()
 
     Moose::out << "MooseApp Type: " << type() << std::endl;
     _early_exit_param = "--show-type";
+    _ready_to_exit = true;
   }
   else if (getInputFileNames().size())
   {
@@ -1054,12 +1065,14 @@ MooseApp::setupOptions()
     moose_server.run();
 
     _early_exit_param = "--language-server";
+    _ready_to_exit = true;
   }
 
   else /* The catch-all case for bad options or missing options, etc. */
   {
     _command_line->printUsage();
     _early_exit_param = "bad or missing";
+    _ready_to_exit = true;
     _exit_code = 1;
   }
 
@@ -1111,19 +1124,26 @@ MooseApp::runInputFile()
   TIME_SECTION("runInputFile", 3);
 
   // If early exit param has been set, then just return
-  if (!_early_exit_param.empty())
+  if (_ready_to_exit)
     return;
 
   _action_warehouse.executeAllActions();
 
   if (isParamSetByUser("mesh_only"))
+  {
     _early_exit_param = "--mesh-only";
+    _ready_to_exit = true;
+  }
   else if (isParamSetByUser("split_mesh"))
+  {
     _early_exit_param = "--split-mesh";
+    _ready_to_exit = true;
+  }
   else if (getParam<bool>("list_constructed_objects"))
   {
     // TODO: ask multiapps for their constructed objects
     _early_exit_param = "--list-constructed-objects";
+    _ready_to_exit = true;
     std::vector<std::string> obj_list = _factory.getConstructedObjects();
     Moose::out << "**START OBJECT DATA**\n";
     for (const auto & name : obj_list)
@@ -1168,7 +1188,7 @@ MooseApp::executeExecutioner()
   TIME_SECTION("executeExecutioner", 3);
 
   // If ready to exit has been set, then just return
-  if (!_early_exit_param.empty())
+  if (_ready_to_exit)
     return;
 
   // run the simulation
@@ -1545,12 +1565,14 @@ MooseApp::run()
 
     Moose::out << docmsg << "\n";
     _early_exit_param = "--docs";
+    _ready_to_exit = true;
     return;
   }
 
   if (showInputs() || copyInputs() || runInputs())
   {
     _early_exit_param = "--show-input, --copy-inputs, or --run";
+    _ready_to_exit = true;
     return;
   }
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1003,6 +1003,12 @@ MooseApp::setupOptions()
     }
     _action_warehouse.build();
 
+    // Check that --check-input was not used with and final task as this will results in a segFault
+    if (_check_input && _action_warehouse.getFinalTask() != "")
+      mooseError("Cannot run --check-input with ",
+                 _action_warehouse.getFinalTask(),
+                 " as this will result in a segfault");
+
     // Setup the AppFileBase for use by the Outputs or other systems that need output file info
     {
       // Extract the CommonOutputAction

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1110,7 +1110,7 @@ MooseApp::runInputFile()
 {
   TIME_SECTION("runInputFile", 3);
 
-  // If ready to exit has been set, then just return
+  // If early exit param has been set, then just return
   if (!_early_exit_param.empty())
     return;
 
@@ -1144,18 +1144,16 @@ MooseApp::errorCheck()
   {
     if (!_early_exit_param.empty())
     {
-      if (_check_input)
-        mooseError(
-            "Incompatible command line arguments provided. --check-input cannot be called with ",
-            _early_exit_param,
-            ".");
-      else
-        mooseError("We should never get here!");
+      mooseAssert(_check_input,
+                  "Something went wrong, we should only get here if _check_input is true.");
+      mooseError(
+          "Incompatible command line arguments provided. --check-input cannot be called with ",
+          _early_exit_param,
+          ".");
     }
-    else
-      mooseError("The Executor is being called without being initialized. This is likely "
-                 "caused by "
-                 "incompatible command line arguments");
+    mooseError("The Executor is being called without being initialized. This is likely "
+               "caused by "
+               "incompatible command line arguments");
   }
 
   auto apps = feProblem().getMultiAppWarehouse().getObjects();
@@ -1552,7 +1550,7 @@ MooseApp::run()
 
   if (showInputs() || copyInputs() || runInputs())
   {
-    _early_exit_param = "true";
+    _early_exit_param = "--show-input, --copy-inputs, or --run";
     return;
   }
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1171,6 +1171,7 @@ MooseApp::errorCheck()
           _early_exit_param,
           ".");
     }
+    // We should never get here
     mooseError("The Executor is being called without being initialized. This is likely "
                "caused by "
                "incompatible command line arguments");

--- a/modules/solid_mechanics/src/base/SolidMechanicsApp.C
+++ b/modules/solid_mechanics/src/base/SolidMechanicsApp.C
@@ -53,7 +53,7 @@ SolidMechanicsApp::runInputFile()
   MooseApp::runInputFile();
 
   if (getParam<bool>("parse_neml2_only"))
-    _ready_to_exit = "parse_neml2_only";
+    _early_exit_param = "--parse-neml2-only";
 }
 
 static void

--- a/modules/solid_mechanics/src/base/SolidMechanicsApp.C
+++ b/modules/solid_mechanics/src/base/SolidMechanicsApp.C
@@ -53,7 +53,10 @@ SolidMechanicsApp::runInputFile()
   MooseApp::runInputFile();
 
   if (getParam<bool>("parse_neml2_only"))
+  {
     _early_exit_param = "--parse-neml2-only";
+    _ready_to_exit = true;
+  }
 }
 
 static void

--- a/modules/solid_mechanics/src/base/SolidMechanicsApp.C
+++ b/modules/solid_mechanics/src/base/SolidMechanicsApp.C
@@ -53,7 +53,7 @@ SolidMechanicsApp::runInputFile()
   MooseApp::runInputFile();
 
   if (getParam<bool>("parse_neml2_only"))
-    _ready_to_exit = true;
+    _ready_to_exit = "parse_neml2_only";
 }
 
 static void

--- a/test/tests/mesh/mesh_only/tests
+++ b/test/tests/mesh/mesh_only/tests
@@ -85,6 +85,6 @@
     expect_err = "Incompatible command line arguments provided. --check-input cannot be called with --mesh-only."
     method = '!dbg'
     issues = '#29788'
-    requirement = 'The system shall throw an error if the user specifies incompatible command line arguments that would cause a segfault.'
+    requirement = 'The system shall throw an error if the user specifies incompatible command line arguments that would access an uninitialized executor or executor.'
   []
 []

--- a/test/tests/mesh/mesh_only/tests
+++ b/test/tests/mesh/mesh_only/tests
@@ -82,7 +82,7 @@
     type = 'RunException'
     input = 'mesh_only.i'
     cli_args = '--check-input --mesh-only'
-    expect_err = "Cannot run --check-input with mesh_only as this will result in a segfault"
+    expect_err = "Incompatible command line arguments provided. --check-input cannot be called with mesh_only."
     method = '!dbg'
     issues = '#29788'
     requirement = 'The system shall throw an error is the user provides a parameter that would result in a segfault when used with --mesh-only'

--- a/test/tests/mesh/mesh_only/tests
+++ b/test/tests/mesh/mesh_only/tests
@@ -82,9 +82,9 @@
     type = 'RunException'
     input = 'mesh_only.i'
     cli_args = '--check-input --mesh-only'
-    expect_err = "Incompatible command line arguments provided. --check-input cannot be called with mesh_only."
+    expect_err = "Incompatible command line arguments provided. --check-input cannot be called with --mesh-only."
     method = '!dbg'
     issues = '#29788'
-    requirement = 'The system shall throw an error is the user provides a parameter that would result in a segfault when used with --mesh-only'
+    requirement = 'The system shall throw an error if the user specifies incompatible command line arguments that would cause a segfault.'
   []
 []

--- a/test/tests/mesh/mesh_only/tests
+++ b/test/tests/mesh/mesh_only/tests
@@ -78,4 +78,13 @@
     issues = '#23386'
     requirement = 'The system shall throw a warning if user-provided extra element id names do not exist on mesh.'
   []
+  [mesh_only_with_incompatible_parameter]
+    type = 'RunException'
+    input = 'mesh_only.i'
+    cli_args = '--check-input --mesh-only'
+    expect_err = "Cannot run --check-input with mesh_only as this will result in a segfault"
+    method = '!dbg'
+    issues = '#29788'
+    requirement = 'The system shall throw an error is the user provides a parameter that would result in a segfault when used with --mesh-only'
+  []
 []


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
- Users may not know why it's segfaulting
## Design
<!--A concise description (design) of the enhancement.-->
- If --check-input is run with any param that creates a final task it results in a segfault
- Added check right after final tasks are set that checks if --check-input is being used as well
## Impact
<!--Will the enhancement change existing APIs or add something new?-->
Will aid in debugging MOOSE inputs

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
closes #29788