### PR TITLE
remove openmpi from moose binary

### DIFF
--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,6 +1,5 @@
 mpi:
   - mpich
-  - openmpi
 
 moose_dev:
   - moose-dev 2025.04.22

--- a/conda/moose/conda_build_config.yaml.template
+++ b/conda/moose/conda_build_config.yaml.template
@@ -1,6 +1,5 @@
 mpi:
   - mpich
-  - openmpi
 
 moose_dev:
   - moose-dev __VERSIONER_MOOSE_DEV_VERSION__


### PR DESCRIPTION
Remove the ability to build the OpenMPI variant for the MOOSE redistributable. This will also affect the Apps that make use of the moose/conda/template build scripts (no MOOSE App will have an OpenMPI variant as well)

Fixes partial reason why Next is stuck.

We might re-introduce OpenMPI again once its working again.

Not bumping hashes, as it is not necessary.

Closes #30513