### PR TITLE
Fix another VTK nlohmann json workaround

### DIFF
--- a/framework/include/utils/ImageSampler.h
+++ b/framework/include/utils/ImageSampler.h
@@ -23,31 +23,8 @@
 // loves to warn about it...
 #include "libmesh/ignore_warnings.h"
 
-// If VTK is built without an external nlohmann, then it assumes it
-// will never be compiled against another nlohmann, and it includes
-// its own copy but modified with macro tricks.  We have probably
-// already included nlohmann headers, which we didn't tamper with
-// because OF COURSE NOT, but now we need to take care not to let the
-// include guards prevent them from including their copy with their
-// different namespace.
-#ifndef MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
-#define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS 0
-// Detect if VTK built with external nlohmann
-#ifdef __has_include
-#if __has_include("vtk_nlohmannjson.h")
-#include "vtk_nlohmannjson.h"
-#if !VTK_MODULE_USE_EXTERNAL_vtknlohmannjson
-#undef MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
-#define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS 1
-#endif // !VTK_MODULE_USE_EXTERNAL_vtknlohmannjson
-#endif // __has_include("vtk_nlohmannjson.h")
-#else  // __has_include
-#error "Could not auto-detect whether VTK built with external nlohmann json. \
-Define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS=1 if built with vendored nlohmann \
-, otherwise define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS=0"
-#endif // __has_include
-#endif // MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
-
+// Include to define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
+#include "VTKNlohmannUndefHack.h"
 #if MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS && !defined(MOOSE_VTK_NLOHMANN_INCLUDED)
 #undef INCLUDE_NLOHMANN_JSON_FWD_HPP_
 #define MOOSE_VTK_NLOHMANN_INCLUDED

--- a/framework/include/utils/MeshBaseImageSampler.h
+++ b/framework/include/utils/MeshBaseImageSampler.h
@@ -23,31 +23,8 @@
 // loves to warn about it...
 #include "libmesh/ignore_warnings.h"
 
-// If VTK is built without an external nlohmann, then it assumes it
-// will never be compiled against another nlohmann, and it includes
-// its own copy but modified with macro tricks.  We have probably
-// already included nlohmann headers, which we didn't tamper with
-// because OF COURSE NOT, but now we need to take care not to let the
-// include guards prevent them from including their copy with their
-// different namespace.
-#ifndef MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
-#define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS 0
-// Detect if VTK built with external nlohmann
-#ifdef __has_include
-#if __has_include("vtk_nlohmannjson.h")
-#include "vtk_nlohmannjson.h"
-#if !VTK_MODULE_USE_EXTERNAL_vtknlohmannjson
-#undef MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
-#define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS 1
-#endif // !VTK_MODULE_USE_EXTERNAL_vtknlohmannjson
-#endif // __has_include("vtk_nlohmannjson.h")
-#else  // __has_include
-#error "Could not auto-detect whether VTK built with external nlohmann json. \
-Define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS=1 if built with vendored nlohmann \
-, otherwise define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS=0"
-#endif // __has_include
-#endif // MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
-
+// Include to define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
+#include "VTKNlohmannUndefHack.h"
 #if MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS && !defined(MOOSE_VTK_NLOHMANN_INCLUDED)
 #undef INCLUDE_NLOHMANN_JSON_FWD_HPP_
 #define MOOSE_VTK_NLOHMANN_INCLUDED

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -50,8 +50,16 @@
 #include <type_traits>
 #include <functional>
 
+// Include to define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
+#include "VTKNlohmannUndefHack.h"
+
+// json_fwd.h actually contains default template argument definitions,
+// so only include it if json.h is not included
 #if !defined(INCLUDE_NLOHMANN_JSON_HPP_) && !defined(MOOSE_NLOHMANN_INCLUDED)
+// only need to undef header guard if VTK built with vendored nlohmann
+#if MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
 #undef INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#endif
 #include "nlohmann/json_fwd.h"
 #define MOOSE_NLOHMANN_INCLUDED
 #endif

--- a/framework/include/utils/VTKNlohmannUndefHack.h
+++ b/framework/include/utils/VTKNlohmannUndefHack.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // If VTK is built without an external nlohmann, then it assumes it
 // will never be compiled against another nlohmann, and it includes
 // its own copy but modified with macro tricks.  We have probably

--- a/framework/include/utils/VTKNlohmannUndefHack.h
+++ b/framework/include/utils/VTKNlohmannUndefHack.h
@@ -1,0 +1,24 @@
+// If VTK is built without an external nlohmann, then it assumes it
+// will never be compiled against another nlohmann, and it includes
+// its own copy but modified with macro tricks.  We have probably
+// already included nlohmann headers, which we didn't tamper with
+// because OF COURSE NOT, but now we need to take care not to let the
+// include guards prevent them from including their copy with their
+// different namespace.
+#ifndef MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
+#define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS 0
+// Detect if VTK built with external nlohmann
+#ifdef __has_include
+#if __has_include("vtk_nlohmannjson.h")
+#include "vtk_nlohmannjson.h"
+#if !VTK_MODULE_USE_EXTERNAL_vtknlohmannjson
+#undef MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS
+#define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS 1
+#endif // !VTK_MODULE_USE_EXTERNAL_vtknlohmannjson
+#endif // __has_include("vtk_nlohmannjson.h")
+#else  // __has_include
+#error "Could not auto-detect whether VTK built with external nlohmann json. \
+Define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS=1 if built with vendored nlohmann \
+, otherwise define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS=0"
+#endif // __has_include
+#endif // MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS


### PR DESCRIPTION
Same problem as issue #30425

Related: #30427, #30464

## Reason
To fix compilation when VTK built with external nlohmann json (avoiding redefinitions).

vtk-9.5.0 is hopefully coming soon which I believe removes their hackery from their public headers, so we can delete all this `#undef` mess soon.