### PR TITLE
A couple of misc additions

### DIFF
--- a/framework/include/utils/MortarUtils.h
+++ b/framework/include/utils/MortarUtils.h
@@ -188,7 +188,7 @@ loopOverMortarSegments(
       if (assembly.needDual())
         mooseAssert(JxW.size() == expected_length, "Fewer than expected JxW values computed");
 #endif
-    }
+    } // end loop over msm_elems
 
     // Reinit dual shape coeffs if dual shape functions needed
     // lindsayad: is there any need to make sure we do this on both reference and displaced?

--- a/framework/include/utils/RankFourTensor.h
+++ b/framework/include/utils/RankFourTensor.h
@@ -197,6 +197,12 @@ public:
   /// Print the rank four tensor
   void print(std::ostream & stm = Moose::out) const;
 
+  friend std::ostream & operator<<(std::ostream & os, const RankFourTensorTempl<T> & t)
+  {
+    t.print(os);
+    return os;
+  }
+
   /// Print the values of the rank four tensor
   void printReal(std::ostream & stm = Moose::out) const;
 

--- a/framework/include/utils/RankThreeTensor.h
+++ b/framework/include/utils/RankThreeTensor.h
@@ -118,6 +118,12 @@ public:
   /// Print the rank three tensor
   void print(std::ostream & stm = Moose::out) const;
 
+  friend std::ostream & operator<<(std::ostream & os, const RankThreeTensorTempl<T> & t)
+  {
+    t.print(os);
+    return os;
+  }
+
   /// copies values from "a" into this tensor
   RankThreeTensorTempl<T> & operator=(const RankThreeTensorTempl<T> & a);
 

--- a/framework/include/utils/SymmetricRankFourTensor.h
+++ b/framework/include/utils/SymmetricRankFourTensor.h
@@ -188,6 +188,12 @@ public:
   /// Print the values of the rank four tensor
   void printReal(std::ostream & stm = Moose::out) const;
 
+  friend std::ostream & operator<<(std::ostream & os, const SymmetricRankFourTensorTempl<T> & t)
+  {
+    t.print(os);
+    return os;
+  }
+
   /// copies values from a into this tensor
   SymmetricRankFourTensorTempl<T> & operator=(const SymmetricRankFourTensorTempl<T> & a) = default;
 

--- a/framework/include/utils/SymmetricRankTwoTensor.h
+++ b/framework/include/utils/SymmetricRankTwoTensor.h
@@ -419,6 +419,12 @@ public:
   /// Print the Real part of the ADReal rank two tensor along with its first nDual dual numbers
   void printADReal(unsigned int nDual, std::ostream & stm = Moose::out) const;
 
+  friend std::ostream & operator<<(std::ostream & os, const SymmetricRankTwoTensorTempl<T> & t)
+  {
+    t.print(os);
+    return os;
+  }
+
   /// Add identity times a to _vals
   void addIa(const T & a);
 

--- a/framework/src/utils/MortarUtils.C
+++ b/framework/src/utils/MortarUtils.C
@@ -29,12 +29,12 @@ projectQPoints3d(const Elem * const msm_elem,
                  const QBase & qrule_msm,
                  std::vector<Point> & q_pts)
 {
-  auto && msm_order = msm_elem->default_order();
-  auto && msm_type = msm_elem->type();
+  const auto msm_elem_order = msm_elem->default_order();
+  const auto msm_elem_type = msm_elem->type();
 
   // Get normal to linearized element, could store and query but computation is easy
-  Point e1 = msm_elem->point(0) - msm_elem->point(1);
-  Point e2 = msm_elem->point(2) - msm_elem->point(1);
+  const Point e1 = msm_elem->point(0) - msm_elem->point(1);
+  const Point e2 = msm_elem->point(2) - msm_elem->point(1);
   const Point normal = e2.cross(e1).unit();
 
   // Get sub-elem (for second order meshes, otherwise trivial)
@@ -203,8 +203,10 @@ projectQPoints3d(const Elem * const msm_elem,
     // Get physical point on msm_elem to project
     Point x0;
     for (auto n : make_range(msm_elem->n_nodes()))
-      x0 += Moose::fe_lagrange_2D_shape(
-                msm_type, msm_order, n, static_cast<const TypeVector<Real> &>(qrule_msm.qp(qp))) *
+      x0 += Moose::fe_lagrange_2D_shape(msm_elem_type,
+                                        msm_elem_order,
+                                        n,
+                                        static_cast<const TypeVector<Real> &>(qrule_msm.qp(qp))) *
             msm_elem->point(n);
 
     // Use msm_elem quadrature point as initial guess


### PR DESCRIPTION
- `operator<<` overloads that helped me in investigating https://github.com/idaholab/moose/pull/30135 (verifying that indeed dataLoad and dataStore of stateful material properties are beautiful codes)
- Some slight variable name clarification in `MortarUtils` that I added while looking at #30198 