### PR TITLE
Removed deprecated PicardSolve parameters

### DIFF
--- a/framework/include/executioners/Executioner.h
+++ b/framework/include/executioners/Executioner.h
@@ -78,12 +78,12 @@ public:
   virtual void postExecute() {}
 
   /**
-   * Override this for actions that should take place before execution, called by PicardSolve
+   * Override this for actions that should take place before execution, called by FixedPointSolve
    */
   virtual void preSolve() {}
 
   /**
-   * Override this for actions that should take place after execution, called by PicardSolve
+   * Override this for actions that should take place after execution, called by FixedPointSolve
    */
   virtual void postSolve() {}
 
@@ -121,25 +121,7 @@ public:
    */
   virtual bool lastSolveConverged() const = 0;
 
-  /// Return underlying PicardSolve object.
-  PicardSolve & picardSolve()
-  {
-    mooseDeprecated("picardSolve() is deprecated. Use fixedPointSolve() instead.");
-    if (_iteration_method == "picard")
-      return *(dynamic_cast<PicardSolve *>(_fixed_point_solve.get()));
-    else
-      mooseError("Cannot return a PicardSolve if the iteration method is not Picard.");
-  }
-
   FixedPointSolve & fixedPointSolve() { return *_fixed_point_solve; }
-
-  /// Augmented Picard convergence check to be called by PicardSolve and can be overridden by derived executioners
-  virtual bool augmentedPicardConvergenceCheck() const
-  {
-    mooseDeprecated(
-        "augmentedPicardConvergenceCheck() is deprecated. Use augmentedCouplingConvergenceCheck.");
-    return false;
-  }
 
   /**
    * Get the verbose output flag

--- a/framework/include/executioners/FixedPointSolve.h
+++ b/framework/include/executioners/FixedPointSolve.h
@@ -198,21 +198,17 @@ protected:
   /// Maximum fixed point iterations
   unsigned int _max_fixed_point_its;
   /// Whether or not we activate fixed point iteration
-  bool _has_fixed_point_its; // TODO: make const once picard parameters are removed
+  const bool _has_fixed_point_its;
   /// Whether or not to treat reaching maximum number of fixed point iteration as converged
-  bool _accept_max_it; // TODO: make const once picard parameters are removed
+  const bool _accept_max_it;
   /// Whether or not to use residual norm to check the fixed point convergence
-  bool _has_fixed_point_norm; // TODO: make const once picard parameters are removed
+  const bool _has_fixed_point_norm;
   /// Relative tolerance on residual norm
-  Real _fixed_point_rel_tol; // TODO: make const once picard parameters are removed
+  const Real _fixed_point_rel_tol;
   /// Absolute tolerance on residual norm
-  Real _fixed_point_abs_tol; // TODO: make const once picard parameters are removed
+  const Real _fixed_point_abs_tol;
   /// Whether or not we force evaluation of residual norms even without multiapps
-  bool _fixed_point_force_norms; // TODO: make const once picard parameters are removed
-
-  /// Postprocessor value for user-defined fixed point convergence check
-  const PostprocessorValue *
-      _fixed_point_custom_pp; // FIXME Make const and private once picard_custom_pp is gone
+  const bool _fixed_point_force_norms;
 
   /// Relaxation factor for fixed point Iteration
   const Real _relax_factor;
@@ -247,6 +243,8 @@ protected:
   MooseFixedPointConvergenceReason _fixed_point_status;
   ///@}
 private:
+  /// Postprocessor value for user-defined fixed point convergence check
+  const PostprocessorValue * const _fixed_point_custom_pp;
   /// Relative tolerance on postprocessor value
   const Real _custom_rel_tol;
   /// Absolute tolerance on postprocessor value

--- a/framework/src/executioners/Executioner.C
+++ b/framework/src/executioners/Executioner.C
@@ -26,7 +26,7 @@ InputParameters
 Executioner::validParams()
 {
   InputParameters params = MooseObject::validParams();
-  params += PicardSolve::validParams();
+  params += FixedPointSolve::validParams();
   params += Reporter::validParams();
   params += ReporterInterface::validParams();
 

--- a/framework/src/executioners/FixedPointSolve.C
+++ b/framework/src/executioners/FixedPointSolve.C
@@ -134,8 +134,6 @@ FixedPointSolve::FixedPointSolve(Executioner & ex)
     _fixed_point_rel_tol(getParam<Real>("fixed_point_rel_tol")),
     _fixed_point_abs_tol(getParam<Real>("fixed_point_abs_tol")),
     _fixed_point_force_norms(getParam<bool>("fixed_point_force_norms")),
-    _fixed_point_custom_pp(isParamValid("custom_pp") ? &getPostprocessorValue("custom_pp")
-                                                     : nullptr),
     _relax_factor(getParam<Real>("relaxation_factor")),
     _transformed_vars(getParam<std::vector<std::string>>("transformed_variables")),
     _transformed_pps(getParam<std::vector<PostprocessorName>>("transformed_postprocessors")),
@@ -143,6 +141,8 @@ FixedPointSolve::FixedPointSolve(Executioner & ex)
     _secondary_relaxation_factor(1.0),
     _fixed_point_it(0),
     _fixed_point_status(MooseFixedPointConvergenceReason::UNSOLVED),
+    _fixed_point_custom_pp(isParamValid("custom_pp") ? &getPostprocessorValue("custom_pp")
+                                                     : nullptr),
     _custom_rel_tol(getParam<Real>("custom_rel_tol")),
     _custom_abs_tol(getParam<Real>("custom_abs_tol")),
     _pp_old(0.0),

--- a/framework/src/executioners/PicardSolve.C
+++ b/framework/src/executioners/PicardSolve.C
@@ -19,83 +19,10 @@ InputParameters
 PicardSolve::validParams()
 {
   InputParameters params = FixedPointSolve::validParams();
-
-  params.addDeprecatedParam<unsigned int>(
-      "picard_max_its",
-      1,
-      "Specifies the maximum number of Picard iterations. "
-      "Mainly used when  wanting to do Picard iterations with MultiApps "
-      "that are set to execute_on timestep_end or timestep_begin. "
-      "Setting this parameter to 1 turns off the Picard iterations.",
-      "Deprecated, use fixed_point_max_its");
-  params.addDeprecatedParam<bool>(
-      "accept_on_max_picard_iteration",
-      false,
-      "True to treat reaching the maximum number of Picard iterations as converged.",
-      "Deprecated, use accept_on_max_fixed_point_iteration");
-  params.addDeprecatedParam<bool>(
-      "disable_picard_residual_norm_check",
-      false,
-      "Disable the Picard residual norm evaluation thus the three parameters "
-      "picard_rel_tol, picard_abs_tol and picard_force_norms.",
-      "Deprecated, use disable_fixed_point_residual_norm_check");
-  params.addDeprecatedParam<Real>("picard_rel_tol",
-                                  1e-8,
-                                  "The relative nonlinear residual drop to shoot for "
-                                  "during Picard iterations. This check is "
-                                  "performed based on the Master app's nonlinear "
-                                  "residual.",
-                                  "Deprecated, use fixed_point_rel_tol");
-  params.addDeprecatedParam<Real>("picard_abs_tol",
-                                  1e-50,
-                                  "The absolute nonlinear residual to shoot for "
-                                  "during Picard iterations. This check is "
-                                  "performed based on the Master app's nonlinear "
-                                  "residual.",
-                                  "Deprecated, use fixed_point_abs_tol");
-  params.addParam<PostprocessorName>("picard_custom_pp",
-                                     "Postprocessor for custom picard convergence check.");
-  params.deprecateParam("picard_custom_pp", "custom_pp", "06/06/2024");
-
-  params.addDeprecatedParam<bool>(
-      "picard_force_norms",
-      false,
-      "Force the evaluation of both the TIMESTEP_BEGIN and TIMESTEP_END norms regardless of the "
-      "existence of active MultiApps with those execute_on flags, default: false.",
-      "Deprecated, use fixed_point_force_norms");
-
   return params;
 }
 
-PicardSolve::PicardSolve(Executioner & ex) : FixedPointSolve(ex)
-{
-  // Handle deprecated parameters
-  if (!parameters().isParamSetByAddParam("picard_max_its"))
-  {
-    _max_fixed_point_its = getParam<unsigned int>("picard_max_its");
-    _has_fixed_point_its = _max_fixed_point_its > 1;
-  }
-
-  if (!parameters().isParamSetByAddParam("accept_on_max_picard_iteration"))
-    _accept_max_it = getParam<bool>("accept_on_max_picard_iteration");
-
-  if (!parameters().isParamSetByAddParam("disable_picard_residual_norm_check"))
-    _has_fixed_point_norm = !getParam<bool>("disable_picard_residual_norm_check");
-
-  if (!parameters().isParamSetByAddParam("picard_rel_tol"))
-    _fixed_point_rel_tol = getParam<Real>("picard_rel_tol");
-
-  if (!parameters().isParamSetByAddParam("picard_abs_tol"))
-    _fixed_point_abs_tol = getParam<Real>("picard_abs_tol");
-
-  if (isParamValid("picard_custom_pp"))
-    _fixed_point_custom_pp = &getPostprocessorValue("picard_custom_pp");
-
-  if (!parameters().isParamSetByAddParam("picard_force_norms"))
-    _fixed_point_force_norms = getParam<bool>("picard_force_norms");
-
-  allocateStorage(true);
-}
+PicardSolve::PicardSolve(Executioner & ex) : FixedPointSolve(ex) { allocateStorage(true); }
 
 void
 PicardSolve::allocateStorage(const bool primary)

--- a/test/tests/controls/pid_control/pid_pp_control.i
+++ b/test/tests/controls/pid_control/pid_pp_control.i
@@ -62,7 +62,7 @@
   line_search = 'none'
 
   # For picard tests
-  picard_abs_tol = 1e-3
+  fixed_point_abs_tol = 1e-3
 []
 
 [Postprocessors]


### PR DESCRIPTION
Many Picard parameters were deprecated years ago and can now be removed to allow beautiful code.
