### PR TITLE
Updated SlepscSupport to support dont_add_these_options

### DIFF
--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -13,6 +13,7 @@
 
 // MOOSE includes
 #include "SolverParams.h"
+#include "MultiMooseEnum.h"
 
 #include "libmesh/petsc_macro.h"
 #include "libmesh/linear_solver.h"
@@ -26,7 +27,6 @@ class NonlinearSystemBase;
 class CommandLine;
 class InputParameters;
 class ParallelParamObject;
-class MultiMooseEnum;
 
 namespace Moose
 {

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -26,9 +26,9 @@ class NonlinearSystemBase;
 class CommandLine;
 class InputParameters;
 class ParallelParamObject;
-class MultiMooseEnum
+class MultiMooseEnum;
 
-    namespace Moose
+namespace Moose
 {
 namespace PetscSupport
 {

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -12,7 +12,6 @@
 #include "libmesh/libmesh.h"
 
 // MOOSE includes
-#include "MultiMooseEnum.h"
 #include "SolverParams.h"
 
 #include "libmesh/petsc_macro.h"
@@ -27,8 +26,9 @@ class NonlinearSystemBase;
 class CommandLine;
 class InputParameters;
 class ParallelParamObject;
+class MultiMooseEnum
 
-namespace Moose
+    namespace Moose
 {
 namespace PetscSupport
 {

--- a/framework/include/utils/SlepcSupport.h
+++ b/framework/include/utils/SlepcSupport.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "MultiMooseEnum.h"
 #include "libmesh/libmesh_config.h"
 
 #ifdef LIBMESH_HAVE_SLEPC
@@ -75,12 +76,14 @@ void setSlepcEigenSolverTolerances(EigenProblem & eigen_problem,
 /**
  * Set SLEPc/PETSc options to trigger free power iteration
  */
-void setFreeNonlinearPowerIterations(unsigned int free_power_iterations);
+void setFreeNonlinearPowerIterations(unsigned int free_power_iterations,
+                                     const MultiMooseEnum & dont_add_these_options);
 
 /*
  * Set SLEPc/PETSc options to turn the eigen-solver back to a regular Newton solver
  */
-void clearFreeNonlinearPowerIterations(const InputParameters & params);
+void clearFreeNonlinearPowerIterations(const InputParameters & params,
+                                       const MultiMooseEnum & dont_add_these_options);
 
 /**
  * Form matrix according to tag

--- a/framework/include/utils/SlepcSupport.h
+++ b/framework/include/utils/SlepcSupport.h
@@ -30,6 +30,7 @@
 class EigenProblem;
 class InputParameters;
 class SolverParams;
+class MultiMooseEnum;
 
 namespace Moose
 {
@@ -75,13 +76,11 @@ void setSlepcEigenSolverTolerances(EigenProblem & eigen_problem,
 
 /**
  * Set SLEPc/PETSc options to trigger free power iteration
- * @param dont_add_these_options a list of options that won't be set.
  */
 void setFreeNonlinearPowerIterations(unsigned int free_power_iterations);
 
 /*
  * Set SLEPc/PETSc options to turn the eigen-solver back to a regular Newton solver
- * @param dont_add_these_options a list of options that won't be set.
  */
 void clearFreeNonlinearPowerIterations(const InputParameters & params);
 

--- a/framework/include/utils/SlepcSupport.h
+++ b/framework/include/utils/SlepcSupport.h
@@ -75,12 +75,14 @@ void setSlepcEigenSolverTolerances(EigenProblem & eigen_problem,
 
 /**
  * Set SLEPc/PETSc options to trigger free power iteration
+ * @param dont_add_these_options a list of options that won't be set.
  */
 void setFreeNonlinearPowerIterations(unsigned int free_power_iterations,
                                      const MultiMooseEnum & dont_add_these_options);
 
 /*
  * Set SLEPc/PETSc options to turn the eigen-solver back to a regular Newton solver
+ * @param dont_add_these_options a list of options that won't be set.
  */
 void clearFreeNonlinearPowerIterations(const InputParameters & params,
                                        const MultiMooseEnum & dont_add_these_options);

--- a/framework/include/utils/SlepcSupport.h
+++ b/framework/include/utils/SlepcSupport.h
@@ -77,15 +77,13 @@ void setSlepcEigenSolverTolerances(EigenProblem & eigen_problem,
  * Set SLEPc/PETSc options to trigger free power iteration
  * @param dont_add_these_options a list of options that won't be set.
  */
-void setFreeNonlinearPowerIterations(unsigned int free_power_iterations,
-                                     const MultiMooseEnum & dont_add_these_options);
+void setFreeNonlinearPowerIterations(unsigned int free_power_iterations);
 
 /*
  * Set SLEPc/PETSc options to turn the eigen-solver back to a regular Newton solver
  * @param dont_add_these_options a list of options that won't be set.
  */
-void clearFreeNonlinearPowerIterations(const InputParameters & params,
-                                       const MultiMooseEnum & dont_add_these_options);
+void clearFreeNonlinearPowerIterations(const InputParameters & params);
 
 /**
  * Form matrix according to tag

--- a/framework/src/executioners/Eigenvalue.C
+++ b/framework/src/executioners/Eigenvalue.C
@@ -13,6 +13,7 @@
 #include "Factory.h"
 #include "MooseApp.h"
 #include "NonlinearEigenSystem.h"
+#include "PetscSupport.h"
 #include "SlepcSupport.h"
 #include "UserObject.h"
 
@@ -153,6 +154,16 @@ Eigenvalue::Eigenvalue(const InputParameters & parameters)
   mooseDeprecated(
       "Please use SLEPc-3.13.0 or higher. Old versions of SLEPc likely produce bad convergence");
 #endif
+
+  // To avoid petsc unused option warnings, ensure we do not set irrelevant options.
+  Moose::PetscSupport::dontAddLinearConvergedReason(_fe_problem);
+  Moose::PetscSupport::dontAddNonlinearConvergedReason(_fe_problem);
+  Moose::PetscSupport::dontAddPetscFlag("-mat_mffd_type", _fe_problem.getPetscOptions());
+  Moose::PetscSupport::dontAddPetscFlag("-st_ksp_atol", _fe_problem.getPetscOptions());
+  Moose::PetscSupport::dontAddPetscFlag("-st_ksp_max_it", _fe_problem.getPetscOptions());
+  Moose::PetscSupport::dontAddPetscFlag("-st_ksp_rtol", _fe_problem.getPetscOptions());
+  if (!_eigen_problem.solverParams()._eigen_matrix_free)
+    Moose::PetscSupport::dontAddPetscFlag("-snes_mf_operator", _fe_problem.getPetscOptions());
 }
 
 #ifdef LIBMESH_HAVE_SLEPC

--- a/framework/src/problems/EigenProblem.C
+++ b/framework/src/problems/EigenProblem.C
@@ -520,7 +520,8 @@ EigenProblem::doFreeNonlinearPowerIterations(unsigned int free_power_iterations)
 
   doFreePowerIteration(true);
   // Set free power iterations
-  Moose::SlepcSupport::setFreeNonlinearPowerIterations(free_power_iterations);
+  Moose::SlepcSupport::setFreeNonlinearPowerIterations(
+      free_power_iterations, this->getPetscOptions().dont_add_these_options);
 
   // Call solver
   _current_nl_sys->solve();
@@ -529,7 +530,8 @@ EigenProblem::doFreeNonlinearPowerIterations(unsigned int free_power_iterations)
   // Clear free power iterations
   auto executioner = getMooseApp().getExecutioner();
   if (executioner)
-    Moose::SlepcSupport::clearFreeNonlinearPowerIterations(executioner->parameters());
+    Moose::SlepcSupport::clearFreeNonlinearPowerIterations(
+        executioner->parameters(), this->getPetscOptions().dont_add_these_options);
   else
     mooseError("There is no executioner for this moose app");
 

--- a/framework/src/problems/EigenProblem.C
+++ b/framework/src/problems/EigenProblem.C
@@ -520,8 +520,7 @@ EigenProblem::doFreeNonlinearPowerIterations(unsigned int free_power_iterations)
 
   doFreePowerIteration(true);
   // Set free power iterations
-  Moose::SlepcSupport::setFreeNonlinearPowerIterations(
-      free_power_iterations, this->getPetscOptions().dont_add_these_options);
+  Moose::SlepcSupport::setFreeNonlinearPowerIterations(free_power_iterations);
 
   // Call solver
   _current_nl_sys->solve();
@@ -530,8 +529,7 @@ EigenProblem::doFreeNonlinearPowerIterations(unsigned int free_power_iterations)
   // Clear free power iterations
   auto executioner = getMooseApp().getExecutioner();
   if (executioner)
-    Moose::SlepcSupport::clearFreeNonlinearPowerIterations(
-        executioner->parameters(), this->getPetscOptions().dont_add_these_options);
+    Moose::SlepcSupport::clearFreeNonlinearPowerIterations(executioner->parameters());
   else
     mooseError("There is no executioner for this moose app");
 

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -402,96 +402,69 @@ setWhichEigenPairsOptions(SolverParams & solver_params,
 }
 
 void
-setFreeNonlinearPowerIterations(unsigned int free_power_iterations,
-                                const MultiMooseEnum & dont_add_these_options)
+setFreeNonlinearPowerIterations(unsigned int free_power_iterations)
 {
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_power_update", "0");
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-snes_max_it", "2");
+  Moose::PetscSupport::setSinglePetscOption("-eps_power_update", "0");
+  Moose::PetscSupport::setSinglePetscOption("-snes_max_it", "2");
   // During each power iteration, we want solver converged unless linear solver does not
   // work. We here use a really loose tolerance for this purpose.
   // -snes_no_convergence_test is a perfect option, but it was removed from PETSc
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-snes_rtol", "0.99999999999");
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_max_it", stringify(free_power_iterations));
+  Moose::PetscSupport::setSinglePetscOption("-snes_rtol", "0.99999999999");
+  Moose::PetscSupport::setSinglePetscOption("-eps_max_it", stringify(free_power_iterations));
   // We always want the number of free power iterations respected so we don't want to stop early if
   // we've satisfied a convergence criterion. Consequently we make this tolerance very tight
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_tol", "1e-50");
+  Moose::PetscSupport::setSinglePetscOption("-eps_tol", "1e-50");
 }
 
 void
-clearFreeNonlinearPowerIterations(const InputParameters & params,
-                                  const MultiMooseEnum & dont_add_these_options)
+clearFreeNonlinearPowerIterations(const InputParameters & params)
 {
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_power_update", "1");
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_max_it", "1");
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-snes_max_it", stringify(params.get<unsigned int>("nl_max_its")));
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-snes_rtol", stringify(params.get<Real>("nl_rel_tol")));
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_tol", stringify(params.get<Real>("eigen_tol")));
+  Moose::PetscSupport::setSinglePetscOption("-eps_power_update", "1");
+  Moose::PetscSupport::setSinglePetscOption("-eps_max_it", "1");
+  Moose::PetscSupport::setSinglePetscOption("-snes_max_it",
+                                            stringify(params.get<unsigned int>("nl_max_its")));
+  Moose::PetscSupport::setSinglePetscOption("-snes_rtol",
+                                            stringify(params.get<Real>("nl_rel_tol")));
+  Moose::PetscSupport::setSinglePetscOption("-eps_tol", stringify(params.get<Real>("eigen_tol")));
 }
 
 void
-setNewtonPetscOptions(SolverParams & solver_params,
-                      const InputParameters & params,
-                      const MultiMooseEnum & dont_add_these_options)
+setNewtonPetscOptions(SolverParams & solver_params, const InputParameters & params)
 {
 #if !SLEPC_VERSION_LESS_THAN(3, 8, 0) || !PETSC_VERSION_RELEASE
   // Whether or not we need to involve an initial inverse power
   bool initial_power = params.get<bool>("_newton_inverse_power");
 
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_type", "power");
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_power_nonlinear", "1");
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_power_update", "1");
+  Moose::PetscSupport::setSinglePetscOption("-eps_type", "power");
+  Moose::PetscSupport::setSinglePetscOption("-eps_power_nonlinear", "1");
+  Moose::PetscSupport::setSinglePetscOption("-eps_power_update", "1");
   // Only one outer iteration in EPS is allowed when Newton/PJFNK/JFNK
   // is used as the eigen solver
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_max_it", "1");
+  Moose::PetscSupport::setSinglePetscOption("-eps_max_it", "1");
   if (initial_power)
   {
-    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-        dont_add_these_options, "-init_eps_power_snes_max_it", "1");
-    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-        dont_add_these_options, "-init_eps_power_ksp_rtol", "1e-2");
-    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-        dont_add_these_options,
-        "-init_eps_max_it",
-        stringify(params.get<unsigned int>("free_power_iterations")));
+    Moose::PetscSupport::setSinglePetscOption("-init_eps_power_snes_max_it", "1");
+    Moose::PetscSupport::setSinglePetscOption("-init_eps_power_ksp_rtol", "1e-2");
+    Moose::PetscSupport::setSinglePetscOption(
+        "-init_eps_max_it", stringify(params.get<unsigned int>("free_power_iterations")));
   }
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_target_magnitude", "");
+  Moose::PetscSupport::setSinglePetscOption("-eps_target_magnitude", "");
   if (solver_params._eigen_matrix_free)
   {
-    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-        dont_add_these_options, "-snes_mf_operator", "1");
+    Moose::PetscSupport::setSinglePetscOption("-snes_mf_operator", "1");
     if (initial_power)
-      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-          dont_add_these_options, "-init_eps_power_snes_mf_operator", "1");
+      Moose::PetscSupport::setSinglePetscOption("-init_eps_power_snes_mf_operator", "1");
   }
   else
   {
-    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-        dont_add_these_options, "-snes_mf_operator", "0");
+    Moose::PetscSupport::setSinglePetscOption("-snes_mf_operator", "0");
     if (initial_power)
-      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-          dont_add_these_options, "-init_eps_power_snes_mf_operator", "0");
+      Moose::PetscSupport::setSinglePetscOption("-init_eps_power_snes_mf_operator", "0");
   }
 #if PETSC_RELEASE_LESS_THAN(3, 13, 0)
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-st_type", "sinvert");
+  Moose::PetscSupport::setSinglePetscOption("-st_type", "sinvert");
   if (initial_power)
-    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-        dont_add_these_options, "-init_st_type", "sinvert");
+    Moose::PetscSupport::setSinglePetscOption("-init_st_type", "sinvert");
 #endif
 #else
   mooseError("Newton-based eigenvalue solver requires SLEPc 3.7.3 or higher");
@@ -499,26 +472,19 @@ setNewtonPetscOptions(SolverParams & solver_params,
 }
 
 void
-setNonlinearPowerOptions(SolverParams & solver_params, EigenProblem & eigen_problem)
+setNonlinearPowerOptions(SolverParams & solver_params)
 {
-  const auto & dont_add_these_options = eigen_problem.getPetscOptions().dont_add_these_options;
 #if !SLEPC_VERSION_LESS_THAN(3, 8, 0) || !PETSC_VERSION_RELEASE
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_type", "power");
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_power_nonlinear", "1");
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-eps_target_magnitude", "");
+  Moose::PetscSupport::setSinglePetscOption("-eps_type", "power");
+  Moose::PetscSupport::setSinglePetscOption("-eps_power_nonlinear", "1");
+  Moose::PetscSupport::setSinglePetscOption("-eps_target_magnitude", "");
   if (solver_params._eigen_matrix_free)
-    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-        dont_add_these_options, "-snes_mf_operator", "1");
+    Moose::PetscSupport::setSinglePetscOption("-snes_mf_operator", "1");
   else
-    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-        dont_add_these_options, "-snes_mf_operator", "0");
+    Moose::PetscSupport::setSinglePetscOption("-snes_mf_operator", "0");
 
 #if PETSC_RELEASE_LESS_THAN(3, 13, 0)
-  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-      dont_add_these_options, "-st_type", "sinvert");
+  Moose::PetscSupport::setSinglePetscOption("-st_type", "sinvert");
 #endif
 #else
   mooseError("Nonlinear Inverse Power requires SLEPc 3.7.3 or higher");
@@ -526,61 +492,54 @@ setNonlinearPowerOptions(SolverParams & solver_params, EigenProblem & eigen_prob
 }
 
 void
-setEigenSolverOptions(SolverParams & solver_params,
-                      const InputParameters & params,
-                      EigenProblem & eigen_problem)
+setEigenSolverOptions(SolverParams & solver_params, const InputParameters & params)
 {
-  const auto & dont_add_these_options = eigen_problem.getPetscOptions().dont_add_these_options;
   // Avoid unused variable warnings when you have SLEPc but not PETSc-dev.
   libmesh_ignore(params);
 
   switch (solver_params._eigen_solve_type)
   {
     case Moose::EST_POWER:
-      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-          dont_add_these_options, "-eps_type", "power");
+      Moose::PetscSupport::setSinglePetscOption("-eps_type", "power");
       break;
 
     case Moose::EST_ARNOLDI:
-      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-          dont_add_these_options, "-eps_type", "arnoldi");
+      Moose::PetscSupport::setSinglePetscOption("-eps_type", "arnoldi");
       break;
 
     case Moose::EST_KRYLOVSCHUR:
-      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-          dont_add_these_options, "-eps_type", "krylovschur");
+      Moose::PetscSupport::setSinglePetscOption("-eps_type", "krylovschur");
       break;
 
     case Moose::EST_JACOBI_DAVIDSON:
-      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
-          dont_add_these_options, "-eps_type", "jd");
+      Moose::PetscSupport::setSinglePetscOption("-eps_type", "jd");
       break;
 
     case Moose::EST_NONLINEAR_POWER:
-      setNonlinearPowerOptions(solver_params, eigen_problem);
+      setNonlinearPowerOptions(solver_params);
       break;
 
     case Moose::EST_NEWTON:
-      setNewtonPetscOptions(solver_params, params, dont_add_these_options);
+      setNewtonPetscOptions(solver_params, params);
       break;
 
     case Moose::EST_PJFNK:
       solver_params._eigen_matrix_free = true;
       solver_params._customized_pc_for_eigen = false;
-      setNewtonPetscOptions(solver_params, params, dont_add_these_options);
+      setNewtonPetscOptions(solver_params, params);
       break;
 
     case Moose::EST_JFNK:
       solver_params._eigen_matrix_free = true;
       solver_params._customized_pc_for_eigen = true;
-      setNewtonPetscOptions(solver_params, params, dont_add_these_options);
+      setNewtonPetscOptions(solver_params, params);
       break;
 
     case Moose::EST_PJFNKMO:
       solver_params._eigen_matrix_free = true;
       solver_params._customized_pc_for_eigen = false;
       solver_params._eigen_matrix_vector_mult = true;
-      setNewtonPetscOptions(solver_params, params, dont_add_these_options);
+      setNewtonPetscOptions(solver_params, params);
       break;
 
     default:
@@ -600,7 +559,7 @@ slepcSetOptions(EigenProblem & eigen_problem,
   // Call "SolverTolerances" first, so some solver specific tolerance such as "eps_max_it"
   // can be overriden
   setSlepcEigenSolverTolerances(eigen_problem, solver_params, params);
-  setEigenSolverOptions(solver_params, params, eigen_problem);
+  setEigenSolverOptions(solver_params, params);
   // when Bx norm postprocessor is provided, we switch off the sign normalization
   if (eigen_problem.bxNormProvided())
     Moose::PetscSupport::setSinglePetscOptionIfAppropriate(

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -193,7 +193,6 @@ setSlepcEigenSolverTolerances(EigenProblem & eigen_problem,
   else
   { // linear eigenvalue problem
     // linear solver
-    const auto & dont_add_these_options = eigen_problem.getPetscOptions().dont_add_these_options;
     Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
         dont_add_these_options,
         solver_params._prefix + "st_ksp_max_it",

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -131,56 +131,82 @@ setSlepcEigenSolverTolerances(EigenProblem & eigen_problem,
                               const SolverParams & solver_params,
                               const InputParameters & params)
 {
+  const auto & dont_add_these_options = eigen_problem.getPetscOptions().dont_add_these_options;
+
   mooseAssert(solver_params._solver_sys_num != libMesh::invalid_uint,
               "The solver system number must be initialized");
 
-  Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "eps_tol",
-                                            stringify(params.get<Real>("eigen_tol")));
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                         solver_params._prefix + "eps_tol",
+                                                         stringify(params.get<Real>("eigen_tol")));
 
-  Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "eps_max_it",
-                                            stringify(params.get<unsigned int>("eigen_max_its")));
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options,
+      solver_params._prefix + "eps_max_it",
+      stringify(params.get<unsigned int>("eigen_max_its")));
 
   // if it is a nonlinear eigenvalue solver, we need to set tolerances for nonlinear solver and
   // linear solver
   if (eigen_problem.isNonlinearEigenvalueSolver(solver_params._solver_sys_num))
   {
     // nonlinear solver tolerances
-    Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "snes_max_it",
-                                              stringify(params.get<unsigned int>("nl_max_its")));
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options,
+        solver_params._prefix + "snes_max_it",
+        stringify(params.get<unsigned int>("nl_max_its")));
 
-    Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "snes_max_funcs",
-                                              stringify(params.get<unsigned int>("nl_max_funcs")));
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options,
+        solver_params._prefix + "snes_max_funcs",
+        stringify(params.get<unsigned int>("nl_max_funcs")));
 
-    Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "snes_atol",
-                                              stringify(params.get<Real>("nl_abs_tol")));
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options,
+        solver_params._prefix + "snes_atol",
+        stringify(params.get<Real>("nl_abs_tol")));
 
-    Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "snes_rtol",
-                                              stringify(params.get<Real>("nl_rel_tol")));
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options,
+        solver_params._prefix + "snes_rtol",
+        stringify(params.get<Real>("nl_rel_tol")));
 
-    Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "snes_stol",
-                                              stringify(params.get<Real>("nl_rel_step_tol")));
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options,
+        solver_params._prefix + "snes_stol",
+        stringify(params.get<Real>("nl_rel_step_tol")));
 
     // linear solver
-    Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "ksp_max_it",
-                                              stringify(params.get<unsigned int>("l_max_its")));
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options,
+        solver_params._prefix + "ksp_max_it",
+        stringify(params.get<unsigned int>("l_max_its")));
 
-    Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "ksp_rtol",
-                                              stringify(params.get<Real>("l_tol")));
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                           solver_params._prefix + "ksp_rtol",
+                                                           stringify(params.get<Real>("l_tol")));
 
-    Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "ksp_atol",
-                                              stringify(params.get<Real>("l_abs_tol")));
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options,
+        solver_params._prefix + "ksp_atol",
+        stringify(params.get<Real>("l_abs_tol")));
   }
   else
   { // linear eigenvalue problem
     // linear solver
-    Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "st_ksp_max_it",
-                                              stringify(params.get<unsigned int>("l_max_its")));
+    const auto & dont_add_these_options = eigen_problem.getPetscOptions().dont_add_these_options;
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options,
+        solver_params._prefix + "st_ksp_max_it",
+        stringify(params.get<unsigned int>("l_max_its")));
 
-    Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "st_ksp_rtol",
-                                              stringify(params.get<Real>("l_tol")));
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                           solver_params._prefix + "st_ksp_rtol",
+                                                           stringify(params.get<Real>("l_tol")));
 
-    Moose::PetscSupport::setSinglePetscOption(solver_params._prefix + "st_ksp_atol",
-                                              stringify(params.get<Real>("l_abs_tol")));
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options,
+        solver_params._prefix + "st_ksp_atol",
+        stringify(params.get<Real>("l_abs_tol")));
   }
 }
 
@@ -271,32 +297,38 @@ storeSolveType(FEProblemBase & fe_problem, const InputParameters & params)
 }
 
 void
-setEigenProblemOptions(SolverParams & solver_params)
+setEigenProblemOptions(SolverParams & solver_params, const MultiMooseEnum & dont_add_these_options)
 {
   switch (solver_params._eigen_problem_type)
   {
     case Moose::EPT_HERMITIAN:
-      Moose::PetscSupport::setSinglePetscOption("-eps_hermitian");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_hermitian");
       break;
 
     case Moose::EPT_NON_HERMITIAN:
-      Moose::PetscSupport::setSinglePetscOption("-eps_non_hermitian");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_non_hermitian");
       break;
 
     case Moose::EPT_GEN_HERMITIAN:
-      Moose::PetscSupport::setSinglePetscOption("-eps_gen_hermitian");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_gen_hermitian");
       break;
 
     case Moose::EPT_GEN_INDEFINITE:
-      Moose::PetscSupport::setSinglePetscOption("-eps_gen_indefinite");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_gen_indefinite");
       break;
 
     case Moose::EPT_GEN_NON_HERMITIAN:
-      Moose::PetscSupport::setSinglePetscOption("-eps_gen_non_hermitian");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_gen_non_hermitian");
       break;
 
     case Moose::EPT_POS_GEN_NON_HERMITIAN:
-      Moose::PetscSupport::setSinglePetscOption("-eps_pos_gen_non_hermitian");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_pos_gen_non_hermitian");
       break;
 
     case Moose::EPT_SLEPC_DEFAULT:
@@ -308,48 +340,58 @@ setEigenProblemOptions(SolverParams & solver_params)
 }
 
 void
-setWhichEigenPairsOptions(SolverParams & solver_params)
+setWhichEigenPairsOptions(SolverParams & solver_params,
+                          const MultiMooseEnum & dont_add_these_options)
 {
   switch (solver_params._which_eigen_pairs)
   {
     case Moose::WEP_LARGEST_MAGNITUDE:
-      Moose::PetscSupport::setSinglePetscOption("-eps_largest_magnitude");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_largest_magnitude");
       break;
 
     case Moose::WEP_SMALLEST_MAGNITUDE:
-      Moose::PetscSupport::setSinglePetscOption("-eps_smallest_magnitude");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_smallest_magnitude");
       break;
 
     case Moose::WEP_LARGEST_REAL:
-      Moose::PetscSupport::setSinglePetscOption("-eps_largest_real");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_largest_real");
       break;
 
     case Moose::WEP_SMALLEST_REAL:
-      Moose::PetscSupport::setSinglePetscOption("-eps_smallest_real");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_smallest_real");
       break;
 
     case Moose::WEP_LARGEST_IMAGINARY:
-      Moose::PetscSupport::setSinglePetscOption("-eps_largest_imaginary");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_largest_imaginary");
       break;
 
     case Moose::WEP_SMALLEST_IMAGINARY:
-      Moose::PetscSupport::setSinglePetscOption("-eps_smallest_imaginary");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_smallest_imaginary");
       break;
 
     case Moose::WEP_TARGET_MAGNITUDE:
-      Moose::PetscSupport::setSinglePetscOption("-eps_target_magnitude");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_target_magnitude");
       break;
 
     case Moose::WEP_TARGET_REAL:
-      Moose::PetscSupport::setSinglePetscOption("-eps_target_real");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_target_real");
       break;
 
     case Moose::WEP_TARGET_IMAGINARY:
-      Moose::PetscSupport::setSinglePetscOption("-eps_target_imaginary");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options,
+                                                             "-eps_target_imaginary");
       break;
 
     case Moose::WEP_ALL_EIGENVALUES:
-      Moose::PetscSupport::setSinglePetscOption("-eps_all");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(dont_add_these_options, "-eps_all");
       break;
 
     case Moose::WEP_SLEPC_DEFAULT:
@@ -361,69 +403,96 @@ setWhichEigenPairsOptions(SolverParams & solver_params)
 }
 
 void
-setFreeNonlinearPowerIterations(unsigned int free_power_iterations)
+setFreeNonlinearPowerIterations(unsigned int free_power_iterations,
+                                const MultiMooseEnum & dont_add_these_options)
 {
-  Moose::PetscSupport::setSinglePetscOption("-eps_power_update", "0");
-  Moose::PetscSupport::setSinglePetscOption("-snes_max_it", "2");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_power_update", "0");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-snes_max_it", "2");
   // During each power iteration, we want solver converged unless linear solver does not
   // work. We here use a really loose tolerance for this purpose.
   // -snes_no_convergence_test is a perfect option, but it was removed from PETSc
-  Moose::PetscSupport::setSinglePetscOption("-snes_rtol", "0.99999999999");
-  Moose::PetscSupport::setSinglePetscOption("-eps_max_it", stringify(free_power_iterations));
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-snes_rtol", "0.99999999999");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_max_it", stringify(free_power_iterations));
   // We always want the number of free power iterations respected so we don't want to stop early if
   // we've satisfied a convergence criterion. Consequently we make this tolerance very tight
-  Moose::PetscSupport::setSinglePetscOption("-eps_tol", "1e-50");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_tol", "1e-50");
 }
 
 void
-clearFreeNonlinearPowerIterations(const InputParameters & params)
+clearFreeNonlinearPowerIterations(const InputParameters & params,
+                                  const MultiMooseEnum & dont_add_these_options)
 {
-  Moose::PetscSupport::setSinglePetscOption("-eps_power_update", "1");
-  Moose::PetscSupport::setSinglePetscOption("-eps_max_it", "1");
-  Moose::PetscSupport::setSinglePetscOption("-snes_max_it",
-                                            stringify(params.get<unsigned int>("nl_max_its")));
-  Moose::PetscSupport::setSinglePetscOption("-snes_rtol",
-                                            stringify(params.get<Real>("nl_rel_tol")));
-  Moose::PetscSupport::setSinglePetscOption("-eps_tol", stringify(params.get<Real>("eigen_tol")));
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_power_update", "1");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_max_it", "1");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-snes_max_it", stringify(params.get<unsigned int>("nl_max_its")));
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-snes_rtol", stringify(params.get<Real>("nl_rel_tol")));
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_tol", stringify(params.get<Real>("eigen_tol")));
 }
 
 void
-setNewtonPetscOptions(SolverParams & solver_params, const InputParameters & params)
+setNewtonPetscOptions(SolverParams & solver_params,
+                      const InputParameters & params,
+                      const MultiMooseEnum & dont_add_these_options)
 {
 #if !SLEPC_VERSION_LESS_THAN(3, 8, 0) || !PETSC_VERSION_RELEASE
   // Whether or not we need to involve an initial inverse power
   bool initial_power = params.get<bool>("_newton_inverse_power");
 
-  Moose::PetscSupport::setSinglePetscOption("-eps_type", "power");
-  Moose::PetscSupport::setSinglePetscOption("-eps_power_nonlinear", "1");
-  Moose::PetscSupport::setSinglePetscOption("-eps_power_update", "1");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_type", "power");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_power_nonlinear", "1");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_power_update", "1");
   // Only one outer iteration in EPS is allowed when Newton/PJFNK/JFNK
   // is used as the eigen solver
-  Moose::PetscSupport::setSinglePetscOption("-eps_max_it", "1");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_max_it", "1");
   if (initial_power)
   {
-    Moose::PetscSupport::setSinglePetscOption("-init_eps_power_snes_max_it", "1");
-    Moose::PetscSupport::setSinglePetscOption("-init_eps_power_ksp_rtol", "1e-2");
-    Moose::PetscSupport::setSinglePetscOption(
-        "-init_eps_max_it", stringify(params.get<unsigned int>("free_power_iterations")));
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options, "-init_eps_power_snes_max_it", "1");
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options, "-init_eps_power_ksp_rtol", "1e-2");
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options,
+        "-init_eps_max_it",
+        stringify(params.get<unsigned int>("free_power_iterations")));
   }
-  Moose::PetscSupport::setSinglePetscOption("-eps_target_magnitude", "");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_target_magnitude", "");
   if (solver_params._eigen_matrix_free)
   {
-    Moose::PetscSupport::setSinglePetscOption("-snes_mf_operator", "1");
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options, "-snes_mf_operator", "1");
     if (initial_power)
-      Moose::PetscSupport::setSinglePetscOption("-init_eps_power_snes_mf_operator", "1");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+          dont_add_these_options, "-init_eps_power_snes_mf_operator", "1");
   }
   else
   {
-    Moose::PetscSupport::setSinglePetscOption("-snes_mf_operator", "0");
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options, "-snes_mf_operator", "0");
     if (initial_power)
-      Moose::PetscSupport::setSinglePetscOption("-init_eps_power_snes_mf_operator", "0");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+          dont_add_these_options, "-init_eps_power_snes_mf_operator", "0");
   }
 #if PETSC_RELEASE_LESS_THAN(3, 13, 0)
-  Moose::PetscSupport::setSinglePetscOption("-st_type", "sinvert");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-st_type", "sinvert");
   if (initial_power)
-    Moose::PetscSupport::setSinglePetscOption("-init_st_type", "sinvert");
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options, "-init_st_type", "sinvert");
 #endif
 #else
   mooseError("Newton-based eigenvalue solver requires SLEPc 3.7.3 or higher");
@@ -431,19 +500,26 @@ setNewtonPetscOptions(SolverParams & solver_params, const InputParameters & para
 }
 
 void
-setNonlinearPowerOptions(SolverParams & solver_params)
+setNonlinearPowerOptions(SolverParams & solver_params, EigenProblem & eigen_problem)
 {
+  const auto & dont_add_these_options = eigen_problem.getPetscOptions().dont_add_these_options;
 #if !SLEPC_VERSION_LESS_THAN(3, 8, 0) || !PETSC_VERSION_RELEASE
-  Moose::PetscSupport::setSinglePetscOption("-eps_type", "power");
-  Moose::PetscSupport::setSinglePetscOption("-eps_power_nonlinear", "1");
-  Moose::PetscSupport::setSinglePetscOption("-eps_target_magnitude", "");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_type", "power");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_power_nonlinear", "1");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-eps_target_magnitude", "");
   if (solver_params._eigen_matrix_free)
-    Moose::PetscSupport::setSinglePetscOption("-snes_mf_operator", "1");
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options, "-snes_mf_operator", "1");
   else
-    Moose::PetscSupport::setSinglePetscOption("-snes_mf_operator", "0");
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options, "-snes_mf_operator", "0");
 
 #if PETSC_RELEASE_LESS_THAN(3, 13, 0)
-  Moose::PetscSupport::setSinglePetscOption("-st_type", "sinvert");
+  Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+      dont_add_these_options, "-st_type", "sinvert");
 #endif
 #else
   mooseError("Nonlinear Inverse Power requires SLEPc 3.7.3 or higher");
@@ -451,54 +527,61 @@ setNonlinearPowerOptions(SolverParams & solver_params)
 }
 
 void
-setEigenSolverOptions(SolverParams & solver_params, const InputParameters & params)
+setEigenSolverOptions(SolverParams & solver_params,
+                      const InputParameters & params,
+                      EigenProblem & eigen_problem)
 {
+  const auto & dont_add_these_options = eigen_problem.getPetscOptions().dont_add_these_options;
   // Avoid unused variable warnings when you have SLEPc but not PETSc-dev.
   libmesh_ignore(params);
 
   switch (solver_params._eigen_solve_type)
   {
     case Moose::EST_POWER:
-      Moose::PetscSupport::setSinglePetscOption("-eps_type", "power");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+          dont_add_these_options, "-eps_type", "power");
       break;
 
     case Moose::EST_ARNOLDI:
-      Moose::PetscSupport::setSinglePetscOption("-eps_type", "arnoldi");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+          dont_add_these_options, "-eps_type", "arnoldi");
       break;
 
     case Moose::EST_KRYLOVSCHUR:
-      Moose::PetscSupport::setSinglePetscOption("-eps_type", "krylovschur");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+          dont_add_these_options, "-eps_type", "krylovschur");
       break;
 
     case Moose::EST_JACOBI_DAVIDSON:
-      Moose::PetscSupport::setSinglePetscOption("-eps_type", "jd");
+      Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+          dont_add_these_options, "-eps_type", "jd");
       break;
 
     case Moose::EST_NONLINEAR_POWER:
-      setNonlinearPowerOptions(solver_params);
+      setNonlinearPowerOptions(solver_params, eigen_problem);
       break;
 
     case Moose::EST_NEWTON:
-      setNewtonPetscOptions(solver_params, params);
+      setNewtonPetscOptions(solver_params, params, dont_add_these_options);
       break;
 
     case Moose::EST_PJFNK:
       solver_params._eigen_matrix_free = true;
       solver_params._customized_pc_for_eigen = false;
-      setNewtonPetscOptions(solver_params, params);
+      setNewtonPetscOptions(solver_params, params, dont_add_these_options);
       break;
 
     case Moose::EST_JFNK:
       solver_params._eigen_matrix_free = true;
       solver_params._customized_pc_for_eigen = true;
-      setNewtonPetscOptions(solver_params, params);
+      setNewtonPetscOptions(solver_params, params, dont_add_these_options);
       break;
 
     case Moose::EST_PJFNKMO:
       solver_params._eigen_matrix_free = true;
       solver_params._customized_pc_for_eigen = false;
       solver_params._eigen_matrix_vector_mult = true;
-      setNewtonPetscOptions(solver_params, params);
+      setNewtonPetscOptions(solver_params, params, dont_add_these_options);
       break;
 
     default:
@@ -511,17 +594,20 @@ slepcSetOptions(EigenProblem & eigen_problem,
                 SolverParams & solver_params,
                 const InputParameters & params)
 {
+  const auto & dont_add_these_options = eigen_problem.getPetscOptions().dont_add_these_options;
+
   Moose::PetscSupport::petscSetOptions(
       eigen_problem.getPetscOptions(), solver_params, &eigen_problem);
   // Call "SolverTolerances" first, so some solver specific tolerance such as "eps_max_it"
   // can be overriden
   setSlepcEigenSolverTolerances(eigen_problem, solver_params, params);
-  setEigenSolverOptions(solver_params, params);
+  setEigenSolverOptions(solver_params, params, eigen_problem);
   // when Bx norm postprocessor is provided, we switch off the sign normalization
   if (eigen_problem.bxNormProvided())
-    Moose::PetscSupport::setSinglePetscOption("-eps_power_sign_normalization", "0", &eigen_problem);
-  setEigenProblemOptions(solver_params);
-  setWhichEigenPairsOptions(solver_params);
+    Moose::PetscSupport::setSinglePetscOptionIfAppropriate(
+        dont_add_these_options, "-eps_power_sign_normalization", "0", &eigen_problem);
+  setEigenProblemOptions(solver_params, eigen_problem.getPetscOptions().dont_add_these_options);
+  setWhichEigenPairsOptions(solver_params, eigen_problem.getPetscOptions().dont_add_these_options);
   Moose::PetscSupport::addPetscOptionsFromCommandline();
 }
 

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -13,7 +13,6 @@
 
 #include "SlepcSupport.h"
 // MOOSE includes
-#include "MultiMooseEnum.h"
 #include "InputParameters.h"
 #include "Conversion.h"
 #include "EigenProblem.h"


### PR DESCRIPTION
This change ensures that simulations that use SlepscSupport do not add
options if they are in `PetscOptions.dont_add_these_options`.

As proof-of-concept, the `EigenValue` executioner was updated such that the tests in `problems/eigen_problem/eigensolvers` no longer emit petsc's unused option warnings.

Ref #28053

