### PR TITLE
Added error to prevent segfault in DebugResidualAux

### DIFF
--- a/framework/src/auxkernels/DebugResidualAux.C
+++ b/framework/src/auxkernels/DebugResidualAux.C
@@ -42,6 +42,9 @@ DebugResidualAux::DebugResidualAux(const InputParameters & parameters)
                _debug_var.name(),
                " in ",
                this->getParam<std::string>("_object_name"));
+  if (!_nodal && debug_order > 0)
+    mooseWarning("Residual output is approximate for variable order " +
+                 Moose::stringify(debug_order));
 }
 
 Real

--- a/framework/src/auxkernels/DebugResidualAux.C
+++ b/framework/src/auxkernels/DebugResidualAux.C
@@ -10,6 +10,8 @@
 #include "DebugResidualAux.h"
 #include "NonlinearSystem.h"
 
+#include "libmesh/string_to_enum.h"
+
 registerMooseObject("MooseApp", DebugResidualAux);
 
 InputParameters
@@ -28,6 +30,18 @@ DebugResidualAux::DebugResidualAux(const InputParameters & parameters)
     _debug_var(_nl_sys.getVariable(_tid, getParam<NonlinearVariableName>("debug_variable"))),
     _residual_copy(_nl_sys.residualGhosted())
 {
+  // Check that variable order/family match aux_variable order/family
+  auto var_order = Utility::string_to_enum<Order>(_var.getParam<MooseEnum>("order"));
+  auto debug_order = Utility::string_to_enum<Order>(_debug_var.getParam<MooseEnum>("order"));
+  auto var_family = Utility::string_to_enum<FEFamily>(_var.getParam<MooseEnum>("family"));
+  auto debug_family = Utility::string_to_enum<FEFamily>(_debug_var.getParam<MooseEnum>("family"));
+  if (var_order != debug_order || var_family != debug_family)
+    mooseError("A mismatch was found between family and order parameters for ",
+               _var.name(),
+               " and ",
+               _debug_var.name(),
+               " in ",
+               this->getParam<std::string>("_object_name"));
 }
 
 Real

--- a/test/tests/auxkernels/debug_residual_aux/mismatch_residual_test.i
+++ b/test/tests/auxkernels/debug_residual_aux/mismatch_residual_test.i
@@ -1,0 +1,70 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 1
+    nx = 4
+  []
+[]
+
+[Variables]
+  [u]
+    order = FIRST
+    family = LAGRANGE
+    block = 0
+  []
+[]
+
+[AuxVariables]
+  [u_residual]
+    order = CONSTANT
+    family = MONOMIAL
+    block = 0
+  []
+[]
+
+[Kernels]
+  [diff_u]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[AuxKernels]
+  [debug_aux]
+    type = DebugResidualAux
+    debug_variable = u
+    variable = u_residual
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = 'left'
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = 'right'
+    value = 1
+  []
+[]
+
+[Executioner]
+  type = Transient
+  start_time = 0
+  end_time = 10
+  dt = 10
+
+  solve_type = NEWTON
+
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]
+

--- a/test/tests/auxkernels/debug_residual_aux/tests
+++ b/test/tests/auxkernels/debug_residual_aux/tests
@@ -1,13 +1,10 @@
 [Tests]
   design = 'source/auxkernels/DebugResidualAux.md'
-  requirement = "The system shall have the ability to create an auxiliary variable that keeps track of the residual for a nonlinear system variable's equation and check that "
+  issues = '#27633'
   [errors]
-    issues = '#27633'
-    [mismatched_params]
-      type = RunException
-      input = mismatch_residual_test.i
-      expect_err = "A mismatch was found between family and order parameters for u_residual and u in debug_aux"
-      detail = "family and order parameters must be the same for the residual output variable and the equation variable."
-    []
+    type = RunException
+    input = mismatch_residual_test.i
+    expect_err = "A mismatch was found between family and order parameters for u_residual and u in debug_aux"
+    requirement = "The system shall have the ability to create an auxiliary variable that keeps track of the residual for a nonlinear system variable's equation and check that family and order parameters must be the same for the residual output variable and the equation variable."
   []
 []

--- a/test/tests/auxkernels/debug_residual_aux/tests
+++ b/test/tests/auxkernels/debug_residual_aux/tests
@@ -1,0 +1,13 @@
+[Tests]
+  design = 'source/auxkernels/DebugResidualAux.md'
+  requirement = "The system shall have the ability to create an auxiliary variable that keeps track of the residual for a nonlinear system variable's equation and check that "
+  [errors]
+    issues = '#27633'
+    [mismatched_params]
+      type = RunException
+      input = mismatch_residual_test.i
+      expect_err = "A mismatch was found between family and order parameters for u_residual and u in debug_aux"
+      detail = "family and order parameters must be the same for the residual output variable and the equation variable."
+    []
+  []
+[]


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
-Makes debugging input file easier

## Design
<!--A concise description (design) of the enhancement.-->
-Added check in DebugResidualAux constructor that checks that order and family parameters match for var and aux var 
-Added basic test for DebugAuxillaryAux
-Added DebugResidualAux test that checks to ensure error is throw when order/family params don't match

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
Less time spent on user support

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
closes #27633