### PR TITLE
Fix uninitialized memory in UMAT

### DIFF
--- a/modules/solid_mechanics/test/plugins/linear_strain_hardening.f
+++ b/modules/solid_mechanics/test/plugins/linear_strain_hardening.f
@@ -69,6 +69,13 @@ C
 C
 C     ELASTIC STIFFNESS
 C
+C     Fully initialize DDSDDE to zero
+      DO I = 1, NTENS
+         DO J = 1, NTENS
+            DDSDDE(I,J) = 0.0
+         END DO
+      END DO
+
       DO K1=1, NDI
          DO K2=1, NDI
             DDSDDE(K2, K1)=ELAM
@@ -155,6 +162,10 @@ C      PRINT *, PJ
          END DO
          DO K=NDI+1,NTENS
             DIR(K) = ((THREE/TWO)*STRESS(K))/PJ
+         END DO
+      ELSE
+         DO K=1,NTENS
+            DIR(K) = 0.0
          END DO
       END IF
 C      PRINT *, DIR

--- a/modules/solid_mechanics/test/tests/umat/multiple_blocks/multiple_blocks_two_materials_parallel.i
+++ b/modules/solid_mechanics/test/tests/umat/multiple_blocks/multiple_blocks_two_materials_parallel.i
@@ -51,17 +51,17 @@
 [Functions]
   [top_pull]
     type = ParsedFunction
-    value = t/100
+    expression = t/100
   []
   # Forced evolution of temperature
   [temperature_load]
     type = ParsedFunction
-    value = '273'
+    expression = '273'
   []
   # Factor to multiply the elasticity tensor in MOOSE
   [elasticity_prefactor]
     type = ParsedFunction
-    value = '1'
+    expression = '1'
   []
 []
 


### PR DESCRIPTION
## Reason
@lindsayad came across a failure in `test:umat/multiple_blocks.multiple_blocks_two_materials_parallel` with valgrind pointing to uninitialized values.

## Design
I went over the code of the fortran UMAT plugin used in this test and found two uninitialized values (some components of the elasticity matrix DDSDDE and a potentially uninitialized direction vector DIR).

## Impact
Added zero initialization to both.

