### PR TITLE
A fix to avoid repartitioning when loading checkpoint files

### DIFF
--- a/test/tests/restart/p_refinement_restart/restarted_steady.i
+++ b/test/tests/restart/p_refinement_restart/restarted_steady.i
@@ -2,6 +2,7 @@
   [cmg]
     type = FileMeshGenerator
     file = steady_out_cp/LATEST
+    skip_partitioning = true
   []
 []
 


### PR DESCRIPTION
This is a followup PR of PR #30052 addressing #30048. Tag @lindsayad 
