### PR TITLE
Having --color option take precedent over MOOSE_COLOR

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -774,13 +774,19 @@ MooseApp::setupOptions()
   {
     // Set from command line
     auto color = getParam<MooseEnum>("color");
-    // Set from environment
-    char * c_color = std::getenv("MOOSE_COLOR");
-    if (c_color)
-      color.assign(std::string(c_color), "While assigning environment variable MOOSE_COLOR");
-    // Set from deprecated --no-color
-    if (getParam<bool>("no_color"))
-      color = "off";
+    if (!isParamSetByUser("color"))
+    {
+      // Set from deprecated --no-color
+      if (getParam<bool>("no_color"))
+        color = "off";
+      // Set from environment
+      else
+      {
+        char * c_color = std::getenv("MOOSE_COLOR");
+        if (c_color)
+          color.assign(std::string(c_color), "While assigning environment variable MOOSE_COLOR");
+      }
+    }
 
     if (color == "auto")
       Moose::setColorConsole(true);


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason

Closes #29812

## Design

Order of priority for color console:
1. `--color` is set by user
2. `--no-color` is set by user
3. `MOOSE_COLOR` env variable is set

## Impact

Users setting `MOOSE_COLOR` will see different behavior with the `--color` option.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
