### PR TITLE
Check if old state exists in neml2 predictor

### DIFF
--- a/apptainer/moose-dev.def
+++ b/apptainer/moose-dev.def
@@ -131,6 +131,10 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
         rpm -i ${CUDA_RPM}
         dnf -y install cuda
         rm -rf ${CUDA_RPM}
+    # the CUDA libtorch needs a symlink for libnvrtc-builtins (the link removes the hash portion from the name)
+        cd ${LIBTORCH_DEST}/libtorch/lib
+        LIBNVRTC=$(ls libnvrtc-builtins-????????.so.*.* | head -n1)
+        ln -s $LIBNVRTC $(echo $LIBNVRTC | cut -d. -f1 | head -c-10).$(echo $LIBNVRTC | cut -d. -f2-)
 {%- endif %}
 {%- endif %}
 

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.02.18" %}
+{% set version = "2025.02.26" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2025.02.18
+  - moose-dev 2025.02.26
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -770,3 +770,34 @@ a29438b9ccb11dc2dddf2b9b0a5d5c0bbaf96472: #29624
   wasp:
     full_version: 2025.01.07_0
     hash: e97f1e3
+e6f3f28c8473edf66a9a63f6a1fff0b3d8dabe3e: # 29978
+  libmesh:
+    full_version: 2024.12.02_1
+    hash: b8b3d69
+  libmesh-vtk:
+    full_version: 9.3.0_5
+    hash: 9a4dbab
+  moose-dev:
+    full_version: 2025.02.26
+    hash: 5c91d05
+  mpi:
+    full_version: 2024.12.23
+    hash: 82bbd28
+  peacock:
+    full_version: 2024.12.23
+    hash: ef44cb6
+  petsc:
+    full_version: 3.22.1.193.g72c1e49ee3d_1
+    hash: e78a9a4
+  pprof:
+    full_version: 2024.12.23_0
+    hash: fe051bc
+  seacas:
+    full_version: 2024.08.15_2
+    hash: 2dd352c
+  tools:
+    full_version: 2024.12.23
+    hash: 5abb5f2
+  wasp:
+    full_version: 2025.01.07_0
+    hash: e97f1e3

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -81,7 +81,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.02.18
+    version: 2025.02.26
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml


### PR DESCRIPTION
## Reason
If a NEML2 model does not hav old state on the input axis the `applyPredictor` step in `NEML2ModelExecutor` will throw an exception.

## Design
Use `has_subaxis` to check for the existence of the old state subaxis and bail early if it doesn't exist.

## Impact
Enable models to run.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
