### PR TITLE
Fixup lead lithium properties documentation and speed of sound

### DIFF
--- a/modules/fluid_properties/doc/content/bib/fluid_properties.bib
+++ b/modules/fluid_properties/doc/content/bib/fluid_properties.bib
@@ -332,52 +332,65 @@ from 0 to 1000 C, 0 to 5000 bar, and 0 to 1 X$_{NaCl}$}},
 
 # Lead-Bismuth properties
 @article{MasdeLesValls2008,
-  author    = {Mas de Les Valls, J. and Others},
-  title     = {Thermophysical Properties of Liquid Pb–Li Alloys for Fusion Applications},
-  journal   = {Journal of Nuclear Materials},
-  volume    = {376},
-  number    = {1--3},
-  pages     = {353--357},
-  year      = {2008},
-  doi       = {10.1016/j.jnucmat.2008.02.057}
+title = {Lead–lithium eutectic material database for nuclear fusion technology},
+journal = {Journal of Nuclear Materials},
+volume = {376},
+number = {3},
+pages = {353-357},
+year = {2008},
+note = {Heavy Liquid Metal Cooled Reactors and Related Technologies},
+issn = {0022-3115},
+doi = {https://doi.org/10.1016/j.jnucmat.2008.02.016},
+url = {https://www.sciencedirect.com/science/article/pii/S0022311508000809},
+author = {E. {Mas de les Valls} and L.A. Sedano and L. Batet and I. Ricapito and A. Aiello and O. Gastaldi and F. Gabriel},
+keywords = {28.52, 52.55, 66},
 }
 
 @article{Schulz1991,
-  author    = {Schulz, B. and Lau, M. K. and McFarlane, P. N.},
-  title     = {Thermophysical Properties of the Li(17)Pb(83) Eutectic Alloy for Fusion Reactor Applications},
-  journal   = {Fusion Engineering and Design},
-  volume    = {14},
-  pages     = {199--205},
-  year      = {1991},
-  doi       = {10.1016/0920-3796(91)90083-7}
+title = {Thermophysical properties of the Li(17)Pb(83)alloy},
+journal = {Fusion Engineering and Design},
+volume = {14},
+number = {3},
+pages = {199-205},
+year = {1991},
+issn = {0920-3796},
+doi = {https://doi.org/10.1016/0920-3796(91)90002-8},
+url = {https://www.sciencedirect.com/science/article/pii/0920379691900028},
+author = {B. Schulz},
 }
 
-@article{Hubberstey1992,
-  author    = {Hubberstey, O. and Galanakis, A. E. and van Loon, J. J. A.},
-  title     = {Re-assessment of the Li–Pb Phase Diagram for Fusion Applications},
-  journal   = {Journal of Nuclear Materials},
-  volume    = {191},
-  number    = {1--3},
-  pages     = {282--290},
-  year      = {1992},
-  doi       = {10.1016/0022-3115(92)90041-K}
+@article{Ueki2009,
+author = {Y. Ueki and M. Hirabayashi and T. Kunugi and T. Yokomine and K. Ara and},
+title = {Acoustic Properties of Pb-17Li Alloy for Ultrasonic Doppler Velocimetry},
+journal = {Fusion Science and Technology},
+volume = {56},
+number = {2},
+pages = {846--850},
+year = {2009},
+publisher = {American Nuclear Society},
+doi = {10.13182/FST56-846},
+URL = {https://doi.org/10.13182/FST56-846},
+eprint = {https://doi.org/10.13182/FST56-846}
 }
 
-@techreport{Giancarli1996,
-  author       = {Giancarli, L. and Others},
-  title        = {Design and Fabrication of a Fusion Blanket Using Liquid Pb-17Li},
-  institution  = {Commissariat \`a l'\'energie atomique (CEA)},
-  year         = {1996},
-  number       = {CEA-R--96-XXX},
-  address      = {France}
+@article{Martelli2009,
+title = {Literature review of lead-lithium thermophysical properties},
+journal = {Fusion Engineering and Design},
+volume = {138},
+pages = {183-195},
+year = {2019},
+issn = {0920-3796},
+doi = {https://doi.org/10.1016/j.fusengdes.2018.11.028},
+url = {https://www.sciencedirect.com/science/article/pii/S0920379618307361},
+author = {D. Martelli and A. Venturini and M. Utili},
+keywords = {Lead-lithium eutectic, PbLi, Thermophysical properties, Fusion}
 }
 
 @techreport{Zinkle1998,
   author       = {Zinkle, S. J.},
-  title        = {Summary of Physical Properties for Pb-17Li as a Fusion Reactor Material},
+  title        = {Summary of Physical Properties for Lithium, Pb-17Li, and (LiF)n•BeF2 Coolants, APEX Study Meeting},
   institution  = {Oak Ridge National Laboratory},
   year         = {1998},
-  number       = {ORNL/TM-1341},
   address      = {Oak Ridge, TN, USA}
 }
 

--- a/modules/fluid_properties/doc/content/source/fluidproperties/LeadLithiumFluidProperties.md
+++ b/modules/fluid_properties/doc/content/source/fluidproperties/LeadLithiumFluidProperties.md
@@ -2,45 +2,55 @@
 
 !syntax description /FluidProperties/LeadLithiumFluidProperties
 
-These properties are based on experiments and compilations reported in the literature, e.g., [!cite](Schulz1991,Hubberstey1992,Giancarli1996,Zinkle1998). Most properties depend only on temperature; the fluid is considered incompressible over the range of interest. The fluid properties are summarized in Table [tab:leadli], which reports the formulas used and their origin.
+These properties are based on experiments and compilations reported in the literature, e.g., [!cite](Schulz1991,Zinkle1998,MasdeLesValls2008). Most properties depend only on temperature; the fluid is considered incompressible over the range of interest. The fluid properties are summarized in Table [tab:leadli], which reports the formulas used and their origin.
 
 !table id=tab:leadli caption=Table of properties, equations, and references for the Lead–Lithium fluid properties.
 | Properties                             | Equations | Reference |
 | :------------------------------------- | :-------- | :-------- |
-| Melting point, $T_{mo}$ `[K]`            | $508$ | [!cite](Hubberstey1992) |
+| Melting point, $T_{mo}$ `[K]`          | $508$ | [!cite](Martelli2009,MasdeLesValls2008) |
 | Density, $\rho$ `[kg/m^3]`             | $\displaystyle 10520.35 - 1.19051\,T$ | [!cite](MasdeLesValls2008) |
-| Viscosity, $\mu$ `[Pa s]`                | $\displaystyle 1.87 \times 10^{-4}\,\exp\!\left(\frac{11640}{8.314\,T}\right)$ | [!cite](Schulz1991) |
-| Specific enthalpy, $h$ `[J/kg]`          | $\displaystyle 195\,(T-T_{mo}) - 0.5\times9.116\times10^{-3}\,(T^2-T_{mo}^2)$ | [!cite](Zinkle1998) |
-| Thermal Conductivity, $k$ `[W/(m-K)]`      | $\displaystyle 14.51 + 0.019631\,T$ | [!cite](Mogahed1995) |
+| Viscosity, $\mu$ `[Pa s]`              | $\displaystyle 1.87 \times 10^{-4}\,\exp\!\left(\frac{11640}{8.314\,T}\right)$ | [!cite](Schulz1991) |
+| Specific enthalpy, $h$ `[J/kg]`        | $\displaystyle 195\,(T-T_{mo}) - 0.5\times9.116\times10^{-3}\,(T^2-T_{mo}^2)$ | [!cite](Zinkle1998) |
+| Thermal Conductivity, $k$ `[W/(m-K)]`       | $\displaystyle 14.51 + 0.019631\,T$ | [!cite](Mogahed1995) |
 | Isobaric Specific Heat, $c_p$ `[J/(kg-K)]`  | $\displaystyle 195 - 9.116\times10^{-3}\,T$ | [!cite](Schulz1991) |
 | Isochoric Specific Heat, $c_v$ `[J/(kg-K)]` | $\displaystyle \frac{c_p}{1+\left(\frac{1.19051}{10520.35-1.19051 \, T}\right)^2 \frac{B_S \, T}{\rho \, c_p}}$ | [!cite](Zinkle1998) |
-| Isentropic Bulk Modulus, $B_S$ `[Pa]`     | $\displaystyle \left(44.73077 - 0.02634615 \, T + 5.76923 \times 10^{-6} \, T^2 \right) \times 10^9$ | [!cite](Hubberstey1992) |
-| Speed of Sound, $c$ `[m/s]`               | $\displaystyle 1959.63 - 0.306\,T$ | [!cite](Schulz1991) |
+| Isentropic Bulk Modulus, $B_S$ `[Pa]`       | $\dfrac{c^2}{\rho} | [!cite](Martelli2009)|
+| Speed of Sound, $c$ `[m/s]`                 | $\displaystyle 1876 - 0.306\,T$ | [!cite](Ueki2009) |
 
 
 !alert note
-The thermal conductivity differs significantly between [!cite](Mogahed1995) and [!cite](MasdeLesValls2008), by nearly 50%.
+The thermal conductivity differs significantly between [!cite](Mogahed1995) and [!cite](MasdeLesValls2008,Zinkle1998,Schulz1991), by nearly 50%.
 
 ## Range of Validity
 
-The properties defined in \texttt{LeadLithiumFluidProperties} are valid for
+The properties defined in `LeadLithiumFluidProperties` are valid in the following temperature ranges:
 
 !equation
-508\,\mathrm{K} \le T \le 1800\,\mathrm{K},
+508\,\mathrm{K} \le T \le 880\,\mathrm{K}, \text{for density}
+
+!equation
+508\,\mathrm{K} \le T \le 873\,\mathrm{K}, \text{for thermal conductivity}
+
+!equation
+508\,\mathrm{K} \le T \le 625\,\mathrm{K}, \text{for specific heat}
+
+!equation
+508\,\mathrm{K} \le T \le 625\,\mathrm{K}, \text{for viscosity}
+
 
 and for pressures near atmospheric up to a few MPa, where the assumption of incompressibility holds.
 
 ## Uncertainties of Lead–Lithium Fluid Properties
 
-Based on experimental studies [!cite](Schulz1991,Hubberstey1992) and compilations in fusion materials handbooks [!cite](Giancarli1996,Zinkle1998), the reported uncertainties for Lead–Lithium fluid properties are approximately:
+Based on experimental studies [!cite](Schulz1991) and compilations in fusion materials handbooks [!cite](Zinkle1998), and thermophysical property reviews [!cite](MasdeLesValls2008), the reported uncertainties for Lead–Lithium fluid properties are approximately:
 
 !table id=tab:lead-std caption=Uncertainties on properties
-| Property                               | Uncertainty (%) |
+| Property                               | Uncertainty / Scattering (%) |
 | :------------------------------------- | :------------- |
-| Density                                | $\approx$  1% |
-| Viscosity                              | $\approx$ 10% |
-| Thermal Conductivity                   | $\approx$ 15% |
-| Isobaric Specific Heat                 | $\approx$  7% |
+| Density                                | $\approx$  4%  [!cite](Martelli2009) |
+| Viscosity                              | $\approx$ 12%  [!cite](Martelli2009) |
+| Thermal Conductivity                   | $\approx$ 37%  [!cite](Martelli2009) |
+| Isobaric Specific Heat                 | $\approx$  32% [!cite](Martelli2009) |
 
 !syntax parameters /FluidProperties/LeadLithiumFluidProperties
 

--- a/modules/fluid_properties/include/fluidproperties/LeadLithiumFluidProperties.h
+++ b/modules/fluid_properties/include/fluidproperties/LeadLithiumFluidProperties.h
@@ -103,6 +103,7 @@ public:
    */
   Real bulk_modulus_from_p_T(Real p, Real T) const;
 
+  Real c_from_p_T(Real p, Real T) const override;
   Real c_from_v_e(Real v, Real e) const override;
   ADReal c_from_v_e(const ADReal & v, const ADReal & e) const override;
 

--- a/modules/fluid_properties/src/fluidproperties/LeadLithiumFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/LeadLithiumFluidProperties.C
@@ -98,22 +98,27 @@ LeadLithiumFluidProperties::T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, R
 Real
 LeadLithiumFluidProperties::bulk_modulus_from_p_T(Real /*p*/, Real T) const
 {
-  return (44.73077 - 0.02634615 * T + 5.76923e-6 * T * T) * 1e9;
+  return Utility::pow<2>(c_from_p_T(0, T)) * rho_from_p_T(0, T);
+}
+
+Real
+LeadLithiumFluidProperties::c_from_p_T(Real /*p*/, Real T) const
+{
+  return 1876 - 0.306 * T;
 }
 
 Real
 LeadLithiumFluidProperties::c_from_v_e(Real v, Real e) const
 {
   Real T = T_from_v_e(v, e);
-  // This is from Schulz 1991. Ueki 2009 in Martelli has 1876 - 0.306 * T
-  return 1959.63 - 0.306 * T;
+  return 1876 - 0.306 * T;
 }
 
 ADReal
 LeadLithiumFluidProperties::c_from_v_e(const ADReal & v, const ADReal & e) const
 {
   ADReal T = SinglePhaseFluidProperties::T_from_v_e(v, e);
-  return 1959.63 - 0.306 * T;
+  return 1876 - 0.306 * T;
 }
 
 Real
@@ -387,7 +392,7 @@ LeadLithiumFluidProperties::mu_from_p_T(
 Real
 LeadLithiumFluidProperties::k_from_p_T(Real /*p*/, Real T) const
 {
-  if (T < _T_mo || T > 880)
+  if (T < _T_mo || T > 873)
     flagInvalidSolution("Temperature out of bounds for the PbLi dynamic viscosity computation");
   return 14.51 + 1.9631e-2 * T;
 }

--- a/modules/fluid_properties/unit/src/LeadLithiumFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/LeadLithiumFluidPropertiesTest.C
@@ -63,10 +63,10 @@ TEST_F(LeadLithiumFluidPropertiesTest, properties)
       const Real e_ref = h_ref - p / rho_ref;
       // Compute thermal conductivity:
       const Real k_ref = 14.51 + 0.019631 * T;
-      // Compute bulk modulus:
-      const Real E_ref = (44.73077 - 0.02634615 * T + 5.76923e-6 * T * T) * 1e9;
       // Compute speed of sound:
-      const Real c_ref = 1959.63 - 0.306 * T;
+      const Real c_ref = 1876. - 0.306 * T;
+      // Compute bulk modulus:
+      const Real E_ref = c_ref * c_ref * rho_ref;
       // Compute isobaric specific heat:
       const Real cp_ref = 195.0 - 9.116e-3 * T;
       // Compute thermal expansion coefficient:
@@ -110,6 +110,7 @@ TEST_F(LeadLithiumFluidPropertiesTest, properties)
       REL_TEST(_fp->bulk_modulus_from_p_T(p, T), E_ref, tol);
 
       // Test speed of sound
+      REL_TEST(_fp->c_from_p_T(p, T), c_ref, tol);
       REL_TEST(_fp->c_from_v_e(v, e), c_ref, tol);
 
       // Test isobaric specific heat


### PR DESCRIPTION
refs #30413 

doco has more issues than I expected, considering the properties were matching Martelli. The titles of citations were wrong, others I could not locate. Hubberstey1992 exists, I see it referenced in several places. But no luck on science direct or google. So it's best not to use it. Others, less sure. 

also switched to the same speed of sound as in Martelli, for consistency. It does not matter for NS, but I am reverting my original decision to use the gpt-provided reference