### PR TITLE
Remove Lemhi. Add WindRiver and Bitterroot.

### DIFF
--- a/modules/doc/content/getting_started/installation/inl_hpc_install_moose.md
+++ b/modules/doc/content/getting_started/installation/inl_hpc_install_moose.md
@@ -1,7 +1,7 @@
 # INL HPC Cluster
 
 The following instructions are for those operating on [!ac](INL) [!ac](HPC) machines. This includes
-Bitterroot, Lemhi, and Sawtooth. It also includes the protected access hosts `rod` and `cone`.
+WindRiver, Bitterroot, and Sawtooth. It also includes the protected access hosts `rod` and `cone`.
 
 Requesting access to [!ac](INL) [!ac](HPC) is handled by the [NCRC](https://inl.gov/ncrc/) group.
 Once access has been granted, one can use [HPC OnDemand](hpc_ondemand.md) services to gain access to
@@ -28,7 +28,7 @@ practice that bundles all application and application dependencies (i.e., MOOSE 
 app), needed to run on any host. This means that applications built within this environment can be
 executed across all [!ac](INL) [!ac](HPC) clusters. For example, you can build an application within
 a compute node on Sawtooth and execute the same executable of the application (providing you follow
-the instructions that follow) on both Bitterroot and Lemhi.
+the instructions that follow) on both Bitterroot and WindRiver.
 
 ## Obtain MOOSE
 

--- a/modules/doc/content/getting_started/installation/inl_hpc_prebuilt_moose.md
+++ b/modules/doc/content/getting_started/installation/inl_hpc_prebuilt_moose.md
@@ -6,8 +6,9 @@ pre-built versions of MOOSE. To request access to these clusters, please follow 
 [INL's Nuclear Computational Resource Center](https://inl.gov/ncrc/) website.
 !style-end!
 
-Once access has been granted, log into Sawtooth or Lemhi using either [inl/hpc_ondemand.md]
-Interactive Shell services, or directly by following our [SSH Primer](inl/hpc_remote.md).
+Once access has been granted, log into Sawtooth, Bitterroot, or Windriver using either 
+[inl/hpc_ondemand.md] Interactive Shell services, or directly by following our 
+[SSH Primer](inl/hpc_remote.md).
 
 At the time of this writing, the following [!ac](INL) [!ac](HPC) clusters are available for use:
 
@@ -30,7 +31,7 @@ module load use.moose moose-openmpi
 
 !alert warning
 If you receive an error about modules not being known, please make sure you are logged into either
-Bitterroot, Sawtooth or Lemhi.
+WindRiver, Bitterroot, or Sawtooth.
 
 Once loaded, `moose` becomes available. You need now only provide input files to run simulations.
 Example input files are also available while this module is loaded.

--- a/modules/doc/content/help/inl/hpc_remote.md
+++ b/modules/doc/content/help/inl/hpc_remote.md
@@ -27,7 +27,7 @@ Host hpclogin hpclogin.inl.gov
   DynamicForward 5555
 
 ## Forwarding
-Host sawtooth1 sawtooth2 lemhi1 lemhi2 rod hoodoo1 viz1
+Host sawtooth1 sawtooth2 bitterroot1 bitterroot2 windriver1 windriver2 rod hoodoo1 viz1
   ProxyJump hpclogin
 ```
 

--- a/modules/doc/content/help/inl/hpc_remote_different_user.md
+++ b/modules/doc/content/help/inl/hpc_remote_different_user.md
@@ -22,7 +22,7 @@ Host hpclogin
   DynamicForward 5555
 
 ## Forwarding
-Host sawtooth1 sawtooth2 lemhi1 lemhi2 rod hoodoo1 viz1
+Host sawtooth1 sawtooth2 bitterroot1 bitterroot2 windriver1 windriver2 rod hoodoo1 viz1
   User doejohn
   ProxyJump hpclogin
 ```

--- a/modules/doc/content/ncrc/applications/ncrc_hpc.md.template
+++ b/modules/doc/content/ncrc/applications/ncrc_hpc.md.template
@@ -2,11 +2,11 @@
 
 Familiarize yourself with [inl/hpc_ondemand.md], and return here with an interactive shell for the
 machine you wish to run your application on. NCRC Application binaries are only available on
-Sawtooth and Lemhi.
+Sawtooth, Bitterroot, and WindRiver.
 
 ## Load {{ApplicationName}} Environment
 
-Logged into either Sawtooth or Lemhi, load the {{ApplicationName}} environment:
+Logged into either Sawtooth, Bitterroot, or WindRiver, load the {{ApplicationName}} environment:
 
 ```bash
 module load use.moose {{ApplicationLower}}-openmpi

--- a/modules/doc/content/ncrc/applications/ncrc_hpc_relap5.md
+++ b/modules/doc/content/ncrc/applications/ncrc_hpc_relap5.md
@@ -2,7 +2,7 @@
 
 !style! halign=left
 To access the HPC, familiarize yourself with [inl/hpc_ondemand.md]. There are three options for
-gaining access to the HPC machines Sawtooth and Lemhi. The first two are accessed via the
+gaining access to the HPC machines Sawtooth, Bitterroot, and WindRiver. The first two are accessed via the
 [HPC OnDemand Dashboard](https://hpcondemand.inl.gov/pun/sys/dashboard).
 !style-end!
 
@@ -19,7 +19,8 @@ Desktop. This takes you to another webpage where you will input the following in
   performing your work. Contact the HPC staff for help determining which project your work pertains
   to.
 
-1. Under the Cluster label, select your choice of machine. (Sawtooth or Lemhi)
+1. Under the Cluster label, select your choice of machine.
+  Presently, only Sawtooth supports the Login job type.
 
 1. Under the Job Type label, select Login.
 
@@ -38,13 +39,13 @@ Option 3, use Secure Shell rather than OnDemand. To do so use the following step
 
 1. Once you have accessed hpclogin, from there you must SSH login to your machine of choice.
 
-NCRC Application binaries, like RELAP5-3D, are only available on Sawtooth and Lemhi.
+NCRC Application binaries, like RELAP5-3D, are only available on Sawtooth, Bitterroot, and WindRiver.
 
 
 ## Load Environment
 
 !style! halign=left
-Once logged into either Sawtooth or Lemhi using any of the methods above, load the RELAP5
+Once logged into either Sawtooth, Bitterroot, or WindRiver using any of the methods above, load the RELAP5
 environment:
 !style-end!
 

--- a/modules/doc/content/ncrc/applications/ncrc_runtest.md.template
+++ b/modules/doc/content/ncrc/applications/ncrc_runtest.md.template
@@ -9,7 +9,7 @@ With {{ApplicationName}} built, we can now run tests to verify a working binary 
   conda activate moose
   ```
 
-- If +[!ac](INL) [!ac](HPC) Sawtooth or Lemhi+ (required each time you log in):
+- If +[!ac](INL) [!ac](HPC) Sawtooth, Bitterroot, or WindRiver+ (required each time you log in):
 
   ```bash
   module load use.moose moose-dev

--- a/modules/doc/content/ncrc/hpc_cluster_information.md
+++ b/modules/doc/content/ncrc/hpc_cluster_information.md
@@ -1,7 +1,7 @@
 | Cluster | Login Nodes | NCPUS | NODES | Max Hours |
 | :- | :- | -: | -: | -: |
+| WindRiver | `windriver1`, `windriver2` | `56` | `843` | `168` |
 | Bitterroot | `bitterroot1`, `bitterroot2` | `56` | `336` | `168` |
 | Sawtooth | `sawtooth1`, `sawtooth2` | `48` | `2052` | `168` |
-| Lemhi | `lemhi1`, `lemhi2` | `20` | `504` | `72` |
 
 Additional information for each cluster can be found at the [INL HPC website](https://inl.gov/hpc).


### PR DESCRIPTION
Closes #30144.

## Reason
Lemhi has retired. WindRiver and Bitterroot are now in service. 

## Design
n/a

## Impact
This PR only impacts documentation. 

I did not purge every reference to Lemhi. For example, _[framework/doc/content/source/auxkernels/HardwareIDAux.md](https://github.com/idaholab/moose/blob/2d43c28fbf29c0abe68a6b685fa2c9db1db8c2c9/framework/doc/content/source/auxkernels/HardwareIDAux.md)_ remains untouched.

Where they were missing, WindRiver and Bitterroot have been added in no particular order.
