### PR TITLE
Libmesh update 20250205

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,8 +4,8 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 1 %}
-{% set version = "2024.12.02" %}
+{% set build = 0 %}
+{% set version = "2025.02.25" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2024.12.02 mpich_1
-  - moose-libmesh 2024.12.02 openmpi_1
+  - moose-libmesh 2025.02.25 mpich_0
+  - moose-libmesh 2025.02.25 openmpi_0
 
 moose_wasp:
   - moose-wasp 2025.02.25

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.02.27" %}
+{% set version = "2025.03.03" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2025.02.27
+  - moose-dev 2025.03.03
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/modules/doc/content/newsletter/2025/2025_02.md
+++ b/modules/doc/content/newsletter/2025/2025_02.md
@@ -11,6 +11,68 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2025.02.14` Update
+
+- Bug fix: `normals` vectors at the sides of edge elements in 3D,
+  which were previously hard-coded to return `(-1,0,0)` and `(1,0,0)`
+  at points 0 and 1 respectively (the correct solution only for
+  x-axis-aligned edges), are now correctly calculated for all edges in
+  2D/3D.  Compatibility with this fix required a corresponding fix in
+  one MOOSE application; developers of any applications not in MOOSE
+  CI who use non-x-axis-aligned edge elements may wish to test their
+  codes for result changes with this update.
+- Bug fix: H(curl) and H(div) element calculations are now correct on
+  2D elements embedded in 3D space and not parallel to the xy plane.
+- Bug fix: Some TIMPI communications of "packed-range" data (data with
+  variable-size data types), when given enough input data (typically
+  ~4MB by default) to split between multiple buffers and given an
+  output iterator that requires correct incrementation, were not
+  correctly preserving that iterator from one buffer to the next.
+  This has been fixed.
+- Fix for a multithreading error in applications where multiple
+  threads are encountering elements with negative mapping Jacobians
+- Preconditioning option, to scale new raw degrees of freedom, when
+  importing mesh constraint rows from a sparse matrix.  This can
+  greatly improve solver robustness on such constrained systems.
+- Command line option `--mpi-thread-type` to manually choose between
+  "single", "funneled", "serialized", and "multiple" MPI
+  initialization threading options.  Initialization still defaults to
+  "funneled" (for maximum compatibility with older MPI
+  implementations), but users of slate/strumpack may need to specify
+  "multiple" for compatibility with those packages.
+- PetscMatrix support for hash-table-based matrices with newer PETSc
+  versions.  This will allow MOOSE much more flexibility in problems
+  (e.g. contact) where a priori determination of matrix sparsity
+  patterns is difficult.
+- Fixes for `HYPRE_SetMemoryLocation` in more complicated (e.g. field
+  split) configurations
+- Removed `contrib/boost`, which was a version incompatible with
+  C++17.  libMesh codes (including MOOSE) which require boost now must
+  have an external boost installation to use.
+- Support for and compiler flag selection for configuring libMesh with
+  newer Intel compilers
+- `MeshTools::n_connected_components()` function to count the number
+  of connected components in a mesh
+- Added operator[] for DenseVector.  This is more consistent with
+  other vector/map container types, and enables more compatibility
+  with generic templated algorithms.
+- `PetscMatrix::frobenius_norm()` method, and refactoring of other
+  norm calculations
+- New `transient_ex3` example application demonstrating a explicit
+  DG/FV formulation of the 2D advection equation
+- Improvements and more options in `calculator` app
+- Improvements and bug fixes in reduced-basis code
+- New grad(div()) problem example code with Raviart-Thomas elements
+- Support for "packing" for Cap'n'Proto users
+- Bug fix in FParser optimized JIT output
+- Bug fix for corrupt time stamps in Exodus outputs with a single time
+  step
+- Bug fixes in programmatic setting of PETSc preconditioners
+- Workarounds for older PETSc error-checking macros are now removed;
+  raw PETSc code should use `LibmeshPetscCall` for error checking.
+- General cleanup in autoconf (`./configure` source) code
+- General refactoring in `FEInterface`
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/modules/doc/content/newsletter/2025/2025_02.md
+++ b/modules/doc/content/newsletter/2025/2025_02.md
@@ -11,7 +11,7 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
-### `2025.02.14` Update
+### `2025.02.25` Update
 
 - Bug fix: `normals` vectors at the sides of edge elements in 3D,
   which were previously hard-coded to return `(-1,0,0)` and `(1,0,0)`
@@ -34,6 +34,10 @@ for a complete description of all MOOSE changes.
 - Preconditioning option, to scale new raw degrees of freedom, when
   importing mesh constraint rows from a sparse matrix.  This can
   greatly improve solver robustness on such constrained systems.
+- Support for the combination of subdomain-restricted variables with
+  subdomain-spanning mesh constraints.  This fixes errors from certain
+  use cases of subdomain-restricted variables on IsoGeometric
+  Analysis meshes.
 - Command line option `--mpi-thread-type` to manually choose between
   "single", "funneled", "serialized", and "multiple" MPI
   initialization threading options.  Initialization still defaults to
@@ -51,6 +55,8 @@ for a complete description of all MOOSE changes.
   have an external boost installation to use.
 - Support for and compiler flag selection for configuring libMesh with
   newer Intel compilers
+- Bug fixes and first-order two-dimensional test coverage for
+  VariationalMeshSmoother.
 - `MeshTools::n_connected_components()` function to count the number
   of connected components in a mesh
 - Added operator[] for DenseVector.  This is more consistent with
@@ -65,6 +71,8 @@ for a complete description of all MOOSE changes.
 - New grad(div()) problem example code with Raviart-Thomas elements
 - Support for "packing" for Cap'n'Proto users
 - Bug fix in FParser optimized JIT output
+- Bug fix for `elem_default_orders()` print style in
+  `MeshBase::get_info()` and `print_info()`.
 - Bug fix for corrupt time stamps in Exodus outputs with a single time
   step
 - Bug fixes in programmatic setting of PETSc preconditioners

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -832,3 +832,34 @@ fd5f7bc651f0d6a8e2d23e5d4c2c2dadca58aa0b: #29978
   wasp:
     full_version: 2025.02.25_0
     hash: 46ea1c0
+2d9ff14e1bf085cdf3219d5a477d7ed017b600a6: #29817
+  libmesh:
+    full_version: 2025.02.25_0
+    hash: dabc922
+  libmesh-vtk:
+    full_version: 9.3.0_5
+    hash: 9a4dbab
+  moose-dev:
+    full_version: 2025.03.03
+    hash: fcaa73c
+  mpi:
+    full_version: 2024.12.23
+    hash: 82bbd28
+  peacock:
+    full_version: 2024.12.23
+    hash: ef44cb6
+  petsc:
+    full_version: 3.22.1.193.g72c1e49ee3d_1
+    hash: e78a9a4
+  pprof:
+    full_version: 2024.12.23_0
+    hash: fe051bc
+  seacas:
+    full_version: 2024.08.15_2
+    hash: 2dd352c
+  tools:
+    full_version: 2024.12.23
+    hash: 5abb5f2
+  wasp:
+    full_version: 2025.02.25_0
+    hash: 46ea1c0

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -44,8 +44,8 @@ packages:
       - scripts/apple-silicon-hdf5-autogen.patch
   # dependers: moose-dev
   libmesh:
-    version: 2024.12.02
-    build_number: 1
+    version: 2025.02.25
+    build_number: 0
     conda: conda/libmesh
     templates:
       conda/libmesh/conda_build_config.yaml.template: conda/libmesh/conda_build_config.yaml
@@ -81,7 +81,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.02.27
+    version: 2025.03.03
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml


### PR DESCRIPTION
Update libMesh submodule:

- Bug fix: `normals` vectors at the sides of edge elements in 3D, which were previously hard-coded to return `(-1,0,0)` and `(1,0,0)`  at points 0 and 1 respectively (the correct solution only for x-axis-aligned edges), are now correctly calculated for all edges in 2D/3D.  Compatibility with this fix required a corresponding fix in one MOOSE application; developers of any applications not in MOOSE CI who use non-x-axis-aligned edge elements may wish to test their codes for result changes with this update.
- Bug fix: H(curl) and H(div) element calculations are now correct on 2D elements embedded in 3D space and not parallel to the xy plane.
- Bug fix: Some TIMPI communications of "packed-range" data (data with variable-size data types), when given enough input data (typically ~4MB by default) to split between multiple buffers and given an output iterator that requires correct incrementation, were not correctly preserving that iterator from one buffer to the next.  This has been fixed.
- Command line option `--mpi-thread-type` to manually choose between "single", "funneled", "serialized", and "multiple" MPI initialization threading options.  Initialization still defaults to "funneled" (for maximum compatibility with older MPI implementations), but users of slate/strumpack may need to specify "multiple" for compatibility with those packages.
- PetscMatrix support for hash-table-based matrices with newer PETSc versions.  This will allow MOOSE much more flexibility in problems (e.g. contact) where a priori determination of matrix sparsity patterns is difficult.
- Fixes for `HYPRE_SetMemoryLocation` in more complicated (e.g. field split) configurations
- Removed `contrib/boost`, which was a version incompatible with C++17.  libMesh codes (including MOOSE) which require boost now must have an external boost installation to use.
- Support for and compiler flag selection for configuring libMesh with newer Intel compilers
- `MeshTools::n_connected_components()` function to count the number of connected components in a mesh
- Added operator[] for DenseVector.  This is more consistent with other vector/map container types, and enables more compatibility with generic templated algorithms.
- `PetscMatrix::frobenius_norm()` method, and refactoring of other norm calculations
- Improvements and more options in `calculator` app
- Improvements and bug fixes in reduced-basis code
- New grad(div()) problem example code with Raviart-Thomas elements
- Support for "packing" for Cap'n'Proto users
- Bug fix in FParser optimized JIT output
- Bug fix for corrupt time stamps in Exodus outputs with a single time step
- Bug fixes in programmatic setting of PETSc preconditioners
- Workarounds for older PETSc error-checking macros are now removed; raw PETSc code should use `LibmeshPetscCall` for error checking.
- General cleanup in autoconf (`./configure` source) code
- General refactoring in `FEInterface`

Edit: a force push also adds:
- Fix for a multithreading error in applications where multiple threads are encountering elements with negative mapping Jacobians
- Preconditioning option, to scale new raw degrees of freedom, when importing mesh constraint rows from a sparse matrix.  This can greatly improve solver robustness on such constrained systems.
- New `transient_ex3` example application demonstrating a explicit DG/FV formulation of the 2D advection equation
