### PR TITLE
Update libmesh: VTK 9.4 configure fixes and nlohmann patch

### DIFF
--- a/apptainer/libmesh.def
+++ b/apptainer/libmesh.def
@@ -62,6 +62,12 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 
         # Build VTK
         cd ${ROOT_BUILD_DIR}/$(basename ${VTK_URL} .tar.gz)
+
+        # Patch nlohmann issue, see MOOSE issue #30372
+        # and discourse.vtk.org/t/nlohmann-json-and-vtks-public-api/15131
+        patch -p1 < ${ROOT_BUILD_DIR}/vtk9.4.2_mr11854_nlohmann.patch
+        rm ${ROOT_BUILD_DIR}/vtk9.4.2_mr11854_nlohmann.patch
+
         mkdir -p build; cd build
         cmake .. \
             -Wno-dev \
@@ -107,3 +113,4 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 %files
     {{ MOOSE_DIR }}/scripts/{{ LIBMESH_BUILD_SCRIPT }} {{ ROOT_BUILD_DIR }}/scripts/{{ LIBMESH_BUILD_SCRIPT }}
     {{ MOOSE_DIR }}/scripts/configure_libmesh.sh {{ ROOT_BUILD_DIR }}/scripts/configure_libmesh.sh
+    {{ MOOSE_DIR }}/conda/libmesh-vtk/vtk9.4.2_mr11854_nlohmann.patch {{ ROOT_BUILD_DIR }}/vtk9.4.2_mr11854_nlohmann.patch

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 0 %}
+{% set build = 1 %}
 {% set vtk_version = "9.4.2" %}
 {% set vtk_friendly_version = "9.4" %}
 {% set sha256 = "36c98e0da96bb12a30fe53708097aa9492e7b66d5c3b366e1c8dc251e2856a02" %}
@@ -17,6 +17,8 @@ source:
   - vtk_friendly_version: {{ vtk_friendly_version }}
   - sha256: {{ sha256 }}
   - path: ../functions/retry_build.sh
+  - patches:
+    - vtk9.4.2_mr11854_nlohmann.patch # see moose issue #30372
 
 build:
   number: {{ build }}

--- a/conda/libmesh-vtk/meta.yaml.template
+++ b/conda/libmesh-vtk/meta.yaml.template
@@ -17,6 +17,8 @@ source:
   - vtk_friendly_version: {{ vtk_friendly_version }}
   - sha256: {{ sha256 }}
   - path: ../functions/retry_build.sh
+  - patches:
+    - vtk9.4.2_mr11854_nlohmann.patch # see moose issue #30372
 
 build:
   number: {{ build }}

--- a/conda/libmesh-vtk/vtk9.4.2_mr11854_nlohmann.patch
+++ b/conda/libmesh-vtk/vtk9.4.2_mr11854_nlohmann.patch
@@ -1,0 +1,296 @@
+diff --git a/Common/Core/Testing/Cxx/CMakeLists.txt b/Common/Core/Testing/Cxx/CMakeLists.txt
+index dded0e378d..82dd9c91cb 100644
+--- a/Common/Core/Testing/Cxx/CMakeLists.txt
++++ b/Common/Core/Testing/Cxx/CMakeLists.txt
+@@ -147,6 +147,7 @@ vtk_add_test_cxx(vtkCommonCoreCxxTests tests
+   TestObservers.cxx
+   TestObserversPerformance.cxx
+   TestOStreamWrapper.cxx
++  TestPrintArrayValues.cxx
+   TestSMP.cxx
+   TestSmartPointer.cxx
+   TestSOADataArray.cxx
+diff --git a/Common/Core/Testing/Cxx/TestPrintArrayValues.cxx b/Common/Core/Testing/Cxx/TestPrintArrayValues.cxx
+new file mode 100644
+index 0000000000..c1f08c3db0
+--- /dev/null
++++ b/Common/Core/Testing/Cxx/TestPrintArrayValues.cxx
+@@ -0,0 +1,38 @@
++// SPDX-FileCopyrightText: Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
++// SPDX-License-Identifier: BSD-3-Clause
++#include "vtkNew.h"
++#include "vtkStringArray.h"
++#include "vtkTypeUInt32Array.h"
++
++#include <sstream>
++
++int TestPrintArrayValues(int, char*[])
++{
++  {
++    vtkNew<vtkTypeUInt32Array> uint32Array;
++    for (int i = 0; i < 10; ++i)
++    {
++      uint32Array->InsertNextValue(i);
++    }
++    std::ostringstream oss;
++    uint32Array->PrintValues(oss);
++    if (oss.str() != "0 1 2 3 4 5 6 7 8 9 ")
++    {
++      std::cerr << oss.str() << " != 0 1 2 3 4 5 6 7 8 9\n";
++      return EXIT_FAILURE;
++    }
++  }
++  {
++    vtkNew<vtkStringArray> stringArray;
++    stringArray->InsertNextValue("VTK");
++    stringArray->InsertNextValue("vtk");
++    std::ostringstream oss;
++    stringArray->PrintValues(oss);
++    if (oss.str() != "VTK vtk ")
++    {
++      std::cerr << oss.str() << " != VTK vtk\n";
++      return EXIT_FAILURE;
++    }
++  }
++  return EXIT_SUCCESS;
++}
+diff --git a/Common/Core/vtkAbstractArray.cxx b/Common/Core/vtkAbstractArray.cxx
+index c1c1628b14..e517fb0db2 100644
+--- a/Common/Core/vtkAbstractArray.cxx
++++ b/Common/Core/vtkAbstractArray.cxx
+@@ -48,11 +48,6 @@
+ #include <iterator>
+ #include <set>
+ 
+-// clang-format off
+-#include "vtk_nlohmannjson.h"
+-#include VTK_NLOHMANN_JSON(json.hpp)
+-// clang-format on
+-
+ VTK_ABI_NAMESPACE_BEGIN
+ vtkInformationKeyMacro(vtkAbstractArray, GUI_HIDE, Integer);
+ vtkInformationKeyMacro(vtkAbstractArray, PER_COMPONENT, InformationVector);
+@@ -65,6 +60,17 @@ VTK_ABI_NAMESPACE_END
+ namespace
+ {
+ typedef std::vector<std::string*> vtkInternalComponentNameBase;
++
++struct PrintDataArrayWorker
++{
++  template <typename InArrayT>
++  void operator()(InArrayT* inArray, std::ostream& outStream)
++  {
++    using T = vtk::GetAPIType<InArrayT>;
++    const auto inRange = vtk::DataArrayValueRange(inArray);
++    std::copy(inRange.begin(), inRange.end(), std::ostream_iterator<T>(outStream, " "));
++  }
++};
+ }
+ 
+ VTK_ABI_NAMESPACE_BEGIN
+@@ -792,29 +798,6 @@ void SampleProminentValues(std::vector<std::vector<vtkVariant>>& uniques, vtkIdT
+     std::copy(si->begin(), si->end(), bi);
+   }
+ }
+-
+-struct WriteDataArrayWorker
+-{
+-  WriteDataArrayWorker(nlohmann::json& result)
+-    : m_result(result)
+-  {
+-  }
+-
+-  template <typename InArrayT>
+-  void operator()(InArrayT* inArray)
+-  {
+-    using T = vtk::GetAPIType<InArrayT>;
+-    const auto inRange = vtk::DataArrayValueRange(inArray);
+-    T val;
+-    for (const auto& value : inRange)
+-    {
+-      val = value;
+-      m_result.push_back(val);
+-    }
+-  }
+-
+-  nlohmann::json& m_result;
+-};
+ } // End anonymous namespace.
+ 
+ VTK_ABI_NAMESPACE_BEGIN
+@@ -928,32 +911,23 @@ void vtkAbstractArray::UpdateDiscreteValueSet(double uncertainty, double minimum
+ }
+ 
+ //------------------------------------------------------------------------------
+-nlohmann::json vtkAbstractArray::SerializeValues()
++void vtkAbstractArray::PrintValues(ostream& os)
+ {
+-  auto result = nlohmann::json::array();
+-
+-  if (auto* darr = vtkDataArray::SafeDownCast(this))
++  if (auto* dataArray = vtkDataArray::SafeDownCast(this))
+   {
+     using Dispatcher = vtkArrayDispatch::DispatchByValueType<vtkArrayDispatch::AllTypes>;
+-    WriteDataArrayWorker worker(result);
+-    if (!Dispatcher::Execute(darr, worker))
++    ::PrintDataArrayWorker worker;
++    if (!Dispatcher::Execute(dataArray, worker, os))
+     {
+-      worker(darr);
++      worker(dataArray, os);
+     }
+   }
+   else
+   {
+     for (vtkIdType ii = 0; ii < this->GetNumberOfValues(); ++ii)
+     {
+-      result.push_back(this->GetVariantValue(ii).ToString());
++      os << this->GetVariantValue(ii).ToString() << ' ';
+     }
+   }
+-  return result;
+-}
+-
+-//------------------------------------------------------------------------------
+-void vtkAbstractArray::PrintValues(ostream& os)
+-{
+-  os << this->SerializeValues().dump() << '\n';
+ }
+ VTK_ABI_NAMESPACE_END
+diff --git a/Common/Core/vtkAbstractArray.h b/Common/Core/vtkAbstractArray.h
+index 2df39d3b00..90d084f01c 100644
+--- a/Common/Core/vtkAbstractArray.h
++++ b/Common/Core/vtkAbstractArray.h
+@@ -45,6 +45,13 @@
+  * Unless `Modified` is called, various cached entities, like array range,
+  * map created for `LookupValue` may become obsolete and yield incorrect results.
+  *
++ * @warning
++ * In VTK 9.4, new method `nlohmann::json vtkAbstractArray::SerializeValues()` was
++ * introduced which required exposing symbols from
++ * VTK::nlohmannjson library in public API. This method will be removed in VTK 9.5 as it caused
++ * difficulty for downstream projects that linked to a different nlohmannjson. It cannot be
++ * deprecated because doing so prevents fixing the underlying issue.
++ *
+  * @sa
+  * vtkDataArray vtkStringArray vtkCellArray
+  */
+@@ -58,9 +65,6 @@
+ #include "vtkVariant.h"       // for variant arguments
+ #include "vtkWrappingHints.h" // For VTK_MARSHALAUTO
+ 
+-#include "vtk_nlohmannjson.h"
+-#include VTK_NLOHMANN_JSON(json_fwd.hpp)
+-
+ VTK_ABI_NAMESPACE_BEGIN
+ class vtkArrayIterator;
+ class vtkDataArray;
+@@ -78,8 +82,11 @@ class VTKCOMMONCORE_EXPORT VTK_MARSHALAUTO vtkAbstractArray : public vtkObject
+ public:
+   vtkTypeMacro(vtkAbstractArray, vtkObject);
+   void PrintSelf(ostream& os, vtkIndent indent) override;
++
++  /**
++   * Print the array values to an `ostream` object.
++   */
+   void PrintValues(ostream& os);
+-  nlohmann::json SerializeValues();
+ 
+   /**
+    * Allocate memory for this array. Delete old storage only if necessary.
+diff --git a/Documentation/release/dev/breaking-change-remove-nlohmann-json-from-public-API.md b/Documentation/release/dev/breaking-change-remove-nlohmann-json-from-public-API.md
+new file mode 100644
+index 0000000000..e06f38bd11
+--- /dev/null
++++ b/Documentation/release/dev/breaking-change-remove-nlohmann-json-from-public-API.md
+@@ -0,0 +1,7 @@
++# Remove usage of the nlohmannjson library from public facing API
++
++The `nlohmann::json vtkAbstractArray::SerializeValues()` method is now removed
++as the public exposure of VTK's vendored `nlohmannjson` library caused difficulty for downstream projects that link to a different nlohmannjson.
++
++These methods were added in [vtk/vtk!11163](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/11163) which was released in 9.4. That merge
++request has now been reverted. These methods are removed (instead of deprecation) because deprecation would prevent fixing the problem.
+diff --git a/IO/CellGrid/vtkCellGridWriter.cxx b/IO/CellGrid/vtkCellGridWriter.cxx
+index 0566aeb6b8..dcb689d2fa 100644
+--- a/IO/CellGrid/vtkCellGridWriter.cxx
++++ b/IO/CellGrid/vtkCellGridWriter.cxx
+@@ -157,6 +157,56 @@ std::string dataTypeToString(int dataType)
+   return "unhandled";
+ }
+ 
++struct WriteDataArrayWorker
++{
++  WriteDataArrayWorker(nlohmann::json& result)
++    : m_result(result)
++  {
++  }
++
++  template <typename InArrayT>
++  void operator()(InArrayT* inArray)
++  {
++    using T = vtk::GetAPIType<InArrayT>;
++    const auto inRange = vtk::DataArrayValueRange(inArray);
++    T val;
++    for (const auto& value : inRange)
++    {
++      val = value;
++      m_result.push_back(val);
++    }
++  }
++
++  nlohmann::json& m_result;
++};
++
++nlohmann::json serializeArrayValues(vtkAbstractArray* arr)
++{
++  auto result = nlohmann::json::array();
++  if (!arr)
++  {
++    return result;
++  }
++
++  if (auto* darr = vtkDataArray::SafeDownCast(arr))
++  {
++    using Dispatcher = vtkArrayDispatch::DispatchByValueType<vtkArrayDispatch::AllTypes>;
++    WriteDataArrayWorker worker(result);
++    if (!Dispatcher::Execute(darr, worker))
++    {
++      worker(darr);
++    }
++  }
++  else
++  {
++    for (vtkIdType ii = 0; ii < arr->GetNumberOfValues(); ++ii)
++    {
++      result.push_back(arr->GetVariantValue(ii).ToString());
++    }
++  }
++  return result;
++}
++
+ bool getCachedRange(vtkCellGridRangeQuery::CacheMap& rangeCache, vtkCellAttribute* attribute,
+   nlohmann::json& rangeInfo)
+ {
+@@ -233,7 +283,7 @@ bool vtkCellGridWriter::ToJSON(nlohmann::json& data, vtkCellGrid* grid)
+       arrayLocations[arr] = groupName;
+       nlohmann::json arrayRecord{ { "name", arr->GetName() },
+         { "tuples", arr->GetNumberOfTuples() }, { "components", arr->GetNumberOfComponents() },
+-        { "type", dataTypeToString(arr->GetDataType()) }, { "data", arr->SerializeValues() } };
++        { "type", dataTypeToString(arr->GetDataType()) }, { "data", serializeArrayValues(arr) } };
+       if (arr == groupScalars)
+       {
+         arrayRecord["default_scalars"] = true;
+diff --git a/Imaging/Core/vtkImageSSIM.cxx b/Imaging/Core/vtkImageSSIM.cxx
+index 8c695784b6..cfc623c31c 100644
+--- a/Imaging/Core/vtkImageSSIM.cxx
++++ b/Imaging/Core/vtkImageSSIM.cxx
+@@ -18,6 +18,8 @@
+ #include "vtkPointData.h"
+ #include "vtkStreamingDemandDrivenPipeline.h"
+ 
++#include <cstdint>
++
+ VTK_ABI_NAMESPACE_BEGIN
+ 
+ vtkStandardNewMacro(vtkImageSSIM);

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -7,8 +7,8 @@ moose_petsc:
   - moose-petsc 3.23.0.6.gd9d7fd11dca openmpi_1
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.4.2 mpich_0
-  - moose-libmesh-vtk 9.4.2 openmpi_0
+  - moose-libmesh-vtk 9.4.2 mpich_1
+  - moose-libmesh-vtk 9.4.2 openmpi_1
 
 zip_keys:
   - mpi

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2025.04.17" %}
+{% set version = "2025.04.22" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2025.04.17 mpich_0
-  - moose-libmesh 2025.04.17 openmpi_0
+  - moose-libmesh 2025.04.22 mpich_0
+  - moose-libmesh 2025.04.22 openmpi_0
 
 moose_wasp:
   - moose-wasp 2025.02.25

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.04.17" %}
+{% set version = "2025.04.22" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_dev:
-  - moose-dev 2025.04.17
+  - moose-dev 2025.04.22
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/framework/include/utils/ImageSampler.h
+++ b/framework/include/utils/ImageSampler.h
@@ -23,6 +23,25 @@
 // loves to warn about it...
 #include "libmesh/ignore_warnings.h"
 
+// If VTK is built without an external nlohmann, then it assumes it
+// will never be compiled against another nlohmann, and it includes
+// its own copy but modified with macro tricks.  We have probably
+// already included nlohman nheaders, which we didn't tamper with
+// because OF COURSE NOT, but now we need to take care not to let the
+// include guards prevent them from including their copy with their
+// different namespace.
+#ifndef MOOSE_VTK_NLOHMANN_INCLUDED
+#ifdef INCLUDE_NLOHMANN_JSON_HPP_
+#define MOOSE_ALREADY_INCLUDED_NLOHMANN_JSON_HPP_
+#undef INCLUDE_NLOHMANN_JSON_HPP_
+#endif
+#ifdef INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define MOOSE_ALREADY_INCLUDED_NLOHMANN_JSON_FWD_HPP_
+#undef INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#endif
+#define MOOSE_VTK_NLOHMANN_INCLUDED
+#endif
+
 #include "vtkSmartPointer.h"
 #include "vtkPNGReader.h"
 #include "vtkTIFFReader.h"
@@ -34,6 +53,21 @@
 #include "vtkImageShiftScale.h"
 #include "vtkImageMagnitude.h"
 #include "vtkImageFlip.h"
+
+#ifdef MOOSE_ALREADY_INCLUDED_NLOHMANN_JSON_HPP_
+#define INCLUDE_NLOHMANN_JSON_HPP_
+#endif
+#ifdef MOOSE_ALREADY_INCLUDED_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#endif
+
+// If VTK is built without an external nlohmann, then it assumes it
+// will never be compiled against another nlohmann, and it defines an
+// nlohmann macro to point to its vtknlohmann copy.  In MOOSE their
+// assumption is wrong.
+#ifdef nlohmann
+#undef nlohmann
+#endif
 
 #include "libmesh/restore_warnings.h"
 

--- a/framework/include/utils/MeshBaseImageSampler.h
+++ b/framework/include/utils/MeshBaseImageSampler.h
@@ -23,6 +23,25 @@
 // loves to warn about it...
 #include "libmesh/ignore_warnings.h"
 
+// If VTK is built without an external nlohmann, then it assumes it
+// will never be compiled against another nlohmann, and it includes
+// its own copy but modified with macro tricks.  We have probably
+// already included nlohman nheaders, which we didn't tamper with
+// because OF COURSE NOT, but now we need to take care not to let the
+// include guards prevent them from including their copy with their
+// different namespace.
+#ifndef MOOSE_VTK_NLOHMANN_INCLUDED
+#ifdef INCLUDE_NLOHMANN_JSON_HPP_
+#define MOOSE_ALREADY_INCLUDED_NLOHMANN_JSON_HPP_
+#undef INCLUDE_NLOHMANN_JSON_HPP_
+#endif
+#ifdef INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define MOOSE_ALREADY_INCLUDED_NLOHMANN_JSON_FWD_HPP_
+#undef INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#endif
+#define MOOSE_VTK_NLOHMANN_INCLUDED
+#endif
+
 #include "vtkSmartPointer.h"
 #include "vtkPNGReader.h"
 #include "vtkTIFFReader.h"
@@ -34,6 +53,21 @@
 #include "vtkImageShiftScale.h"
 #include "vtkImageMagnitude.h"
 #include "vtkImageFlip.h"
+
+#ifdef MOOSE_ALREADY_INCLUDED_NLOHMANN_JSON_HPP_
+#define INCLUDE_NLOHMANN_JSON_HPP_
+#endif
+#ifdef MOOSE_ALREADY_INCLUDED_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#endif
+
+// If VTK is built without an external nlohmann, then it assumes it
+// will never be compiled against another nlohmann, and it defines an
+// nlohmann macro to point to its vtknlohmann alternative.  In MOOSE
+// their assumption is wrong.
+#ifdef nlohmann
+#undef nlohmann
+#endif
 
 #include "libmesh/restore_warnings.h"
 

--- a/modules/solid_mechanics/examples/cframe_iga/tests
+++ b/modules/solid_mechanics/examples/cframe_iga/tests
@@ -4,6 +4,7 @@
     input = 'cframe_iga.i'
     max_parallel = 1 # number of VTK output files changes with num processes, so we are sticking w/ one for now
     xmldiff = 'cframe_iga_out_001.pvtu cframe_iga_out_001_0.vtu'
+    ignored_items = "root['VTKFile']['@version']"
     # See #24187, set vtk to >=9.0 once #21449 is resolved
     capabilities = 'petsc>=3.12.0 & method!=dbg & exodus>=8.0 & vtk>=9.1'
     valgrind = none

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1049,3 +1049,34 @@ a32adecb7fa52400a518df2e172a3ab40724cbe7: #29633
   wasp:
     full_version: 2025.02.25_2
     hash: e181ec5
+9e2022df200246bd91dc2a56b2981d4feaea8918: #30362; VTK and libmesh for VTK fixes
+  libmesh:
+    full_version: 2025.04.22_0
+    hash: e0eb0da
+  libmesh-vtk:
+    full_version: 9.4.2_1
+    hash: 59e681e
+  moose-dev:
+    full_version: 2025.04.22
+    hash: 8a3a8dd
+  mpi:
+    full_version: 2025.04.17
+    hash: a9161d1
+  peacock:
+    full_version: 2025.04.17
+    hash: a231b10
+  petsc:
+    full_version: 3.23.0.6.gd9d7fd11dca_1
+    hash: ff9a7ec
+  pprof:
+    full_version: 2025.04.17_0
+    hash: f8fd1e3
+  seacas:
+    full_version: 2025.02.27_1
+    hash: 5d0701b
+  tools:
+    full_version: 2025.04.17
+    hash: 827cc6f
+  wasp:
+    full_version: 2025.02.25_2
+    hash: e181ec5

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -26,7 +26,7 @@ packages:
   # dependers: libmesh, moose-dev
   libmesh-vtk:
     version: 9.4.2
-    build_number: 0
+    build_number: 1
     conda: conda/libmesh-vtk
     templates:
       conda/libmesh-vtk/conda_build_config.yaml.template: conda/libmesh-vtk/conda_build_config.yaml
@@ -66,7 +66,7 @@ packages:
       - scripts/apple-silicon-hdf5-autogen.patch
   # dependers: moose-dev
   libmesh:
-    version: 2025.04.17
+    version: 2025.04.22
     build_number: 0
     conda: conda/libmesh
     templates:
@@ -103,7 +103,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.04.17
+    version: 2025.04.22
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -35,6 +35,7 @@ packages:
       - mpi
     influential:
       - conda/libmesh-vtk/build.sh
+      - conda/libmesh-vtk/vtk9.4.2_mr11854_nlohmann.patch
   # dependers: peacock
   peacock:
     version: 2025.04.17

--- a/test/tests/meshgenerators/file_mesh_generator/tests
+++ b/test/tests/meshgenerators/file_mesh_generator/tests
@@ -95,7 +95,7 @@
     # when a spline control node is at a finite element's centroid.
     max_parallel = 1
     xmldiff = '3d_steady_diffusion_iga_out_001.pvtu 3d_steady_diffusion_iga_out_001_0.vtu'
-
+    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to read IsoGeometric Analysis meshes with 3D elements and sidesets in ExodusII format.'
     design = 'meshgenerators/FileMeshGenerator.md'
     issues = '#18768'


### PR DESCRIPTION
refs #30349

VTK 9.4 is not discoverable by libmesh configure. This update patches that.