### PR TITLE
Include what we use in SamplerTest.C

### DIFF
--- a/unit/src/SamplerTest.C
+++ b/unit/src/SamplerTest.C
@@ -9,6 +9,10 @@
 
 #include "gtest/gtest.h"
 
+#include <algorithm> // std::upper_bound
+#include <iterator>  // std::distance
+#include <vector>
+
 int
 getLocation(const std::vector<unsigned int> & offsets, unsigned int global_index)
 {


### PR DESCRIPTION
Closes #30510

## Reason
I was getting a compiler error for this file - `std::upper_bound` wasn't included. Maybe because I have unity builds off.

## Impact
I'll be able to build the unit tests :)