### PR TITLE
Honor `FindValueOnLine` error logic, improve errors

### DIFF
--- a/framework/src/postprocessors/FindValueOnLine.C
+++ b/framework/src/postprocessors/FindValueOnLine.C
@@ -79,6 +79,14 @@ FindValueOnLine::execute()
   Real s_right = 1.0;
   Real right = getValueAtPoint(_end_point);
 
+  // Helper for erroring; won't error if error_if_not_found=false
+  const auto error = [this](auto &&... message)
+  {
+    if (_error_if_not_found)
+      mooseError(std::scientific, std::setprecision(4), message...);
+    _position = _default_value;
+  };
+
   /**
    * Here we determine the direction of the solution. i.e. the left might be the high value
    * while the right might be the low value.
@@ -87,35 +95,19 @@ FindValueOnLine::execute()
   // Initial bounds check
   if ((left_to_right && _target < left) || (!left_to_right && _target < right))
   {
-    if (_error_if_not_found)
-    {
-      mooseError("Target value \"",
-                 _target,
-                 "\" is less than the minimum sampled value \"",
-                 std::min(left, right),
-                 "\"");
-    }
-    else
-    {
-      _position = _default_value;
-      return;
-    }
+    error("Target value ",
+          _target,
+          " is less than the minimum sampled value ",
+          std::min(left, right));
+    return;
   }
   if ((left_to_right && _target > right) || (!left_to_right && _target > left))
   {
-    if (_error_if_not_found)
-    {
-      mooseError("Target value \"",
-                 _target,
-                 "\" is greater than the maximum sampled value \"",
-                 std::max(left, right),
-                 "\"");
-    }
-    else
-    {
-      _position = _default_value;
-      return;
-    }
+    error("Target value ",
+          _target,
+          " is greater than the maximum sampled value ",
+          std::max(left, right));
+    return;
   }
 
   bool found_it = false;
@@ -147,12 +139,15 @@ FindValueOnLine::execute()
 
   // Return error if target value (within tol) was not found within depth bisections
   if (!found_it)
-    mooseError("Target value \"",
-               std::setprecision(10),
-               _target,
-               "\" not found on line within tolerance, last sample: ",
-               value,
-               ".");
+  {
+    error("Target value ",
+          _target,
+          " not found on line within tolerance.\nLast sample: ",
+          value,
+          ", difference from target: ",
+          std::abs(_target - value));
+    return;
+  }
 
   _position = s * _length;
 }


### PR DESCRIPTION
Closes #30559

If a value isn't found within tolerance, this honors `error_if_not_found` and doesn't error if set to false. In addition, improves the errors to actually use scientific notation and reports the difference in the out of tolerance case.

For example (when out of tolerance):

```
*** ERROR ***
/data/harblh/projects/moose/test/tests/postprocessors/find_value_on_line/findvalueonline.i:45.3:
The following error occurred in the Postprocessor 'pos' of type FindValueOnLine.

Target value 5.0000e-01 not found on line within tolerance.
Last sample: 5.0000e-01, difference from target: 1.9073e-06
```

FYI @gambka @ghezc