### PR TITLE
Import pycapabilities only when used

### DIFF
--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -14,7 +14,6 @@ from collections import OrderedDict
 import json
 import yaml
 import sys
-import pycapabilities
 
 MOOSE_OPTIONS = {
     'ad_size' : { 're_option' : r'#define\s+MOOSE_AD_MAX_DOFS_PER_ELEM\s+(\d+)',
@@ -570,6 +569,7 @@ def checkCapabilities(supported: dict, requested: str, certain):
     """
     Get capabilities JSON and compare it to the required capabilities
     """
+    import pycapabilities
     [status, message, doc] = pycapabilities.check(requested, supported)
     if status == pycapabilities.PARSE_FAIL:
         raise ValueError(f"Failed to parse capabilities='{requested}'")


### PR DESCRIPTION
## Reason
Importing `pycapabilities` with trigger the build of the python binary module. That module depends on framework, so if no executable is present, this build can take a long time. We use `util.py` in cases where no executable is even required. 

## Design
Import `pycapabilities` late. The test harness checks for the existence of an executable anyways, before using capabilities. So if framework hasn't been built we would get a more meaningful error message. If capabilities are not used, then there is no need to do a lengthy compile otherwise.

## Impact
Better user experience.