### PR TITLE
Add Sequoia 15.4-related package change news to April newsletter

### DIFF
--- a/modules/doc/content/newsletter/2025/2025_04.md
+++ b/modules/doc/content/newsletter/2025/2025_04.md
@@ -5,6 +5,12 @@ This MOOSE Newsletter edition is in progress. Please check back in May 2025
 for a complete description of all MOOSE changes.
 !alert-end!
 
+## Minimum supported MacOS version is now Ventura (13.3)
+
+Due to the recent `moose-dev` package changes [described below](2025_04.md#conda-package-changes),
+the minimum MacOS version compatible with MOOSE development is now Ventura (13.3). If you cannot
+update your MacOS version, please consider using the [Docker-based installation option for MOOSE](https://mooseframework.inl.gov/getting_started/installation/docker.html).
+
 ## MOOSE Improvements
 
 ### `capabilities` parameter in `tests` specs
@@ -49,8 +55,10 @@ Check `MooseApp::registerCapabilities()` for examples.
 - Add mutex to fparser `setEpsilon` to prevent thread races
 - Add `QBase::get_base_order()` API allowing comparison of multiple quadrature rules independent of p-refinement level
 - Update TIMPI submodule
-    - Use MPI-4 APIs for `MPI_Count`, i.e. 64-bit, size support, when available
-    - Fix for uninitialized warning with gcc 13.3
+
+  - Use MPI-4 APIs for `MPI_Count`, i.e. 64-bit, size support, when available
+  - Fix for uninitialized warning with gcc 13.3
+
 - Remove phony make code which could trigger multiple netgen builds
 - Get metaphysicl config include
 - Allow instantiation of `DenseVector::print` with dual numbers
@@ -61,6 +69,7 @@ Check `MooseApp::registerCapabilities()` for examples.
 ### `2025.04.17` Update
 
 - Autoconf-submodule (ACSM) update
+
   - When recent clang versions are detected, the compiler flag
     `-fno-assume-unique-vtables` is used.  This enables `dynamic_cast`
     to work reliably on macOS 15 (Sequoia) environments, which fixes a
@@ -68,7 +77,9 @@ Check `MooseApp::registerCapabilities()` for examples.
   - More thorough detection for code coverage support when
     --enable-coverage builds may require it from multiple languages'
     compilers.
+
 - TIMPI submodule update
+
   - Fixes and tests for `timpi_version.h` utilities
   - Unit test fixes for C++14 compilers
   - `timpi_pure` attribute for pure functions; on C++17 and newer
@@ -79,6 +90,7 @@ Check `MooseApp::registerCapabilities()` for examples.
     parallel reductions on user-defined types without first specifying
     their attributes now fails to compile, instead of compiling but not
     working correctly.
+
 - Added support for creating and computing on arbitrary polygons in 2D
 - Better tolerance computations when stitching meshes along a boundary
   with discrete NodeElem elements
@@ -107,6 +119,17 @@ Check `MooseApp::registerCapabilities()` for examples.
   quadrature code
 - More assertions
 
+### `2025.04.22` Update
+
+- Add option to variational smoother to preserve subdomain boundaries, and add test for new option.
+- Drop `LOG_SCOPE` calls from `DofMap::dof_indices()`
+- Update citations
+- Update traffic
+- Fixes for VTK 9.4
+
+  - Add check for failures to find VTK macros
+  - Detect new VTK macros from new VTK header file
+
 ## PETSc-level Changes
 
 ### `2025.04.02` Update
@@ -116,3 +139,42 @@ We updated PETSc to version 3.23. For a summary of changes please see the PETSc 
 ## Bug Fixes and Minor Enhancements
 
 ## Conda Package Changes
+
+### `2025.04.22` Update to the `moose-dev` Package
+
+The `moose-dev` conda package was updated in order to address MOOSE build issues encountered after
+the recent MacOS update to Sequoia 15.4. This required a number of dependency package updates and
+changes. Context for this issue can be found in [`idaholab/moose#30227`](https://github.com/idaholab/moose/issues/30227),
+and descriptions of the compiler and dependency package updates can be found below.
+
+#### MacOS Compiler Updates to Clang, MPICH, OpenMPI
+
+The `moose-mpi` package (now version `2025.04.17`) was updated to use newer Clang compilers on
+MacOS, version 18.1.8. This necessitated an update to the MPICH and OpenMPI wrappers as well. MPICH
+is now version 4.3.0, and OpenMPI is now version 5.0.7. On a related note, gfortran was updated to
+version 13.3.0 on MacOS platforms to correspond with this change.
+
+!alert! note title=Linux compiler/wrapper versions unchanged
+GCC, MPICH, and OpenMPI versions were not changed on Linux! They remain at GCC 12.3.0, MPICH 4.2.1,
+and OpenMPI 4.1.6.
+!alert-end!
+
+#### VTK Updated to 9.4.2
+
+The [VTK data visualization library](https://vtk.org/) was updated to the latest release (9.4.2) for
+all platforms.
+
+#### HDF5 Changes
+
+The HDF5 version was updated to `1.14.3` on MacOS, while `1.14.2` remains the installed version on
+Linux systems.
+
+#### Python 3.12 Available
+
+Python 3.12 compatibility was added, making the `moose-dev` package compatible with Python 3.9 - 3.12.
+Python 3.12 is now the default version installed when installing the `moose-dev` package.
+
+#### Plotly Added
+
+The interactive graphing library for Python, [plotly](https://plotly.com/python/), is now available
+in the `moose-tools` package. The version currently installed is 6.0.1.


### PR DESCRIPTION
This adds news updates related to PRs #29765 and #30362.

@roystgnr Double-check that I added everything you wanted for the quick VTK 9.4-related libMesh update.

@milljm Take a look at the conda package changes summary, please!
