### PR TITLE
Bump abs_zero for joule heating test

### DIFF
--- a/modules/combined/test/tests/electromagnetic_joule_heating/tests
+++ b/modules/combined/test/tests/electromagnetic_joule_heating/tests
@@ -50,6 +50,6 @@
     requirement = 'The system shall calculate the heating of a copper wire when supplied with a current.'
     design = 'ADJouleHeatingSource.md'
     issues = '#30000'
-    abs_zero = 1e-8
+    abs_zero = 1e-4
   []
 []


### PR DESCRIPTION
Refs failure on libmesh/libmesh#4140 and libmesh/libmesh#4183 which I could not reproduce myself even in the same container. However, if I just ran this test with 2 procs then I got exodiffs