### PR TITLE
Read command line arguments in file by line rather than by space

### DIFF
--- a/framework/doc/content/source/vectorpostprocessors/CSVReader.md
+++ b/framework/doc/content/source/vectorpostprocessors/CSVReader.md
@@ -1,1 +1,0 @@
-CSVReaderVectorPostprocessor.md

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -481,9 +481,10 @@ MultiApp::readCommandLineArguments()
         MooseUtils::checkFileReadable(cli_args_file);
 
         std::ifstream is(cli_args_file.c_str());
-        std::copy(std::istream_iterator<std::string>(is),
-                  std::istream_iterator<std::string>(),
-                  std::back_inserter(cli_args));
+        // Read by line rather than space separated like the cli_args parameter
+        std::string line;
+        while (std::getline(is, line))
+          cli_args.push_back(line);
 
         // We do not allow empty files
         if (!cli_args.size())

--- a/test/tests/multiapps/cliargs_from_file/cliargs_oneline.txt
+++ b/test/tests/multiapps/cliargs_from_file/cliargs_oneline.txt
@@ -1,1 +1,0 @@
-BCs/right/value=0.5 BCs/right/value=1 BCs/right/value=2 BCs/right/value=3

--- a/test/tests/multiapps/cliargs_from_file/tests
+++ b/test/tests/multiapps/cliargs_from_file/tests
@@ -10,21 +10,12 @@
     requirement = "The system shall support reading command-line arguments from a file with multiple lines"
   [../]
 
-  [./one_line_file]
-    type = 'Exodiff'
-    input = 'cliargs_parent.i'
-    exodiff = 'cliargs_parent_out.e		cliargs_parent_out_sub_app0.e	cliargs_parent_out_sub_app1.e	cliargs_parent_out_sub_app2.e	cliargs_parent_out_sub_app3.e'
-    cli_args = 'MultiApps/sub_app/cli_args_files=cliargs_oneline.txt'
-    prereq = multiline_file
-    requirement = "The system shall support reading command-line arguments from a file with a single line"
-  [../]
-
   [./two_files]
     type = 'Exodiff'
     input = 'cliargs_parent.i'
     exodiff = 'cliargs_parent_out.e		cliargs_parent_out_sub_app0.e	cliargs_parent_out_sub_app1.e	cliargs_parent_out_sub_app2.e	cliargs_parent_out_sub_app3.e'
     cli_args = 'MultiApps/sub_app/positions_file="positions_1.txt positions_2.txt" MultiApps/sub_app/input_files="cliargs_sub_1.i cliargs_sub_2.i" MultiApps/sub_app/cli_args_files="cliargs_1.txt cliargs_2.txt"'
-    prereq = one_line_file
+    prereq = multiline_file
     requirement = "The system shall support reading command-line arguments from multiple files"
   [../]
 


### PR DESCRIPTION
I'm fairly sure everyone was already using lines rather than spaces, but the way it was read was with spaces and would see vector parameters '1 2 3' as new cli_args for the next child app

refs #18596

@caolwec