### PR TITLE
Libmesh submodule update 20250417

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,8 +4,8 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 1 %}
-{% set version = "2025.04.02" %}
+{% set build = 0 %}
+{% set version = "2025.04.17" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2025.04.02 mpich_1
-  - moose-libmesh 2025.04.02 openmpi_1
+  - moose-libmesh 2025.04.17 mpich_0
+  - moose-libmesh 2025.04.17 openmpi_0
 
 moose_wasp:
   - moose-wasp 2025.02.25

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.04.11" %}
+{% set version = "2025.04.17" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2025.04.11
+  - moose-dev 2025.04.17
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/modules/doc/content/newsletter/2025/2025_04.md
+++ b/modules/doc/content/newsletter/2025/2025_04.md
@@ -58,6 +58,55 @@ Check `MooseApp::registerCapabilities()` for examples.
 - Add begin/end members to DenseVector allowing for range based looping
 - Avoid creating temporary array for hashword2() overload taking 64-bit inputs
 
+### `2025.04.17` Update
+
+- Autoconf-submodule (ACSM) update
+  - When recent clang versions are detected, the compiler flag
+    `-fno-assume-unique-vtables` is used.  This enables `dynamic_cast`
+    to work reliably on macOS 15 (Sequoia) environments, which fixes a
+    number of libMesh and MOOSE failures there.
+  - More thorough detection for code coverage support when
+    --enable-coverage builds may require it from multiple languages'
+    compilers.
+- TIMPI submodule update
+  - Fixes and tests for `timpi_version.h` utilities
+  - Unit test fixes for C++14 compilers
+  - `timpi_pure` attribute for pure functions; on C++17 and newer
+    compilers this prevents ignoring the function return values
+  - Marked `verify()` and `semiverify()` as pure.  This prevents the
+    common usage error of not asserting the result when intended.
+  - Removed default `Attributes` values.  Code which attempts
+    parallel reductions on user-defined types without first specifying
+    their attributes now fails to compile, instead of compiling but not
+    working correctly.
+- Added support for creating and computing on arbitrary polygons in 2D
+- Better tolerance computations when stitching meshes along a boundary
+  with discrete NodeElem elements
+- Fix for reading of Gmsh files with physicals of different types but
+  the same id numbers
+- Migrated more print methods of templated classes into headers, to
+  enable user instantiations with unanticipated types
+- Added "-V" option to the meshtool utility app to apply the
+  `VariationalSmoother` to the input mesh
+- Moved `demangle()` to `libmesh_common.h`.  Any failures in
+  `cast_ptr` or `cast_ref` in dbg or devel modes are now reported
+  using demangled typenames.
+- Fix for return values of `FE::n_quadrature_points()`: after using a
+  user-specified list of quadrature points rather than a
+  quadrature-rule-generated list, the length of the specified list is
+  now correctly returned.  This fixes undefined behavior in
+  `JumpErrorEstimator` subclasses with the `integrate_slits` option
+  enabled, which fixes a valgrind-detected error and a potential test
+  failure in libMesh unit tests.
+- Fix for undefined behavior in `SimplexRefiner`.  This similarly
+  fixes a libMesh unit test.
+- Fix for a Netgen configuration error: configuring the same
+  Netgen-enabled libMesh build directory for a second time no longer
+  leaves Netgen in an "unbuilt, but marked as built" state.
+- Refactoring for simplicity and forward compatibility in Gaussian
+  quadrature code
+- More assertions
+
 ## PETSc-level Changes
 
 ### `2025.04.02` Update

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1018,3 +1018,34 @@ a32adecb7fa52400a518df2e172a3ab40724cbe7: #29633
   wasp:
     full_version: 2025.02.25_1
     hash: a8340b3
+cefb0dba7f4dfc3c44d0730b2b9de51ba83cf5a1: #30349
+  libmesh:
+    full_version: 2025.04.17_0
+    hash: dfe39db
+  libmesh-vtk:
+    full_version: 9.3.0_6
+    hash: 83f29bc
+  moose-dev:
+    full_version: 2025.04.17
+    hash: 2c1a166
+  mpi:
+    full_version: 2025.03.24
+    hash: d5b4334
+  peacock:
+    full_version: 2025.03.24
+    hash: f8f84d6
+  petsc:
+    full_version: 3.23.0.6.gd9d7fd11dca_0
+    hash: 2eee4ef
+  pprof:
+    full_version: 2024.12.23_0
+    hash: fe051bc
+  seacas:
+    full_version: 2025.02.27_0
+    hash: 067e220
+  tools:
+    full_version: 2025.03.24
+    hash: 8af34cd
+  wasp:
+    full_version: 2025.02.25_1
+    hash: a8340b3

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -65,8 +65,8 @@ packages:
       - scripts/apple-silicon-hdf5-autogen.patch
   # dependers: moose-dev
   libmesh:
-    version: 2025.04.02
-    build_number: 1
+    version: 2025.04.17
+    build_number: 0
     conda: conda/libmesh
     templates:
       conda/libmesh/conda_build_config.yaml.template: conda/libmesh/conda_build_config.yaml
@@ -102,7 +102,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.04.11
+    version: 2025.04.17
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml


### PR DESCRIPTION
- Autoconf-submodule (ACSM) update 
  - When recent clang versions are detected, the compiler flag `-fno-assume-unique-vtables` is used.  This enables `dynamic_cast` to work reliably on macOS 15 (Sequoia) environments, which fixes a number of libMesh and MOOSE failures there.
  - More thorough detection for code coverage support when `--enable-coverage` builds may require it from multiple languages' compilers.
- TIMPI submodule update
  - Fixes and tests for `timpi_version.h` utilities
  - Unit test fixes for C++14 compilers
  - `timpi_pure` attribute for pure functions; on C++17 and newer compilers this prevents ignoring the function return values
  - Marked `verify()` and `semiverify()` as pure.  This prevents the common usage error of not asserting the result when intended.
  - Removed default `Attributes` values.  Code which attempts parallel reductions on user-defined types without first specifying their attributes now fails to compile, instead of compiling but not working correctly.
- Added support for creating and computing on arbitrary polygons in 2D
- Better tolerance computations when stitching meshes along a boundary with discrete NodeElem elements
- Fix for reading of Gmsh files with physicals of different types but the same id numbers 
- Migrated more print methods of templated classes into headers, to enable user instantiations with unanticipated types
- Added "-V" option to the meshtool utility app to apply the `VariationalSmoother` to the input mesh
- Moved `demangle()` to `libmesh_common.h`.  Any failures in `cast_ptr` or `cast_ref` in dbg or devel modes are now reported using demangled typenames.
- Fix for return values of `FE::n_quadrature_points()`: after using a user-specified list of quadrature points rather than a quadrature-rule-generated list, the length of the specified list is now correctly returned.  This fixes undefined behavior in `JumpErrorEstimator` subclasses with the `integrate_slits` option enabled, which fixes a valgrind-detected error and a potential test failure in libMesh unit tests.
- Fix for undefined behavior in `SimplexRefiner`.  This similarly fixes a libMesh unit test.
- Fix for a Netgen configuration error: configuring the same Netgen-enabled libMesh build directory for a second time no longer leaves Netgen in an "unbuilt, but marked as built" state.
- Refactoring for simplicity and forward compatibility in Gaussian quadrature code
- More assertions