### PR TITLE
Add default phrase when empty validation and verification sections exist in the VVR

### DIFF
--- a/python/MooseDocs/extensions/sqa.py
+++ b/python/MooseDocs/extensions/sqa.py
@@ -494,10 +494,18 @@ class SQAVerificationCommand(SQARequirementsCommand):
         settings['link-{}'.format(subcommand)] = True
         matrix = SQARequirementMatrix(parent)
         SQARequirementMatrixHeading(matrix, category=category, string=subcommand.title())
+
+        # Used in check for number of verification and/or validation requirements
+        num_vv_reqs = 0
+
         for requirements in self.extension.requirements(category).values():
             for req in requirements:
                 if getattr(req, subcommand) is not None:
                     self._addRequirement(matrix, info, page, req, requirements, category, settings)
+                    num_vv_reqs += 1
+
+        if num_vv_reqs == 0:
+            tokens.String(parent, content="No test cases of this type exist for this application, beyond those of its dependencies.")
 
         return parent
 

--- a/python/MooseDocs/test/extensions/test_sqa.py
+++ b/python/MooseDocs/test/extensions/test_sqa.py
@@ -160,7 +160,9 @@ class TestSQAVerificationAndValidation(MooseDocsTestCase):
         if ext == sqa:
             return dict(active=True,
                         categories=dict(Demo=dict(directories=['python/MooseDocs/test'],
-                                                  specs=['demo'])))
+                                                  specs=['demo']),
+                                        Empty=dict(directories=['python/MooseDocs/test'],
+                                                   specs=['demo2'])))
     def testVerification(self):
         text = "!sqa verification category=Demo link-spec=false link-design=false link-issues=false link-results=false link-collections=false link-types=false"
         ast = self.tokenize(text)
@@ -216,6 +218,12 @@ class TestSQAVerificationAndValidation(MooseDocsTestCase):
         self.assertToken(ast(0)(7)(2)(0), 'String', content='Validation: ')
         self.assertToken(ast(0)(7)(2)(1), 'AutoLink', page='katex.md')
         self.assertToken(ast(0)(7)(2)(3), 'AutoLink', page='bibtex.md')
+
+    def testVAndVNoTests(self):
+        text = "!sqa validation category=Empty link-spec=false link-design=false link-issues=false link-results=false link-collections=false link-types=false"
+        ast = self.tokenize(text)
+        self.assertSize(ast, 1)
+        self.assertToken(ast(0), 'String', size=0, content='No test cases of this type exist for this application, beyond those of its dependencies.')
 
 class TestSQARequirementsCrossReference(MooseDocsTestCase):
     EXTENSIONS = [core, command, floats, autolink, heading, civet, sqa, table, modal]
@@ -621,6 +629,7 @@ class TestSQARequiremetnsWithCollectionsAndTypesAST(MooseDocsTestCase):
         self.assertToken(ast(0,0), 'SQARequirementMatrixHeading', string='Tree')
         self.assertToken(ast(0,1), 'SQARequirementMatrixItem', reqname='r0')
         self.assertToken(ast(0,2), 'SQARequirementMatrixItem', reqname='r2')
+        self.assertToken(ast(1), 'String', size=0, content='No requirements of this type exist for this application, beyond those of its dependencies.')
 
 class TestSQARegex(unittest.TestCase):
     def testIssue(self):


### PR DESCRIPTION
## Reason
It was discovered, when improving the SQA documentation for a MOOSE-based application, that no default message exists when `!sqa verification` or `!sqa validation` is used *and* no verification or validation cases exist. This could be taken (during an audit) as leaving SQA documentation blank by accident, when some modules or applications may intentionally not have V&V cases, leaving it to their downstream applications to implement them. A reasonable default phrase should be displayed in this scenario.

## Design
This should be implemented similarly to how it was done for requirements in #24063. When no test specs are encountered that are labeled validation or verification, a String token should be produced to display the default phrase. 


## Impact
No impact to MOOSE results. Improved defaults when fields in SQA documentation (most of the time in the VVR, in this case) are empty, indicating intentionality on the part of the developers.


> [!NOTE]
> This PR also improves the test for the requirements default implemented in #24063.
