### PR TITLE
Remove more shared library files and symlinks

### DIFF
--- a/scripts/clobber.py
+++ b/scripts/clobber.py
@@ -81,6 +81,8 @@ class Clobber(object):
                 ".gcov",
                 ".gch",
                 ".so",
+                ".so.0",
+                ".so.0.0.0",
                 )
 
         for root, subdirs, files in os.walk(self.top_dir, topdown=True):


### PR DESCRIPTION
If we ever bump our versioning then we'll need to add more entries here as well, but this gets everying we want `make clobber` to get for now.

Fixes #30505 for me

## Reason
With this patch `make clobber` now removes all our shared libraries (on Linux; Mac might have the same problem still?)

## Design
Remove everything ending with .so.0 and .so.0.0.0, not just .so

## Impact
This is less intrusive than the original behavior (fixed by #20780) of removing everything *containing* .so, and it gets the libraries while still not mistakenly removing e.g. `phy.solidwall_outlet_3eqn.i` in the `thermal_hydraulics` tests.