### PR TITLE
Match changes in libMesh::QBase APIs

### DIFF
--- a/framework/include/utils/ArbitraryQuadrature.h
+++ b/framework/include/utils/ArbitraryQuadrature.h
@@ -53,13 +53,20 @@ public:
 private:
   /**
    * These functions must be defined to fulfill the interface expected
-   * by the quadrature initialization routines.  Please do not
-   * modify the function names or signatures.
+   * by the quadrature initialization routines.  The names and
+   * signatures depend on what version of libMesh we are compiled
+   * against.
    */
+#ifdef LIBMESH_QBASE_INIT_ARGUMENTS_REMOVED
+  void init_1D() override;
+  void init_2D() override;
+  void init_3D() override;
+#else
   void init_1D(const libMesh::ElemType _type = libMesh::INVALID_ELEM,
                unsigned int p_level = 0) override;
   void init_2D(const libMesh::ElemType _type = libMesh::INVALID_ELEM,
                unsigned int p_level = 0) override;
   void init_3D(const libMesh::ElemType _type = libMesh::INVALID_ELEM,
                unsigned int p_level = 0) override;
+#endif // LIBMESH_QBASE_INIT_ARGUMENTS_REMOVED
 };

--- a/framework/src/utils/ArbitraryQuadrature.C
+++ b/framework/src/utils/ArbitraryQuadrature.C
@@ -41,23 +41,35 @@ ArbitraryQuadrature::setWeights(const std::vector<Real> & weights)
   _weights = weights;
 }
 
+#ifdef LIBMESH_QBASE_INIT_ARGUMENTS_REMOVED
 void
-ArbitraryQuadrature::init_1D(const ElemType _type, unsigned int p_level)
+ArbitraryQuadrature::init_1D()
 {
-  this->_type = _type;
-  this->_p_level = p_level;
 }
 
 void
-ArbitraryQuadrature::init_2D(const ElemType _type, unsigned int p_level)
+ArbitraryQuadrature::init_2D()
 {
-  this->_type = _type;
-  this->_p_level = p_level;
 }
 
 void
-ArbitraryQuadrature::init_3D(const ElemType _type, unsigned int p_level)
+ArbitraryQuadrature::init_3D()
 {
-  this->_type = _type;
-  this->_p_level = p_level;
 }
+
+#else
+void
+ArbitraryQuadrature::init_1D(const ElemType, unsigned int)
+{
+}
+
+void
+ArbitraryQuadrature::init_2D(const ElemType, unsigned int)
+{
+}
+
+void
+ArbitraryQuadrature::init_3D(const ElemType, unsigned int)
+{
+}
+#endif // LIBMESH_QBASE_INIT_ARGUMENTS_REMOVED


### PR DESCRIPTION
This fixes #29875 for me; assuming it passes MOOSE CI then it should also be backwards-compatible with the current (and immediately upcoming) libMesh submodule versions.