### PR TITLE
Fix bad parameter defaults in radiation heat transfer BCs

### DIFF
--- a/modules/heat_transfer/include/bcs/InfiniteCylinderRadiativeBC.h
+++ b/modules/heat_transfer/include/bcs/InfiniteCylinderRadiativeBC.h
@@ -26,6 +26,9 @@ public:
 protected:
   virtual GenericReal<is_ad> coefficient() const override;
 
+  /// Emissivity of the boundary
+  const Real _eps_boundary;
+
   /// emissivity of the cylinder in radiative heat transfer with the boundary
   const Real _eps_cylinder;
 

--- a/modules/heat_transfer/include/bcs/RadiativeHeatFluxBCBase.h
+++ b/modules/heat_transfer/include/bcs/RadiativeHeatFluxBCBase.h
@@ -42,9 +42,6 @@ protected:
   /// Function describing the temperature of the body irhs
   const Function & _tinf;
 
-  /// Emissivity of the boundary
-  const Real _eps_boundary;
-
   usingGenericIntegratedBCMembers;
 };
 

--- a/modules/heat_transfer/include/fvbcs/FVInfiniteCylinderRadiativeBC.h
+++ b/modules/heat_transfer/include/fvbcs/FVInfiniteCylinderRadiativeBC.h
@@ -25,6 +25,9 @@ public:
 protected:
   virtual Real coefficient() const override;
 
+  /// Emissivity of the boundary
+  const Real _eps_boundary;
+
   /// emissivity of the cylinder in radiative heat transfer with the boundary
   const Real _eps_cylinder;
 

--- a/modules/heat_transfer/include/fvbcs/FVRadiativeHeatFluxBCBase.h
+++ b/modules/heat_transfer/include/fvbcs/FVRadiativeHeatFluxBCBase.h
@@ -43,7 +43,4 @@ protected:
   /// Function describing the temperature of the body completely surrounding the surface, e.g. the
   /// temperature of the body we are in radiative heat transfer with
   const Moose::Functor<ADReal> & _tinf;
-
-  /// Emissivity of the boundary
-  const Real _eps_boundary;
 };

--- a/modules/heat_transfer/src/bcs/ADConvectiveHeatFluxBC.C
+++ b/modules/heat_transfer/src/bcs/ADConvectiveHeatFluxBC.C
@@ -44,9 +44,14 @@ ADConvectiveHeatFluxBC::ADConvectiveHeatFluxBC(const InputParameters & parameter
 {
   if (_T_infinity || _htc)
   {
-    if (_T_infinity_functor || _htc_functor)
+    if (_T_infinity_functor)
       paramError("T_infinity_functor",
-                 "Either material properties or functors should be specified");
+                 "Either material properties or functors should be specified for both T_infinity "
+                 "and the heat transfer coefficient.");
+    if (_htc_functor)
+      paramError("heat_transfer_coefficient_functor",
+                 "Either material properties or functors should be specified for both T_infinity "
+                 "and the heat transfer coefficient");
     if (!_htc)
       paramError("heat_transfer_coefficient",
                  "Heat transfer coefficient material property must be specified");

--- a/modules/heat_transfer/src/bcs/InfiniteCylinderRadiativeBC.C
+++ b/modules/heat_transfer/src/bcs/InfiniteCylinderRadiativeBC.C
@@ -18,6 +18,7 @@ InputParameters
 InfiniteCylinderRadiativeBCTempl<is_ad>::validParams()
 {
   InputParameters params = RadiativeHeatFluxBCBaseTempl<is_ad>::validParams();
+  params.addRequiredParam<Real>("boundary_emissivity", "Emissivity of the boundary.");
   params.addParam<Real>("cylinder_emissivity",
                         1,
                         "Emissivity of the cylinder in radiative heat transfer with the boundary.");
@@ -34,6 +35,7 @@ template <bool is_ad>
 InfiniteCylinderRadiativeBCTempl<is_ad>::InfiniteCylinderRadiativeBCTempl(
     const InputParameters & parameters)
   : RadiativeHeatFluxBCBaseTempl<is_ad>(parameters),
+    _eps_boundary(this->template getParam<Real>("boundary_emissivity")),
     _eps_cylinder(this->template getParam<Real>("cylinder_emissivity")),
     _boundary_radius(this->template getParam<Real>("boundary_radius")),
     _cylinder_radius(this->template getParam<Real>("cylinder_radius"))

--- a/modules/heat_transfer/src/bcs/RadiativeHeatFluxBCBase.C
+++ b/modules/heat_transfer/src/bcs/RadiativeHeatFluxBCBase.C
@@ -17,9 +17,9 @@ RadiativeHeatFluxBCBaseTempl<is_ad>::validParams()
 {
   InputParameters params = GenericIntegratedBC<is_ad>::validParams();
   params.addParam<Real>("stefan_boltzmann_constant", 5.670367e-8, "The Stefan-Boltzmann constant.");
-  params.addParam<FunctionName>(
-      "Tinfinity", "0", "Temperature of the body in radiative heat transfer.");
-  params.addParam<Real>("boundary_emissivity", 1, "Emissivity of the boundary.");
+  params.addRequiredParam<FunctionName>("Tinfinity",
+                                        "Temperature of the body in radiative heat transfer.");
+  params.addRequiredParam<Real>("boundary_emissivity", "Emissivity of the boundary.");
   params.addClassDescription("Boundary condition for radiative heat flux where temperature and the"
                              "temperature of a body in radiative heat transfer are specified.");
   return params;

--- a/modules/heat_transfer/src/bcs/RadiativeHeatFluxBCBase.C
+++ b/modules/heat_transfer/src/bcs/RadiativeHeatFluxBCBase.C
@@ -19,7 +19,6 @@ RadiativeHeatFluxBCBaseTempl<is_ad>::validParams()
   params.addParam<Real>("stefan_boltzmann_constant", 5.670367e-8, "The Stefan-Boltzmann constant.");
   params.addRequiredParam<FunctionName>("Tinfinity",
                                         "Temperature of the body in radiative heat transfer.");
-  params.addRequiredParam<Real>("boundary_emissivity", "Emissivity of the boundary.");
   params.addClassDescription("Boundary condition for radiative heat flux where temperature and the"
                              "temperature of a body in radiative heat transfer are specified.");
   return params;
@@ -30,8 +29,7 @@ RadiativeHeatFluxBCBaseTempl<is_ad>::RadiativeHeatFluxBCBaseTempl(
     const InputParameters & parameters)
   : GenericIntegratedBC<is_ad>(parameters),
     _sigma_stefan_boltzmann(this->template getParam<Real>("stefan_boltzmann_constant")),
-    _tinf(getFunction("Tinfinity")),
-    _eps_boundary(this->template getParam<Real>("boundary_emissivity"))
+    _tinf(getFunction("Tinfinity"))
 {
 }
 

--- a/modules/heat_transfer/src/fvbcs/FVInfiniteCylinderRadiativeBC.C
+++ b/modules/heat_transfer/src/fvbcs/FVInfiniteCylinderRadiativeBC.C
@@ -16,6 +16,7 @@ InputParameters
 FVInfiniteCylinderRadiativeBC::validParams()
 {
   InputParameters params = FVRadiativeHeatFluxBCBase::validParams();
+  params.addRequiredParam<Real>("boundary_emissivity", "Emissivity of the boundary.");
   params.addParam<Real>("cylinder_emissivity",
                         1,
                         "Emissivity of the cylinder in radiative heat transfer with the boundary.");
@@ -30,6 +31,7 @@ FVInfiniteCylinderRadiativeBC::validParams()
 
 FVInfiniteCylinderRadiativeBC::FVInfiniteCylinderRadiativeBC(const InputParameters & parameters)
   : FVRadiativeHeatFluxBCBase(parameters),
+    _eps_boundary(getParam<Real>("boundary_emissivity")),
     _eps_cylinder(getParam<Real>("cylinder_emissivity")),
     _boundary_radius(getParam<Real>("boundary_radius")),
     _cylinder_radius(getParam<Real>("cylinder_radius"))

--- a/modules/heat_transfer/src/fvbcs/FVRadiativeHeatFluxBCBase.C
+++ b/modules/heat_transfer/src/fvbcs/FVRadiativeHeatFluxBCBase.C
@@ -16,9 +16,9 @@ FVRadiativeHeatFluxBCBase::validParams()
   InputParameters params = FVFluxBC::validParams();
   params.addCoupledVar("temperature", "temperature variable");
   params.addParam<Real>("stefan_boltzmann_constant", 5.670367e-8, "The Stefan-Boltzmann constant.");
-  params.addParam<MooseFunctorName>(
-      "Tinfinity", "0", "Temperature of the body in radiative heat transfer.");
-  params.addParam<Real>("boundary_emissivity", 1, "Emissivity of the boundary.");
+  params.addRequiredParam<MooseFunctorName>("Tinfinity",
+                                            "Temperature of the body in radiative heat transfer.");
+  params.addRequiredParam<Real>("boundary_emissivity", "Emissivity of the boundary.");
   params.addClassDescription("Boundary condition for radiative heat flux where temperature and the"
                              "temperature of a body in radiative heat transfer are specified.");
   return params;

--- a/modules/heat_transfer/src/fvbcs/FVRadiativeHeatFluxBCBase.C
+++ b/modules/heat_transfer/src/fvbcs/FVRadiativeHeatFluxBCBase.C
@@ -18,7 +18,6 @@ FVRadiativeHeatFluxBCBase::validParams()
   params.addParam<Real>("stefan_boltzmann_constant", 5.670367e-8, "The Stefan-Boltzmann constant.");
   params.addRequiredParam<MooseFunctorName>("Tinfinity",
                                             "Temperature of the body in radiative heat transfer.");
-  params.addRequiredParam<Real>("boundary_emissivity", "Emissivity of the boundary.");
   params.addClassDescription("Boundary condition for radiative heat flux where temperature and the"
                              "temperature of a body in radiative heat transfer are specified.");
   return params;
@@ -28,8 +27,7 @@ FVRadiativeHeatFluxBCBase::FVRadiativeHeatFluxBCBase(const InputParameters & par
   : FVFluxBC(parameters),
     _T(isParamValid("temperature") ? adCoupledValue("temperature") : _u),
     _sigma_stefan_boltzmann(getParam<Real>("stefan_boltzmann_constant")),
-    _tinf(getFunctor<ADReal>("Tinfinity")),
-    _eps_boundary(getParam<Real>("boundary_emissivity"))
+    _tinf(getFunctor<ADReal>("Tinfinity"))
 {
   if (!isParamValid("temperature"))
     _var.requireQpComputations();

--- a/modules/heat_transfer/test/tests/fvbcs/fv_radiative_heat_flux/test.i
+++ b/modules/heat_transfer/test/tests/fvbcs/fv_radiative_heat_flux/test.i
@@ -35,6 +35,9 @@
     boundary_radius = 1
     cylinder_radius = 12
     cylinder_emissivity = 0.4
+    # Using previous defaults
+    boundary_emissivity = 1
+    Tinfinity = 0
   []
   [top]
     type = FVInfiniteCylinderRadiativeBC
@@ -45,6 +48,9 @@
     boundary_radius = 1
     cylinder_radius = 12
     cylinder_emissivity = 0.4
+    # Using previous defaults
+    boundary_emissivity = 1
+    Tinfinity = 0
   []
   [other]
     type = FVDirichletBC

--- a/modules/heat_transfer/test/tests/radiative_bcs/ad_function_radiative_bc.i
+++ b/modules/heat_transfer/test/tests/radiative_bcs/ad_function_radiative_bc.i
@@ -59,6 +59,8 @@
     boundary = bot_right
     # htc/(stefan-boltzmann*4*T_inf^3)
     emissivity_function = '3/(5.670367e-8*4*300*300*300)'
+    # Using previous default
+    Tinfinity = 0
   []
 []
 

--- a/modules/heat_transfer/test/tests/radiative_bcs/function_radiative_bc.i
+++ b/modules/heat_transfer/test/tests/radiative_bcs/function_radiative_bc.i
@@ -60,6 +60,8 @@
     boundary = bot_right
     # htc/(stefan-boltzmann*4*T_inf^3)
     emissivity_function = '3/(5.670367e-8*4*300*300*300)'
+    # Using previous default
+    Tinfinity = 0
   [../]
 []
 

--- a/modules/navier_stokes/src/functormaterials/GeneralFunctorFluidProps.C
+++ b/modules/navier_stokes/src/functormaterials/GeneralFunctorFluidProps.C
@@ -31,7 +31,7 @@ GeneralFunctorFluidProps::validParams()
       false,
       "Whether to force the definition of a density functor from the fluid properties");
   params.addParam<bool>("neglect_derivatives_of_density_time_derivative",
-                        false,
+                        true,
                         "Whether to neglect the derivatives with regards to nonlinear variables "
                         "of the density time derivatives");
 

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/natural_convection/natural_circulation_pipe.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/natural_convection/natural_circulation_pipe.i
@@ -131,6 +131,7 @@ gamma = 1.4
     T_fluid = T_fluid
     speed = speed
     force_define_density = true
+    neglect_derivatives_of_density_time_derivative = false
     mu_rampdown = 'mu_rampdown_fn'
     characteristic_length = 1
     porosity = porosity

--- a/modules/thermal_hydraulics/include/bcs/ADRadiativeHeatFluxBC.h
+++ b/modules/thermal_hydraulics/include/bcs/ADRadiativeHeatFluxBC.h
@@ -22,6 +22,8 @@ public:
 protected:
   virtual ADReal coefficient() const override;
 
+  /// Emissivity of the boundary
+  const Real _eps_boundary;
   /// View factor function
   const Function & _view_factor_fn;
 

--- a/modules/thermal_hydraulics/include/bcs/RadiativeHeatFluxBC.h
+++ b/modules/thermal_hydraulics/include/bcs/RadiativeHeatFluxBC.h
@@ -22,6 +22,8 @@ public:
 protected:
   virtual Real coefficient() const override;
 
+  /// Emissivity of the boundary
+  const Real _eps_boundary;
   /// View factor function
   const Function & _view_factor_fn;
 

--- a/modules/thermal_hydraulics/src/bcs/ADRadiativeHeatFluxBC.C
+++ b/modules/thermal_hydraulics/src/bcs/ADRadiativeHeatFluxBC.C
@@ -17,6 +17,7 @@ ADRadiativeHeatFluxBC::validParams()
 {
   InputParameters params = ADRadiativeHeatFluxBCBase::validParams();
 
+  params.addRequiredParam<Real>("boundary_emissivity", "Emissivity of the boundary.");
   params.addParam<FunctionName>("view_factor", "1", "View factor function");
   params.addDeprecatedParam<PostprocessorName>(
       "scale_pp",
@@ -35,7 +36,7 @@ ADRadiativeHeatFluxBC::validParams()
 
 ADRadiativeHeatFluxBC::ADRadiativeHeatFluxBC(const InputParameters & parameters)
   : ADRadiativeHeatFluxBCBase(parameters),
-
+    _eps_boundary(getParam<Real>("boundary_emissivity")),
     _view_factor_fn(getFunction("view_factor")),
     _scale_pp(getPostprocessorValue("scale_pp")),
     _scale_fn(getFunction("scale"))

--- a/modules/thermal_hydraulics/src/bcs/RadiativeHeatFluxBC.C
+++ b/modules/thermal_hydraulics/src/bcs/RadiativeHeatFluxBC.C
@@ -17,6 +17,7 @@ RadiativeHeatFluxBC::validParams()
 {
   InputParameters params = RadiativeHeatFluxBCBase::validParams();
 
+  params.addRequiredParam<Real>("boundary_emissivity", "Emissivity of the boundary.");
   params.addParam<FunctionName>("view_factor", "1", "View factor function");
   params.addParam<PostprocessorName>(
       "scale_pp", 1.0, "Post-processor by which to scale boundary condition");
@@ -29,7 +30,7 @@ RadiativeHeatFluxBC::validParams()
 
 RadiativeHeatFluxBC::RadiativeHeatFluxBC(const InputParameters & parameters)
   : RadiativeHeatFluxBCBase(parameters),
-
+    _eps_boundary(getParam<Real>("boundary_emissivity")),
     _view_factor_fn(getFunction("view_factor")),
     _scale_pp(getPostprocessorValue("scale_pp"))
 {


### PR DESCRIPTION
also moving an attribute that was getting ignored in its class and only used in derived classes, which wasnt a good design

refs #29839