### PR TITLE
Prepare meshes for stitching

### DIFF
--- a/modules/reactor/src/meshgenerators/PatternedCartesianMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PatternedCartesianMeshGenerator.C
@@ -1060,8 +1060,8 @@ PatternedCartesianMeshGenerator::addPeripheralMesh(
                                           (i != extra_dist.size() - 1) &&
                                               _create_outward_interface_boundaries);
 
-      if (mesh.is_prepared()) // Need to prepare if the other is prepared to stitch
-        meshp0->prepare_for_use();
+      // The other_mesh must be prepared before stitching
+      meshp0->prepare_for_use();
 
       // rotate the peripheral mesh to the desired side of the hexagon.
       MeshTools::Modification::rotate(*meshp0, rotation_angle, 0, 0);

--- a/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
@@ -1086,8 +1086,8 @@ PatternedHexMeshGenerator::addPeripheralMesh(
                                           (i != extra_dist.size() - 1) &&
                                               _create_outward_interface_boundaries);
 
-      if (mesh.is_prepared()) // Need to prepare if the other is prepared to stitch
-        meshp0->prepare_for_use();
+      // The other_mesh must be prepared before stitching
+      meshp0->prepare_for_use();
 
       // rotate the peripheral mesh to the desired side of the hexagon.
       MeshTools::Modification::rotate(*meshp0, rotation_angle, 0, 0);


### PR DESCRIPTION
Without this we may not have the neighbor_ptr values that the stitching code needs, which is causing exodiff test failures after an upcoming libMesh fix (libMesh/libmesh#4152).

This fixes #30398