### PR TITLE
Revert "Make Transient APIs more atomic"

### DIFF
--- a/framework/include/executioners/TransientBase.h
+++ b/framework/include/executioners/TransientBase.h
@@ -75,8 +75,6 @@ public:
    */
   virtual void incrementStepOrReject();
 
-  virtual void advanceState();
-
   virtual void endStep(Real input_time = -1.0);
 
   /**

--- a/framework/src/executioners/TransientBase.C
+++ b/framework/src/executioners/TransientBase.C
@@ -344,10 +344,10 @@ TransientBase::incrementStepOrReject()
         _problem.adaptMesh();
 #endif
 
-      advanceState();
-
       _time_old = _time;
       _t_step++;
+
+      _problem.advanceState();
 
       if (_t_step == 1)
         return;
@@ -387,12 +387,6 @@ TransientBase::incrementStepOrReject()
     _time_stepper->rejectStep();
     _time = _time_old;
   }
-}
-
-void
-TransientBase::advanceState()
-{
-  _problem.advanceState();
 }
 
 void


### PR DESCRIPTION
Reverts idaholab/moose#30135

Apparently this did not help the Griffin team achieve the capability they want, it decreases encapsulation, and it breaks some of @dschwen's work