### PR TITLE
Add capability to de-register syntax from MOOSE App

### DIFF
--- a/framework/include/parser/Syntax.h
+++ b/framework/include/parser/Syntax.h
@@ -116,6 +116,11 @@ public:
                             int line = -1);
 
   /**
+   * De-registers all actions associated with a given syntax
+   */
+  void removeAllActionsForSyntax(const std::string & syntax);
+
+  /**
    *  Registration function that replaces existing Moose Actions with a completely new action
    *  Note: This function will remove all actions associated with this piece of syntax _NOT_ just
    *        a single match of some kind

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -172,6 +172,12 @@ Syntax::replaceActionSyntax(const std::string & action,
 }
 
 void
+Syntax::removeAllActionsForSyntax(const std::string & syntax)
+{
+  _syntax_to_actions.erase(syntax);
+}
+
+void
 Syntax::deprecateActionSyntax(const std::string & syntax)
 {
   const std::string message = "\"[" + syntax + "]\" is deprecated.";

--- a/framework/src/physics/DiffusionPhysicsBase.C
+++ b/framework/src/physics/DiffusionPhysicsBase.C
@@ -168,6 +168,8 @@ DiffusionPhysicsBase::addInitialConditionsFromComponents()
 {
   InputParameters params = getFactory().getValidParams("FunctorIC");
 
+  // ICs from components are considered always set by the user, so we do not skip them when
+  // restarting
   for (const auto & [component_name, component_bc_map] : _components_initial_conditions)
   {
     if (!component_bc_map.count(_var_name))

--- a/unit/src/SyntaxTest.C
+++ b/unit/src/SyntaxTest.C
@@ -25,6 +25,7 @@ protected:
 
     _syntax.registerActionSyntax("SomeAction", "TopBlock");
     _syntax.registerActionSyntax("SomeAction", "TopBlock", "second");
+    _syntax.registerActionSyntax("AnotherAction", "AnotherTopBlock");
   }
 
   Syntax _syntax;
@@ -83,6 +84,10 @@ TEST_F(SyntaxTest, errorChecks)
     EXPECT_NE(msg.find("is not a registered task name"), std::string::npos)
         << "failed with unexpected error: " << msg;
   }
+
+  // Test de-registering syntax
+  _syntax.removeAllActionsForSyntax("AnotherTopBlock");
+  EXPECT_EQ(_syntax.getAssociatedActions().count("AnotherTopBlock"), 0);
 }
 
 TEST_F(SyntaxTest, general)


### PR DESCRIPTION
refs #30113

this one is a tad tricky to test imo. I d have to mess with the TestApp.C which is a little unorthodox?

I ll let the reviewer decide if we want coverage on this or if it's simple enough 