### PR TITLE
Fixes setup instructions for Blue Crab and execution info output formatting

### DIFF
--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -374,10 +374,10 @@ outputExecutionInformation(const MooseApp & app, FEProblemBase & problem)
         << "  TimeIntegrator(s): " << MooseUtils::join(time_integrator_names, ", ") << '\n';
 
   for (const std::size_t i : make_range(problem.numSolverSystems()))
-    oss << std::setw(console_field_width) << "  Solver Mode"
-        << (problem.numSolverSystems() > 1 ? std::string("for system " + std::to_string(i))
-                                           : std::string(""))
-        << ": " << problem.solverTypeString(i) << '\n';
+    oss << std::setw(console_field_width)
+        << "  Solver Mode" +
+               (problem.numSolverSystems() > 1 ? " - system " + std::to_string(i) : "") + ": "
+        << problem.solverTypeString(i) << '\n';
 
   const std::string & pc_desc = problem.getPetscOptions().pc_description;
   if (!pc_desc.empty())

--- a/modules/doc/content/ncrc/applications/ncrc_develop.md.template
+++ b/modules/doc/content/ncrc/applications/ncrc_develop.md.template
@@ -10,7 +10,7 @@ continuing. Please see MOOSE's
 information on how to reach us in the event troubleshooting fails.
 
 If you need to update {{ApplicationName}}, know that by following through the
-'[Building {{ApplicationName}}](ncrc_develop_{{ApplicationLower}}.md#build)' steps again,
+[Building {{ApplicationName}}](ncrc_develop_{{ApplicationLower}}.md#build) steps again,
 effectively performs an update each time.
 
 ## Environment
@@ -122,12 +122,12 @@ either a Conda update, or rebuild PETSc/libMesh:
 
 - If +Personal Machine (Conda)+:
 
-  !package! code
+  !versioner! code
   conda activate base
   conda env remove -n moose
-  conda create -n moose moose-dev=__MOOSE_DEV__ __DEFAULT_MPI__
+  conda create -n moose moose-dev=__VERSIONER_CONDA_VERSION_MOOSE_DEV__
   conda activate moose
-  !package-end!
+  !versioner-end!
 
 - If +[!ac](INL) [!ac](HPC) Sawtooth or Lemhi+:
 


### PR DESCRIPTION
## Reason
a) The execution info is currently being printed like this `Solver Mode              : Linear` and b) in the setup instructions for Blue Crab, a command is currently rendering like this `conda create -n moose moose-dev=__MOOSE_DEV__ mpich`.

## Design
Simple bug fix for both issues a) and b).

## Impact
a) Every or the vast majority of MOOSE apps and b) every new Blue Crab user/dev.
