### PR TITLE
Update code to recognize --allow-unused flag in --mesh-only mode

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1113,6 +1113,12 @@ public:
    */
   bool forceRestart() const { return _force_restart; }
 
+  /// Returns whether the flag for unused parameters is set to throw a warning only
+  bool unusedFlagIsWarning() const { return _enable_unused_check == WARN_UNUSED; }
+
+  /// Returns whether the flag for unused parameters is set to throw an error
+  bool unusedFlagIsError() const { return _enable_unused_check == ERROR_UNUSED; }
+
 protected:
   /**
    * Helper method for dynamic loading of objects

--- a/framework/src/actions/MeshOnlyAction.C
+++ b/framework/src/actions/MeshOnlyAction.C
@@ -37,7 +37,9 @@ void
 MeshOnlyAction::act()
 {
   // Run error checking on input file first before trying to generate a mesh
-  _app.builder().errorCheck(comm(), false, true);
+  bool warn = _app.unusedFlagIsWarning();
+  bool err = _app.unusedFlagIsError();
+  _app.builder().errorCheck(comm(), warn, err);
 
   std::string mesh_file = _app.parameters().get<std::string>("mesh_only");
   auto & mesh_ptr = _app.actionWarehouse().mesh();

--- a/test/tests/mesh/mesh_only/tests
+++ b/test/tests/mesh/mesh_only/tests
@@ -108,4 +108,23 @@
     should_crash = true
     capabilities = 'method!=dbg'
   []
+  [mesh_only_allow_unused]
+    type = 'Exodiff'
+    input = 'mesh_only.i'
+    cli_args = 'Mesh/extrude/x=5 --allow-unused --mesh-only 3d_chimney.e'
+    exodiff = '3d_chimney.e'
+    recover = false
+    issues = '#30370'
+    requirement = 'The system shall allow writing out the mesh without running a simulation when unused parameters exist but the flag to allow unused parameters is turned on.'
+    capabilities = 'method!=dbg'
+  []
+  [mesh_only_with_check_input_allow_unused]
+    type = 'RunApp'
+    input = 'mesh_only.i'
+    cli_args = 'Mesh/extrude/x=5 --allow-unused --check-input --mesh-only'
+    expect_out = 'Syntax OK'
+    max_parallel = 1
+    issues = '#30370'
+    requirement = 'The system shall report the successful parsing and interpretation of input file sytax with unused parameters when using the "--check-input", "--mesh-only", and "--allow-unused" command line flags'
+  []
 []


### PR DESCRIPTION
refs #30370

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
