### PR TITLE
Remove capabilities from tests that don't need it

### DIFF
--- a/python/TestHarness/tests/TestHarnessTestCase.py
+++ b/python/TestHarness/tests/TestHarnessTestCase.py
@@ -20,8 +20,10 @@ class TestHarnessTestCase(unittest.TestCase):
     TestCase class for running TestHarness commands.
     """
 
-    def runTests(self, *args, tmp_output=True, as_json=False):
+    def runTests(self, *args, tmp_output=True, as_json=False, no_capabilities=True):
         cmd = ['./run_tests'] + list(args) + ['--term-format', 'njCst']
+        if no_capabilities:
+            cmd += ['--no-capabilities']
         sp_kwargs = {'cwd': os.path.join(os.getenv('MOOSE_DIR'), 'test'),
                      'text': True}
         context = tempfile.TemporaryDirectory if tmp_output else nullcontext

--- a/python/TestHarness/tests/test_ExtraInfo.py
+++ b/python/TestHarness/tests/test_ExtraInfo.py
@@ -39,7 +39,8 @@ class TestHarnessTester(TestHarnessTestCase):
         # will use the --ignore feature to force the test to run
         # regardless if that check(s) would otherwise cause this
         # test to be skipped.
-        output = self.runTests('-c', '-i', 'extra_info', '--ignore', '-e')
+        output = self.runTests('-c', '-i', 'extra_info', '--ignore', '-e',
+                               no_capabilities=False)
 
         # Parse the output, and find the caveat string
         raw_caveat_string = re.findall(r'\[(.*)\]', output)

--- a/python/TestHarness/tests/test_MinADSize.py
+++ b/python/TestHarness/tests/test_MinADSize.py
@@ -15,6 +15,6 @@ class TestHarnessTester(TestHarnessTestCase):
         """
         Test AD vector size
         """
-        output = self.runTests('-i', 'ad_size', '--no-color')
+        output = self.runTests('-i', 'ad_size', '--no-color', no_capabilities=False)
         self.assertRegex(output, r'tests/test_harness.enough \.* OK')
         self.assertRegex(output, r'tests/test_harness\.too_few \.* \[NEEDS: AD_SIZE>=1000\] SKIP')


### PR DESCRIPTION
Closes #30678

The addition of the capabilities parse time added in https://github.com/idaholab/moose/pull/30613 led to non-deterministic output in the replay test (the timing that the capabilities are parsed changes).
