### PR TITLE
Option to disable input parsing when listing moose inputs

### DIFF
--- a/framework/doc/content/js/moose_input_parser.js
+++ b/framework/doc/content/js/moose_input_parser.js
@@ -2,7 +2,6 @@
 function getSyntaxData(element) {
     // Use regex to extract the text we want to display and meta data for the element
     const content = element.textContent;
-    console.log(content);
     const match = /(\w+)\<\<\<(.*?)\>\>\>/.exec(content);
     if (!match || match.length < 3) {
         return element;
@@ -35,7 +34,7 @@ window.addEventListener('load', function () {
     const parsed_classes = ["moose-parsed-syntax", "moose-parsed-class", "moose-parsed-parameter"];
 
     // Get all the elements with the prism-specific classes
-    const elementsArray = parsed_classes.flatMap(parsed_class => 
+    const elementsArray = parsed_classes.flatMap(parsed_class =>
         Array.from(document.getElementsByClassName(parsed_class))
     );
 

--- a/python/MooseDocs/extensions/listing.py
+++ b/python/MooseDocs/extensions/listing.py
@@ -36,6 +36,10 @@ class ListingExtension(command.CommandExtension):
         config = command.CommandExtension.defaultConfig()
         config['prefix'] = ('Listing', "The caption prefix (e.g., Fig.).")
         config['modal-link'] = (True, "Insert modal links with complete files.")
+        config['parse-input-syntax'] = (
+            True,
+            "Whether to include links and tool-tips for rendered MOOSE inputs.",
+        )
         return config
 
     def extend(self, reader, renderer):
@@ -143,7 +147,7 @@ class LocalListingCommand(command.CommandComponent):
         `framework/doc/content/js/moose_input_parser.js` JavaScript file knows
         how to add the approriate HTML links and tooltips.
         """
-        if self.extension.syntax is None:
+        if self.extension.syntax is None or not self.extension['parse-input-syntax']:
             return content
 
         syntax_ext: appsyntax.AppSyntaxExtension = self.extension.syntax # Convenience


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

The rendering of moose input content on application websites seems to be fickle. I believe the latest JS changes fixes the recent issues seen. But it would be beneficial to include an option to turn it off in case something keeps popping up for a particular application.

## Design
<!--A concise description (design) of the enhancement.-->

New option in the listing config that can disable the input parsing with this in the `config.yml`:

```yaml
    MooseDocs.extensions.listing:
        active: True
        parse-input-syntax: False
```

## Impact
<!--Will the enhancement change existing APIs or add something new?-->

Make the doc build a little more customizable.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
