### PR TITLE
Fix for divergence crtieria in parsed Convergence when no convergence objects are used

### DIFF
--- a/framework/src/convergence/ParsedConvergence.C
+++ b/framework/src/convergence/ParsedConvergence.C
@@ -63,7 +63,8 @@ ParsedConvergence::initialSetup()
   const auto divergence_expression = isParamValid("divergence_expression")
                                          ? getParam<std::string>("divergence_expression")
                                          : MooseUtils::join(_convergence_symbol_names, "|");
-  _divergence_function = makeParsedFunction(divergence_expression);
+  if (divergence_expression.size())
+    _divergence_function = makeParsedFunction(divergence_expression);
 }
 
 void
@@ -160,7 +161,9 @@ ParsedConvergence::checkConvergence(unsigned int iter)
   updateSymbolValues(iter);
 
   const Real converged_real = evaluate(_convergence_function, _convergence_function_params, name());
-  const Real diverged_real = evaluate(_divergence_function, _divergence_function_params, name());
+  const Real diverged_real =
+      _divergence_function ? evaluate(_divergence_function, _divergence_function_params, name())
+                           : 0;
 
   if (convertRealToBool(diverged_real, "divergence_expression"))
     return MooseConvergenceStatus::DIVERGED;

--- a/test/tests/convergence/parsed_convergence/tests
+++ b/test/tests/convergence/parsed_convergence/tests
@@ -8,6 +8,14 @@
     csvdiff = 'test_converge_out.csv'
     requirement = 'The system shall be allow arbitrary convergence criteria based on Convergence objects, functions, post-processors, and constants.'
   []
+  [no_error_div]
+    type = RunApp
+    input = 'test_converge.i'
+    cli_args = 'Convergence/parsed_conv/convergence_expression=1'
+    requirement = 'The system shall be able to parse expressions that do not include any other convergence objects.'
+    # same output files
+    prereq = test_converge
+  []
   [test_diverge_default]
     type = RunException
     input = 'test_diverge_default.i'


### PR DESCRIPTION
## Reason
Right now the divergence expression parsing errors with a cryptic message when we attempt to:
- not set a divergence expression
- set a convergence expression without any Convergence objects in the symbols

## Design
Simply not have  a divergence criterion

## Impact
Fix a bug in a common use case for ParsedConvergence

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
