### PR TITLE
Prevent building the FP apps with only the relevant FP submodule

### DIFF
--- a/modules/fluid_properties/fluid_properties.mk
+++ b/modules/fluid_properties/fluid_properties.mk
@@ -27,7 +27,7 @@ GEN_REVISION_save := ${GEN_REVISION}
 
 # AIR
 ifneq ($(AIR_FP_CONTENT),)
-ifneq ($(BUILDING_FP_APP), yes)
+ifneq ($(BUILDING_FP_APP), air)
   AIR_DIR            := $(AIR_FP_DIR)
 	APPLICATION_DIR    := $(AIR_FP_DIR)
 	APPLICATION_NAME   := air
@@ -41,7 +41,7 @@ endif
 
 # CARBON_DIOXIDE
 ifneq ($(CARBON_DIOXIDE_FP_CONTENT),)
-ifneq ($(BUILDING_FP_APP), yes)
+ifneq ($(BUILDING_FP_APP), carbon_dioxide)
   CARBON_DIOXIDE_DIR := $(CARBON_DIOXIDE_FP_DIR)
 	APPLICATION_DIR    := $(CARBON_DIOXIDE_FP_DIR)
 	APPLICATION_NAME   := carbon_dioxide
@@ -55,7 +55,7 @@ endif
 
 # NITROGEN
 ifneq ($(NITROGEN_FP_CONTENT),)
-ifneq ($(BUILDING_FP_APP), yes)
+ifneq ($(BUILDING_FP_APP), nitrogen)
 	NITROGEN_DIR       := $(NITROGEN_FP_DIR)
 	APPLICATION_DIR    := $(NITROGEN_FP_DIR)
 	APPLICATION_NAME   := nitrogen
@@ -69,7 +69,7 @@ endif
 
 # HELIUM
 ifneq ($(HELIUM_FP_CONTENT),)
-ifneq ($(BUILDING_FP_APP), yes)
+ifneq ($(BUILDING_FP_APP), helium)
 	HELIUM_DIR         := $(HELIUM_FP_DIR)
 	APPLICATION_DIR    := $(HELIUM_FP_DIR)
 	APPLICATION_NAME   := helium
@@ -83,7 +83,7 @@ endif
 
 # POTASSIUM
 ifneq ($(POTASSIUM_FP_CONTENT),)
-ifneq ($(BUILDING_FP_APP), yes)
+ifneq ($(BUILDING_FP_APP), potassium)
 	POTASSIUM_DIR      := $(POTASSIUM_FP_DIR)
 	APPLICATION_DIR    := $(POTASSIUM_FP_DIR)
 	APPLICATION_NAME   := potassium
@@ -97,7 +97,7 @@ endif
 
 # SODIUM
 ifneq ($(SODIUM_FP_CONTENT),)
-ifneq ($(BUILDING_FP_APP), yes)
+ifneq ($(BUILDING_FP_APP), sodium)
 	SODIUM_DIR         := $(SODIUM_FP_DIR)
 	APPLICATION_DIR    := $(SODIUM_FP_DIR)
 	APPLICATION_NAME   := sodium


### PR DESCRIPTION
see idaholab/moose#27027
refs #27097

needs to be merged with
https://github.inl.gov/ncrc/carbon_dioxide/pull/176
https://github.inl.gov/ncrc/nitrogen/pull/209
https://github.inl.gov/ncrc/helium/pull/205
https://github.inl.gov/ncrc/sodium/pull/226
https://github.inl.gov/ncrc/potassium/pull/191
https://github.inl.gov/ncrc/air/pull/171