### PR TITLE
Check if bounds are SNES vi later since MOOSE-PCs add their options on initialSetup()

### DIFF
--- a/framework/include/bounds/BoundsBase.h
+++ b/framework/include/bounds/BoundsBase.h
@@ -28,8 +28,8 @@ public:
   BoundsBase(const InputParameters & parameters);
 
 protected:
-  virtual void initialSetup() override;
-  virtual Real computeValue() override;
+  virtual void initialSetup() override final;
+  virtual Real computeValue() override final;
 
   /**
    * Method to get bound value for a variable.

--- a/framework/include/bounds/BoundsBase.h
+++ b/framework/include/bounds/BoundsBase.h
@@ -28,6 +28,7 @@ public:
   BoundsBase(const InputParameters & parameters);
 
 protected:
+  virtual void initialSetup() override;
   virtual Real computeValue() override;
 
   /**

--- a/framework/src/bounds/BoundsBase.C
+++ b/framework/src/bounds/BoundsBase.C
@@ -36,10 +36,6 @@ BoundsBase::BoundsBase(const InputParameters & parameters)
     _fe_var(_bounded_var.isFV() ? nullptr
                                 : &_subproblem.getStandardVariable(_tid, _bounded_var_name))
 {
-  if (!Moose::PetscSupport::isSNESVI(*dynamic_cast<FEProblemBase *>(&_c_fe_problem)))
-    mooseDoOnce(
-        mooseWarning("A variational inequalities solver must be used in conjunction with Bounds"));
-
   // Check that the bounded variable is of a supported type
   if (!_bounded_var.isNodal() && (_bounded_var.feType().order != libMesh::CONSTANT))
     paramError("bounded_variable", "Bounded variable must be nodal or of a CONSTANT order!");
@@ -52,6 +48,14 @@ BoundsBase::BoundsBase(const InputParameters & parameters)
     paramError("variable",
                "Dummy bounds aux variable and bounded variable must use the same finite element "
                "order and family");
+}
+
+void
+BoundsBase::initialSetup()
+{
+  if (!Moose::PetscSupport::isSNESVI(*dynamic_cast<FEProblemBase *>(&_c_fe_problem)))
+    mooseDoOnce(
+        mooseWarning("A variational inequalities solver must be used in conjunction with Bounds"));
 }
 
 Real

--- a/test/tests/bounds/old_value_bounds.i
+++ b/test/tests/bounds/old_value_bounds.i
@@ -112,13 +112,19 @@
   []
 []
 
+[Preconditioning]
+  [smp]
+    type = SMP
+    petsc_options_iname = '-snes_type'
+    petsc_options_value = 'vinewtonrsls'
+  []
+[]
+
 [Executioner]
   type = Transient
   num_steps = 2
 
   solve_type = 'PJFNK'
-  petsc_options_iname = '-snes_type'
-  petsc_options_value = 'vinewtonrsls'
 []
 
 [Outputs]


### PR DESCRIPTION


not on construction
refs #30684



<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
