### PR TITLE
Error when MeshGenerator and MooseMesh objects are both present

### DIFF
--- a/framework/include/actions/SetupMeshAction.h
+++ b/framework/include/actions/SetupMeshAction.h
@@ -35,7 +35,4 @@ private:
   const bool _use_split;
   /// The split mesh file (if any); comes from either Mesh/split_file or --split-file
   const std::string _split_file;
-
-  /// Whether to ignore mesh generators and use FileMesh when both are present in input
-  bool _are_mesh_generators_superseded;
 };

--- a/framework/include/actions/SetupMeshAction.h
+++ b/framework/include/actions/SetupMeshAction.h
@@ -37,5 +37,5 @@ private:
   const std::string _split_file;
 
   /// Whether to ignore mesh generators and use FileMesh when both are present in input
-  bool _file_mesh_supersedes_mesh_generators;
+  bool _are_mesh_generators_superseded;
 };

--- a/framework/include/actions/SetupMeshAction.h
+++ b/framework/include/actions/SetupMeshAction.h
@@ -35,4 +35,7 @@ private:
   const bool _use_split;
   /// The split mesh file (if any); comes from either Mesh/split_file or --split-file
   const std::string _split_file;
+
+  /// Whether to ignore mesh generators and use FileMesh when both are present in input
+  bool _file_mesh_supersedes_mesh_generators;
 };

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -124,8 +124,7 @@ SetupMeshAction::SetupMeshAction(const InputParameters & params)
   : MooseObjectAction(params),
     _use_split(getParam<bool>("use_split") || _app.getParam<bool>("use_split")),
     _split_file(_app.isParamSetByUser("split_file") ? _app.getParam<std::string>("split_file")
-                                                    : getParam<std::string>("split_file")),
-    _are_mesh_generators_superseded(false)
+                                                    : getParam<std::string>("split_file"))
 {
 }
 
@@ -288,8 +287,6 @@ SetupMeshAction::act()
               mooseError("Mesh Generators present but the [Mesh] block is set to construct a \"",
                          _type,
                          "\" mesh, which does not use Mesh Generators in constructing the mesh. ");
-              _are_mesh_generators_superseded = true;
-              break;
             }
         }
       }
@@ -313,8 +310,8 @@ SetupMeshAction::act()
       // 1. We have mesh generators
       // 2. We are not using the pre-split mesh
       // 3. We are not: recovering/restarting and we are the master application
-      if ((!_app.getMeshGeneratorNames().empty() && !_are_mesh_generators_superseded) &&
-          !_use_split && !((_app.isRecovering() || _app.isRestarting()) && _app.isUltimateMaster()))
+      if (!_app.getMeshGeneratorNames().empty() && !_use_split &&
+          !((_app.isRecovering() || _app.isRestarting()) && _app.isUltimateMaster()))
       {
         auto & mesh_generator_system = _app.getMeshGeneratorSystem();
         auto mesh_base =

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -285,12 +285,12 @@ SetupMeshAction::act()
           for (auto generator_action_ptr : generator_actions)
             if (dynamic_cast<AddMeshGeneratorAction *>(generator_action_ptr))
             {
-              mooseWarning("Mesh Generators present but the [Mesh] block is set to construct a \"",
-                           _type,
-                           "\" mesh, which does not use Mesh Generators in constructing the mesh. ",
-                           "The ",
-                           _type,
-                           " will supersede the Mesh Generators.");
+              mooseError("Mesh Generators present but the [Mesh] block is set to construct a \"",
+                         _type,
+                         "\" mesh, which does not use Mesh Generators in constructing the mesh. ",
+                         "The ",
+                         _type,
+                         " will supersede the Mesh Generators.");
               _file_mesh_supersedes_mesh_generators = true;
               break;
             }

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -125,7 +125,7 @@ SetupMeshAction::SetupMeshAction(const InputParameters & params)
     _use_split(getParam<bool>("use_split") || _app.getParam<bool>("use_split")),
     _split_file(_app.isParamSetByUser("split_file") ? _app.getParam<std::string>("split_file")
                                                     : getParam<std::string>("split_file")),
-    _file_mesh_supersedes_mesh_generators(false)
+    _are_mesh_generators_superseded(false)
 {
 }
 
@@ -291,7 +291,7 @@ SetupMeshAction::act()
                          "The ",
                          _type,
                          " will supersede the Mesh Generators.");
-              _file_mesh_supersedes_mesh_generators = true;
+              _are_mesh_generators_superseded = true;
               break;
             }
         }
@@ -316,7 +316,7 @@ SetupMeshAction::act()
       // 1. We have mesh generators
       // 2. We are not using the pre-split mesh
       // 3. We are not: recovering/restarting and we are the master application
-      if ((!_app.getMeshGeneratorNames().empty() && !_file_mesh_supersedes_mesh_generators) &&
+      if ((!_app.getMeshGeneratorNames().empty() && !_are_mesh_generators_superseded) &&
           !_use_split && !((_app.isRecovering() || _app.isRestarting()) && _app.isUltimateMaster()))
       {
         auto & mesh_generator_system = _app.getMeshGeneratorSystem();

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -287,10 +287,7 @@ SetupMeshAction::act()
             {
               mooseError("Mesh Generators present but the [Mesh] block is set to construct a \"",
                          _type,
-                         "\" mesh, which does not use Mesh Generators in constructing the mesh. ",
-                         "The ",
-                         _type,
-                         " will supersede the Mesh Generators.");
+                         "\" mesh, which does not use Mesh Generators in constructing the mesh. ");
               _are_mesh_generators_superseded = true;
               break;
             }

--- a/test/tests/meshgenerators/generated_mesh_generator/tests
+++ b/test/tests/meshgenerators/generated_mesh_generator/tests
@@ -86,9 +86,9 @@
     input = 'generated_mesh_generator.i'
     cli_args = '--mesh-only Mesh/type=GeneratedMesh'
     expect_err = 'Mesh Generators present but the \[Mesh\] block is set to construct a "GeneratedMesh" mesh, which does not use Mesh Generators in constructing the mesh.'
-    requirement = 'The system shall generate a warning if Mesh Generators are used with a mesh type that does not accept them'
+    requirement = 'The system shall generate an error if Mesh Generators are used with a mesh type that does not accept them'
     design = 'meshgenerators/GeneratedMeshGenerator.md'
-    issues = '#13959'
+    issues = '#13959 #29992'
   []
 
   [with_subdomain_ids_test]


### PR DESCRIPTION
EDIT: The accepted solution is to not allow both MeshGenerator and MooseMesh objects by changing the `mooseWarning` to a `mooseError`.

When a `FileMesh` and Mesh Generators are both simultaneously present in an input, a warning is raised in the `setup_mesh` task of `SetupMeshActions` because these types are not meant to be used with each other. In the following `set_mesh_base` task of `SetupMeshActions`, the mesh base is either:
1. set to an existing base from the `mesh_generator_system`, if Mesh Generators are present, or
2. built on-the-fly if Mesh Generators are not present.

Approach (1) is currently used when both `FileMesh` and Mesh Generator objects are present. Because the aforementioned warning is phrased to imply that  FileMesh objects do not use Mesh Generators, and because `FileMesh` objects are the default mesh type absent user input, an argument can be made that approach (2) should be used instead when `FileMesh` and Mesh Generators are simultaneously present.

This PR makes the change from approach (1) to (2) and makes the wording in the warning more explicit to reflect this change.

Consider the following case that prompted this change. The input file contains a `FileMeshGenerator` (i.e., a Mesh Generator). For restart purposes, the user wants to change the mesh file to a checkpoint, doing so by specifying `Mesh/file=cp/LATEST` on the command line. This results in an input with both a `FileMesh` and a Mesh Generator (the `FileMeshGenerator`). MOOSE raises the warning:
> Mesh Generators present but the [Mesh] block is set to construct a "FileMesh" mesh, which does not use Mesh Generators in constructing the mesh.

This warning implies that the `FileMesh` will be constructed instead of the Mesh Generator (`FileMeshGenerator`). However, the `SetupMeshAction` then proceeds to set the mesh base according to option (1), which utilizes the mesh base from the `mesh_generator_system` instead of building the mesh base on-the-fly, which is the correct approach for a `FileMesh` object. Finally, in the `init_mesh` task of `SetupMeshAction`, the `init` method of the `FileMesh` attempts to read the mesh in from the checkpoint file. However, because the mesh base was not correctly set, it already contains a nonzero number of elements. libMesh’s `CheckpointIO::read` method doesn’t like that the mesh object it is to populate from the checkpoint file already contains elements, so it throws a nondescript assertion error that took yours truly a long time to get to the bottom of. This PR is my solution to the issue.

In the input file of the above example, the mesh is not modified with other generators after the `FileMeshGenerator`. In this case, the obvious solution is to simply change the `FileMeshGenerator` in the input to a `FileMesh` to completely avoid having Mesh Generators in the first place. However, there could be more complex use cases that benefit from this PR.

There is also the reverse situation: where a `FileMesh` is specified in the input file, a `FileMeshGenerator` is specified on the command line. In this case, the `FileMesh` will stiff have precedence, and the warning will state this. If the user wants their command line option to be effective, they should override the input file’s existing `FileMeshGenerator` instead of trying to use a `FileMesh`.

Closes #29992 
