### PR TITLE
Libmesh submodule update, add pymongo to tools, add --fast to mfem build

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,8 +4,8 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 1 %}
-{% set version = "2025.05.23" %}
+{% set build = 0 %}
+{% set version = "2025.06.25" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -10,7 +10,7 @@ moose_wasp:
   - moose-wasp 2025.05.13
 
 moose_tools:
-  - moose-tools 2025.06.13
+  - moose-tools 2025.06.26
 
 zip_keys:
   - mpi

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2025.05.23 mpich_1
-  - moose-libmesh 2025.05.23 openmpi_1
+  - moose-libmesh 2025.06.25 mpich_0
+  - moose-libmesh 2025.06.25 openmpi_0
 
 moose_wasp:
   - moose-wasp 2025.05.13

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.06.20" %}
+{% set version = "2025.06.25" %}
 
 package:
   name: moose-dev

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.06.25" %}
+{% set version = "2025.06.26" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -2,7 +2,7 @@ mpi:
   - mpich
 
 moose_dev:
-  - moose-dev 2025.06.25
+  - moose-dev 2025.06.26
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -2,7 +2,7 @@ mpi:
   - mpich
 
 moose_dev:
-  - moose-dev 2025.06.20
+  - moose-dev 2025.06.25
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,7 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.06.13" %}
+{% set version = "2025.06.26" %}
 
 package:
   name: moose-tools
@@ -55,6 +55,7 @@ requirements:
     - pyflakes
     - pylatexenc
     - pylint
+    - pymongo
     - python
     - pyyaml
     - requests
@@ -89,6 +90,7 @@ test:
     - pyflakes
     - pylatexenc
     - pylint
+    - pymongo
     - requests
     - skimage
     - sympy

--- a/conda/tools/meta.yaml.template
+++ b/conda/tools/meta.yaml.template
@@ -55,6 +55,7 @@ requirements:
     - pyflakes
     - pylatexenc
     - pylint
+    - pymongo
     - python
     - pyyaml
     - requests
@@ -89,6 +90,7 @@ test:
     - pyflakes
     - pylatexenc
     - pylint
+    - pymongo
     - requests
     - skimage
     - sympy

--- a/modules/doc/content/newsletter/2025/2025_06.md
+++ b/modules/doc/content/newsletter/2025/2025_06.md
@@ -11,6 +11,44 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2025.06.26` Update
+
+- Complete overhaul of `VariationalMeshSmoother` code.  This gives
+  support for more finite element types and converges to more optimal
+  meshes.
+- Enabled FE caching as appropriate for variable types with a
+  dependency on edge/face orientation.  Added command-line
+  `--disable-caching` option to help with debugging.
+- Refactoring of `StaticCondensation` code, improved support for
+  static condensation with adaptive mesh refinement.
+- Added `matrixsolve` app for testing linear solver behavior with mesh
+  files
+- Avoid redundant work when preparing algebraic ghosting in parallel
+- Compatibility with more Abaqus-format mesh files
+- Support for `Elem::opposite_side()` on `Prism` elements
+- Fixes for `BoundaryInfo::sync()` with certain combinations of serial
+  and distributed mesh status.  Enabled serialization and/or
+  redistribution of distributed boundary meshes with separate interior
+  meshes.  Added `MeshBase::interior_mesh()` to track the interior
+  mesh of a boundary mesh.
+- Fix unintentionally set `parent()` on 0D side elements of 1D
+  interior elements.  Removed deprecated `proxy` option from side and
+  edge element construction.
+- Refactoring to use new `Elem::inherit_data_from()` helper.  This
+  likely fixes potential issues on certain IGA and p-refined meshes.
+- More exhaustive testing for `BoundaryInfo::sync()` methods,
+  including multiple combinations of mesh type, distribution status,
+  and dimensionality.
+- Clarifications in Doxygen documentation
+- Minor code simplification/refactoring
+- Update TIMPI submodule
+
+  - Enabled `minloc()` and `maxloc()` of arbitrary data types
+    overriding `TIMPI::OpFunction<T>`.  Added tests using
+    `OpFunction<std::pair>`.
+  - Added missing cstdint include, fixing builds with some compilers.
+
+
 ## PETSc-level Changes
 
 ## Bug Fixes, Minor Changes, and Minor Enhancements

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1229,3 +1229,32 @@ bda476600e034d573d0bf2632f617a2d49794a42: #30485; Update mfem, libmesh, nlohmann
   wasp:
     full_version: 2025.05.13_1
     hash: 3e37a23
+ca3944140e845b4b8586365397d7fe1110ebeb89: #30791; libMesh submodule update, add pymongo to tools, add --fast to mfem build script
+  libmesh:
+    full_version: 2025.06.25_0
+    hash: 985bf51
+  libmesh-vtk:
+    full_version: 9.4.2_3
+    hash: 16265eb
+  moose-dev:
+    full_version: 2025.06.26
+    hash: b5c6af5
+  mpi:
+    full_version: 2025.06.13
+    hash: fcdc117
+  petsc:
+    full_version: 3.23.0.6.gd9d7fd11dca_2
+    hash: '9531950'
+  pprof:
+    full_version: 2025.06.13
+    hash: 3d296db
+  seacas:
+    full_version: 2025.05.22_0
+    hash: '1278418'
+  tools:
+    full_version: 2025.06.26
+    hash: d73012a
+  wasp:
+    full_version: 2025.05.13_1
+    hash: 3e37a23
+

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -7,7 +7,7 @@
 packages:
   # dependers: moose-dev
   tools:
-    version: 2025.06.13
+    version: 2025.06.26
     conda: conda/tools
     templates:
       conda/tools/meta.yaml.template: conda/tools/meta.yaml
@@ -93,7 +93,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.06.25
+    version: 2025.06.26
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -56,8 +56,8 @@ packages:
       - scripts/apple-silicon-hdf5-autogen.patch
   # dependers: moose-dev
   libmesh:
-    version: 2025.05.23
-    build_number: 1
+    version: 2025.06.25
+    build_number: 0
     conda: conda/libmesh
     templates:
       conda/libmesh/conda_build_config.yaml.template: conda/libmesh/conda_build_config.yaml
@@ -93,7 +93,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.06.20
+    version: 2025.06.25
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml


### PR DESCRIPTION
LibMesh update summary:

```
    - Complete overhaul of `VariationalMeshSmoother` code.  This gives
      support for more finite element types and converges to more optimal
      meshes.
    - Enabled FE caching as appropriate for variable types with a
      dependency on edge/face orientation.  Added command-line
      `--disable-caching` option to help with debugging.
    - Refactoring of `StaticCondensation` code, improved support for
      static condensation with adaptive mesh refinement.
    - Added `matrixsolve` app for testing linear solver behavior with mesh
      files
    - Avoid redundant work when preparing algebraic ghosting in parallel
    - Compatibility with more Abaqus-format mesh files
    - Support for `Elem::opposite_side()` on `Prism` elements
    - Fixes for `BoundaryInfo::sync()` with certain combinations of serial
      and distributed mesh status.  Enabled serialization and/or
      redistribution of distributed boundary meshes with separate interior
      meshes.  Added `MeshBase::interior_mesh()` to track the interior
      mesh of a boundary mesh.
    - Fix unintentionally set `parent()` on 0D side elements of 1D
      interior elements.  Removed deprecated `proxy` option from side and
      edge element construction.
    - Refactoring to use new `Elem::inherit_data_from()` helper.  This
      likely fixes potential issues on certain IGA and p-refined meshes.
    - More exhaustive testing for `BoundaryInfo::sync()` methods,
      including multiple combinations of mesh type, distribution status,
      and dimensionality.
    - Clarifications in Doxygen documentation
    - Minor code simplification/refactoring
    - Update TIMPI submodule
    
      - Enabled `minloc()` and `maxloc()` of arbitrary data types
        overriding `TIMPI::OpFunction<T>`.  Added tests using
        `OpFunction<std::pair>`.
      - Added missing cstdint include, fixing builds with some compilers.
```

Adds the `--fast` option to `scripts/update_and_rebuild_mfem.sh`, which closes https://github.com/idaholab/moose/issues/30731.

Adds `pymongo` to `tools` to support test result database collection, which refs https://github.com/idaholab/moose/issues/30819.