### PR TITLE
Treat boundary unrestricted like block unrestricted

### DIFF
--- a/framework/include/warehouses/MooseObjectWarehouseBase.h
+++ b/framework/include/warehouses/MooseObjectWarehouseBase.h
@@ -291,9 +291,10 @@ MooseObjectWarehouseBase<T>::addObject(std::shared_ptr<T> object,
   std::shared_ptr<BlockRestrictable> blk = std::dynamic_pointer_cast<BlockRestrictable>(object);
 
   // Boundary Restricted
-  if (bnd && bnd->boundaryRestricted())
+  if (bnd)
   {
-    const std::set<BoundaryID> & ids = bnd->boundaryIDs();
+    const std::set<BoundaryID> & ids =
+        bnd->boundaryRestricted() ? bnd->boundaryIDs() : bnd->meshBoundaryIDs();
     for (std::set<BoundaryID>::const_iterator it = ids.begin(); it != ids.end(); ++it)
     {
       _all_boundary_objects[tid][*it].push_back(object);


### PR DESCRIPTION
Closes #30221

Ultimately we might want to store (block|boundary)-unrestricted objects in a separate list rather than copying them into the map entry for each boundary. This seems like unnecessary work and slows map lookups down in cases of many blocks/boundaries.