### PR TITLE
Increase size of factorization space on test that sometimes fail

### DIFF
--- a/modules/navier_stokes/test/tests/finite_volume/ins/mms/rc.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/mms/rc.i
@@ -187,8 +187,8 @@ rho=1.1
 [Executioner]
   type = Steady
   solve_type = 'NEWTON'
-  petsc_options_iname = '-pc_type -pc_factor_shift_type'
-  petsc_options_value = 'lu       NONZERO'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type -pc_factor_mat_solver_package -mat_mumps_icntl_14'
+  petsc_options_value = 'lu       NONZERO               mumps                         300'
   nl_rel_tol = 1e-12
 []
 


### PR DESCRIPTION
with

 PC failed due to FACTOR_OUTMEMORY
refs #30127 

Alex used these options to solve a similar error message on a TMAP case. I suspect the fix works equally well here