### PR TITLE
Turn off search value diagnostics by default, turn on missed-value check by default in field transfers

### DIFF
--- a/framework/src/transfers/MultiAppGeneralFieldTransfer.C
+++ b/framework/src/transfers/MultiAppGeneralFieldTransfer.C
@@ -1483,12 +1483,12 @@ MultiAppGeneralFieldTransfer::setSolutionVectorValues(
           const auto target_location =
               hasToMultiApp()
                   ? " on target app " + std::to_string(getGlobalTargetAppIndex(problem_id))
-                  : " on parent app ";
+                  : " on parent app";
           const auto info_msg = "\nThis check can be turned off by setting 'error_on_miss' to "
                                 "false. The 'extrapolation_constant' parameter will be used to set "
                                 "the local value at missed points.";
           if (is_nodal)
-            mooseError("No source value could be found for node ",
+            mooseError("No source value for node ",
                        dof_object_id,
                        target_location,
                        " could be located. Node details:\n",
@@ -1496,7 +1496,7 @@ MultiAppGeneralFieldTransfer::setSolutionVectorValues(
                        "\n",
                        info_msg);
           else
-            mooseError("No source value could be found for element ",
+            mooseError("No source value for element ",
                        dof_object_id,
                        target_location,
                        " could be located. Element details:\n",

--- a/test/tests/fvkernels/fv_simple_diffusion/neumann.i
+++ b/test/tests/fvkernels/fv_simple_diffusion/neumann.i
@@ -45,7 +45,7 @@
   []
 []
 
-[Materials]
+[FunctorMaterials]
   [diff]
     type = ADGenericFunctorMaterial
     prop_names = 'coeff'

--- a/test/tests/transfers/general_field/nearest_node/mesh_division/main_match_division.i
+++ b/test/tests/transfers/general_field/nearest_node/mesh_division/main_match_division.i
@@ -134,6 +134,8 @@
     to_mesh_division_usage = 'matching_division'
     greedy_search = true
     use_bounding_boxes = false
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub_elem]
@@ -147,6 +149,8 @@
     to_mesh_division_usage = 'matching_division'
     greedy_search = true
     use_bounding_boxes = false
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []
 

--- a/test/tests/transfers/general_field/shape_evaluation/between_siblings/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/shape_evaluation/between_siblings/main_between_multiapp.i
@@ -14,18 +14,22 @@
 []
 
 # This application use at most 3 processes
-[MultiApps/ma1]
-  type = TransientMultiApp
-  input_files = sub_between_diffusion1.i
-  max_procs_per_app = 3
-  output_in_position = true
+[MultiApps]
+  [ma1]
+    type = TransientMultiApp
+    input_files = sub_between_diffusion1.i
+    max_procs_per_app = 3
+    output_in_position = true
+  []
 []
 
 # This application will use as many processes as the main app
-[MultiApps/ma2]
-  type = TransientMultiApp
-  input_files = sub_between_diffusion2.i
-  output_in_position = true
+[MultiApps]
+  [ma2]
+    type = TransientMultiApp
+    input_files = sub_between_diffusion2.i
+    output_in_position = true
+  []
 []
 
 [Transfers]
@@ -37,6 +41,8 @@
     source_variable = sent_nodal
     variable = received_nodal
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [app2_to_1_nodal_nodal]
     type = MultiAppGeneralFieldShapeEvaluationTransfer
@@ -45,6 +51,8 @@
     source_variable = sent_nodal
     variable = received_nodal
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   # Elemental to elemental variables
@@ -55,6 +63,8 @@
     source_variable = sent_elem
     variable = received_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [app2_to_1_elem_elem]
     type = MultiAppGeneralFieldShapeEvaluationTransfer
@@ -63,6 +73,8 @@
     source_variable = sent_elem
     variable = received_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   # Elemental to nodal variables
@@ -73,6 +85,8 @@
     source_variable = sent_elem
     variable = received_nodal
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [app2_to_1_elem_nodal]
     type = MultiAppGeneralFieldShapeEvaluationTransfer
@@ -81,6 +95,8 @@
     source_variable = sent_elem
     variable = received_nodal
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   # Nodal to elemental variables
@@ -91,6 +107,8 @@
     source_variable = sent_nodal
     variable = received_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [app2_to_1_nodal_elem]
     type = MultiAppGeneralFieldShapeEvaluationTransfer
@@ -99,6 +117,8 @@
     source_variable = sent_nodal
     variable = received_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []
 

--- a/test/tests/transfers/general_field/shape_evaluation/boundary/main.i
+++ b/test/tests/transfers/general_field/shape_evaluation/boundary/main.i
@@ -93,6 +93,8 @@
     source_variable = to_sub
     variable = from_main
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [to_sub_elem]
@@ -101,6 +103,8 @@
     source_variable = to_sub_elem
     variable = from_main_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub]
@@ -109,6 +113,8 @@
     source_variable = to_main
     variable = from_sub
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub_elem]
@@ -117,5 +123,7 @@
     source_variable = to_main_elem
     variable = from_sub_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/general_field/shape_evaluation/displaced/parent.i
+++ b/test/tests/transfers/general_field/shape_evaluation/displaced/parent.i
@@ -64,6 +64,8 @@
     variable = indicator_const_mon
     displaced_source_mesh = true
     execute_on = 'initial timestep_begin'
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [pull_indicator_nodal]
     type = MultiAppGeneralFieldShapeEvaluationTransfer
@@ -72,6 +74,8 @@
     variable = indicator_nodal
     displaced_source_mesh = true
     execute_on = 'initial timestep_begin'
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [pull_indicator_higher]
     type = MultiAppGeneralFieldShapeEvaluationTransfer

--- a/test/tests/transfers/general_field/shape_evaluation/duplicated_shape_evaluation_tests/fromsub.i
+++ b/test/tests/transfers/general_field/shape_evaluation/duplicated_shape_evaluation_tests/fromsub.i
@@ -71,5 +71,7 @@
     variable = 'transferred_u elemental_transferred_u'
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/general_field/shape_evaluation/duplicated_shape_evaluation_tests/fromsub_source_displaced.i
+++ b/test/tests/transfers/general_field/shape_evaluation/duplicated_shape_evaluation_tests/fromsub_source_displaced.i
@@ -70,6 +70,8 @@
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
     displaced_source_mesh = true
+    # Test features non-overlapping meshes
+    error_on_miss = false
   [../]
   [./elemental_from_sub]
     source_variable = sub_u
@@ -77,5 +79,7 @@
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
     displaced_source_mesh = true
+    # Test features non-overlapping meshes
+    error_on_miss = false
   [../]
 []

--- a/test/tests/transfers/general_field/shape_evaluation/duplicated_shape_evaluation_tests/fromsub_target_displaced.i
+++ b/test/tests/transfers/general_field/shape_evaluation/duplicated_shape_evaluation_tests/fromsub_target_displaced.i
@@ -79,6 +79,8 @@
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
     displaced_target_mesh = true
+    # Test features non-overlapping meshes
+    error_on_miss = false
   [../]
   [./elemental_from_sub]
     source_variable = sub_u
@@ -86,5 +88,7 @@
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
     displaced_target_mesh = true
+    # Test features non-overlapping meshes
+    error_on_miss = false
   [../]
 []

--- a/test/tests/transfers/general_field/shape_evaluation/duplicated_shape_evaluation_tests/tests
+++ b/test/tests/transfers/general_field/shape_evaluation/duplicated_shape_evaluation_tests/tests
@@ -60,7 +60,7 @@
     [missed_point]
       type = 'RunException'
       input = 'missing_parent.i'
-      expect_err = 'could not be located'
+      expect_err = 'No source value for node '
 
       detail = "the evaluation point does not exist"
     []

--- a/test/tests/transfers/general_field/shape_evaluation/mesh_division/main.i
+++ b/test/tests/transfers/general_field/shape_evaluation/mesh_division/main.i
@@ -80,6 +80,8 @@
     to_multi_app = sub
     source_variable = to_sub
     variable = from_main
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [to_sub_elem]
@@ -87,6 +89,8 @@
     to_multi_app = sub
     source_variable = to_sub_elem
     variable = from_main_elem
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub]
@@ -94,6 +98,8 @@
     from_multi_app = sub
     source_variable = to_main
     variable = from_sub
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub_elem]
@@ -101,6 +107,8 @@
     from_multi_app = sub
     source_variable = to_main_elem
     variable = from_sub_elem
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []
 

--- a/test/tests/transfers/general_field/shape_evaluation/mesh_division/main_match_subapps.i
+++ b/test/tests/transfers/general_field/shape_evaluation/mesh_division/main_match_subapps.i
@@ -95,6 +95,8 @@
     variable = from_main
     from_mesh_division = middle
     from_mesh_division_usage = 'matching_subapp_index'
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [to_sub_elem]
@@ -104,6 +106,8 @@
     variable = from_main_elem
     from_mesh_division = middle
     from_mesh_division_usage = 'matching_subapp_index'
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub]
@@ -113,6 +117,8 @@
     variable = from_sub
     to_mesh_division = middle
     to_mesh_division_usage = 'matching_subapp_index'
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub_elem]

--- a/test/tests/transfers/general_field/shape_evaluation/regular/main.i
+++ b/test/tests/transfers/general_field/shape_evaluation/regular/main.i
@@ -86,6 +86,8 @@
     source_variable = to_main
     variable = from_sub
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub_elem]
@@ -94,5 +96,7 @@
     source_variable = to_main_elem
     variable = from_sub_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/general_field/shape_evaluation/regular/main_array.i
+++ b/test/tests/transfers/general_field/shape_evaluation/regular/main_array.i
@@ -96,6 +96,8 @@
     variable = 'from_sub from_sub'
     target_variable_components = '0 1'
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub_elem]
@@ -106,5 +108,7 @@
     variable = 'from_sub_elem from_sub_elem'
     target_variable_components = '0 1'
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/general_field/shape_evaluation/subdomain/main.i
+++ b/test/tests/transfers/general_field/shape_evaluation/subdomain/main.i
@@ -84,6 +84,8 @@
     from_blocks = 1
     to_blocks = 1
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [to_sub_elem]
@@ -94,6 +96,8 @@
     from_blocks = 1
     to_blocks = 1
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub]
@@ -104,6 +108,8 @@
     from_blocks = 1
     to_blocks = 1
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub_elem]
@@ -114,5 +120,7 @@
     from_blocks = 1
     to_blocks = 1
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/general_field/user_object/between_siblings/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/user_object/between_siblings/main_between_multiapp.i
@@ -14,16 +14,20 @@
 []
 
 # This application use at most 3 processes
-[MultiApps/ma1]
-  type = TransientMultiApp
-  input_files = sub_between_diffusion1.i
-  max_procs_per_app = 3
+[MultiApps]
+  [ma1]
+    type = TransientMultiApp
+    input_files = sub_between_diffusion1.i
+    max_procs_per_app = 3
+  []
 []
 
 # This application will use as many processes as the main app
-[MultiApps/ma2]
-  type = TransientMultiApp
-  input_files = sub_between_diffusion2.i
+[MultiApps]
+  [ma2]
+    type = TransientMultiApp
+    input_files = sub_between_diffusion2.i
+  []
 []
 
 [Transfers]
@@ -35,6 +39,8 @@
     source_user_object = sent_nodal
     variable = received_nodal
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [app2_to_1_nodal_nodal]
     type = MultiAppGeneralFieldUserObjectTransfer
@@ -43,6 +49,8 @@
     source_user_object = sent_nodal
     variable = received_nodal
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   # Elemental to elemental variables
@@ -53,6 +61,8 @@
     source_user_object = sent_elem
     variable = received_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [app2_to_1_elem_elem]
     type = MultiAppGeneralFieldUserObjectTransfer
@@ -61,6 +71,8 @@
     source_user_object = sent_elem
     variable = received_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   # Elemental to nodal variables
@@ -71,6 +83,8 @@
     source_user_object = sent_elem
     variable = received_nodal
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [app2_to_1_elem_nodal]
     type = MultiAppGeneralFieldUserObjectTransfer
@@ -79,6 +93,8 @@
     source_user_object = sent_elem
     variable = received_nodal
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   # Nodal to elemental variables
@@ -89,6 +105,8 @@
     source_user_object = sent_nodal
     variable = received_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [app2_to_1_nodal_elem]
     type = MultiAppGeneralFieldUserObjectTransfer
@@ -97,6 +115,8 @@
     source_user_object = sent_nodal
     variable = received_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []
 

--- a/test/tests/transfers/general_field/user_object/boundary/main.i
+++ b/test/tests/transfers/general_field/user_object/boundary/main.i
@@ -108,6 +108,8 @@
     source_user_object = to_sub
     variable = from_main
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [to_sub_elem]
@@ -116,6 +118,8 @@
     source_user_object = to_sub_elem
     variable = from_main_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub]
@@ -124,6 +128,8 @@
     source_user_object = to_main
     variable = from_sub
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub_elem]
@@ -132,5 +138,7 @@
     source_user_object = to_main_elem
     variable = from_sub_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/general_field/user_object/duplicated_user_object_tests/3d_1d_parent.i
+++ b/test/tests/transfers/general_field/user_object/duplicated_user_object_tests/3d_1d_parent.i
@@ -18,10 +18,10 @@
 []
 
 [AuxVariables]
-  [./from_sub_app_var]
+  [from_sub_app_var]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 []
 
 [UserObjects]
@@ -113,5 +113,7 @@
 
     fixed_bounding_box_size = '0.25 0.25 0'
     from_app_must_contain_point = false
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/general_field/user_object/duplicated_user_object_tests/parent.i
+++ b/test/tests/transfers/general_field/user_object/duplicated_user_object_tests/parent.i
@@ -81,6 +81,8 @@
     skip_coordinate_collapsing = true
     from_app_must_contain_point = false
     bbox_factor = 1.0000001
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [element_layered_transfer]
     type = MultiAppGeneralFieldUserObjectTransfer
@@ -90,5 +92,7 @@
     skip_coordinate_collapsing = true
     from_app_must_contain_point = false
     bbox_factor = 1.0000001
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/general_field/user_object/duplicated_user_object_tests/tests
+++ b/test/tests/transfers/general_field/user_object/duplicated_user_object_tests/tests
@@ -71,7 +71,7 @@
     type = 'RunException'
     input = '3d_1d_parent.i'
     cli_args = 'Transfers/layered_transfer_from_sub_app/error_on_miss=true Transfers/layered_transfer_from_sub_app/from_app_must_contain_point=true'
-    expect_err = 'could not be located'
+    expect_err = 'No source value for element '
     prereq = transfer/3d_1d
 
     requirement = "The system shall report an error if a parent node/element is "

--- a/test/tests/transfers/general_field/user_object/nearest_position/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/user_object/nearest_position/main_between_multiapp.i
@@ -28,20 +28,24 @@
 []
 
 # This application uses at most 3 processes
-[MultiApps/ma1]
-  type = TransientMultiApp
-  input_files = sub_between_diffusion.i
-  max_procs_per_app = 3
-  positions_objects = 'input_app1'
-  output_in_position = true
+[MultiApps]
+  [ma1]
+    type = TransientMultiApp
+    input_files = sub_between_diffusion.i
+    max_procs_per_app = 3
+    positions_objects = 'input_app1'
+    output_in_position = true
+  []
 []
 
 # This application will use as many processes as the main app
-[MultiApps/ma2]
-  type = TransientMultiApp
-  input_files = sub_between_diffusion.i
-  positions_objects = 'input_app2'
-  output_in_position = true
+[MultiApps]
+  [ma2]
+    type = TransientMultiApp
+    input_files = sub_between_diffusion.i
+    positions_objects = 'input_app2'
+    output_in_position = true
+  []
 []
 
 [Transfers]
@@ -56,6 +60,8 @@
     use_nearest_position = input_app1
     # slight inflation to avoid floating point issues on borders
     bbox_factor = 1.001
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [app2_to_1_nodal_nodal]
     type = MultiAppGeneralFieldUserObjectTransfer
@@ -66,6 +72,8 @@
     extrapolation_constant = -1
     use_nearest_position = input_app2
     bbox_factor = 1.001
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   # Elemental to elemental variables
@@ -78,6 +86,8 @@
     extrapolation_constant = -1
     use_nearest_position = input_app1
     bbox_factor = 1.001
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [app2_to_1_elem_elem]
     type = MultiAppGeneralFieldUserObjectTransfer
@@ -88,6 +98,8 @@
     extrapolation_constant = -1
     use_nearest_position = input_app2
     bbox_factor = 1.001
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []
 

--- a/test/tests/transfers/general_field/user_object/regular/main.i
+++ b/test/tests/transfers/general_field/user_object/regular/main.i
@@ -101,6 +101,8 @@
     source_user_object = to_main
     variable = from_sub
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub_elem]
@@ -109,5 +111,7 @@
     source_user_object = to_main_elem
     variable = from_sub_elem
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/general_field/user_object/subdomain/main.i
+++ b/test/tests/transfers/general_field/user_object/subdomain/main.i
@@ -99,6 +99,8 @@
     from_blocks = 1
     to_blocks = 1
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [to_sub_elem]
@@ -109,6 +111,8 @@
     from_blocks = 1
     to_blocks = 1
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub]
@@ -119,6 +123,8 @@
     from_blocks = 1
     to_blocks = 1
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 
   [from_sub_elem]
@@ -129,5 +135,7 @@
     from_blocks = 1
     to_blocks = 1
     extrapolation_constant = -1
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/multiapp_conservative_transfer/parent_conservative_transfer.i
+++ b/test/tests/transfers/multiapp_conservative_transfer/parent_conservative_transfer.i
@@ -62,6 +62,8 @@
     to_multi_app = sub
     from_postprocessors_to_be_preserved = 'from_postprocessor'
     to_postprocessors_to_be_preserved = 'to_postprocessor'
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []
 

--- a/test/tests/transfers/multiapp_conservative_transfer/parent_nearest_point.i
+++ b/test/tests/transfers/multiapp_conservative_transfer/parent_nearest_point.i
@@ -121,6 +121,8 @@
     # 1 pp is specified on the subapp side
     to_postprocessors_to_be_preserved = 'to_nearest_point'
     from_postprocessors_to_be_preserved = 'sink'
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []
 

--- a/test/tests/transfers/multiapp_conservative_transfer/parent_power_density.i
+++ b/test/tests/transfers/multiapp_conservative_transfer/parent_power_density.i
@@ -129,6 +129,8 @@
     # 1 pp is specified on the subapp side
     to_postprocessors_to_be_preserved = 'from_sub0 from_sub1'
     from_postprocessors_to_be_preserved = 'sink'
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []
 

--- a/test/tests/transfers/multiapp_conservative_transfer/parent_userobject.i
+++ b/test/tests/transfers/multiapp_conservative_transfer/parent_userobject.i
@@ -101,6 +101,8 @@
 
     from_postprocessors_to_be_preserved = 'from_postprocessor'
     to_postprocessors_to_be_preserved = 'to_nearest_point'
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [element_layered_transfer]
     source_user_object = layered_average
@@ -111,5 +113,7 @@
 
     from_postprocessors_to_be_preserved = 'from_postprocessor'
     to_postprocessors_to_be_preserved = 'to_nearest_point_element'
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/multiapp_mesh_function_transfer/exec_on_mismatch.i
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/exec_on_mismatch.i
@@ -86,11 +86,15 @@
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
     execute_on = 'initial timestep_end'
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [elemental_from_sub]
     source_variable = sub_u
     variable = elemental_transferred_u
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/multiapp_mesh_function_transfer/fromsub.i
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/fromsub.i
@@ -71,5 +71,7 @@
     variable = 'transferred_u elemental_transferred_u'
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/multiapp_mesh_function_transfer/fromsub_source_displaced.i
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/fromsub_source_displaced.i
@@ -70,6 +70,8 @@
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
     displaced_source_mesh = true
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [elemental_from_sub]
     source_variable = sub_u
@@ -77,5 +79,7 @@
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
     displaced_source_mesh = true
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/multiapp_mesh_function_transfer/fromsub_target_displaced.i
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/fromsub_target_displaced.i
@@ -79,6 +79,8 @@
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
     displaced_target_mesh = true
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
   [elemental_from_sub]
     source_variable = sub_u
@@ -86,5 +88,7 @@
     type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = sub
     displaced_target_mesh = true
+    # Test features non-overlapping meshes
+    error_on_miss = false
   []
 []

--- a/test/tests/transfers/multiapp_mesh_function_transfer/tests
+++ b/test/tests/transfers/multiapp_mesh_function_transfer/tests
@@ -78,7 +78,7 @@
     [mismatch_exec_on_sibling]
       type = 'RunApp'
       input = 'exec_on_mismatch.i'
-      cli_args = "MultiApps/active='sub_sibling_1 sub_sibling_2' Transfers/active=from_sub Transfers/from_sub/type=MultiAppCopyTransfer Transfers/from_sub/variable=sub_u Transfers/from_sub/from_multi_app=sub_sibling_1 Transfers/from_sub/to_multi_app=sub_sibling_2"
+      cli_args = "MultiApps/active='sub_sibling_1 sub_sibling_2' Transfers/active=from_sub Transfers/from_sub/type=MultiAppGeneralFieldShapeEvaluationTransfer Transfers/from_sub/variable=sub_u Transfers/from_sub/from_multi_app=sub_sibling_1 Transfers/from_sub/to_multi_app=sub_sibling_2"
       expect_out = 'MultiAppTransfer execute_on flags do not match'
       allow_warnings = true
       max_parallel = 1


### PR DESCRIPTION
It is non-standard to have poor-scaling code be active in opt-mode
It is also non-standard to run diagnostics in opt-mode.

So less turn this diagnostic off by default. 

this other check is fast and imo more important