### PR TITLE
Bug fix for allowing unused inputs not found in lattice pattern of PatternedHex/CartesianMeshGenerator

### DIFF
--- a/modules/reactor/include/meshgenerators/PatternedCartesianMeshGenerator.h
+++ b/modules/reactor/include/meshgenerators/PatternedCartesianMeshGenerator.h
@@ -94,6 +94,8 @@ protected:
   std::vector<std::vector<boundary_id_type>> _interface_boundary_id_shift_pattern;
   /// Type of quadrilateral elements to be generated in the periphery region
   QUAD_ELEM_TYPE _boundary_quad_elem_type;
+  /// Whether to allow additional assembly types to be passed to "inputs" parameter without being used in lattice
+  const bool _allow_unused_inputs;
 
   /**
    * Adds background and duct region mesh to each part outer part of stitched square meshes. Note

--- a/modules/reactor/include/meshgenerators/PatternedHexMeshGenerator.h
+++ b/modules/reactor/include/meshgenerators/PatternedHexMeshGenerator.h
@@ -96,6 +96,8 @@ protected:
   std::vector<std::vector<boundary_id_type>> _interface_boundary_id_shift_pattern;
   /// Type of quadrilateral elements to be generated in the periphery region
   QUAD_ELEM_TYPE _boundary_quad_elem_type;
+  /// Whether to allow additional assembly types to be passed to "inputs" parameter without being used in lattice
+  const bool _allow_unused_inputs;
 
   /**
    * Adds background and duct region mesh to stitched hexagon meshes. Note that the function works

--- a/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
@@ -368,6 +368,7 @@ CoreMeshGenerator::CoreMeshGenerator(const InputParameters & parameters)
         params.set<boundary_id_type>("external_boundary_id") = radial_boundary;
         params.set<BoundaryName>("external_boundary_name") = RGMB::CORE_BOUNDARY_NAME;
         params.set<double>("rotate_angle") = 0.0;
+        params.set<bool>("allow_unused_inputs") = true;
 
         addMeshSubgenerator(patterned_mg_name, name() + "_pattern", params);
       }

--- a/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
@@ -125,6 +125,10 @@ PatternedHexMeshGenerator::validParams()
       "boundary_region_element_type",
       quad_elem_type,
       "Type of the quadrilateral elements to be generated in the boundary region.");
+  params.addParam<bool>(
+      "allow_unused_inputs",
+      false,
+      "Whether additional input assemblies can be part of inputs without being used in lattice");
   params.addParamNamesToGroup(
       "background_block_id background_block_name duct_block_ids boundary_region_element_type "
       "duct_block_names external_boundary_id external_boundary_name "
@@ -179,7 +183,8 @@ PatternedHexMeshGenerator::PatternedHexMeshGenerator(const InputParameters & par
     _use_exclude_id(isParamValid("exclude_id")),
     _use_interface_boundary_id_shift(isParamValid("interface_boundary_id_shift_pattern")),
     _boundary_quad_elem_type(
-        getParam<MooseEnum>("boundary_region_element_type").template getEnum<QUAD_ELEM_TYPE>())
+        getParam<MooseEnum>("boundary_region_element_type").template getEnum<QUAD_ELEM_TYPE>()),
+    _allow_unused_inputs(getParam<bool>("allow_unused_inputs"))
 {
   declareMeshProperty("pattern_pitch_meta", 0.0);
   declareMeshProperty("input_pitch_meta", 0.0);
@@ -221,10 +226,11 @@ PatternedHexMeshGenerator::PatternedHexMeshGenerator(const InputParameters & par
   if (*std::max_element(pattern_max_array.begin(), pattern_max_array.end()) >= _input_names.size())
     paramError("pattern",
                "Elements of this parameter must be smaller than the length of input_name.");
-  if ((unsigned int)std::distance(pattern_1d.begin(),
-                                  std::unique(pattern_1d.begin(), pattern_1d.end())) <
-      _input_names.size())
-    paramError("pattern", "All the meshes provided in inputs must be used here.");
+  if (std::set<unsigned int>(pattern_1d.begin(), pattern_1d.end()).size() < _input_names.size() &&
+      !_allow_unused_inputs)
+    paramError("pattern",
+               "All the meshes provided in inputs must be used in the lattice pattern. To bypass "
+               "this requirement, set 'allow_unused_inputs = true'");
 
   if (isParamValid("background_block_id"))
   {

--- a/modules/reactor/test/tests/meshgenerators/patterned_cartesian_mesh_generator/patterned_pattern_unused.i
+++ b/modules/reactor/test/tests/meshgenerators/patterned_cartesian_mesh_generator/patterned_pattern_unused.i
@@ -1,0 +1,75 @@
+[Mesh]
+  [square_1]
+    type = PolygonConcentricCircleMeshGenerator
+    num_sides = 4
+    num_sectors_per_side = '2 2 2 2'
+    background_intervals = 1
+    ring_radii = 3.0
+    ring_intervals = 1
+    ring_block_ids = '10'
+    ring_block_names = 'center_tri_1'
+    background_block_ids = 20
+    background_block_names = background
+    polygon_size = 5.0
+    preserve_volumes = on
+    flat_side_up = true
+  []
+  [square_2]
+    type = PolygonConcentricCircleMeshGenerator
+    num_sides = 4
+    num_sectors_per_side = '2 2 2 2'
+    background_intervals = 1
+    ring_radii = 2.5
+    ring_intervals = 1
+    ring_block_ids = '40'
+    ring_block_names = 'center_tri_2'
+    background_block_ids = 20
+    background_block_names = background
+    polygon_size = 5.0
+    preserve_volumes = on
+    flat_side_up = true
+  []
+  [pattern]
+    type = PatternedCartesianMeshGenerator
+    inputs = 'square_1 square_2'
+    pattern = '0 0 0 0;
+               0 1 0 0;
+               0 0 1 0;
+               0 0 0 0'
+    square_size = 48
+    duct_sizes = '21 22 23'
+    duct_intervals = '2 2 2'
+    rotate_angle = 0
+    duct_block_ids = '2000 2100 2200'
+    background_block_id = 1500
+  []
+  [pattern_unused]
+    type = PatternedCartesianMeshGenerator
+    inputs = 'square_1 square_2'
+    pattern = '0 0 0 0;
+               0 1 0 0;
+               0 0 1 0;
+               0 0 0 0'
+    square_size = 48
+    duct_sizes = '21 22 23'
+    duct_intervals = '2 2 2'
+    rotate_angle = 0
+    duct_block_ids = '2000 2100 2200'
+    background_block_id = 1500
+  []
+  [pattern_2]
+    type = PatternedCartesianMeshGenerator
+    inputs = 'pattern pattern_unused'
+    pattern = '0 0;
+               0 0'
+    pattern_boundary = none
+    generate_core_metadata = true
+  []
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    output_extra_element_ids = false
+  []
+[]

--- a/modules/reactor/test/tests/meshgenerators/patterned_cartesian_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/patterned_cartesian_mesh_generator/tests
@@ -108,6 +108,14 @@
     requirement = 'The system shall stitch square patterned meshes to form a large mesh.'
     recover = false
   []
+  [patterned_pattern_allow_unused]
+    type = 'Exodiff'
+    input = 'patterned_pattern_unused.i'
+    exodiff = 'patterned_pattern.e'
+    cli_args = 'Mesh/pattern_2/allow_unused_inputs=true --mesh-only "patterned_pattern.e"'
+    requirement ='The system shall allow input structures to be defined in "inputs" without being part of the Cartesian lattice.'
+    recover = false
+  []
   [patterned_pattern_cd]
     type = 'Exodiff'
     input = 'patterned_pattern_cd.i'
@@ -254,7 +262,7 @@
     input = 'patterned_2d.i'
     cli_args = 'Mesh/pattern/pattern="0 0;0 0"
                   --mesh-only "patterned_err.e"'
-    expect_err = 'All the meshes provided in inputs must be used here.'
+    expect_err = 'All the meshes provided in inputs must be used in the lattice pattern.'
     requirement = 'The system shall throw an error if not all the cartesian meshes provided in inputs are used in pattern.'
   []
   [err_no_appropriate_pitch_meta]

--- a/modules/reactor/test/tests/meshgenerators/patterned_hex_mesh_generator/patterned_pattern_unused.i
+++ b/modules/reactor/test/tests/meshgenerators/patterned_hex_mesh_generator/patterned_pattern_unused.i
@@ -1,0 +1,55 @@
+[Mesh]
+  [hex_1]
+    type = PolygonConcentricCircleMeshGenerator
+    num_sides = 6
+    num_sectors_per_side = '4 4 4 4 4 4'
+    background_intervals = 2
+    ring_radii = 4.0
+    ring_intervals = 2
+    ring_block_ids = '10 15'
+    ring_block_names = 'center_tri center'
+    background_block_ids = 20
+    background_block_names = background
+    polygon_size = 5.0
+    preserve_volumes = on
+  []
+  [pattern_1]
+    type = PatternedHexMeshGenerator
+    inputs = 'hex_1'
+    pattern = '0 0;
+              0 0 0;
+               0 0'
+    hexagon_size = 15
+    background_block_id = 80
+    background_block_name = hex_background
+  []
+  [pattern_unused]
+    type = PatternedHexMeshGenerator
+    inputs = 'hex_1'
+    pattern = '0 0;
+              0 0 0;
+               0 0'
+    hexagon_size = 15
+    background_block_id = 80
+    background_block_name = hex_background
+  []
+  [pattern_2]
+    type = PatternedHexMeshGenerator
+    inputs = 'pattern_1 pattern_unused'
+    pattern_boundary = none
+    generate_core_metadata = true
+    allow_unused_inputs = true
+    pattern = '0 0 0;
+              0 0 0 0;
+             0 0 0 0 0;
+              0 0 0 0;
+               0 0 0'
+  []
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    output_extra_element_ids = false
+  []
+[]

--- a/modules/reactor/test/tests/meshgenerators/patterned_hex_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/patterned_hex_mesh_generator/tests
@@ -111,6 +111,14 @@
     requirement ='The system shall stitch hexagon meshes twice to form a larger mesh.'
     recover = false
   []
+  [patterned_pattern_allow_unused]
+    type = 'Exodiff'
+    input = 'patterned_pattern_unused.i'
+    exodiff = 'patterned_pattern.e'
+    cli_args = 'Mesh/pattern_2/allow_unused_inputs=true --mesh-only "patterned_pattern.e"'
+    requirement ='The system shall allow input structures to be defined in "inputs" without being part of the hexagonal lattice.'
+    recover = false
+  []
   [patterned_pattern_cd]
     type = 'Exodiff'
     input = 'patterned_pattern_cd.i'
@@ -244,7 +252,7 @@
     type = 'RunException'
     input = 'patterned_2d_err.i'
     cli_args = '--mesh-only "patterned_err.e"'
-    expect_err = 'All the meshes provided in inputs must be used here.'
+    expect_err = 'All the meshes provided in inputs must be used in the lattice pattern.'
     requirement ='The system shall throw an error if not all the hexagonal meshes provided in inputs are used in pattern.'
   []
   [err_no_appropriate_pitch_meta]


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->

refs #30100
