### PR TITLE
Numerical evaluation of strain energy rate density for creep laws

### DIFF
--- a/modules/solid_mechanics/include/actions/DomainIntegralAction.h
+++ b/modules/solid_mechanics/include/actions/DomainIntegralAction.h
@@ -154,4 +154,5 @@ protected:
   MaterialPropertyName _functionally_graded_youngs_modulus;
   /// Whether to create automatic differentiation objects from the action
   const bool _use_ad;
+  const bool _use_incremental_serd;
 };

--- a/modules/solid_mechanics/include/materials/PowerLawCreepStressUpdate.h
+++ b/modules/solid_mechanics/include/materials/PowerLawCreepStressUpdate.h
@@ -58,6 +58,8 @@ protected:
     return computeResidualInternal<GenericChainedReal<is_ad>>(effective_trial_stress, scalar);
   }
 
+  virtual Real computeCreepStrainRate(const Real& stress_eq) override;
+
   /// Temperature variable value
   const GenericVariableValue<is_ad> * const _temperature;
 

--- a/modules/solid_mechanics/include/materials/PowerLawCreepStressUpdate.h
+++ b/modules/solid_mechanics/include/materials/PowerLawCreepStressUpdate.h
@@ -58,7 +58,7 @@ protected:
     return computeResidualInternal<GenericChainedReal<is_ad>>(effective_trial_stress, scalar);
   }
 
-  virtual Real computeCreepStrainRate(const Real& stress_eq) override;
+  virtual GenericReal<is_ad> computeCreepStrainRate(const GenericReal<is_ad> & stress_eq) override;
 
   /// Temperature variable value
   const GenericVariableValue<is_ad> * const _temperature;

--- a/modules/solid_mechanics/include/materials/RadialReturnCreepStressUpdateBase.h
+++ b/modules/solid_mechanics/include/materials/RadialReturnCreepStressUpdateBase.h
@@ -50,9 +50,16 @@ protected:
     return TangentCalculationMethod::PARTIAL;
   }
 
+  virtual Real computeCreepStrainRate(const Real& stress_eq) ;
+
+  virtual Real computeStrainEnergyRateDensity(
+      const GenericMaterialProperty<RankTwoTensor, is_ad> & stress,
+      const GenericMaterialProperty<RankTwoTensor, is_ad> & strain_rate) override;
+
   /// Creep strain material property
   GenericMaterialProperty<RankTwoTensor, is_ad> & _creep_strain;
   const MaterialProperty<RankTwoTensor> & _creep_strain_old;
+  const bool & _compute_numerical_serd;
 };
 
 typedef RadialReturnCreepStressUpdateBaseTempl<false> RadialReturnCreepStressUpdateBase;

--- a/modules/solid_mechanics/include/materials/RadialReturnCreepStressUpdateBase.h
+++ b/modules/solid_mechanics/include/materials/RadialReturnCreepStressUpdateBase.h
@@ -50,7 +50,7 @@ protected:
     return TangentCalculationMethod::PARTIAL;
   }
 
-  virtual Real computeCreepStrainRate(const Real& stress_eq) ;
+  virtual GenericReal<is_ad> computeCreepStrainRate(const GenericReal<is_ad> & /*stress_eq*/);
 
   virtual Real computeStrainEnergyRateDensity(
       const GenericMaterialProperty<RankTwoTensor, is_ad> & stress,
@@ -59,7 +59,9 @@ protected:
   /// Creep strain material property
   GenericMaterialProperty<RankTwoTensor, is_ad> & _creep_strain;
   const MaterialProperty<RankTwoTensor> & _creep_strain_old;
-  const bool & _compute_numerical_serd;
+
+private:
+  std::string _serd_integration_order;
 };
 
 typedef RadialReturnCreepStressUpdateBaseTempl<false> RadialReturnCreepStressUpdateBase;

--- a/modules/solid_mechanics/include/materials/StrainEnergyRateDensity.h
+++ b/modules/solid_mechanics/include/materials/StrainEnergyRateDensity.h
@@ -40,15 +40,20 @@ private:
 
   /// The strain energy density material property
   MaterialProperty<Real> & _strain_energy_rate_density;
+  const MaterialProperty<Real> & _strain_energy_rate_density_old;
 
   /// Current and old values of stress
   const GenericMaterialProperty<RankTwoTensor, is_ad> & _stress;
+  const MaterialProperty<RankTwoTensor> & _stress_old;
 
   /// Current value of the strain increment for incremental models
   const GenericMaterialProperty<RankTwoTensor, is_ad> & _strain_rate;
+  /// Current value of the strain increment for incremental models
+  const MaterialProperty<RankTwoTensor> & _strain_rate_old;
 
   /// number of plastic models
   const unsigned _num_models;
+  bool _use_incremental_serd;
 
   /// The user supplied list of inelastic models to compute the strain energy release rate
   std::vector<GenericStressUpdateBase<is_ad> *> _inelastic_models;

--- a/modules/solid_mechanics/src/actions/DomainIntegralAction.C
+++ b/modules/solid_mechanics/src/actions/DomainIntegralAction.C
@@ -133,6 +133,9 @@ DomainIntegralAction::validParams()
   params.addParam<bool>("use_automatic_differentiation",
                         false,
                         "Flag to use automatic differentiation (AD) objects when possible");
+  params.addParam<bool>("use_incremental_serd",
+                        false,
+                        "Flag to use incremetnal computation of strain energy rate density");
   params.addParam<bool>("output_vpp",
                         true,
                         "Flag to control the vector postprocessor outputs. Select false to "
@@ -173,7 +176,8 @@ DomainIntegralAction::DomainIntegralAction(const InputParameters & params)
     _incremental(getParam<bool>("incremental")),
     _convert_J_to_K(isParamValid("convert_J_to_K") ? getParam<bool>("convert_J_to_K") : false),
     _fgm_crack(false),
-    _use_ad(getParam<bool>("use_automatic_differentiation"))
+    _use_ad(getParam<bool>("use_automatic_differentiation")),
+    _use_incremental_serd(getParam<bool>("use_incremental_serd"))
 {
 
   if (isParamValid("functionally_graded_youngs_modulus_crack_dir_gradient") !=
@@ -971,7 +975,7 @@ DomainIntegralAction::act()
         params.set<std::vector<SubdomainName>>("block") = {_blocks};
         params.set<std::vector<MaterialName>>("inelastic_models") =
             getParam<std::vector<MaterialName>>("inelastic_models");
-
+        params.set<bool>("use_incremental_serd") = _use_incremental_serd;
         _problem->addMaterial(mater_type_name, mater_name, params);
       }
     }

--- a/modules/solid_mechanics/src/materials/PowerLawCreepStressUpdate.C
+++ b/modules/solid_mechanics/src/materials/PowerLawCreepStressUpdate.C
@@ -69,6 +69,13 @@ PowerLawCreepStressUpdateTempl<is_ad>::computeStressInitialize(
   _exp_time = std::pow(_t - _start_time, _m_exponent);
 }
 
+template<bool is_ad>
+Real 
+PowerLawCreepStressUpdateTempl<is_ad>::computeCreepStrainRate(const Real& stress_eq)
+{
+  return _coefficient*std::pow(stress_eq, _n_exponent)* MetaPhysicL::raw_value(_exponential) * _exp_time;
+}
+
 template <bool is_ad>
 template <typename ScalarType>
 ScalarType
@@ -76,8 +83,7 @@ PowerLawCreepStressUpdateTempl<is_ad>::computeResidualInternal(
     const GenericReal<is_ad> & effective_trial_stress, const ScalarType & scalar)
 {
   const ScalarType stress_delta = effective_trial_stress - _three_shear_modulus * scalar;
-  const ScalarType creep_rate =
-      _coefficient * std::pow(stress_delta, _n_exponent) * _exponential * _exp_time;
+  Real creep_rate = computeCreepStrainRate(MetaPhysicL::raw_value(stress_delta)); 
   return creep_rate * _dt - scalar;
 }
 
@@ -102,9 +108,13 @@ PowerLawCreepStressUpdateTempl<is_ad>::computeStrainEnergyRateDensity(
   if (_n_exponent <= 1)
     return 0.0;
 
-  Real creep_factor = _n_exponent / (_n_exponent + 1);
-
-  return MetaPhysicL::raw_value(creep_factor * stress[_qp].doubleContraction((strain_rate)[_qp]));
+  if(!RadialReturnCreepStressUpdateBaseTempl<is_ad>::_compute_numerical_serd)
+  {
+    Real creep_factor = _n_exponent / (_n_exponent + 1);
+    return MetaPhysicL::raw_value(creep_factor * stress[_qp].doubleContraction((strain_rate)[_qp]));
+  }
+  else
+    return RadialReturnCreepStressUpdateBaseTempl<is_ad>::computeStrainEnergyRateDensity(stress, strain_rate);
 }
 
 template <bool is_ad>

--- a/modules/solid_mechanics/src/materials/PowerLawCreepStressUpdate.C
+++ b/modules/solid_mechanics/src/materials/PowerLawCreepStressUpdate.C
@@ -69,11 +69,11 @@ PowerLawCreepStressUpdateTempl<is_ad>::computeStressInitialize(
   _exp_time = std::pow(_t - _start_time, _m_exponent);
 }
 
-template<bool is_ad>
-Real 
-PowerLawCreepStressUpdateTempl<is_ad>::computeCreepStrainRate(const Real& stress_eq)
+template <bool is_ad>
+GenericReal<is_ad>
+PowerLawCreepStressUpdateTempl<is_ad>::computeCreepStrainRate(const GenericReal<is_ad> & stress_eq)
 {
-  return _coefficient*std::pow(stress_eq, _n_exponent)* MetaPhysicL::raw_value(_exponential) * _exp_time;
+  return _coefficient * std::pow(stress_eq, _n_exponent) * _exponential * _exp_time;
 }
 
 template <bool is_ad>
@@ -83,7 +83,8 @@ PowerLawCreepStressUpdateTempl<is_ad>::computeResidualInternal(
     const GenericReal<is_ad> & effective_trial_stress, const ScalarType & scalar)
 {
   const ScalarType stress_delta = effective_trial_stress - _three_shear_modulus * scalar;
-  Real creep_rate = computeCreepStrainRate(MetaPhysicL::raw_value(stress_delta)); 
+  const ScalarType creep_rate =
+      _coefficient * std::pow(stress_delta, _n_exponent) * _exponential * _exp_time;
   return creep_rate * _dt - scalar;
 }
 
@@ -108,13 +109,8 @@ PowerLawCreepStressUpdateTempl<is_ad>::computeStrainEnergyRateDensity(
   if (_n_exponent <= 1)
     return 0.0;
 
-  if(!RadialReturnCreepStressUpdateBaseTempl<is_ad>::_compute_numerical_serd)
-  {
-    Real creep_factor = _n_exponent / (_n_exponent + 1);
-    return MetaPhysicL::raw_value(creep_factor * stress[_qp].doubleContraction((strain_rate)[_qp]));
-  }
-  else
-    return RadialReturnCreepStressUpdateBaseTempl<is_ad>::computeStrainEnergyRateDensity(stress, strain_rate);
+  Real creep_factor = _n_exponent / (_n_exponent + 1);
+  return MetaPhysicL::raw_value(creep_factor * stress[_qp].doubleContraction((strain_rate)[_qp]));
 }
 
 template <bool is_ad>

--- a/modules/solid_mechanics/src/materials/RadialReturnCreepStressUpdateBase.C
+++ b/modules/solid_mechanics/src/materials/RadialReturnCreepStressUpdateBase.C
@@ -8,6 +8,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "RadialReturnCreepStressUpdateBase.h"
+#include "libmesh/string_to_enum.h"
+#include "libmesh/quadrature_gauss.h"
 
 template <bool is_ad>
 InputParameters
@@ -15,7 +17,10 @@ RadialReturnCreepStressUpdateBaseTempl<is_ad>::validParams()
 {
   InputParameters params = RadialReturnStressUpdateTempl<is_ad>::validParams();
   params.set<std::string>("effective_inelastic_strain_name") = "effective_creep_strain";
-  params.addParam<bool>("compute_numerical_serd", false, "method to compute strain energy rate density either numerically or analytically");
+  params.addParam<std::string>(
+      "serd_integration_order",
+      "FIFTH",
+      "numerical integration order for computing strain energy rate density");
   return params;
 }
 
@@ -26,9 +31,9 @@ RadialReturnCreepStressUpdateBaseTempl<is_ad>::RadialReturnCreepStressUpdateBase
     _creep_strain(this->template declareGenericProperty<RankTwoTensor, is_ad>(this->_base_name +
                                                                               "creep_strain")),
     _creep_strain_old(
-        this->template getMaterialPropertyOld<RankTwoTensor>(this->_base_name + "creep_strain")),
-    _compute_numerical_serd(this->template getParam<bool>("compute_numerical_serd"))
+        this->template getMaterialPropertyOld<RankTwoTensor>(this->_base_name + "creep_strain"))
 {
+  _serd_integration_order = parameters.get<std::string>("serd_integration_order");
 }
 
 template <bool is_ad>
@@ -73,42 +78,43 @@ RadialReturnCreepStressUpdateBaseTempl<is_ad>::computeStressFinalize(
   _creep_strain[_qp] = _creep_strain_old[_qp] + plastic_strain_increment;
 }
 
-template<bool is_ad>
-Real 
-RadialReturnCreepStressUpdateBaseTempl<is_ad>::computeCreepStrainRate(const Real& stress_eq)
+template <bool is_ad>
+GenericReal<is_ad>
+RadialReturnCreepStressUpdateBaseTempl<is_ad>::computeCreepStrainRate(
+    const GenericReal<is_ad> & /*stress_eq*/)
 {
   mooseError("This is a base class. Developers need to write their own creep law");
 }
 
-template<bool is_ad>
-Real 
+template <bool is_ad>
+Real
 RadialReturnCreepStressUpdateBaseTempl<is_ad>::computeStrainEnergyRateDensity(
-      const GenericMaterialProperty<RankTwoTensor, is_ad> & stress,
-      const GenericMaterialProperty<RankTwoTensor, is_ad> & strain_rate)
+    const GenericMaterialProperty<RankTwoTensor, is_ad> & stress,
+    const GenericMaterialProperty<RankTwoTensor, is_ad> & strain_rate)
 {
-  if(_compute_numerical_serd)
+  // Create a Gauss quadrature rule of the specified order
+  std::unique_ptr<QGauss> qrule =
+      std::make_unique<QGauss>(1, Utility::string_to_enum<Order>(_serd_integration_order));
+
+  // Get the weights and points
+  std::vector<Real> weights = qrule->get_weights();
+  std::vector<Point> points = qrule->get_points();
+
+  const GenericReal<is_ad> sigma_eq = std::sqrt(3.0 * stress[_qp].secondInvariant());
+  const GenericReal<is_ad> eps_eq =
+      std::sqrt(2.0 / 3.0 * strain_rate[_qp].doubleContraction(strain_rate[_qp]));
+
+  Real integral = MetaPhysicL::raw_value(sigma_eq * eps_eq);
+  // Perform the integral using Gaussian quadrature
+  for (unsigned int k = 0; k < points.size(); ++k)
   {
-    // Gaussian quadrature weights and points for 5-point rule
-    const Real weights[5] = {0.2369268851, 0.4786286705, 0.5688888889, 0.4786286705, 0.2369268851};
-    const Real points[5] = {-0.9061798459, -0.5384693101, 0.0, 0.5384693101, 0.9061798459};
-    const Real sigma_eq = std::sqrt(3.0 * MetaPhysicL::raw_value(stress[_qp].secondInvariant()));
-    const Real eps_eq = std::sqrt( 2.0/3.0*MetaPhysicL::raw_value(strain_rate[_qp].doubleContraction(strain_rate[_qp])) );
-
-    Real integral = sigma_eq*eps_eq;
-    // Perform the integral using Gaussian quadrature
-    for (unsigned int k = 0; k < 5; ++k)
-    {
-      //Transform Gaussian points to the interval [0, sigma]
-      Real sigma_eq_tmp = 0.5 * (points[k] + 1) * sigma_eq; // Map to [0, sigma_eq]
-      Real strain_rate_tmp = computeCreepStrainRate(sigma_eq_tmp); 
-      integral -= 0.5*sigma_eq*weights[k]*strain_rate_tmp;
-    }
-    return integral;
-
+    // Transform Gaussian points to the interval [0, sigma]
+    GenericReal<is_ad> sigma_eq_tmp = 0.5 * (points[k](0) + 1) * sigma_eq; // Map to [0, sigma_eq]
+    GenericReal<is_ad> strain_rate_tmp = computeCreepStrainRate(sigma_eq_tmp);
+    integral -= 0.5 * weights[k] * MetaPhysicL::raw_value(sigma_eq * strain_rate_tmp);
   }
-  else
-    mooseError("The base class does not have a close-form for strain energy rate density");
-}      
+  return integral;
+}
 
 template class RadialReturnCreepStressUpdateBaseTempl<false>;
 template class RadialReturnCreepStressUpdateBaseTempl<true>;

--- a/modules/solid_mechanics/test/include/materials/PowerLawCreepTest.h
+++ b/modules/solid_mechanics/test/include/materials/PowerLawCreepTest.h
@@ -43,6 +43,10 @@ protected:
     return _initial_guess;
   }
 
+  virtual Real computeStrainEnergyRateDensity(
+      const GenericMaterialProperty<RankTwoTensor, is_ad> & stress,
+      const GenericMaterialProperty<RankTwoTensor, is_ad> & strain_rate) override;
+
   const int _failure_step;
   const Real _initial_guess;
 

--- a/modules/solid_mechanics/test/src/materials/PowerLawCreepTest.C
+++ b/modules/solid_mechanics/test/src/materials/PowerLawCreepTest.C
@@ -64,3 +64,13 @@ PowerLawCreepTestTempl<is_ad>::computeDerivative(const GenericReal<is_ad> & effe
 
   return PowerLawCreepStressUpdateTempl<is_ad>::computeDerivative(effective_trial_stress, scalar);
 }
+
+template <bool is_ad>
+Real
+PowerLawCreepTestTempl<is_ad>::computeStrainEnergyRateDensity(
+    const GenericMaterialProperty<RankTwoTensor, is_ad> & stress,
+    const GenericMaterialProperty<RankTwoTensor, is_ad> & strain_rate)
+{
+  return RadialReturnCreepStressUpdateBaseTempl<is_ad>::computeStrainEnergyRateDensity(stress,
+                                                                                       strain_rate);
+}

--- a/modules/solid_mechanics/test/tests/strain_energy_density/gold/numerical_rate_model_out.csv
+++ b/modules/solid_mechanics/test/tests/strain_energy_density/gold/numerical_rate_model_out.csv
@@ -1,0 +1,1 @@
+rate_model_out.csv

--- a/modules/solid_mechanics/test/tests/strain_energy_density/numerical_rate_model.i
+++ b/modules/solid_mechanics/test/tests/strain_energy_density/numerical_rate_model.i
@@ -83,17 +83,18 @@
     inelastic_models = 'powerlawcrp'
   [../]
   [./powerlawcrp]
-    type = PowerLawCreepStressUpdate
+    type =PowerLawCreepTest #PowerLawCreepStressUpdate
     coefficient = 3.125e-21 # 7.04e-17 #
     n_exponent = 4.0
     m_exponent = 0.0
     activation_energy = 0.0
+    failure_step = 1000000000
     # max_inelastic_increment = 0.01
   [../]
   [./strain_energy_rate_density]
     type = StrainEnergyRateDensity
     inelastic_models = 'powerlawcrp'
- [../]
+  [../]
 []
 
 [Executioner]

--- a/modules/solid_mechanics/test/tests/strain_energy_density/tests
+++ b/modules/solid_mechanics/test/tests/strain_energy_density/tests
@@ -58,6 +58,17 @@
     requirement = 'The system shall be capable of calculating strain energy density incrementally in '
                   'materials with inelastic stress and isotropic plasticity.'
   []
+  [rate_model_numerical]
+    type = 'CSVDiff'
+    input = 'numerical_rate_model.i'
+    csvdiff = 'numerical_rate_model_out.csv'
+    rel_err = 3e-2
+    abs_zero = 1e-8
+    design = 'StrainEnergyRateDensity.md'
+    allow_test_objects = true
+    requirement = 'The system shall be capable of calculating strain energy rate density numerically with elastic '
+                  'stress and finite strain.'
+  []
   [rate_model]
     type = 'CSVDiff'
     input = 'rate_model.i'
@@ -65,7 +76,7 @@
     rel_err = 1e-6
     abs_zero = 1e-8
     design = 'StrainEnergyRateDensity.md'
-    requirement = 'The system shall be capable of calculating strain energy rate density with elastic '
+    requirement = 'The system shall be capable of calculating strain energy rate density analytically with elastic '
                   'stress and finite strain.'
   []
   [rate_model_small]


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->
refs #30466
## Reason
<!--Why do you need this feature or what is the enhancement?-->
Some creep materials do not have an analytical form of strain energy rate density, so it requires a numerical evaluation for this quantity.
## Design
<!--A concise description (design) of the enhancement.-->
Strain energy rate density (SERD) can always be computed numerically, we will implement a numerical evaluation in the base class with 5-point integration rule. We will overide this method in the derived class by providing an analytical evaluation of SERD. Additionally, users need to provide a closed-form for the creep law they intend to use.
## Impact
<!--Will the enhancement change existing APIs or add something new?-->
It is applicable in the case the analytical form of SERD is not available or in the case of surrogate creep models. Addtionally, SERD is needed to compute C(t) integral used to advance cracks in XFEM.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
