### PR TITLE
Fix docs for ElementalVariableValue and replicated, distributed and split meshes

### DIFF
--- a/framework/doc/content/framework/documenting.md
+++ b/framework/doc/content/framework/documenting.md
@@ -75,7 +75,7 @@ cd doc
 ./moosedocs.py generate SolidMechanicsApp
 ```
 
-To generate pages for the framework, the moose test application can be used as follows.
+To generate pages for the framework, the MOOSE test application can be used as follows.
 
 ```bash
 cd ~/projects/moose/test

--- a/framework/doc/content/source/mesh/TiledMesh.md
+++ b/framework/doc/content/source/mesh/TiledMesh.md
@@ -27,7 +27,7 @@ The example utilizes a cube (cube.e) mesh as input as shown in Figure 1, which i
 0 to 10 in the x, y, and z-directions.
 
 As specified in the input file for this test (see below), this mesh is then used to create two tiles in the x, y,
-and z directions. To execute the example and create a new mesh, the moose test application is executed with the special "--mesh-only" flag, which indicates that only the mesh operations should be performed. Running this command will create
+and z directions. To execute the example and create a new mesh, the MOOSE test application is executed with the special "--mesh-only" flag, which indicates that only the mesh operations should be performed. Running this command will create
 the resulting mesh file (tiled_mesh_test_in.e), which is intended to be used by a separate input file to run a
 complete simulation.
 

--- a/framework/doc/content/source/meshgenerators/TiledMeshGenerator.md
+++ b/framework/doc/content/source/meshgenerators/TiledMeshGenerator.md
@@ -18,7 +18,7 @@ is a regular cube on the domain from 0 to 10 in the x, y, and z-directions.
 
 As specified in the input file for this test (see below), this mesh is then used
 to create two tiles in the x, y, and z directions. To execute the example and
-create a new mesh, the moose test application can be executed with the special
+create a new mesh, the MOOSE test application can be executed with the special
 "--mesh-only" flag, which indicates that only the mesh operations should be
 performed. Running this command will create the resulting mesh file
 (tiled_mesh_test_in.e), which is intended to be used by a separate input file

--- a/framework/doc/content/source/postprocessors/ElementalVariableValue.md
+++ b/framework/doc/content/source/postprocessors/ElementalVariableValue.md
@@ -7,8 +7,10 @@
 In some cases it may be of interest to output an elemental variable value (e.g., stress)
 at a particular location in the model.  This is accomplished by using the
 `ElementalVariableValue` postprocessor. This postprocessor takes a specific element ID
-to sample (only a single ID). The value of the specified variable is integrated over the
-element and then returned.
+to sample (only a single ID). The value of the specified variable is averaged over the
+quadrature points on the element and then returned. Note this corresponds exactly to
+the average value of the variable over the element only for FV variables, constant FE
+variables and linear cartesian FE variables.
 
 ## Example Input Syntax
 

--- a/framework/doc/content/source/problems/SolutionInvalidity.md
+++ b/framework/doc/content/source/problems/SolutionInvalidity.md
@@ -25,7 +25,7 @@ Solution Invalid Warnings:
 ---------------------------------------------------------------------------------------------------------
 ```
 
-1. *Object*: shows the moose object name registered for the solution invalid detection and an optional description
+1. *Object*: shows the MOOSE object name registered for the solution invalid detection and an optional description
 2. *Converged*: shows the number of solution invalid warnings for the latest iteration, at convergence
 3. *Timestep*: shows the number of solution invalid warnings for the latest time step over all iterations
 4. *Total*: shows the total number of solution invalid warnings for the entire simulation

--- a/framework/doc/content/source/reporters/SolutionInvalidityReporter.md
+++ b/framework/doc/content/source/reporters/SolutionInvalidityReporter.md
@@ -4,7 +4,7 @@
 
 The [/SolutionInvalidity.md] holds solution invalid warning information for MOOSE. This Reporter stores the summary of solution invalid warning occurrences from the [/SolutionInvalidity.md] in the Reporter value 'solution_invalidity'.
 
-1. *object_type*: shows the moose object name registered for the solution invalid detection and an optional description
+1. *object_type*: shows the MOOSE object name registered for the solution invalid detection and an optional description
 2. *converged_counts*: the number of solution invalid warnings for the latest iteration, at convergence
 3. *timestep_counts*: shows the number of solution invalid warnings for the latest time step
 4. *total_counts*: shows the total number of solution invalid warnings for the entire simulation

--- a/framework/doc/content/source/variables/ArrayMooseVariable.md
+++ b/framework/doc/content/source/variables/ArrayMooseVariable.md
@@ -30,7 +30,7 @@ The following map is useful for understanding the template:
 The three rows correspond to standard, vector and array variables.
 OutputType is the data type used for templating.
 RealEigenVector is a typedef in [MooseTypes.h] as *Eigen::Matrix<Real, Eigen::Dynamic, 1>*.
-OutputShape is for the type of shape functions and OutputData is the type of basis function expansion coefficients that are stored in the moose array variable grabbed from the solution vector.
+OutputShape is for the type of shape functions and OutputData is the type of basis function expansion coefficients that are stored in the MOOSE array variable grabbed from the solution vector.
 
 ## Kernels for Array Variables
 

--- a/framework/doc/content/syntax/LinearFVBCs/index.md
+++ b/framework/doc/content/syntax/LinearFVBCs/index.md
@@ -98,8 +98,8 @@ we implemented the following four APIs:
 
 ## LinearFVBCs source code: LinearFVAdvectionDiffusionFunctorDirichletBC
 
-`LinearFVAdvectionDiffusionFunctorDirichletBC` object assigns a value on a boundary. This value is computed using a moose
-functor. For more information on the functor system in moose, see [Functors/index.md].
+`LinearFVAdvectionDiffusionFunctorDirichletBC` object assigns a value on a boundary. This value is computed using a MOOSE
+functor. For more information on the functor system in MOOSE, see [Functors/index.md].
 
 !listing framework/src/linearfvbcs/LinearFVAdvectionDiffusionFunctorDirichletBC.C
          start=#include

--- a/framework/doc/content/syntax/Mesh/index.md
+++ b/framework/doc/content/syntax/Mesh/index.md
@@ -129,12 +129,19 @@ The core of the mesh capabilities are derived from [libMesh], which has two unde
 parallel mesh formats: "replicated" and "distributed".
 
 The replicated mesh format is the default format for MOOSE and is the most appropriate format to
-utilize for nearly all simulations. In parallel, the replicated format copies the complete mesh to
-all processors allowing for efficient access to the geometry elements.
+utilize for nearly all simulations. In parallel, the replicated format generates or reads the
+complete mesh on all processors and keeps the complete mesh on all processors for the duration
+of the simulation allowing for efficient access to the geometry elements.
 
 The distributed mesh format is useful when the mesh data structure dominates memory usage. Only the
-pieces of the mesh "owned" by a processor are actually stored on the processor. If the mesh is too
-large to read in on a single processor, it can be split prior to the simulation.
+pieces of the mesh "owned" by a processor are actually kept on the processor during the simulation.
+Note, however, that even for distributed meshes, if the mesh is not generated or read in a split
+fashion, the mesh will still initially be generated or read in its entirety on all processors, thus
+requiring sufficient memory on each processor for this to happen, before each processor then
+deletes all elements it does not own relieving memory pressure. If the mesh is too large to fit on
+a single processor, the user can either split-generate the mesh using, e.g.
+[DistributedRectilinearMeshGenerator.md], or split the mesh prior to reading it in as explained
+[below](#mesh-splitting).
 
 !alert note
 Both the "replicated" and "distributed" mesh formats are parallel with respect to the execution of
@@ -161,7 +168,7 @@ out.e.4.2
 out.e.4.3
 ```
 
-## Mesh splitting
+## Mesh splitting id=mesh-splitting
 
 For large meshes, MOOSE provides the ability to pre-split a mesh for use in the "distributed"
 format/mode. To split and use a mesh for distributed runs:
@@ -189,7 +196,7 @@ for each spatial dimension in the 'displacements' parameters within the Mesh blo
 
 !listing modules/solid_mechanics/test/tests/truss/truss_2d.i block=Mesh
 
-Once enabled, the any object that should operate on the displaced configuration should set the
+Once enabled, any object that should operate on the displaced configuration should set the
 "use_displaced_mesh" to true. For example, the following snippet enables the computation of a
 [Postprocessor](/Postprocessors/index.md) with and without the displaced configuration.
 

--- a/framework/doc/content/syntax/Mesh/splitting.md
+++ b/framework/doc/content/syntax/Mesh/splitting.md
@@ -23,13 +23,13 @@ Splitting 42 ways...
 
 This will create three split configurations for your mesh that include 13, 42, and 1000 chunks
 each.  If your input file uses the mesh file `foo.e`, this process will generate a directory
-named `foo.cpr`.  In general, you should neither rename this directory nor modify its
+named `foo.cpa.gz`.  In general, you should neither rename this directory nor modify its
 contents.  All split configurations for the mesh will be stored in this directory (even across
 independent splitting operations).
 
-For non-file-based mesh cases (e.g. GeneratedMesh), you will need to tell MOOSE what name to use
-for the split mesh files it will generate using the `--split-file <file_name>` flag; in general,
-you should use the `.cpr` file extension here. For example:
+For non-file-based mesh cases (e.g. [GeneratedMesh.md]), you will need to tell MOOSE what name to
+use for the split mesh files it will generate using the `--split-file <file_name>` flag; you must
+use the `.cpa.gz` (gzipped ASCII) or `.cpr` (binary) extensions here. For example:
 
 ```
 $ moose-app-opt -i your_input.i --split-mesh 42 --split-file foo.cpr
@@ -56,11 +56,11 @@ The mesh splitter commands do not work with a [distributed mesh](syntax/Mesh/ind
 
 ## Using Split Meshes
 
-There are two ways of referring to distributed meshes in MOOSE, as split or as distributed. A split mesh is a distributed mesh. A split mesh is read from a pre-split mesh file (from a [Checkpoint.md] or using the instructions above). A distributed mesh can be generated in parallel or loaded entirely replicated then distributed.
+There are two types of distributed meshes in MOOSE: split or non-split. A split mesh is always a distributed mesh. A split mesh is read from a pre-split mesh file (from a [Checkpoint.md] or using the instructions above).
 
 ### Loading a split mesh using [FileMeshGenerator.md]
 
-A split mesh, i.e. a `.cpr` file, may be loaded using a [FileMeshGenerator.md] if access to the mesh is needed before the full simulation case is set-up, notably for additional mesh generation with [mesh generators](syntax/Mesh/index.md#mesh-generators). In fact this approach is recommended; it leads to correct element ghosting whereas the approach we introduce in the following section may not.
+A split mesh, i.e. a `.cpa.gz` or `.cpr` file, may be loaded using a [FileMeshGenerator.md] if access to the mesh is needed before the full simulation case is set-up, notably for additional mesh generation with [mesh generators](syntax/Mesh/index.md#mesh-generators). In fact this approach is recommended; it leads to correct element ghosting whereas the approach we introduce in the following section may not.
 
 ### Loading a split mesh using `--use-split`
 
@@ -84,4 +84,4 @@ $ mpiexec -n 42 moose-app-opt -i your_input.i --use-split --split-file foo.cpr
 ```
 
 !alert warning
-The `--use-split` option skips entirely the `[Mesh]` block of the input file, and as such some data structure initializations required if further mesh operations are necessary at the simulation start-up stage. 
+The `--use-split` option skips entirely the `[Mesh]` block of the input file, and as such some data structure initialization required if further mesh operations are necessary at the simulation start-up stage.

--- a/framework/doc/content/syntax/Mesh/splitting.md
+++ b/framework/doc/content/syntax/Mesh/splitting.md
@@ -3,7 +3,7 @@
 MOOSE provides the ability to pre-split a mesh into several chunks for use with
 [distributed mesh](/Mesh/index.md#replicated-and-distributed-mesh).
 This can be useful if the whole mesh is too big to fit into memory. A split-mesh
-workflow involves generating the mesh split configuration(s) and then telling moose
+workflow involves generating the mesh split configuration(s) and then telling MOOSE
 to use them when you run simulations.  This is described in the sections below.
 
 ## Generating Split Configurations


### PR DESCRIPTION
## Reason
This fixes some descriptions which were just wrong or outdated and expands on other sections.

## Design
For `ElementalVariableValue` I opted to fix the documentation instead of changing the implementation, though I'm open to suggestions. For the mesh docs, I based some of the expanded explanations on what @loganharbour wrote [here](https://github.com/idaholab/moose/discussions/25053#discussioncomment-6578013).

## Impact
Hopefully users will have a better understanding of what's happening in `ElementalVariableValue` and with our mesh reading/generating capabilities.
