### PR TITLE
Remove redundant build_side_ptr() proxy parameter

### DIFF
--- a/framework/src/geomsearch/PenetrationInfo.C
+++ b/framework/src/geomsearch/PenetrationInfo.C
@@ -222,7 +222,7 @@ dataLoad(std::istream & stream, PenetrationInfo *& pinfo, void * context)
     loadHelper(stream, pinfo->_elem, context);
     loadHelper(stream, pinfo->_side_num, context);
     // Rebuild the side element.
-    pinfo->_side = pinfo->_elem->build_side_ptr(pinfo->_side_num, false).release();
+    pinfo->_side = pinfo->_elem->build_side_ptr(pinfo->_side_num).release();
 
     loadHelper(stream, pinfo->_normal, context);
     loadHelper(stream, pinfo->_distance, context);

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -1670,7 +1670,7 @@ PenetrationThread::createInfoForElem(std::vector<PenetrationInfo *> & thisElemIn
     if (already_have_info_this_side)
       break;
 
-    const Elem * side = (elem->build_side_ptr(sides[i], false)).release();
+    const Elem * side = (elem->build_side_ptr(sides[i])).release();
 
     // Only continue with creating info for this side if the side contains
     // all of the nodes in nodes_that_must_be_on_side

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -764,7 +764,7 @@ MooseMesh::buildLowerDMesh()
 
       if (build_side)
       {
-        std::unique_ptr<Elem> side_elem(elem->build_side_ptr(side, false));
+        std::unique_ptr<Elem> side_elem(elem->build_side_ptr(side));
 
         // The side will be added with the same processor id as the parent.
         side_elem->processor_id() = elem->processor_id();

--- a/framework/src/meshgenerators/LowerDBlockFromSidesetGenerator.C
+++ b/framework/src/meshgenerators/LowerDBlockFromSidesetGenerator.C
@@ -180,7 +180,7 @@ LowerDBlockFromSidesetGenerator::generate()
     const auto side = elem_side.side;
 
     // Build a non-proxy element from this side.
-    std::unique_ptr<Elem> side_elem(elem->build_side_ptr(side, /*proxy=*/false));
+    std::unique_ptr<Elem> side_elem(elem->build_side_ptr(side));
 
     // The side will be added with the same processor id as the parent.
     side_elem->processor_id() = elem->processor_id();


### PR DESCRIPTION
Fixes #30718

## Reason
The libMesh `build_side_ptr()` default was changed to `proxy=false` since 2021, since even users of `true` can now get equally correct+efficient behavior from `false`, and the parameter is going to be removed entirely shortly.

## Design
Switch from explicit to implicit/default specification of `false`.

## Impact
No API or behavior changes from this PR (all explicit calls in MOOSE specified `false`); merging this PR will enable a subsequent libMesh API change that may require similar code updates in applications before the next libMesh submodule update.