### PR TITLE
Torch visc uq

### DIFF
--- a/modules/navier_stokes/examples/bouyant_channel/channel_test_1.i
+++ b/modules/navier_stokes/examples/bouyant_channel/channel_test_1.i
@@ -1,0 +1,316 @@
+mu = 1.0
+rho = 1.0
+k = 5.0
+cp = 4816
+alpha = 150
+alpha_b = 0.001
+Pr_t = 0.9
+advected_interp_method = 'average'
+velocity_interp_method = 'rc'
+
+pressure_tag = "pressure_grad"
+
+[Mesh]
+  [mesh]
+    type = CartesianMeshGenerator
+    dim = 2
+    dx = '10.0'
+    dy = '1.0'
+    ix = '50'
+    iy = '10'
+  []
+[]
+
+[GlobalParams]
+  rhie_chow_user_object = 'rc'
+[]
+
+[Problem]
+  nl_sys_names = 'u_system v_system pressure_system energy_system'
+  previous_nl_solution_required = true
+[]
+
+[UserObjects]
+  [rc]
+    type = INSFVRhieChowInterpolatorSegregated
+    u = vel_x
+    v = vel_y
+    pressure = pressure
+  []
+[]
+
+[Variables]
+  [vel_x]
+    type = INSFVVelocityVariable
+    initial_condition = 0.5
+    solver_sys = u_system
+    two_term_boundary_expansion = false
+  []
+  [vel_y]
+    type = INSFVVelocityVariable
+    initial_condition = 0.0
+    solver_sys = v_system
+    two_term_boundary_expansion = false
+  []
+  [pressure]
+    type = INSFVPressureVariable
+    solver_sys = pressure_system
+    initial_condition = 0.2
+    two_term_boundary_expansion = false
+  []
+  [T_fluid]
+    type = INSFVEnergyVariable
+    initial_condition = 300
+    solver_sys = energy_system
+    two_term_boundary_expansion = false
+  []
+[]
+
+[FVKernels]
+  [u_advection]
+    type = INSFVMomentumAdvection
+    variable = vel_x
+    advected_interp_method = ${advected_interp_method}
+    velocity_interp_method = ${velocity_interp_method}
+    rho = ${rho}
+    momentum_component = 'x'
+  []
+  [u_viscosity]
+    type = INSFVMomentumDiffusion
+    variable = vel_x
+    mu = ${mu}
+    momentum_component = 'x'
+  []
+  [u_viscosity_turbulent]
+    type = INSFVMomentumDiffusion
+    variable = vel_x
+    mu = 'mu_t_torch'
+    momentum_component = 'x'
+    complete_expansion = true
+    u = vel_x
+    v = vel_y
+  []
+  [u_pressure]
+    type = INSFVMomentumPressure
+    variable = vel_x
+    momentum_component = 'x'
+    pressure = pressure
+    extra_vector_tags = ${pressure_tag}
+  []
+  [u_gravity]
+    type = INSFVMomentumGravity
+    momentum_component = 'x'
+    variable = vel_x
+    gravity = '0 -9.81 0'
+    rho = ${rho}
+  []
+
+  [v_advection]
+    type = INSFVMomentumAdvection
+    variable = vel_y
+    advected_interp_method = ${advected_interp_method}
+    velocity_interp_method = ${velocity_interp_method}
+    rho = ${rho}
+    momentum_component = 'y'
+  []
+  [v_viscosity]
+    type = INSFVMomentumDiffusion
+    variable = vel_y
+    mu = ${mu}
+    momentum_component = 'y'
+  []
+  [v_viscosity_turbulent]
+    type = INSFVMomentumDiffusion
+    variable = vel_y
+    mu = 'mu_t_torch'
+    momentum_component = 'y'
+    complete_expansion = true
+    u = vel_x
+    v = vel_y
+  []
+  [v_pressure]
+    type = INSFVMomentumPressure
+    variable = vel_y
+    momentum_component = 'y'
+    pressure = pressure
+    extra_vector_tags = ${pressure_tag}
+  []
+  [v_buoyancy]
+    type = INSFVMomentumBoussinesq
+    variable = vel_y
+    momentum_component = 'y'
+    T_fluid = T_fluid
+    gravity = '0 -9.81 0'
+    rho = ${rho}
+    ref_temperature = 300.0
+  []
+  [v_gravity]
+    type = INSFVMomentumGravity
+    variable = vel_y
+    momentum_component = 'y'
+    gravity = '0 -9.81 0'
+    rho = ${rho}
+  []
+
+  [p_diffusion]
+    type = FVAnisotropicDiffusion
+    variable = pressure
+    coeff = "Ainv"
+    coeff_interp_method = 'average'
+  []
+  [p_source]
+    type = FVDivergence
+    variable = pressure
+    vector_field = "HbyA"
+    force_boundary_execution = true
+  []
+
+  [energy_advection]
+    type = INSFVEnergyAdvection
+    variable = T_fluid
+    velocity_interp_method = ${velocity_interp_method}
+    advected_interp_method = ${advected_interp_method}
+  []
+  [energy_diffusion]
+    type = FVDiffusion
+    coeff = ${k}
+    variable = T_fluid
+  []
+  [temp_turb_conduction]
+    type = FVDiffusion
+    coeff = 'k_t'
+    variable = T_fluid
+  []
+[]
+
+[FVBCs]
+  [inlet-u]
+    type = INSFVInletVelocityBC
+    boundary = 'left'
+    variable = vel_x
+    function = '1.0'
+  []
+  [inlet-v]
+    type = INSFVInletVelocityBC
+    boundary = 'left'
+    variable = vel_y
+    function = '0.0'
+  []
+  [walls-u]
+    type = INSFVNoSlipWallBC
+    boundary = 'top bottom'
+    variable = vel_x
+    function = 0.0
+  []
+  [walls-v]
+    type = INSFVNoSlipWallBC
+    boundary = 'top bottom'
+    variable = vel_y
+    function = 0.0
+  []
+  [outlet_p]
+    type = INSFVOutletPressureBC
+    boundary = 'right'
+    variable = pressure
+    function = 1.0
+  []
+  [zero-grad-pressure]
+    type = FVFunctionNeumannBC
+    variable = pressure
+    boundary = 'top left bottom'
+    function = 0.0
+  []
+  [inlet_t]
+    type = FVDirichletBC
+    boundary = 'left'
+    variable = T_fluid
+    value = 300
+  []
+  [top_t]
+    type = FVDirichletBC
+    boundary = 'top'
+    variable = T_fluid
+    value = 400
+  []
+  [bottom_t]
+    type = FVDirichletBC
+    boundary = 'bottom'
+    variable = T_fluid
+    value = 300
+  []
+  ##########################################################
+[]
+
+[Executioner]
+  type = SIMPLENonlinearAssembly
+  momentum_l_abs_tol = 1e-11
+  pressure_l_abs_tol = 1e-11
+  energy_l_abs_tol = 1e-11
+  momentum_l_tol = 0
+  pressure_l_tol = 0
+  energy_l_tol = 0
+  rhie_chow_user_object = 'rc'
+  momentum_systems = 'u_system v_system'
+  pressure_system = 'pressure_system'
+  energy_system = 'energy_system'
+  pressure_gradient_tag = ${pressure_tag}
+  momentum_equation_relaxation = 0.7
+  pressure_variable_relaxation = 0.3
+  energy_equation_relaxation = 0.5
+  num_iterations = 500
+  pressure_absolute_tolerance = 1e-10
+  momentum_absolute_tolerance = 1e-10
+  energy_absolute_tolerance = 1e-10
+  print_fields = false
+  continue_on_max_its = true
+[]
+
+[UserObjects]
+  [cody_net]
+    type = TorchScriptUserObject
+    filename = "cody_net.pt"
+    load_during_construction = true
+    execute_on = INITIAL
+  []
+[]
+
+
+
+[Materials]
+  [const_functor]
+    type = ADGenericFunctorMaterial
+    prop_names = 'cp alpha alpha_b'
+    prop_values = '${cp} ${alpha} ${alpha_b}'
+  []
+  [const_mu_t]
+    type = ADGenericFunctorMaterial
+    prop_names = 'mu_t'
+    prop_values = '0.1'
+  []
+  [net_material] # Populates mu_t_torch
+    type = TorchScriptTurbulentViscosityMaterial
+    torch_script_userobject = cody_net
+    u = vel_x
+    v = vel_y
+  []
+  [k_t]
+    type = ADParsedFunctorMaterial
+    expression = 'mu_t * cp / Pr_t'
+    functor_names = 'mu_t ${cp} ${Pr_t}'
+    functor_symbols = 'mu_t cp Pr_t'
+    property_name = 'k_t'
+  []
+  [ins_fv]
+    type = INSFVEnthalpyFunctorMaterial
+    rho = ${rho}
+    temperature = 'T_fluid'
+  []
+[]
+
+[Outputs]
+  exodus = true
+  csv = false
+  perf_graph = false
+  print_nonlinear_residuals = false
+  print_linear_residuals = true
+[]

--- a/modules/navier_stokes/include/materials/TorchScriptTurbulentViscosityMaterial.h
+++ b/modules/navier_stokes/include/materials/TorchScriptTurbulentViscosityMaterial.h
@@ -38,6 +38,10 @@ protected:
   const Moose::Functor<ADReal> * _v_var;
   /// z-velocity
   const Moose::Functor<ADReal> * _w_var;
+  /// k for viscosity
+  const Real & _k;
+  /// Debug output flag
+  const bool & _debug;
 
   /// The user object that holds the torch module
   const TorchScriptUserObject & _torch_script_userobject;

--- a/modules/navier_stokes/include/materials/TorchScriptTurbulentViscosityMaterial.h
+++ b/modules/navier_stokes/include/materials/TorchScriptTurbulentViscosityMaterial.h
@@ -1,0 +1,59 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifdef LIBTORCH_ENABLED
+
+#pragma once
+
+#include "Material.h"
+#include "TorchScriptUserObject.h"
+
+/**
+ * This material declares properties which are evaluated as
+ * based on a torch script neural network.
+ */
+class TorchScriptTurbulentViscosityMaterial : public Material
+{
+public:
+  static InputParameters validParams();
+
+  TorchScriptTurbulentViscosityMaterial(const InputParameters & parameters);
+
+protected:
+  virtual void initQpStatefulProperties() override;
+  virtual void computeQpProperties() override;
+
+  /// Dimmension of the mesh
+  const unsigned int _mesh_dimension;
+
+  /// x-velocity
+  const Moose::Functor<ADReal> & _u_var;
+  /// y-velocity
+  const Moose::Functor<ADReal> * _v_var;
+  /// z-velocity
+  const Moose::Functor<ADReal> * _w_var;
+
+  /// The user object that holds the torch module
+  const TorchScriptUserObject & _torch_script_userobject;
+
+  /// Place holder for the inputs to the neural network
+  torch::Tensor _input_tensor;
+
+  /// Vector of all the properties, for now we don't support AD
+  GenericMaterialProperty<Real, false> * _properties;
+
+private:
+  /**
+   * A helper method for evaluating the torch script module and populating the
+   * material properties.
+   */
+  void computeQpValues();
+};
+
+#endif

--- a/modules/navier_stokes/src/materials/TorchScriptTurbulentViscosityMaterial.C
+++ b/modules/navier_stokes/src/materials/TorchScriptTurbulentViscosityMaterial.C
@@ -1,0 +1,116 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifdef LIBTORCH_ENABLED
+
+#include "TorchScriptTurbulentViscosityMaterial.h"
+
+registerMooseObject("MooseApp", TorchScriptTurbulentViscosityMaterial);
+
+InputParameters
+TorchScriptTurbulentViscosityMaterial::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addClassDescription(
+      "Material object which relies on the evaluation of a TorchScript module to compute the turbulent dynamic viscosity.");
+  params.addRequiredParam<MooseFunctorName>("u", "The velocity in the x direction.");
+  params.addParam<MooseFunctorName>("v", "The velocity in the y direction.");
+  params.addParam<MooseFunctorName>("w", "The velocity in the z direction.");
+  params.addRequiredParam<UserObjectName>(
+      "torch_script_userobject",
+      "The name of the user object which contains the torch script module.");
+
+  return params;
+}
+
+TorchScriptTurbulentViscosityMaterial::TorchScriptTurbulentViscosityMaterial(const InputParameters & parameters)
+  : Material(parameters),
+    _mesh_dimension(_mesh.dimension()),
+    _u_var(getFunctor<ADReal>("u")),
+    _v_var(parameters.isParamValid("v") ? &(getFunctor<ADReal>("v")) : nullptr),
+    _w_var(parameters.isParamValid("w") ? &(getFunctor<ADReal>("w")) : nullptr),
+    _torch_script_userobject(getUserObject<TorchScriptUserObject>("torch_script_userobject")),
+    _input_tensor(torch::zeros(
+        {1, 2},
+        torch::TensorOptions().dtype(torch::kFloat64).device(_app.getLibtorchDevice())))
+{
+    _properties = &declareGenericProperty<Real, false>("mu_t_torch");
+}
+
+void
+TorchScriptTurbulentViscosityMaterial::initQpStatefulProperties()
+{
+  computeQpValues();
+}
+
+void
+TorchScriptTurbulentViscosityMaterial::computeQpProperties()
+{
+  computeQpValues();
+}
+
+void
+TorchScriptTurbulentViscosityMaterial::computeQpValues()
+{
+    
+  const auto r = makeElemArg(_current_elem);
+  const auto t = determineState();
+
+  Real eta_1 = 0.0;
+  Real eta_2 = 0.0;
+
+  const auto u_grad_x = _u_var.gradient(r,t)(0);
+  eta_1 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (u_grad_x + u_grad_x)));
+  eta_2 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (u_grad_x - u_grad_x)));
+
+  if (_mesh_dimension > 1)
+  {
+    const auto u_grad_y = _u_var.gradient(r,t)(1);
+    const auto v_grad_x = _v_var->gradient(r,t)(0);
+    const auto v_grad_y = _v_var->gradient(r,t)(1);
+
+    eta_1 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (u_grad_y + v_grad_x)));
+    eta_1 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (v_grad_x + u_grad_y)));
+    eta_1 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (v_grad_y + v_grad_y)));
+
+    eta_2 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (u_grad_y - v_grad_x)));
+    eta_2 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (v_grad_x - u_grad_y)));
+    eta_2 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (v_grad_y - v_grad_y)));
+  }
+  if (_mesh_dimension > 2)
+  {
+    const auto u_grad_z = _u_var.gradient(r,t)(2);
+    const auto v_grad_z = _v_var->gradient(r,t)(2);
+    const auto w_grad_x = _v_var->gradient(r,t)(0);
+    const auto w_grad_y = _v_var->gradient(r,t)(1);
+    const auto w_grad_z = _v_var->gradient(r,t)(2);
+
+    eta_1 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (u_grad_z + w_grad_x)));
+    eta_1 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (w_grad_x + u_grad_z)));
+    eta_1 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (v_grad_z + w_grad_y)));
+    eta_1 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (w_grad_y + v_grad_z)));
+    eta_1 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (w_grad_z + w_grad_z)));
+
+    eta_2 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (u_grad_z - w_grad_x)));
+    eta_2 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (w_grad_x - u_grad_z)));
+    eta_2 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (v_grad_z - w_grad_y)));
+    eta_2 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (w_grad_y - v_grad_z)));
+    eta_2 += MetaPhysicL::raw_value(Utility::pow<2>(0.5 * (w_grad_z - w_grad_z)));
+  }
+
+  auto input_accessor = _input_tensor.accessor<Real, 2>();
+  input_accessor[0][0] =  eta_1;
+  input_accessor[0][1] =  eta_2;
+
+  const auto output = _torch_script_userobject.evaluate(_input_tensor);
+  const auto output_accessor = output.accessor<Real, 2>();
+  (*_properties)[_qp] = output_accessor[0][0];
+}
+
+#endif


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
- This feature revises the TorchScriptTurbulentViscosityMaterial to incorporate the G1 value into the turbulent viscosity. Also adds parameterization of k and an optional debug flag.
- Fixes bouyant_channel/channel_test_1.i to allow the Neural Network predictions to be used in the simulation.


## Design
<!--A concise description (design) of the enhancement.-->
- Creates Aux variable to convert scalar NN output to a functor through AuxKernel.
- Added k and debug members to class in order to parameterize them in input file.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
- Adds parameterization

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
