### PR TITLE
TestHarness check for executables of other METHODs

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1014,16 +1014,18 @@ class TestHarness:
                 os.path.join(testharness_dir, '../../../../bin')]
         dirs = list(dict.fromkeys(dirs)) # remove duplicates
         matches = []
+        matched_names = []
         for other_name in all_names:
             for dir in dirs:
                 path = os.path.join(dir, other_name)
                 if os.path.exists(path):
                     matches.append(path)
+                    matched_names.append(other_name)
             exe_path = shutil.which(other_name)
             if exe_path:
                 matches.append(exe_path)
+                matched_names.append(other_name)
 
-        matched_names = [os.path.split(match)[1] for match in matches]
         if name in matched_names:
             return matches[matched_names.index(name)]
         elif len(matched_names):

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1029,16 +1029,17 @@ class TestHarness:
         elif len(matched_names):
             # Eliminate any duplicates
             matched_names = set(matched_names)
-            available_methods = [matched_name.split('-')[-1] for matched_name in matched_names]
+            available_methods = "'" + "', '".join([matched_name.split('-')[-1] for matched_name in matched_names]) + "'"
+            matched_names = "'" + "', '".join(matched_names) + "'"
             err_message = (f'\nThe following executable(s) were found, but METHOD '
-                           f'is set to {self.options.method}: {", ".join(matched_names)}'
-                           f'\nTo use one of these executables, set the "METHOD" environmental '
-                           f'variable to one of the following values: {", ".join(available_methods)}'
+                           f'is set to \'{self.options.method}\': {matched_names}'
+                           f'\nTo use one of these executables, set the \'METHOD\' environment '
+                           f'variable to one of the following values: {available_methods}'
                            )
         else:
             err_message = ""
 
-        raise FileNotFoundError(f'Failed to find MOOSE executable {name}{err_message}')
+        raise FileNotFoundError(f'Failed to find MOOSE executable \'{name}\'{err_message}')
 
     def initialize(self):
         # Load the scheduler plugins

--- a/python/TestHarness/tests/test_GetExecutable.py
+++ b/python/TestHarness/tests/test_GetExecutable.py
@@ -1,0 +1,119 @@
+#* This file is part of the MOOSE framework
+#* https://mooseframework.inl.gov
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import os, io, glob
+import unittest
+import mock
+import TestHarness
+from contextlib import redirect_stdout
+
+class TestHarnessTester(unittest.TestCase):
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+        self.MOOSE_DIR = os.getenv('MOOSE_DIR')
+        self.all_methods = {'opt', 'oprof', 'dbg', 'devel'}
+
+    def helperGetPresentMethods(self, directory):
+        """
+        Returns methods of executables matching the pattern "*-method" in location directory.
+        """
+
+        prev_dir = os.getcwd()
+        os.chdir(os.path.join(self.MOOSE_DIR, directory))
+
+        try:
+            present_methods = set()
+            for method in self.all_methods:
+                matches = glob.glob(f"*-{method}")
+                if matches:
+                    present_methods.add(method)
+
+        finally:
+            os.chdir(prev_dir)
+
+        return present_methods
+
+    def helperTestGetExecutable(self, testroot_path, method, expect_fail):
+        os.chdir(os.path.join(self.MOOSE_DIR, testroot_path))
+        out = io.StringIO()
+        with redirect_stdout(out):
+            with self.assertRaises(SystemExit) as e:
+                args = ['', method, '--test-root', 'testroot']
+                TestHarness.TestHarness.buildAndRun(args, None, self.MOOSE_DIR)
+            if expect_fail:
+                self.assertNotEqual(e.exception.code, 0)
+            else:
+                self.assertEqual(e.exception.code, 0)
+        return out.getvalue()
+
+    def testMethodIsAbsentInTest(self):
+        """
+        Test for method that does not exist in test
+        """
+        test_dir = 'test'
+        present_methods = self.helperGetPresentMethods(test_dir)
+        absent_methods = self.all_methods - present_methods
+        if absent_methods:
+            method = list(absent_methods)[0]
+        else:
+            # Cannot test for an absent method when all methods are present
+            return
+
+        out = self.helperTestGetExecutable(test_dir, f'--{method}', True)
+        self.assertIn('Failed to find MOOSE executable', out)
+
+    def testMethodIsAbsentInCombined(self):
+        """
+        Test for method that does not exist in combined
+        """
+        test_dir = os.path.join('modules', 'combined')
+        present_methods = self.helperGetPresentMethods(test_dir)
+        absent_methods = self.all_methods - present_methods
+        if absent_methods:
+            method = list(absent_methods)[0]
+        else:
+            # Cannot test for an absent method when all methods are present
+            return
+
+        out = self.helperTestGetExecutable('modules', f'--{method}', True)
+        self.assertIn('Failed to find MOOSE executable', out)
+
+    def testMethodIsPresentInTest(self):
+        """
+        Test for method that exists in test
+        """
+        test_dir = 'test'
+        present_methods = self.helperGetPresentMethods(test_dir)
+        if present_methods:
+            method = list(present_methods)[0]
+        else:
+            # Cannot test for a present method when all methods are absent
+            return
+
+        out = self.helperTestGetExecutable(test_dir, f'--{method}', False)
+        self.assertNotIn('Failed to find MOOSE executable', out)
+
+    def testMethodIsPresentInCombined(self):
+        """
+        Test for method that exists in combined
+        """
+        test_dir = os.path.join('modules', 'combined')
+        present_methods = self.helperGetPresentMethods(test_dir)
+        if present_methods:
+            method = list(present_methods)[0]
+        else:
+            # Cannot test for a present method when all methods are absent
+            return
+
+        out = self.helperTestGetExecutable('modules', f'--{method}', False)
+        self.assertNotIn('Failed to find MOOSE executable', out)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -287,4 +287,10 @@
     requirement = 'The system shall provide a common interface for storing and retrieving output that supports sanitization
     issues = '#27562'
   []
+  [test_method]
+    type = PythonUnitTest
+    input = test_GetExecutable.py
+    requirement = "The system shall test the functionality of the TestHarness.getExecutable method."
+    issues = '#30200'
+  []
 []


### PR DESCRIPTION
Improves the helpfulness of the `TestHarness` error message if the executable is not found, but executables for other METHODs are present.

Closes #30200 
