### PR TITLE
Add classes for elastic precipitate growth in polycrystals.

### DIFF
--- a/modules/phase_field/include/materials/CompositeEigenstrainInteraction.h
+++ b/modules/phase_field/include/materials/CompositeEigenstrainInteraction.h
@@ -1,0 +1,35 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ComputeEigenstrainInteractionBase.h"
+#include "CompositeTensorBase.h"
+#include "RankTwoTensor.h"
+
+/**
+ * CompositeEigenstrainInteraction provides a simple RankTwoTensor type
+ * MaterialProperty that can be used as an Eigenstrain Interaction tensor in a mechanics simulation.
+ * This tensor is computes as a weighted sum of base Eigenstrain Interaction tensors where each weight
+ * can be a scalar material property that may depend on simulation variables.
+ * The generic logic that computes a weighted sum of tensors is located in the
+ * templated base class CompositeTensorBase.
+ */
+class CompositeEigenstrainInteraction : public CompositeTensorBase<RankTwoTensor, ComputeEigenstrainInteractionBase>
+{
+public:
+  static InputParameters validParams();
+
+  CompositeEigenstrainInteraction(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpEigenstrainInteraction();
+
+  const std::string _M_name;
+};

--- a/modules/phase_field/include/materials/ComputeAnisotropicMultiGrainEigenstrain.h
+++ b/modules/phase_field/include/materials/ComputeAnisotropicMultiGrainEigenstrain.h
@@ -1,0 +1,92 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef COMPUTEANISOTROPICMULTIGRAINEIGENSTRAIN_H
+#define COMPUTEANISOTROPICMULTIGRAINEIGENSTRAIN_H
+
+#include "ComputeEigenstrainBase.h"
+#include "DerivativeMaterialInterface.h"
+#include "RankTwoTensor.h"
+#include "GrainTrackerInterface.h"
+
+class ComputeAnisotropicMultiGrainEigenstrain;
+template <typename>
+class RankTwoTensorTempl;
+typedef RankTwoTensorTempl<Real> RankTwoTensor;
+class EulerAngleProvider;
+class RotationTensor;
+class GrainTrackerInterface;
+
+template <>
+InputParameters validParams<ComputeAnisotropicMultiGrainEigenstrain>();
+
+/**
+ * ComputeAnisotropicMultiGrainEigenstrain is a class for models that compute
+ * eigenstrains of an anisotropic material in a multi grain structure.
+ */
+class ComputeAnisotropicMultiGrainEigenstrain
+  : public DerivativeMaterialInterface<ComputeEigenstrainBase>
+{
+public:
+  ComputeAnisotropicMultiGrainEigenstrain(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpEigenstrain() override;
+  /*
+   * Compute the total strain in each direction relative to the stress-free
+   * temperatures at thevcurrent temperature, as well as the current
+   * instantaneous thermal expansion coefficients and the constant eigenstrain
+   * coefficients
+   * param total_strain      The current total strain
+   *                         (\delta L / L)
+   * param instantaneous_cte The current instantaneous coefficient of thermal
+   *                         expansion (derivative of thermal_strain wrt
+   *                         temperature
+   */
+  // virtual void computeThermalStrain(Real & total_strain, Real & instantaneous_cte) = 0;
+
+  // const VariableValue & _temperature;
+  const MaterialProperty<Real> & _temperature;
+  // MaterialProperty<RankTwoTensor> & _deigenstrain_dT;
+
+  /// Anisotropic stress free temperatures
+  const VariableValue & _stress_free_temperature_xx;
+  const VariableValue & _stress_free_temperature_yy;
+  const VariableValue & _stress_free_temperature_zz;
+
+  /// Anisotropic constant eigenstrain values
+  const Real & _constant_eigenstrain_xx;
+  const Real & _constant_eigenstrain_yy;
+  const Real & _constant_eigenstrain_zz;
+
+  /// Anisotropic thermal expansion coefficients
+  const Real & _thermal_expansion_coeff_xx;
+  const Real & _thermal_expansion_coeff_yy;
+  const Real & _thermal_expansion_coeff_zz;
+
+  /// Number of order parameters
+  const unsigned int _op_num;
+
+  /// Order parameters
+  std::vector<const VariableValue *> _vals;
+
+  /// object providing the Euler angles
+  const EulerAngleProvider & _euler;
+
+  /// Grain tracker used to get unique grain IDs
+  const GrainTrackerInterface & _grain_tracker;
+
+  // /// Base name of the material system /////////////////////////////////////////
+  // const std::string _orientation_name;
+  // ///Stores the current orientation
+  // MaterialProperty<Real> & _orientation;
+
+};
+
+#endif // COMPUTEANISOTROPICMULTIGRAINEIGENSTRAIN_H

--- a/modules/phase_field/include/materials/ComputeEigenstrainInteractionBase.h
+++ b/modules/phase_field/include/materials/ComputeEigenstrainInteractionBase.h
@@ -1,0 +1,53 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+#include "RankTwoTensorForward.h"
+
+/**
+ * ComputeEigenstrainInteractionBase is the base class for eigenstrain interaction tensors
+ */
+class ComputeEigenstrainInteractionBase : public Material
+{
+public:
+  static InputParameters validParams();
+
+  ComputeEigenstrainInteractionBase(const InputParameters & parameters);
+
+protected:
+  virtual void initQpStatefulProperties();
+  virtual void computeQpProperties();
+
+  ///Compute the eigenstrain interaction and store in _eigenstrainInteraction
+  virtual void computeQpEigenstrainInteraction() = 0;
+
+  ///Base name prepended to material property name
+  const std::string _base_name;
+
+  ///Material property name for the eigenstrain interaction tensor
+  std::string _eigenstrainInteraction_name;
+
+  ///Stores the current total eigenstrain interaction
+  MaterialProperty<RankTwoTensor> & _eigenstrainInteraction;
+
+  /**
+   * Helper function for models that compute the eigenstrain interaction based on a volumetric
+   * strain.  This function computes the diagonal components of the eigenstrain interaction tensor
+   * as logarithmic strains.
+   * @param volumetric_strain The current volumetric strain to be applied
+   * @return Current strain in one direction due to volumetric strain, expressed as a logarithmic
+   * strain
+   */
+  Real computeVolumetricStrainComponent(const Real volumetric_strain) const;
+
+  /// Restartable data to check for the zeroth and first time steps for thermal calculations
+  bool & _step_zero;
+};

--- a/modules/phase_field/include/postprocessors/GrainTrackerElasticity_OR.h
+++ b/modules/phase_field/include/postprocessors/GrainTrackerElasticity_OR.h
@@ -1,0 +1,50 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GrainDataTracker.h"
+#include "RankFourTensor.h"
+
+class EulerAngleProvider;
+
+/**
+ * Manage a list of elasticity tensors for the grains
+ */
+class GrainTrackerElasticity_OR : public GrainDataTracker<RankFourTensor>
+{
+public:
+  static InputParameters validParams();
+
+  GrainTrackerElasticity_OR(const InputParameters & parameters);
+
+protected:
+  RankFourTensor newGrain(unsigned int new_grain_id);
+
+  /// generate random rotations when the Euler Angle provider runs out of data (otherwise error out)
+  const bool _random_rotations;
+
+  /// unrotated elasticity tensor
+  RankFourTensor _C_ijkl;
+
+  /// object providing the Euler angles
+  const EulerAngleProvider & _euler;
+
+  // Input additional Euler angles for the orientation relationship
+  const Real & _Euler_angles_OR_1;
+  const Real & _Euler_angles_OR_2;
+  const Real & _Euler_angles_OR_3;
+
+  // new function to obtain the orientation of each grain
+  // Real newGrain(unsigned int new_grain_id);
+  /// orientation (first euler angle)
+  // Real _orientation;
+
+
+};

--- a/modules/phase_field/src/materials/CompositeEigenstrainInteraction.C
+++ b/modules/phase_field/src/materials/CompositeEigenstrainInteraction.C
@@ -1,0 +1,35 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "CompositeEigenstrainInteraction.h"
+
+registerMooseObject("TensorMechanicsApp", CompositeEigenstrainInteraction);
+
+InputParameters
+CompositeEigenstrainInteraction::validParams()
+{
+  InputParameters params =
+      CompositeTensorBase<RankTwoTensor, ComputeEigenstrainInteractionBase>::validParams();
+  params.addClassDescription("Assemble an Eigenstrain Interaction tensor from multiple tensor contributions "
+                             "weighted by material properties");
+  return params;
+}
+
+CompositeEigenstrainInteraction::CompositeEigenstrainInteraction(const InputParameters & parameters)
+  : CompositeTensorBase<RankTwoTensor, ComputeEigenstrainInteractionBase>(parameters)
+{
+  initializeDerivativeProperties(_base_name + "elastic_strain_int");
+}
+
+void
+CompositeEigenstrainInteraction::computeQpEigenstrainInteraction()
+{
+  // Define Eigenstrain Interaction (and fill in the derivatives of elastic strain with a prefactor of -1)
+  computeQpTensorProperties(_eigenstrainInteraction, -1.0);
+}

--- a/modules/phase_field/src/materials/ComputeAnisotropicMultiGrainEigenstrain.C
+++ b/modules/phase_field/src/materials/ComputeAnisotropicMultiGrainEigenstrain.C
@@ -1,0 +1,180 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeAnisotropicMultiGrainEigenstrain.h"
+#include "RankTwoTensor.h"
+#include "EulerAngleProvider.h"
+#include "RotationTensor.h"
+
+registerMooseObject("PhaseFieldApp",ComputeAnisotropicMultiGrainEigenstrain);
+
+template <>
+InputParameters
+validParams<ComputeAnisotropicMultiGrainEigenstrain>()
+{
+  InputParameters params = validParams<ComputeEigenstrainBase>();
+  params.addClassDescription(
+    "Compute spatially and temporally dependent eigstrain by adding constant eigenstrain and the thermal expansion");
+  // params.addCoupledVar("temperature", "Coupled temperature");
+  params.addRequiredParam<MaterialPropertyName>("temperature", "Temperature");
+  params.addRequiredCoupledVar("stress_free_temperature_xx",
+                               "Reference temperature at which there is no "
+                               "thermal expansion for thermal eigenstrain in "
+                               "the xx direction "
+                               "calculation");
+  params.addRequiredCoupledVar("stress_free_temperature_yy",
+                               "Reference temperature at which there is no "
+                               "thermal expansion for thermal eigenstrain in "
+                               "the yy direction "
+                               "calculation");
+  params.addRequiredCoupledVar("stress_free_temperature_zz",
+                               "Reference temperature at which there is no "
+                               "thermal expansion for thermal eigenstrain in "
+                               "the zz direction "
+                               "calculation");
+  params.addRequiredParam<Real>("constant_eigenstrain_xx", "Constant eigenstrain along x");
+  params.addRequiredParam<Real>("constant_eigenstrain_yy", "Constant eigenstrain along y");
+  params.addRequiredParam<Real>("constant_eigenstrain_zz", "Constant eigenstrain along z");
+  params.addRequiredParam<Real>("thermal_expansion_coeff_xx", "Thermal expansion coefficient along x");
+  params.addRequiredParam<Real>("thermal_expansion_coeff_yy", "Thermal expansion coefficient along y");
+  params.addRequiredParam<Real>("thermal_expansion_coeff_zz", "Thermal expansion coefficient qlong z");
+  params.addRequiredCoupledVarWithAutoBuild(
+      "v", "var_name_base", "op_num", "Array of coupled variables");
+  params.addRequiredParam<UserObjectName>("euler_angle_provider",
+                                          "Name of Euler angle provider user object");
+  params.addRequiredParam<UserObjectName>("grain_tracker",
+                                          "the GrainTracker UserObject to get values from");
+
+  return params;
+}
+
+ComputeAnisotropicMultiGrainEigenstrain::ComputeAnisotropicMultiGrainEigenstrain(
+    const InputParameters & parameters)
+  : DerivativeMaterialInterface<ComputeEigenstrainBase>(parameters),
+    // _temperature(coupledValue("temperature")),
+    _temperature(getMaterialProperty<Real>("temperature")),
+    // _deigenstrain_dT(declarePropertyDerivative<RankTwoTensor>(_eigenstrain_name,
+                                                              // getVar("temperature", 0)->name())),
+    _stress_free_temperature_xx(coupledValue("stress_free_temperature_xx")),
+    _stress_free_temperature_yy(coupledValue("stress_free_temperature_yy")),
+    _stress_free_temperature_zz(coupledValue("stress_free_temperature_zz")),
+    _constant_eigenstrain_xx(getParam<Real>("constant_eigenstrain_xx")),
+    _constant_eigenstrain_yy(getParam<Real>("constant_eigenstrain_yy")),
+    _constant_eigenstrain_zz(getParam<Real>("constant_eigenstrain_zz")),
+    _thermal_expansion_coeff_xx(getParam<Real>("thermal_expansion_coeff_xx")),
+    _thermal_expansion_coeff_yy(getParam<Real>("thermal_expansion_coeff_yy")),
+    _thermal_expansion_coeff_zz(getParam<Real>("thermal_expansion_coeff_zz")),
+    _op_num(coupledComponents("v")),
+    _vals(_op_num),
+    _euler(getUserObject<EulerAngleProvider>("euler_angle_provider")),
+    _grain_tracker(getUserObject<GrainTrackerInterface>("grain_tracker")) //,
+    // _orientation_name("orientation_name"),//////////////////////////////////////////////////////////////////////
+    // _orientation(declareProperty<Real>(_orientation_name)) ///////////////////////////////////
+{
+    // Loop over variables (ops)
+    for (auto op_index = decltype(_op_num)(0); op_index < _op_num; ++op_index)
+    {
+      // Initialize variables
+      _vals[op_index] = &coupledValue("v", op_index);
+    }
+}
+
+void
+ComputeAnisotropicMultiGrainEigenstrain::computeQpEigenstrain()
+{
+  Real theta1 = _constant_eigenstrain_xx + _thermal_expansion_coeff_xx * (_temperature[_qp] - _stress_free_temperature_xx[_qp]);
+  Real theta2 = _constant_eigenstrain_yy + _thermal_expansion_coeff_yy * (_temperature[_qp] - _stress_free_temperature_yy[_qp]);
+  Real theta3 = _constant_eigenstrain_zz + _thermal_expansion_coeff_zz * (_temperature[_qp] - _stress_free_temperature_zz[_qp]);
+
+  RankTwoTensor I1(1, 0, 0, 0, 0, 0);
+  RankTwoTensor I2(0, 1, 0, 0, 0, 0);
+  RankTwoTensor I3(0, 0, 1, 0, 0, 0);
+
+  RankTwoTensor theta0 = theta1 * I1 + theta2 * I2 + theta3 * I3;
+  RankTwoTensor dtheta_dt0 = _thermal_expansion_coeff_xx * I1 + _thermal_expansion_coeff_yy * I2 +
+                             _thermal_expansion_coeff_zz * I3;
+
+  _eigenstrain[_qp].zero();
+  // _deigenstrain_dT[_qp].zero();
+
+  Real sum_h = 0.0;
+
+  //get the vector that maps active order parameters to grain ids
+  const auto & op_to_grains = _grain_tracker.getVarToFeatureVector(_current_elem->id());
+
+  //loop over the active OPs
+  for (auto op_index = beginIndex(op_to_grains); op_index < op_to_grains.size(); ++op_index)
+  {
+
+    auto grain_id = op_to_grains[op_index];
+    // _console << "printing the grain ID \n"; //////////////////////////////////////////////////////////////////////
+    // _console << beginIndex(op_to_grains) << "\n";
+    // _console << op_to_grains.size() << "\n";
+    // _console << op_to_grains[op_index] << "\n";
+    // _console << grain_id << "\n";
+    // _console << _euler.getGrainNum() << "\n";
+    // _console << (FeatureFloodCount::invalid_id) << "\n";
+    // _console << (op_to_grains[op_index] == FeatureFloodCount::invalid_id) << "\n";
+    // printf("%u", grain_id);//////////////////////////////////////////////////////////////////////
+    // printf("%u", _euler.getGrainNum());//////////////////////////////////////////////////////////////////////
+    if (op_to_grains[op_index] == FeatureFloodCount::invalid_id)
+        continue;
+
+    EulerAngles angles;
+
+    //make sure you have enough Euler angles in the file and grab the right one
+    if (grain_id < _euler.getGrainNum())
+    {
+      angles = _euler.getEulerAngles(grain_id);
+    }
+    else
+      mooseError("ComputeAnisotropicMultiGrainEigenstrain has run out of grain rotation data.");
+
+    //Interpolation factor for the eigenstrain tensors - this goes between 0 and 1 if eta is 0 or 1
+    //Using standard PF interpolation function.
+    // Real n = (*_vals[op_index])[_qp];
+    // Real h = n*n*n*(6*n*n - 15*n + 10);
+
+    RankTwoTensor theta = theta0;
+    // Real angle1 = angles.phi1;//////////////////////////////////////////////////////////////////////
+    RankTwoTensor dtheta_dt = dtheta_dt0;
+    theta.rotate(RotationTensor(RealVectorValue(angles)));
+    dtheta_dt.rotate(RotationTensor(RealVectorValue(angles)));
+
+
+    // Interpolation factor for elasticity tensors
+    Real h = (1.0 + std::sin(libMesh::pi * ((*_vals[op_index])[_qp] - 0.5))) / 2.0;
+
+    RankTwoTensor local_eigenstrain;
+    // Real local_orientation; //////////////////////////////////////////////////////////////////////
+    // RankTwoTensor local_deigenstrain_dT;
+
+    local_eigenstrain = theta * h;
+    // local_orientation = angle1 * h;//////////////////////////////////////////////////////////////////////
+    // local_deigenstrain_dT = dtheta_dt * h;
+
+    // local_eigenstrain.rotate(RotationTensor(RealVectorValue(angles)));
+    // local_deigenstrain_dT.rotate(RotationTensor(RealVectorValue(angles)));
+
+    _eigenstrain[_qp] += local_eigenstrain;
+    // _orientation[_qp] += local_orientation;//////////////////////////////////////////////////////////////////////
+    // _deigenstrain_dT[_qp] += local_deigenstrain_dT;
+
+    sum_h += h;
+  }
+
+  //Normalize the tensor to a sum of order parameters = 1...
+  //anything divided by near-zero is going to explode
+  const Real tol = 1.0e-10;
+  sum_h = std::max(sum_h, tol);
+
+  _eigenstrain[_qp] /= sum_h;
+  // _orientation[_qp] /= sum_h; //////////////////////////////////////////////////////////////////////
+  // _deigenstrain_dT[_qp] /= sum_h;
+}

--- a/modules/phase_field/src/materials/ComputeEigenstrainInteractionBase.C
+++ b/modules/phase_field/src/materials/ComputeEigenstrainInteractionBase.C
@@ -1,0 +1,75 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeEigenstrainInteractionBase.h"
+
+#include "RankTwoTensor.h"
+
+InputParameters
+ComputeEigenstrainInteractionBase::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple mechanics material systems on the same "
+                               "block, i.e. for multiple phases");
+  params.addRequiredParam<std::string>("eigenstrainInteraction_name",
+                                       "Material property name for the eigenstrain interaction tensor computed "
+                                       "by this model. IMPORTANT: The name of this property must "
+                                       "also be provided to the strain calculator.");
+  return params;
+}
+
+ComputeEigenstrainInteractionBase::ComputeEigenstrainInteractionBase(const InputParameters & parameters)
+  : Material(parameters),
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
+    _eigenstrainInteraction_name(_base_name + getParam<std::string>("eigenstrainInteraction_name")),
+    _eigenstrainInteraction(declareProperty<RankTwoTensor>(_eigenstrainInteraction_name)),
+    _step_zero(declareRestartableData<bool>("step_zero", true))
+{
+}
+
+void
+ComputeEigenstrainInteractionBase::initQpStatefulProperties()
+{
+  // This property can be promoted to be stateful by other models that use it,
+  // so it needs to be initalized.
+  _eigenstrainInteraction[_qp].zero();
+}
+
+void
+ComputeEigenstrainInteractionBase::computeQpProperties()
+{
+  if (_t_step >= 1)
+    _step_zero = false;
+
+  // Skip the eigenstrain interaction calculation in step zero because no solution is computed during
+  // the zeroth step, hence computing the eigenstrain in the zeroth step would result in
+  // an incorrect calculation of mechanical_strain, which is stateful.
+  if (!_step_zero)
+    computeQpEigenstrainInteraction();
+}
+
+Real
+ComputeEigenstrainInteractionBase::computeVolumetricStrainComponent(const Real volumetric_strain) const
+{
+  // The engineering strain in a given direction is:
+  // epsilon_eng = cbrt(volumetric_strain + 1.0) - 1.0
+  //
+  // We need to provide this as a logarithmic strain to be consistent with the strain measure
+  // used for finite strain:
+  // epsilon_log = log(1.0 + epsilon_eng)
+  //
+  // This can be simplified down to a more direct form:
+  // epsilon_log = log(cbrt(volumetric_strain + 1.0))
+  // or:
+  // epsilon_log = (1/3) log(volumetric_strain + 1.0)
+
+  return std::log(volumetric_strain + 1.0) / 3.0;
+}

--- a/modules/phase_field/src/postprocessors/GrainTrackerElasticity_OR.C
+++ b/modules/phase_field/src/postprocessors/GrainTrackerElasticity_OR.C
@@ -1,0 +1,80 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "GrainTrackerElasticity_OR.h"
+#include "EulerAngleProvider.h"
+#include "RotationTensor.h"
+
+registerMooseObject("PhaseFieldApp", GrainTrackerElasticity_OR);
+
+InputParameters
+GrainTrackerElasticity_OR::validParams()
+{
+  InputParameters params = GrainTracker::validParams();
+  params.addParam<bool>("random_rotations",
+                        true,
+                        "Generate random rotations when the Euler Angle "
+                        "provider runs out of data (otherwise error "
+                        "out)");
+  params.addRequiredParam<std::vector<Real>>("C_ijkl", "Unrotated stiffness tensor");
+  params.addParam<MooseEnum>(
+      "fill_method", RankFourTensor::fillMethodEnum() = "symmetric9", "The fill method");
+  params.addRequiredParam<UserObjectName>("euler_angle_provider",
+                                          "Name of Euler angle provider user object");
+  params.addParam<Real>("Euler_angles_OR_1", 0, "Euler angle in direction 1 for orientation relationship rotation");
+  params.addParam<Real>("Euler_angles_OR_2", 0, "Euler angle in direction 2 for orientation relationship rotation");
+  params.addParam<Real>("Euler_angles_OR_3", 0, "Euler angle in direction 3 for orientation relationship rotation");
+  return params;
+}
+
+GrainTrackerElasticity_OR::GrainTrackerElasticity_OR(const InputParameters & parameters)
+  : GrainDataTracker<RankFourTensor>(parameters),
+    _random_rotations(getParam<bool>("random_rotations")),
+    _C_ijkl(getParam<std::vector<Real>>("C_ijkl"),
+            getParam<MooseEnum>("fill_method").getEnum<RankFourTensor::FillMethod>()),
+    _euler(getUserObject<EulerAngleProvider>("euler_angle_provider")),
+    _Euler_angles_OR_1(getParam<Real>("Euler_angles_OR_1")),
+    _Euler_angles_OR_2(getParam<Real>("Euler_angles_OR_2")),
+    _Euler_angles_OR_3(getParam<Real>("Euler_angles_OR_3"))
+{
+}
+
+RankFourTensor
+GrainTrackerElasticity_OR::newGrain(unsigned int new_grain_id)
+{
+  EulerAngles angles;
+
+  if (new_grain_id < _euler.getGrainNum())
+  {
+      angles = _euler.getEulerAngles(new_grain_id);
+  }
+  else
+  {
+    if (_random_rotations)
+    {
+      angles.random();
+    }
+    else
+      mooseError("GrainTrackerElasticity has run out of grain rotation data.");
+  }
+
+  EulerAngles angles_OR;
+  angles_OR.phi1 = _Euler_angles_OR_1;
+  angles_OR.Phi = _Euler_angles_OR_2;
+  angles_OR.phi2 = _Euler_angles_OR_3;
+
+  RankFourTensor C_ijkl = _C_ijkl;
+
+  // Rotate for the orientation relationship
+  C_ijkl.rotate(RotationTensor(RealVectorValue(angles_OR)));
+  // Rotate for the grain texture
+  C_ijkl.rotate(RotationTensor(RealVectorValue(angles))); // Only works becasue the grain texture rotation is around z, which is the last rotation for OR
+
+  return C_ijkl;
+}


### PR DESCRIPTION
(Ref. #30674)

This is not ready for show time now -- at all. 
These classes were developed quite a few years ago and we have a collaboration that might make use of it. 
This PR is a way to share them and track progress.
 
A couple things to note:
- these classes were developed quite a few years ago and will surely not build. They need to be updated. 
- clang format is not followed
- there is a lot of commented lines that should be removed
- `GrainTrackerElasticity_OR` should probably be merged with `GrainTrackerElasticity`, or inherit from it to limit unnecessary duplicates. 
- Tests and documentation should be created for each of these classes. 
