### PR TITLE
Use newton solve type to avoid failing PJFNK + residual and jac together on Mac M4 pro

### DIFF
--- a/test/tests/fvkernels/fv_simple_diffusion/tests
+++ b/test/tests/fvkernels/fv_simple_diffusion/tests
@@ -37,7 +37,7 @@
       input = 'neumann.i'
       exodiff = 'neumann_together.e'
       detail = 'together'
-      cli_args = 'Outputs/file_base=neumann_together Executioner/residual_and_jacobian_together=true'
+      cli_args = 'Outputs/file_base=neumann_together Executioner/solve_type=Newton Executioner/residual_and_jacobian_together=true'
     []
   []
 


### PR DESCRIPTION
refs #30525

This is to keep the M3 test suite clean. This test without the change passes on linux smh
