### PR TITLE
Only get status if a value was found

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -204,9 +204,9 @@ class Tester(MooseObject, OutputInterface):
     # in the previous results
     def previousTesterStatus(self, options):
         test_dir_entry, test_entry = self.getResultsEntry(options, False, True)
-        status_entry = test_entry['status']
         status = (self.test_status.createStatus(), '', '')
         if test_entry:
+            status_entry = test_entry['status']
             status = (self.test_status.createStatus(str(status_entry['status'])),
                       str(status_entry['status_message']),
                       status_entry['caveats'])


### PR DESCRIPTION
refs #30522, fixes issue added in https://github.com/idaholab/moose/pull/30523

We only want to get the status entry if a test entry was found.
