### PR TITLE
Formatted table speedup

### DIFF
--- a/framework/include/utils/FormattedTable.h
+++ b/framework/include/utils/FormattedTable.h
@@ -279,8 +279,13 @@ private:
   void printRow(std::pair<Real, std::map<std::string, std::shared_ptr<TableValueBase>>> & row_data,
                 bool align);
 
-  /// Fill any values that are not defined (usually when there are mismatched column lengths)
-  void fillEmptyValues();
+  /**
+   *  Fill any values that are not defined (usually when there are mismatched column lengths)
+   *
+   *  If \p last_n_entries is non-zero, only values in that many final
+   *  rows will be examined and filled.
+   */
+  void fillEmptyValues(unsigned int last_n_entries = 0);
 
   /// The optional output file stream
   std::string _output_file_name;

--- a/framework/src/utils/FormattedTable.C
+++ b/framework/src/utils/FormattedTable.C
@@ -310,8 +310,7 @@ FormattedTable::printTablePiece(std::ostream & out,
   printRowDivider(out, col_widths, col_begin, col_end);
   out << "|";
   if (_output_time)
-    out << std::setw(_column_width) << std::left << " time"
-        << " |";
+    out << std::setw(_column_width) << std::left << " time" << " |";
   for (auto header_it = col_begin; header_it != col_end; ++header_it)
     out << " " << std::setw(col_widths[*header_it]) << *header_it << "|";
   out << "\n";
@@ -575,11 +574,22 @@ FormattedTable::clear()
 void
 FormattedTable::fillEmptyValues()
 {
-  for (auto & it : _data)
-    for (const auto & col_name : _column_names)
-      if (!it.second[col_name])
-        it.second[col_name] =
-            std::dynamic_pointer_cast<TableValueBase>(std::make_shared<TableValue<char>>('0'));
+  for (auto & [time, datamap] : _data)
+  {
+    if (datamap.size() != _column_names.size())
+    {
+      for (const auto & col_name : _column_names)
+        if (!datamap[col_name])
+          datamap[col_name] =
+              std::dynamic_pointer_cast<TableValueBase>(std::make_shared<TableValue<char>>('0'));
+    }
+    else
+    {
+      for (auto & [key, val] : datamap)
+        if (!val)
+          val = std::dynamic_pointer_cast<TableValueBase>(std::make_shared<TableValue<char>>('0'));
+    }
+  }
 }
 
 MooseEnum

--- a/framework/src/utils/FormattedTable.C
+++ b/framework/src/utils/FormattedTable.C
@@ -303,7 +303,7 @@ FormattedTable::printTablePiece(std::ostream & out,
                                 std::vector<std::string>::iterator & col_begin,
                                 std::vector<std::string>::iterator & col_end)
 {
-  fillEmptyValues();
+  fillEmptyValues(last_n_entries);
   /**
    * Print out the header row
    */
@@ -572,10 +572,16 @@ FormattedTable::clear()
 }
 
 void
-FormattedTable::fillEmptyValues()
+FormattedTable::fillEmptyValues(unsigned int last_n_entries)
 {
-  for (auto & [time, datamap] : _data)
+  auto begin = _data.begin();
+  auto end = _data.end();
+  if (last_n_entries && (last_n_entries < _data.size()))
+    begin = end - last_n_entries;
+
+  for (auto it = begin; it != end; ++it)
   {
+    auto & datamap = it->second;
     if (datamap.size() != _column_names.size())
     {
       for (const auto & col_name : _column_names)


### PR DESCRIPTION
Refs #30831

## Reason
Makes console output with very large data tables much faster.

## Design
We were spending 90%+ of runtime uselessly in some (ODE with a zillion time step) cases

## Impact
This adds an optional parameter to an existing API, though most of the speedup is just done by reducing the amount of string hashing we do regardless of the parameter's value.

This could probably be made faster still, but with much more intrusive code changes, so I want to see how this benchmarks for @Naktakala first.  If it's fast enough as-is then we can just declare victory and close the issue.