### PR TITLE
Take more care of property derivatives in PorousFlowBrine

### DIFF
--- a/modules/porous_flow/doc/content/source/materials/PorousFlowBrine.md
+++ b/modules/porous_flow/doc/content/source/materials/PorousFlowBrine.md
@@ -2,6 +2,15 @@
 
 !syntax description /Materials/PorousFlowBrine
 
+A class for providing brine fluid properties (water and NaCl) where the properties are computed using [BrineFluidProperties](/BrineFluidProperties.md).
+
+The salt mass fraction (kg/kg) can be set as a nonlinear variable, an auxillary variable, or simply as a constant value using the `xnacl` input parameter. If no value is provided, the salinity is assumed to be zero and the brine properties will be just the water properties.
+
+!alert note
+If `xnacl` is a nonlinear variable, it is important to list that variable in the [PorousFlowDictator](/PorousFlowDictator.md) to ensure that the correct Jacobian contribution is calculated
+
+This material also allows the user to provide a specific water fluid properties userobject. If no water userobject is provided, the [Water97FluidProperties](/Water97FluidProperties.md) fluid properties are used by default. This option allows users to implement a tabulated version of the water fluid properties to reduce the computational burden, see [TabulatedFluidProperties](/TabulatedFluidProperties.md) for details.
+
 !syntax parameters /Materials/PorousFlowBrine
 
 !syntax inputs /Materials/PorousFlowBrine

--- a/modules/porous_flow/include/materials/PorousFlowBrine.h
+++ b/modules/porous_flow/include/materials/PorousFlowBrine.h
@@ -50,4 +50,7 @@ protected:
 
   /// NaCl mass fraction at the qps or nodes
   const VariableValue & _xnacl;
+
+  /// Flag to denote whether NaCl mass fraction is a nonlinear variable
+  const bool _is_xnacl_pfvar;
 };

--- a/modules/porous_flow/src/materials/PorousFlowBrine.C
+++ b/modules/porous_flow/src/materials/PorousFlowBrine.C
@@ -59,7 +59,8 @@ PorousFlowBrine::PorousFlowBrine(const InputParameters & parameters)
                                                _mass_fraction_variable_name))
                       : nullptr),
     _is_xnacl_nodal(isCoupled("xnacl") ? getFieldVar("xnacl", 0)->isNodal() : false),
-    _xnacl(_nodal_material && _is_xnacl_nodal ? coupledDofValues("xnacl") : coupledValue("xnacl"))
+    _xnacl(_nodal_material && _is_xnacl_nodal ? coupledDofValues("xnacl") : coupledValue("xnacl")),
+    _is_xnacl_pfvar(_dictator.isPorousFlowVariable(coupled("xnacl")))
 {
   if (parameters.isParamSetByUser("water_fp"))
   {
@@ -113,7 +114,8 @@ PorousFlowBrine::computeQpProperties()
     (*_density)[_qp] = rho;
     (*_ddensity_dp)[_qp] = drho_dp;
     (*_ddensity_dT)[_qp] = drho_dT;
-    (*_ddensity_dX)[_qp] = drho_dx;
+    if (_is_xnacl_pfvar)
+      (*_ddensity_dX)[_qp] = drho_dx;
 
     // Viscosity and derivatives wrt pressure and temperature
     Real mu, dmu_dp, dmu_dT, dmu_dx;
@@ -122,7 +124,8 @@ PorousFlowBrine::computeQpProperties()
     (*_viscosity)[_qp] = mu;
     (*_dviscosity_dp)[_qp] = dmu_dp;
     (*_dviscosity_dT)[_qp] = dmu_dT;
-    (*_dviscosity_dX)[_qp] = dmu_dx;
+    if (_is_xnacl_pfvar)
+      (*_dviscosity_dX)[_qp] = dmu_dx;
   }
 
   // Internal energy and derivatives wrt pressure and temperature
@@ -134,7 +137,8 @@ PorousFlowBrine::computeQpProperties()
     (*_internal_energy)[_qp] = e;
     (*_dinternal_energy_dp)[_qp] = de_dp;
     (*_dinternal_energy_dT)[_qp] = de_dT;
-    (*_dinternal_energy_dX)[_qp] = de_dx;
+    if (_is_xnacl_pfvar)
+      (*_dinternal_energy_dX)[_qp] = de_dx;
   }
 
   // Enthalpy and derivatives wrt pressure and temperature
@@ -146,6 +150,7 @@ PorousFlowBrine::computeQpProperties()
     (*_enthalpy)[_qp] = h;
     (*_denthalpy_dp)[_qp] = dh_dp;
     (*_denthalpy_dT)[_qp] = dh_dT;
-    (*_denthalpy_dX)[_qp] = dh_dx;
+    if (_is_xnacl_pfvar)
+      (*_denthalpy_dX)[_qp] = dh_dx;
   }
 }

--- a/modules/porous_flow/test/tests/jacobian/fflux15.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux15.i
@@ -1,0 +1,136 @@
+# 1phase, 2components (water and tracer using BrineFluidProperties with constant salinity),
+# constant insitu permeability and relative perm, nonzero gravity
+
+[Mesh]
+  [mesh]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 1
+    xmin = 0
+    xmax = 10
+    ny = 1
+    ymin = 0
+    ymax = 10
+  []
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+  gravity = '0 -10 0'
+[]
+
+[Variables]
+  [pp]
+  []
+  [tracer]
+  []
+[]
+
+[ICs]
+  [pp]
+    type = RandomIC
+    variable = pp
+    min = 1e6
+    max = 2e6
+  []
+  [tracer]
+    type = RandomIC
+    variable = tracer
+    min = 0.1
+    max = 0.2
+  []
+[]
+
+[Kernels]
+  [mass0]
+    type = PorousFlowMassTimeDerivative
+    variable = pp
+    fluid_component = 0
+  []
+  [mass1]
+    type = PorousFlowMassTimeDerivative
+    variable = tracer
+    fluid_component = 1
+  []
+  [flux0]
+    type = PorousFlowAdvectiveFlux
+    fluid_component = 0
+    variable = pp
+  []
+  [flux1]
+    type = PorousFlowAdvectiveFlux
+    fluid_component = 1
+    variable = tracer
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp tracer'
+    number_fluid_phases = 1
+    number_fluid_components = 2
+  []
+  [pc]
+    type = PorousFlowCapillaryPressureConst
+    pc = 0
+  []
+[]
+
+[FluidProperties]
+  [brine]
+    type = BrineFluidProperties
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = PorousFlowTemperature
+  []
+  [ppss]
+    type = PorousFlow1PhaseP
+    porepressure = pp
+    capillary_pressure = pc
+  []
+  [massfrac]
+    type = PorousFlowMassFraction
+    mass_fraction_vars = 'tracer'
+  []
+  [brine]
+    type = PorousFlowBrine
+    phase = 0
+    xnacl = 0.1
+  []
+  [permeability]
+    type = PorousFlowPermeabilityConst
+    permeability = '1e-14 0 0 0 2e-14 0 0 0 3e-14'
+  []
+  [porosity]
+    type = PorousFlowPorosityConst
+    porosity = 0.1
+  []
+  [relperm]
+    type = PorousFlowRelativePermeabilityConst
+    kr = 1
+    phase = 0
+  []
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]
+

--- a/modules/porous_flow/test/tests/jacobian/tests
+++ b/modules/porous_flow/test/tests/jacobian/tests
@@ -316,7 +316,7 @@
     cli_args = 'Executioner/num_steps=1 -mat_fd_type ds'
     threading = '!pthreads'
     requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 2-component multicomponent fluid (brine) with tracer.'
-    issues = '#6845 #23609'
+    issues = '#6845 #23609 #30662'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
   [fflux01_fully_saturated]

--- a/modules/porous_flow/test/tests/jacobian/tests
+++ b/modules/porous_flow/test/tests/jacobian/tests
@@ -308,6 +308,17 @@
     issues = '#6845 #23609'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
+  [fflux15]
+    type = 'PetscJacobianTester'
+    input = 'fflux15.i'
+    ratio_tol = 1E-6 # lots of chain rules here
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1 -mat_fd_type ds'
+    threading = '!pthreads'
+    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 2-component multicomponent fluid (brine) with tracer.'
+    issues = '#6845 #23609'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
   [fflux01_fully_saturated]
     type = 'PetscJacobianTester'
     input = 'fflux01_fully_saturated.i'


### PR DESCRIPTION
When salt mass fraction is not a nonlinear variable, then the fluid property derivative wrt mass fraction is set to zero to avoid incorrect Jacobian entries

Fixes #30661
