### PR TITLE
Set FParser epsilon to zero

### DIFF
--- a/framework/src/utils/FunctionParserUtils.C
+++ b/framework/src/utils/FunctionParserUtils.C
@@ -42,7 +42,7 @@ FunctionParserUtils<is_ad>::validParams()
   params.addParamNamesToGroup(
       "enable_jit enable_ad_cache enable_auto_optimize disable_fpoptimizer evalerror_behavior",
       "Parsed expression advanced");
-  params.addParam<Real>("epsilon", FunctionParser::epsilon(), "Fuzzy comparison tolerance");
+  params.addParam<Real>("epsilon", 0, "Fuzzy comparison tolerance");
   return params;
 }
 
@@ -191,22 +191,34 @@ template <>
 void
 FunctionParserUtils<false>::functionsOptimize(SymFunctionPtr & parsed_function)
 {
+  // set desired epsilon for optimization!
+  auto tmp_eps = parsed_function->epsilon();
+  parsed_function->setEpsilon(_epsilon);
+
   // base function
   if (!_disable_fpoptimizer)
     parsed_function->Optimize();
   if (_enable_jit && !parsed_function->JITCompile())
     mooseInfo("Failed to JIT compile expression, falling back to byte code interpretation.");
+
+  parsed_function->setEpsilon(tmp_eps);
 }
 
 template <>
 void
 FunctionParserUtils<true>::functionsOptimize(SymFunctionPtr & parsed_function)
 {
+  // set desired epsilon for optimization!
+  auto tmp_eps = parsed_function->epsilon();
+  parsed_function->setEpsilon(_epsilon);
+
   // base function
   if (!_disable_fpoptimizer)
     parsed_function->Optimize();
   if (!_enable_jit || !parsed_function->JITCompile())
     mooseError("AD parsed objects require JIT compilation to be enabled and working.");
+
+  parsed_function->setEpsilon(tmp_eps);
 }
 
 // explicit instantiation

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mmb_2material_cost_initial.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/2d_mmb_2material_cost_initial.i
@@ -131,6 +131,7 @@ C2 = 1.0
                  "if(mat_den<${rho1},E1,E2)"
     coupled_variables = 'mat_den'
     property_name = E_phys
+    epsilon = 1e-12
   []
 
   [Cost_mat]
@@ -143,6 +144,7 @@ C2 = 1.0
                  "if(mat_den<${rho1},C1,C2)"
     coupled_variables = 'mat_den'
     property_name = Cost_mat
+    epsilon = 1e-12
   []
 
   [poissons_ratio]

--- a/modules/combined/test/tests/optimization/compliance_sensitivity/paper_three_materials_test.i
+++ b/modules/combined/test/tests/optimization/compliance_sensitivity/paper_three_materials_test.i
@@ -150,6 +150,7 @@ C3 = 1.0
                  "if(mat_den<${rho1},E1,if(mat_den<${rho2},E2,E3))"
     coupled_variables = 'mat_den'
     property_name = E_phys
+    epsilon = 1e-12
   []
 
   [Cost_mat]
@@ -164,6 +165,7 @@ C3 = 1.0
                  "if(mat_den<${rho1},C1,if(mat_den<${rho2},C2,C3))"
     coupled_variables = 'mat_den'
     property_name = Cost_mat
+    epsilon = 1e-12
   []
   [CostDensity]
     type = ParsedMaterial

--- a/modules/phase_field/test/tests/mobility_derivative/mobility_derivative_direct_test.i
+++ b/modules/phase_field/test/tests/mobility_derivative/mobility_derivative_direct_test.i
@@ -65,6 +65,7 @@
     property_name = M
     coupled_variables = c
     expression = 'if(c<-1,0.1,if(c>1,0.1,1-.9*c^2))'
+    epsilon = 1e-12
     outputs = exodus
     derivative_order = 2
   [../]


### PR DESCRIPTION
## Reason
Function parser performs fuzzy comparisons with an epsilon value, that by default, is too large (1e-12). This can lead to numerical convergence stagnation. What's even worse is that the epsilon is utilized during the function optimization stage, and can lead to wrong simplifications. 

## Design
It is safer to default the epsilon to zero.

## Impact
Safer parsed material/aux evaluations.