### PR TITLE
Register old names of subchannel objects for backwards compatibility

### DIFF
--- a/modules/subchannel/src/auxkernels/SCMBlockedMassFlowRateAux.C
+++ b/modules/subchannel/src/auxkernels/SCMBlockedMassFlowRateAux.C
@@ -11,6 +11,10 @@
 #include "SCM.h"
 
 registerMooseObject("SubChannelApp", SCMBlockedMassFlowRateAux);
+registerMooseObjectRenamed("SubChannelApp",
+                           BlockedMassFlowRateAux,
+                           "06/30/2025 24:00",
+                           SCMBlockedMassFlowRateAux);
 
 InputParameters
 SCMBlockedMassFlowRateAux::validParams()

--- a/modules/subchannel/src/auxkernels/SCMFlatMassFlowRateAux.C
+++ b/modules/subchannel/src/auxkernels/SCMFlatMassFlowRateAux.C
@@ -11,6 +11,10 @@
 #include "SCM.h"
 
 registerMooseObject("SubChannelApp", SCMFlatMassFlowRateAux);
+registerMooseObjectRenamed("SubChannelApp",
+                           FlatMassFlowRateAux,
+                           "06/30/2025 24:00",
+                           SCMFlatMassFlowRateAux);
 
 InputParameters
 SCMFlatMassFlowRateAux::validParams()

--- a/modules/subchannel/src/auxkernels/SCMMassFlowRateAux.C
+++ b/modules/subchannel/src/auxkernels/SCMMassFlowRateAux.C
@@ -10,6 +10,10 @@
 #include "SCMMassFlowRateAux.h"
 
 registerMooseObject("SubChannelApp", SCMMassFlowRateAux);
+registerMooseObjectRenamed("SubChannelApp",
+                           MassFlowRateAux,
+                           "06/30/2025 24:00",
+                           SCMMassFlowRateAux);
 
 InputParameters
 SCMMassFlowRateAux::validParams()

--- a/modules/subchannel/src/auxkernels/SCMQuadPowerAux.C
+++ b/modules/subchannel/src/auxkernels/SCMQuadPowerAux.C
@@ -13,6 +13,7 @@
 #include "SCM.h"
 
 registerMooseObject("SubChannelApp", SCMQuadPowerAux);
+registerMooseObjectRenamed("SubChannelApp", QuadPowerAux, "06/30/2025 24:00", SCMQuadPowerAux);
 
 InputParameters
 SCMQuadPowerAux::validParams()

--- a/modules/subchannel/src/auxkernels/SCMRZPinQPrimeAux.C
+++ b/modules/subchannel/src/auxkernels/SCMRZPinQPrimeAux.C
@@ -10,6 +10,7 @@
 #include "SCMRZPinQPrimeAux.h"
 
 registerMooseObject("SubChannelApp", SCMRZPinQPrimeAux);
+registerMooseObjectRenamed("SubChannelApp", RZPinQPrimeAux, "06/30/2025 24:00", SCMRZPinQPrimeAux);
 
 InputParameters
 SCMRZPinQPrimeAux ::validParams()

--- a/modules/subchannel/src/auxkernels/SCMTriDuctQPrimeAux.C
+++ b/modules/subchannel/src/auxkernels/SCMTriDuctQPrimeAux.C
@@ -10,6 +10,10 @@
 #include "SCMTriDuctQPrimeAux.h"
 
 registerMooseObject("SubChannelApp", SCMTriDuctQPrimeAux);
+registerMooseObjectRenamed("SubChannelApp",
+                           TriDuctQPrimeAux,
+                           "06/30/2025 24:00",
+                           SCMTriDuctQPrimeAux);
 
 InputParameters
 SCMTriDuctQPrimeAux::validParams()

--- a/modules/subchannel/src/auxkernels/SCMTriDuctQPrimeFVAux.C
+++ b/modules/subchannel/src/auxkernels/SCMTriDuctQPrimeFVAux.C
@@ -10,6 +10,10 @@
 #include "SCMTriDuctQPrimeFVAux.h"
 
 registerMooseObject("SubChannelApp", SCMTriDuctQPrimeFVAux);
+registerMooseObjectRenamed("SubChannelApp",
+                           TriDuctQPrimeFVAux,
+                           "06/30/2025 24:00",
+                           SCMTriDuctQPrimeFVAux);
 
 InputParameters
 SCMTriDuctQPrimeFVAux::validParams()

--- a/modules/subchannel/src/auxkernels/SCMTriPowerAux.C
+++ b/modules/subchannel/src/auxkernels/SCMTriPowerAux.C
@@ -13,6 +13,7 @@
 #include "SCM.h"
 
 registerMooseObject("SubChannelApp", SCMTriPowerAux);
+registerMooseObjectRenamed("SubChannelApp", TriPowerAux, "06/30/2025 24:00", SCMTriPowerAux);
 
 InputParameters
 SCMTriPowerAux::validParams()

--- a/modules/subchannel/src/ics/SCMMassFlowRateIC.C
+++ b/modules/subchannel/src/ics/SCMMassFlowRateIC.C
@@ -10,6 +10,7 @@
 #include "SCMMassFlowRateIC.h"
 
 registerMooseObject("SubChannelApp", SCMMassFlowRateIC);
+registerMooseObjectRenamed("SubChannelApp", MassFlowRateIC, "06/30/2025 24:00", SCMMassFlowRateIC);
 
 InputParameters
 SCMMassFlowRateIC::validParams()

--- a/modules/subchannel/src/ics/SCMQuadFlowAreaIC.C
+++ b/modules/subchannel/src/ics/SCMQuadFlowAreaIC.C
@@ -14,6 +14,7 @@
 #include "SCM.h"
 
 registerMooseObject("SubChannelApp", SCMQuadFlowAreaIC);
+registerMooseObjectRenamed("SubChannelApp", QuadFlowAreaIC, "06/30/2025 24:00", SCMQuadFlowAreaIC);
 
 InputParameters
 SCMQuadFlowAreaIC::validParams()

--- a/modules/subchannel/src/ics/SCMQuadPowerIC.C
+++ b/modules/subchannel/src/ics/SCMQuadPowerIC.C
@@ -15,6 +15,7 @@ using namespace std;
 using namespace Eigen;
 
 registerMooseObject("SubChannelApp", SCMQuadPowerIC);
+registerMooseObjectRenamed("SubChannelApp", QuadPowerIC, "06/30/2025 24:00", SCMQuadPowerIC);
 
 InputParameters
 SCMQuadPowerIC::validParams()

--- a/modules/subchannel/src/ics/SCMQuadWettedPerimIC.C
+++ b/modules/subchannel/src/ics/SCMQuadWettedPerimIC.C
@@ -11,6 +11,10 @@
 #include "QuadSubChannelMesh.h"
 
 registerMooseObject("SubChannelApp", SCMQuadWettedPerimIC);
+registerMooseObjectRenamed("SubChannelApp",
+                           QuadWettedPerimIC,
+                           "06/30/2025 24:00",
+                           SCMQuadWettedPerimIC);
 
 InputParameters
 SCMQuadWettedPerimIC::validParams()

--- a/modules/subchannel/src/ics/SCMTriFlowAreaIC.C
+++ b/modules/subchannel/src/ics/SCMTriFlowAreaIC.C
@@ -12,6 +12,7 @@
 #include "SCM.h"
 
 registerMooseObject("SubChannelApp", SCMTriFlowAreaIC);
+registerMooseObjectRenamed("SubChannelApp", TriFlowAreaIC, "06/30/2025 24:00", SCMTriFlowAreaIC);
 
 InputParameters
 SCMTriFlowAreaIC::validParams()

--- a/modules/subchannel/src/ics/SCMTriPowerIC.C
+++ b/modules/subchannel/src/ics/SCMTriPowerIC.C
@@ -12,6 +12,7 @@
 #include "TriSubChannelMesh.h"
 
 registerMooseObject("SubChannelApp", SCMTriPowerIC);
+registerMooseObjectRenamed("SubChannelApp", TriPowerIC, "06/30/2025 24:00", SCMTriPowerIC);
 
 InputParameters
 SCMTriPowerIC::validParams()

--- a/modules/subchannel/src/ics/SCMTriWettedPerimIC.C
+++ b/modules/subchannel/src/ics/SCMTriWettedPerimIC.C
@@ -11,6 +11,10 @@
 #include "TriSubChannelMesh.h"
 
 registerMooseObject("SubChannelApp", SCMTriWettedPerimIC);
+registerMooseObjectRenamed("SubChannelApp",
+                           TriWettedPerimIC,
+                           "06/30/2025 24:00",
+                           SCMTriWettedPerimIC);
 
 InputParameters
 SCMTriWettedPerimIC::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMDetailedQuadInterWrapperMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMDetailedQuadInterWrapperMeshGenerator.C
@@ -14,6 +14,10 @@
 #include "libmesh/unstructured_mesh.h"
 
 registerMooseObject("SubChannelApp", SCMDetailedQuadInterWrapperMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           DetailedQuadInterWrapperMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMDetailedQuadInterWrapperMeshGenerator);
 
 InputParameters
 SCMDetailedQuadInterWrapperMeshGenerator::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMDetailedQuadPinMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMDetailedQuadPinMeshGenerator.C
@@ -12,6 +12,10 @@
 #include "libmesh/cell_prism6.h"
 
 registerMooseObject("SubChannelApp", SCMDetailedQuadPinMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           DetailedQuadPinMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMDetailedQuadPinMeshGenerator);
 
 InputParameters
 SCMDetailedQuadPinMeshGenerator::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMDetailedQuadSubChannelMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMDetailedQuadSubChannelMeshGenerator.C
@@ -14,6 +14,10 @@
 #include "libmesh/unstructured_mesh.h"
 
 registerMooseObject("SubChannelApp", SCMDetailedQuadSubChannelMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           DetailedQuadSubChannelMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMDetailedQuadSubChannelMeshGenerator);
 
 InputParameters
 SCMDetailedQuadSubChannelMeshGenerator::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMDetailedTriPinMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMDetailedTriPinMeshGenerator.C
@@ -12,6 +12,10 @@
 #include "libmesh/cell_prism6.h"
 
 registerMooseObject("SubChannelApp", SCMDetailedTriPinMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           DetailedTriPinMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMDetailedTriPinMeshGenerator);
 
 InputParameters
 SCMDetailedTriPinMeshGenerator::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMDetailedTriSubChannelMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMDetailedTriSubChannelMeshGenerator.C
@@ -15,6 +15,10 @@
 #include "libmesh/unstructured_mesh.h"
 
 registerMooseObject("SubChannelApp", SCMDetailedTriSubChannelMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           DetailedTriSubChannelMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMDetailedTriSubChannelMeshGenerator);
 
 InputParameters
 SCMDetailedTriSubChannelMeshGenerator::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMQuadInterWrapperMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMQuadInterWrapperMeshGenerator.C
@@ -13,6 +13,10 @@
 #include <numeric>
 
 registerMooseObject("SubChannelApp", SCMQuadInterWrapperMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           QuadInterWrapperMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMQuadInterWrapperMeshGenerator);
 
 InputParameters
 SCMQuadInterWrapperMeshGenerator::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMQuadPinMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMQuadPinMeshGenerator.C
@@ -12,6 +12,10 @@
 #include "libmesh/edge_edge2.h"
 
 registerMooseObject("SubChannelApp", SCMQuadPinMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           QuadPinMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMQuadPinMeshGenerator);
 
 InputParameters
 SCMQuadPinMeshGenerator::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMQuadSubChannelMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMQuadSubChannelMeshGenerator.C
@@ -13,6 +13,10 @@
 #include <numeric>
 
 registerMooseObject("SubChannelApp", SCMQuadSubChannelMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           QuadSubChannelMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMQuadSubChannelMeshGenerator);
 
 InputParameters
 SCMQuadSubChannelMeshGenerator::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMTriDuctMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMTriDuctMeshGenerator.C
@@ -14,6 +14,10 @@
 #include "libmesh/unstructured_mesh.h"
 
 registerMooseObject("SubChannelApp", SCMTriDuctMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           TriDuctMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMTriDuctMeshGenerator);
 
 InputParameters
 SCMTriDuctMeshGenerator::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMTriInterWrapperMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMTriInterWrapperMeshGenerator.C
@@ -14,6 +14,10 @@
 #include "libmesh/unstructured_mesh.h"
 
 registerMooseObject("SubChannelApp", SCMTriInterWrapperMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           TriInterWrapperMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMTriInterWrapperMeshGenerator);
 
 InputParameters
 SCMTriInterWrapperMeshGenerator::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMTriPinMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMTriPinMeshGenerator.C
@@ -13,6 +13,10 @@
 #include <numeric>
 
 registerMooseObject("SubChannelApp", SCMTriPinMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           TriPinMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMTriPinMeshGenerator);
 
 InputParameters
 SCMTriPinMeshGenerator::validParams()

--- a/modules/subchannel/src/meshgenerators/SCMTriSubChannelMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMTriSubChannelMeshGenerator.C
@@ -14,6 +14,10 @@
 #include "libmesh/unstructured_mesh.h"
 
 registerMooseObject("SubChannelApp", SCMTriSubChannelMeshGenerator);
+registerMooseObjectRenamed("SubChannelApp",
+                           TriSubChannelMeshGenerator,
+                           "06/30/2025 24:00",
+                           SCMTriSubChannelMeshGenerator);
 
 InputParameters
 SCMTriSubChannelMeshGenerator::validParams()

--- a/modules/subchannel/src/postprocessors/SCMPinSurfaceTemperature.C
+++ b/modules/subchannel/src/postprocessors/SCMPinSurfaceTemperature.C
@@ -18,6 +18,10 @@
 #include "SCM.h"
 
 registerMooseObject("SubChannelApp", SCMPinSurfaceTemperature);
+registerMooseObjectRenamed("SubChannelApp",
+                           PinSurfaceTemperature,
+                           "06/30/2025 24:00",
+                           SCMPinSurfaceTemperature);
 
 InputParameters
 SCMPinSurfaceTemperature::validParams()

--- a/modules/subchannel/src/postprocessors/SCMPlanarMean.C
+++ b/modules/subchannel/src/postprocessors/SCMPlanarMean.C
@@ -18,6 +18,7 @@
 #include "SCM.h"
 
 registerMooseObject("SubChannelApp", SCMPlanarMean);
+registerMooseObjectRenamed("SubChannelApp", PlanarMean, "06/30/2025 24:00", SCMPlanarMean);
 
 InputParameters
 SCMPlanarMean::validParams()

--- a/modules/subchannel/src/transfers/SCMPinSolutionTransfer.C
+++ b/modules/subchannel/src/transfers/SCMPinSolutionTransfer.C
@@ -11,6 +11,10 @@
 #include "SubChannelMesh.h"
 
 registerMooseObject("SubChannelApp", SCMPinSolutionTransfer);
+registerMooseObjectRenamed("SubChannelApp",
+                           PinSolutionTransfer,
+                           "06/30/2025 24:00",
+                           SCMPinSolutionTransfer);
 
 InputParameters
 SCMPinSolutionTransfer::validParams()

--- a/modules/subchannel/src/transfers/SCMSolutionTransfer.C
+++ b/modules/subchannel/src/transfers/SCMSolutionTransfer.C
@@ -11,6 +11,10 @@
 #include "SubChannelMesh.h"
 
 registerMooseObject("SubChannelApp", SCMSolutionTransfer);
+registerMooseObjectRenamed("SubChannelApp",
+                           SolutionTransfer,
+                           "06/30/2025 24:00",
+                           SCMSolutionTransfer);
 
 InputParameters
 SCMSolutionTransfer::validParams()


### PR DESCRIPTION
refs  #28497

the nice thing is that when we want to get rid of the old names in a couple years we can just revert this commit