### PR TITLE
Change more references from mooseframework.org to mooseframework.inl.gov

### DIFF
--- a/framework/contrib/capabilities/capabilities.C
+++ b/framework/contrib/capabilities/capabilities.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/include/base/Capabilities.h
+++ b/framework/include/base/Capabilities.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/include/kernels/ADKernelCurl.h
+++ b/framework/include/kernels/ADKernelCurl.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/include/kernels/GenericKernelCurl.h
+++ b/framework/include/kernels/GenericKernelCurl.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/include/kernels/KernelCurl.h
+++ b/framework/include/kernels/KernelCurl.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/include/libtorch/materials/TorchScriptMaterial.h
+++ b/framework/include/libtorch/materials/TorchScriptMaterial.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/include/libtorch/userobjects/TorchScriptUserObject.h
+++ b/framework/include/libtorch/userobjects/TorchScriptUserObject.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/include/linearfvbcs/LinearFVAdvectionDiffusionFunctorNeumannBC.h
+++ b/framework/include/linearfvbcs/LinearFVAdvectionDiffusionFunctorNeumannBC.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/include/mfem/mesh/MFEMMesh.h
+++ b/framework/include/mfem/mesh/MFEMMesh.h
@@ -1,7 +1,7 @@
 #ifdef MFEM_ENABLED
 
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/include/utils/CapabilityUtils.h
+++ b/framework/include/utils/CapabilityUtils.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/src/base/Capabilities.C
+++ b/framework/src/base/Capabilities.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/src/kernels/ADKernelCurl.C
+++ b/framework/src/kernels/ADKernelCurl.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/src/kernels/KernelCurl.C
+++ b/framework/src/kernels/KernelCurl.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/src/libtorch/materials/TorchScriptMaterial.C
+++ b/framework/src/libtorch/materials/TorchScriptMaterial.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/src/libtorch/userobjects/TorchScriptUserObject.C
+++ b/framework/src/libtorch/userobjects/TorchScriptUserObject.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/src/linearfvbcs/LinearFVAdvectionDiffusionFunctorNeumannBC.C
+++ b/framework/src/linearfvbcs/LinearFVAdvectionDiffusionFunctorNeumannBC.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/src/mfem/mesh/MFEMMesh.C
+++ b/framework/src/mfem/mesh/MFEMMesh.C
@@ -1,7 +1,7 @@
 #ifdef MFEM_ENABLED
 
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/framework/src/utils/CapabilityUtils.C
+++ b/framework/src/utils/CapabilityUtils.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/fluid_properties/include/fluidproperties/LeadLithiumFluidProperties.h
+++ b/modules/fluid_properties/include/fluidproperties/LeadLithiumFluidProperties.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/fluid_properties/src/fluidproperties/LeadLithiumFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/LeadLithiumFluidProperties.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/fluid_properties/unit/include/LeadLithiumFluidPropertiesTest.h
+++ b/modules/fluid_properties/unit/include/LeadLithiumFluidPropertiesTest.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/fluid_properties/unit/src/LeadLithiumFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/LeadLithiumFluidPropertiesTest.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/navier_stokes/include/functormaterials/DittusBoelterFunctorMaterial.h
+++ b/modules/navier_stokes/include/functormaterials/DittusBoelterFunctorMaterial.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/navier_stokes/src/functormaterials/DittusBoelterFunctorMaterial.C
+++ b/modules/navier_stokes/src/functormaterials/DittusBoelterFunctorMaterial.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/solid_mechanics/include/neml2/models/LAROMANCE6DInterpolation.h
+++ b/modules/solid_mechanics/include/neml2/models/LAROMANCE6DInterpolation.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/solid_mechanics/include/neml2/models/LibtorchModel.h
+++ b/modules/solid_mechanics/include/neml2/models/LibtorchModel.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/solid_mechanics/src/neml2/models/LAROMANCE6DInterpolation.C
+++ b/modules/solid_mechanics/src/neml2/models/LAROMANCE6DInterpolation.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/solid_mechanics/src/neml2/models/LibtorchModel.C
+++ b/modules/solid_mechanics/src/neml2/models/LibtorchModel.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/solid_mechanics/test/tests/neml2/laromance/models/create_6D_dummy_grid_json.py
+++ b/modules/solid_mechanics/test/tests/neml2/laromance/models/create_6D_dummy_grid_json.py
@@ -1,5 +1,5 @@
 # * This file is part of the MOOSE framework
-# * https://www.mooseframework.org
+# * https://mooseframework.inl.gov
 # *
 # * All rights reserved, see COPYRIGHT for full restrictions
 # * https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/auxkernels/FlowModelGasMixAux.h
+++ b/modules/thermal_hydraulics/include/auxkernels/FlowModelGasMixAux.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/base/FlowModel1PhaseBase.h
+++ b/modules/thermal_hydraulics/include/base/FlowModel1PhaseBase.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/base/FlowModelGasMix.h
+++ b/modules/thermal_hydraulics/include/base/FlowModelGasMix.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/base/THMIndicesGasMix.h
+++ b/modules/thermal_hydraulics/include/base/THMIndicesGasMix.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/base/THMNames.h
+++ b/modules/thermal_hydraulics/include/base/THMNames.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/bcs/BoundaryFluxGasMixBC.h
+++ b/modules/thermal_hydraulics/include/bcs/BoundaryFluxGasMixBC.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/components/FlowBoundary1PhaseBase.h
+++ b/modules/thermal_hydraulics/include/components/FlowBoundary1PhaseBase.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/components/FlowBoundaryGasMix.h
+++ b/modules/thermal_hydraulics/include/components/FlowBoundaryGasMix.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/components/FlowChannel1PhaseBase.h
+++ b/modules/thermal_hydraulics/include/components/FlowChannel1PhaseBase.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/components/FlowChannelGasMix.h
+++ b/modules/thermal_hydraulics/include/components/FlowChannelGasMix.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/components/SolidWallGasMix.h
+++ b/modules/thermal_hydraulics/include/components/SolidWallGasMix.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/dgkernels/NumericalFluxGasMixDGKernel.h
+++ b/modules/thermal_hydraulics/include/dgkernels/NumericalFluxGasMixDGKernel.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/ics/FlowModelGasMixIC.h
+++ b/modules/thermal_hydraulics/include/ics/FlowModelGasMixIC.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/materials/FluidPropertiesGasMixMaterial.h
+++ b/modules/thermal_hydraulics/include/materials/FluidPropertiesGasMixMaterial.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/materials/SlopeReconstructionGasMixMaterial.h
+++ b/modules/thermal_hydraulics/include/materials/SlopeReconstructionGasMixMaterial.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/userobjects/BoundaryFluxGasMixGhostBase.h
+++ b/modules/thermal_hydraulics/include/userobjects/BoundaryFluxGasMixGhostBase.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/userobjects/BoundaryFluxGasMixGhostWall.h
+++ b/modules/thermal_hydraulics/include/userobjects/BoundaryFluxGasMixGhostWall.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/userobjects/NumericalFlux1D.h
+++ b/modules/thermal_hydraulics/include/userobjects/NumericalFlux1D.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/userobjects/NumericalFluxGasMixBase.h
+++ b/modules/thermal_hydraulics/include/userobjects/NumericalFluxGasMixBase.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/userobjects/NumericalFluxGasMixHLLC.h
+++ b/modules/thermal_hydraulics/include/userobjects/NumericalFluxGasMixHLLC.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/include/utils/FlowModelGasMixUtils.h
+++ b/modules/thermal_hydraulics/include/utils/FlowModelGasMixUtils.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/auxkernels/FlowModelGasMixAux.C
+++ b/modules/thermal_hydraulics/src/auxkernels/FlowModelGasMixAux.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/base/FlowModel1PhaseBase.C
+++ b/modules/thermal_hydraulics/src/base/FlowModel1PhaseBase.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/base/FlowModelGasMix.C
+++ b/modules/thermal_hydraulics/src/base/FlowModelGasMix.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/bcs/BoundaryFluxGasMixBC.C
+++ b/modules/thermal_hydraulics/src/bcs/BoundaryFluxGasMixBC.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/components/FlowBoundary1PhaseBase.C
+++ b/modules/thermal_hydraulics/src/components/FlowBoundary1PhaseBase.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/components/FlowBoundaryGasMix.C
+++ b/modules/thermal_hydraulics/src/components/FlowBoundaryGasMix.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/components/FlowChannel1PhaseBase.C
+++ b/modules/thermal_hydraulics/src/components/FlowChannel1PhaseBase.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/components/FlowChannelGasMix.C
+++ b/modules/thermal_hydraulics/src/components/FlowChannelGasMix.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/components/SolidWallGasMix.C
+++ b/modules/thermal_hydraulics/src/components/SolidWallGasMix.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/dgkernels/NumericalFluxGasMixDGKernel.C
+++ b/modules/thermal_hydraulics/src/dgkernels/NumericalFluxGasMixDGKernel.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/ics/FlowModelGasMixIC.C
+++ b/modules/thermal_hydraulics/src/ics/FlowModelGasMixIC.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/materials/FluidPropertiesGasMixMaterial.C
+++ b/modules/thermal_hydraulics/src/materials/FluidPropertiesGasMixMaterial.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/materials/SlopeReconstructionGasMixMaterial.C
+++ b/modules/thermal_hydraulics/src/materials/SlopeReconstructionGasMixMaterial.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/userobjects/BoundaryFluxGasMixGhostBase.C
+++ b/modules/thermal_hydraulics/src/userobjects/BoundaryFluxGasMixGhostBase.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/userobjects/BoundaryFluxGasMixGhostWall.C
+++ b/modules/thermal_hydraulics/src/userobjects/BoundaryFluxGasMixGhostWall.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/userobjects/NumericalFlux1D.C
+++ b/modules/thermal_hydraulics/src/userobjects/NumericalFlux1D.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/userobjects/NumericalFluxGasMixBase.C
+++ b/modules/thermal_hydraulics/src/userobjects/NumericalFluxGasMixBase.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/userobjects/NumericalFluxGasMixHLLC.C
+++ b/modules/thermal_hydraulics/src/userobjects/NumericalFluxGasMixHLLC.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/src/utils/FlowModelGasMixUtils.C
+++ b/modules/thermal_hydraulics/src/utils/FlowModelGasMixUtils.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/unit/include/FlowModelGasMixUtilsTest.h
+++ b/modules/thermal_hydraulics/unit/include/FlowModelGasMixUtilsTest.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/unit/include/TestNumericalFlux1D.h
+++ b/modules/thermal_hydraulics/unit/include/TestNumericalFlux1D.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/unit/include/TestNumericalFluxGasMixBase.h
+++ b/modules/thermal_hydraulics/unit/include/TestNumericalFluxGasMixBase.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/unit/include/TestNumericalFluxGasMixHLLC.h
+++ b/modules/thermal_hydraulics/unit/include/TestNumericalFluxGasMixHLLC.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/unit/src/FlowModelGasMixUtilsTest.C
+++ b/modules/thermal_hydraulics/unit/src/FlowModelGasMixUtilsTest.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/unit/src/TestNumericalFlux1D.C
+++ b/modules/thermal_hydraulics/unit/src/TestNumericalFlux1D.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/unit/src/TestNumericalFluxGasMixBase.C
+++ b/modules/thermal_hydraulics/unit/src/TestNumericalFluxGasMixBase.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/modules/thermal_hydraulics/unit/src/TestNumericalFluxGasMixHLLC.C
+++ b/modules/thermal_hydraulics/unit/src/TestNumericalFluxGasMixHLLC.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/python/pycapabilities/tests/test_capabilities.py
+++ b/python/pycapabilities/tests/test_capabilities.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #* This file is part of the MOOSE framework
-#* https://www.mooseframework.org
+#* https://mooseframework.inl.gov
 #*
 #* All rights reserved, see COPYRIGHT for full restrictions
 #* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/scripts/update_and_rebuild_conduit.sh
+++ b/scripts/update_and_rebuild_conduit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #* This file is part of the MOOSE framework
-#* https://www.mooseframework.org
+#* https://mooseframework.inl.gov
 #*
 #* All rights reserved, see COPYRIGHT for full restrictions
 #* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/scripts/update_and_rebuild_mfem.sh
+++ b/scripts/update_and_rebuild_mfem.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #* This file is part of the MOOSE framework
-#* https://www.mooseframework.org
+#* https://mooseframework.inl.gov
 #*
 #* All rights reserved, see COPYRIGHT for full restrictions
 #* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/test/include/auxkernels/VectorCoupledOldAux.h
+++ b/test/include/auxkernels/VectorCoupledOldAux.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/test/include/kernels/ADCoupledCurlSuppliedFieldProduct.h
+++ b/test/include/kernels/ADCoupledCurlSuppliedFieldProduct.h
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/test/src/auxkernels/VectorCoupledOldAux.C
+++ b/test/src/auxkernels/VectorCoupledOldAux.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/test/src/kernels/ADCoupledCurlSuppliedFieldProduct.C
+++ b/test/src/kernels/ADCoupledCurlSuppliedFieldProduct.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/test/tests/materials/torchscript_material/generate_net.py
+++ b/test/tests/materials/torchscript_material/generate_net.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #* This file is part of the MOOSE framework
-#* https://www.mooseframework.org
+#* https://mooseframework.inl.gov
 #*
 #* All rights reserved, see COPYRIGHT for full restrictions
 #* https://github.com/idaholab/moose/blob/master/COPYRIGHT

--- a/unit/src/CapabilitiesTest.C
+++ b/unit/src/CapabilitiesTest.C
@@ -1,5 +1,5 @@
 //* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
+//* https://mooseframework.inl.gov
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT


### PR DESCRIPTION
References #29882, which isn't as dead as it first appears. Also see PR #58 on large_media
