### PR TITLE
Added documentation on hit command to view merged input

### DIFF
--- a/modules/doc/content/application_usage/command_line_usage.md
+++ b/modules/doc/content/application_usage/command_line_usage.md
@@ -89,7 +89,7 @@ Below are a few important command-line options you should be aware of:
 
 ### `-i`
 
-The most important option is `-i` this is how you specify an input file to read like so:
+The most important option is `-i`, which is how the input file(s) are specified:
 
 ```
 ./yourapp-opt -i input.i
@@ -107,7 +107,10 @@ The input files are processed from left to right, so in this example, `base.i`
 is processed before `input.i`. This feature is useful when you have multiple
 input files that share input: you can factor out the common input into another
 file (e.g., `base.i`) so that you do not duplicate it (and thus risk changing
-it in one input file but not another).
+it in one input file but not another). Note that if the same input parameter
+appears in multiple input files, the value in the rightmost input file on the
+command line takes precedence, i.e., files to the right override the files to
+the left.
 
 ### `--dump`
 

--- a/modules/doc/content/application_usage/input_syntax.md
+++ b/modules/doc/content/application_usage/input_syntax.md
@@ -134,11 +134,7 @@ can include other files. The only requirement is that the included files
 must contain a set of syntactically complete blocks or parameters.
 
 Functionally, including a file is equivalent to inserting the
-text of the file at the `!include` location. If a block already exists, then
-its sub-blocks and parameters are merged into the existing block to avoid
-having multiple blocks of the same name. Note, however, that this merging
-should no effect on the input, since all input, including user-defined parameters
-are order-independent.
+text of the file at the `!include` location.
 
 !alert warning title=Included input parameters cannot be overridden by default
 Note that parameters from the parent or included files do not override each other by default,

--- a/modules/doc/content/application_usage/input_syntax.md
+++ b/modules/doc/content/application_usage/input_syntax.md
@@ -134,70 +134,26 @@ can include other files. The only requirement is that the included files
 must contain a set of syntactically complete blocks or parameters.
 
 Functionally, including a file is equivalent to inserting the
-text of the file at the `!include` location. Therefore,
-for example, if the included file uses a value `${somevar}` defined in the parent file
-via `somevar = somval`, then the `!include` statement must occur *after* the
-`somevar` definition.
-
-!alert! warning title=Beware merge-related include ordering issues
-When an included file contains the same block as the parent file, the blocks get
-*merged*. The merge moves the second instance of the block into the first, not
-the first into the second. For example,
-
-`file1.i`:
-
-```
-[BlockA]
-  param1 = 4
-[]
-
-!include file2.i
-```
-
-`file2.i`:
-
-```
-val3 = 8
-
-[BlockA]
-  param2 = ${val3}
-[]
-```
-
-This effectively produces the input
-
-```
-[BlockA]
-  param1 = 4
-[]
-
-val3 = 8
-
-[BlockA]
-  param2 = ${val3}
-[]
-```
-
-and after the merge operation,
-
-```
-[BlockA]
-  param1 = 4
-  param2 = ${val3}
-[]
-
-val3 = 8
-```
-
-This results in an error, since `${val3}` is now used before it is defined.
-Therefore, files must be partitioned with this behavior in mind.
-!alert-end!
+text of the file at the `!include` location. If a block already exists, then
+its sub-blocks and parameters are merged into the existing block to avoid
+having multiple blocks of the same name. Note, however, that this merging
+should no effect on the input, since all input, including user-defined parameters
+are order-independent.
 
 !alert warning title=Included input parameters cannot be overridden by default
 Note that parameters from the parent or included files do not override each other by default,
 as this is just interpreted as providing the input parameter twice, resulting in a parsing error.
 To override parameters, you must either use command-line arguments or the explicit
 override syntax defined below.
+
+!alert! tip title=Viewing a single equivalent input file
+If you would like to view an equivalent input file after the include operations
+and parameter overrides (see the following section), you can use the `hit` utility:
+
+```
+~/projects/moose/framework/contrib/hit/hit braceexpr myinput.i
+```
+!alert-end!
 
 ## Parameter override syntax
 


### PR DESCRIPTION
A few different improvements to multiple-input documentation, including a tip about using the `hit` utility.
