### PR TITLE
Support old format for specs in case the requirement report is being used with a single spec

### DIFF
--- a/python/moosesqa/SQARequirementReport.py
+++ b/python/moosesqa/SQARequirementReport.py
@@ -51,8 +51,13 @@ class SQARequirementReport(SQAReport):
 
         # Build Requirement objects and remove directory based dict
         requirements = []
-        for s in specs:
-            req_dict = get_requirements_from_tests(directories, s.split(), self.include_non_testable)
+        if not isinstance(specs, str):
+            for s in specs:
+                req_dict = get_requirements_from_tests(directories, s.split(), self.include_non_testable)
+                for values in req_dict.values():
+                    requirements += values
+        else:
+            req_dict = get_requirements_from_tests(directories, specs, self.include_non_testable)
             for values in req_dict.values():
                 requirements += values
 

--- a/python/moosesqa/test/test_SQARequirementReport.py
+++ b/python/moosesqa/test/test_SQARequirementReport.py
@@ -28,8 +28,21 @@ class TestSQARequirementReport(unittest.TestCase):
     @mock.patch('mooseutils.colorText', side_effect=lambda t, c, **kwargs: '{}:{}'.format(c,t))
     def testOptions(self, *args):
 
-        # test single spec
+        # test single spec (specified as a list)
         reporter = SQARequirementReport(title='testing', specs=['spec_missing_req'],
+                                        directories=['python/moosesqa/test/specs'])
+        r = reporter.getReport()
+        self.assertEqual(reporter.status, SQAReport.Status.ERROR)
+        self.assertIn('log_missing_requirement: 1', r)
+        self.assertIn('log_missing_design: 1', r)
+        self.assertIn('log_missing_issues: 1', r)
+        self.assertIn('log_empty_requirement: 1', r)
+        self.assertIn('log_empty_design: 1', r)
+        self.assertIn('log_empty_issues: 1',r )
+        self.assertIn('log_duplicate_requirement: 1', r)
+
+        # test single spec (specified as a string)
+        reporter = SQARequirementReport(title='testing', specs='spec_missing_req',
                                         directories=['python/moosesqa/test/specs'])
         r = reporter.getReport()
         self.assertEqual(reporter.status, SQAReport.Status.ERROR)


### PR DESCRIPTION
MOOSE is still using a single spec, and other apps might as well

refs #29713
