### PR TITLE
Fix a couple of bugs in checkNonConformalMeshFromAdaptivity()

### DIFF
--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -703,12 +703,13 @@ MeshDiagnosticsGenerator::checkNonConformalMeshFromAdaptivity(
       // case of non-conformality
       bool node_on_elem = false;
 
-      // non-vertex nodes are not cause for the kind of non-conformality we are looking for
-      if (!elem->is_vertex(elem->get_node_index(node)))
-        continue;
-
       if (elem->get_node_index(node) != libMesh::invalid_uint)
+      {
         node_on_elem = true;
+        // non-vertex nodes are not cause for the kind of non-conformality we are looking for
+        if (!elem->is_vertex(elem->get_node_index(node)))
+          continue;
+      }
 
       // Keep track of all the elements this node is a part of. They are potentially the
       // 'fine' (refined) elements next to a coarser element
@@ -745,7 +746,7 @@ MeshDiagnosticsGenerator::checkNonConformalMeshFromAdaptivity(
              fine_elements.size() != 3)
       continue;
     else if ((elem_type == TET4 || elem_type == TET10 || elem_type == TET14) &&
-             (fine_elements.size() % 4 != 0))
+             (fine_elements.size() % 2 != 0))
       continue;
 
     // only one coarse element in front of refined elements except for tets. Whatever we're

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/tests
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/tests
@@ -224,11 +224,11 @@
       detail = 'triangle elements refined twice near an unrefined triangle element,'
     []
     [tet]
-      type = 'RunApp'
+      type = 'RunException'
       input = 'detect_amr_tet.i'
-      cli_args = '--mesh-only'
       mesh_mode = replicated
-      expect_out = 'Number of non-conformal nodes likely due to mesh refinement detected by heuristic: 8'
+      cli_args = 'Mesh/big_one/nz=2 Mesh/cut_one/nz=2 Mesh/diag/search_for_adaptivity_nonconformality=ERROR --mesh-only'
+      expect_err = 'Number of non-conformal nodes likely due to mesh refinement detected by heuristic: 15'
 
       detail = 'tetrahedral elements,'
     []


### PR DESCRIPTION
## Reason
This is part of an ongoing investigation on tetrahedral refinement in libMesh and MOOSE. Refs libmesh/libMesh#4117.

## Design
1) I know this check is a heuristic, but even then we shouldn't be relying on `elem->is_vertex(libMesh::invalid_uint)` returning true for low order elements.
2) It is not necessarily the case that the no. of refined tetrahedra sharing a node is `4m`. Depending on the diagonal choice of the neighbouring tetrahedra, it could be of the form `4m + 6n`.

## Impact
Slightly better checks for non-conformity.
