### PR TITLE
Do not create symlink

### DIFF
--- a/conda/generate_recipe.sh
+++ b/conda/generate_recipe.sh
@@ -72,11 +72,11 @@ IS_MOOSE TMP_DIR RECIPES SKIP_DOCS PREFIX_PACKAGE_WITH MOOSE_OPTIONS)
         cp "${cfile}" "${TMP_DIR}/${RECIPES}"
         for THIS in "${REPLACE[@]}"; do
             if [ "$(uname)" == 'Darwin' ]; then
-                ARG='-i '
+                ARG='-i ""'
             else
-                ARG='-i'
+                ARG='-i""'
             fi
-            sed "${ARG}"'' -e "s|<${THIS}>|${!THIS}|g" \
+            sed "${ARG}" -e "s|<${THIS}>|${!THIS}|g" \
               "${TMP_DIR}/${RECIPES}/$(basename "${cfile}")"
         done
     done
@@ -145,7 +145,7 @@ if [ "$(basename "${REPO}" .git)" == 'moose' ]; then
 else
     export IS_MOOSE=''
     export MOOSE='/moose'
-    export PREFIX_PACKAGE_WITH="${PREFIX_PACKAGE_WITH:-''}"
+    export PREFIX_PACKAGE_WITH="${PREFIX_PACKAGE_WITH:-'ncrc-'}"
 fi
 SKIP_DOCS='False'
 if [ -n "${MOOSE_SKIP_DOCS}" ]; then

--- a/conda/generate_recipe.sh
+++ b/conda/generate_recipe.sh
@@ -12,30 +12,31 @@ function create_tmp()
     if [ -z "$TMP_DIR" ]; then DO_TRAP="True"; fi
     # Protect running build
     umask 077
-    if [ `uname` == "Darwin" ]; then
-        TMP_DIR=${TMP_DIR:-`mktemp -d -t $APPLICATION`}
+    if [ "$(uname)" == 'Darwin' ]; then
+        TMP_DIR=${TMP_DIR:-$(mktemp -d -t "${APPLICATION}")}
     else
-        TMP_DIR=${TMP_DIR:-`mktemp -d -t $APPLICATION.XXXXXXXX`}
+        TMP_DIR=${TMP_DIR:-$(mktemp -d -t "${APPLICATION}".XXXXXXXX)}
     fi
-    if [ -z "$CIVET_HOME" ] && [ -n "$DO_TRAP" ]; then
+    if [ -z "${CIVET_HOME}" ] && [ -n "${DO_TRAP}" ]; then
         trap 'rm -rf "$TMP_DIR"' EXIT
     fi
-    if [ -d "$TMP_DIR/$RECIPES" ]; then
-        rm "$TMP_DIR/$RECIPES/"*
+    if [ -d "${TMP_DIR}/${RECIPES}" ]; then
+        rm "${TMP_DIR}/${RECIPES}/"*
     fi
-    mkdir -p "$TMP_DIR/$RECIPES"
+    mkdir -p "${TMP_DIR}/${RECIPES}"
 }
 
 function create_env()
 {
-    conda create -p $TMP_DIR/_env -q -y
-    source activate $TMP_DIR/_env
-    export CONDARC=$TMP_DIR/.condarc
-    export CONDA_ENVS_PATH=$TMP_DIR/_env/.envs
+    conda create -p "${TMP_DIR}"/_env -q -y
+    # shellcheck disable=SC1091  # 'activate' available after install of miniforge
+    source activate "${TMP_DIR}"/_env
+    export CONDARC="${TMP_DIR}"/.condarc
+    export CONDA_ENVS_PATH="${TMP_DIR}"/_env/.envs
     conda config --env --set ssl_verify false
     conda config --env --set channel_priority strict
-    conda config --env --add envs_dirs $TMP_DIR/_env/.envs
-    conda config --env --add pkgs_dirs $TMP_DIR/_env/.pkgs
+    conda config --env --add envs_dirs "${TMP_DIR}"/_env/.envs
+    conda config --env --add pkgs_dirs "${TMP_DIR}"/_env/.pkgs
     conda config --env --set changeps1 false
     conda config --env --set always_yes true
     conda config --env --add channels conda-forge
@@ -46,46 +47,61 @@ function create_env()
 function clean_repo()
 {
     printf "Cleaning repo\n"
-    if [ $(git -C "$REPO" status | grep -c -i "^untracked files:") -ge 1 ] && [ -z "$CIVET_HOME" ]; then
-        read -p "Untracked files in $APPLICATION. Press Enter to delete files and continue. CTRL-C to Cancel. "
+    if [ "$(git -C "$REPO" status | grep -c -i "^untracked files:")" -ge 1 ] && \
+    [ -z "${CIVET_HOME}" ]; then
+        read -r -p "Untracked files in ${APPLICATION}. Press Enter to delete files and continue. \
+CTRL-C to Cancel. "
     fi
-    git -C "$REPO" clean -xfd &>/dev/null
-    git -C "$REPO" submodule foreach --recursive git clean -xfd &>/dev/null
-    git -C "$SCRIPT_DIR" clean -xfd &> /dev/null
+    git -C "${REPO}" clean -xfd &>/dev/null
+    git -C "${REPO}" submodule foreach --recursive git clean -xfd &>/dev/null
+    git -C "${SCRIPT_DIR}" clean -xfd &> /dev/null
 }
 
 function string_replace()
 {
-    printf "Creating recipes at $TMP_DIR/$RECIPES\n"
-    REPLACE=(APPLICATION FORMATTED_APPLICATION EXECUTABLE REPO BUILD VERSION MOOSE_JOBS MOOSE IS_MOOSE TMP_DIR RECIPES SKIP_DOCS PREFIX_PACKAGE_WITH MOOSE_OPTIONS)
-    for sfile in `find $SCRIPT_DIR/$TEMPLATE -type l`; do
-        cat "$sfile" > "$TMP_DIR/$RECIPES/$(basename $sfile)"
+    local REPLACE ARG
+    printf 'Creating recipes at %s/%s\n' "${TMP_DIR}" "${RECIPES}"
+    REPLACE=(APPLICATION FORMATTED_APPLICATION EXECUTABLE REPO BUILD VERSION MOOSE_JOBS MOOSE \
+IS_MOOSE TMP_DIR RECIPES SKIP_DOCS PREFIX_PACKAGE_WITH MOOSE_OPTIONS)
+    # shellcheck disable=SC2044  # we will never allow spaces in our filesnames
+    for sfile in $(find "${SCRIPT_DIR}/${TEMPLATE}" -type l); do
+        cat "${sfile}" > "${TMP_DIR}/${RECIPES}/$(basename "${sfile}")"
     done
-    for cfile in `find $SCRIPT_DIR/$TEMPLATE -type f`; do
-        cp "$cfile" "$TMP_DIR/$RECIPES"
+    # shellcheck disable=SC2044 # we will never allow spaces in our filesnames
+    for cfile in $(find "${SCRIPT_DIR}/${TEMPLATE}" -type f); do
+        cp "${cfile}" "${TMP_DIR}/${RECIPES}"
         for THIS in "${REPLACE[@]}"; do
-            if [ `uname ` == "Darwin" ]; then
-                sed -i '' -e "s|\<${THIS}\>|${!THIS}|g" "$TMP_DIR/$RECIPES/$(basename $cfile)"
+            if [ "$(uname)" == 'Darwin' ]; then
+                ARG='-i '
             else
-                sed -i'' -e "s|<${THIS}>|${!THIS}|g" "$TMP_DIR/$RECIPES/$(basename $cfile)"
+                ARG='-i'
             fi
+            sed "${ARG}"'' -e "s|<${THIS}>|${!THIS}|g" \
+              "${TMP_DIR}/${RECIPES}/$(basename "${cfile}")"
         done
     done
 }
 
 function conda_build()
 {
-    if [ -z "$CIVET_HOME" ]; then
+    if [ -z "${CIVET_HOME}" ]; then
         printf "Installing everything necessary to a temporary location (including Conda)\n"
         create_tmp
-        printf "TEMP DIR: $TMP_DIR\n"
+        printf 'TEMP DIR: %s\n' "${TMP_DIR}"
         create_env
         clean_repo
         string_replace || exit 1
-        cd "$TMP_DIR/$RECIPES" || exit 1
+        cd "${TMP_DIR}/${RECIPES}" || exit 1
         mkdir -p "${SCRIPT_DIR}/packages/${APPLICATION}" || exit 1
         conda-build . --output-folder "${SCRIPT_DIR}/packages/${APPLICATION}" || exit 1
-        printf "Built: ${SCRIPT_DIR}/packages/${APPLICATION}/${ARCH}/${PREFIX_PACKAGE_WITH}${FORMATTED_APPLICATION}-${VERSION}-build_${BUILD}.tar.bz2\n"
+        printf 'Built: %s/packages/%s/%s/%s%s-%s-build_%s.conda\n' \
+          "${SCRIPT_DIR}" \
+          "${APPLICATION}" \
+          "${ARCH}" \
+          "${PREFIX_PACKAGE_WITH}" \
+          "${FORMATTED_APPLICATION}" \
+          "${VERSION}" \
+          "${BUILD}"
     else
         TMP_DIR="$BUILD_ROOT"
         clean_repo
@@ -94,23 +110,33 @@ function conda_build()
     fi
 }
 
-if ! `type conda &>/dev/null` || ! `type activate &>/dev/null`; then
-    printf "Conda not installed. Or not properly available (activate not available).\n"
+if ! type conda &>/dev/null || ! type activate &>/dev/null; then
+    printf 'Conda not installed. Or not properly available (activate not available).\n'
     exit 1
 elif [ -z "$2" ]; then
-    printf "Supply possitional arguments:\n\t$0 /path/to/application jobs\n\nExample:\n\t$0 /home/user/moose 24\n"
+    printf '
+Supply possitional arguments:
+\t%s /path/to/application jobs
+
+Example:
+\t%s /home/user/moose 24
+\n' "$0" "$0"
     exit 1
 elif ! [ -d "$1" ]; then
-    printf "$1 not found\n"
+    printf '%s not found\n' "${1}"
     exit 1
 fi
-if [ "$(uname)" == "Darwin" ]; then
-    ARCH="osx-64"
+if [ "$(uname)" == 'Darwin' ]; then
+    if [ "$(uname -m)" == 'arm64' ]; then
+        ARCH='osx-arm64'
+    else
+        ARCH='osx-64'
+    fi
 else
-    ARCH="linux-64"
+    ARCH='linux-64'
 fi
 # We are building moose
-if [ "$(basename "$REPO" .git)" == "moose" ]; then
+if [ "$(basename "${REPO}" .git)" == 'moose' ]; then
     export IS_MOOSE='/modules'
     export MOOSE=''
     export EXECUTABLE='combined'
@@ -119,18 +145,19 @@ if [ "$(basename "$REPO" .git)" == "moose" ]; then
 else
     export IS_MOOSE=''
     export MOOSE='/moose'
-    export PREFIX_PACKAGE_WITH=${PREFIX_PACKAGE_WITH:-'ncrc-'}
+    export PREFIX_PACKAGE_WITH="${PREFIX_PACKAGE_WITH:-''}"
 fi
 SKIP_DOCS='False'
-if [ -n "$MOOSE_SKIP_DOCS" ]; then
+if [ -n "${MOOSE_SKIP_DOCS}" ]; then
     printf "Influential environment variable: MOOSE_SKIP_DOCS detected.\n"
-    export SKIP_DOCS="True"
+    export SKIP_DOCS='True'
 fi
-export APPLICATION=$(basename "$REPO" .git)
-export FORMATTED_APPLICATION=$(echo $APPLICATION | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')
-export RECIPES=".recipes/$APPLICATION"
-export EXECUTABLE=${EXECUTABLE:-$APPLICATION}
-export VERSION=$(git -C "$REPO" log -1 --date=format:"%Y_%m_%d" --pretty=format:"%ad")
-export BUILD=0
+APPLICATION=$(basename "$REPO" .git)
+FORMATTED_APPLICATION=$(echo "${APPLICATION}" | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')
+RECIPES=".recipes/${APPLICATION}"
+EXECUTABLE=${EXECUTABLE:-${APPLICATION}}
+VERSION=$(git -C "${REPO}" log -1 --date=format:"%Y_%m_%d" --pretty=format:"%ad")
+BUILD=0
+export APPLICATION FORMATTED_APPLICATION RECIPES EXECUTABLE VERSION BUILD
 conda_build
 exit 0

--- a/conda/template/build.sh
+++ b/conda/template/build.sh
@@ -34,23 +34,18 @@ source "${SRC_DIR:?}/retry_build.sh"
 # or 3 failed attempts, or 1 unknown/unhandled failure
 retry_build
 
-cd "${PREFIX:?}/bin"
-ln -s ${INSTALL_DIR:?}/bin/<EXECUTABLE>-opt .
-ln -s ${INSTALL_DIR:?}/bin/moose_test_runner .
-cd "${PREFIX:?}/share"
-if ! [[ -d "<APPLICATION>" ]]; then
-    ln -s "${INSTALL_DIR:?}/share/<APPLICATION>" .
-fi
 mkdir -p "${PREFIX:?}/etc/conda/activate.d" "${PREFIX:?}/etc/conda/deactivate.d"
 cat <<EOF > "${PREFIX:?}/etc/conda/activate.d/activate_${PKG_NAME:?}.sh"
 export MOOSE_ADFPARSER_JIT_INCLUDE=${INSTALL_DIR}/include/moose/ADRealMonolithic.h
 export <FORMATTED_APPLICATION>_DOCS=${INSTALL_DIR}/share/<APPLICATION>/doc/index.html
 export NCRC_APP=<FORMATTED_APPLICATION>
+export PATH=\$PATH:\${CONDA_PREFIX}/${APPLICATION}/bin
 EOF
 cat <<EOF > "${PREFIX:?}/etc/conda/deactivate.d/deactivate_${PKG_NAME:?}.sh"
 unset MOOSE_ADFPARSER_JIT_INCLUDE
 unset <FORMATTED_APPLICATION>_DOCS
 unset NCRC_APP
+export PATH=\${PATH%":\${CONDA_PREFIX}/${APPLICATION}/bin"}
 EOF
 if [[ "${APPLICATION:?}" == "moose" ]]; then
     cat <<EOF >> "${PREFIX:?}/etc/conda/activate.d/activate_${PKG_NAME:?}.sh"


### PR DESCRIPTION
No longer create symlink for

```pre
CONDA_PREFIX/bin/application-opt --> CONDA_PREFIX/application/bin/application-opt
```

This was causing an issue when MOOSE tried to discover where its shared data directory was:

```bash
$(which application-opt)/../share/data/moose
CONDA_PREFIX/share/data/moose
            ^ whoops
```

Instead, modify PATH variable as we should have been doing in the activation script routine. While the build.sh looks correct, the 'share' directory already exists, and thus was never created (we were trying to create/hijack CONDA_PREFIX/share).

TLC/shell linting on generate_recipe.sh script.

TODO: need to test Linux arch. Not sure why this was working on that platform.

Closes #30108