### PR TITLE
Fixup minor issues with contact SQA

### DIFF
--- a/modules/contact/doc/config.yml
+++ b/modules/contact/doc/config.yml
@@ -6,6 +6,7 @@ Content:
         root_dir: ${MOOSE_DIR}/modules/doc/content
         content:
             - help/finite_element_concepts/nodal_patch_recovery.md
+            - application_usage/restart_recover.md
 Renderer:
     type: MooseDocs.base.MaterializeRenderer
 
@@ -28,6 +29,9 @@ Extensions:
         shortcuts: !include framework/doc/globals.yml
     MooseDocs.extensions.acronym:
         acronyms: !include framework/doc/acronyms.yml
+    MooseDocs.extensions.bibtex:
+        duplicates:
+            - puso2008segment # also in framework
     MooseDocs.extensions.template:
         active: True
     MooseDocs.extensions.sqa:

--- a/modules/contact/doc/sqa_contact.yml
+++ b/modules/contact/doc/sqa_contact.yml
@@ -4,6 +4,6 @@ specs:
     - tests
 dependencies:
     - framework
-    - tensor_mechanics
+    - solid_mechanics
 repo: moose
 reports: !include ${MOOSE_DIR}/modules/contact/doc/sqa_reports.yml

--- a/modules/contact/doc/sqa_reports.yml
+++ b/modules/contact/doc/sqa_reports.yml
@@ -8,7 +8,6 @@ Applications:
             - ${MOOSE_DIR}/framework/doc/unregister.yml
         remove:
             - ${MOOSE_DIR}/framework/doc/remove.yml
-        log_missing_markdown: WARNING
 
 Documents:
     software_quality_plan: sqa/inl_records.md#software_quality_plan
@@ -27,14 +26,10 @@ Documents:
     software_library_list: sqa/contact_sll.md
     communication_and_contact_information: sqa/framework_cci.md
     software_coding_standards: sqa/framework_scs.md
-    log_user_manual: WARNING
-    log_theory_manual: WARNING
+    user_manual: modules/contact/tutorials/introduction/index.md
+    theory_manual: modules/contact/index.md
 
 Requirements:
     contact:
         directories:
             - ${MOOSE_DIR}/modules/contact
-        log_duplicate_requirement: WARNING
-        log_missing: WARNING
-        log_missing_requirement: WARNING
-        log_testable: WARNING


### PR DESCRIPTION
This PR:

- Removes `tensor_mechanics` remnant in sqa_contact.yml
- Fixes up SQA warnings for theory and user documentation for contact (since those exist), and turn all warnings to errors.
- Fixes up documentation build errors and warnings when building contact module documentation by itself.

Closes #30437