### PR TITLE
Cache calls to runExe in moosedocs tests

### DIFF
--- a/python/MooseDocs/test/extensions/test_versioner.py
+++ b/python/MooseDocs/test/extensions/test_versioner.py
@@ -24,6 +24,7 @@ class TestTemplate(MooseDocsTestCase):
     EXTENSIONS = [core, command, versioner]
 
     def setUp(self):
+      super().setUp()
       self.packages = Versioner().get_packages('HEAD')
 
     def setupExtension(self, ext):


### PR DESCRIPTION
Closes #30676

This caches (most) calls to runExe so that we don't call the app with the same arguments more than once within a single set of tests.

MooseDocs tests before:

```
Ran 66 tests in 316.6 seconds. Average test time 8.7 seconds, maximum test time 219.2 seconds.
```

MooseDocs tests after:

```
Ran 66 tests in 165.9 seconds. Average test time 6.0 seconds, maximum test time 65.1 seconds.
```
