### PR TITLE
Optimize AD residual and Jacobian object contributions

### DIFF
--- a/framework/include/kernels/ADKernel.h
+++ b/framework/include/kernels/ADKernel.h
@@ -107,6 +107,7 @@ protected:
   const ADTemplateVariablePhiValue<T> & _phi;
 
   ADReal _r;
+  std::vector<Real> _residuals_nonad;
   std::vector<ADReal> _residuals;
 
   /// The current gradient of the shape functions

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -3813,6 +3813,7 @@ Assembly::elementVolume(const Elem * elem) const
 void
 Assembly::addCachedJacobian(GlobalDataKey)
 {
+#ifndef NDEBUG
   if (!_subproblem.checkNonlocalCouplingRequirement())
   {
     mooseAssert(_cached_jacobian_rows.size() == _cached_jacobian_cols.size(),
@@ -3821,6 +3822,7 @@ Assembly::addCachedJacobian(GlobalDataKey)
       mooseAssert(_cached_jacobian_rows[i].size() == _cached_jacobian_cols[i].size(),
                   "Error: Cached data sizes MUST be the same for a given tag!");
   }
+#endif
 
   for (MooseIndex(_cached_jacobian_rows) i = 0; i < _cached_jacobian_rows.size(); i++)
     if (_sys.hasMatrix(i))

--- a/framework/src/bcs/ADIntegratedBC.C
+++ b/framework/src/bcs/ADIntegratedBC.C
@@ -99,14 +99,12 @@ ADIntegratedBCTempl<T>::computeResidual()
   for (auto & r : _residuals)
     r = 0;
 
-  if (_use_displaced_mesh)
-    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-      for (_i = 0; _i < _test.size(); _i++)
-        _residuals[_i] += raw_value(_ad_JxW[_qp] * _ad_coord[_qp] * computeQpResidual());
-  else
-    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-      for (_i = 0; _i < _test.size(); _i++)
-        _residuals[_i] += raw_value(_JxW[_qp] * _coord[_qp] * computeQpResidual());
+  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+  {
+    const auto jxw_c = _JxW[_qp] * _coord[_qp];
+    for (_i = 0; _i < _test.size(); _i++)
+      _residuals[_i] += jxw_c * raw_value(computeQpResidual());
+  }
 
   addResiduals(_assembly, _residuals, _var.dofIndices(), _var.scalingFactor());
 
@@ -134,8 +132,11 @@ ADIntegratedBCTempl<T>::computeResidualsForJacobian()
     }
   else
     for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto jxw_c = _JxW[_qp] * _coord[_qp];
       for (_i = 0; _i < _test.size(); _i++)
-        _residuals_and_jacobians[_i] += _JxW[_qp] * _coord[_qp] * computeQpResidual();
+        _residuals_and_jacobians[_i] += jxw_c * computeQpResidual();
+    }
 }
 
 template <typename T>

--- a/framework/src/fvkernels/FVElementalKernel.C
+++ b/framework/src/fvkernels/FVElementalKernel.C
@@ -54,7 +54,7 @@ void
 FVElementalKernel::computeResidual()
 {
   prepareVectorTag(_assembly, _var.number());
-  _local_re(0) += MetaPhysicL::raw_value(computeQpResidual() * _assembly.elemVolume());
+  _local_re(0) += MetaPhysicL::raw_value(computeQpResidual()) * _assembly.elemVolume();
   accumulateTaggedLocalResidual();
 }
 

--- a/framework/src/fvkernels/FVFluxKernel.C
+++ b/framework/src/fvkernels/FVFluxKernel.C
@@ -126,7 +126,7 @@ FVFluxKernel::computeResidual(const FaceInfo & fi)
   _face_info = &fi;
   _normal = fi.normal();
   _face_type = fi.faceType(std::make_pair(_var.number(), _var.sys().number()));
-  auto r = MetaPhysicL::raw_value(fi.faceArea() * fi.faceCoord() * computeQpResidual());
+  auto r = fi.faceArea() * fi.faceCoord() * MetaPhysicL::raw_value(computeQpResidual());
 
   // residual contributions for a flux kernel go to both neighboring faces.
   // They are equal in magnitude but opposite in direction due to the outward

--- a/framework/src/interfacekernels/ADInterfaceKernel.C
+++ b/framework/src/interfacekernels/ADInterfaceKernel.C
@@ -88,8 +88,9 @@ ADInterfaceKernelTempl<T>::computeElemNeighResidual(Moose::DGResidualType type)
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
   {
     initQpResidual(type);
+    const auto jxw_p = _JxW[_qp] * _coord[_qp];
     for (_i = 0; _i < test_space.size(); _i++)
-      _local_re(_i) += raw_value(_ad_JxW[_qp] * _ad_coord[_qp] * computeQpResidual(type));
+      _local_re(_i) += jxw_p * raw_value(computeQpResidual(type));
   }
 
   accumulateTaggedLocalResidual();
@@ -154,8 +155,9 @@ ADInterfaceKernelTempl<T>::computeElemNeighJacobian(Moose::DGJacobianType type)
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
   {
     initQpResidual(resid_type);
+    const auto jxw_c = _ad_JxW[_qp] * _ad_coord[_qp];
     for (_i = 0; _i < test_space.size(); _i++)
-      residuals[_i] += _ad_JxW[_qp] * _ad_coord[_qp] * computeQpResidual(resid_type);
+      residuals[_i] += jxw_c * computeQpResidual(resid_type);
   }
 
   const bool element_var_is_var = (type == Moose::ElementElement || type == Moose::ElementNeighbor);
@@ -208,8 +210,9 @@ ADInterfaceKernelTempl<T>::computeOffDiagElemNeighJacobian(Moose::DGJacobianType
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
   {
     initQpResidual(resid_type);
+    const auto jxw_c = _ad_JxW[_qp] * _ad_coord[_qp];
     for (_i = 0; _i < test_space.size(); _i++)
-      residuals[_i] += _ad_JxW[_qp] * _ad_coord[_qp] * computeQpResidual(resid_type);
+      residuals[_i] += jxw_c * computeQpResidual(resid_type);
   }
 
   // We assert earlier that the type cannot be Moose::ElementNeighbor (nor Moose::NeighborElement)

--- a/framework/src/kernels/ADKernel.C
+++ b/framework/src/kernels/ADKernel.C
@@ -111,16 +111,15 @@ ADKernelTempl<T>::computeResidual()
 {
   precalculateResidual();
 
+  // We use a non-AD residual vector
   std::vector<Real> residuals(_test.size(), 0);
 
-  if (_use_displaced_mesh)
-    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-      for (_i = 0; _i < _test.size(); _i++)
-        residuals[_i] += raw_value(_ad_JxW[_qp] * _ad_coord[_qp] * computeQpResidual());
-  else
-    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-      for (_i = 0; _i < _test.size(); _i++)
-        residuals[_i] += raw_value(_JxW[_qp] * _coord[_qp] * computeQpResidual());
+  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+  {
+    const auto jxw_c = _JxW[_qp] * _coord[_qp];
+    for (_i = 0; _i < _test.size(); _i++)
+      residuals[_i] += jxw_c * raw_value(computeQpResidual());
+  }
 
   addResiduals(_assembly, residuals, _var.dofIndices(), _var.scalingFactor());
 
@@ -149,8 +148,11 @@ ADKernelTempl<T>::computeResidualsForJacobian()
     }
   else
     for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto jxw_c = _JxW[_qp] * _coord[_qp];
       for (_i = 0; _i < _test.size(); _i++)
-        _residuals[_i] += _JxW[_qp] * _coord[_qp] * computeQpResidual();
+        _residuals[_i] += jxw_c * computeQpResidual();
+    }
 }
 
 template <typename T>

--- a/framework/src/postprocessors/NumNonlinearIterations.C
+++ b/framework/src/postprocessors/NumNonlinearIterations.C
@@ -24,6 +24,9 @@ NumNonlinearIterations::validParams()
       false,
       "When set to true, accumulates to count the total over all Picard iterations for each step");
   params.addClassDescription("Outputs the number of nonlinear iterations");
+
+  // Not supported
+  params.suppressParameter<bool>("use_displaced_mesh");
   return params;
 }
 

--- a/framework/src/postprocessors/TimestepSize.C
+++ b/framework/src/postprocessors/TimestepSize.C
@@ -17,6 +17,9 @@ TimestepSize::validParams()
 {
   InputParameters params = GeneralPostprocessor::validParams();
   params.addClassDescription("Reports the timestep size");
+
+  // Not supported
+  params.suppressParameter<bool>("use_displaced_mesh");
   return params;
 }
 

--- a/modules/solid_mechanics/test/tests/ad_2D_geometries/tests
+++ b/modules/solid_mechanics/test/tests/ad_2D_geometries/tests
@@ -55,7 +55,7 @@
     input = '2D-RZ_finiteStrain_resid.i'
     exodiff = '2D-RZ_finiteStrain_resid_bbar_out.e'
     use_old_floor = true
-    abs_zero = 1e-8
+    abs_zero = 1.1e-8
     compiler = 'GCC CLANG'
     cli_args = 'GlobalParams/volumetric_locking_correction=true Outputs/file_base=2D-RZ_finiteStrain_resid_bbar_out'
     prereq = 'axisym_resid'
@@ -126,7 +126,7 @@
     input = '2D-RZ_finiteStrain_resid.i'
     compiler = 'GCC CLANG'
     run_sim = 'True'
-    ratio_tol = 5e-8
+    ratio_tol = 9e-8
     difference_tol = 1e1
     issues = '#12650'
     design = 'source/materials/ADComputeAxisymmetricRZFiniteStrain.md'
@@ -138,8 +138,8 @@
     compiler = 'GCC CLANG'
     cli_args = 'GlobalParams/volumetric_locking_correction=true'
     run_sim = 'True'
-    ratio_tol = 5e-8
-    difference_tol = 10
+    ratio_tol = 5e-7
+    difference_tol = 20
     issues = '#12650'
     design = 'source/materials/ADComputeAxisymmetricRZFiniteStrain.md VolumetricLocking.md'
     requirement = 'The ADComputeAxisymmetricRZFiniteStrain class shall compute the reaction forces on the top surface of a cylinder which is loaded axially in tension when using the B-bar volumetric locking correction and shall produce perfect jacobians.'

--- a/modules/solid_mechanics/test/tests/ad_viscoplasticity_stress_update/tests
+++ b/modules/solid_mechanics/test/tests/ad_viscoplasticity_stress_update/tests
@@ -13,7 +13,7 @@
     input = 'creep.i'
     cli_args = "-snes_test_err 1e-11"
     run_sim = 'True'
-    ratio_tol = 1e-7
+    ratio_tol = 1.5e-7
     difference_tol = 1e8
     prereq = creep
     requirement = 'The Jacobian for the AD regular creep problem shall be perfect'


### PR DESCRIPTION
seems this gains the 5% for February. This only improves AD computations though, and likely not FV