### PR TITLE
Add routines to prevent adding ICs/time derivatives twice in Physics

### DIFF
--- a/framework/include/interfaces/BlockRestrictable.h
+++ b/framework/include/interfaces/BlockRestrictable.h
@@ -128,6 +128,13 @@ public:
   bool hasBlocks(const std::vector<SubdomainName> & names) const;
 
   /**
+   * Test if the supplied set of block names are valid for this object
+   * @param names A vector of SubdomainNames to check
+   * @return True if the given ids are valid for this object
+   */
+  bool hasBlocks(const std::set<SubdomainName> & names) const;
+
+  /**
    * Test if the supplied block ids are valid for this object
    * @param id A SubdomainID to check
    * @return True if the given id is valid for this object

--- a/framework/include/interfaces/BlockRestrictable.h
+++ b/framework/include/interfaces/BlockRestrictable.h
@@ -129,7 +129,7 @@ public:
 
   /**
    * Test if the supplied set of block names are valid for this object
-   * @param names A vector of SubdomainNames to check
+   * @param names A set of SubdomainNames to check
    * @return True if the given ids are valid for this object
    */
   bool hasBlocks(const std::set<SubdomainName> & names) const;

--- a/framework/include/interfaces/BlockRestrictable.h
+++ b/framework/include/interfaces/BlockRestrictable.h
@@ -241,7 +241,7 @@ private:
   FEProblemBase * _blk_feproblem;
 
   /// Pointer to Mesh
-  MooseMesh * _blk_mesh;
+  const MooseMesh * _blk_mesh;
 
   /// An empty set for referencing when boundary_ids is not included
   const std::set<BoundaryID> _empty_boundary_ids;

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -327,6 +327,7 @@ public:
   /**
    * @return The MaterialData for thread \p tid
    */
+  const MaterialData & getMaterialData(const THREAD_ID tid) const { return _material_data[tid]; }
   MaterialData & getMaterialData(const THREAD_ID tid) { return _material_data[tid]; }
 
   /**

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -738,8 +738,9 @@ public:
    * @param subdomain_names The names of the subdomains
    * @return The subdomain ids from the passed subdomain names.
    */
-  std::vector<SubdomainID> getSubdomainIDs(const std::vector<SubdomainName> & subdomain_name) const;
-  std::set<SubdomainID> getSubdomainIDs(const std::set<SubdomainName> & subdomain_name) const;
+  std::vector<SubdomainID>
+  getSubdomainIDs(const std::vector<SubdomainName> & subdomain_names) const;
+  std::set<SubdomainID> getSubdomainIDs(const std::set<SubdomainName> & subdomain_names) const;
 
   /**
    * This method sets the name for \p subdomain_id to \p name

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -735,10 +735,11 @@ public:
   /**
    * Get the associated subdomainIDs for the subdomain names that are passed in.
    *
-   * @param subdomain_name The names of the subdomains
+   * @param subdomain_names The names of the subdomains
    * @return The subdomain ids from the passed subdomain names.
    */
   std::vector<SubdomainID> getSubdomainIDs(const std::vector<SubdomainName> & subdomain_name) const;
+  std::set<SubdomainID> getSubdomainIDs(const std::set<SubdomainName> & subdomain_name) const;
 
   /**
    * This method sets the name for \p subdomain_id to \p name

--- a/framework/include/physics/PhysicsBase.h
+++ b/framework/include/physics/PhysicsBase.h
@@ -168,6 +168,7 @@ protected:
    * @param blocks the vector blocks to check for whether it contains every block in the mesh
    */
   bool allMeshBlocks(const std::vector<SubdomainName> & blocks) const;
+  bool allMeshBlocks(const std::set<SubdomainName> & blocks) const;
 
   /**
    * Process the given petsc option pairs into the system solver settings

--- a/framework/include/physics/PhysicsBase.h
+++ b/framework/include/physics/PhysicsBase.h
@@ -169,6 +169,12 @@ protected:
    */
   bool allMeshBlocks(const std::vector<SubdomainName> & blocks) const;
   bool allMeshBlocks(const std::set<SubdomainName> & blocks) const;
+  // These APIs can deal with ANY_BLOCK_ID or ids with no names. They will be slower than the
+  // MooseMeshUtils' APIs, but are more convenient for setup purposes
+  /// Get the set of subdomain ids for the incoming vector of subdomain names
+  std::set<SubdomainID> getSubdomainIDs(const std::set<SubdomainName> & blocks) const;
+  /// Get the vector of subdomain names and ids for the incoming set of subdomain IDs
+  std::vector<std::string> getSubdomainNamesAndIDs(const std::set<SubdomainID> & blocks) const;
 
   /**
    * Process the given petsc option pairs into the system solver settings

--- a/framework/include/physics/PhysicsBase.h
+++ b/framework/include/physics/PhysicsBase.h
@@ -184,7 +184,8 @@ protected:
 
   // Routines to help with deciding when to create objects
   /**
-   * Returns whether this Physics should create the variable or if it already exists
+   * Returns whether this Physics should create the variable. Will return false if the variable
+   * already exists and has the necessary block restriction.
    * @param var_name name of the variable
    * @param blocks block restriction to use. If empty, no block restriction
    * @param error_if_aux error if the variable is auxiliary
@@ -194,7 +195,8 @@ protected:
                             const bool error_if_aux);
 
   /**
-   * Returns whether this Physics should create the IC or whether it already exists
+   * Returns whether this Physics should create the variable. Will return false if the initial
+   * condition already exists and has the necessary block restriction.
    * @param var_name name of the variable
    * @param blocks block restriction to use. If empty, no block restriction
    * @param ic_is_default_ic whether this IC is from a default parameter, and therefore should be
@@ -211,8 +213,8 @@ protected:
                       const bool error_if_already_defined) const;
 
   /**
-   * Returns whether this Physics should create the time derivative for this
-   * variable and these blocks
+   * Returns whether this Physics should create the variable. Will return false if the time
+   * derivative kernel already exists and has the necessary block restriction.
    * @param var_name name of the variable
    * @param blocks block restriction to use. If empty, no block restriction
    * @param error_if_already_defined two time derivatives can be defined on the same subdomain, but

--- a/framework/include/physics/PhysicsBase.h
+++ b/framework/include/physics/PhysicsBase.h
@@ -175,6 +175,12 @@ protected:
   void addPetscPairsToPetscOptions(
       const std::vector<std::pair<MooseEnumItem, std::string>> & petsc_pair_options);
 
+  // Helpers to check on variable types
+  /// Whether the variable is a finite volume variable
+  bool isVariableFV(const VariableName & var_name) const;
+  /// Whether the variable is a scalar variable (global single scalar, not a field)
+  bool isVariableScalar(const VariableName & var_name) const;
+
   // Routines to help with deciding when to create objects
   /**
    * Returns whether this Physics should create the variable or if it already exists

--- a/framework/include/physics/PhysicsBase.h
+++ b/framework/include/physics/PhysicsBase.h
@@ -209,6 +209,24 @@ protected:
                       const bool ic_is_default_ic,
                       const bool error_if_already_defined) const;
 
+  /**
+   * Returns whether this Physics should create the time derivative for this
+   * variable and these blocks
+   * @param var_name name of the variable
+   * @param blocks block restriction to use. If empty, no block restriction
+   * @param error_if_already_defined two time derivatives can be defined on the same subdomain, but
+   * it is usually not correct. So if this is set to true, any overlap between the subdomains of two
+   * time derivatives for the same variable will cause an error. If set to false, the existing time
+   * derivative will be deemed as sufficient, and this routine will return false.
+   */
+  bool shouldCreateTimeDerivative(const VariableName & var_name,
+                                  const std::vector<SubdomainName> & blocks,
+                                  const bool error_if_already_defined) const;
+
+  // Other conceivable "shouldCreate" routines for things that are unique to a variable
+  // - shouldCreateTimeIntegrator
+  // - shouldCreatePredictor/Corrector
+
   /// System names for the system(s) owning the solver variables
   std::vector<SolverSystemName> _system_names;
 

--- a/framework/include/physics/PhysicsBase.h
+++ b/framework/include/physics/PhysicsBase.h
@@ -186,6 +186,23 @@ protected:
                             const std::vector<SubdomainName> & blocks,
                             const bool error_if_aux);
 
+  /**
+   * Returns whether this Physics should create the IC or whether it already exists
+   * @param var_name name of the variable
+   * @param blocks block restriction to use. If empty, no block restriction
+   * @param ic_is_default_ic whether this IC is from a default parameter, and therefore should be
+   * skipped when recovering/restarting
+   * @param error_if_already_defined two ICs cannot be defined on the same subdomain, so if this is
+   * set to true, any overlap between the subdomains of two ICs for the same variable will cause an
+   * error. If set to false, the existing ICs will take priority, and this routine will return
+   * false. Setting 'error_if_already_defined' to '!ic_is_default_ic' is a good idea if it is ok to
+   * overwrite the default IC value of the Physics.
+   */
+  bool shouldCreateIC(const VariableName & var_name,
+                      const std::vector<SubdomainName> & blocks,
+                      const bool ic_is_default_ic,
+                      const bool error_if_already_defined) const;
+
   /// System names for the system(s) owning the solver variables
   std::vector<SolverSystemName> _system_names;
 

--- a/framework/include/physics/PhysicsBase.h
+++ b/framework/include/physics/PhysicsBase.h
@@ -227,6 +227,14 @@ protected:
   // - shouldCreateTimeIntegrator
   // - shouldCreatePredictor/Corrector
 
+  /**
+   * When this is called, we are knowingly not using the value of these parameters. This routine
+   * checks whether these parameters simply have defaults or were passed by the user
+   * @param param_names the parameters we are ignoring
+   */
+  void reportPotentiallyMissedParameters(const std::vector<std::string> & param_names,
+                                         const std::string & object_type) const;
+
   /// System names for the system(s) owning the solver variables
   std::vector<SolverSystemName> _system_names;
 

--- a/framework/include/physics/PhysicsBase.h
+++ b/framework/include/physics/PhysicsBase.h
@@ -175,6 +175,17 @@ protected:
   void addPetscPairsToPetscOptions(
       const std::vector<std::pair<MooseEnumItem, std::string>> & petsc_pair_options);
 
+  // Routines to help with deciding when to create objects
+  /**
+   * Returns whether this Physics should create the variable or if it already exists
+   * @param var_name name of the variable
+   * @param blocks block restriction to use. If empty, no block restriction
+   * @param error_if_aux error if the variable is auxiliary
+   */
+  bool shouldCreateVariable(const VariableName & var_name,
+                            const std::vector<SubdomainName> & blocks,
+                            const bool error_if_aux);
+
   /// System names for the system(s) owning the solver variables
   std::vector<SolverSystemName> _system_names;
 

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -208,6 +208,7 @@ public:
   nonlocalCouplingEntries(const THREAD_ID tid, const unsigned int nl_sys_num);
 
   virtual bool hasVariable(const std::string & var_name) const override;
+  // NOTE: hasAuxiliaryVariable defined in parent class
   bool hasSolverVariable(const std::string & var_name) const;
   using SubProblem::getVariable;
   virtual const MooseVariableFieldBase &

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1867,7 +1867,7 @@ public:
   /*
    * @return The MaterialData for the type \p type for thread \p tid
    */
-  MaterialData & getMaterialData(Moose::MaterialDataType type, const THREAD_ID tid = 0);
+  MaterialData & getMaterialData(Moose::MaterialDataType type, const THREAD_ID tid = 0) const;
 
   /**
    * @returns Whether the original matrix nonzero pattern is restored before each Jacobian assembly

--- a/framework/include/utils/MooseMeshUtils.h
+++ b/framework/include/utils/MooseMeshUtils.h
@@ -115,6 +115,8 @@ SubdomainID getSubdomainID(const SubdomainName & subdomain_name, const MeshBase 
  */
 std::vector<subdomain_id_type> getSubdomainIDs(const libMesh::MeshBase & mesh,
                                                const std::vector<SubdomainName> & subdomain_name);
+std::set<subdomain_id_type> getSubdomainIDs(const libMesh::MeshBase & mesh,
+                                            const std::set<SubdomainName> & subdomain_name);
 
 /**
  * Calculates the centroid of a MeshBase.

--- a/framework/include/warehouses/MooseObjectWarehouseBase.h
+++ b/framework/include/warehouses/MooseObjectWarehouseBase.h
@@ -91,17 +91,24 @@ public:
    */
   bool hasObjects(THREAD_ID tid = 0) const;
   bool hasActiveObjects(THREAD_ID tid = 0) const;
-  bool hasObjectsForVariable(const VariableName & var_name, THREAD_ID tid /* = 0*/) const;
-  bool hasObjectsForVariableAndBlocks(const VariableName & var_name,
-                                      const std::set<SubdomainName> & blocks,
-                                      std::set<SubdomainName> & blocks_covered,
-                                      THREAD_ID tid /* = 0*/) const;
+  bool hasObjectsForVariable(const VariableName & var_name, THREAD_ID tid) const;
   bool hasActiveBlockObjects(THREAD_ID tid = 0) const;
   bool hasActiveBlockObjects(SubdomainID id, THREAD_ID tid = 0) const;
   bool hasActiveBoundaryObjects(THREAD_ID tid = 0) const;
   bool hasActiveBoundaryObjects(BoundaryID id, THREAD_ID tid = 0) const;
   bool hasBoundaryObjects(BoundaryID id, THREAD_ID tid = 0) const;
   ///@}
+
+  /**
+   * Whether there are objects for this variable and the set of blocks passed
+   * @param var_name name of the variable
+   * @param blocks blocks to consider
+   * @param blocks_covered subset of blocks for which there is an object
+   */
+  bool hasObjectsForVariableAndBlocks(const VariableName & var_name,
+                                      const std::set<SubdomainID> & blocks,
+                                      std::set<SubdomainID> & blocks_covered,
+                                      THREAD_ID tid) const;
 
   /**
    * Return a set of active SubdomainsIDs
@@ -118,8 +125,10 @@ public:
   ///@}
 
   /// Getter for objects that have the 'variable' set to a particular variable
+  /// Note that users should check whether there are objects using 'hasObjectsForVariable' before
+  /// calling this routine, because it will throw if there are no objects for this variable
   const std::vector<std::shared_ptr<T>> & getObjectsForVariable(const VariableName & var_name,
-                                                                THREAD_ID tid /* = 0*/) const;
+                                                                THREAD_ID tid) const;
 
   /**
    * Updates the active objects storage.
@@ -476,7 +485,7 @@ MooseObjectWarehouseBase<T>::hasActiveObjects(THREAD_ID tid /* = 0*/) const
 template <typename T>
 bool
 MooseObjectWarehouseBase<T>::hasObjectsForVariable(const VariableName & var_name,
-                                                   THREAD_ID tid /* = 0*/) const
+                                                   THREAD_ID tid) const
 {
   checkThreadID(tid);
   return _all_variable_objects[tid].count(var_name);
@@ -484,11 +493,10 @@ MooseObjectWarehouseBase<T>::hasObjectsForVariable(const VariableName & var_name
 
 template <typename T>
 bool
-MooseObjectWarehouseBase<T>::hasObjectsForVariableAndBlocks(
-    const VariableName & var_name,
-    const std::set<SubdomainName> & blocks,
-    std::set<SubdomainName> & blocks_covered,
-    THREAD_ID tid /* = 0*/) const
+MooseObjectWarehouseBase<T>::hasObjectsForVariableAndBlocks(const VariableName & var_name,
+                                                            const std::set<SubdomainID> & blocks,
+                                                            std::set<SubdomainID> & blocks_covered,
+                                                            THREAD_ID tid /* = 0*/) const
 {
   checkThreadID(tid);
   blocks_covered.clear();

--- a/framework/include/warehouses/MooseObjectWarehouseBase.h
+++ b/framework/include/warehouses/MooseObjectWarehouseBase.h
@@ -18,6 +18,7 @@
 #include "MaterialPropertyInterface.h"
 #include "MooseVariableDependencyInterface.h"
 #include "SubProblem.h"
+#include "MooseApp.h"
 
 // Forward declarations
 class MooseVariableFieldBase;

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -70,6 +70,7 @@ AuxKernelTempl<ComputeValueType>::validParams()
 
   params.declareControllable("enable"); // allows Control to enable/disable this type of object
   params.registerBase("AuxKernel");
+  params.registerSystemAttributeName("AuxKernel");
 
   if (typeid(AuxKernelTempl<ComputeValueType>).name() == typeid(VectorAuxKernel).name())
     params.registerBase("VectorAuxKernel");

--- a/framework/src/bcs/BoundaryCondition.C
+++ b/framework/src/bcs/BoundaryCondition.C
@@ -26,6 +26,7 @@ BoundaryCondition::validParams()
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
   params.addCoupledVar("displacements", "The displacements");
   params.registerBase("BoundaryCondition");
+  params.registerSystemAttributeName("BoundaryCondition");
 
   return params;
 }

--- a/framework/src/constraints/Constraint.C
+++ b/framework/src/constraints/Constraint.C
@@ -26,6 +26,7 @@ Constraint::validParams()
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.registerBase("Constraint");
+  params.registerSystemAttributeName("Constraint");
 
   return params;
 }

--- a/framework/src/dampers/Damper.C
+++ b/framework/src/dampers/Damper.C
@@ -18,6 +18,7 @@ Damper::validParams()
   InputParameters params = MooseObject::validParams();
   params.declareControllable("enable"); // allows Control to enable/disable this type of object
   params.registerBase("Damper");
+  params.registerSystemAttributeName("Damper");
   params.addParam<Real>("min_damping",
                         0.0,
                         "Minimum value of computed damping. Damping lower than "

--- a/framework/src/dgkernels/DGKernelBase.C
+++ b/framework/src/dgkernels/DGKernelBase.C
@@ -61,6 +61,7 @@ DGKernelBase::validParams()
   params.addParam<std::vector<BoundaryName>>(
       "exclude_boundary", "The internal side sets to be excluded from this kernel.");
   params.registerBase("DGKernel");
+  params.registerSystemAttributeName("DGKernel");
 
   return params;
 }

--- a/framework/src/dirackernels/DiracKernelBase.C
+++ b/framework/src/dirackernels/DiracKernelBase.C
@@ -51,6 +51,8 @@ DiracKernelBase::validParams()
 
   params.addParamNamesToGroup("use_displaced_mesh drop_duplicate_points", "Advanced");
   params.declareControllable("enable");
+  params.registerSystemAttributeName("DiracKernel");
+
   return params;
 }
 

--- a/framework/src/functions/PiecewiseTabularBase.C
+++ b/framework/src/functions/PiecewiseTabularBase.C
@@ -21,7 +21,7 @@ PiecewiseTabularBase::validParams()
   MooseEnum axis("x=0 y=1 z=2");
   params.addParam<MooseEnum>(
       "axis", axis, "The axis used (x, y, or z) if this is to be a function of position");
-  params.addParam<Real>("scale_factor", 1.0, "Scale factor to be applied to the ordinate values");
+  params.addParam<Real>("scale_factor", 1.0, "Scale factor to be applied to the output values");
   params.declareControllable("scale_factor");
 
   // Data from input file parameters

--- a/framework/src/interfacekernels/InterfaceKernelBase.C
+++ b/framework/src/interfacekernels/InterfaceKernelBase.C
@@ -35,6 +35,7 @@ InterfaceKernelBase::validParams()
   params.declareControllable("enable");
   params.addRequiredCoupledVar("neighbor_var", "The variable on the other side of the interface.");
   params.set<std::string>("_moose_base") = "InterfaceKernel";
+  params.registerSystemAttributeName("InterfaceKernel");
   params.addParam<std::vector<AuxVariableName>>(
       "save_in",
       {},

--- a/framework/src/interfaces/BlockRestrictable.C
+++ b/framework/src/interfaces/BlockRestrictable.C
@@ -222,6 +222,12 @@ BlockRestrictable::hasBlocks(const std::vector<SubdomainName> & names) const
 }
 
 bool
+BlockRestrictable::hasBlocks(const std::set<SubdomainName> & names) const
+{
+  return hasBlocks(_blk_mesh->getSubdomainIDs(names));
+}
+
+bool
 BlockRestrictable::hasBlocks(const SubdomainID id) const
 {
   if (_blk_ids.empty() || _blk_ids.find(Moose::ANY_BLOCK_ID) != _blk_ids.end())

--- a/framework/src/kernels/KernelBase.C
+++ b/framework/src/kernels/KernelBase.C
@@ -23,6 +23,7 @@ KernelBase::validParams()
   auto params = ResidualObject::validParams();
   params += BlockRestrictable::validParams();
   params += MaterialPropertyInterface::validParams();
+  params.registerSystemAttributeName("Kernel");
 
   params.addParam<std::vector<AuxVariableName>>(
       "save_in",

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -122,7 +122,7 @@ MaterialPropertyStorage::updateStatefulPropsForPRefinement(
   else
     n_qpoints = qrule_face.n_points();
 
-  getMaterialData(tid).resize(n_qpoints);
+  _material_data[tid].resize(n_qpoints);
 
   mooseAssert(elem.active(), "We should be doing p-refinement on active elements only");
   mooseAssert(elem.processor_id() == pid, "Prolongation should be occurring locally");
@@ -173,7 +173,7 @@ MaterialPropertyStorage::prolongStatefulProps(
   else
     n_qpoints = qrule_face.n_points();
 
-  getMaterialData(tid).resize(n_qpoints);
+  _material_data[tid].resize(n_qpoints);
 
   unsigned int n_children = elem.n_children();
 
@@ -452,7 +452,7 @@ MaterialPropertyStorage::swap(const THREAD_ID tid, const Elem & elem, unsigned i
 
   for (const auto state : stateIndexRange())
     shallowSwapData(_stateful_prop_id_to_prop_id,
-                    getMaterialData(tid).props(state),
+                    _material_data[tid].props(state),
                     // Would be nice to make this setProps()
                     initAndSetProps(&elem, side, state));
 }
@@ -465,7 +465,7 @@ MaterialPropertyStorage::swapBack(const THREAD_ID tid, const Elem & elem, unsign
   for (const auto state : stateIndexRange())
     shallowSwapDataBack(_stateful_prop_id_to_prop_id,
                         setProps(&elem, side, state),
-                        getMaterialData(tid).props(state));
+                        _material_data[tid].props(state));
 
   // Workaround for MOOSE difficulties in keeping materialless
   // elements (e.g. Lower D elements in Mortar code) materials
@@ -537,7 +537,7 @@ MaterialPropertyStorage::initProps(const THREAD_ID tid,
                                    unsigned int side,
                                    unsigned int n_qpoints)
 {
-  auto & material_data = getMaterialData(tid);
+  auto & material_data = _material_data[tid];
   material_data.resize(n_qpoints);
 
   auto & mat_props = initAndSetProps(elem, side, state);

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1736,6 +1736,12 @@ MooseMesh::getSubdomainIDs(const std::vector<SubdomainName> & subdomain_name) co
   return MooseMeshUtils::getSubdomainIDs(getMesh(), subdomain_name);
 }
 
+std::set<SubdomainID>
+MooseMesh::getSubdomainIDs(const std::set<SubdomainName> & subdomain_name) const
+{
+  return MooseMeshUtils::getSubdomainIDs(getMesh(), subdomain_name);
+}
+
 void
 MooseMesh::setSubdomainName(SubdomainID subdomain_id, const SubdomainName & name)
 {

--- a/framework/src/nodalkernels/NodalKernelBase.C
+++ b/framework/src/nodalkernels/NodalKernelBase.C
@@ -41,6 +41,7 @@ NodalKernelBase::validParams()
       "contributions to.  Everything about that variable must match everything "
       "about this variable (the type, what blocks it's on, etc.)");
   params.registerBase("NodalKernel");
+  params.registerSystemAttributeName("NodalKernel");
   params.addParamNamesToGroup("diag_save_in save_in", "Advanced");
   return params;
 }

--- a/framework/src/physics/DiffusionCG.C
+++ b/framework/src/physics/DiffusionCG.C
@@ -120,7 +120,7 @@ DiffusionCG::addFEKernels()
   }
 
   // Time derivative term
-  if (isTransient())
+  if (shouldCreateTimeDerivative(_var_name, _blocks, false))
   {
     const std::string kernel_type = _use_ad ? "ADTimeDerivative" : "TimeDerivative";
     InputParameters params = getFactory().getValidParams(kernel_type);

--- a/framework/src/physics/DiffusionCG.C
+++ b/framework/src/physics/DiffusionCG.C
@@ -220,14 +220,10 @@ void
 DiffusionCG::addSolverVariables()
 {
   // If the variable was added outside the Physics
-  if (variableExists(_var_name, /*error_if_aux*/ true))
+  if (!shouldCreateVariable(_var_name, _blocks, true))
   {
-    if (isParamSetByUser("variable_order"))
-      paramError("variable_order",
-                 "Cannot specify the variable order if variable " + _var_name +
-                     " is defined outside the Physics block");
-    else
-      return;
+    reportPotentiallyMissedParameters({"variable_order", "system_names"}, "MooseVariable");
+    return;
   }
 
   const std::string variable_type = "MooseVariable";

--- a/framework/src/physics/DiffusionFV.C
+++ b/framework/src/physics/DiffusionFV.C
@@ -181,16 +181,16 @@ DiffusionFV::addFVBCs()
 void
 DiffusionFV::addSolverVariables()
 {
-  if (variableExists(_var_name, true))
+  if (!shouldCreateVariable(_var_name, _blocks, true))
+  {
+    reportPotentiallyMissedParameters({"system_names"}, "MooseVariableFVReal");
     return;
+  }
 
   const std::string variable_type = "MooseVariableFVReal";
   InputParameters params = getFactory().getValidParams(variable_type);
   assignBlocks(params, _blocks);
   params.set<SolverSystemName>("solver_sys") = getSolverSystem(_var_name);
-
-  // TODO: Do we need to use a different variable name maybe?
-  // Or add API to extend block definition of a boundary
   getProblem().addVariable(variable_type, _var_name, params);
 }
 

--- a/framework/src/physics/DiffusionFV.C
+++ b/framework/src/physics/DiffusionFV.C
@@ -100,7 +100,7 @@ DiffusionFV::addFVKernels()
     getProblem().addFVKernel(kernel_type, prefix() + _var_name + "_source", params);
   }
   // Time derivative
-  if (isTransient())
+  if (shouldCreateTimeDerivative(_var_name, _blocks, false))
   {
     const std::string kernel_type = "FVTimeKernel";
     InputParameters params = getFactory().getValidParams(kernel_type);

--- a/framework/src/physics/DiffusionPhysicsBase.C
+++ b/framework/src/physics/DiffusionPhysicsBase.C
@@ -159,7 +159,8 @@ DiffusionPhysicsBase::addInitialConditions()
                   !parameters().hasDefault("initial_condition"),
               "Should not have a default");
   if (isParamValid("initial_condition") &&
-      shouldCreateIC(_var_name, remaining_blocks, /*ic is a default*/ false, true))
+      shouldCreateIC(
+          _var_name, remaining_blocks, /*ic is a default*/ false, /*error if defined*/ true))
   {
     params.set<VariableName>("variable") = _var_name;
     params.set<FunctionName>("function") = getParam<FunctionName>("initial_condition");

--- a/framework/src/physics/DiffusionPhysicsBase.C
+++ b/framework/src/physics/DiffusionPhysicsBase.C
@@ -158,7 +158,8 @@ DiffusionPhysicsBase::addInitialConditions()
   mooseAssert(parameters().isParamSetByUser("initial_condition") ||
                   !parameters().hasDefault("initial_condition"),
               "Should not have a default");
-  if (parameters().isParamSetByUser("initial_condition") && remaining_blocks.size())
+  if (isParamValid("initial_condition") &&
+      shouldCreateIC(_var_name, remaining_blocks, /*ic is a default*/ false, true))
   {
     params.set<VariableName>("variable") = _var_name;
     params.set<FunctionName>("function") = getParam<FunctionName>("initial_condition");

--- a/framework/src/physics/PhysicsBase.C
+++ b/framework/src/physics/PhysicsBase.C
@@ -593,10 +593,10 @@ PhysicsBase::shouldCreateIC(const VariableName & var_name,
   const std::set<SubdomainName> blocks_set(blocks.begin(), blocks.end());
   if (isVariableFV(var_name))
     has_all_blocks = _problem->getFVInitialConditionWarehouse().hasObjectsForVariableAndBlocks(
-        var_name, blocks_set, blocks_covered);
+        var_name, blocks_set, blocks_covered, 0);
   else
     has_all_blocks = _problem->getInitialConditionWarehouse().hasObjectsForVariableAndBlocks(
-        var_name, blocks_set, blocks_covered);
+        var_name, blocks_set, blocks_covered, 0);
 
   const bool has_some_blocks = !blocks_covered.empty();
   if (!has_some_blocks)
@@ -667,7 +667,14 @@ PhysicsBase::shouldCreateTimeDerivative(const VariableName & var_name,
     if (time_kernels.size())
     {
       some_block_covered = true;
-      blocks_covered.insert(block);
+      if (block == "ANY_BLOCK_ID")
+      {
+        for (const auto & time_kernel : time_kernels)
+          if (const auto blk = dynamic_cast<BlockRestrictable *>(time_kernel))
+            blocks_covered.insert(blk->blocks().begin(), blk->blocks().end());
+      }
+      else
+        blocks_covered.insert(block);
     }
     else
       all_blocks_covered = false;

--- a/framework/src/physics/PhysicsBase.C
+++ b/framework/src/physics/PhysicsBase.C
@@ -580,7 +580,7 @@ PhysicsBase::shouldCreateIC(const VariableName & var_name,
                             const bool error_if_already_defined) const
 {
   // Handle recover
-  if (ic_is_default_ic && (_app.isRecovering() || _app.isRecovering()))
+  if (ic_is_default_ic && (_app.isRestarting() || _app.isRecovering()))
     return false;
   // do not set initial conditions if we are loading fields from the mesh file
   if (getParam<bool>("initialize_variables_from_mesh_file"))

--- a/framework/src/physics/PhysicsBase.C
+++ b/framework/src/physics/PhysicsBase.C
@@ -529,3 +529,27 @@ PhysicsBase::addPetscPairsToPetscOptions(
         *this,
         po);
 }
+
+bool
+PhysicsBase::shouldCreateVariable(const VariableName & var_name,
+                                  const std::vector<SubdomainName> & blocks,
+                                  const bool error_if_aux,
+                                  const bool error_if_missing_subdomains,
+                                  const bool add_missing_subdomains)
+{
+  mooseAssert(!error_if_missing_subdomains || !add_missing_subdomains,
+              "These two options are not compatible");
+  if (!variableExists(var_name, error_if_aux))
+    return true;
+  // check block restriction
+  auto & var = _problem->getVariable(0, var_name);
+  if (var.hasBlocks(blocks))
+    return false;
+  else if (!error_if_missing_subdomains)
+    mooseError("Variable '" + var_name + "' already exists with subdomain restriction '" +
+               Moose::stringify(var.blocks()) + "' which does not include the subdomains '" +
+               Moose::stringify(blocks) + "', required for this Physics.");
+  // Looks like the missing subdomains were not an issue since we set 'error_if_missing..' to false
+  else
+    return true;
+}

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3736,7 +3736,7 @@ FEProblemBase::getMaterial(std::string name,
 }
 
 MaterialData &
-FEProblemBase::getMaterialData(Moose::MaterialDataType type, const THREAD_ID tid)
+FEProblemBase::getMaterialData(Moose::MaterialDataType type, const THREAD_ID tid) const
 {
   switch (type)
   {

--- a/framework/src/scalarkernels/ScalarKernelBase.C
+++ b/framework/src/scalarkernels/ScalarKernelBase.C
@@ -29,6 +29,7 @@ ScalarKernelBase::validParams()
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
   params.registerBase("ScalarKernel");
+  params.registerSystemAttributeName("ScalarKernel");
 
   return params;
 }

--- a/framework/src/splits/Split.C
+++ b/framework/src/splits/Split.C
@@ -69,6 +69,7 @@ Split::validParams()
                                             "PETSc option values for the FieldSplit solver");
 
   params.registerBase("Split");
+  params.registerSystemAttributeName("Split");
   return params;
 }
 

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -455,6 +455,8 @@ NonlinearSystemBase::addKernel(const std::string & kernel_name,
         _factory.create<KernelBase>(kernel_name, name, parameters, tid);
     _kernels.addObject(kernel, tid);
     postAddResidualObject(*kernel);
+    // Add to theWarehouse, a centralized storage for all moose objects
+    _fe_problem.theWarehouse().add(kernel);
   }
 
   if (parameters.get<std::vector<AuxVariableName>>("save_in").size() > 0)
@@ -474,6 +476,8 @@ NonlinearSystemBase::addHDGKernel(const std::string & kernel_name,
     auto kernel = _factory.create<HDGKernel>(kernel_name, name, parameters, tid);
     _kernels.addObject(kernel, tid);
     _hybridized_kernels.addObject(kernel, tid);
+    // Add to theWarehouse, a centralized storage for all moose objects
+    _fe_problem.theWarehouse().add(kernel);
     postAddResidualObject(*kernel);
   }
 }
@@ -489,6 +493,8 @@ NonlinearSystemBase::addNodalKernel(const std::string & kernel_name,
     std::shared_ptr<NodalKernelBase> kernel =
         _factory.create<NodalKernelBase>(kernel_name, name, parameters, tid);
     _nodal_kernels.addObject(kernel, tid);
+    // Add to theWarehouse, a centralized storage for all moose objects
+    _fe_problem.theWarehouse().add(kernel);
     postAddResidualObject(*kernel);
   }
 
@@ -506,6 +512,8 @@ NonlinearSystemBase::addScalarKernel(const std::string & kernel_name,
   std::shared_ptr<ScalarKernelBase> kernel =
       _factory.create<ScalarKernelBase>(kernel_name, name, parameters);
   postAddResidualObject(*kernel);
+  // Add to theWarehouse, a centralized storage for all moose objects
+  _fe_problem.theWarehouse().add(kernel);
   _scalar_kernels.addObject(kernel);
 }
 
@@ -542,6 +550,8 @@ NonlinearSystemBase::addBoundaryCondition(const std::string & bc_name,
                  "'.");
 
     _nodal_bcs.addObject(nbc);
+    // Add to theWarehouse, a centralized storage for all moose objects
+    _fe_problem.theWarehouse().add(nbc);
     _vars[tid].addBoundaryVars(boundary_ids, nbc->getCoupledVars());
 
     if (parameters.get<std::vector<AuxVariableName>>("save_in").size() > 0)
@@ -563,6 +573,8 @@ NonlinearSystemBase::addBoundaryCondition(const std::string & bc_name,
   else if (ibc)
   {
     _integrated_bcs.addObject(ibc, tid);
+    // Add to theWarehouse, a centralized storage for all moose objects
+    _fe_problem.theWarehouse().add(ibc);
     _vars[tid].addBoundaryVars(boundary_ids, ibc->getCoupledVars());
 
     if (parameters.get<std::vector<AuxVariableName>>("save_in").size() > 0)
@@ -617,6 +629,8 @@ NonlinearSystemBase::addDiracKernel(const std::string & kernel_name,
         _factory.create<DiracKernelBase>(kernel_name, name, parameters, tid);
     postAddResidualObject(*kernel);
     _dirac_kernels.addObject(kernel, tid);
+    // Add to theWarehouse, a centralized storage for all moose objects
+    _fe_problem.theWarehouse().add(kernel);
   }
 }
 
@@ -629,6 +643,8 @@ NonlinearSystemBase::addDGKernel(std::string dg_kernel_name,
   {
     auto dg_kernel = _factory.create<DGKernelBase>(dg_kernel_name, name, parameters, tid);
     _dg_kernels.addObject(dg_kernel, tid);
+    // Add to theWarehouse, a centralized storage for all moose objects
+    _fe_problem.theWarehouse().add(dg_kernel);
     postAddResidualObject(*dg_kernel);
   }
 
@@ -656,6 +672,8 @@ NonlinearSystemBase::addInterfaceKernel(std::string interface_kernel_name,
     _vars[tid].addBoundaryVar(boundary_ids, ik_var);
 
     _interface_kernels.addObject(interface_kernel, tid);
+    // Add to theWarehouse, a centralized storage for all moose objects
+    _fe_problem.theWarehouse().add(interface_kernel);
     _vars[tid].addBoundaryVars(boundary_ids, interface_kernel->getCoupledVars());
   }
 }
@@ -695,6 +713,8 @@ NonlinearSystemBase::addSplit(const std::string & split_name,
 {
   std::shared_ptr<Split> split = _factory.create<Split>(split_name, name, parameters);
   _splits.addObject(split);
+  // Add to theWarehouse, a centralized storage for all moose objects
+  _fe_problem.theWarehouse().add(split);
 }
 
 std::shared_ptr<Split>

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -183,13 +183,22 @@ getBoundaryIDSet(const MeshBase & mesh,
 }
 
 std::vector<subdomain_id_type>
-getSubdomainIDs(const MeshBase & mesh, const std::vector<SubdomainName> & subdomain_name)
+getSubdomainIDs(const MeshBase & mesh, const std::vector<SubdomainName> & subdomain_names)
 {
-  std::vector<SubdomainID> ids(subdomain_name.size());
+  std::vector<SubdomainID> ids(subdomain_names.size());
 
-  for (const auto i : index_range(subdomain_name))
-    ids[i] = MooseMeshUtils::getSubdomainID(subdomain_name[i], mesh);
+  for (const auto i : index_range(subdomain_names))
+    ids[i] = MooseMeshUtils::getSubdomainID(subdomain_names[i], mesh);
 
+  return ids;
+}
+
+std::set<subdomain_id_type>
+getSubdomainIDs(const MeshBase & mesh, const std::set<SubdomainName> & subdomain_names)
+{
+  std::set<SubdomainID> ids;
+  for (const auto & name : subdomain_names)
+    ids.insert(MooseMeshUtils::getSubdomainID(name, mesh));
   return ids;
 }
 

--- a/modules/heat_transfer/src/physics/HeatConductionCG.C
+++ b/modules/heat_transfer/src/physics/HeatConductionCG.C
@@ -90,7 +90,7 @@ HeatConductionCG::addFEKernels()
       paramError("heat_source_functor", "Unsupported functor type.");
     getProblem().addKernel(kernel_type, prefix() + _temperature_name + "_source_functor", params);
   }
-  if (shouldCreateTimeDerivative(_temperature_name, _blocks, false))
+  if (shouldCreateTimeDerivative(_temperature_name, _blocks, /*error if already defined*/ false))
   {
     const std::string kernel_type =
         _use_ad ? "ADHeatConductionTimeDerivative" : "SpecificHeatConductionTimeDerivative";
@@ -231,7 +231,7 @@ HeatConductionCG::addFEBCs()
 void
 HeatConductionCG::addSolverVariables()
 {
-  if (!shouldCreateVariable(_temperature_name, _blocks, true))
+  if (!shouldCreateVariable(_temperature_name, _blocks, /*error if aux*/ true))
   {
     reportPotentiallyMissedParameters({"system_names"}, "MooseVariable");
     return;

--- a/modules/heat_transfer/src/physics/HeatConductionCG.C
+++ b/modules/heat_transfer/src/physics/HeatConductionCG.C
@@ -90,7 +90,7 @@ HeatConductionCG::addFEKernels()
       paramError("heat_source_functor", "Unsupported functor type.");
     getProblem().addKernel(kernel_type, prefix() + _temperature_name + "_source_functor", params);
   }
-  if (shouldCreateTimeDerivative( _temperature_name, _blocks, false))
+  if (shouldCreateTimeDerivative(_temperature_name, _blocks, false))
   {
     const std::string kernel_type =
         _use_ad ? "ADHeatConductionTimeDerivative" : "SpecificHeatConductionTimeDerivative";
@@ -231,8 +231,11 @@ HeatConductionCG::addFEBCs()
 void
 HeatConductionCG::addSolverVariables()
 {
-  if (variableExists(_temperature_name, /*error_if_aux=*/true))
+  if (!shouldCreateVariable(_temperature_name, _blocks, true))
+  {
+    reportPotentiallyMissedParameters({"system_names"}, "MooseVariable");
     return;
+  }
 
   const std::string variable_type = "MooseVariable";
   // defaults to linear lagrange FE family

--- a/modules/heat_transfer/src/physics/HeatConductionCG.C
+++ b/modules/heat_transfer/src/physics/HeatConductionCG.C
@@ -90,7 +90,7 @@ HeatConductionCG::addFEKernels()
       paramError("heat_source_functor", "Unsupported functor type.");
     getProblem().addKernel(kernel_type, prefix() + _temperature_name + "_source_functor", params);
   }
-  if (isTransient())
+  if (shouldCreateTimeDerivative( _temperature_name, _blocks, false))
   {
     const std::string kernel_type =
         _use_ad ? "ADHeatConductionTimeDerivative" : "SpecificHeatConductionTimeDerivative";

--- a/modules/heat_transfer/src/physics/HeatConductionFV.C
+++ b/modules/heat_transfer/src/physics/HeatConductionFV.C
@@ -238,8 +238,12 @@ HeatConductionFV::addFVBCs()
 void
 HeatConductionFV::addSolverVariables()
 {
-  if (shouldCreateVariable(_temperature_name, _blocks, true, true, true))
+  if (!shouldCreateVariable(_temperature_name, _blocks, true))
+  {
+    reportPotentiallyMissedParameters({"system_names", "temperature_scaling"},
+                                      "MooseVariableFVReal");
     return;
+  }
 
   const std::string variable_type = "MooseVariableFVReal";
   InputParameters params = getFactory().getValidParams(variable_type);

--- a/modules/heat_transfer/src/physics/HeatConductionFV.C
+++ b/modules/heat_transfer/src/physics/HeatConductionFV.C
@@ -104,7 +104,7 @@ HeatConductionFV::addFVKernels()
                  "Unsupported functor type. Consider using 'heat_source_var'.");
     getProblem().addFVKernel(kernel_type, prefix() + _temperature_name + "_source_functor", params);
   }
-  if (shouldCreateTimeDerivative(_temperature_name, _blocks, false))
+  if (shouldCreateTimeDerivative(_temperature_name, _blocks, /*error if already defined*/ false))
   {
     const bool use_functors =
         isParamValid("density_functor") || isParamValid("specific_heat_functor");
@@ -238,7 +238,7 @@ HeatConductionFV::addFVBCs()
 void
 HeatConductionFV::addSolverVariables()
 {
-  if (!shouldCreateVariable(_temperature_name, _blocks, true))
+  if (!shouldCreateVariable(_temperature_name, _blocks, /*error if aux*/ true))
   {
     reportPotentiallyMissedParameters({"system_names", "temperature_scaling"},
                                       "MooseVariableFVReal");

--- a/modules/heat_transfer/src/physics/HeatConductionPhysicsBase.C
+++ b/modules/heat_transfer/src/physics/HeatConductionPhysicsBase.C
@@ -99,7 +99,7 @@ HeatConductionPhysicsBase::addInitialConditions()
   // Always obey the user, but dont set a hidden default when restarting
   if (shouldCreateIC(_temperature_name,
                      _blocks,
-                     /*whether IC is a default*/ isParamSetByUser("initial_temperature"),
+                     /*whether IC is a default*/ !isParamSetByUser("initial_temperature"),
                      /*error if already an IC*/ isParamSetByUser("initial_temperature")))
   {
     InputParameters params = getFactory().getValidParams("FunctionIC");

--- a/modules/heat_transfer/src/physics/HeatConductionPhysicsBase.C
+++ b/modules/heat_transfer/src/physics/HeatConductionPhysicsBase.C
@@ -97,7 +97,10 @@ HeatConductionPhysicsBase::addInitialConditions()
     return;
 
   // Always obey the user, but dont set a hidden default when restarting
-  if (!_app.isRestarting() || parameters().isParamSetByUser("initial_temperature"))
+  if (shouldCreateIC(_temperature_name,
+                     _blocks,
+                     /*whether IC is a default*/ isParamSetByUser("initial_temperature"),
+                     /*error if already an IC*/ isParamSetByUser("initial_temperature")))
   {
     InputParameters params = getFactory().getValidParams("FunctionIC");
     assignBlocks(params, _blocks);

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysics.C
@@ -168,7 +168,7 @@ WCNSFVFlowPhysics::addSolverVariables()
   // Velocities
   for (const auto d : make_range(dimension()))
   {
-    if (!shouldCreateVariable(_velocity_names[d], _blocks, true))
+    if (!shouldCreateVariable(_velocity_names[d], _blocks, /*error if aux*/ true))
       reportPotentiallyMissedParameters({"system_names",
                                          "momentum_scaling",
                                          "momentum_face_interpolation",
@@ -203,7 +203,7 @@ WCNSFVFlowPhysics::addSolverVariables()
       getParam<MooseEnum>("porosity_interface_pressure_treatment") != "automatic";
   const auto pressure_type =
       using_bernouilli_pressure_var ? "BernoulliPressureVariable" : "INSFVPressureVariable";
-  if (!shouldCreateVariable(_pressure_name, _blocks, true))
+  if (!shouldCreateVariable(_pressure_name, _blocks, /*error if aux*/ true))
   {
     std::vector<std::string> potentially_missed = {"system_names",
                                                    "mass_scaling",
@@ -278,7 +278,7 @@ WCNSFVFlowPhysics::addFVKernels()
 
   // Mass equation: time derivative
   if (_compressibility == "weakly-compressible" &&
-      shouldCreateTimeDerivative(_pressure_name, _blocks, false))
+      shouldCreateTimeDerivative(_pressure_name, _blocks, /*error if already defined*/ false))
     addMassTimeKernels();
 
   // Mass equation: divergence of momentum
@@ -411,7 +411,7 @@ WCNSFVFlowPhysics::addMomentumTimeKernels()
     params.set<NonlinearVariableName>("variable") = _velocity_names[d];
     params.set<MooseEnum>("momentum_component") = NS::directions[d];
 
-    if (shouldCreateTimeDerivative(_velocity_names[d], _blocks, false))
+    if (shouldCreateTimeDerivative(_velocity_names[d], _blocks, /*error if already defined*/ false))
       getProblem().addFVKernel(kernel_type, kernel_name + _velocity_names[d], params);
   }
 }

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysics.C
@@ -264,7 +264,8 @@ WCNSFVFlowPhysics::addFVKernels()
     return;
 
   // Mass equation: time derivative
-  if (_compressibility == "weakly-compressible" && isTransient())
+  if (_compressibility == "weakly-compressible" &&
+      shouldCreateTimeDerivative(_pressure_name, _blocks, false))
     addMassTimeKernels();
 
   // Mass equation: divergence of momentum
@@ -397,7 +398,8 @@ WCNSFVFlowPhysics::addMomentumTimeKernels()
     params.set<NonlinearVariableName>("variable") = _velocity_names[d];
     params.set<MooseEnum>("momentum_component") = NS::directions[d];
 
-    getProblem().addFVKernel(kernel_type, kernel_name + _velocity_names[d], params);
+    if (shouldCreateTimeDerivative(_velocity_names[d], _blocks, false))
+      getProblem().addFVKernel(kernel_type, kernel_name + _velocity_names[d], params);
   }
 }
 

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysics.C
@@ -168,9 +168,12 @@ WCNSFVFlowPhysics::addSolverVariables()
   // Velocities
   for (const auto d : make_range(dimension()))
   {
-    if (variableExists(_velocity_names[d], true))
-      checkBlockRestrictionIdentical(_velocity_names[d],
-                                     getProblem().getVariable(0, _velocity_names[d]).blocks());
+    if (!shouldCreateVariable(_velocity_names[d], _blocks, true))
+      reportPotentiallyMissedParameters({"system_names",
+                                         "momentum_scaling",
+                                         "momentum_face_interpolation",
+                                         "momentum_two_term_bc_expansion"},
+                                        "INSFVVelocityVariable");
     else if (_define_variables)
     {
       std::string variable_type = "INSFVVelocityVariable";
@@ -185,11 +188,8 @@ WCNSFVFlowPhysics::addSolverVariables()
       params.set<bool>("two_term_boundary_expansion") =
           getParam<bool>("momentum_two_term_bc_expansion");
 
-      for (const auto d : make_range(dimension()))
-      {
-        params.set<SolverSystemName>("solver_sys") = getSolverSystem(_velocity_names[d]);
-        getProblem().addVariable(variable_type, _velocity_names[d], params);
-      }
+      params.set<SolverSystemName>("solver_sys") = getSolverSystem(_velocity_names[d]);
+      getProblem().addVariable(variable_type, _velocity_names[d], params);
     }
     else
       paramError("velocity_variable",
@@ -198,14 +198,26 @@ WCNSFVFlowPhysics::addSolverVariables()
   }
 
   // Pressure
-  if (variableExists(_pressure_name, true))
-    checkBlockRestrictionIdentical(_pressure_name,
-                                   getProblem().getVariable(0, _pressure_name).blocks());
+  const bool using_pinsfv_pressure_var =
+      _porous_medium_treatment &&
+      getParam<MooseEnum>("porosity_interface_pressure_treatment") != "automatic";
+  if (!shouldCreateVariable(_pressure_name, _blocks, true))
+  {
+    std::vector<std::string> potentially_missed = {"system_names",
+                                                   "mass_scaling",
+                                                   "pressure_face_interpolation",
+                                                   "pressure_two_term_bc_expansion"};
+    if (using_pinsfv_pressure_var)
+    {
+      std::vector<std::string> other_missed = {"pressure_allow_expansion_on_bernoulli_faces",
+                                               "pressure_drop_sidesets",
+                                               "pressure_drop_form_factors"};
+      potentially_missed.insert(potentially_missed.end(), other_missed.begin(), other_missed.end());
+    }
+    reportPotentiallyMissedParameters(potentially_missed, "INSFVPressureVariable");
+  }
   else if (_define_variables)
   {
-    const bool using_pinsfv_pressure_var =
-        _porous_medium_treatment &&
-        getParam<MooseEnum>("porosity_interface_pressure_treatment") != "automatic";
     const auto pressure_type =
         using_pinsfv_pressure_var ? "BernoulliPressureVariable" : "INSFVPressureVariable";
 
@@ -249,11 +261,13 @@ WCNSFVFlowPhysics::addSolverVariables()
     lm_params.set<MooseEnum>("family") = "scalar";
     lm_params.set<MooseEnum>("order") = "first";
 
-    if (type == "point-value" || type == "average")
+    if ((type == "point-value" || type == "average") && !_problem->hasScalarVariable("lambda"))
     {
       lm_params.set<SolverSystemName>("solver_sys") = getSolverSystem("lambda");
       getProblem().addVariable("MooseVariableScalar", "lambda", lm_params);
     }
+    else
+      reportPotentiallyMissedParameters({"system_names"}, "MooseVariableScalar");
   }
 }
 

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
@@ -332,14 +332,14 @@ WCNSFVFlowPhysicsBase::addInitialConditions()
 
     if (shouldCreateIC(_velocity_names[d],
                        _blocks,
-                       /*whether IC is a default*/ isParamSetByUser("initial_velocity"),
+                       /*whether IC is a default*/ !isParamSetByUser("initial_velocity"),
                        /*error if already an IC*/ isParamSetByUser("initial_velocity")))
       getProblem().addInitialCondition("FunctionIC", prefix() + _velocity_names[d] + "_ic", params);
   }
 
   if (shouldCreateIC(_pressure_name,
                      _blocks,
-                     /*whether IC is a default*/ isParamSetByUser("initial_pressure"),
+                     /*whether IC is a default*/ !isParamSetByUser("initial_pressure"),
                      /*error if already an IC*/ isParamSetByUser("initial_pressure")))
   {
     params.set<VariableName>("variable") = _pressure_name;

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
@@ -321,27 +321,26 @@ WCNSFVFlowPhysicsBase::addInitialConditions()
                "The number of velocity components in the " + type() + " initial condition is not " +
                    std::to_string(dimension()) + " or 3!");
 
-  // do not set initial conditions if we load from file
-  if (getParam<bool>("initialize_variables_from_mesh_file"))
-    return;
-  // do not set initial conditions if we are not defining variables
-  if (!_define_variables)
-    return;
-
   InputParameters params = getFactory().getValidParams("FunctionIC");
   assignBlocks(params, _blocks);
   auto vvalue = getParam<std::vector<FunctionName>>("initial_velocity");
 
-  if (!_app.isRestarting() || parameters().isParamSetByUser("initial_velocity"))
-    for (const auto d : make_range(dimension()))
-    {
-      params.set<VariableName>("variable") = _velocity_names[d];
-      params.set<FunctionName>("function") = vvalue[d];
+  for (const auto d : make_range(dimension()))
+  {
+    params.set<VariableName>("variable") = _velocity_names[d];
+    params.set<FunctionName>("function") = vvalue[d];
 
+    if (shouldCreateIC(_velocity_names[d],
+                       _blocks,
+                       /*whether IC is a default*/ isParamSetByUser("initial_velocity"),
+                       /*error if already an IC*/ isParamSetByUser("initial_velocity")))
       getProblem().addInitialCondition("FunctionIC", prefix() + _velocity_names[d] + "_ic", params);
-    }
+  }
 
-  if (!_app.isRestarting() || parameters().isParamSetByUser("initial_pressure"))
+  if (shouldCreateIC(_pressure_name,
+                     _blocks,
+                     /*whether IC is a default*/ isParamSetByUser("initial_pressure"),
+                     /*error if already an IC*/ isParamSetByUser("initial_pressure")))
   {
     params.set<VariableName>("variable") = _pressure_name;
     params.set<FunctionName>("function") = getParam<FunctionName>("initial_pressure");

--- a/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysics.C
@@ -40,10 +40,12 @@ WCNSFVFluidHeatTransferPhysics::addSolverVariables()
     return;
 
   // Dont add if the user already defined the variable
-  if (variableExists(_fluid_temperature_name,
-                     /*error_if_aux=*/true))
-    checkBlockRestrictionIdentical(_fluid_temperature_name,
-                                   getProblem().getVariable(0, _fluid_temperature_name).blocks());
+  if (!shouldCreateVariable(_fluid_temperature_name, _blocks, true))
+    reportPotentiallyMissedParameters({"system_names",
+                                       "energy_scaling",
+                                       "energy_face_interpolation",
+                                       "energy_two_term_bc_expansion"},
+                                      "INSFVEnergyVariable");
   else if (_define_variables)
   {
     auto params = getFactory().getValidParams("INSFVEnergyVariable");

--- a/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysics.C
@@ -40,7 +40,7 @@ WCNSFVFluidHeatTransferPhysics::addSolverVariables()
     return;
 
   // Dont add if the user already defined the variable
-  if (!shouldCreateVariable(_fluid_temperature_name, _blocks, true))
+  if (!shouldCreateVariable(_fluid_temperature_name, _blocks, /*error if aux*/ true))
     reportPotentiallyMissedParameters({"system_names",
                                        "energy_scaling",
                                        "energy_face_interpolation",

--- a/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysicsBase.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysicsBase.C
@@ -125,7 +125,8 @@ WCNSFVFluidHeatTransferPhysicsBase::addFVKernels()
   if (!_has_energy_equation)
     return;
 
-  if (shouldCreateTimeDerivative(_fluid_temperature_name, _blocks, false))
+  if (shouldCreateTimeDerivative(
+          _fluid_temperature_name, _blocks, /*error if already defined*/ false))
     addEnergyTimeKernels();
 
   addEnergyAdvectionKernels();

--- a/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysicsBase.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysicsBase.C
@@ -125,7 +125,7 @@ WCNSFVFluidHeatTransferPhysicsBase::addFVKernels()
   if (!_has_energy_equation)
     return;
 
-  if (isTransient())
+  if (shouldCreateTimeDerivative(_fluid_temperature_name, _blocks, false))
     addEnergyTimeKernels();
 
   addEnergyAdvectionKernels();
@@ -213,9 +213,6 @@ WCNSFVFluidHeatTransferPhysicsBase::addInitialConditions()
         "initial_temperature",
         "T_fluid is defined externally of WCNSFVFluidHeatTransferPhysicsBase, so should the inital "
         "condition");
-  // do not set initial conditions if we load from file
-  if (getParam<bool>("initialize_variables_from_mesh_file"))
-    return;
   // do not set initial conditions if we are not defining variables
   if (!_define_variables)
     return;
@@ -223,15 +220,21 @@ WCNSFVFluidHeatTransferPhysicsBase::addInitialConditions()
   InputParameters params = getFactory().getValidParams("FunctionIC");
   assignBlocks(params, _blocks);
 
-  if (!_app.isRestarting() || parameters().isParamSetByUser("initial_temperature"))
+  if (shouldCreateIC(_fluid_temperature_name,
+                     _blocks,
+                     /*whether IC is a default*/ isParamSetByUser("initial_temperature"),
+                     /*error if already an IC*/ isParamSetByUser("initial_temperature")))
   {
     params.set<VariableName>("variable") = _fluid_temperature_name;
     params.set<FunctionName>("function") = getParam<FunctionName>("initial_temperature");
 
     getProblem().addInitialCondition("FunctionIC", _fluid_temperature_name + "_ic", params);
   }
-  if ((!_app.isRestarting() && parameters().isParamValid("initial_enthalpy")) ||
-      parameters().isParamSetByUser("initial_enthalpy"))
+  if (parameters().isParamValid("initial_enthalpy") &&
+      shouldCreateIC(_fluid_enthalpy_name,
+                     _blocks,
+                     /*whether IC is a default*/ false,
+                     /*error if already an IC*/ true))
   {
     params.set<VariableName>("variable") = _fluid_enthalpy_name;
     params.set<FunctionName>("function") = getParam<FunctionName>("initial_enthalpy");

--- a/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysicsBase.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysicsBase.C
@@ -222,7 +222,7 @@ WCNSFVFluidHeatTransferPhysicsBase::addInitialConditions()
 
   if (shouldCreateIC(_fluid_temperature_name,
                      _blocks,
-                     /*whether IC is a default*/ isParamSetByUser("initial_temperature"),
+                     /*whether IC is a default*/ !isParamSetByUser("initial_temperature"),
                      /*error if already an IC*/ isParamSetByUser("initial_temperature")))
   {
     params.set<VariableName>("variable") = _fluid_temperature_name;

--- a/modules/navier_stokes/src/physics/WCNSFVScalarTransportPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVScalarTransportPhysics.C
@@ -75,7 +75,8 @@ WCNSFVScalarTransportPhysics::addScalarTimeKernels()
     assignBlocks(params, _blocks);
     params.set<NonlinearVariableName>("variable") = vname;
 
-    getProblem().addFVKernel(kernel_type, prefix() + "ins_" + vname + "_time", params);
+    if (shouldCreateTimeDerivative(vname, _blocks, false))
+      getProblem().addFVKernel(kernel_type, prefix() + "ins_" + vname + "_time", params);
   }
 }
 

--- a/modules/navier_stokes/src/physics/WCNSFVScalarTransportPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVScalarTransportPhysics.C
@@ -48,11 +48,10 @@ WCNSFVScalarTransportPhysics::addSolverVariables()
   for (const auto name_i : index_range(_passive_scalar_names))
   {
     // Dont add if the user already defined the variable
-    if (variableExists(_passive_scalar_names[name_i], /*error_if_aux=*/true))
+    if (!shouldCreateVariable(_passive_scalar_names[name_i], _blocks, true))
     {
-      checkBlockRestrictionIdentical(
-          _passive_scalar_names[name_i],
-          getProblem().getVariable(0, _passive_scalar_names[name_i]).blocks());
+      reportPotentiallyMissedParameters({"system_names", "passive_scalar_scaling"},
+                                        "INSFVScalarFieldVariable");
       continue;
     }
 

--- a/modules/navier_stokes/src/physics/WCNSFVScalarTransportPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVScalarTransportPhysics.C
@@ -48,7 +48,7 @@ WCNSFVScalarTransportPhysics::addSolverVariables()
   for (const auto name_i : index_range(_passive_scalar_names))
   {
     // Dont add if the user already defined the variable
-    if (!shouldCreateVariable(_passive_scalar_names[name_i], _blocks, true))
+    if (!shouldCreateVariable(_passive_scalar_names[name_i], _blocks, /*error if aux*/ true))
     {
       reportPotentiallyMissedParameters({"system_names", "passive_scalar_scaling"},
                                         "INSFVScalarFieldVariable");
@@ -74,7 +74,7 @@ WCNSFVScalarTransportPhysics::addScalarTimeKernels()
     assignBlocks(params, _blocks);
     params.set<NonlinearVariableName>("variable") = vname;
 
-    if (shouldCreateTimeDerivative(vname, _blocks, false))
+    if (shouldCreateTimeDerivative(vname, _blocks, /* error if already defined */ false))
       getProblem().addFVKernel(kernel_type, prefix() + "ins_" + vname + "_time", params);
   }
 }

--- a/modules/navier_stokes/src/physics/WCNSFVTurbulencePhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVTurbulencePhysics.C
@@ -846,7 +846,7 @@ WCNSFVTurbulencePhysics::addInitialConditions()
     // Always obey the user specification of an initial condition
     if (shouldCreateIC(_turbulent_viscosity_name,
                        _blocks,
-                       /*whether IC is a default*/ isParamSetByUser("initial_mu_t"),
+                       /*whether IC is a default*/ !isParamSetByUser("initial_mu_t"),
                        /*error if already an IC*/ isParamSetByUser("initial_mu_t")))
       getProblem().addInitialCondition(ic_type, prefix() + "initial_mu_turb", params);
   }
@@ -856,16 +856,16 @@ WCNSFVTurbulencePhysics::addInitialConditions()
 
   params.set<VariableName>("variable") = _tke_name;
   params.set<FunctionName>("function") = getParam<FunctionName>("initial_tke");
-  if (shouldCreateIC(_turbulent_viscosity_name,
+  if (shouldCreateIC(_tke_name,
                      _blocks,
-                     /*whether IC is a default*/ isParamSetByUser("initial_tke"),
+                     /*whether IC is a default*/ !isParamSetByUser("initial_tke"),
                      /*error if already an IC*/ isParamSetByUser("initial_tke")))
     getProblem().addInitialCondition(ic_type, prefix() + "initial_tke", params);
   params.set<VariableName>("variable") = _tked_name;
   params.set<FunctionName>("function") = getParam<FunctionName>("initial_tked");
-  if (shouldCreateIC(_turbulent_viscosity_name,
+  if (shouldCreateIC(_tked_name,
                      _blocks,
-                     /*whether IC is a default*/ isParamSetByUser("initial_tked"),
+                     /*whether IC is a default*/ !isParamSetByUser("initial_tked"),
                      /*error if already an IC*/ isParamSetByUser("initial_tked")))
     getProblem().addInitialCondition(ic_type, prefix() + "initial_tked", params);
 }

--- a/modules/navier_stokes/src/physics/WCNSFVTurbulencePhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVTurbulencePhysics.C
@@ -338,7 +338,7 @@ WCNSFVTurbulencePhysics::addSolverVariables()
   {
     // Dont add if the user already defined the variable
     // Add turbulent kinetic energy variable
-    if (!shouldCreateVariable(_tke_name, _blocks, true))
+    if (!shouldCreateVariable(_tke_name, _blocks, /*error if aux*/ true))
       reportPotentiallyMissedParameters(
           {"system_names", "tke_scaling", "tke_face_interpolation", "tke_two_term_bc_expansion"},
           "INSFVEnergyVariable");
@@ -359,7 +359,7 @@ WCNSFVTurbulencePhysics::addSolverVariables()
                      ") supplied to the WCNSFVTurbulencePhysics does not exist!");
 
     // Add turbulent kinetic energy dissipation variable
-    if (!shouldCreateVariable(_tked_name, _blocks, true))
+    if (!shouldCreateVariable(_tked_name, _blocks, /*error if aux*/ true))
       reportPotentiallyMissedParameters(
           {"system_names", "tked_scaling", "tked_face_interpolation", "tked_two_term_bc_expansion"},
           "INSFVEnergyVariable");
@@ -391,7 +391,7 @@ WCNSFVTurbulencePhysics::addAuxiliaryVariables()
     if (isParamValid("mixing_length_two_term_bc_expansion"))
       params.set<bool>("two_term_boundary_expansion") =
           getParam<bool>("mixing_length_two_term_bc_expansion");
-    if (!shouldCreateVariable(_tke_name, _blocks, false))
+    if (!shouldCreateVariable(_tke_name, _blocks, /*error if aux*/ false))
       reportPotentiallyMissedParameters({"mixing_length_two_term_bc_expansion"},
                                         "MooseVariableFVReal");
     else
@@ -404,7 +404,7 @@ WCNSFVTurbulencePhysics::addAuxiliaryVariables()
     if (isParamValid("turbulent_viscosity_two_term_bc_expansion"))
       params.set<bool>("two_term_boundary_expansion") =
           getParam<bool>("turbulent_viscosity_two_term_bc_expansion");
-    if (!shouldCreateVariable(_turbulent_viscosity_name, _blocks, false))
+    if (!shouldCreateVariable(_turbulent_viscosity_name, _blocks, /*error if aux*/ false))
       reportPotentiallyMissedParameters({"turbulent_viscosity_two_term_bc_expansion"},
                                         "MooseVariableFVReal");
     else
@@ -414,7 +414,7 @@ WCNSFVTurbulencePhysics::addAuxiliaryVariables()
   {
     auto params = getFactory().getValidParams("MooseVariableFVReal");
     assignBlocks(params, _blocks);
-    if (shouldCreateVariable(NS::k_t, _blocks, false))
+    if (shouldCreateVariable(NS::k_t, _blocks, /*error if aux*/ false))
       getProblem().addAuxVariable("MooseVariableFVReal", NS::k_t, params);
   }
 }
@@ -611,10 +611,10 @@ WCNSFVTurbulencePhysics::addKEpsilonTimeDerivatives()
   assignBlocks(params, _blocks);
 
   params.set<NonlinearVariableName>("variable") = _tke_name;
-  if (shouldCreateTimeDerivative(_tke_name, _blocks, false))
+  if (shouldCreateTimeDerivative(_tke_name, _blocks, /*error if already defined*/ false))
     getProblem().addFVKernel(kernel_type, prefix() + "tke_time", params);
   params.set<NonlinearVariableName>("variable") = _tked_name;
-  if (shouldCreateTimeDerivative(_tked_name, _blocks, false))
+  if (shouldCreateTimeDerivative(_tked_name, _blocks, /*error if already defined*/ false))
     getProblem().addFVKernel(kernel_type, prefix() + "tked_time", params);
 }
 

--- a/modules/navier_stokes/src/physics/WCNSLinearFVFlowPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSLinearFVFlowPhysics.C
@@ -110,9 +110,8 @@ WCNSLinearFVFlowPhysics::addSolverVariables()
   // Velocities
   for (const auto d : make_range(dimension()))
   {
-    if (variableExists(_velocity_names[d], true))
-      checkBlockRestrictionIdentical(_velocity_names[d],
-                                     getProblem().getVariable(0, _velocity_names[d]).blocks());
+    if (!shouldCreateVariable(_velocity_names[d], _blocks, true))
+      reportPotentiallyMissedParameters({"system_names"}, "MooseLinearVariableFVReal");
     else if (_define_variables)
     {
       std::string variable_type = "MooseLinearVariableFVReal";
@@ -130,9 +129,8 @@ WCNSLinearFVFlowPhysics::addSolverVariables()
   }
 
   // Pressure
-  if (variableExists(_pressure_name, true))
-    checkBlockRestrictionIdentical(_pressure_name,
-                                   getProblem().getVariable(0, _pressure_name).blocks());
+  if (!shouldCreateVariable(_pressure_name, _blocks, true))
+    reportPotentiallyMissedParameters({"system_names"}, "MooseLinearVariableFVReal");
   else if (_define_variables)
   {
     const auto pressure_type = "MooseLinearVariableFVReal";

--- a/modules/navier_stokes/src/physics/WCNSLinearFVFlowPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSLinearFVFlowPhysics.C
@@ -218,7 +218,8 @@ WCNSLinearFVFlowPhysics::addMomentumTimeKernels()
   for (const auto d : make_range(dimension()))
   {
     params.set<LinearVariableName>("variable") = _velocity_names[d];
-    getProblem().addLinearFVKernel(kernel_type, kernel_name + "_" + NS::directions[d], params);
+    if (shouldCreateTimeDerivative(_velocity_names[d], _blocks, false))
+      getProblem().addLinearFVKernel(kernel_type, kernel_name + "_" + NS::directions[d], params);
   }
 }
 

--- a/modules/navier_stokes/src/physics/WCNSLinearFVFlowPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSLinearFVFlowPhysics.C
@@ -110,7 +110,7 @@ WCNSLinearFVFlowPhysics::addSolverVariables()
   // Velocities
   for (const auto d : make_range(dimension()))
   {
-    if (!shouldCreateVariable(_velocity_names[d], _blocks, true))
+    if (!shouldCreateVariable(_velocity_names[d], _blocks, /*error if aux*/ true))
       reportPotentiallyMissedParameters({"system_names"}, "MooseLinearVariableFVReal");
     else if (_define_variables)
     {
@@ -129,7 +129,7 @@ WCNSLinearFVFlowPhysics::addSolverVariables()
   }
 
   // Pressure
-  if (!shouldCreateVariable(_pressure_name, _blocks, true))
+  if (!shouldCreateVariable(_pressure_name, _blocks, /*error if aux*/ true))
     reportPotentiallyMissedParameters({"system_names"}, "MooseLinearVariableFVReal");
   else if (_define_variables)
   {
@@ -216,7 +216,7 @@ WCNSLinearFVFlowPhysics::addMomentumTimeKernels()
   for (const auto d : make_range(dimension()))
   {
     params.set<LinearVariableName>("variable") = _velocity_names[d];
-    if (shouldCreateTimeDerivative(_velocity_names[d], _blocks, false))
+    if (shouldCreateTimeDerivative(_velocity_names[d], _blocks, /*error if already defined*/ false))
       getProblem().addLinearFVKernel(kernel_type, kernel_name + "_" + NS::directions[d], params);
   }
 }

--- a/modules/navier_stokes/src/physics/WCNSLinearFVFluidHeatTransferPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSLinearFVFluidHeatTransferPhysics.C
@@ -62,7 +62,7 @@ WCNSLinearFVFluidHeatTransferPhysics::addSolverVariables()
   const auto variable_name = _solve_for_enthalpy ? _fluid_enthalpy_name : _fluid_temperature_name;
 
   // Dont add if the user already defined the variable
-  if (!shouldCreateVariable(variable_name, _blocks, true))
+  if (!shouldCreateVariable(variable_name, _blocks, /*error if aux*/ true))
     reportPotentiallyMissedParameters({"system_names"}, "MooseLinearVariableFVReal");
   else if (_define_variables)
   {

--- a/modules/navier_stokes/src/physics/WCNSLinearFVFluidHeatTransferPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSLinearFVFluidHeatTransferPhysics.C
@@ -62,10 +62,8 @@ WCNSLinearFVFluidHeatTransferPhysics::addSolverVariables()
   const auto variable_name = _solve_for_enthalpy ? _fluid_enthalpy_name : _fluid_temperature_name;
 
   // Dont add if the user already defined the variable
-  if (variableExists(variable_name,
-                     /*error_if_aux=*/true))
-    checkBlockRestrictionIdentical(variable_name,
-                                   getProblem().getVariable(0, variable_name).blocks());
+  if (!shouldCreateVariable(variable_name, _blocks, true))
+    reportPotentiallyMissedParameters({"system_names"}, "MooseLinearVariableFVReal");
   else if (_define_variables)
   {
     const auto var_type = "MooseLinearVariableFVReal";

--- a/modules/navier_stokes/src/physics/WCNSLinearFVScalarTransportPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSLinearFVScalarTransportPhysics.C
@@ -52,11 +52,10 @@ WCNSLinearFVScalarTransportPhysics::addSolverVariables()
   for (const auto name_i : index_range(_passive_scalar_names))
   {
     // Dont add if the user already defined the variable
-    if (variableExists(_passive_scalar_names[name_i], /*error_if_aux=*/true))
+    if (!shouldCreateVariable(_passive_scalar_names[name_i], _blocks, true))
     {
-      checkBlockRestrictionIdentical(
-          _passive_scalar_names[name_i],
-          getProblem().getVariable(0, _passive_scalar_names[name_i]).blocks());
+      reportPotentiallyMissedParameters({"system_names", "passive_scalar_scaling"},
+                                        "MooseLinearVariableFVReal");
       continue;
     }
 

--- a/modules/navier_stokes/src/physics/WCNSLinearFVScalarTransportPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSLinearFVScalarTransportPhysics.C
@@ -52,7 +52,7 @@ WCNSLinearFVScalarTransportPhysics::addSolverVariables()
   for (const auto name_i : index_range(_passive_scalar_names))
   {
     // Dont add if the user already defined the variable
-    if (!shouldCreateVariable(_passive_scalar_names[name_i], _blocks, true))
+    if (!shouldCreateVariable(_passive_scalar_names[name_i], _blocks, /*error if aux*/ true))
     {
       reportPotentiallyMissedParameters({"system_names", "passive_scalar_scaling"},
                                         "MooseLinearVariableFVReal");
@@ -78,7 +78,7 @@ WCNSLinearFVScalarTransportPhysics::addScalarTimeKernels()
   for (const auto & vname : _passive_scalar_names)
   {
     params.set<LinearVariableName>("variable") = vname;
-    if (shouldCreateTimeDerivative(vname, _blocks, false))
+    if (shouldCreateTimeDerivative(vname, _blocks, /*error if already defined */ false))
       getProblem().addLinearFVKernel(kernel_type, prefix() + "ins_" + vname + "_time", params);
   }
 }

--- a/modules/navier_stokes/src/physics/WCNSLinearFVScalarTransportPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSLinearFVScalarTransportPhysics.C
@@ -79,7 +79,8 @@ WCNSLinearFVScalarTransportPhysics::addScalarTimeKernels()
   for (const auto & vname : _passive_scalar_names)
   {
     params.set<LinearVariableName>("variable") = vname;
-    getProblem().addLinearFVKernel(kernel_type, prefix() + "ins_" + vname + "_time", params);
+    if (shouldCreateTimeDerivative(vname, _blocks, false))
+      getProblem().addLinearFVKernel(kernel_type, prefix() + "ins_" + vname + "_time", params);
   }
 }
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/action/restart-block-restriction/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/action/restart-block-restriction/tests
@@ -9,16 +9,15 @@
                   "on a mesh which doesn't have a default block."
     recover = false
   []
+  # note that we are working to enable this, where the block restriction of the variable could be extended
+  # OR the action could live on a smaller domain than the variable
   [restricted-data-error]
     type = 'RunException'
     input = ns-restart-transient.i
     requirement = 'The system shall throw an error if the block-restrictions of the external variable and the action are different.'
-    cli_args = "Modules/NavierStokesFV/block='1 2' "
+    cli_args = "Modules/NavierStokesFV/block='1' Variables/pressure/block=1 "
                "Problem/allow_initial_conditions_with_restart=true"
-    expect_err = "(The suppled variable \(vel_x\) does not have the same block-restriction as the "
-                 "NSFVAction. The restriction of the variable is: \(ANY_BLOCK_ID\) while the "
-                 "restriction for the action is: \(1, 2\)|Physics 'NavierStokesFV' and object "
-                 "'vel_x' have different block restrictions.)"
+    expect_err = "Block restriction of interpolator user object 'ins_rhie_chow_interpolator' \(1\) doesn't match the block restriction of variable 'vel_x'"
     prereq = restricted-data-save
     recover = false
   []

--- a/modules/navier_stokes/test/tests/finite_volume/physics/restart/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/physics/restart/tests
@@ -39,6 +39,7 @@
       type = CSVDiff
       input = 2d_channel_scalar_turbulence_init.i
       csvdiff = 'restart_user_ics.csv'
+      prereq = 'restart/default'
       cli_args = "Physics/NavierStokes/Flow/all_flow/initial_velocity='0.1 1e-6 0'
                   Physics/NavierStokes/Flow/all_flow/initial_pressure=2e5
                   Physics/NavierStokes/FluidHeatTransfer/all_energy/initial_temperature='355'

--- a/modules/scalar_transport/src/physics/MultiSpeciesDiffusionCG.C
+++ b/modules/scalar_transport/src/physics/MultiSpeciesDiffusionCG.C
@@ -117,7 +117,7 @@ MultiSpeciesDiffusionCG::addFEKernels()
     }
 
     // Time derivative term
-    if (isTransient())
+    if (shouldCreateTimeDerivative(var_name, _blocks, false))
     {
       const std::string kernel_type = _use_ad ? "ADTimeDerivative" : "TimeDerivative";
       InputParameters params = getFactory().getValidParams(kernel_type);

--- a/modules/scalar_transport/src/physics/MultiSpeciesDiffusionPhysicsBase.C
+++ b/modules/scalar_transport/src/physics/MultiSpeciesDiffusionPhysicsBase.C
@@ -169,14 +169,20 @@ MultiSpeciesDiffusionPhysicsBase::addInitialConditions()
 
   // always obey the user specification of initial conditions
   // There are no default values, so no need to consider whether the app is restarting
-  if (isParamValid("initial_conditions_species"))
-    for (const auto i : index_range(_species_names))
+  for (const auto i : index_range(_species_names))
+  {
+    const auto & var_name = _species_names[i];
+    if (isParamValid("initial_conditions_species") &&
+        shouldCreateIC(var_name,
+                       _blocks,
+                       /*whether IC is a default*/ false,
+                       /*error if already an IC*/ true))
     {
-      const auto & var_name = _species_names[i];
       params.set<VariableName>("variable") = var_name;
       params.set<FunctionName>("function") =
           getParam<std::vector<FunctionName>>("initial_conditions_species")[i];
 
       getProblem().addInitialCondition("FunctionIC", prefix() + var_name + "_ic", params);
     }
+  }
 }

--- a/modules/scalar_transport/test/tests/physics/restart/tests
+++ b/modules/scalar_transport/test/tests/physics/restart/tests
@@ -14,6 +14,7 @@
     [restart_with_user_ics]
       type = CSVDiff
       input = test_cg.i
+      prereq = 'restart/user_ics'
       csvdiff = 'restart_user_ics.csv'
       cli_args = "Physics/MultiSpeciesDiffusion/ContinuousGalerkin/diff/initial_conditions_species='2 3 4'
                   Problem/restart_file_base=user_ics_cp/LATEST Problem/allow_initial_conditions_with_restart=true
@@ -23,6 +24,7 @@
     [restart_from_file]
       type = CSVDiff
       input = test_cg.i
+      prereq = 'restart/restart_with_user_ics'
       csvdiff = 'from_file.csv'
       cli_args = "Mesh/active='fmg_restart' Outputs/file_base=from_file"
       detail = 'when performing manual restart from a mesh file, ignoring the default initial condition.'

--- a/test/tests/physics/block_restriction/diffusion_cg.i
+++ b/test/tests/physics/block_restriction/diffusion_cg.i
@@ -1,0 +1,79 @@
+[Mesh]
+  [cmg]
+    type = CartesianMeshGenerator
+    dim = 2
+    dx = '1 2'
+    dy = '2 1'
+    ix = '2 3'
+    iy = '3 2'
+    subdomain_id = '0 1
+                    1 0'
+  []
+  [split_boundaries]
+    type = BreakBoundaryOnSubdomainGenerator
+    input = cmg
+  []
+  allow_renumbering = false
+[]
+
+# We need to add these items before the Physics to trigger the
+# Physics behavior of erroring / skipping the objects if incompatible/compatible objects
+# already exist
+[Variables]
+  [u]
+  []
+[]
+
+[ICs]
+  [extern]
+    type = FunctionIC
+    function = 0
+    variable = u
+  []
+[]
+
+[Kernels]
+  active = ''
+  [extern]
+    type = TimeDerivative
+    variable = u
+  []
+[]
+
+[Physics]
+  [Diffusion]
+    [ContinuousGalerkin]
+      [diff]
+        source_functor = 2
+        diffusivity_matprop = '1'
+
+        # Test all the ways of setting the boundary conditions
+        neumann_boundaries = 'left_to_0 right_to_0 top_to_0 bottom_to_0'
+        boundary_fluxes = '1 1 1 1'
+        dirichlet_boundaries = 'left_to_1 right_to_1 top_to_1 bottom_to_1'
+        boundary_values = '2 2 2 2'
+      []
+    []
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  num_steps = 10
+  # Output the setup
+  verbose = true
+[]
+
+# Form output for testing
+[VectorPostprocessors]
+  [sample]
+    type = NodalValueSampler
+    variable = 'u'
+    sort_by = 'id'
+  []
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/test/tests/physics/block_restriction/gold/diffusion_cg_out_sample_0010.csv
+++ b/test/tests/physics/block_restriction/gold/diffusion_cg_out_sample_0010.csv
@@ -1,0 +1,1 @@
+../../gold/diffusion_cg_out_sample_0010.csv

--- a/test/tests/physics/block_restriction/tests
+++ b/test/tests/physics/block_restriction/tests
@@ -1,0 +1,64 @@
+[Tests]
+  issues = '#30533'
+  design = 'Physics/index.md'
+  [variable_already_exists]
+    type = CSVDiff
+    input = 'diffusion_cg.i'
+    cli_args = "Variables/u/block='1 0' Physics/Diffusion/ContinuousGalerkin/diff/block='0 1'"
+    csvdiff = 'diffusion_cg_out_sample_0010.csv'
+    requirement = 'The system shall be able to define the variables outside the Physics shorthand syntax.'
+  []
+  # DiffusionPhysics does not have a default IC, so specifying an IC to it would need to be obeyed
+  # and would always cause an error if there is another IC
+  [time_derivative_already_exists]
+    type = CSVDiff
+    input = 'diffusion_cg.i'
+    cli_args = "Kernels/active='extern'"
+    csvdiff = 'diffusion_cg_out_sample_0010.csv'
+    requirement = 'The system shall be able to define the time derivative outside the Physics shorthand syntax.'
+  []
+
+  [errors]
+    requirement = 'The system shall return an error if'
+    [variable_block_res_conflicting]
+     type = RunException
+      input = 'diffusion_cg.i'
+      cli_args = "Variables/u/block='1'"
+      expect_err = "Variable 'u' already exists with subdomain restriction '1' which does not include the subdomains 'ANY_BLOCK_ID', required for this Physics."
+      detail = 'a variable is defined both in the Physics shorthand syntax and the regular syntax but with different block restrictions,'
+    []
+    [variable_parameter_ignored]
+      type = RunException
+      input = 'diffusion_cg.i'
+      cli_args = "Variables/u/block='0 1' Physics/Diffusion/ContinuousGalerkin/diff/blocks='0 1' Physics/Diffusion/ContinuousGalerkin/diff/variable_order=SECOND"
+      expect_err = "User-specified values for parameters 'variable_order' for object of type 'MooseVariable' were not used because the corresponding object was not created by this Physics"
+      detail = 'parameters for the variable are specified to the Physics shorthand syntax but then ignored due to a pre-existing variable definition,'
+    []
+    [ic_conflicting]
+      type = RunException
+      input = 'diffusion_cg.i'
+      cli_args = 'Physics/Diffusion/ContinuousGalerkin/diff/initial_condition=2'
+      expect_err = "ICs for variable 'u' have already been defined for blocks 'ANY_BLOCK_ID'."
+      detail = 'a variable initial condition is defined both in the Physics shorthand syntax and the regular syntax for the same variable on the same blocks,'
+    []
+    [td_defined_on_not_enough_blocks]
+      type = RunException
+      input = 'diffusion_cg.i'
+      cli_args = "Kernels/active='extern' Kernels/extern/block=1"
+      expect_err = 'There is a partial overlap between the subdomains covered by pre-existing time derivatives, defined on blocks: 1'
+      detail = 'a time derivative is specified with a block restriction in the regular syntax, while the Physics shorthand syntax seeks to define it without a block restriction.'
+    []
+  []
+  [warnings]
+    requirement = 'The system shall emit a warning if'
+    [variable_parameter_ignored]
+      type = RunApp
+      input = 'diffusion_cg.i'
+      cli_args = "Variables/u/block='0 1' Physics/Diffusion/ContinuousGalerkin/diff/variable_order=SECOND"
+      expect_out = "User-specifed values for parameters 'variable_order' for object of type 'MooseVariable' were not used because the corresponding object was not created by this Physics"
+      allow_unused = true
+      allow_warnings = true
+      detail = 'parameters for the variable are specified to the Physics shorthand syntax but then ignored due to a pre-existing variable definition.'
+    []
+  []
+[]

--- a/test/tests/physics/block_restriction/tests
+++ b/test/tests/physics/block_restriction/tests
@@ -6,7 +6,7 @@
     input = 'diffusion_cg.i'
     cli_args = "Variables/u/block='1 0' Physics/Diffusion/ContinuousGalerkin/diff/block='0 1'"
     csvdiff = 'diffusion_cg_out_sample_0010.csv'
-    requirement = 'The system shall be able to define the variables outside the Physics shorthand syntax.'
+    requirement = 'The system shall be able to define the variables outside shorthand physics syntax.'
   []
   # DiffusionPhysics does not have a default IC, so specifying an IC to it would need to be obeyed
   # and would always cause an error if there is another IC
@@ -15,7 +15,7 @@
     input = 'diffusion_cg.i'
     cli_args = "Kernels/active='extern'"
     csvdiff = 'diffusion_cg_out_sample_0010.csv'
-    requirement = 'The system shall be able to define the time derivative outside the Physics shorthand syntax.'
+    requirement = 'The system shall be able to define the time derivative outside the shorthand physics syntax.'
   []
 
   [errors]
@@ -25,28 +25,28 @@
       input = 'diffusion_cg.i'
       cli_args = "Variables/u/block='1'"
       expect_err = "Variable 'u' already exists with subdomain restriction '1' which does not include the subdomains 'ANY_BLOCK_ID', required for this Physics."
-      detail = 'a variable is defined both in the Physics shorthand syntax and the regular syntax but with different block restrictions,'
+      detail = 'a variable is defined both in the shorthand physics syntax and the regular syntax but with different block restrictions,'
     []
     [variable_parameter_ignored]
       type = RunException
       input = 'diffusion_cg.i'
       cli_args = "Variables/u/block='0 1' Physics/Diffusion/ContinuousGalerkin/diff/blocks='0 1' Physics/Diffusion/ContinuousGalerkin/diff/variable_order=SECOND"
       expect_err = "User-specified values for parameters 'variable_order' for object of type 'MooseVariable' were not used because the corresponding object was not created by this Physics"
-      detail = 'parameters for the variable are specified to the Physics shorthand syntax but then ignored due to a pre-existing variable definition,'
+      detail = 'parameters for the variable are specified to the shorthand physics syntax but then ignored due to a pre-existing variable definition,'
     []
     [ic_conflicting]
       type = RunException
       input = 'diffusion_cg.i'
       cli_args = 'Physics/Diffusion/ContinuousGalerkin/diff/initial_condition=2'
       expect_err = "ICs for variable 'u' have already been defined for blocks 'ANY_BLOCK_ID'."
-      detail = 'a variable initial condition is defined both in the Physics shorthand syntax and the regular syntax for the same variable on the same blocks,'
+      detail = 'a variable initial condition is defined both in the shorthand physics syntax and the regular syntax for the same variable on the same blocks,'
     []
     [td_defined_on_not_enough_blocks]
       type = RunException
       input = 'diffusion_cg.i'
       cli_args = "Kernels/active='extern' Kernels/extern/block=1"
-      expect_err = 'There is a partial overlap between the subdomains covered by pre-existing time derivatives, defined on blocks: 1'
-      detail = 'a time derivative is specified with a block restriction in the regular syntax, while the Physics shorthand syntax seeks to define it without a block restriction.'
+      expect_err = 'There is a partial overlap between the subdomains covered by pre-existing time derivative kernel\(s\), defined on blocks \(ids\): \(unnamed\) \(1\)'
+      detail = 'a time derivative is specified with a block restriction in the regular syntax, while the shorthand physics syntax seeks to define it without a block restriction.'
     []
   []
   [warnings]
@@ -58,7 +58,7 @@
       expect_out = "User-specifed values for parameters 'variable_order' for object of type 'MooseVariable' were not used because the corresponding object was not created by this Physics"
       allow_unused = true
       allow_warnings = true
-      detail = 'parameters for the variable are specified to the Physics shorthand syntax but then ignored due to a pre-existing variable definition.'
+      detail = 'parameters for the variable are specified to the shorthand physics syntax but then ignored due to a pre-existing variable definition.'
     []
   []
 []


### PR DESCRIPTION
refs #30533

we can imagine the same thing for time integrators / ...

I added a bunch of utilities

I might split off some commits into separate PRs here