### PR TITLE
Obey block restriction of initial conditions in Generic Projector algorithm coded into InitialCondition base class

### DIFF
--- a/framework/include/ics/InitialConditionTempl.h
+++ b/framework/include/ics/InitialConditionTempl.h
@@ -84,12 +84,6 @@ public:
   void setOtherCOneVertices();
 
   /**
-   * set the temporary solution vector for an external (e.g. considered from an element that is
-   * outside the block restriction of this initial condition) non-vertex node of a C0 variable
-   */
-  void setCZeroNonVertexExternalNode();
-
-  /**
    * Helps perform multiplication of GradientTypes: a normal dot product for vectors and a
    * contraction for tensors
    */

--- a/framework/include/ics/InitialConditionTempl.h
+++ b/framework/include/ics/InitialConditionTempl.h
@@ -84,6 +84,12 @@ public:
   void setOtherCOneVertices();
 
   /**
+   * set the temporary solution vector for an external (e.g. considered from an element that is
+   * outside the block restriction of this initial condition) non-vertex node of a C0 variable
+   */
+  void setCZeroNonVertexExternalNode();
+
+  /**
    * Helps perform multiplication of GradientTypes: a normal dot product for vectors and a
    * contraction for tensors
    */

--- a/framework/src/ics/InitialConditionTempl.C
+++ b/framework/src/ics/InitialConditionTempl.C
@@ -155,8 +155,16 @@ InitialConditionTempl<T>::compute()
     // not duplicate _dof_indices code badly!
     if (!_current_elem->is_vertex(_n))
     {
-      if (out_of_block_restriction && _cont == C_ZERO)
-        setCZeroNonVertexExternalNode();
+      if (out_of_block_restriction)
+      {
+        if (_cont == C_ZERO)
+          setCZeroVertices();
+        else if (_cont == C_ONE)
+          setOtherCOneVertices();
+        else
+          mooseDoOnce(mooseWarning(
+              "Block restriction treatment could miss side or edge degrees of freedom"));
+      }
       else
         _current_dof += _nc;
       continue;
@@ -298,13 +306,6 @@ InitialConditionTempl<RealVectorValue>::setCZeroVertices()
 }
 
 template <typename T>
-void
-InitialConditionTempl<T>::setCZeroNonVertexExternalNode()
-{
-  setCZeroVertices();
-}
-
-template <typename T>
 T
 InitialConditionTempl<T>::gradientComponent(GradientType grad, unsigned int i)
 {
@@ -411,6 +412,7 @@ template <>
 void
 InitialConditionTempl<RealVectorValue>::setHermiteVertices()
 {
+  mooseError("Not implemented");
 }
 
 template <typename T>

--- a/framework/src/ics/InitialConditionTempl.C
+++ b/framework/src/ics/InitialConditionTempl.C
@@ -173,6 +173,11 @@ InitialConditionTempl<T>::compute()
   // From here on out we won't be sampling at nodes anymore
   _current_node = nullptr;
 
+  // If we are not defined on the element,
+  // we have no business running on its sides and edges
+  if (!hasBlocks(_current_elem->subdomain_id()))
+    return;
+
   auto & dof_map = _var.dofMap();
   const bool add_p_level =
       dof_map.should_p_refine(dof_map.var_group_from_var_number(_var.number()));
@@ -249,7 +254,7 @@ InitialConditionTempl<T>::compute()
 
   // Make sure every DoF got reached!
   for (unsigned int i = 0; i != n_dofs; ++i)
-    libmesh_assert(_dof_is_fixed[i]);
+    libmesh_assert(_dof_is_fixed[i] || !mask(i));
 
   // Lock the new_vector since it is shared among threads.
   {

--- a/framework/src/ics/InitialConditionTempl.C
+++ b/framework/src/ics/InitialConditionTempl.C
@@ -155,13 +155,15 @@ InitialConditionTempl<T>::compute()
     // not duplicate _dof_indices code badly!
     if (!_current_elem->is_vertex(_n))
     {
+      // Use regular nodal-value setting instead of generic projector then
       if (out_of_block_restriction)
       {
-        if (_cont == C_ZERO)
+        // Check _nc in case we are on a second order mesh but setting a first order variable
+        if (_cont == C_ZERO && _nc > 0)
           setCZeroVertices();
-        else if (_cont == C_ONE)
+        else if (_cont == C_ONE && _nc > 0)
           setOtherCOneVertices();
-        else
+        else if (_nc != 0)
           mooseDoOnce(mooseWarning(
               "Block restriction treatment could miss side or edge degrees of freedom"));
       }
@@ -282,7 +284,8 @@ InitialConditionTempl<T>::setCZeroVertices()
 {
   // Assume that C_ZERO elements have a single nodal
   // value shape function
-  libmesh_assert(_nc == 1);
+  mooseAssert(_nc == 1,
+              "Expecting only one component on vertex and yet we have: " + std::to_string(_nc));
   _qp = _n;
   _current_node = _current_elem->node_ptr(_n);
   _Ue(_current_dof) = value(*_current_node);

--- a/framework/src/ics/InitialConditionTempl.C
+++ b/framework/src/ics/InitialConditionTempl.C
@@ -175,15 +175,14 @@ InitialConditionTempl<T>::compute()
 
   // If we are not defined on the element,
   // we have no business running on its sides and edges
-  if (!hasBlocks(_current_elem->subdomain_id()))
-    return;
+  const bool out_of_block_restriction = (!hasBlocks(_current_elem->subdomain_id()));
 
   auto & dof_map = _var.dofMap();
   const bool add_p_level =
       dof_map.should_p_refine(dof_map.var_group_from_var_number(_var.number()));
 
   // In 3D, project any edge values next
-  if (_dim > 2 && _cont != DISCONTINUOUS)
+  if (_dim > 2 && _cont != DISCONTINUOUS && !out_of_block_restriction)
     for (unsigned int e = 0; e != _current_elem->n_edges(); ++e)
     {
       FEInterface::dofs_on_edge(_current_elem, _dim, _fe_type, e, _side_dofs, add_p_level);
@@ -208,7 +207,7 @@ InitialConditionTempl<T>::compute()
     }
 
   // Project any side values (edges in 2D, faces in 3D)
-  if (_dim > 1 && _cont != DISCONTINUOUS)
+  if (_dim > 1 && _cont != DISCONTINUOUS && !out_of_block_restriction)
     for (unsigned int s = 0; s != _current_elem->n_sides(); ++s)
     {
       FEInterface::dofs_on_side(_current_elem, _dim, _fe_type, s, _side_dofs, add_p_level);
@@ -242,7 +241,7 @@ InitialConditionTempl<T>::compute()
       _free_dof[_free_dofs++] = i;
 
   // There may be nothing to project
-  if (_free_dofs)
+  if (_free_dofs && !out_of_block_restriction)
   {
     // Initialize FE data
     fe->attach_quadrature_rule(qrule.get());

--- a/test/tests/ics/block_restriction/test.i
+++ b/test/tests/ics/block_restriction/test.i
@@ -13,10 +13,17 @@
     block_id = 1
     combinatorial_geometry = 'y > 1'
   []
+  second_order = true
 []
 
 [Variables]
   [c1]
+  []
+[]
+
+[AuxVariables]
+  [c2]
+    order = second
   []
 []
 
@@ -33,6 +40,14 @@
     value = 0.1
     variable = c1
     block = 1
+  []
+  [c2]
+    type = SolutionIC
+    # aux variables are not stored in solutionUO
+    from_variable = 'c1'
+    solution_uo = 2phase
+    variable = c2
+    block = 0
   []
 []
 

--- a/test/tests/ics/block_restriction/test.i
+++ b/test/tests/ics/block_restriction/test.i
@@ -1,0 +1,59 @@
+[Mesh]
+  [main]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 10
+    ny = 9
+    xmax = 4
+    ymax = 3
+  []
+  [top_block]
+    type = ParsedSubdomainMeshGenerator
+    input = main
+    block_id = 1
+    combinatorial_geometry = 'y > 1'
+  []
+[]
+
+[Variables]
+  [c1]
+  []
+[]
+
+[ICs]
+  [c1]
+    type = SolutionIC
+    from_variable = 'c1'
+    solution_uo = 2phase
+    variable = c1
+    block = 0
+  []
+  [top_c1]
+    type = ConstantIC
+    value = 0.1
+    variable = c1
+    block = 1
+  []
+[]
+
+[UserObjects]
+  [2phase]
+    type = SolutionUserObject
+    mesh = 'start_out.e'
+    system_variables = 'c1'
+    timestep = LATEST
+  []
+[]
+
+
+[Executioner]
+  type = Steady
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/ics/block_restriction/tests
+++ b/test/tests/ics/block_restriction/tests
@@ -10,7 +10,7 @@
   [block_ic]
     type = RunApp
     input = 'test.i'
-    cli_args = 'ICs/top_c1/value=3 Mesh/second_order=true'
+    cli_args = 'ICs/top_c1/value=3'
     # this test would error if the SolutionIC is called outside of block 0, due to the extent of start.e
     requirement = 'The system shall be able to block restrict nodal initial conditions.'
     prereq = 'generate_restart'

--- a/test/tests/ics/block_restriction/tests
+++ b/test/tests/ics/block_restriction/tests
@@ -1,0 +1,18 @@
+[Tests]
+  issues = '#30825'
+  design = 'ICs/index.md BlockRestrictable.md'
+  [generate_restart]
+    type = RunApp
+    input = 'test.i'
+    cli_args = "Mesh/main/ymax=1 UserObjects/active='' ICs/active=top_c1 ICs/top_c1/block=0 Outputs/file_base=start_out"
+    requirement = 'The system shall be able to generate a restart file for checking block restrictions of nodal initial conditions.'
+  []
+  [block_ic]
+    type = RunApp
+    input = 'test.i'
+    cli_args = 'ICs/top_c1/value=3 Mesh/second_order=true'
+    # this test would error if the SolutionIC is called outside of block 0, due to the extent of start.e
+    requirement = 'The system shall be able to block restrict nodal initial conditions.'
+    prereq = 'generate_restart'
+  []
+[]


### PR DESCRIPTION
refs #30825

EDIT:
the last commit might not be the best thing we can do here since it only works for higher order C-zero variables. I don't like the special casing much compared to the previous structure of that code.

We could alternatively check every single edge & side when outside the block restriction. This would cause more lookups but would be more general.
However, when considering an element, outside the block restriction for a non-continuous variable, I don't expect we need to be working on its sides & edges, even those that are on "inside block restriction"-side. 
So it's just for Hermite & non-hermite C1 that there is a question.

EDIT2:
see [Add second order node special treatment for continuous variables](https://github.com/idaholab/moose/pull/30826/commits/1afe910442fdc12689c5377bf403936c850c62b9) for the idea above (first idea)
see [Alternative fix: examine sides of the block restriction and only act when the side is shared](https://github.com/idaholab/moose/pull/30826/commits/00ee8ea9f9f1c2b5ea7d8218d8c6da1c210ead8c) for an alternative that should work not just for C0.
We check every side/edge before using them in a Cholesky solve, they only get used when bordering the block restriction.
Seems more expensive.

EDIT3:
revised the first idea to make it work for C1.
I think this covers enough of the need, and added a warning for the un-implemented stuff.
Second idea is failing tests in SAM