### PR TITLE
Turn SCM test InputParameters parameters to const InputParameters & parameters

### DIFF
--- a/modules/subchannel/test/include/base/SubChannelTestApp.h
+++ b/modules/subchannel/test/include/base/SubChannelTestApp.h
@@ -14,7 +14,7 @@
 class SubChannelTestApp : public SubChannelApp
 {
 public:
-  SubChannelTestApp(InputParameters parameters);
+  SubChannelTestApp(const InputParameters & parameters);
   virtual ~SubChannelTestApp();
 
   static void registerApps();

--- a/modules/subchannel/test/src/base/SubChannelTestApp.C
+++ b/modules/subchannel/test/src/base/SubChannelTestApp.C
@@ -19,7 +19,7 @@ SubChannelTestApp::validParams()
   return params;
 }
 
-SubChannelTestApp::SubChannelTestApp(InputParameters parameters) : SubChannelApp(parameters)
+SubChannelTestApp::SubChannelTestApp(const InputParameters & parameters) : SubChannelApp(parameters)
 {
   SubChannelTestApp::registerAll(
       _factory, _action_factory, _syntax, getParam<bool>("allow_test_objects"));


### PR DESCRIPTION
closes #30778
