### PR TITLE
use MOOSE_MPI_COMMAND when starting up TestHarness

### DIFF
--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -216,6 +216,17 @@ LIBTORCH_OPTIONS = {
                  }
 }
 
+## Check for MOOSE_MPI_COMMAND in environment and make the appropriate command
+def getMPICommand():
+    # default to no MPI
+    mpi_command = ''
+    # use MOOSE_MPI_COMMAND if set
+    if os.environ.get('MOOSE_MPI_COMMAND'):
+        # run on one cpu
+        mpi_command = os.environ['MOOSE_MPI_COMMAND'] + ' -n 1 '
+    return mpi_command
+
+
 ## Run a command and return the output, or ERROR: + output if retcode != 0
 def runCommand(cmd, cwd=None):
     # On Windows it is not allowed to close fds while redirecting output
@@ -528,7 +539,7 @@ def getCapabilities(exe):
     Get capabilities JSON and compare it to the required capabilities
     """
     assert exe
-    output = runCommand("%s --show-capabilities" % exe)
+    output = runCommand(f"{getMPICommand()}{exe} --show-capabilities")
     return parseMOOSEJSON(output, '--show-capabilities')
 
 def getCapability(exe, name):
@@ -723,7 +734,7 @@ def getExeJSON(exe: str) -> str:
     """
     Calls --json on the given executable
     """
-    return runCommand("%s --json" % exe)
+    return runCommand(f"{getMPICommand()}{exe} --json")
 
 def getExeObjects(json: dict) -> set[str]:
     """

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -216,17 +216,6 @@ LIBTORCH_OPTIONS = {
                  }
 }
 
-## Check for MOOSE_MPI_COMMAND in environment and make the appropriate command
-def getMPICommand():
-    # default to no MPI
-    mpi_command = ''
-    # use MOOSE_MPI_COMMAND if set
-    if os.environ.get('MOOSE_MPI_COMMAND'):
-        # run on one cpu
-        mpi_command = os.environ['MOOSE_MPI_COMMAND'] + ' -n 1 '
-    return mpi_command
-
-
 ## Run a command and return the output, or ERROR: + output if retcode != 0
 def runCommand(cmd, cwd=None):
     # On Windows it is not allowed to close fds while redirecting output
@@ -539,7 +528,7 @@ def getCapabilities(exe):
     Get capabilities JSON and compare it to the required capabilities
     """
     assert exe
-    output = runCommand(f"{getMPICommand()}{exe} --show-capabilities")
+    output = runCommand(f"{os.environ.get('MOOSE_MPI_COMMAND', 'mpiexec')} -n 1 {exe} --show-capabilities")
     return parseMOOSEJSON(output, '--show-capabilities')
 
 def getCapability(exe, name):
@@ -734,7 +723,7 @@ def getExeJSON(exe: str) -> str:
     """
     Calls --json on the given executable
     """
-    return runCommand(f"{getMPICommand()}{exe} --json")
+    return runCommand(f"{os.environ.get('MOOSE_MPI_COMMAND', 'mpiexec')} -n 1 {exe} --json")
 
 def getExeObjects(json: dict) -> set[str]:
     """


### PR DESCRIPTION
## Reason
Tests cannot be run on some (possibly SLURM-based) HPC systems where mpiexec is needed to run MOOSE executables

## Design
Use MOOSE_MPI_COMMAND when calling executable directly in TestHarness. No change if MOOSE_MPI_COMMAND is unset. Only affects a few calls to executable to get capabilities.

## Impact
Better HPC compatibility


refs #30512, #11751
