### PR TITLE
Fix XMLDiff docs

### DIFF
--- a/python/doc/content/python/testers/XMLDiff.md
+++ b/python/doc/content/python/testers/XMLDiff.md
@@ -8,13 +8,13 @@
 Test configuration options are added to the `tests` file.
 
 - `xmldiff`: A list of `XML` files to compare
-- `gold_dir`: The directory where the \"gold standard\" files reside relative to the TEST_DIR: (default: ./gold/)
-- `abs_zero`: Absolute zero cutoff used in exodiff comparisons, defaults to 1e-10
-- `rel_err`: Relative error value used in exodiff comparisons, defaults to 5.5e-6
+- `gold_dir`: The directory where the "gold standard" files reside relative to the TEST_DIR: (default: ./gold/)
+- `abs_zero`: Absolute zero cutoff used in xmldiff comparisons, defaults to 1e-10
+- `rel_err`: Relative error value used in xmldiff comparisons, defaults to 5.5e-6
 - `ignored_attributes`: Ignore an attribute. For example, type and version in sample `XML` block below
 
 ```
-<VTKFile type=\"Foo\" version=\"0.1\">")
+<VTKFile type="Foo" version="0.1">
 ```
 
 Other test commands & restrictions may be found in the [TestHarness documentation](TestHarness.md).


### PR DESCRIPTION
## Reason
Documentation mentions exodiff instead of xmldiff
Format of example is not right either

## Design
Correct documentation

## Impact
Correct documentation helps users focus on their problem 
