### PR TITLE
Generate wall temperature materials with multiple heat transfers

### DIFF
--- a/modules/thermal_hydraulics/doc/content/source/materials/ConvectiveHeatTransferCoefficientMaterial.md
+++ b/modules/thermal_hydraulics/doc/content/source/materials/ConvectiveHeatTransferCoefficientMaterial.md
@@ -5,7 +5,7 @@
 The heat transfer coefficient $h$ is simply derived from the definition of the Nusselt number $Nu$:
 
 !equation
-Nu = \dfrac{Nu k}{D_h}
+h = \dfrac{Nu k}{D_h}
 
 with $k$ the thermal conductivity and $D_h$ the hydraulic diameter.
 

--- a/modules/thermal_hydraulics/doc/content/source/materials/WallHeatTransferCoefficient3EqnDittusBoelterMaterial.md
+++ b/modules/thermal_hydraulics/doc/content/source/materials/WallHeatTransferCoefficient3EqnDittusBoelterMaterial.md
@@ -13,7 +13,7 @@ The Nusselt number in this correlation is:
 !equation
 Nu = 0.023 Re^{\dfrac{4}{5}} Pr^n;
 
-with $n$ = 0.4 if the fluid temperature is greater than the wall temperature and 0.3 otherwise,
+with $n$ = 0.4 if the fluid temperature is lower than the wall temperature and 0.3 otherwise,
 $Re$ the Reynolds number and $Pr$ the Prandtl number.
 
 !syntax parameters /Materials/WallHeatTransferCoefficient3EqnDittusBoelterMaterial

--- a/modules/thermal_hydraulics/src/closures/WallTemperature1PhaseClosures.C
+++ b/modules/thermal_hydraulics/src/closures/WallTemperature1PhaseClosures.C
@@ -46,10 +46,11 @@ WallTemperature1PhaseClosures::addMooseObjectsFlowChannel(const FlowChannelBase 
   const unsigned int n_ht_connections = flow_channel_1phase.getNumberOfHeatTransferConnections();
   if ((n_ht_connections > 0) && (flow_channel.getTemperatureMode()))
   {
+    for (unsigned int i = 0; i < n_ht_connections; i++)
+      addWallTemperatureFromAuxMaterial(flow_channel_1phase, i);
+
     if (flow_channel.getNumberOfHeatTransferConnections() > 1)
       addAverageWallTemperatureMaterial(flow_channel_1phase);
-    else
-      addWallTemperatureFromAuxMaterial(flow_channel_1phase);
   }
 }
 

--- a/modules/thermal_hydraulics/test/tests/closures/wall_temperature_1phase/gold/multiple_out.csv
+++ b/modules/thermal_hydraulics/test/tests/closures/wall_temperature_1phase/gold/multiple_out.csv
@@ -1,2 +1,2 @@
-time,T_wall
-0,600
+time,T_wall,T_wall_1,T_wall_2
+0,600,500,700

--- a/modules/thermal_hydraulics/test/tests/closures/wall_temperature_1phase/multiple.i
+++ b/modules/thermal_hydraulics/test/tests/closures/wall_temperature_1phase/multiple.i
@@ -16,3 +16,15 @@
     T_wall = 700
   []
 []
+[Postprocessors]
+  [T_wall_1]
+    type = ADElementAverageMaterialProperty
+    mat_prop = T_wall:1
+    execute_on = 'INITIAL'
+  []
+  [T_wall_2]
+    type = ADElementAverageMaterialProperty
+    mat_prop = T_wall:2
+    execute_on = 'INITIAL'
+  []
+[]

--- a/modules/thermal_hydraulics/test/tests/problems/three_pipe_shock/tests
+++ b/modules/thermal_hydraulics/test/tests/problems/three_pipe_shock/tests
@@ -7,7 +7,7 @@
     input = 'three_pipe_shock.i'
     csvdiff = 'three_pipe_shock.csv'
     heavy = True
-    max_time = 600
+    max_time = 650
     requirement = 'The system shall be able to model a 3-pipe shock.'
   []
 []


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
Create wall temperature materials for each individual heat transfer when `WallTemperature1PhaseClosures` are used with multiple heat transfers.

## Design
<!--A concise description (design) of the enhancement.-->
Create wall temperature material for each heat transfer connected to the flow channel.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
The user won't have to manually add the materials for wall temperatures.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
