### PR TITLE
Add vector data to `ValidationCase`

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -930,7 +930,8 @@ class TestHarness:
         # 2 - Added 'unique_test_id' (tests/*/tests/*/unique_test_id) to Job output if set
         # 3 - Added 'json_metadata' (tests/*/tests/*/tester/json_metadata) to Tester output
         # 4 - Added 'validation' (tests/*/tests/validation) to Job output if set
-        testharness = {'version': 4,
+        # 5 - Added validation data types (tests/*/tests/data/type) to Job output if set
+        testharness = {'version': 5,
                        'start_time': datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
                        'end_time': None,
                        'args': sys.argv[1:],

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -896,9 +896,10 @@ class Job(OutputInterface):
                     job_data['validation']['results'].append(value)
                 data = {k: v for k, v in case.data.items() if v.validation}
                 for key, value in data.items():
-                    value = asdict(value)
-                    value.pop('validation')
-                    job_data['validation']['data'][key] = value
+                    value_dict = asdict(value)
+                    value_dict['type'] = value.__class__.__name__.split('.')[-1]
+                    value_dict.pop('validation')
+                    job_data['validation']['data'][key] = value_dict
 
         # Extend with data from the scheduler, if any
         job_data.update(scheduler.appendResultFileJob(self))

--- a/python/TestHarness/tests/test_Validation.py
+++ b/python/TestHarness/tests/test_Validation.py
@@ -28,19 +28,24 @@ class TestHarnessTester(TestHarnessTestCase):
         self.assertEqual('number', result['data_key'])
         # Validation data
         data = validation['data']
-        self.assertEqual(len(data), 1)
+        self.assertEqual(len(data), 2)
+        # Numeric value
         number = data['number']
         self.assertEqual(100.0, number['value'])
         self.assertEqual('Number', number['description'])
         self.assertEqual('coolunits', number['units'])
         self.assertEqual(95.0, number['bounds'][0])
         self.assertEqual(105.0, number['bounds'][1])
+        # Arbitrary data (dict)
+        useless_dict = data['useless_dict']
+        self.assertEqual({'foo': 'bar'}, useless_dict['value'])
+        self.assertEqual('A useless dictionary', useless_dict['description'])
 
         # Check on-screen output
         output = test['output']
         validation_output = output['validation']
         self.assertIn('Running validation case', validation_output)
-        self.assertIn('Acquired 1 data value(s), 1 result(s): 1 ok, 0 fail, 0 skip', validation_output)
+        self.assertIn('Acquired 2 data value(s), 1 result(s): 1 ok, 0 fail, 0 skip', validation_output)
 
         # Check timing; validation execution exists
         timing = test['timing']

--- a/python/TestHarness/tests/test_Validation.py
+++ b/python/TestHarness/tests/test_Validation.py
@@ -47,10 +47,12 @@ class TestHarnessTester(TestHarnessTestCase):
         self.assertEqual('coolunits', number['units'])
         self.assertEqual(95.0, number['bounds'][0])
         self.assertEqual(105.0, number['bounds'][1])
+        self.assertEqual('ScalarData', number['type'])
         # Arbitrary data (dict)
         useless_dict = data['useless_dict']
         self.assertEqual({'foo': 'bar'}, useless_dict['value'])
         self.assertEqual('A useless dictionary', useless_dict['description'])
+        self.assertEqual('Data', useless_dict['type'])
         # Vector data
         vector = data['vector']
         self.assertEqual([0, 1], vector['x'])
@@ -61,6 +63,7 @@ class TestHarnessTester(TestHarnessTestCase):
         self.assertEqual('K', vector['units'])
         self.assertEqual([0, 1], vector['bounds'][0])
         self.assertEqual([2, 3], vector['bounds'][1])
+        self.assertEqual('VectorData', vector['type'])
 
         # Check on-screen output
         output = test['output']

--- a/python/TestHarness/tests/test_Validation.py
+++ b/python/TestHarness/tests/test_Validation.py
@@ -20,15 +20,26 @@ class TestHarnessTester(TestHarnessTestCase):
         self.assertTrue(validation['script'].endswith('validation_ok.py'))
         # Validation results
         results = validation['results']
-        self.assertEqual(len(results), 1)
-        result = results[0]
-        self.assertEqual('OK', result['status'])
-        self.assertIn('within bounds', result['message'])
-        self.assertEqual('TestCase.testValidation', result['test'],)
-        self.assertEqual('number', result['data_key'])
+        self.assertEqual(len(results), 3)
+        # Results from number
+        number_results = [r for r in results if r['data_key'] == 'number']
+        self.assertEqual(len(number_results), 1)
+        number_result = number_results[0]
+        self.assertEqual('OK', number_result['status'])
+        self.assertIn('within bounds', number_result['message'])
+        self.assertEqual('TestCase.testValidation', number_result['test'])
+        # Results from vector
+        vector_results = [r for r in results if r['data_key'] == 'vector']
+        self.assertEqual(len(vector_results), 2)
+        for i, result in enumerate(vector_results):
+            self.assertEqual('OK', result['status'])
+            self.assertIn('within bounds', result['message'])
+            self.assertIn(f'index {i}', result['message'])
+            self.assertEqual('TestCase.testValidation', result['test'])
+
         # Validation data
         data = validation['data']
-        self.assertEqual(len(data), 2)
+        self.assertEqual(len(data), 3)
         # Numeric value
         number = data['number']
         self.assertEqual(100.0, number['value'])
@@ -40,12 +51,22 @@ class TestHarnessTester(TestHarnessTestCase):
         useless_dict = data['useless_dict']
         self.assertEqual({'foo': 'bar'}, useless_dict['value'])
         self.assertEqual('A useless dictionary', useless_dict['description'])
+        # Vector data
+        vector = data['vector']
+        self.assertEqual([0, 1], vector['x'])
+        self.assertEqual([1, 2], vector['value'])
+        self.assertEqual('Position', vector['x_description'])
+        self.assertEqual('Temperature', vector['description'])
+        self.assertEqual('cm', vector['x_units'])
+        self.assertEqual('K', vector['units'])
+        self.assertEqual([0, 1], vector['bounds'][0])
+        self.assertEqual([2, 3], vector['bounds'][1])
 
         # Check on-screen output
         output = test['output']
         validation_output = output['validation']
         self.assertIn('Running validation case', validation_output)
-        self.assertIn('Acquired 2 data value(s), 1 result(s): 1 ok, 0 fail, 0 skip', validation_output)
+        self.assertIn('Acquired 3 data value(s), 3 result(s): 3 ok, 0 fail, 0 skip', validation_output)
 
         # Check timing; validation execution exists
         timing = test['timing']

--- a/python/TestHarness/tests/test_ValidationCase.py
+++ b/python/TestHarness/tests/test_ValidationCase.py
@@ -15,12 +15,21 @@ from TestHarness.validation import NoTestsDefined, TestMissingResults, TestRunEx
 from FactorySystem.InputParameters import InputParameters
 
 class TestValidationCase(unittest.TestCase):
+    """
+    Test cases for ValidationCase
+    """
     def testNoTests(self):
+        """
+        Checks that an exception is raised when running without tests
+        """
         test = ValidationCase()
         with self.assertRaises(NoTestsDefined):
             test.run()
 
     def testAddResult(self):
+        """
+        Tests the addition of a result message via ValidationCase.addResult()
+        """
         test_message = 'What a cool message'
 
         for validation in [True, False]:
@@ -42,6 +51,10 @@ class TestValidationCase(unittest.TestCase):
                 self.assertEqual(result.validation, validation)
 
     def testMissingResult(self):
+        """
+        Checks that an exception is thrown when tests are ran
+        but no results are stored
+        """
         class Test(ValidationCase):
             def test(self):
                 pass
@@ -52,6 +65,9 @@ class TestValidationCase(unittest.TestCase):
         self.assertEqual(len(test.results), 0)
 
     def testAddData(self):
+        """
+        Tests the addition of arbitrary data via ValidationCase.addData()
+        """
         args = {'key': 'some_dict',
                 'value': {'foo': 'bar'},
                 'description': 'Useless dictionary'}
@@ -64,18 +80,27 @@ class TestValidationCase(unittest.TestCase):
             self.assertEqual(getattr(data, key), value)
         self.assertIsNone(data.test)
 
-    def testAddDataCheckType(self):
-        case = ValidationCase()
-
+    def testAddDataChecks(self):
+        """
+        Tests checks performed in ValidationCase.addData()
+        """
         # Description not a string
         with self.assertRaisesRegex(TypeError, 'description is not of type str'):
-            case.addData('unused', None, None)
+            ValidationCase().addData('unused', None, None)
 
     def testAddDataNonSerializable(self):
+        """
+        Checks that an exception is thrown when data is added that cannot
+        be serialized (must be JSON serializable so that the test harness
+        can dump it)
+        """
         with self.assertRaisesRegex(TypeError, 'not JSON serializable'):
             ValidationCase().addData('key', b'1234', 'unused')
 
     def testCheckBounds(self):
+        """
+        Tests the ValidationCase.checkBounds() method
+        """
         number_format = ValidationCase.number_format
         value, min_value, max_value, units = 1, 0, 2, 'coolunits'
 
@@ -116,6 +141,9 @@ class TestValidationCase(unittest.TestCase):
         self.assertEqual(message, ' '.join(exp_message))
 
     def testCheckBoundsChecks(self):
+        """
+        Tests the data type checking performed in ValidationCase.checkBounds()
+        """
         # Non-numeric values
         with self.assertRaisesRegex(ValueError, 'value: could not convert string'):
             ValidationCase.checkBounds('abc', 0, 1, None)
@@ -129,6 +157,9 @@ class TestValidationCase(unittest.TestCase):
             ValidationCase.checkBounds(0, 2, 1, None)
 
     def testToFloat(self):
+        """
+        Tests the to-float conversion helper in ValidationCase.toFloat()
+        """
         # Success
         value = float(1.01)
         self.assertEqual(value, ValidationCase.toFloat(value))
@@ -145,6 +176,9 @@ class TestValidationCase(unittest.TestCase):
             ValidationCase.toFloat('abcd', context)
 
     def testAddScalarData(self):
+        """
+        Tests the storing of scalar data in ValidationCase.addScalarData()
+        """
         args = {'key': 'peak_temperature',
                 'value': 1.234,
                 'description': 'Peak temperature',
@@ -160,6 +194,9 @@ class TestValidationCase(unittest.TestCase):
         self.assertIsNone(data.test)
 
     def testAddScalarDataChecks(self):
+        """
+        Tests the data validation performed in ValidationCase.addScalarData()
+        """
         case = ValidationCase()
 
         # Non-numeric value
@@ -215,6 +252,10 @@ class TestValidationCase(unittest.TestCase):
         self.assertEqual(data.nominal, float(nominal))
 
     def testAddScalarDataBounded(self):
+        """
+        Tests the addition of scalar data in ValidationCase.addScalarData()
+        with bounds via the 'bounds' keyword argument
+        """
         key = 'data'
         value = 1.234
         bounds = (value - 1.0, value + 0.1)
@@ -227,6 +268,10 @@ class TestValidationCase(unittest.TestCase):
         self.assertEqual(bounds, data.bounds)
 
     def testAddScalarDataNominal(self):
+        """
+        Tests the addition of scalar data in ValidationCase.addScalarData()
+        with a nominal value via the 'nominal' keyword argument
+        """
         key = 'test'
         nominal = 1.1
         test = ValidationCase()
@@ -236,6 +281,9 @@ class TestValidationCase(unittest.TestCase):
         self.assertEqual(nominal, all_data[key].nominal)
 
     def testAddScalarDataBoundedCheck(self):
+        """
+        Tests the checking of bounds for scalar data in ValidationCase.addScalarData()
+        """
         class Test(ValidationCase):
             def test_pass(self):
                 self.addScalarData('pass', 1.0, 'foo', None, bounds=(0.9, 1.1))
@@ -264,6 +312,9 @@ class TestValidationCase(unittest.TestCase):
             self.assertEqual(f'Test.test_{case}', data.test)
 
     def testToListFloat(self):
+        """
+        Tests the conversion helper ValidationCase.toListFloat()
+        """
         # Success list
         values = [1.0, 2.0]
         self.assertEqual(ValidationCase.toListFloat(values), values)
@@ -301,6 +352,9 @@ class TestValidationCase(unittest.TestCase):
             ValidationCase.toListFloat(values, 'foobar:')
 
     def testAddVectorDataChecks(self):
+        """
+        Tests the data validation performed in ValidationCase.addVectorData()
+        """
         good_args = {'x': ([0.0, 1.0], 'description_x', 'units_x'),
                      'value': ([1.0, 2.0], 'description_value', 'units_value')}
 
@@ -375,6 +429,9 @@ class TestValidationCase(unittest.TestCase):
             ValidationCase().addVectorData('k', *good_args.values(), nominal=[1, 2, 3])
 
     def testAddVectorData(self):
+        """
+        Tests the storing of vector data in ValidationCase.addVectorData()
+        """
         x = ([0.0, 1.0], 'Position', 'cm')
         value = ([1.0, 2.0], 'Temperature', 'K')
 
@@ -394,6 +451,10 @@ class TestValidationCase(unittest.TestCase):
         self.assertEqual(data.x_units, x[2])
 
     def testAddVectorDataNominal(self):
+        """
+        Tests the addition of vector data in ValidationCase.addVectorData()
+        with a nominal value via the 'nominal' keyword argument
+        """
         key = 'k'
         x = ([0.0, 1.0], 'Position', 'cm')
         value = ([1.0, 2.0], 'Temperature', 'K')
@@ -406,6 +467,10 @@ class TestValidationCase(unittest.TestCase):
         self.assertEqual(nominal, all_data[key].nominal)
 
     def testAddVectorDataBounded(self):
+        """
+        Tests the addition of vector data in ValidationCase.addVectorData()
+        with bounds via the 'bounds' keyword argument
+        """
         key = 'data'
         x = ([0, 1], 'description_x', 'units_x')
         value = ([1, 2], 'description_value', 'units_value')
@@ -417,6 +482,9 @@ class TestValidationCase(unittest.TestCase):
         self.assertEqual(bounds, test.data[key].bounds)
 
     def testAddVectorDataBoundedCheck(self):
+        """
+        Tests the checking of bounds for vector data in ValidationCase.addVectorData()
+        """
         class TestValidationCase(ValidationCase):
             def test_pass(self):
                 self.addVectorData('pass',
@@ -459,6 +527,10 @@ class TestValidationCase(unittest.TestCase):
             check_result('fail_both', i, ValidationCase.Status.FAIL)
 
     def testInitialize(self):
+        """
+        Tests that a derived ValiationCase with an initialize()
+        method has that method called
+        """
         class Test(ValidationCase):
             def __init__(self):
                 self.value_set = False
@@ -474,6 +546,10 @@ class TestValidationCase(unittest.TestCase):
         self.assertTrue(test.value_set)
 
     def testFinalize(self):
+        """
+        Tests that a derived ValiationCase with an finalize()
+        method has that method called
+        """
         class Test(ValidationCase):
             def __init__(self):
                 self.value_set = False
@@ -489,6 +565,9 @@ class TestValidationCase(unittest.TestCase):
         self.assertTrue(test.value_set)
 
     def testTestException(self):
+        """
+        Tests that exceptions within individual tests are caught
+        """
         class Test(ValidationCase):
             def test(self):
                 raise Exception('foo')
@@ -498,12 +577,19 @@ class TestValidationCase(unittest.TestCase):
             test.run()
 
     def testGetTesterOutputs(self):
+        """
+        Tests getting tester outputs from within a case
+        """
         outputs = ['foo.csv', 'bar.e']
         test = ValidationCase(tester_outputs = outputs)
         self.assertEqual(outputs, test.getTesterOutputs())
         self.assertEqual(['bar.e'], test.getTesterOutputs(extension='.e'))
 
     def testWithParameters(self):
+        """
+        Tests that parameters set at construction of a ValidationCase
+        can be accessed within the tests.
+        """
         required_value = 500
         default_value = 1.0
         optional_value = 2.0

--- a/python/TestHarness/tests/test_ValidationCase.py
+++ b/python/TestHarness/tests/test_ValidationCase.py
@@ -568,13 +568,16 @@ class TestValidationCase(unittest.TestCase):
         """
         Tests that exceptions within individual tests are caught
         """
+        raised_exe = Exception('foo')
         class Test(ValidationCase):
             def test(self):
-                raise Exception('foo')
+                raise raised_exe
 
         test = Test()
-        with self.assertRaises(TestRunException):
+        with self.assertRaises(TestRunException) as exe:
             test.run()
+        self.assertEqual(len(exe.exception.exceptions), 1)
+        self.assertEqual(exe.exception.exceptions[0], raised_exe)
 
     def testGetTesterOutputs(self):
         """

--- a/python/TestHarness/tests/test_ValidationCase.py
+++ b/python/TestHarness/tests/test_ValidationCase.py
@@ -125,6 +125,22 @@ class TestValidationCase(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'Min bound greater than max'):
             ValidationCase.checkBounds(0, 2, 1, None)
 
+    def testToFloat(self):
+        # Success
+        value = float(1.01)
+        self.assertEqual(value, ValidationCase.toFloat(value))
+
+        # Integer to float
+        value = int(1)
+        to_value = ValidationCase.toFloat(value)
+        self.assertTrue(isinstance(to_value, float))
+        self.assertEqual(to_value, float(value))
+
+        # Catch exception
+        context = 'some context'
+        with self.assertRaisesRegex(ValueError, 'some context: could not convert string to float'):
+            ValidationCase.toFloat('abcd', context)
+
     def testAddScalarData(self):
         args = {'key': 'peak_temperature',
                 'value': 1.234,

--- a/python/TestHarness/tests/test_ValidationCase.py
+++ b/python/TestHarness/tests/test_ValidationCase.py
@@ -175,6 +175,10 @@ class TestValidationCase(unittest.TestCase):
             status = test.Status.OK if case == 'pass' else test.Status.FAIL
             self.assertEqual(status, result.status)
             self.assertEqual(case, result.data_key)
+            if case == 'pass':
+                self.assertIn('within bounds', result.message)
+            else:
+                self.assertIn('out of bounds', result.message)
             data = test.data[case]
             self.assertEqual(f'Test.test_{case}', data.test)
 

--- a/python/TestHarness/tests/test_ValidationCase.py
+++ b/python/TestHarness/tests/test_ValidationCase.py
@@ -117,9 +117,9 @@ class TestValidationCase(unittest.TestCase):
 
     def testCheckBoundsChecks(self):
         # Bounds not numeric
-        with self.assertRaisesRegex(TypeError, 'Min bound not numeric'):
+        with self.assertRaisesRegex(ValueError, 'Min bound: could not convert string'):
             ValidationCase.checkBounds(0, 'abc', 1, None)
-        with self.assertRaisesRegex(TypeError, 'Max bound not numeric'):
+        with self.assertRaisesRegex(ValueError, 'Max bound: could not convert string'):
             ValidationCase.checkBounds(0, 1, 'abc', None)
 
         # Bound min greater than max

--- a/python/TestHarness/tests/test_ValidationCase.py
+++ b/python/TestHarness/tests/test_ValidationCase.py
@@ -9,6 +9,8 @@
 
 # pylint: disable
 import unittest
+import typing
+from dataclasses import dataclass
 import numpy as np
 from TestHarness import ValidationCase
 from TestHarness.validation import NoTestsDefined, TestMissingResults, TestRunException
@@ -94,8 +96,16 @@ class TestValidationCase(unittest.TestCase):
         be serialized (must be JSON serializable so that the test harness
         can dump it)
         """
+        # Bad data value
         with self.assertRaisesRegex(TypeError, 'not JSON serializable'):
             ValidationCase().addData('key', b'1234', 'unused')
+
+        # Bad data class
+        @dataclass(kw_only=True)
+        class BadData(ValidationCase.Data):
+            bad_value: typing.Any
+        with self.assertRaisesRegex(TypeError, 'not JSON serializable'):
+            ValidationCase()._addData(BadData, 'key', 1234, 'unused', bad_value=b'1234')
 
     def testCheckBounds(self):
         """

--- a/python/TestHarness/tests/test_ValidationCase.py
+++ b/python/TestHarness/tests/test_ValidationCase.py
@@ -74,14 +74,14 @@ class TestValidationCase(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, 'not JSON serializable'):
             ValidationCase().addData('key', b'1234', 'unused')
 
-    def testAddFloatData(self):
+    def testAddScalarData(self):
         args = {'key': 'peak_temperature',
                 'value': 1.234,
                 'description': 'Peak temperature',
                 'units': 'K'}
 
         test = ValidationCase()
-        test.addFloatData(*args.values())
+        test.addScalarData(*args.values())
         all_data = test.data
         self.assertEqual(len(all_data), 1)
         data = test.data[args['key']]
@@ -89,79 +89,79 @@ class TestValidationCase(unittest.TestCase):
             self.assertEqual(getattr(data, key), value)
         self.assertIsNone(data.test)
 
-    def testAddFloatDataCheckType(self):
+    def testAddScalarDataCheckType(self):
         case = ValidationCase()
 
         # Non-numeric value
         with self.assertRaisesRegex(TypeError, 'value: not of type float or int'):
-            ValidationCase().addFloatData('non_numeric', 'abcd', 'unused', None)
+            ValidationCase().addScalarData('non_numeric', 'abcd', 'unused', None)
 
         # Allow integers
         value = int(1)
-        case.addFloatData('to_float', value, 'unused', None)
+        case.addScalarData('to_float', value, 'unused', None)
         data = case.data['to_float']
         self.assertTrue(isinstance(data.value, float))
         self.assertEqual(data.value, float(value))
 
         # Non string description
         with self.assertRaisesRegex(TypeError, 'description: not of type str'):
-            ValidationCase().addFloatData('bad_description', 1, None, None)
+            ValidationCase().addScalarData('bad_description', 1, None, None)
 
         # Non string units
         with self.assertRaisesRegex(TypeError, 'units: not of type str or None'):
-            ValidationCase().addFloatData('bad_units', 1, 'unused', 1)
+            ValidationCase().addScalarData('bad_units', 1, 'unused', 1)
 
         # Non-tuple bounds
         with self.assertRaisesRegex(TypeError, 'bounds: not of type tuple'):
-            ValidationCase().addFloatData('bad_bounds', 1, 'unused', None, bounds=[])
+            ValidationCase().addScalarData('bad_bounds', 1, 'unused', None, bounds=[])
 
         # Bad-sized bounds
         with self.assertRaisesRegex(TypeError, 'bounds: not of length 2'):
-            ValidationCase().addFloatData('bad_bounds_len', 1, 'unused', None, bounds=(None, None, None))
+            ValidationCase().addScalarData('bad_bounds_len', 1, 'unused', None, bounds=(None, None, None))
 
         # Bad min bounds type
         with self.assertRaisesRegex(TypeError, 'bounds: min bounds not of type int or float'):
-            ValidationCase().addFloatData('bad_bounds_len', 1, 'unused', None, bounds=(None, None))
+            ValidationCase().addScalarData('bad_bounds_len', 1, 'unused', None, bounds=(None, None))
 
         # Bad max bounds type
         with self.assertRaisesRegex(TypeError, 'bounds: max bounds not of type int or float'):
-            ValidationCase().addFloatData('bad_bounds_len', 1, 'unused', None, bounds=(1, None))
+            ValidationCase().addScalarData('bad_bounds_len', 1, 'unused', None, bounds=(1, None))
 
         # Bounds int to float
-        case.addFloatData('bounds_to_float', 1, 'unused', None, bounds=(1, 2))
+        case.addScalarData('bounds_to_float', 1, 'unused', None, bounds=(1, 2))
         bounds_to_float_data = case.data['bounds_to_float']
         assert isinstance(bounds_to_float_data.bounds[0], float)
         assert isinstance(bounds_to_float_data.bounds[1], float)
 
-    def testAddFloatDataBounded(self):
+    def testAddScalarDataBounded(self):
         key = 'data'
         value = 1.234
         bounds = (value - 1.0, value + 0.1)
 
         test = ValidationCase()
-        test.addFloatData(key, value, 'unused', None, bounds=bounds)
+        test.addScalarData(key, value, 'unused', None, bounds=bounds)
         all_data = test.data
         self.assertEqual(len(all_data), 1)
         data = all_data[key]
         self.assertEqual(bounds, data.bounds)
 
-    def testAddFloatDataNominal(self):
+    def testAddScalarDataNominal(self):
         key = 'test'
         nominal = 1.1
         test = ValidationCase()
-        test.addFloatData(key, 1.0, 'unused', None,  nominal=nominal)
+        test.addScalarData(key, 1.0, 'unused', None,  nominal=nominal)
         all_data = test.data
         self.assertEqual(len(all_data), 1)
         self.assertEqual(nominal, all_data[key].nominal)
 
-    def testAddFloatDataBoundedCheck(self):
+    def testAddScalarDataBoundedCheck(self):
         class Test(ValidationCase):
             def test_pass(self):
-                self.addFloatData('pass', 1.0, 'foo', None, bounds=(0.9, 1.1))
+                self.addScalarData('pass', 1.0, 'foo', None, bounds=(0.9, 1.1))
             def test_fail_lower(self):
-                self.addFloatData('fail_lower', 2.0, 'foo', None, bounds=(2.1, 3.0))
+                self.addScalarData('fail_lower', 2.0, 'foo', None, bounds=(2.1, 3.0))
             def test_fail_upper(self):
-                self.addFloatData('fail_upper', 3.0, 'foo', None, bounds=(2.0, 2.2))
+                self.addScalarData('fail_upper', 3.0, 'foo', None, bounds=(2.0, 2.2))
 
         test = Test()
         test.run()

--- a/python/TestHarness/tests/test_ValidationCase.py
+++ b/python/TestHarness/tests/test_ValidationCase.py
@@ -116,14 +116,16 @@ class TestValidationCase(unittest.TestCase):
         self.assertEqual(message, ' '.join(exp_message))
 
     def testCheckBoundsChecks(self):
-        # Bounds not numeric
-        with self.assertRaisesRegex(ValueError, 'Min bound: could not convert string'):
+        # Non-numeric values
+        with self.assertRaisesRegex(ValueError, 'value: could not convert string'):
+            ValidationCase.checkBounds('abc', 0, 1, None)
+        with self.assertRaisesRegex(ValueError, 'min_bound: could not convert string'):
             ValidationCase.checkBounds(0, 'abc', 1, None)
-        with self.assertRaisesRegex(ValueError, 'Max bound: could not convert string'):
+        with self.assertRaisesRegex(ValueError, 'max_bound: could not convert string'):
             ValidationCase.checkBounds(0, 1, 'abc', None)
 
         # Bound min greater than max
-        with self.assertRaisesRegex(ValueError, 'Min bound greater than max'):
+        with self.assertRaisesRegex(ValueError, 'min_bound greater than max_bound'):
             ValidationCase.checkBounds(0, 2, 1, None)
 
     def testToFloat(self):

--- a/python/TestHarness/tests/test_ValidationCase.py
+++ b/python/TestHarness/tests/test_ValidationCase.py
@@ -356,9 +356,9 @@ class TestValidationCase(unittest.TestCase):
 
         # Has nans
         values = [None]
-        with self.assertRaisesRegex(ValueError, 'value at index 0 is nan'):
+        with self.assertRaisesRegex(ValueError, 'value\\(s\\) at indices \\[0\\] are nan'):
             ValidationCase.toListFloat(values)
-        with self.assertRaisesRegex(ValueError, 'foobar: value at index 0 is nan'):
+        with self.assertRaisesRegex(ValueError, 'foobar: value\\(s\\) at indices \\[0\\] are nan'):
             ValidationCase.toListFloat(values, 'foobar:')
 
     def testAddVectorDataChecks(self):

--- a/python/TestHarness/validation/ValidationCase.py
+++ b/python/TestHarness/validation/ValidationCase.py
@@ -316,7 +316,7 @@ class ValidationCase(MooseObject):
 
         if data.bounds is not None:
             status, message = self.checkBounds(data.value, data.bounds, data.units)
-            self.addResult(status, ' '.join(message), **result_kwargs)
+            self.addResult(status, message, **result_kwargs)
 
     @property
     def results(self) -> list[Result]:

--- a/python/TestHarness/validation/ValidationCase.py
+++ b/python/TestHarness/validation/ValidationCase.py
@@ -273,10 +273,10 @@ class ValidationCase(MooseObject):
 
         return status, ' '.join(message)
 
-    def addFloatData(self, key: str, value: NumericDataType, description: str,
-                     units: Optional[str], **kwargs) -> None:
+    def addScalarData(self, key: str, value: NumericDataType, description: str,
+                      units: Optional[str], **kwargs) -> None:
         """
-        Adds a piece of float data to the validation data.
+        Adds a piece of scalar (float or int) data to the validation data.
 
         Will also perform checking on the data if bounds are set and
         store an associated Result.

--- a/python/TestHarness/validation/ValidationCase.py
+++ b/python/TestHarness/validation/ValidationCase.py
@@ -282,31 +282,6 @@ class ValidationCase(MooseObject):
         self._addData(self.Data, key, value, description)
 
     @staticmethod
-    def checkBounds(value: float, min_value: float, max_value: float, units: Optional[str]):
-        if isinstance(min_value, int):
-            min_value = float(min_value)
-        if not isinstance(min_value, float):
-            raise TypeError('Min bound not numeric')
-        if isinstance(max_value, int):
-            max_value = float(max_value)
-        if not isinstance(max_value, float):
-            raise TypeError('Max bound not numeric')
-        if min_value > max_value:
-            raise ValueError('Min bound greater than max')
-
-        success = value >= min_value and value <= max_value
-        status = ValidationCase.Status.OK if success else ValidationCase.Status.FAIL
-
-        units = f' {units}' if units is not None else ''
-        number_format = ValidationCase.number_format
-        message = [f'value {value:{number_format}}{units}']
-        message += [('within' if success else 'out of') + ' bounds;']
-        message += [f'min = {min_value:{number_format}}{units},']
-        message += [f'max = {max_value:{number_format}}{units}']
-
-        return status, ' '.join(message)
-
-    @staticmethod
     def toFloat(value: typing.Any, context: Optional[str] = None) -> float:
         """
         Converts the given value to float, if possible.
@@ -322,6 +297,25 @@ class ValidationCase(MooseObject):
                     raise type(e)(f'{context}: {e}') from e
                 raise
         return value
+
+    @staticmethod
+    def checkBounds(value: float, min_value: float, max_value: float, units: Optional[str]):
+        min_value = ValidationCase.toFloat(min_value, 'Min bound')
+        max_value = ValidationCase.toFloat(max_value, 'Max bound')
+        if min_value > max_value:
+            raise ValueError('Min bound greater than max')
+
+        success = value >= min_value and value <= max_value
+        status = ValidationCase.Status.OK if success else ValidationCase.Status.FAIL
+
+        units = f' {units}' if units is not None else ''
+        number_format = ValidationCase.number_format
+        message = [f'value {value:{number_format}}{units}']
+        message += [('within' if success else 'out of') + ' bounds;']
+        message += [f'min = {min_value:{number_format}}{units},']
+        message += [f'max = {max_value:{number_format}}{units}']
+
+        return status, ' '.join(message)
 
     def addScalarData(self, key: str, value: Number, description: str,
                       units: Optional[str], **kwargs) -> None:

--- a/python/TestHarness/validation/ValidationCase.py
+++ b/python/TestHarness/validation/ValidationCase.py
@@ -17,7 +17,7 @@ import math
 from numbers import Number
 from typing import Optional, Tuple, Union
 from enum import Enum
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 from numpy.typing import NDArray
 import numpy as np
@@ -276,6 +276,12 @@ class ValidationCase(MooseObject):
                          description=description,
                          test=self._current_test,
                          **kwargs)
+
+        # Make sure that we can dump all of the data. The TestHarness
+        # relies on being able to call dump on these types, so we
+        # would rather die here instead of later
+        json.dumps(asdict(data))
+
         self._data[key] = data
         return data
 

--- a/python/TestHarness/validation/ValidationCase.py
+++ b/python/TestHarness/validation/ValidationCase.py
@@ -15,7 +15,7 @@ import sys
 import json
 import math
 from numbers import Number
-from typing import Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 from enum import Enum
 from dataclasses import asdict, dataclass
 
@@ -138,7 +138,7 @@ class ValidationCase(MooseObject):
         # The data key
         key: str
         # The data
-        value: typing.Any
+        value: Any
         # Human readable description of the data
         description: str
         # The test that added this data, if any
@@ -262,7 +262,7 @@ class ValidationCase(MooseObject):
         print(f'[{status.value:>4}] {prefix}{message}')
         self._results.append(status_value)
 
-    def _addData(self, data_type: typing.Type, key: str, value: typing.Any,
+    def _addData(self, data_type: typing.Type, key: str, value: Any,
                  description: str, **kwargs) -> Data:
         """
         Internal method for creating and inserting data.
@@ -294,7 +294,7 @@ class ValidationCase(MooseObject):
         self._data[key] = data
         return data
 
-    def addData(self, key: str, value: typing.Any, description: str, **kwargs) -> None:
+    def addData(self, key: str, value: Any, description: str, **kwargs) -> None:
         """
         Adds a piece of arbitrary typed data to the validation data.
 
@@ -313,7 +313,7 @@ class ValidationCase(MooseObject):
         self._addData(self.Data, key, value, description, **kwargs)
 
     @staticmethod
-    def toFloat(value: typing.Any, context: Optional[str] = None) -> float:
+    def toFloat(value: Any, context: Optional[str] = None) -> float:
         """
         Converts the given value to float, if possible.
 
@@ -333,7 +333,7 @@ class ValidationCase(MooseObject):
     def checkBounds(value: float,
                     min_bound: float,
                     max_bound: float,
-                    units: Optional[str]) -> Tuple[Status, str]:
+                    units: Union[str, None]) -> Tuple[Status, str]:
         """
         Performs bounds checking for a scalar value and associates
         a pass/fail with a status and a message
@@ -409,7 +409,7 @@ class ValidationCase(MooseObject):
             self.addResult(status, message, **result_kwargs)
 
     @staticmethod
-    def toListFloat(value: typing.Any, context: Optional[str] = None) -> list[float]:
+    def toListFloat(value: Any, context: Optional[str] = None) -> list[float]:
         """
         Attempts to convert the given value to a one-dimensional
         list of floating point values
@@ -427,11 +427,10 @@ class ValidationCase(MooseObject):
             raise TypeError(f'{prefix}array conversion failed') from e
         if arr.ndim != 1:
             raise TypeError(f'{prefix}not one-dimensional')
-        value = arr.tolist()
-        for i, v in enumerate(value):
-            if math.isnan(v):
-                raise ValueError(f'{prefix}value at index {i} is nan')
-        return value
+        nan_ind = np.argwhere(np.isnan(arr)).reshape((-1))
+        if nan_ind.size > 0:
+            raise ValueError(f'{prefix}value(s) at indices {nan_ind} are nan')
+        return arr.tolist()
 
     def addVectorData(self, key: str, x: VectorDataInputType,
                       value: VectorDataInputType, **kwargs) -> None:

--- a/test/tests/test_harness/validation_fail.py
+++ b/test/tests/test_harness/validation_fail.py
@@ -2,5 +2,4 @@ from TestHarness import ValidationCase
 
 class TestCase(ValidationCase):
     def testValidation(self):
-        self.addFloatData('number', 100.0, 'Number', None,
-                          bounds=(101.0, 200.0))
+        self.addScalarData('number', 100.0, 'Number', None, bounds=(101.0, 200.0))

--- a/test/tests/test_harness/validation_fail.py
+++ b/test/tests/test_harness/validation_fail.py
@@ -2,5 +2,5 @@ from TestHarness import ValidationCase
 
 class TestCase(ValidationCase):
     def testValidation(self):
-        self.addFloatData('number', 100.0, None, 'Number',
+        self.addFloatData('number', 100.0, 'Number', None,
                           bounds=(101.0, 200.0))

--- a/test/tests/test_harness/validation_ok.py
+++ b/test/tests/test_harness/validation_ok.py
@@ -52,8 +52,8 @@ class TestCase(ValidationCase):
         # we define the bounds here, the data will be checked
         # to be within bounds and will produce a validation
         # failure if it is without of bounds.
-        self.addFloatData('number', self.value, 'Number', 'coolunits',
-                          bounds=(self.lower_bound, self.upper_bound))
+        self.addScalarData('number', self.value, 'Number', 'coolunits',
+                           bounds=(self.lower_bound, self.upper_bound))
 
         # Store some arbitrary data. This data isn't particularly
         # meaningful, but it describes storing an arbitrary dictionary.

--- a/test/tests/test_harness/validation_ok.py
+++ b/test/tests/test_harness/validation_ok.py
@@ -52,5 +52,9 @@ class TestCase(ValidationCase):
         # we define the bounds here, the data will be checked
         # to be within bounds and will produce a validation
         # failure if it is without of bounds.
-        self.addFloatData('number', self.value, 'coolunits', 'Number',
+        self.addFloatData('number', self.value, 'Number', 'coolunits',
                           bounds=(self.lower_bound, self.upper_bound))
+
+        # Store some arbitrary data. This data isn't particularly
+        # meaningful, but it describes storing an arbitrary dictionary.
+        self.addData('useless_dict', {'foo': 'bar'}, 'A useless dictionary')

--- a/test/tests/test_harness/validation_ok.py
+++ b/test/tests/test_harness/validation_ok.py
@@ -58,3 +58,10 @@ class TestCase(ValidationCase):
         # Store some arbitrary data. This data isn't particularly
         # meaningful, but it describes storing an arbitrary dictionary.
         self.addData('useless_dict', {'foo': 'bar'}, 'A useless dictionary')
+
+        # Store some arbitrary vector data. Also not meaningful, but
+        # is an example.
+        self.addVectorData('vector',
+                           ([0, 1], 'Position', 'cm'),
+                           ([1, 2], 'Temperature', 'K'),
+                           bounds=(([0, 1], [2, 3])))


### PR DESCRIPTION
Closes https://github.com/idaholab/moose/issues/30768

- Renames `ValidationCase.addFloatData` to `ValidationCase.addScalarData` for consistency
- Adds `ValidationCase.addVectorData` for adding vector data
- Unifies bounds checking
- Improves docstrings
- Adds more type checking