### PR TITLE
Allow writing console output to separate files while also using checkpoint output from another file

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -735,10 +735,6 @@ class Tester(MooseObject, OutputInterface):
             if self.specs['working_directory'][:1] == os.path.sep:
                 self.setStatus(self.fail, 'ABSOLUTE PATH DETECTED')
 
-        # We can't offer the option of reading output files outside of initial TestDir
-        if self.specs['working_directory'] and options.sep_files:
-            reasons['working_directory'] = '--sep-files* enabled'
-
         # Explicitly skip HPC tests
         if not self.specs['hpc'] and options.hpc:
             reasons['hpc'] = 'hpc=false'


### PR DESCRIPTION

refs #29805

I m not sure why we dont allow it?
@loganharbour 
