### PR TITLE
Libmesh update 20250304

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2025.02.25" %}
+{% set version = "2025.03.06" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2025.02.25 mpich_0
-  - moose-libmesh 2025.02.25 openmpi_0
+  - moose-libmesh 2025.03.06 mpich_0
+  - moose-libmesh 2025.03.06 openmpi_0
 
 moose_wasp:
   - moose-wasp 2025.02.25

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.03.03" %}
+{% set version = "2025.03.06" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2025.03.03
+  - moose-dev 2025.03.06
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -1790,11 +1790,7 @@ Assembly::reinitAtPhysical(const Elem * elem, const std::vector<Point> & physica
               "current subdomain has been set incorrectly");
   _current_elem_volume_computed = false;
 
-  FEInterface::inverse_map(elem->dim(),
-                           _holder_fe_helper[elem->dim()]->get_fe_type(),
-                           elem,
-                           physical_points,
-                           _temp_reference_points);
+  FEMap::inverse_map(elem->dim(), elem, physical_points, _temp_reference_points);
 
   reinit(elem, _temp_reference_points);
 
@@ -2004,11 +2000,8 @@ Assembly::reinitElemAndNeighbor(const Elem * elem,
   if (neighbor_reference_points)
     _current_neighbor_ref_points = *neighbor_reference_points;
   else
-    FEInterface::inverse_map(neighbor_dim,
-                             FEType(),
-                             neighbor,
-                             _current_q_points_face.stdVector(),
-                             _current_neighbor_ref_points);
+    FEMap::inverse_map(
+        neighbor_dim, neighbor, _current_q_points_face.stdVector(), _current_neighbor_ref_points);
 
   _current_neighbor_side_elem = &_current_neighbor_side_elem_builder(*neighbor, neighbor_side);
 
@@ -2417,8 +2410,7 @@ Assembly::reinitNeighborAtPhysical(const Elem * neighbor,
                                    const std::vector<Point> & physical_points)
 {
   unsigned int neighbor_dim = neighbor->dim();
-  FEInterface::inverse_map(
-      neighbor_dim, FEType(), neighbor, physical_points, _current_neighbor_ref_points);
+  FEMap::inverse_map(neighbor_dim, neighbor, physical_points, _current_neighbor_ref_points);
 
   if (_need_JxW_neighbor)
   {
@@ -2453,8 +2445,7 @@ Assembly::reinitNeighborAtPhysical(const Elem * neighbor,
                                    const std::vector<Point> & physical_points)
 {
   unsigned int neighbor_dim = neighbor->dim();
-  FEInterface::inverse_map(
-      neighbor_dim, FEType(), neighbor, physical_points, _current_neighbor_ref_points);
+  FEMap::inverse_map(neighbor_dim, neighbor, physical_points, _current_neighbor_ref_points);
 
   reinitFENeighbor(neighbor, _current_neighbor_ref_points);
   reinitNeighbor(neighbor, _current_neighbor_ref_points);

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -1871,9 +1871,9 @@ Assembly::reinitFVFace(const FaceInfo & fi)
     // The order of the element that is used for initing here doesn't matter since this will just
     // be used for constant monomials (which only need a single integration point)
     if (dim == 3)
-      _current_qrule_face->init(QUAD4);
+      _current_qrule_face->init(QUAD4, /* p_level = */ 0, /* simple_type_only = */ true);
     else
-      _current_qrule_face->init(EDGE2);
+      _current_qrule_face->init(EDGE2, /* p_level = */ 0, /* simple_type_only = */ true);
   }
 
   _current_side_elem = &_current_side_elem_builder(*_current_elem, _current_side);

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -836,7 +836,7 @@ Assembly::reinitFE(const Elem * elem)
     {
       FEBase & fe = *it.second;
       auto fe_type = it.first;
-      auto num_shapes = fe.n_shape_functions();
+      auto num_shapes = FEInterface::n_shape_functions(fe_type, elem);
       auto & grad_phi = _ad_grad_phi_data[fe_type];
 
       grad_phi.resize(num_shapes);
@@ -857,7 +857,7 @@ Assembly::reinitFE(const Elem * elem)
     {
       FEVectorBase & fe = *it.second;
       auto fe_type = it.first;
-      auto num_shapes = fe.n_shape_functions();
+      auto num_shapes = FEInterface::n_shape_functions(fe_type, elem);
       auto & grad_phi = _ad_vector_grad_phi_data[fe_type];
 
       grad_phi.resize(num_shapes);
@@ -1041,7 +1041,7 @@ Assembly::computeSinglePointMapAD(const Elem * elem,
 
   auto dim = elem->dim();
   const auto & elem_nodes = elem->get_nodes();
-  auto num_shapes = fe->n_shape_functions();
+  auto num_shapes = FEInterface::n_shape_functions(fe->get_fe_type(), elem);
   const auto & phi_map = fe->get_fe_map().get_phi_map();
   const auto & dphidxi_map = fe->get_fe_map().get_dphidxi_map();
   const auto & dphideta_map = fe->get_fe_map().get_dphideta_map();
@@ -2141,7 +2141,7 @@ Assembly::computeADFace(const Elem & elem, const unsigned int side)
     {
       FEBase & fe = *it.second;
       auto fe_type = it.first;
-      auto num_shapes = fe.n_shape_functions();
+      auto num_shapes = FEInterface::n_shape_functions(fe_type, &elem);
       auto & grad_phi = _ad_grad_phi_data_face[fe_type];
 
       grad_phi.resize(num_shapes);
@@ -2161,7 +2161,7 @@ Assembly::computeADFace(const Elem & elem, const unsigned int side)
     {
       FEVectorBase & fe = *it.second;
       auto fe_type = it.first;
-      auto num_shapes = fe.n_shape_functions();
+      auto num_shapes = FEInterface::n_shape_functions(fe_type, &elem);
       auto & grad_phi = _ad_vector_grad_phi_data_face[fe_type];
 
       grad_phi.resize(num_shapes);

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -1425,7 +1425,7 @@ Assembly::computeFaceMap(const Elem & elem, const unsigned int side, const std::
       }
 
       const auto n_mapping_shape_functions =
-          FE<2, LAGRANGE>::n_shape_functions(side_elem.type(), side_elem.default_order());
+          FE<2, LAGRANGE>::n_dofs(&side_elem, side_elem.default_order());
 
       for (unsigned int i = 0; i < n_mapping_shape_functions; i++)
       {
@@ -1491,7 +1491,7 @@ Assembly::computeFaceMap(const Elem & elem, const unsigned int side, const std::
       }
 
       const unsigned int n_mapping_shape_functions =
-          FE<3, LAGRANGE>::n_shape_functions(side_elem.type(), side_elem.default_order());
+          FE<3, LAGRANGE>::n_dofs(&side_elem, side_elem.default_order());
 
       for (unsigned int i = 0; i < n_mapping_shape_functions; i++)
       {

--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -276,7 +276,7 @@ findContactPoint(PenetrationInfo & p_info,
   if (dot > 0.0)
     p_info._distance = -p_info._distance;
 
-  contact_point_on_side = FEInterface::on_reference_element(ref_point, side->type());
+  contact_point_on_side = side->on_reference_element(ref_point);
 
   p_info._tangential_distance = 0.0;
 

--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -35,7 +35,8 @@ namespace Moose
  * @param p_info The penetration info object, contains primary_elem, side, various other information
  * @param fe_elem FE object for the element
  * @param fe_side FE object for the side
- * @param fe_side_type The type of fe_side, needed for inverse_map routines
+ * @param fe_side_type Unused; was used for a now-deprecated
+ * inverse_map overload.
  * @param start_with_centroid if true, start inverse mapping procedure from element centroid
  * @param tangential_tolerance 'tangential' tolerance for determining whether a contact point on a
  * side
@@ -49,7 +50,7 @@ void
 findContactPoint(PenetrationInfo & p_info,
                  FEBase * fe_elem,
                  FEBase * fe_side,
-                 FEType & fe_side_type,
+                 FEType & /* fe_side_type */,
                  const libMesh::Point & secondary_point,
                  bool start_with_centroid,
                  const Real tangential_tolerance,
@@ -109,8 +110,7 @@ findContactPoint(PenetrationInfo & p_info,
   libMesh::Point ref_point;
 
   if (start_with_centroid)
-    ref_point = FEInterface::inverse_map(
-        dim - 1, fe_side_type, side, side->vertex_average(), TOLERANCE, false);
+    ref_point = FEMap::inverse_map(dim - 1, side, side->vertex_average(), TOLERANCE, false);
   else
     ref_point = p_info._closest_point_ref;
 

--- a/framework/src/ics/InitialConditionTempl.C
+++ b/framework/src/ics/InitialConditionTempl.C
@@ -55,8 +55,6 @@ InitialConditionTempl<T>::compute()
 
   // The dimension of the current element
   _dim = _current_elem->dim();
-  // The element type
-  const ElemType elem_type = _current_elem->type();
   // The number of nodes on the new element
   const unsigned int n_nodes = _current_elem->n_nodes();
 
@@ -125,7 +123,7 @@ InitialConditionTempl<T>::compute()
 
   for (_n = 0; _n != n_nodes; ++_n)
   {
-    _nc = FEInterface::n_dofs_at_node(_dim, _fe_type, elem_type, _n);
+    _nc = FEInterface::n_dofs_at_node(_fe_type, _current_elem, _n);
 
     // for nodes that are in more than one subdomain, only compute the initial
     // condition once on the lowest numbered block

--- a/framework/src/loops/MaxQpsThread.C
+++ b/framework/src/loops/MaxQpsThread.C
@@ -50,20 +50,20 @@ MaxQpsThread::operator()(const libMesh::ConstElemRange & range)
     assem.setVolumeQRule(elem);
 
     auto & qrule = assem.writeableQRule();
-    qrule->init(elem->type(), elem->p_level());
+    qrule->init(*elem);
     if (qrule->n_points() > _max)
       _max = qrule->n_points();
 
-    if (elem->dim())
-    {
-      // We are assuming here that side 0 ends up with at least as many quadrature points as any
-      // other side
-      assem.setFaceQRule(elem, /*side=*/0);
-      auto & qrule_face = assem.writeableQRuleFace();
-      qrule_face->init(elem->side_type(0), elem->p_level());
-      if (qrule_face->n_points() > _max)
-        _max = qrule->n_points();
-    }
+    // We used to check side quadrature rules too - badly (assuming
+    // side 0 doesn't have a smaller rule than the others, which is
+    // often untrue on prisms) and generally unnecessarily (a side
+    // rule will always use fewer points than a corresponding interior
+    // rule).
+    //
+    // We should handle the possibility of users manually specifying a
+    // higher order for side than for interior integration.  Doing
+    // this efficiently will need to wait for a new libMesh API,
+    // though.
 
     // In initial conditions nodes are enumerated as pretend quadrature points
     // using the _qp index to access coupled variables. In order to be able to

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2370,7 +2370,7 @@ MooseMesh::buildPRefinementAndCoarseningMaps(Assembly * const assembly)
     const auto & face_phys_points = fe_face->get_xyz();
     fe_face->attach_quadrature_rule(qrule_face);
 
-    qrule->init(elem->type(), elem->p_level());
+    qrule->init(*elem);
     volume_ref_points_coarse = qrule->get_points();
     fe_face->reinit(elem, (unsigned int)0);
     libMesh::FEMap::inverse_map(dim, elem, face_phys_points, face_ref_points_coarse);
@@ -2382,7 +2382,7 @@ MooseMesh::buildPRefinementAndCoarseningMaps(Assembly * const assembly)
     for (const auto p_level : p_levels)
     {
       mesh_refinement.uniformly_p_refine(1);
-      qrule->init(elem->type(), elem->p_level());
+      qrule->init(*elem);
       volume_ref_points_fine = qrule->get_points();
       fe_face->reinit(elem, (unsigned int)0);
       libMesh::FEMap::inverse_map(dim, elem, face_phys_points, face_ref_points_fine);

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2373,8 +2373,7 @@ MooseMesh::buildPRefinementAndCoarseningMaps(Assembly * const assembly)
     qrule->init(elem->type(), elem->p_level());
     volume_ref_points_coarse = qrule->get_points();
     fe_face->reinit(elem, (unsigned int)0);
-    libMesh::FEInterface::inverse_map(
-        dim, p_refinable_fe_type, elem, face_phys_points, face_ref_points_coarse);
+    libMesh::FEMap::inverse_map(dim, elem, face_phys_points, face_ref_points_coarse);
 
     p_levels.resize(max_p_level + 1);
     std::iota(p_levels.begin(), p_levels.end(), 0);
@@ -2386,8 +2385,7 @@ MooseMesh::buildPRefinementAndCoarseningMaps(Assembly * const assembly)
       qrule->init(elem->type(), elem->p_level());
       volume_ref_points_fine = qrule->get_points();
       fe_face->reinit(elem, (unsigned int)0);
-      libMesh::FEInterface::inverse_map(
-          dim, p_refinable_fe_type, elem, face_phys_points, face_ref_points_fine);
+      libMesh::FEMap::inverse_map(dim, elem, face_phys_points, face_ref_points_fine);
 
       const auto map_key = std::make_pair(elem_type, p_level);
       auto & volume_refine_map = _elem_type_to_p_refinement_map[map_key];
@@ -2627,7 +2625,7 @@ MooseMesh::findAdaptivityQpMaps(const Elem * template_elem,
 
   std::vector<Point> parent_ref_points;
 
-  libMesh::FEInterface::inverse_map(elem->dim(), FEType(), elem, *q_points, parent_ref_points);
+  libMesh::FEMap::inverse_map(elem->dim(), elem, *q_points, parent_ref_points);
   libMesh::MeshRefinement mesh_refinement(mesh);
   mesh_refinement.uniformly_refine(1);
 
@@ -2673,7 +2671,7 @@ MooseMesh::findAdaptivityQpMaps(const Elem * template_elem,
 
     std::vector<Point> child_ref_points;
 
-    libMesh::FEInterface::inverse_map(elem->dim(), FEType(), elem, *q_points, child_ref_points);
+    libMesh::FEMap::inverse_map(elem->dim(), elem, *q_points, child_ref_points);
     child_to_ref_points[child] = child_ref_points;
 
     std::vector<QpMap> & qp_map = refinement_map[child];

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -890,8 +890,8 @@ DisplacedProblem::reinitElemNeighborAndLowerD(const Elem * elem,
     {
       auto qps = _assembly[tid][currentNlSysNum()]->qPointsFaceNeighbor().stdVector();
       std::vector<Point> reference_points;
-      FEInterface::inverse_map(
-          lower_d_elem_neighbor->dim(), FEType(), lower_d_elem_neighbor, qps, reference_points);
+      FEMap::inverse_map(
+          lower_d_elem_neighbor->dim(), lower_d_elem_neighbor, qps, reference_points);
       reinitLowerDElem(lower_d_elem_neighbor, tid, &qps);
     }
   }

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -2330,8 +2330,8 @@ FEProblemBase::reinitElemNeighborAndLowerD(const Elem * elem,
     {
       auto qps = _assembly[tid][0]->qPointsFaceNeighbor().stdVector();
       std::vector<Point> reference_points;
-      FEInterface::inverse_map(
-          lower_d_elem_neighbor->dim(), FEType(), lower_d_elem_neighbor, qps, reference_points);
+      FEMap::inverse_map(
+          lower_d_elem_neighbor->dim(), lower_d_elem_neighbor, qps, reference_points);
       reinitLowerDElem(lower_d_elem_neighbor, tid, &reference_points);
     }
   }

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -425,7 +425,7 @@ MultiAppProjectionTransfer::execute()
 
     for (const auto & elem : to_mesh.active_local_element_ptr_range())
     {
-      qrule.init(elem->type(), elem->p_level());
+      qrule.init(elem);
 
       bool element_is_evaled = false;
       std::vector<Real> evals(qrule.n_points(), 0.);

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -425,7 +425,7 @@ MultiAppProjectionTransfer::execute()
 
     for (const auto & elem : to_mesh.active_local_element_ptr_range())
     {
-      qrule.init(elem);
+      qrule.init(*elem);
 
       bool element_is_evaled = false;
       std::vector<Real> evals(qrule.n_points(), 0.);

--- a/modules/doc/content/newsletter/2025/2025_03.md
+++ b/modules/doc/content/newsletter/2025/2025_03.md
@@ -11,6 +11,45 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2025.03.06` Update
+
+- Quadrature API changes.  A few virtual `QBase` methods have had
+  changed signatures, and some methods have been deprecated in favor
+  of newer versions, requiring `Elem` inputs rather than mere
+  `ElemType` inputs, to enable support for elements like arbitrary
+  polygons and polyhedra where a single class can take on different
+  topologies at run time.
+- `FE` and `FEInterface` API changes.  Some methods have been
+  deprecated in favor of newer versions, either in `Elem` or taking an
+  `Elem` rather than an `ElemType` argument, also for runtime-topology
+  compatibility.
+- Add APIs to control `System` name prefixing from C++, not just from
+  the command line.  This will enable fixes for a MOOSE bug with
+  independent preconditioning of multiple nonlinear systems, affecting
+  the optimization module.
+- Added an `integrate_slits` option to `JumpErrorEstimator`-based
+  estimators
+- Added an `OverlapCoupling` ghosting functor, useful for integrating
+  on slit meshes or between manifolds of overlapping meshes.
+- Bug fix: `DistributedMesh::add_point` now operates correctly when
+  given a node id that was recently deleted from the mesh but has not
+  yet been cleaned from the internal node container.
+- Bug fix: `Prism6::build_side_ptr()` now sets `subdomain_id()`; this
+  fixes a failure in adaptive mesh refinement of Prism6 elements with
+  subdomain-restricted variables.
+- Bug fix: methods which elevated mesh element order no longer
+  renumber nodes and elements while doing so.  This fixes potential
+  iterator invalidations in some use cases, and it's more efficient.
+- Bug fix: when copying nodes and elements from a source mesh into a
+  target `DistributedMesh` that is too small to use all its processors,
+  the target mesh was left in an invalid state.  This fixes errors
+  triggered by certain mesh stitching operations.
+- Bug fix for range estimation bug in FParser optimizer
+- Minor FE code refactoring for more simplicity and readability
+- Minor optimization to some hash (and thus `unordered_map`) use cases
+- Cleaned up and commented code with high-precision floating-point
+  constants
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -863,3 +863,34 @@ fd5f7bc651f0d6a8e2d23e5d4c2c2dadca58aa0b: #29978
   wasp:
     full_version: 2025.02.25_0
     hash: 46ea1c0
+9c3c8d833ce9c5d8fbb748dc6b870a075f4b2827:
+  libmesh:
+    full_version: 2025.03.06_0
+    hash: c2aeeb2
+  libmesh-vtk:
+    full_version: 9.3.0_5
+    hash: 9a4dbab
+  moose-dev:
+    full_version: 2025.03.06
+    hash: ca0a369
+  mpi:
+    full_version: 2024.12.23
+    hash: 82bbd28
+  peacock:
+    full_version: 2024.12.23
+    hash: ef44cb6
+  petsc:
+    full_version: 3.22.1.193.g72c1e49ee3d_1
+    hash: e78a9a4
+  pprof:
+    full_version: 2024.12.23_0
+    hash: fe051bc
+  seacas:
+    full_version: 2024.08.15_2
+    hash: 2dd352c
+  tools:
+    full_version: 2024.12.23
+    hash: 5abb5f2
+  wasp:
+    full_version: 2025.02.25_0
+    hash: 46ea1c0

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -44,7 +44,7 @@ packages:
       - scripts/apple-silicon-hdf5-autogen.patch
   # dependers: moose-dev
   libmesh:
-    version: 2025.02.25
+    version: 2025.03.06
     build_number: 0
     conda: conda/libmesh
     templates:
@@ -81,7 +81,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.03.03
+    version: 2025.03.06
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml


### PR DESCRIPTION
- Quadrature API changes.  A few virtual `QBase` methods have had
  changed signatures, and some methods have been deprecated in favor
  of newer versions, requiring `Elem` inputs rather than mere
  `ElemType` inputs, to enable support for elements like arbitrary
  polygons and polyhedra where a single class can take on different
  topologies at run time.
- `FE` and `FEInterface` API changes.  Some methods have been
  deprecated in favor of newer versions, either in `Elem` or taking an
  `Elem` rather than an `ElemType` argument, also for runtime-topology
  compatibility.
- Add APIs to control `System` name prefixing from C++, not just from
  the command line.  This will enable fixes for a MOOSE bug with 
  independent preconditioning of multiple nonlinear systems, affecting
  the optimization module.
- Added an `integrate_slits` option to `JumpErrorEstimator`-based
  estimators
- Added an `OverlapCoupling` ghosting functor, useful for integrating
  on slit meshes or between manifolds of overlapping meshes.
- Bug fix: `DistributedMesh::add_point` now operates correctly when
  given a node id that was recently deleted from the mesh but has not
  yet been cleaned from the internal node container. 
- Bug fix: `Prism6::build_side_ptr()` now sets `subdomain_id()`; this
  fixes a failure in adaptive mesh refinement of Prism6 elements with
  subdomain-restricted variables.
- Bug fix: methods which elevated mesh element order no longer
  renumber nodes and elements while doing so.  This fixes potential
  iterator invalidations in some use cases, and it's more efficient.
- Bug fix: when copying nodes and elements from a source mesh into a
  target `DistributedMesh` that is too small to use all its processors,
  the target mesh was left in an invalid state.  This fixes errors
  triggered by certain mesh stitching operations.
- Bug fix for range estimation bug in FParser optimizer
- Minor FE code refactoring for more simplicity and readability
- Minor optimization to some hash (and thus `unordered_map`) use cases
- Cleaned up and commented code with high-precision floating-point
  constants

@lindsayad was hoping to get one more libMesh PR squeezed into this, and we can wait for that before merging, but I want to get the API changes into CI right away and see what surprises may be in store.