### PR TITLE
Documentation and preconditioner fixes for MFEM backend

### DIFF
--- a/framework/doc/content/source/mfem/kernels/MFEMCurlCurlKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMCurlCurlKernel.md
@@ -22,7 +22,7 @@ This term arises from the weak form of the curl curl operator
 
 ## Example Input File Syntax
 
-!listing mfem/kernels/curlcurl.i block=Kernels
+!listing mfem/kernels/curlcurl.i block=/Kernels
 
 !syntax parameters /Kernels/MFEMCurlCurlKernel
 

--- a/framework/doc/content/source/mfem/kernels/MFEMDiffusionKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMDiffusionKernel.md
@@ -22,7 +22,7 @@ This term arises from the weak form of the Laplacian operator
 
 ## Example Input File Syntax
 
-!listing mfem/kernels/diffusion.i block=Kernels
+!listing mfem/kernels/diffusion.i block=/Kernels
 
 !syntax parameters /Kernels/MFEMDiffusionKernel
 

--- a/framework/doc/content/source/mfem/kernels/MFEMDivDivKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMDivDivKernel.md
@@ -22,7 +22,7 @@ This term arises from the weak form of the grad div operator
 
 ## Example Input File Syntax
 
-!listing mfem/kernels/graddiv.i block=Kernels
+!listing mfem/kernels/graddiv.i block=/Kernels
 
 !syntax parameters /Kernels/MFEMDivDivKernel
 

--- a/framework/doc/content/source/mfem/kernels/MFEMLinearElasticityKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMLinearElasticityKernel.md
@@ -38,7 +38,7 @@ material Young's modulus $E$ and the Poisson ratio $\nu$ using
 
 ## Example Input File Syntax
 
-!listing mfem/kernels/linearelasticity.i block=Kernels
+!listing mfem/kernels/linearelasticity.i block=/Kernels
 
 !syntax parameters /Kernels/MFEMLinearElasticityKernel
 

--- a/framework/doc/content/source/mfem/kernels/MFEMTimeDerivativeMassKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMTimeDerivativeMassKernel.md
@@ -22,7 +22,7 @@ k \dot{u}
 
 ## Example Input File Syntax
 
-!listing mfem/kernels/heattransfer.i block=Kernels
+!listing mfem/kernels/heattransfer.i block=/Kernels
 
 !syntax parameters /Kernels/MFEMTimeDerivativeMassKernel
 

--- a/framework/doc/content/source/mfem/kernels/MFEMVectorDomainLFKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMVectorDomainLFKernel.md
@@ -21,7 +21,7 @@ This term arises from the weak form of the forcing term
 
 ## Example Input File Syntax
 
-!listing mfem/kernels/gravity.i block=Kernels
+!listing mfem/kernels/gravity.i block=/Kernels
 
 !syntax parameters /Kernels/MFEMVectorDomainLFKernel
 

--- a/framework/doc/content/source/mfem/kernels/MFEMVectorFEDomainLFKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMVectorFEDomainLFKernel.md
@@ -21,7 +21,7 @@ This term arises from the weak form of the forcing term
 
 ## Example Input File Syntax
 
-!listing mfem/kernels/curlcurl.i block=Kernels
+!listing mfem/kernels/curlcurl.i block=/Kernels
 
 !syntax parameters /Kernels/MFEMVectorFEDomainLFKernel
 

--- a/framework/doc/content/source/mfem/kernels/MFEMVectorFEMassKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMVectorFEMassKernel.md
@@ -22,7 +22,7 @@ k \vec u
 
 ## Example Input File Syntax
 
-!listing mfem/kernels/curlcurl.i block=Kernels
+!listing mfem/kernels/curlcurl.i block=/Kernels
 
 !syntax parameters /Kernels/MFEMVectorFEMassKernel
 

--- a/framework/doc/content/source/mfem/mesh/MFEMMesh.md
+++ b/framework/doc/content/source/mfem/mesh/MFEMMesh.md
@@ -13,7 +13,7 @@ for use in an `MFEMProblem`. Exodus files are supported, along with other mesh f
  [here](https://mfem.org/mesh-formats/).
 
 As MOOSE checks for the existence of a `libMesh` MOOSE mesh at various points during setup,
-`MFEMMesh` currently builds an dummy MOOSE mesh of a single quad alongside the MFEM mesh. This dummy
+`MFEMMesh` currently builds a dummy MOOSE mesh of a single quad alongside the MFEM mesh. This dummy
 mesh should not be used in an `MFEMProblem`; all MFEM objects should access the `mfem::ParMesh` via
 the `getMFEMParMesh()` accessor as needed.
 

--- a/framework/include/mfem/bcs/MFEMEssentialBC.h
+++ b/framework/include/mfem/bcs/MFEMEssentialBC.h
@@ -25,7 +25,7 @@ public:
   virtual const std::string & getTrialVariableName() const { return _test_var_name; }
 
   // Apply the essential BC, overwritign the values of gridfunc on the boundary as desired.
-  virtual void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh) = 0;
+  virtual void ApplyBC(mfem::GridFunction & gridfunc) = 0;
 };
 
 #endif

--- a/framework/include/mfem/bcs/MFEMScalarDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMScalarDirichletBC.h
@@ -19,7 +19,7 @@ public:
 
   MFEMScalarDirichletBC(const InputParameters & parameters);
 
-  void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh) override;
+  void ApplyBC(mfem::GridFunction & gridfunc) override;
 
 protected:
   mfem::ConstantCoefficient & _coef;

--- a/framework/include/mfem/bcs/MFEMScalarFunctorDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMScalarFunctorDirichletBC.h
@@ -19,7 +19,7 @@ public:
 
   MFEMScalarFunctorDirichletBC(const InputParameters & parameters);
 
-  void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh) override;
+  void ApplyBC(mfem::GridFunction & gridfunc) override;
 
 protected:
   const MFEMScalarCoefficientName & _coef_name;

--- a/framework/include/mfem/bcs/MFEMVectorDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorDirichletBC.h
@@ -18,7 +18,7 @@ class MFEMVectorDirichletBC : public MFEMVectorDirichletBCBase
 public:
   static InputParameters validParams();
   MFEMVectorDirichletBC(const InputParameters & parameters);
-  void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh) override;
+  void ApplyBC(mfem::GridFunction & gridfunc) override;
 };
 
 #endif

--- a/framework/include/mfem/bcs/MFEMVectorFunctorDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorFunctorDirichletBC.h
@@ -19,7 +19,7 @@ public:
   static InputParameters validParams();
   MFEMVectorFunctorDirichletBC(const InputParameters & parameters);
   ~MFEMVectorFunctorDirichletBC() override = default;
-  void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh) override;
+  void ApplyBC(mfem::GridFunction & gridfunc) override;
 };
 
 #endif

--- a/framework/include/mfem/bcs/MFEMVectorFunctorDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorFunctorDirichletBC.h
@@ -16,6 +16,7 @@ class MFEMVectorFunctorDirichletBC : public MFEMVectorFunctorDirichletBCBase
 {
 
 public:
+  static InputParameters validParams();
   MFEMVectorFunctorDirichletBC(const InputParameters & parameters);
   ~MFEMVectorFunctorDirichletBC() override = default;
   void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh) override;

--- a/framework/include/mfem/bcs/MFEMVectorFunctorNormalDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorFunctorNormalDirichletBC.h
@@ -19,7 +19,7 @@ public:
   static InputParameters validParams();
   MFEMVectorFunctorNormalDirichletBC(const InputParameters & parameters);
   ~MFEMVectorFunctorNormalDirichletBC() override = default;
-  void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh) override;
+  void ApplyBC(mfem::GridFunction & gridfunc) override;
 };
 
 #endif

--- a/framework/include/mfem/bcs/MFEMVectorFunctorTangentialDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorFunctorTangentialDirichletBC.h
@@ -19,7 +19,7 @@ public:
   static InputParameters validParams();
   MFEMVectorFunctorTangentialDirichletBC(const InputParameters & parameters);
   ~MFEMVectorFunctorTangentialDirichletBC() override = default;
-  void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh) override;
+  void ApplyBC(mfem::GridFunction & gridfunc) override;
 };
 
 #endif

--- a/framework/include/mfem/bcs/MFEMVectorFunctorTangentialDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorFunctorTangentialDirichletBC.h
@@ -16,6 +16,7 @@
 class MFEMVectorFunctorTangentialDirichletBC : public MFEMVectorFunctorDirichletBCBase
 {
 public:
+  static InputParameters validParams();
   MFEMVectorFunctorTangentialDirichletBC(const InputParameters & parameters);
   ~MFEMVectorFunctorTangentialDirichletBC() override = default;
   void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh) override;

--- a/framework/include/mfem/bcs/MFEMVectorNormalDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorNormalDirichletBC.h
@@ -18,7 +18,7 @@ class MFEMVectorNormalDirichletBC : public MFEMVectorDirichletBCBase
 public:
   static InputParameters validParams();
   MFEMVectorNormalDirichletBC(const InputParameters & parameters);
-  void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh) override;
+  void ApplyBC(mfem::GridFunction & gridfunc) override;
 };
 
 #endif

--- a/framework/include/mfem/bcs/MFEMVectorTangentialDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorTangentialDirichletBC.h
@@ -18,7 +18,7 @@ class MFEMVectorTangentialDirichletBC : public MFEMVectorDirichletBCBase
 public:
   static InputParameters validParams();
   MFEMVectorTangentialDirichletBC(const InputParameters & parameters);
-  void ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh) override;
+  void ApplyBC(mfem::GridFunction & gridfunc) override;
 };
 
 #endif

--- a/framework/include/mfem/equation_systems/EquationSystem.h
+++ b/framework/include/mfem/equation_systems/EquationSystem.h
@@ -87,6 +87,11 @@ public:
   const std::vector<std::string> & TestVarNames() const { return _test_var_names; }
 
 protected:
+  // Deletes the HypreParMatrix associated with any pointer stored in _h_blocks,
+  // and then proceeds to delete all dynamically allocated memory for _h_blocks
+  // itself, resetting all dimensions to zero.
+  void DeleteAllBlocks();
+
   bool VectorContainsName(const std::vector<std::string> & the_vector,
                           const std::string & name) const;
 

--- a/framework/include/mfem/problem/MFEMProblemData.h
+++ b/framework/include/mfem/problem/MFEMProblemData.h
@@ -35,7 +35,6 @@ public:
   std::shared_ptr<Moose::MFEM::EquationSystem> eqn_system{nullptr};
   std::shared_ptr<mfem::NewtonSolver> nonlinear_solver{nullptr};
 
-  std::shared_ptr<MFEMSolverBase> jacobian_preconditioner{nullptr};
   std::shared_ptr<MFEMSolverBase> jacobian_solver{nullptr};
 
   Moose::MFEM::FECollections fecs;

--- a/framework/include/mfem/solvers/MFEMCGSolver.h
+++ b/framework/include/mfem/solvers/MFEMCGSolver.h
@@ -31,9 +31,6 @@ public:
 
 protected:
   void constructSolver(const InputParameters & parameters) override;
-
-private:
-  std::shared_ptr<MFEMSolverBase> _preconditioner{nullptr};
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMGMRESSolver.h
+++ b/framework/include/mfem/solvers/MFEMGMRESSolver.h
@@ -31,9 +31,6 @@ public:
 
 protected:
   void constructSolver(const InputParameters & parameters) override;
-
-private:
-  std::shared_ptr<MFEMSolverBase> _preconditioner{nullptr};
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMHypreBoomerAMG.h
+++ b/framework/include/mfem/solvers/MFEMHypreBoomerAMG.h
@@ -34,7 +34,6 @@ protected:
 
 private:
   std::shared_ptr<mfem::ParFiniteElementSpace> _mfem_fespace{nullptr};
-  mfem::real_t _strength_threshold;
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMHypreFGMRES.h
+++ b/framework/include/mfem/solvers/MFEMHypreFGMRES.h
@@ -31,9 +31,6 @@ public:
 
 protected:
   void constructSolver(const InputParameters & parameters) override;
-
-private:
-  std::shared_ptr<MFEMSolverBase> _preconditioner{nullptr};
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMHypreGMRES.h
+++ b/framework/include/mfem/solvers/MFEMHypreGMRES.h
@@ -32,9 +32,6 @@ public:
 
 protected:
   void constructSolver(const InputParameters & parameters) override;
-
-private:
-  std::shared_ptr<MFEMSolverBase> _preconditioner{nullptr};
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMHyprePCG.h
+++ b/framework/include/mfem/solvers/MFEMHyprePCG.h
@@ -31,9 +31,6 @@ public:
 
 protected:
   void constructSolver(const InputParameters & parameters) override;
-
-private:
-  std::shared_ptr<MFEMSolverBase> _preconditioner{nullptr};
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMSolverBase.h
+++ b/framework/include/mfem/solvers/MFEMSolverBase.h
@@ -29,10 +29,10 @@ public:
   /// Retrieves the preconditioner userobject if present, sets the member pointer to
   /// said object if still unset, and sets the solver to use this preconditioner.
   template <typename T>
-  void setPreconditioner(const std::shared_ptr<T> & solver);
+  void setPreconditioner(T & solver);
 
-  /// Returns a shared pointer to the instance of the Solver derived-class.
-  virtual std::shared_ptr<mfem::Solver> getSolver() { return _solver; }
+  /// Returns the wrapped MFEM solver
+  mfem::Solver & getSolver();
 
   /// Updates the solver with the given bilinear form and essential dof list, in case an LOR or algebraic solver is needed.
   virtual void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) = 0;
@@ -48,8 +48,15 @@ protected:
   bool _lor;
 
   // Solver and preconditioner to be used for the problem
-  std::shared_ptr<mfem::Solver> _solver{nullptr};
-  MFEMSolverBase * _preconditioner{nullptr};
+  std::unique_ptr<mfem::Solver> _solver;
+  MFEMSolverBase * _preconditioner;
 };
+
+inline mfem::Solver &
+MFEMSolverBase::getSolver()
+{
+  mooseAssert(_solver, "Attempting to retrieve solver before it's been constructed");
+  return *_solver;
+}
 
 #endif

--- a/framework/include/mfem/solvers/MFEMSolverBase.h
+++ b/framework/include/mfem/solvers/MFEMSolverBase.h
@@ -26,6 +26,11 @@ public:
 
   MFEMSolverBase(const InputParameters & parameters);
 
+  /// Retrieves the preconditioner userobject if present, sets the member pointer to
+  /// said object if still unset, and sets the solver to use this preconditioner.
+  template <typename T>
+  void setPreconditioner(const std::shared_ptr<T> & solver);
+
   /// Returns a shared pointer to the instance of the Solver derived-class.
   virtual std::shared_ptr<mfem::Solver> getSolver() { return _solver; }
 

--- a/framework/include/mfem/solvers/MFEMSolverBase.h
+++ b/framework/include/mfem/solvers/MFEMSolverBase.h
@@ -32,7 +32,8 @@ public:
   /// Updates the solver with the given bilinear form and essential dof list, in case an LOR or algebraic solver is needed.
   virtual void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) = 0;
 
-  bool isLOR() const { return _lor; }
+  /// Returns whether or not this solver (or its preconditioner) uses LOR
+  bool isLOR() const { return _lor || (_preconditioner && _preconditioner->isLOR()); }
 
 protected:
   /// Override in derived classes to construct and set the solver options.
@@ -41,8 +42,9 @@ protected:
   // Variable defining whether to use LOR solver
   bool _lor;
 
-  // Solver to be used for the problem
+  // Solver and preconditioner to be used for the problem
   std::shared_ptr<mfem::Solver> _solver{nullptr};
+  MFEMSolverBase * _preconditioner{nullptr};
 };
 
 #endif

--- a/framework/src/mfem/bcs/MFEMBoundaryCondition.C
+++ b/framework/src/mfem/bcs/MFEMBoundaryCondition.C
@@ -42,7 +42,11 @@ MFEMBoundaryCondition::MFEMBoundaryCondition(const InputParameters & parameters)
   {
     _bdr_attributes[i] = std::stoi(_boundary_names[i]);
   }
-  mfem::ParMesh & mesh(getMFEMProblem().mesh().getMFEMParMesh());
+  mfem::ParMesh & mesh(*getMFEMProblem()
+                            .getProblemData()
+                            .gridfunctions.GetRef(_test_var_name)
+                            .ParFESpace()
+                            ->GetParMesh());
   mfem::common::AttrToMarker(mesh.bdr_attributes.Max(), _bdr_attributes, _bdr_markers);
 }
 

--- a/framework/src/mfem/bcs/MFEMScalarDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMScalarDirichletBC.C
@@ -32,11 +32,9 @@ MFEMScalarDirichletBC::MFEMScalarDirichletBC(const InputParameters & parameters)
 }
 
 void
-MFEMScalarDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh)
+MFEMScalarDirichletBC::ApplyBC(mfem::GridFunction & gridfunc)
 {
-  mfem::Array<int> ess_bdrs(mesh.bdr_attributes.Max());
-  ess_bdrs = getBoundaries();
-  gridfunc.ProjectBdrCoefficient(_coef, ess_bdrs);
+  gridfunc.ProjectBdrCoefficient(_coef, getBoundaries());
 }
 
 #endif

--- a/framework/src/mfem/bcs/MFEMScalarFunctorDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMScalarFunctorDirichletBC.C
@@ -34,11 +34,9 @@ MFEMScalarFunctorDirichletBC::MFEMScalarFunctorDirichletBC(const InputParameters
 }
 
 void
-MFEMScalarFunctorDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh)
+MFEMScalarFunctorDirichletBC::ApplyBC(mfem::GridFunction & gridfunc)
 {
-  mfem::Array<int> ess_bdrs(mesh.bdr_attributes.Max());
-  ess_bdrs = getBoundaries();
-  gridfunc.ProjectBdrCoefficient(_coef, ess_bdrs);
+  gridfunc.ProjectBdrCoefficient(_coef, getBoundaries());
 }
 
 #endif

--- a/framework/src/mfem/bcs/MFEMScalarFunctorDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMScalarFunctorDirichletBC.C
@@ -17,6 +17,7 @@ InputParameters
 MFEMScalarFunctorDirichletBC::validParams()
 {
   InputParameters params = MFEMEssentialBC::validParams();
+  params.addClassDescription("Applies a Dirichlet condition to a scalar variable.");
   params.addRequiredParam<MFEMScalarCoefficientName>(
       "coefficient",
       "The coefficient setting the values on the essential boundary. A coefficient can be any of "

--- a/framework/src/mfem/bcs/MFEMVectorDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorDirichletBC.C
@@ -29,11 +29,9 @@ MFEMVectorDirichletBC::MFEMVectorDirichletBC(const InputParameters & parameters)
 }
 
 void
-MFEMVectorDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh)
+MFEMVectorDirichletBC::ApplyBC(mfem::GridFunction & gridfunc)
 {
-  mfem::Array<int> ess_bdrs(mesh.bdr_attributes.Max());
-  ess_bdrs = getBoundaries();
-  gridfunc.ProjectBdrCoefficient(_vec_coef, ess_bdrs);
+  gridfunc.ProjectBdrCoefficient(_vec_coef, getBoundaries());
 }
 
 #endif

--- a/framework/src/mfem/bcs/MFEMVectorFunctorBoundaryIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorFunctorBoundaryIntegratedBC.C
@@ -17,6 +17,8 @@ InputParameters
 MFEMVectorFunctorBoundaryIntegratedBC::validParams()
 {
   InputParameters params = MFEMIntegratedBC::validParams();
+  params.addClassDescription("Adds the boundary integrator to an MFEM problem for the linear form "
+                             "$(\\vec f, \\vec v)_{\\partial\\Omega}$");
   params.addRequiredParam<MFEMVectorCoefficientName>(
       "vector_coefficient",
       "Vector coefficient used in the boundary integrator. A coefficient can be any of the "

--- a/framework/src/mfem/bcs/MFEMVectorFunctorDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorFunctorDirichletBC.C
@@ -28,11 +28,9 @@ MFEMVectorFunctorDirichletBC::MFEMVectorFunctorDirichletBC(const InputParameters
 }
 
 void
-MFEMVectorFunctorDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh)
+MFEMVectorFunctorDirichletBC::ApplyBC(mfem::GridFunction & gridfunc)
 {
-  mfem::Array<int> ess_bdrs(mesh.bdr_attributes.Max());
-  ess_bdrs = getBoundaries();
-  gridfunc.ProjectBdrCoefficient(_vec_coef, ess_bdrs);
+  gridfunc.ProjectBdrCoefficient(_vec_coef, getBoundaries());
 }
 
 #endif

--- a/framework/src/mfem/bcs/MFEMVectorFunctorDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorFunctorDirichletBC.C
@@ -13,6 +13,15 @@
 
 registerMooseObject("MooseApp", MFEMVectorFunctorDirichletBC);
 
+InputParameters
+MFEMVectorFunctorDirichletBC::validParams()
+{
+  InputParameters params = MFEMVectorFunctorDirichletBCBase::validParams();
+  params.addClassDescription(
+      "Applies a Dirichlet condition to all components of a vector variable.");
+  return params;
+}
+
 MFEMVectorFunctorDirichletBC::MFEMVectorFunctorDirichletBC(const InputParameters & parameters)
   : MFEMVectorFunctorDirichletBCBase(parameters)
 {

--- a/framework/src/mfem/bcs/MFEMVectorFunctorNormalDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorFunctorNormalDirichletBC.C
@@ -29,11 +29,9 @@ MFEMVectorFunctorNormalDirichletBC::MFEMVectorFunctorNormalDirichletBC(
 }
 
 void
-MFEMVectorFunctorNormalDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh)
+MFEMVectorFunctorNormalDirichletBC::ApplyBC(mfem::GridFunction & gridfunc)
 {
-  mfem::Array<int> ess_bdrs(mesh.bdr_attributes.Max());
-  ess_bdrs = getBoundaries();
-  gridfunc.ProjectBdrCoefficientNormal(_vec_coef, ess_bdrs);
+  gridfunc.ProjectBdrCoefficientNormal(_vec_coef, getBoundaries());
 }
 
 #endif

--- a/framework/src/mfem/bcs/MFEMVectorFunctorNormalIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorFunctorNormalIntegratedBC.C
@@ -17,6 +17,8 @@ InputParameters
 MFEMVectorFunctorNormalIntegratedBC::validParams()
 {
   InputParameters params = MFEMIntegratedBC::validParams();
+  params.addClassDescription("Adds the boundary integrator to an MFEM problem for the linear form "
+                             "$(\\vec f \\cdot \\hat n, v)_{\\partial\\Omega}$");
   params.addRequiredParam<MFEMVectorCoefficientName>(
       "vector_coefficient",
       "Vector coefficient whose normal component will be used in the integrated BC. A coefficient "

--- a/framework/src/mfem/bcs/MFEMVectorFunctorTangentialDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorFunctorTangentialDirichletBC.C
@@ -29,11 +29,9 @@ MFEMVectorFunctorTangentialDirichletBC::MFEMVectorFunctorTangentialDirichletBC(
 }
 
 void
-MFEMVectorFunctorTangentialDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh)
+MFEMVectorFunctorTangentialDirichletBC::ApplyBC(mfem::GridFunction & gridfunc)
 {
-  mfem::Array<int> ess_bdrs(mesh.bdr_attributes.Max());
-  ess_bdrs = getBoundaries();
-  gridfunc.ProjectBdrCoefficientTangent(_vec_coef, ess_bdrs);
+  gridfunc.ProjectBdrCoefficientTangent(_vec_coef, getBoundaries());
 }
 
 #endif

--- a/framework/src/mfem/bcs/MFEMVectorFunctorTangentialDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorFunctorTangentialDirichletBC.C
@@ -13,6 +13,15 @@
 
 registerMooseObject("MooseApp", MFEMVectorFunctorTangentialDirichletBC);
 
+InputParameters
+MFEMVectorFunctorTangentialDirichletBC::validParams()
+{
+  InputParameters params = MFEMVectorFunctorDirichletBCBase::validParams();
+  params.addClassDescription(
+      "Applies a Dirichlet condition to the tangential components of a vector variable.");
+  return params;
+}
+
 MFEMVectorFunctorTangentialDirichletBC::MFEMVectorFunctorTangentialDirichletBC(
     const InputParameters & parameters)
   : MFEMVectorFunctorDirichletBCBase(parameters)

--- a/framework/src/mfem/bcs/MFEMVectorNormalDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorNormalDirichletBC.C
@@ -28,11 +28,9 @@ MFEMVectorNormalDirichletBC::MFEMVectorNormalDirichletBC(const InputParameters &
 }
 
 void
-MFEMVectorNormalDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh)
+MFEMVectorNormalDirichletBC::ApplyBC(mfem::GridFunction & gridfunc)
 {
-  mfem::Array<int> ess_bdrs(mesh.bdr_attributes.Max());
-  ess_bdrs = getBoundaries();
-  gridfunc.ProjectBdrCoefficientNormal(_vec_coef, ess_bdrs);
+  gridfunc.ProjectBdrCoefficientNormal(_vec_coef, getBoundaries());
 }
 
 #endif

--- a/framework/src/mfem/bcs/MFEMVectorTangentialDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorTangentialDirichletBC.C
@@ -28,11 +28,9 @@ MFEMVectorTangentialDirichletBC::MFEMVectorTangentialDirichletBC(const InputPara
 }
 
 void
-MFEMVectorTangentialDirichletBC::ApplyBC(mfem::GridFunction & gridfunc, mfem::Mesh & mesh)
+MFEMVectorTangentialDirichletBC::ApplyBC(mfem::GridFunction & gridfunc)
 {
-  mfem::Array<int> ess_bdrs(mesh.bdr_attributes.Max());
-  ess_bdrs = getBoundaries();
-  gridfunc.ProjectBdrCoefficientTangent(_vec_coef, ess_bdrs);
+  gridfunc.ProjectBdrCoefficientTangent(_vec_coef, getBoundaries());
 }
 
 #endif

--- a/framework/src/mfem/equation_systems/EquationSystem.C
+++ b/framework/src/mfem/equation_systems/EquationSystem.C
@@ -137,7 +137,7 @@ EquationSystem::ApplyEssentialBCs()
     global_ess_markers = 0;
     for (auto & bc : bcs)
     {
-      bc->ApplyBC(trial_gf, *pmesh);
+      bc->ApplyBC(trial_gf);
 
       mfem::Array<int> ess_bdrs(bc->getBoundaries());
       for (auto it = 0; it != pmesh->bdr_attributes.Max(); ++it)

--- a/framework/src/mfem/postprocessors/MFEML2Error.C
+++ b/framework/src/mfem/postprocessors/MFEML2Error.C
@@ -19,8 +19,8 @@ MFEML2Error::validParams()
 {
   InputParameters params = MFEMPostprocessor::validParams();
   params.addClassDescription(
-      "Computes L2 error $\\left\\Vert u_{ex} - u_{h}\\right\\Vert_{\rm L2}$ for "
-      "gridfucntions using H1 or L2 elements.");
+      "Computes L2 error $\\left\\Vert u_{ex} - u_{h}\\right\\Vert_{\\rm L2}$ for "
+      "gridfunctions using H1 or L2 elements.");
   params.addParam<MFEMScalarCoefficientName>("function",
                                              "The analytic solution to compare against.");
   params.addParam<VariableName>("variable",

--- a/framework/src/mfem/postprocessors/MFEMVectorL2Error.C
+++ b/framework/src/mfem/postprocessors/MFEMVectorL2Error.C
@@ -19,8 +19,8 @@ MFEMVectorL2Error::validParams()
 {
   InputParameters params = MFEMPostprocessor::validParams();
   params.addClassDescription(
-      "Computes L2 error $\\left\\Vert \vec u_{ex} - \vec u_{h}\\right\\Vert_{\rm L2}$ for vector "
-      "gridfucntions.");
+      "Computes L2 error $\\left\\Vert \\vec u_{ex} - \\vec u_{h}\\right\\Vert_{\\rm L2}$ for "
+      "vector gridfunctions.");
   params.addParam<MFEMVectorCoefficientName>("function",
                                              "The analytic solution to compare against.");
   params.addParam<VariableName>(

--- a/framework/src/mfem/problem/MFEMProblem.C
+++ b/framework/src/mfem/problem/MFEMProblem.C
@@ -102,7 +102,6 @@ MFEMProblem::addBoundaryCondition(const std::string & bc_name,
   {
     auto object_ptr = getUserObject<MFEMIntegratedBC>(name).getSharedPtr();
     auto bc = std::dynamic_pointer_cast<MFEMIntegratedBC>(object_ptr);
-    bc->getBoundaries();
     if (getProblemData().eqn_system)
     {
       getProblemData().eqn_system->AddIntegratedBC(std::move(bc));
@@ -117,7 +116,6 @@ MFEMProblem::addBoundaryCondition(const std::string & bc_name,
   {
     auto object_ptr = getUserObject<MFEMEssentialBC>(name).getSharedPtr();
     auto mfem_bc = std::dynamic_pointer_cast<MFEMEssentialBC>(object_ptr);
-    mfem_bc->getBoundaries();
     if (getProblemData().eqn_system)
     {
       getProblemData().eqn_system->AddEssentialBC(std::move(mfem_bc));

--- a/framework/src/mfem/problem/MFEMProblem.C
+++ b/framework/src/mfem/problem/MFEMProblem.C
@@ -65,9 +65,6 @@ MFEMProblem::addMFEMPreconditioner(const std::string & user_object_name,
                                    InputParameters & parameters)
 {
   FEProblemBase::addUserObject(user_object_name, name, parameters);
-  auto object_ptr = getUserObject<MFEMSolverBase>(name).getSharedPtr();
-
-  getProblemData().jacobian_preconditioner = std::dynamic_pointer_cast<MFEMSolverBase>(object_ptr);
 }
 
 void

--- a/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
@@ -40,7 +40,7 @@ EquationSystemProblemOperator::Solve(mfem::Vector &)
       *_equation_system->_blfs.Get(_equation_system->_test_var_names.at(0)),
       _equation_system->_ess_tdof_lists.at(0));
 
-  _problem.nonlinear_solver->SetSolver(*_problem.jacobian_solver->getSolver());
+  _problem.nonlinear_solver->SetSolver(_problem.jacobian_solver->getSolver());
   _problem.nonlinear_solver->SetOperator(*GetEquationSystem());
   _problem.nonlinear_solver->Mult(_true_rhs, _true_x);
 

--- a/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
@@ -33,8 +33,7 @@ EquationSystemProblemOperator::Solve(mfem::Vector &)
 {
   GetEquationSystem()->BuildJacobian(_true_x, _true_rhs);
 
-  if ((_problem.jacobian_solver->isLOR() || _problem.jacobian_preconditioner->isLOR()) &&
-      _equation_system->_test_var_names.size() > 1)
+  if (_problem.jacobian_solver->isLOR() && _equation_system->_test_var_names.size() > 1)
     mooseError("LOR solve is only supported for single-variable systems");
 
   _problem.jacobian_solver->updateSolver(

--- a/framework/src/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.C
@@ -47,8 +47,7 @@ TimeDomainEquationSystemProblemOperator::ImplicitSolve(const double dt,
   _problem.coefficients.setTime(GetTime());
   BuildEquationSystemOperator(dt);
 
-  if ((_problem.jacobian_solver->isLOR() || _problem.jacobian_preconditioner->isLOR()) &&
-      _equation_system->_test_var_names.size() > 1)
+  if (_problem.jacobian_solver->isLOR() && _equation_system->_test_var_names.size() > 1)
     mooseError("LOR solve is only supported for single-variable systems");
 
   _problem.jacobian_solver->updateSolver(

--- a/framework/src/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.C
@@ -54,7 +54,7 @@ TimeDomainEquationSystemProblemOperator::ImplicitSolve(const double dt,
       *_equation_system->_blfs.Get(_equation_system->_test_var_names.at(0)),
       _equation_system->_ess_tdof_lists.at(0));
 
-  _problem.nonlinear_solver->SetSolver(*_problem.jacobian_solver->getSolver());
+  _problem.nonlinear_solver->SetSolver(_problem.jacobian_solver->getSolver());
   _problem.nonlinear_solver->SetOperator(*GetEquationSystem());
   _problem.nonlinear_solver->Mult(_true_rhs, dX_dt);
   SetTrialVariablesFromTrueVectors();

--- a/framework/src/mfem/solvers/MFEMCGSolver.C
+++ b/framework/src/mfem/solvers/MFEMCGSolver.C
@@ -39,26 +39,25 @@ void
 MFEMCGSolver::constructSolver(const InputParameters &)
 {
   auto solver =
-      std::make_shared<mfem::CGSolver>(getMFEMProblem().mesh().getMFEMParMesh().GetComm());
+      std::make_unique<mfem::CGSolver>(getMFEMProblem().mesh().getMFEMParMesh().GetComm());
   solver->SetRelTol(getParam<mfem::real_t>("l_tol"));
   solver->SetAbsTol(getParam<mfem::real_t>("l_abs_tol"));
   solver->SetMaxIter(getParam<int>("l_max_its"));
   solver->SetPrintLevel(getParam<int>("print_level"));
-  setPreconditioner(solver);
-  _solver = solver;
+  setPreconditioner(*solver);
+  _solver = std::move(solver);
 }
 
 void
 MFEMCGSolver::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs)
 {
-
   if (_lor && _preconditioner)
     mooseError("LOR solver cannot take a preconditioner");
 
   if (_preconditioner)
   {
     _preconditioner->updateSolver(a, tdofs);
-    setPreconditioner(std::dynamic_pointer_cast<mfem::CGSolver>(_solver));
+    setPreconditioner(static_cast<mfem::CGSolver &>(*_solver));
   }
   else if (_lor)
   {

--- a/framework/src/mfem/solvers/MFEMCGSolver.C
+++ b/framework/src/mfem/solvers/MFEMCGSolver.C
@@ -30,11 +30,7 @@ MFEMCGSolver::validParams()
   return params;
 }
 
-MFEMCGSolver::MFEMCGSolver(const InputParameters & parameters)
-  : MFEMSolverBase(parameters),
-    _preconditioner(isParamSetByUser("preconditioner")
-                        ? getMFEMProblem().getProblemData().jacobian_preconditioner
-                        : nullptr)
+MFEMCGSolver::MFEMCGSolver(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
   constructSolver(parameters);
 }
@@ -49,8 +45,12 @@ MFEMCGSolver::constructSolver(const InputParameters &)
   solver->SetMaxIter(getParam<int>("l_max_its"));
   solver->SetPrintLevel(getParam<int>("print_level"));
 
-  if (_preconditioner)
+  if (isParamSetByUser("preconditioner"))
+  {
+    _preconditioner =
+        &const_cast<MFEMSolverBase &>(getUserObject<MFEMSolverBase>("preconditioner"));
     solver->SetPreconditioner(*_preconditioner->getSolver());
+  }
 
   _solver = solver;
 }

--- a/framework/src/mfem/solvers/MFEMCGSolver.C
+++ b/framework/src/mfem/solvers/MFEMCGSolver.C
@@ -44,14 +44,7 @@ MFEMCGSolver::constructSolver(const InputParameters &)
   solver->SetAbsTol(getParam<mfem::real_t>("l_abs_tol"));
   solver->SetMaxIter(getParam<int>("l_max_its"));
   solver->SetPrintLevel(getParam<int>("print_level"));
-
-  if (isParamSetByUser("preconditioner"))
-  {
-    _preconditioner =
-        &const_cast<MFEMSolverBase &>(getUserObject<MFEMSolverBase>("preconditioner"));
-    solver->SetPreconditioner(*_preconditioner->getSolver());
-  }
-
+  setPreconditioner(solver);
   _solver = solver;
 }
 
@@ -65,9 +58,7 @@ MFEMCGSolver::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs)
   if (_preconditioner)
   {
     _preconditioner->updateSolver(a, tdofs);
-    auto solver = std::dynamic_pointer_cast<mfem::CGSolver>(_solver);
-    solver->SetPreconditioner(*_preconditioner->getSolver());
-    _solver = solver;
+    setPreconditioner(std::dynamic_pointer_cast<mfem::CGSolver>(_solver));
   }
   else if (_lor)
   {

--- a/framework/src/mfem/solvers/MFEMGMRESSolver.C
+++ b/framework/src/mfem/solvers/MFEMGMRESSolver.C
@@ -30,11 +30,7 @@ MFEMGMRESSolver::validParams()
   return params;
 }
 
-MFEMGMRESSolver::MFEMGMRESSolver(const InputParameters & parameters)
-  : MFEMSolverBase(parameters),
-    _preconditioner(isParamSetByUser("preconditioner")
-                        ? getMFEMProblem().getProblemData().jacobian_preconditioner
-                        : nullptr)
+MFEMGMRESSolver::MFEMGMRESSolver(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
   constructSolver(parameters);
 }
@@ -49,8 +45,12 @@ MFEMGMRESSolver::constructSolver(const InputParameters &)
   solver->SetMaxIter(getParam<int>("l_max_its"));
   solver->SetPrintLevel(getParam<int>("print_level"));
 
-  if (_preconditioner)
+  if (isParamSetByUser("preconditioner"))
+  {
+    _preconditioner =
+        &const_cast<MFEMSolverBase &>(getUserObject<MFEMSolverBase>("preconditioner"));
     solver->SetPreconditioner(*_preconditioner->getSolver());
+  }
 
   _solver = solver;
 }

--- a/framework/src/mfem/solvers/MFEMGMRESSolver.C
+++ b/framework/src/mfem/solvers/MFEMGMRESSolver.C
@@ -39,26 +39,25 @@ void
 MFEMGMRESSolver::constructSolver(const InputParameters &)
 {
   auto solver =
-      std::make_shared<mfem::GMRESSolver>(getMFEMProblem().mesh().getMFEMParMesh().GetComm());
+      std::make_unique<mfem::GMRESSolver>(getMFEMProblem().mesh().getMFEMParMesh().GetComm());
   solver->SetRelTol(getParam<mfem::real_t>("l_tol"));
   solver->SetAbsTol(getParam<mfem::real_t>("l_abs_tol"));
   solver->SetMaxIter(getParam<int>("l_max_its"));
   solver->SetPrintLevel(getParam<int>("print_level"));
-  setPreconditioner(solver);
-  _solver = solver;
+  setPreconditioner(*solver);
+  _solver = std::move(solver);
 }
 
 void
 MFEMGMRESSolver::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs)
 {
-
   if (_lor && _preconditioner)
     mooseError("LOR solver cannot take a preconditioner");
 
   if (_preconditioner)
   {
     _preconditioner->updateSolver(a, tdofs);
-    setPreconditioner(std::dynamic_pointer_cast<mfem::GMRESSolver>(_solver));
+    setPreconditioner(static_cast<mfem::GMRESSolver &>(*_solver));
   }
   else if (_lor)
   {

--- a/framework/src/mfem/solvers/MFEMGMRESSolver.C
+++ b/framework/src/mfem/solvers/MFEMGMRESSolver.C
@@ -44,14 +44,7 @@ MFEMGMRESSolver::constructSolver(const InputParameters &)
   solver->SetAbsTol(getParam<mfem::real_t>("l_abs_tol"));
   solver->SetMaxIter(getParam<int>("l_max_its"));
   solver->SetPrintLevel(getParam<int>("print_level"));
-
-  if (isParamSetByUser("preconditioner"))
-  {
-    _preconditioner =
-        &const_cast<MFEMSolverBase &>(getUserObject<MFEMSolverBase>("preconditioner"));
-    solver->SetPreconditioner(*_preconditioner->getSolver());
-  }
-
+  setPreconditioner(solver);
   _solver = solver;
 }
 
@@ -65,9 +58,7 @@ MFEMGMRESSolver::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdof
   if (_preconditioner)
   {
     _preconditioner->updateSolver(a, tdofs);
-    auto solver = std::dynamic_pointer_cast<mfem::GMRESSolver>(_solver);
-    solver->SetPreconditioner(*_preconditioner->getSolver());
-    _solver = solver;
+    setPreconditioner(std::dynamic_pointer_cast<mfem::GMRESSolver>(_solver));
   }
   else if (_lor)
   {

--- a/framework/src/mfem/solvers/MFEMHypreADS.C
+++ b/framework/src/mfem/solvers/MFEMHypreADS.C
@@ -34,10 +34,10 @@ MFEMHypreADS::MFEMHypreADS(const InputParameters & parameters)
 void
 MFEMHypreADS::constructSolver(const InputParameters &)
 {
-  auto solver = std::make_shared<mfem::HypreADS>(_mfem_fespace.getFESpace().get());
+  auto solver = std::make_unique<mfem::HypreADS>(_mfem_fespace.getFESpace().get());
   solver->SetPrintLevel(getParam<int>("print_level"));
 
-  _solver = solver;
+  _solver = std::move(solver);
 }
 
 void

--- a/framework/src/mfem/solvers/MFEMHypreADS.C
+++ b/framework/src/mfem/solvers/MFEMHypreADS.C
@@ -28,6 +28,7 @@ MFEMHypreADS::validParams()
 MFEMHypreADS::MFEMHypreADS(const InputParameters & parameters)
   : MFEMSolverBase(parameters), _mfem_fespace(getUserObject<MFEMFESpace>("fespace"))
 {
+  mfem::Hypre::Init();
   constructSolver(parameters);
 }
 

--- a/framework/src/mfem/solvers/MFEMHypreAMS.C
+++ b/framework/src/mfem/solvers/MFEMHypreAMS.C
@@ -32,6 +32,7 @@ MFEMHypreAMS::validParams()
 MFEMHypreAMS::MFEMHypreAMS(const InputParameters & parameters)
   : MFEMSolverBase(parameters), _mfem_fespace(getUserObject<MFEMFESpace>("fespace"))
 {
+  mfem::Hypre::Init();
   constructSolver(parameters);
 }
 

--- a/framework/src/mfem/solvers/MFEMHypreAMS.C
+++ b/framework/src/mfem/solvers/MFEMHypreAMS.C
@@ -50,7 +50,6 @@ MFEMHypreAMS::constructSolver(const InputParameters &)
 void
 MFEMHypreAMS::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs)
 {
-
   if (_lor)
   {
     if (_mfem_fespace.getFESpace()->GetMesh()->GetElement(0)->GetGeometryType() !=

--- a/framework/src/mfem/solvers/MFEMHypreAMS.C
+++ b/framework/src/mfem/solvers/MFEMHypreAMS.C
@@ -38,13 +38,13 @@ MFEMHypreAMS::MFEMHypreAMS(const InputParameters & parameters)
 void
 MFEMHypreAMS::constructSolver(const InputParameters &)
 {
-  auto solver = std::make_shared<mfem::HypreAMS>(_mfem_fespace.getFESpace().get());
+  auto solver = std::make_unique<mfem::HypreAMS>(_mfem_fespace.getFESpace().get());
   if (getParam<bool>("singular"))
     solver->SetSingularProblem();
 
   solver->SetPrintLevel(getParam<int>("print_level"));
 
-  _solver = solver;
+  _solver = std::move(solver);
 }
 
 void

--- a/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
+++ b/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
@@ -27,14 +27,15 @@ MFEMHypreBoomerAMG::validParams()
       "fespace", "H1 FESpace to use in HypreBoomerAMG setup for elasticity problems.");
   params.addParam<mfem::real_t>(
       "strength_threshold", 0.25, "HypreBoomerAMG strong threshold. Defaults to 0.25.");
+  MooseEnum errmode("ignore=0 warn=1 abort=2", "abort", false);
+  params.addParam<MooseEnum>("error_mode", errmode, "Set the behavior for treating hypre errors.");
   return params;
 }
 
 MFEMHypreBoomerAMG::MFEMHypreBoomerAMG(const InputParameters & parameters)
   : MFEMSolverBase(parameters),
     _mfem_fespace(isParamSetByUser("fespace") ? getUserObject<MFEMFESpace>("fespace").getFESpace()
-                                              : nullptr),
-    _strength_threshold(getParam<mfem::real_t>("strength_threshold"))
+                                              : nullptr)
 {
   constructSolver(parameters);
 }
@@ -47,7 +48,8 @@ MFEMHypreBoomerAMG::constructSolver(const InputParameters &)
   solver->SetTol(getParam<mfem::real_t>("l_tol"));
   solver->SetMaxIter(getParam<int>("l_max_its"));
   solver->SetPrintLevel(getParam<int>("print_level"));
-  solver->SetStrengthThresh(_strength_threshold);
+  solver->SetStrengthThresh(getParam<mfem::real_t>("strength_threshold"));
+  solver->SetErrorMode(mfem::HypreSolver::ErrorMode(int(getParam<MooseEnum>("error_mode"))));
 
   if (_mfem_fespace && !mfem::HypreUsingGPU())
     solver->SetElasticityOptions(_mfem_fespace.get());
@@ -64,7 +66,7 @@ MFEMHypreBoomerAMG::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & t
     lor_solver->GetSolver().SetTol(getParam<mfem::real_t>("l_tol"));
     lor_solver->GetSolver().SetMaxIter(getParam<int>("l_max_its"));
     lor_solver->GetSolver().SetPrintLevel(getParam<int>("print_level"));
-    lor_solver->GetSolver().SetStrengthThresh(_strength_threshold);
+    lor_solver->GetSolver().SetStrengthThresh(getParam<mfem::real_t>("strength_threshold"));
 
     if (_mfem_fespace && !mfem::HypreUsingGPU())
       lor_solver->GetSolver().SetElasticityOptions(_mfem_fespace.get());

--- a/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
+++ b/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
@@ -58,7 +58,6 @@ MFEMHypreBoomerAMG::constructSolver(const InputParameters &)
 void
 MFEMHypreBoomerAMG::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs)
 {
-
   if (_lor)
   {
     auto lor_solver = new mfem::LORSolver<mfem::HypreBoomerAMG>(a, tdofs);

--- a/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
+++ b/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
@@ -43,7 +43,7 @@ MFEMHypreBoomerAMG::MFEMHypreBoomerAMG(const InputParameters & parameters)
 void
 MFEMHypreBoomerAMG::constructSolver(const InputParameters &)
 {
-  auto solver = std::make_shared<mfem::HypreBoomerAMG>();
+  auto solver = std::make_unique<mfem::HypreBoomerAMG>();
 
   solver->SetTol(getParam<mfem::real_t>("l_tol"));
   solver->SetMaxIter(getParam<int>("l_max_its"));
@@ -54,7 +54,7 @@ MFEMHypreBoomerAMG::constructSolver(const InputParameters &)
   if (_mfem_fespace && !mfem::HypreUsingGPU())
     solver->SetElasticityOptions(_mfem_fespace.get());
 
-  _solver = solver;
+  _solver = std::move(solver);
 }
 
 void

--- a/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
+++ b/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
@@ -37,6 +37,7 @@ MFEMHypreBoomerAMG::MFEMHypreBoomerAMG(const InputParameters & parameters)
     _mfem_fespace(isParamSetByUser("fespace") ? getUserObject<MFEMFESpace>("fespace").getFESpace()
                                               : nullptr)
 {
+  mfem::Hypre::Init();
   constructSolver(parameters);
 }
 

--- a/framework/src/mfem/solvers/MFEMHypreFGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreFGMRES.C
@@ -44,18 +44,7 @@ MFEMHypreFGMRES::constructSolver(const InputParameters &)
   solver->SetMaxIter(getParam<int>("l_max_its"));
   solver->SetKDim(getParam<int>("kdim"));
   solver->SetPrintLevel(getParam<int>("print_level"));
-
-  if (isParamSetByUser("preconditioner"))
-  {
-    _preconditioner =
-        &const_cast<MFEMSolverBase &>(getUserObject<MFEMSolverBase>("preconditioner"));
-    auto hypre_preconditioner =
-        std::dynamic_pointer_cast<mfem::HypreSolver>(_preconditioner->getSolver());
-    if (!hypre_preconditioner)
-      mooseError("Hypre FGMRES preconditioner must be a Hypre Solver");
-    solver->SetPreconditioner(*hypre_preconditioner);
-  }
-
+  setPreconditioner(solver);
   _solver = solver;
 }
 
@@ -69,11 +58,7 @@ MFEMHypreFGMRES::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdof
   if (_preconditioner)
   {
     _preconditioner->updateSolver(a, tdofs);
-    auto hypre_preconditioner =
-        std::dynamic_pointer_cast<mfem::HypreSolver>(_preconditioner->getSolver());
-    auto solver = std::dynamic_pointer_cast<mfem::HypreFGMRES>(_solver);
-    solver->SetPreconditioner(*hypre_preconditioner);
-    _solver = solver;
+    setPreconditioner(std::dynamic_pointer_cast<mfem::HypreFGMRES>(_solver));
   }
   else if (_lor)
   {

--- a/framework/src/mfem/solvers/MFEMHypreFGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreFGMRES.C
@@ -31,6 +31,7 @@ MFEMHypreFGMRES::validParams()
 
 MFEMHypreFGMRES::MFEMHypreFGMRES(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
+  mfem::Hypre::Init();
   constructSolver(parameters);
 }
 

--- a/framework/src/mfem/solvers/MFEMHypreFGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreFGMRES.C
@@ -29,11 +29,7 @@ MFEMHypreFGMRES::validParams()
   return params;
 }
 
-MFEMHypreFGMRES::MFEMHypreFGMRES(const InputParameters & parameters)
-  : MFEMSolverBase(parameters),
-    _preconditioner(isParamSetByUser("preconditioner")
-                        ? getMFEMProblem().getProblemData().jacobian_preconditioner
-                        : nullptr)
+MFEMHypreFGMRES::MFEMHypreFGMRES(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
   constructSolver(parameters);
 }
@@ -49,8 +45,10 @@ MFEMHypreFGMRES::constructSolver(const InputParameters &)
   solver->SetKDim(getParam<int>("kdim"));
   solver->SetPrintLevel(getParam<int>("print_level"));
 
-  if (_preconditioner)
+  if (isParamSetByUser("preconditioner"))
   {
+    _preconditioner =
+        &const_cast<MFEMSolverBase &>(getUserObject<MFEMSolverBase>("preconditioner"));
     auto hypre_preconditioner =
         std::dynamic_pointer_cast<mfem::HypreSolver>(_preconditioner->getSolver());
     if (!hypre_preconditioner)

--- a/framework/src/mfem/solvers/MFEMHypreGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreGMRES.C
@@ -31,11 +31,7 @@ MFEMHypreGMRES::validParams()
   return params;
 }
 
-MFEMHypreGMRES::MFEMHypreGMRES(const InputParameters & parameters)
-  : MFEMSolverBase(parameters),
-    _preconditioner(isParamSetByUser("preconditioner")
-                        ? getMFEMProblem().getProblemData().jacobian_preconditioner
-                        : nullptr)
+MFEMHypreGMRES::MFEMHypreGMRES(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
   constructSolver(parameters);
 }
@@ -52,8 +48,10 @@ MFEMHypreGMRES::constructSolver(const InputParameters &)
   solver->SetKDim(getParam<int>("kdim"));
   solver->SetPrintLevel(getParam<int>("print_level"));
 
-  if (_preconditioner)
+  if (isParamSetByUser("preconditioner"))
   {
+    _preconditioner =
+        &const_cast<MFEMSolverBase &>(getUserObject<MFEMSolverBase>("preconditioner"));
     auto hypre_preconditioner =
         std::dynamic_pointer_cast<mfem::HypreSolver>(_preconditioner->getSolver());
     if (!hypre_preconditioner)

--- a/framework/src/mfem/solvers/MFEMHypreGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreGMRES.C
@@ -33,6 +33,7 @@ MFEMHypreGMRES::validParams()
 
 MFEMHypreGMRES::MFEMHypreGMRES(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
+  mfem::Hypre::Init();
   constructSolver(parameters);
 }
 

--- a/framework/src/mfem/solvers/MFEMHypreGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreGMRES.C
@@ -39,29 +39,27 @@ MFEMHypreGMRES::MFEMHypreGMRES(const InputParameters & parameters) : MFEMSolverB
 void
 MFEMHypreGMRES::constructSolver(const InputParameters &)
 {
-
   auto solver =
-      std::make_shared<mfem::HypreGMRES>(getMFEMProblem().mesh().getMFEMParMesh().GetComm());
+      std::make_unique<mfem::HypreGMRES>(getMFEMProblem().mesh().getMFEMParMesh().GetComm());
   solver->SetTol(getParam<mfem::real_t>("l_tol"));
   solver->SetAbsTol(getParam<mfem::real_t>("l_abs_tol"));
   solver->SetMaxIter(getParam<int>("l_max_its"));
   solver->SetKDim(getParam<int>("kdim"));
   solver->SetPrintLevel(getParam<int>("print_level"));
-  setPreconditioner(solver);
-  _solver = solver;
+  setPreconditioner(*solver);
+  _solver = std::move(solver);
 }
 
 void
 MFEMHypreGMRES::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs)
 {
-
   if (_lor && _preconditioner)
     mooseError("LOR solver cannot take a preconditioner");
 
   if (_preconditioner)
   {
     _preconditioner->updateSolver(a, tdofs);
-    setPreconditioner(std::dynamic_pointer_cast<mfem::HypreGMRES>(_solver));
+    setPreconditioner(static_cast<mfem::HypreGMRES &>(*_solver));
   }
   else if (_lor)
   {

--- a/framework/src/mfem/solvers/MFEMHypreGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreGMRES.C
@@ -47,18 +47,7 @@ MFEMHypreGMRES::constructSolver(const InputParameters &)
   solver->SetMaxIter(getParam<int>("l_max_its"));
   solver->SetKDim(getParam<int>("kdim"));
   solver->SetPrintLevel(getParam<int>("print_level"));
-
-  if (isParamSetByUser("preconditioner"))
-  {
-    _preconditioner =
-        &const_cast<MFEMSolverBase &>(getUserObject<MFEMSolverBase>("preconditioner"));
-    auto hypre_preconditioner =
-        std::dynamic_pointer_cast<mfem::HypreSolver>(_preconditioner->getSolver());
-    if (!hypre_preconditioner)
-      mooseError("Hypre GMRES preconditioner must be a Hypre Solver");
-    solver->SetPreconditioner(*hypre_preconditioner);
-  }
-
+  setPreconditioner(solver);
   _solver = solver;
 }
 
@@ -72,11 +61,7 @@ MFEMHypreGMRES::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs
   if (_preconditioner)
   {
     _preconditioner->updateSolver(a, tdofs);
-    auto hypre_preconditioner =
-        std::dynamic_pointer_cast<mfem::HypreSolver>(_preconditioner->getSolver());
-    auto solver = std::dynamic_pointer_cast<mfem::HypreGMRES>(_solver);
-    solver->SetPreconditioner(*hypre_preconditioner);
-    _solver = solver;
+    setPreconditioner(std::dynamic_pointer_cast<mfem::HypreGMRES>(_solver));
   }
   else if (_lor)
   {

--- a/framework/src/mfem/solvers/MFEMHyprePCG.C
+++ b/framework/src/mfem/solvers/MFEMHyprePCG.C
@@ -32,6 +32,7 @@ MFEMHyprePCG::validParams()
 
 MFEMHyprePCG::MFEMHyprePCG(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
+  mfem::Hypre::Init();
   constructSolver(parameters);
 }
 

--- a/framework/src/mfem/solvers/MFEMHyprePCG.C
+++ b/framework/src/mfem/solvers/MFEMHyprePCG.C
@@ -30,11 +30,7 @@ MFEMHyprePCG::validParams()
   return params;
 }
 
-MFEMHyprePCG::MFEMHyprePCG(const InputParameters & parameters)
-  : MFEMSolverBase(parameters),
-    _preconditioner(isParamSetByUser("preconditioner")
-                        ? getMFEMProblem().getProblemData().jacobian_preconditioner
-                        : nullptr)
+MFEMHyprePCG::MFEMHyprePCG(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
   constructSolver(parameters);
 }
@@ -50,8 +46,10 @@ MFEMHyprePCG::constructSolver(const InputParameters &)
   solver->SetMaxIter(getParam<int>("l_max_its"));
   solver->SetPrintLevel(getParam<int>("print_level"));
 
-  if (_preconditioner)
+  if (isParamSetByUser("preconditioner"))
   {
+    _preconditioner =
+        &const_cast<MFEMSolverBase &>(getUserObject<MFEMSolverBase>("preconditioner"));
     auto hypre_preconditioner =
         std::dynamic_pointer_cast<mfem::HypreSolver>(_preconditioner->getSolver());
     if (!hypre_preconditioner)

--- a/framework/src/mfem/solvers/MFEMOperatorJacobiSmoother.C
+++ b/framework/src/mfem/solvers/MFEMOperatorJacobiSmoother.C
@@ -32,7 +32,7 @@ MFEMOperatorJacobiSmoother::MFEMOperatorJacobiSmoother(const InputParameters & p
 void
 MFEMOperatorJacobiSmoother::constructSolver(const InputParameters &)
 {
-  _solver = std::make_shared<mfem::OperatorJacobiSmoother>();
+  _solver = std::make_unique<mfem::OperatorJacobiSmoother>();
 }
 
 void

--- a/framework/src/mfem/solvers/MFEMSolverBase.C
+++ b/framework/src/mfem/solvers/MFEMSolverBase.C
@@ -34,8 +34,6 @@ template <typename T>
 void
 MFEMSolverBase::setPreconditioner(T & solver)
 {
-  static_assert(std::is_base_of_v<mfem::Solver, T>);
-
   if (isParamSetByUser("preconditioner"))
   {
     if (!_preconditioner)
@@ -48,12 +46,8 @@ MFEMSolverBase::setPreconditioner(T & solver)
         solver.SetPreconditioner(*hypre_pre);
       else
         mooseError("hypre solver preconditioners must themselves be hypre solvers");
-    else if constexpr (std::is_base_of_v<mfem::IterativeSolver, T>)
-      solver.SetPreconditioner(mfem_pre);
     else
-      mooseAssert(
-          true,
-          "We should never get here because we only instantiate this method for iterative solvers");
+      solver.SetPreconditioner(mfem_pre);
   }
 }
 

--- a/framework/src/mfem/solvers/MFEMSuperLU.C
+++ b/framework/src/mfem/solvers/MFEMSuperLU.C
@@ -32,7 +32,7 @@ MFEMSuperLU::MFEMSuperLU(const InputParameters & parameters) : MFEMSolverBase(pa
 void
 MFEMSuperLU::constructSolver(const InputParameters &)
 {
-  _solver = std::make_shared<Moose::MFEM::SuperLUSolver>(
+  _solver = std::make_unique<Moose::MFEM::SuperLUSolver>(
       getMFEMProblem().mesh().getMFEMParMesh().GetComm());
 }
 

--- a/python/MooseDocs/extensions/listing.py
+++ b/python/MooseDocs/extensions/listing.py
@@ -406,7 +406,7 @@ class InputListingCommand(FileListingCommand):
         hit = pyhit.load(filename)
         out = []
         for block in blocks.split():
-            node = moosetree.find(hit, lambda n: n.fullpath.endswith(block.strip('/')))
+            node = moosetree.find(hit, lambda n: n.fullpath.endswith(block.rstrip('/')))
             if node is None:
                 msg = "Unable to find block '{}' in {}."
                 raise exceptions.MooseDocsException(msg, block, filename)

--- a/test/tests/mfem/kernels/tests
+++ b/test/tests/mfem/kernels/tests
@@ -20,9 +20,10 @@
     xmldiff = 'OutputData/CurlCurlLOR/Run0/Run0.pvd
                 OutputData/CurlCurlLOR/Run0/Cycle000001/proc000000.vtu'
     ignored_items = "root['VTKFile']['@version']"
-    cli_args = 'FESpaces/HCurlFESpace/fec_order=THIRD Solver/type=MFEMGMRESSolver '
-               'Solver/l_tol=1e-14 Solver/preconditioner=ams Preconditioner/ams/low_order_refined=true '
-               'Outputs/ParaViewDataCollection/file_base=OutputData/CurlCurlLOR '
+    cli_args = 'FESpaces/HCurlFESpace/fec_order=THIRD '
+               'Solver/type=MFEMGMRESSolver Solver/l_tol=1e-14 '
+               'Preconditioner/ams/low_order_refined=true '
+               'Outputs/ParaViewDataCollection/file_base=OutputData/CurlCurlLOR'
     requirement = 'The system shall have the ability to solve a LOR definite Maxwell problem with Nedelec elements of the first kind using MFEM.'
     capabilities = 'mfem'
     max_parallel = 1
@@ -37,7 +38,6 @@
     xmldiff = 'OutputData/Diffusion/Run0/Run0.pvd
                 OutputData/Diffusion/Run0/Cycle000001/proc000000.vtu'
     ignored_items = "root['VTKFile']['@version']"
-    cli_args = 'Solver/type=MFEMCGSolver Solver/preconditioner=boomeramg'
     requirement = 'The system shall have the ability to solve a diffusion problem using MFEM.'
     capabilities = 'mfem'
     max_parallel = 1
@@ -62,10 +62,11 @@
     xmldiff = 'OutputData/DiffusionLOR/Run0/Run0.pvd '
               'OutputData/DiffusionLOR/Run0/Cycle000001/proc000000.vtu'
     ignored_items = "root['VTKFile']['@version']"
-    cli_args = 'FESpaces/H1FESpace/fec_order=SECOND Solver/type=MFEMCGSolver Solver/l_tol=1e-16 '
-               'Solver/preconditioner=boomeramg Preconditioner/boomeramg/low_order_refined=true '
-               'Outputs/ParaViewDataCollection/file_base=OutputData/DiffusionLOR '
-    requirement = 'MOOSE shall have the ability to solve a diffusion problem with Low-Order-Refined preconditioning set up from MOOSE and produce the same result as a native MFEM run.'
+    cli_args = 'FESpaces/H1FESpace/fec_order=SECOND '
+               'Solver/type=MFEMCGSolver Solver/preconditioner=jacobi '
+               'Preconditioner/jacobi/low_order_refined=true '
+               'Outputs/ParaViewDataCollection/file_base=OutputData/DiffusionLOR'
+    requirement = 'The system shall have the ability to solve a diffusion problem with Low-Order-Refined preconditioning set up from MOOSE and produce the same result as a native MFEM run.'
     capabilities = 'mfem'
     max_parallel = 1
     recover = false
@@ -89,9 +90,8 @@
                 OutputData/GradDivLOR/Run0/Cycle000001/proc000000.vtu'
     ignored_items = "root['VTKFile']['@version']"
     cli_args = 'Mesh/file=../mesh/beam-hex.mesh FESpaces/HDivFESpace/fec_order=THIRD '
-               'Solver/type=MFEMCGSolver Solver/l_tol=1e-14 Solver/preconditioner=ADS '
                'Preconditioner/ADS/low_order_refined=true '
-               'Outputs/ParaViewDataCollection/file_base=OutputData/GradDivLOR '
+               'Outputs/ParaViewDataCollection/file_base=OutputData/GradDivLOR'
     requirement = 'The system shall have the ability to solve a LOR grad-div problem with Raviart-Thomas elements using MFEM.'
     capabilities = 'mfem'
     max_parallel = 1
@@ -106,9 +106,7 @@
               'OutputData/HeatConduction/Run0/Cycle000004/proc000000.vtu'
     cli_args = 'BCs/active="bottom top_dirichlet" '
                'Executioner/dt=0.25 Executioner/end_time=1.0 '
-               'Outputs/ParaViewDataCollection/file_base=OutputData/HeatConduction '
-               'Solver/type=MFEMCGSolver Solver/preconditioner=boomeramg '
-               'Executioner/assembly_level=element'
+               'Outputs/ParaViewDataCollection/file_base=OutputData/HeatConduction'
     ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a transient heat conduction problem using MFEM.'
     capabilities = 'mfem'
@@ -141,10 +139,11 @@
     ignored_items = "root['VTKFile']['@version']"
     cli_args = 'BCs/active="bottom top_dirichlet" '
                'Executioner/dt=0.25 Executioner/end_time=1.0 '
-               'FESpaces/H1FESpace/fec_order=SECOND Solver/type=MFEMCGSolver Solver/l_tol=1e-22 '
-               'Solver/preconditioner=boomeramg Preconditioner/boomeramg/low_order_refined=true '
-               'Outputs/ParaViewDataCollection/file_base=OutputData/HeatConductionLOR '
-    requirement = 'MOOSE shall have the ability to solve a transient heat conduction problem with Low-Order-Refined preconditioning set up from MOOSE and produce the same result as a native MFEM run.'
+               'FESpaces/H1FESpace/fec_order=SECOND '
+               'Solver/type=MFEMCGSolver Solver/preconditioner=jacobi '
+               'Preconditioner/jacobi/low_order_refined=true '
+               'Outputs/ParaViewDataCollection/file_base=OutputData/HeatConductionLOR'
+    requirement = 'The system shall have the ability to solve a transient heat conduction problem with Low-Order-Refined preconditioning set up from MOOSE and produce the same result as a native MFEM run.'
     capabilities = 'mfem'
     max_parallel = 1
     recover = false
@@ -153,8 +152,7 @@
     type = XMLDiff
     input = heattransfer.i
     xmldiff = 'OutputData/HeatTransfer/Run0/Run0.pvd
-               OutputData/HeatTransfer/Run0/Cycle000003/proc000000.vtu'
-    cli_args = 'Solver/type=MFEMCGSolver Solver/preconditioner=boomeramg '
+                OutputData/HeatTransfer/Run0/Cycle000003/proc000000.vtu'
     ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a transient heat conduction problem with a heat transfer coefficient on one boundary using MFEM.'
     capabilities = 'mfem'

--- a/test/tests/mfem/kernels/tests
+++ b/test/tests/mfem/kernels/tests
@@ -26,6 +26,7 @@
                'Outputs/ParaViewDataCollection/file_base=OutputData/CurlCurlLOR'
     requirement = 'The system shall have the ability to solve a LOR definite Maxwell problem with Nedelec elements of the first kind using MFEM.'
     capabilities = 'mfem'
+    valgrind = heavy
     max_parallel = 1
     recover = false
     max_threads = 1
@@ -94,6 +95,7 @@
                'Outputs/ParaViewDataCollection/file_base=OutputData/GradDivLOR'
     requirement = 'The system shall have the ability to solve a LOR grad-div problem with Raviart-Thomas elements using MFEM.'
     capabilities = 'mfem'
+    valgrind = heavy
     max_parallel = 1
     recover = false
     abs_zero = 1e-6
@@ -127,6 +129,7 @@
     ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a transient heat conduction problem with element assembly using MFEM.'
     capabilities = 'mfem'
+    valgrind = none
     max_parallel = 1
     recover = false
   []

--- a/test/tests/mfem/outputs/tests
+++ b/test/tests/mfem/outputs/tests
@@ -5,8 +5,7 @@
     type = CheckFiles
     input = ../kernels/diffusion.i
     cli_args = 'Outputs/active="ParaViewDataCollection VisItDataCollection ConduitDataCollection" '
-               'Outputs/ParaViewDataCollection/file_base=OutputData/ParaViewDataCollection '
-               'Solver/type=MFEMCGSolver Solver/preconditioner=boomeramg'
+               'Outputs/ParaViewDataCollection/file_base=OutputData/ParaViewDataCollection'
     check_files = 'OutputData/ParaViewDataCollection/Run0/Run0.pvd '
                   'OutputData/ParaViewDataCollection/Run0/Cycle000001/proc000000.vtu '
                   'OutputData/VisItDataCollection/Run0_000000/mesh.000000 '

--- a/unit/src/MFEMEssentialBCTest.C
+++ b/unit/src/MFEMEssentialBCTest.C
@@ -53,6 +53,10 @@ public:
     _vector_h1_gridfunc.ProjectCoefficient(_vector_zero);
     _vector_hcurl_gridfunc.ProjectCoefficient(_vector_zero);
     _vector_hdiv_gridfunc.ProjectCoefficient(_vector_zero);
+    // Register a dummy (Par)GridFunction for the variable the BCs apply to
+    auto pm = _mfem_mesh_ptr->getMFEMParMeshPtr().get();
+    auto pgf = std::make_shared<mfem::ParGridFunction>(pm, &_scalar_gridfunc);
+    _mfem_problem->getProblemData().gridfunctions.Register("test_variable_name", pgf);
   }
 
   void check_boundary(int /*bound*/,

--- a/unit/src/MFEMEssentialBCTest.C
+++ b/unit/src/MFEMEssentialBCTest.C
@@ -111,7 +111,7 @@ TEST_F(MFEMEssentialBCTest, MFEMScalarDirichletBC)
   EXPECT_EQ(essential_bc.getTestVariableName(), "test_variable_name");
 
   // Test applying the BC
-  essential_bc.ApplyBC(_scalar_gridfunc, *_mfem_mesh_ptr->getMFEMParMeshPtr().get());
+  essential_bc.ApplyBC(_scalar_gridfunc);
 
   // Check the correct boundary values have been applied
   mfem::GridFunctionCoefficient scalar_variable(&_scalar_gridfunc);
@@ -141,7 +141,7 @@ TEST_F(MFEMEssentialBCTest, MFEMScalarFunctorDirichletBC)
   EXPECT_EQ(essential_bc.getTestVariableName(), "test_variable_name");
 
   // Test applying the BC
-  essential_bc.ApplyBC(_scalar_gridfunc, *_mfem_mesh_ptr->getMFEMParMeshPtr().get());
+  essential_bc.ApplyBC(_scalar_gridfunc);
 
   // Check the correct boundary values have been applied
   mfem::GridFunctionCoefficient scalar_variable(&_scalar_gridfunc);
@@ -171,7 +171,7 @@ TEST_F(MFEMEssentialBCTest, MFEMVectorDirichletBC)
   EXPECT_EQ(essential_bc.getTestVariableName(), "test_variable_name");
 
   // Test applying the BC
-  essential_bc.ApplyBC(_vector_h1_gridfunc, *_mfem_mesh_ptr->getMFEMParMeshPtr().get());
+  essential_bc.ApplyBC(_vector_h1_gridfunc);
 
   // Check the correct boundary values have been applied
   mfem::VectorGridFunctionCoefficient variable(&_vector_h1_gridfunc);
@@ -207,7 +207,7 @@ TEST_F(MFEMEssentialBCTest, MFEMVectorFunctorDirichletBC)
   EXPECT_EQ(essential_bc.getTestVariableName(), "test_variable_name");
 
   // Test applying the BC
-  essential_bc.ApplyBC(_vector_h1_gridfunc, *_mfem_mesh_ptr->getMFEMParMeshPtr().get());
+  essential_bc.ApplyBC(_vector_h1_gridfunc);
 
   // Check the correct boundary values have been applied
   mfem::VectorGridFunctionCoefficient variable(&_vector_h1_gridfunc);
@@ -245,7 +245,7 @@ TEST_F(MFEMEssentialBCTest, MFEMVectorNormalDirichletBC)
   EXPECT_EQ(essential_bc.getTestVariableName(), "test_variable_name");
 
   // Test applying the BC
-  essential_bc.ApplyBC(_vector_hdiv_gridfunc, *_mfem_mesh_ptr->getMFEMParMeshPtr().get());
+  essential_bc.ApplyBC(_vector_hdiv_gridfunc);
 
   // Check the correct boundary values have been applied
   mfem::VectorGridFunctionCoefficient variable(&_vector_hdiv_gridfunc);
@@ -283,7 +283,7 @@ TEST_F(MFEMEssentialBCTest, MFEMVectorFunctorNormalDirichletBC)
   EXPECT_EQ(essential_bc.getTestVariableName(), "test_variable_name");
 
   // Test applying the BC
-  essential_bc.ApplyBC(_vector_hdiv_gridfunc, *_mfem_mesh_ptr->getMFEMParMeshPtr().get());
+  essential_bc.ApplyBC(_vector_hdiv_gridfunc);
 
   // Check the correct boundary values have been applied
   mfem::VectorGridFunctionCoefficient variable(&_vector_hdiv_gridfunc);
@@ -322,7 +322,7 @@ TEST_F(MFEMEssentialBCTest, MFEMVectorTangentialDirichletBC)
   EXPECT_EQ(essential_bc.getTestVariableName(), "test_variable_name");
 
   // Test applying the BC
-  essential_bc.ApplyBC(_vector_hcurl_gridfunc, *_mfem_mesh_ptr->getMFEMParMeshPtr().get());
+  essential_bc.ApplyBC(_vector_hcurl_gridfunc);
   // Check the correct boundary values have been applied
   mfem::VectorGridFunctionCoefficient variable(&_vector_hcurl_gridfunc);
   mfem::Vector expected({1., 2., 3.});
@@ -361,7 +361,7 @@ TEST_F(MFEMEssentialBCTest, MFEMVectorFunctorTangentialDirichletBC)
   EXPECT_EQ(essential_bc.getTestVariableName(), "test_variable_name");
 
   // Test applying the BC
-  essential_bc.ApplyBC(_vector_hcurl_gridfunc, *_mfem_mesh_ptr->getMFEMParMeshPtr().get());
+  essential_bc.ApplyBC(_vector_hcurl_gridfunc);
 
   // Check the correct boundary values have been applied
   mfem::VectorGridFunctionCoefficient variable(&_vector_hcurl_gridfunc);

--- a/unit/src/MFEMIntegratedBCTest.C
+++ b/unit/src/MFEMIntegratedBCTest.C
@@ -1,5 +1,8 @@
 #ifdef MFEM_ENABLED
 
+#include "libmesh/ignore_warnings.h"
+#include "mfem/miniapps/common/mfem-common.hpp"
+#include "libmesh/restore_warnings.h"
 #include "MFEMObjectUnitTest.h"
 #include "MFEMScalarFunctorBoundaryIntegratedBC.h"
 #include "MFEMVectorBoundaryIntegratedBC.h"
@@ -11,7 +14,15 @@
 class MFEMIntegratedBCTest : public MFEMObjectUnitTest
 {
 public:
-  MFEMIntegratedBCTest() : MFEMObjectUnitTest("MooseUnitApp") {}
+  MFEMIntegratedBCTest() : MFEMObjectUnitTest("MooseUnitApp")
+  {
+    // Register a dummy (Par)GridFunction for the variable the BCs apply to
+    auto pm = _mfem_mesh_ptr->getMFEMParMeshPtr().get();
+    mfem::common::H1_FESpace fe(pm, 1);
+    mfem::GridFunction gf(&fe);
+    auto pgf = std::make_shared<mfem::ParGridFunction>(pm, &gf);
+    _mfem_problem->getProblemData().gridfunctions.Register("test_variable_name", pgf);
+  }
 };
 
 /**

--- a/unit/src/MFEMSolverTest.C
+++ b/unit/src/MFEMSolverTest.C
@@ -98,7 +98,7 @@ public:
     a.FormLinearSystem(ess_tdof_list, x, b, A, X, B);
 
     solver.updateSolver(a, ess_tdof_list);
-    auto solver_ptr = std::dynamic_pointer_cast<SolverType>(solver.getSolver()).get();
+    auto solver_ptr = dynamic_cast<SolverType *>(&solver.getSolver());
     // Test MFEMKernel returns an integrator of the expected type
     ASSERT_TRUE(solver_ptr != nullptr);
     solver_ptr->SetOperator(*A);
@@ -203,10 +203,10 @@ TEST_F(MFEMSolverTest, MFEMHypreBoomerAMG)
       addObject<MFEMHypreBoomerAMG>("MFEMHypreBoomerAMG", "solver1", solver_params);
 
   // Test MFEMSolver returns an solver of the expected type
-  auto solver_downcast = std::dynamic_pointer_cast<mfem::HypreBoomerAMG>(solver.getSolver());
+  auto solver_downcast = dynamic_cast<mfem::HypreBoomerAMG *>(&solver.getSolver());
   // HypreBoomerAMG warnings are tripped by zero rows in matrices; turn this off for this test
   solver_downcast->SetErrorMode(mfem::HypreSolver::ErrorMode::IGNORE_HYPRE_ERRORS);
-  ASSERT_NE(solver_downcast.get(), nullptr);
+  ASSERT_NE(solver_downcast, nullptr);
   testDiffusionSolve<mfem::HypreBoomerAMG>(solver, 1e-5);
 }
 
@@ -232,8 +232,8 @@ TEST_F(MFEMSolverTest, MFEMHypreADS)
   MFEMHypreADS & solver = addObject<MFEMHypreADS>("MFEMHypreADS", "solver1", solver_params);
 
   // Test MFEMSolver returns a solver of the expected type
-  auto solver_downcast = std::dynamic_pointer_cast<mfem::HypreADS>(solver.getSolver());
-  ASSERT_NE(solver_downcast.get(), nullptr);
+  auto solver_downcast = dynamic_cast<mfem::HypreADS *>(&solver.getSolver());
+  ASSERT_NE(solver_downcast, nullptr);
 }
 
 /**
@@ -258,8 +258,8 @@ TEST_F(MFEMSolverTest, MFEMHypreAMS)
   MFEMHypreAMS & solver = addObject<MFEMHypreAMS>("MFEMHypreAMS", "solver1", solver_params);
 
   // Test MFEMSolver returns an solver of the expected type
-  auto solver_downcast = std::dynamic_pointer_cast<mfem::HypreAMS>(solver.getSolver());
-  ASSERT_NE(solver_downcast.get(), nullptr);
+  auto solver_downcast = dynamic_cast<mfem::HypreAMS *>(&solver.getSolver());
+  ASSERT_NE(solver_downcast, nullptr);
 }
 
 /**
@@ -381,8 +381,7 @@ TEST_F(MFEMSolverTest, MFEMHypreBoomerAMGLOR)
 
   solver.updateSolver(a, ess_tdof_list);
 
-  auto solver_ptr =
-      std::dynamic_pointer_cast<mfem::LORSolver<mfem::HypreBoomerAMG>>(solver.getSolver()).get();
+  auto solver_ptr = dynamic_cast<mfem::LORSolver<mfem::HypreBoomerAMG> *>(&solver.getSolver());
   // Test MFEMKernel returns an integrator of the expected type
   ASSERT_TRUE(solver_ptr != nullptr);
 }


### PR DESCRIPTION
## Reason
Incomplete or incorrectly rendering documentation.
A bug introduced in #30591 prevents the correct selection of the solver's preconditioner.

## Design
Added or fixed documentation. Had to improve `extractInputBlocks()` in `listing.py` to strip trailing slashes only.
Fixed preconditioning selection bug by essentially rolling back to the original design whereby we get the respective user object from the solver constructor, not an `MFEMProblem` method.

## Impact
Beautiful documentation.
Most notably, this should mean we now use the preconditioner we intended to: some tests marked LOR were in fact running without LOR.