### PR TITLE
Don't clobber in contrib

### DIFF
--- a/scripts/clobber.py
+++ b/scripts/clobber.py
@@ -87,6 +87,7 @@ class Clobber(object):
             self.ignore_dir(root, subdirs, "moose")
             self.ignore_dir(root, subdirs, ".git")
             self.ignore_dir(root, subdirs, ".svn")
+            self.ignore_dir(root, subdirs, "contrib")
 
             self.remove_dir(root, subdirs, ".libs")
             self.remove_dir(root, subdirs, ".jitcache")


### PR DESCRIPTION
I'm very tired of having to update and rebuild wasp and now mfem after running a `make clobberall` in which I only wanted to clean moose-herd code

Refs #25717