### PR TITLE
Add test spec path to job header

### DIFF
--- a/python/FactorySystem/Parser.py
+++ b/python/FactorySystem/Parser.py
@@ -166,6 +166,7 @@ class Parser:
             params.addPrivateParam('_warehouse', self.warehouse)
             params.addPrivateParam('_parser', self)
             params.addPrivateParam('_root', self.root)
+            params.addPrivateParam('_node', node)
 
             # Build the object
             try:

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -654,7 +654,11 @@ class Job(OutputInterface):
         else:
             command = self.getCommand()
 
-        output = 'Working Directory: ' + self.getTestDir() + '\nRunning command: ' + command + '\n'
+        node = self.specs['_node']
+        header = [f'Test spec: {node.filename()}:{node.line()}',
+                  f'Working directory: {self.getTestDir()}',
+                  f'Running command: {command}']
+        output = '\n'.join(header) + '\n'
 
         # Whether or not to limit the runner_run output, which is the output from the
         # actual run (the process that the harness runs)


### PR DESCRIPTION
Closes #30770

Before:

```
kernels/simple_diffusion.test: Working directory: /data/harblh/worktrees/moose/test_harness_spec_output/test/tests/kernels/simple_diffusion
kernels/simple_diffusion.test: Running command: /data/harblh/worktrees/moose/test_harness_spec_output/test/moose_test-opt -i simple_diffusion.i --error --error-override --libtorch-device cpu
```

After:

```
kernels/simple_diffusion.test: Test spec: /data/harblh/worktrees/moose/test_harness_spec_output/test/tests/kernels/simple_diffusion/tests:2
kernels/simple_diffusion.test: Working directory: /data/harblh/worktrees/moose/test_harness_spec_output/test/tests/kernels/simple_diffusion
kernels/simple_diffusion.test: Running command: /data/harblh/worktrees/moose/test_harness_spec_output/test/moose_test-opt -i simple_diffusion.i --error --error-override --libtorch-device cpu
```

This way, you can easily cmd+click from output to go directly to the test entry of concern.