### PR TITLE
Skip some solid mechanics tests in dbg mode

### DIFF
--- a/modules/solid_mechanics/examples/coal_mining/tests
+++ b/modules/solid_mechanics/examples/coal_mining/tests
@@ -18,6 +18,7 @@
     type = 'CSVDiff'
     input = 'cosserat_elastic.i'
     csvdiff = 'cosserat_elastic.csv'
+    heavy = true
   [../]
   [./cosserat_wp_only_csv]
     type = 'CSVDiff'

--- a/modules/solid_mechanics/test/tests/2D_geometries/tests
+++ b/modules/solid_mechanics/test/tests/2D_geometries/tests
@@ -63,6 +63,7 @@
     rel_err = 5E-4
     design = 'source/materials/ComputeAxisymmetricRZFiniteStrain.md'
     requirement = 'The ComputeAxisymmetricRZFiniteStrain class shall compute the mechanical response for a pressurized hollow cylinder with a small incremental axisymmetric strain formulation.'
+    capabilities = 'method!=dbg'
   [../]
   [./3D_RZ_finitestrain]
     type = Exodiff

--- a/modules/solid_mechanics/test/tests/CylindricalRankTwoAux/tests
+++ b/modules/solid_mechanics/test/tests/CylindricalRankTwoAux/tests
@@ -7,6 +7,7 @@
     exodiff = 'test_out.e'
     requirement = "The Tensor Mechanics system shall support transformations
     of a rank two tensor into cylindircal coordinates."
+    capabilities = 'method!=dbg'
   []
   [test_Bbar]
     type = 'Exodiff'
@@ -16,5 +17,6 @@
     prereq = 'test'
     requirement = "The Tensor Mechanics system including volumetric locking
     correction shall support transformations of a rank two tensor into cylindircal coordinates."
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/action/tests
+++ b/modules/solid_mechanics/test/tests/action/tests
@@ -154,6 +154,7 @@
       expect_out = "all: CONSTANT CONSTANT CONSTANT\n.*\nall: MONOMIAL MONOMIAL MONOMIAL\n"
       cli_args = "Physics/SolidMechanics/QuasiStatic/verbose=true"
       detail = "with the default options when parameters are not explicitly specified,"
+      capabilities = 'method!=dbg'
     []
     [material_output_order.single]
       type = RunApp
@@ -162,6 +163,7 @@
       cli_args = "Physics/SolidMechanics/QuasiStatic/verbose=true "
                  "Physics/SolidMechanics/QuasiStatic/material_output_order=FIRST"
       detail = "with given order and default family,"
+      capabilities = 'method!=dbg'
     []
     [material_output_order.family_single]
       type = RunApp
@@ -171,6 +173,7 @@
                  "Physics/SolidMechanics/QuasiStatic/material_output_order=FIRST "
                  "Physics/SolidMechanics/QuasiStatic/material_output_family=LAGRANGE"
       detail = "with given order and family,"
+      capabilities = 'method!=dbg'
     []
     [material_output_order.error1]
       type = RunException
@@ -180,6 +183,7 @@
                    "MONOMIAL; 1 to assign all outputs the same value, or the same size as the number "
                    "of generate outputs listed."
       detail = "with an error message when the wrong number of parameters are supplied,"
+      capabilities = 'method!=dbg'
     []
     [material_output_first_lagrange_manual]
       type = Exodiff
@@ -188,12 +192,14 @@
       max_parallel = 1
       max_threads = 1
       detail = "generates correct output using an AuxKernel,"
+      capabilities = 'method!=dbg'
     []
     [material_output_first_lagrange_automatic]
       type = Exodiff
       input = "material_output_first_lagrange_automatic.i"
       exodiff = "material_output_first_lagrange_automatic_out.e"
       detail = "generates correct output using the action."
+      capabilities = 'method!=dbg'
     []
   []
   [custom_output]

--- a/modules/solid_mechanics/test/tests/ad_2D_geometries/tests
+++ b/modules/solid_mechanics/test/tests/ad_2D_geometries/tests
@@ -8,6 +8,7 @@
                 Materials/stress/type=ADComputeLinearElasticStress'
     design = 'source/materials/ADComputeAxisymmetricRZSmallStrain.md'
     requirement = 'The ADComputeAxisymmetricRZSmallStrain class shall compute the mechanical response for a pressurized hollow cylinder with a small total axisymmetric strain formulation.'
+    capabilities = 'method!=dbg'
   [../]
   [./axisym_incremental_strain]
     type = Exodiff
@@ -19,6 +20,7 @@
     prereq = 'axisym_smallstrain'
     design = 'source/materials/ADComputeAxisymmetricRZIncrementalStrain.md'
     requirement = 'The ADComputeAxisymmetricRZIncrementalStrain class shall compute the mechanical response for a pressurized hollow cylinder with a small incremental axisymmetric strain formulation.'
+    capabilities = 'method!=dbg'
   [../]
   [./axisym_finitestrain]
     type = Exodiff
@@ -27,6 +29,7 @@
     rel_err = 5E-4
     design = 'source/materials/ADComputeAxisymmetricRZFiniteStrain.md'
     requirement = 'The ADComputeAxisymmetricRZFiniteStrain class shall compute the mechanical response for a pressurized hollow cylinder with a small incremental axisymmetric strain formulation.'
+    capabilities = 'method!=dbg'
   [../]
   [./3D_RZ_finitestrain]
     type = Exodiff
@@ -48,6 +51,7 @@
     abs_zero = 1e-8
     design = 'source/materials/ADComputeAxisymmetricRZFiniteStrain.md'
     requirement = 'The ADComputeAxisymmetricRZFiniteStrain class shall compute the reaction forces on the top surface of a cylinder which is loaded axially in tension.'
+    capabilities = 'method!=dbg'
   [../]
   [./axisym_resid_Bbar]
     type = Exodiff
@@ -59,6 +63,7 @@
     prereq = 'axisym_resid'
     design = 'source/materials/ADComputeAxisymmetricRZFiniteStrain.md VolumetricLocking.md'
     requirement = 'The ADComputeAxisymmetricRZFiniteStrain class shall compute the reaction forces on the top surface of a cylinder which is loaded axially in tension when using the B-bar volumetric locking correction.'
+    capabilities = 'method!=dbg'
   [../]
   [./axisymmetric_vlc_centerline_pp]
     type = CSVDiff

--- a/modules/solid_mechanics/test/tests/ad_anisotropic_creep/tests
+++ b/modules/solid_mechanics/test/tests/ad_anisotropic_creep/tests
@@ -8,6 +8,7 @@
     min_parallel = 2
     custom_cmp = 'generalized.exodiff'
     requirement = 'The system shall avoid regression on material time step and combined anisotropic creep computations'
+    capabilities = 'method!=dbg'
   []
   [ad_aniso_creep_x_3d]
     type = 'CSVDiff'
@@ -17,6 +18,7 @@
     min_parallel = 2
     rel_err = 1.0e-4
     abs_zero = 5.0e-7
+    capabilities = 'method!=dbg'
   []
   [aniso_creep_x_3d]
     type = 'CSVDiff'
@@ -26,6 +28,7 @@
     min_parallel = 2
     rel_err = 1.0e-4
     abs_zero = 5.0e-7
+    capabilities = 'method!=dbg'
   []
   [ad_aniso_creep_x_3d_aniso_elasticity]
     type = 'CSVDiff'
@@ -75,6 +78,7 @@
     min_parallel = 2
     rel_err = 1.0e-4
     abs_zero = 5.0e-7
+    capabilities = 'method!=dbg'
   []
   [ad_aniso_creep_y_3d]
     type = 'CSVDiff'
@@ -84,6 +88,7 @@
     min_parallel = 2
     rel_err = 1.0e-5
     abs_zero = 1.0e-7
+    capabilities = 'method!=dbg'
   []
   [ad_aniso_creep_z_3d]
     type = 'CSVDiff'
@@ -93,6 +98,7 @@
     min_parallel = 2
     rel_err = 1.0e-5
     abs_zero = 1.0e-7
+    capabilities = 'method!=dbg'
   []
   [ad_aniso_iso_iso]
     type = 'CSVDiff'
@@ -105,6 +111,7 @@
     min_parallel = 2
     rel_err = 1.0e-5
     abs_zero = 1.0e-8
+    capabilities = 'method!=dbg'
   []
   [jac_ad]
     type = 'PetscJacobianTester'
@@ -145,6 +152,7 @@
     min_parallel = 2
     rel_err = 1.0e-4
     abs_zero = 1.0e-8
+    capabilities = 'method!=dbg'
   []
   [aniso_creep_integration_error]
     type = 'CSVDiff'

--- a/modules/solid_mechanics/test/tests/ad_elastic/tests
+++ b/modules/solid_mechanics/test/tests/ad_elastic/tests
@@ -19,6 +19,7 @@
     prereq = 'finite_elastic-noad'
     requirement = 'We shall be able to reproduce finite strain elasticity results of the hand-coded simulation using automatic differentiation.'
     design = 'ADComputeFiniteStrain.md'
+    capabilities = 'method!=dbg'
   [../]
   [./finite_elastic-jac]
     type = 'PetscJacobianTester'

--- a/modules/solid_mechanics/test/tests/ad_finite_strain_jacobian/tests
+++ b/modules/solid_mechanics/test/tests/ad_finite_strain_jacobian/tests
@@ -26,6 +26,7 @@
     issues = '#7228 #13260'
     requirement = 'Finite strain methods in Tensor Mechanics should be able to adequately simulate a
                    tensile test simulation in 3D using AD and match non-AD methods'
+    capabilities = 'method!=dbg'
   []
   [3d_bar_Bbar]
     type = Exodiff
@@ -37,6 +38,7 @@
     requirement = 'Finite strain methods in Tensor Mechanics should be able to adequately simulate a
                    tensile test simulation in 3D using a volumetric locking correction using AD and
                    match non-AD methods'
+    capabilities = 'method!=dbg'
   []
 
   [ad_eigen_sol]

--- a/modules/solid_mechanics/test/tests/ad_plastic/tests
+++ b/modules/solid_mechanics/test/tests/ad_plastic/tests
@@ -7,6 +7,7 @@
     cli_args = 'Materials/elastic_strain/inelastic_models="creep_ten"'
     requirement = "The AD multiple inelastic stress calculator shall provide a correct stress for a single power law creep model (reference computation)"
     design = 'PowerLawCreepStressUpdate.md'
+    capabilities = 'method!=dbg'
   [../]
   [./powerlaw_zero]
     type = 'CSVDiff'
@@ -16,6 +17,7 @@
     prereq = powerlaw_ten
     requirement = "The AD multiple inelastic stress calculator shall provide a correct stress for a single power law creep model and an additional zero creep power law model"
     design = 'ADComputeMultipleInelasticStress.md'
+    capabilities = 'method!=dbg'
   [../]
   [./powerlaw_sum]
     type = 'CSVDiff'
@@ -26,6 +28,7 @@
     valgrind = HEAVY
     requirement = "The AD multiple inelastic stress calculator shall provide a correct stress for the linear combination of two power law creep models"
     design = 'ADComputeMultipleInelasticStress.md'
+    capabilities = 'method!=dbg'
   [../]
   [./powerlaw_cycle]
     type = 'CSVDiff'
@@ -35,6 +38,7 @@
     prereq = powerlaw_sum
     requirement = "The AD multiple inelastic stress calculator shall provide a correct stress when cycling through two identical power law creep models"
     design = 'ADComputeMultipleInelasticStress.md'
+    capabilities = 'method!=dbg'
   [../]
 
   # the Jacobian norms have been compared to the norms of the handcoded jacobians and the tolerances set accordingly

--- a/modules/solid_mechanics/test/tests/ad_return_mapping/tests
+++ b/modules/solid_mechanics/test/tests/ad_return_mapping/tests
@@ -8,5 +8,6 @@
     requirement = "The return mapping algorithm shall use automatic differentiation to compute the "
                   "derivative of the yield function with respect to the internal variable, and the "
                   "solution should be the same as existing hand coded derivative."
+    heavy = true
   []
 []

--- a/modules/solid_mechanics/test/tests/ad_smeared_cracking/tests
+++ b/modules/solid_mechanics/test/tests/ad_smeared_cracking/tests
@@ -22,6 +22,7 @@
     exodiff = cracking_function_out.e
     custom_cmp = cracking_function.cmp
     requirement = 'The MOOSE SolidMechanics module shall simulate cracking while the cracking strength is prescribed by an elemental AuxVariable using AD and match non-AD methods.'
+    capabilities = 'method!=dbg'
   []
   [exponential]
     type = Exodiff
@@ -30,6 +31,7 @@
     custom_cmp = cracking_exponential.cmp
     use_old_floor = true
     requirement = 'The MOOSE SolidMechanics module shall simulate exponential stress release using AD and match non-AD methods.'
+    capabilities = 'method!=dbg'
   []
   [rz_exponential]
     type = Exodiff
@@ -46,6 +48,7 @@
     input = cracking_power.i
     exodiff = cracking_power_out.e
     requirement = 'The MOOSE SolidMechanics module shall demonstrate softening using the power law for smeared cracking using AD and match non-AD methods.'
+    capabilities = 'method!=dbg'
   []
   [multiple_softening]
     type = Exodiff
@@ -54,6 +57,7 @@
     requirement = 'The MOOSE SolidMechanics module shall demonstrate the prescribed softening laws in three directions, power law (x), exponential (y), and abrupt (z) using AD and match non-AD methods.'
     # PR #26848. Clang 16 Apple Si is not compatible.
     machine = X86_64
+    capabilities = 'method!=dbg'
   []
   [xyz]
     type = Exodiff
@@ -62,6 +66,7 @@
     use_old_floor = true
     custom_cmp = cracking_xyz.cmp
     requirement = 'The MOOSE SolidMechanics module shall simulate smeared cracking in the x y and z directions using AD and match non-AD methods.'
+    capabilities = 'method!=dbg'
   []
   [plane_stress]
     type = Exodiff
@@ -79,6 +84,7 @@
     custom_cmp = cracking_rotation.cmp
     max_parallel = 1
     requirement = 'The MOOSE SolidMechanics module shall demonstrate that the smeared cracking model correctly handles finite rotation of cracked elements using AD and match non-AD methods.'
+    capabilities = 'method!=dbg'
   []
   [cracking_rotation_pres_dir_x]
     type = Exodiff

--- a/modules/solid_mechanics/test/tests/ad_viscoplasticity_stress_update/tests
+++ b/modules/solid_mechanics/test/tests/ad_viscoplasticity_stress_update/tests
@@ -25,6 +25,7 @@
     input = exact.i
     csvdiff = exact_spherical_out.csv
     requirement = 'The ADViscoplasticityStressUpdate class shall compute a ratio between the gauge stress, equilvalent stress, and hydrostatic stress across a wide swath of exponents and stress states using spherical pore geometry in spherical coordinates.'
+    capabilities = 'method!=dbg'
   []
   [exact_spherical-jac]
     type = 'PetscJacobianTester'
@@ -44,6 +45,7 @@
     cli_args = 'GlobalParams/pore_shape_model=CYLINDRICAL Outputs/file_base=exact_cylindrical_out'
     prereq = exact_spherical
     requirement = 'The ADViscoplasticityStressUpdate class shall compute a ratio between the gauge stress, equilvalent stress, and hydrostatic stress across a wide swath of exponents and stress states using spherical pore geometry in cylindrical coordinates.'
+    capabilities = 'method!=dbg'
   []
   [exact_cylindrical-jac]
     type = 'PetscJacobianTester'

--- a/modules/solid_mechanics/test/tests/anisotropic_elastoplasticity/tests
+++ b/modules/solid_mechanics/test/tests/anisotropic_elastoplasticity/tests
@@ -31,6 +31,7 @@
                'Executioner/TimeStepper/time_dt=\'1.0e-4 1.0e-7 1.0e-7\''
     requirement = 'The system shall be able to solve anisotropic plasticity and anisotropic '
                   'elastoplasticity problems with elastoplastic anisotropy'
+    capabilities = 'method!=dbg'
   []
   [ad_uniaxial_x_linear]
     type = 'CSVDiff'
@@ -67,6 +68,7 @@
     # Added max_time so that it does not TIMEOUT in debug test
     max_time = 600
     requirement = 'Compute hoop plastic strain in a cylinder oriented along the x axis and compare it for two elements located separately in hoop direction for coarsely meshed model'
+    capabilities = 'method!=dbg'
   []
   [3D_hoop_strain_comparison_coarse_yaxis]
     type = 'CSVDiff'
@@ -75,6 +77,7 @@
     # Added max_time so that it does not TIMEOUT in debug test
     max_time = 600
     requirement = 'Compute hoop plastic strain in a cylinder oriented along the y axis and compare it for two elements located separately in hoop direction for coarsely meshed model'
+    capabilities = 'method!=dbg'
   []
   [3D_hoop_strain_comparison_coarse_zaxis]
     type = 'CSVDiff'
@@ -83,5 +86,6 @@
     # Added max_time so that it does not TIMEOUT in debug test
     max_time = 600
     requirement = 'Compute hoop plastic strain in a cylinder oriented along the z axis and compare it for two elements located separately in hoop direction for coarsely meshed model'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/anisotropic_plasticity/tests
+++ b/modules/solid_mechanics/test/tests/anisotropic_plasticity/tests
@@ -8,6 +8,7 @@
     csvdiff = 'anis_plasticity_test_out.csv'
     requirement = 'Anisotropic plasticity must yield same results as finite strain elasticity if '
                   'yield condition is never met'
+    capabilities = 'method!=dbg'
   []
 
   [anis_elasticity_test]
@@ -16,6 +17,7 @@
     csvdiff = 'anis_elasticity_test_out.csv'
     requirement = 'Anisotropic plasticity must yield same results as finite strain elasticity if '
                   'yield condition is never met --elasticity'
+    capabilities = 'method!=dbg'
   []
 
   [ad_aniso_plasticity_x]

--- a/modules/solid_mechanics/test/tests/beam/dynamic/tests
+++ b/modules/solid_mechanics/test/tests/beam/dynamic/tests
@@ -9,6 +9,7 @@
     requirement = "The mechanics system shall correctly predict the natural frequencies"
                   " of an Euler-Bernoulli beam modeled using beam elements with"
                   " consistent mass/inertia."
+    capabilities = 'method!=dbg'
   [../]
   [./dyn_timoshenko]
     type = 'Exodiff'
@@ -18,6 +19,7 @@
     requirement = "The mechanics system shall correctly predict the natural frequencies"
                   " of a Timoshenko beam modeled using beam elements with consistent"
                   " mass/inertia."
+    capabilities = 'method!=dbg'
   [../]
   [./dyn_euler_rayleigh_hht]
     type = 'Exodiff'
@@ -154,6 +156,7 @@
 
     requirement = "The mechanics system shall correctly predict the natural frequency"
                   " of a cantilever beam modeled using beam elements with a mass at the free end."
+    capabilities = 'method!=dbg'
   [../]
   [./error_1]
     type = 'RunException'

--- a/modules/solid_mechanics/test/tests/beam/static/tests
+++ b/modules/solid_mechanics/test/tests/beam/static/tests
@@ -23,7 +23,7 @@
     type = 'Exodiff'
     input = 'euler_small_strain_y.i'
     exodiff = 'euler_small_strain_y_out.e'
-    verification = 'beam_vandv.md' 
+    verification = 'beam_vandv.md'
     requirement = "The mechanics system shall accurately predict the"
                   " static bending response of a Euler-Bernoulli beam modeled using"
                   " beam elements under small deformations in the y direction."
@@ -45,6 +45,7 @@
     requirement = "The mechanics system shall accurately predict the"
                   " static bending response of a Euler-Bernoulli beam modeled using"
                   " beam elements under finite deformations in the y direction."
+    capabilities = 'method!=dbg'
   [../]
   [./euler_finite_rot_z]
     type = 'Exodiff'
@@ -54,6 +55,7 @@
     requirement = "The mechanics system shall accurately predict the"
                   " static bending response of a Euler-Bernoulli beam modeled using"
                   " beam elements under finite deformations in the z direction."
+    capabilities = 'method!=dbg'
   [../]
   [./euler_small_y_with_action]
     type = 'Exodiff'

--- a/modules/solid_mechanics/test/tests/capped_mohr_coulomb/tests
+++ b/modules/solid_mechanics/test/tests/capped_mohr_coulomb/tests
@@ -178,6 +178,7 @@
     input = 'random4.i'
     csvdiff = 'random4.csv'
     cli_args = 'Mesh/nx=10 Mesh/ny=12 Mesh/xmax=10 Mesh/ymax=12'
+    capabilities = 'method!=dbg'
   [../]
   [./random4_heavy]
     type = CSVDiff

--- a/modules/solid_mechanics/test/tests/capped_weak_plane/tests
+++ b/modules/solid_mechanics/test/tests/capped_weak_plane/tests
@@ -164,6 +164,7 @@
     requirement = "The CappedWeakPlaneStressUpdate model shall correctly represent the behavior of a beam with its ends fully clamped"
     design = "CappedWeakPlaneStressUpdate.md"
     issues = "#7960"
+    capabilities = 'method!=dbg'
   [../]
 
   [./pull_and_shear_1step]
@@ -184,6 +185,7 @@
     requirement = "The CappedWeakPlaneStressUpdate model shall correctly represent a dynamic problem with plasticity in which a column of material is pulled in tension"
     design = "CappedWeakPlaneStressUpdate.md"
     issues = "#7960"
+    capabilities = 'method!=dbg'
   [../]
   [./push_and_shear]
     type = Exodiff
@@ -193,6 +195,7 @@
     requirement = "The CappedWeakPlaneStressUpdate model shall correctly represent a dynamic problem with plasticity in which a column of material is pushed in compression"
     design = "CappedWeakPlaneStressUpdate.md"
     issues = "#7960"
+    capabilities = 'method!=dbg'
   [../]
   [./throw_test]
     type = 'RunException'

--- a/modules/solid_mechanics/test/tests/cohesive_zone_model/tests
+++ b/modules/solid_mechanics/test/tests/cohesive_zone_model/tests
@@ -38,6 +38,7 @@
       recover = false
       detail = "The finite strain cohesive zone model shall converge quadratically when using the "
                "hand-coded Jacobian"
+    capabilities = 'method!=dbg'
     []
     [small_strain_incremental]
       type = Exodiff
@@ -74,6 +75,7 @@
       detail = "The finite strain cohesive zone model shall return the same results of the total "
                "formulation when using an incremental material"
       allow_test_objects = true
+      capabilities = 'method!=dbg'
     []
     [multiple_action_and_materials]
       type = Exodiff
@@ -250,6 +252,7 @@
       mesh_mode = 'REPLICATED'
       recover = false
       allow_test_objects = true
+      capabilities = 'method!=dbg'
     []
     [czm_total_stretch_rotate_total_lagrangian]
       type = Exodiff
@@ -260,6 +263,7 @@
                "and interface rotations when using a total strain material."
       mesh_mode = 'REPLICATED'
       recover = false
+      capabilities = 'method!=dbg'
     []
   []
 
@@ -283,6 +287,7 @@
       abs_zero = 1e-6
       rel_err = 1e-5
       detail = "under mode I loading with scaled normal strength."
+      capabilities = 'method!=dbg'
     []
     [shear]
       type = Exodiff
@@ -341,6 +346,7 @@
       recover = false
       detail = "The system shall converge quadratically when using the handcoded Jacobian of the 3DC "
                "traction separation model"
+      capabilities = 'method!=dbg'
     []
     [normal_load]
       type = Exodiff
@@ -409,6 +415,7 @@
       recover = false
       detail = "The solution obtained using AD CZM shall match"
       abs_zero = 1e-6
+      capabilities = 'method!=dbg'
     []
     [non_AD_solution]
       type = Exodiff
@@ -436,6 +443,7 @@
       recover = false
       detail = "The solution obtained using AD CZM shall match"
       abs_zero = 1e-6
+      capabilities = 'method!=dbg'
     []
     [non_AD_solution]
       type = Exodiff

--- a/modules/solid_mechanics/test/tests/combined_creep_plasticity/tests
+++ b/modules/solid_mechanics/test/tests/combined_creep_plasticity/tests
@@ -29,10 +29,10 @@
     exodiff = 'combined_stress_prescribed_out.e'
     rel_err = 1e-5
     abs_zero = 1e-09
-    capabilities = 'superlu'
     requirement = "MOOSE tensor mechanics module shall solve a combined creep
                    and plasticity 3D cube problem with a time-varying pressure
                    BC."
+    capabilities = 'superlu & method!=dbg'
   []
   [stress_relaxation]
     type = 'Exodiff'

--- a/modules/solid_mechanics/test/tests/cross_section_deflection/tests
+++ b/modules/solid_mechanics/test/tests/cross_section_deflection/tests
@@ -7,6 +7,7 @@
     cli_args = "VectorPostprocessors/section_output/positions='10.0 18.0'"
     csvdiff = 'test_one_step_out_section_output_0001.csv'
     requirement = 'The system shall compute the average of the nodal displacements of a cross section defined by the user via a nodal vector.'
+    capabilities = 'method!=dbg'
   []
   [test_one_step_auto_positions]
     type = 'CSVDiff'
@@ -14,12 +15,14 @@
     cli_args = 'Outputs/file_base=test_one_step_auto_out'
     csvdiff = 'test_one_step_auto_out_section_output_0001.csv'
     requirement = 'The system shall compute the average of the nodal displacements of a cross section defined by the user via a nodal vector at automatically determined positions.'
+    capabilities = 'method!=dbg'
   []
   [test_adapt]
     type = 'CSVDiff'
     input = 'test_adapt.i'
     csvdiff = 'test_adapt_out_section_output_0001.csv test_adapt_out_section_output_0002.csv'
     requirement = 'The system shall compute the average of the nodal displacements of a cross section at automatically located points that are updated with mesh adaptivity.'
+    capabilities = 'method!=dbg'
   []
   [test_adapt_err]
     type = 'RunException'
@@ -28,6 +31,7 @@
     expect_err = "Node counts do not match for all axial positions. If this behavior is desired to "
                  "accommodate nonuniform meshes, set 'require_equal_node_counts=false'"
     requirement = 'The system shall compute the average of the nodal displacements of a cross section at automatically located points that are updated with mesh adaptivity and raise an error if node counts do not match for all axial positions.'
+    capabilities = 'method!=dbg'
   []
   [test_one_step_empty_positions_err]
     type = 'RunException'
@@ -56,12 +60,14 @@
     input = 'test_one_step_two_ducts.i'
     csvdiff = 'test_one_step_two_ducts_out_section_output_0001.csv test_one_step_two_ducts_out_section_output_two_0001.csv'
     requirement = 'The system shall compute the average of the nodal displacements of a cross section defined by the user via two nodal vector and two reference points for two respective ducts.'
+    capabilities = 'method!=dbg'
   []
   [test_therm_exp]
     type = 'CSVDiff'
     input = 'test_therm_exp.i'
     csvdiff = 'test_therm_exp_out_section_output_0001.csv'
     requirement = 'The system shall compute the average of the nodal displacements of a cross section with mechanically and thermally induced deformation.'
+    capabilities = 'method!=dbg'
   []
   [test_therm_exp_symm]
     type = 'CSVDiff'
@@ -70,5 +76,6 @@
     ignore_columns = 'node_count'
     rel_err = 5e-3
     requirement = 'The system shall compute the average of the nodal displacements of a cross section with mechanically and thermally induced deformation with a symmetry plane not aligned with a Cartesian coordinate, and match a reference solution without the symmetry plane.'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/cp_eigenstrains/tests
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/cp_eigenstrains/tests
@@ -10,6 +10,7 @@
                   'changing temperature'
     design = '/ComputeCrystalPlasticityThermalEigenstrain.md '
              '/ComputeMultipleCrystalPlasticityStress.md'
+    capabilities = 'method!=dbg'
   []
   [thermal_eigenstrain_restart]
     type = 'CSVDiff'
@@ -24,6 +25,7 @@
                   'the simulation is restarted'
     design = '/ComputeMultipleCrystalPlasticityStress.md'
     prereq = 'thermal_eigenstrain'
+    capabilities = 'method!=dbg'
   []
   [multiple_eigenstrains]
     type = 'CSVDiff'
@@ -35,6 +37,7 @@
                   'individual eigenstrains'
     design = '/ComputeCrystalPlasticityThermalEigenstrain.md '
              '/ComputeMultipleCrystalPlasticityStress.md'
+    capabilities = 'method!=dbg'
   []
   [thermal_eigenstrain_011orientation]
     type = 'CSVDiff'
@@ -51,6 +54,7 @@
                   'changing temperature under a 011 loading orientation'
     design = '/ComputeCrystalPlasticityThermalEigenstrain.md '
              '/ComputeMultipleCrystalPlasticityStress.md'
+    capabilities = 'method!=dbg'
   []
   [hcp_thermal_eigenstrain]
     type = 'CSVDiff'
@@ -64,6 +68,7 @@
     design = '/ComputeCrystalPlasticityThermalEigenstrain.md '
              '/ComputeMultipleCrystalPlasticityStress.md '
              '/CrystalPlasticityHCPDislocationSlipBeyerleinUpdate.md'
+    capabilities = 'method!=dbg'
   []
   [volumetric_eigenstrain_increase]
     type = 'CSVDiff'
@@ -78,6 +83,7 @@
     design = '/ComputeCrystalPlasticityVolumetricEigenstrain.md '
              '/ComputeMultipleCrystalPlasticityStress.md '
              '/CrystalPlasticityKalidindiUpdate.md'
+    capabilities = 'method!=dbg'
   []
   [volumetric_eigenstrain_increase_restart]
     type = 'CSVDiff'
@@ -91,6 +97,7 @@
                   'upon simulation restart.'
     design = '/ComputeCrystalPlasticityVolumetricEigenstrain.md '
              '/ComputeMultipleCrystalPlasticityStress.md'
+    capabilities = 'method!=dbg'
   []
   [hcp_volumetric_eigenstrain_decrease]
     type = 'CSVDiff'
@@ -104,6 +111,7 @@
     design = '/ComputeCrystalPlasticityVolumetricEigenstrain.md '
              '/ComputeMultipleCrystalPlasticityStress.md '
              '/CrystalPlasticityHCPDislocationSlipBeyerleinUpdate.md'
+    capabilities = 'method!=dbg'
   []
   [volumetric_eigenstrain_parabolic]
     type = 'CSVDiff'
@@ -118,6 +126,7 @@
     design = '/ComputeCrystalPlasticityVolumetricEigenstrain.md '
              '/ComputeMultipleCrystalPlasticityStress.md '
              '/CrystalPlasticityKalidindiUpdate.md'
+    capabilities = 'method!=dbg'
   []
   [volumetric_eigenstrain_density_check]
     type = 'RunException'

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/hcp_single_crystal/tests
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/hcp_single_crystal/tests
@@ -13,6 +13,7 @@
       detail =  'compute the slip system strength and resolved applied shear '
                 'stress for the prismatic<a> and pyramidal<c+a> slip systems when '
                 'loaded along the c-axis;'
+      capabilities = 'method!=dbg'
     []
     [update_method_hcp_aprismatic_active]
       type = 'CSVDiff'
@@ -21,6 +22,7 @@
       allow_warnings = true
       detail = 'evolve the forest dislocation and substructure densities on '
                'prismatic<a> slip planes when loaded in an appropriate orientation;'
+      capabilities = 'method!=dbg'
     []
     [update_method_hcp_capyramidal_active]
       type = 'CSVDiff'
@@ -30,6 +32,7 @@
       detail = 'evolve the forest dislocation densities on pyramidal <c+a> slip '
                'planes and the substructure density when the crystal is loaded in '
                'an appropriate orientation.'
+      capabilities = 'method!=dbg'
     []
     [update_method_hcp_basal_active]
       type = 'CSVDiff'
@@ -39,6 +42,7 @@
       allow_warnings = true
       detail = 'evolve the forest dislocation densities on basal <a> slip '
                'planes when the crystal is loaded in an appropriate orientation.'
+      capabilities = 'method!=dbg'
     []
     [update_method_hcp_no_substructure]
       type = 'CSVDiff'
@@ -46,6 +50,7 @@
       csvdiff = 'update_method_hcp_no_substructure_out.csv'
       allow_warnings = true
       detail = 'prevent the calculation of a negative substructure density increment.'
+      capabilities = 'method!=dbg'
     []
     [update_method_hcp_no_negative_aprismatic]
       type = 'CSVDiff'
@@ -53,6 +58,7 @@
       csvdiff = 'update_method_hcp_no_negative_aprismatic_out.csv'
       allow_warnings = true
       detail = 'prevent the calculation of a negative total forest density.'
+      capabilities = 'method!=dbg'
     []
     [update_method_hcp_size_slip_modes]
       type = 'RunException'
@@ -160,6 +166,7 @@
                  'Executioner/dt=0.125'
       detail = 'continue to evolve the forest dislocation densities on basal <a> slip planes.'
       prereq = 'constitutive_model/update_method_hcp_basal_active'
+      capabilities = 'method!=dbg'
     []
     [update_method_hcp_aprismatic_capyramidal_restart]
       type = 'CSVDiff'

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/hcp_twinning/tests
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/hcp_twinning/tests
@@ -11,6 +11,7 @@
                'in Miller-Bravais indices and shall calculate a twin volume '
                'fraction when using the FCC Kalidindi twinning model with a '
                'modified input file.'
+      capabilities = 'method!=dbg'
     []
     [demonstration_combined_hcp_slip_twins]
       type = CSVDiff
@@ -19,6 +20,7 @@
       cli_args = 'Outputs/out/type=Checkpoint Outputs/out/execute_on=Final'
       detail = 'compute a plastic velocity gradient that accounts for deformation '
                'contributions from both slip and twinning in an HCP crystal.'
+      capabilities = 'method!=dbg'
     []
   []
   [demonstration_combined_hcp_slip_twins_restart]
@@ -34,5 +36,6 @@
     issues = '#26458'
     design = '/ComputeMultipleCrystalPlasticityStress.md /CrystalPlasticityHCPDislocationSlipBeyerleinUpdate.md /CrystalPlasticityTwinningKalidindiUpdate.md'
     prereq = 'coupling_demonstration/demonstration_combined_hcp_slip_twins'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/monolithic_material_based/cp_slip_rate_integ/tests
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/monolithic_material_based/cp_slip_rate_integ/tests
@@ -16,6 +16,7 @@
     valgrind = HEAVY
     issues = '#5082 #5683'
     requirement = 'The system shall compute the stress and strain response of a single crystal using the Kalidindi constitutive equation for hardening as a function of slip rate on each slip system with the substepping capability that reduces the intermediate time step size to aid with convergence within the crystal plasticity hardening model.'
+    capabilities = 'method!=dbg'
   [../]
   [./test_with_linesearch]
     type = 'Exodiff'
@@ -25,5 +26,6 @@
     max_time = 350
     valgrind = HEAVY
     requirement = 'The system shall compute the stress and strain response of a single crystal using the Kalidindi constitutive equation for hardening as a function of slip rate on each slip system with the bisection line search method within the crystal plasticity hardening model to aid with convergence.'
+    capabilities = 'method!=dbg'
   [../]
 []

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/monolithic_material_based/tests
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/monolithic_material_based/tests
@@ -40,6 +40,7 @@
       allow_warnings = true
       max_parallel = 1
       detail = 'test_cutback'
+      capabilities = 'method!=dbg'
     []
     [test_substep]
       type = 'Exodiff'

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/stress_update_material_based/tests
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/stress_update_material_based/tests
@@ -51,6 +51,7 @@
     requirement = 'The crystal plasticity system shall provide a substepping capability for improved '
                   'convergence using the stress-update based crystal plasticity implementation'
     design = '/ComputeMultipleCrystalPlasticityStress.md /CrystalPlasticityKalidindiUpdate.md'
+    capabilities = 'method!=dbg'
   []
   [linesearch]
     type = 'Exodiff'
@@ -69,6 +70,7 @@
     requirement = 'The crystal plasticity rotations shall correctly rotate the elasticity tensors at '
                   'each material point using the stress-update based crystal plasticity implementation'
     design = '/ComputeElasticityTensorCP.md'
+    capabilities = 'method!=dbg'
   []
   [patch_recovery]
     type = 'Exodiff'
@@ -81,6 +83,7 @@
                   "the stress-update based crystal plasticity implementation"
     design = 'nodal_patch_recovery.md'
     issues = '#18721'
+    capabilities = 'method!=dbg'
   []
   [use_substep_dt]
     type = 'CSVDiff'
@@ -92,6 +95,7 @@
     requirement = 'The system shall apply correct boundary condition after timestep being cut during '
                   'substepping using the stress-update based crystal plasticity implementation'
     design = '/ComputeMultipleCrystalPlasticityStress.md'
+    capabilities = 'method!=dbg'
   []
   [update_euler_angle_111_orientation]
     type = 'CSVDiff'
@@ -107,6 +111,7 @@
     issues = '#19473'
     design = '/ComputeUpdatedEulerAngle.md '
              '/ComputeMultipleCrystalPlasticityStress.md'
+    capabilities = 'method!=dbg'
   []
   [update_euler_angle_112_orientation]
     type = 'CSVDiff'
@@ -122,6 +127,7 @@
     issues = '#19473'
     design = '/ComputeUpdatedEulerAngle.md '
              '/ComputeMultipleCrystalPlasticityStress.md'
+    capabilities = 'method!=dbg'
   []
   [update_euler_angle_123_orientation]
     type = 'CSVDiff'
@@ -137,6 +143,7 @@
     issues = '#19473'
     design = '/ComputeUpdatedEulerAngle.md '
              '/ComputeMultipleCrystalPlasticityStress.md'
+    capabilities = 'method!=dbg'
   []
   [bicrystal_test]
     type = 'CSVDiff'
@@ -148,6 +155,7 @@
                   'the base_name input parameter.'
     issues = '#21036'
     design = '/ComputeMultipleCrystalPlasticityStress.md'
+    capabilities = 'method!=dbg'
   []
   [bicrystal_test_restart]
     type = 'CSVDiff'
@@ -160,6 +168,7 @@
     issues = '#26458'
     design = '/ComputeMultipleCrystalPlasticityStress.md'
     prereq = 'bicrystal_test'
+    capabilities = 'method!=dbg'
   []
   [rotation_matrix_update_euler_angle_111_orientation]
     type = 'CSVDiff'
@@ -172,6 +181,7 @@
     issues = '#23451'
     design = '/ComputeElasticityTensorCP.md '
              '/ComputeUpdatedEulerAngle.md '
+    capabilities = 'method!=dbg'
   []
   [rotation_matrix_update_euler_angle_011_orientation]
     type = 'CSVDiff'
@@ -188,6 +198,7 @@
     issues = '#23451'
     design = '/ComputeElasticityTensorCP.md '
              '/ComputeUpdatedEulerAngle.md '
+    capabilities = 'method!=dbg'
   []
   [rotation_matrix_update_euler_angle_112_orientation]
     type = 'CSVDiff'
@@ -202,6 +213,7 @@
     issues = '#23451'
     design = '/ComputeElasticityTensorCP.md '
              '/ComputeUpdatedEulerAngle.md '
+    capabilities = 'method!=dbg'
   []
   [rotation_matrix_and_euler_angles_error]
     type = RunException

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/twinning/tests
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/twinning/tests
@@ -14,6 +14,7 @@
                'applied shear stress and resistance to twin propagation, the '
                'corresponding twin volume fraction per twin system, and the total '
                'value of the twin volume fraction across all twin systems.'
+      capabilities = 'method!=dbg'
     []
     [check_direction_twin_propagation]
       type = 'CSVDiff'
@@ -22,6 +23,7 @@
       allow_warnings = true
       detail = 'compute a non-zero twin volume fraction, and associate plastic '
                'shear increment, for only postive applied shear stress values.'
+      capabilities = 'method!=dbg'
     []
     [coplanar_twin_hardening]
       type = 'CSVDiff'
@@ -29,6 +31,7 @@
       csvdiff = 'coplanar_twin_hardening_out.csv'
       detail = 'calculate the coplanar twin propogation resistance contribution '
                'as a function of the twin volume fractions on coplanar systems alone.'
+      capabilities = 'method!=dbg'
     []
     [non_coplanar_twin_hardening]
       type = 'CSVDiff'
@@ -37,6 +40,7 @@
       detail = 'calculate the contribution to twin propagation resistance from '
                'non-coplanar systems as a function of only the twin volume fraction '
                'on non-coplanar twin systems.'
+      capabilities = 'method!=dbg'
     []
     [upper_twin_fraction_limit]
       type = CSVDiff
@@ -45,6 +49,7 @@
       allow_warnings = true
       detail = 'set the plastic shear increments due to twinning to zero once '
                'the total twin volume fraction limit is reached.'
+      capabilities = 'method!=dbg'
     []
     [upper_twin_fraction_limit_error]
       type = RunException
@@ -78,6 +83,7 @@
       cli_args = 'Outputs/out/type=Checkpoint Outputs/out/execute_on=Final'
       detail = 'compute plastic shear due to both slip and twin propagation when '
                'loaded under tension in a 111 orientation.'
+      capabilities = 'method!=dbg'
     []
     [combined_twinning_slip_111compression]
       type = CSVDiff
@@ -86,6 +92,7 @@
       cli_args = 'BCs/tdisp/function=-0.02*t Outputs/file_base=combined_twinning_slip_111compression_out '
       detail = 'compute a near-zero twin volume fraction when loaded under '
                'compression in a 111 orientation.'
+      capabilities = 'method!=dbg'
     []
     [combined_twinning_slip_100tension]
       type = CSVDiff
@@ -94,6 +101,7 @@
       cli_args = 'BCs/tdisp/function=0.025*t Outputs/file_base=combined_twinning_slip_100tension_out'
       detail = 'compute a near-zero volume fraction of twins for all twin system '
                'when a 100 oriented crystal is loaded under tension.'
+      capabilities = 'method!=dbg'
     []
     [combined_twinning_slip_100compression]
       type = CSVDiff
@@ -101,6 +109,7 @@
       csvdiff = 'combined_twinning_slip_100compression_out.csv'
       detail = 'compute both dislocation glide and twin propagation in a 100 '
                'oriented crystal loaded under compression.'
+      capabilities = 'method!=dbg'
     []
   []
   [restart_capabilities]

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/user_object_based/tests
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/user_object_based/tests
@@ -37,8 +37,9 @@
     input = 'user_object.i'
     exodiff = 'user_object_out.e'
     issues = '#6097'
-    requirement = 'The crystal plasticity system shall use pluggable user objects to dtermine the plasticity state variable evolution'
+    requirement = 'The crystal plasticity system shall use pluggable user objects to determine the plasticity state variable evolution'
     design = '/FiniteStrainUObasedCP.md'
+    capabilities = 'method!=dbg'
   []
   [save_euler]
     type = 'Exodiff'
@@ -47,6 +48,7 @@
     issues = '#6097'
     requirement = 'The crystal plasticity system shall make local Euler angles at material points available for output'
     design = '/FiniteStrainUObasedCP.md'
+    capabilities = 'method!=dbg'
   []
   [substep]
     type = 'Exodiff'
@@ -56,6 +58,7 @@
     issues = '#6097'
     requirement = 'The crystal plasticity system shall provide a substepping capability for improved convergence'
     design = '/FiniteStrainUObasedCP.md'
+    capabilities = 'method!=dbg'
   []
   [linesearch]
     type = 'Exodiff'
@@ -72,6 +75,7 @@
     issues = '#10629'
     requirement = 'The crystal plasticity rotations shall correctly rotate the elasticity tensors at each material point'
     design = '/ComputeElasticityTensorCP.md'
+    capabilities = 'method!=dbg'
   []
   [user_object_Voce_BCC]
     type = 'Exodiff'
@@ -80,6 +84,7 @@
     issues = '#11307'
     requirement = 'The crystal plasticity system shall provide a plugin user object implementing the Voce hardening law'
     design = '/CrystalPlasticityStateVarRateComponentVoce.md'
+    capabilities = 'method!=dbg'
   []
   [patch_recovery]
     type = 'Exodiff'
@@ -92,6 +97,7 @@
                   "plasticity finite strain application."
     design = 'nodal_patch_recovery.md'
     issues = '#18721'
+    capabilities = 'method!=dbg'
   []
   [prop_block_read]
     type = 'Exodiff'
@@ -101,6 +107,7 @@
     requirement = 'The system shall provide an object to read values from a file and map them onto a mesh besed on mesh block IDs'
     design = 'PropertyReadFile.md'
     allow_warnings = true # number of blocks is smaller than number of data points in CSV file
+    capabilities = 'method!=dbg'
   []
   [use_substep_dt]
     type = 'CSVDiff'
@@ -111,5 +118,6 @@
     issues = '#17340'
     requirement = 'The system shall apply correct boundary condition after timestep being cut during substepping'
     design = '/FiniteStrainUObasedCP.md'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/domain_integral_thermal/tests
+++ b/modules/solid_mechanics/test/tests/domain_integral_thermal/tests
@@ -7,6 +7,7 @@
     custom_cmp = 'j_integral_2d.cmp'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D coupled with thermal effects.'
     issues = '#3807 #10232'
+    capabilities = 'method!=dbg'
   []
   [c_integral_2d]
     type = 'Exodiff'
@@ -15,6 +16,7 @@
     custom_cmp = 'c_integral_2d.cmp'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the C integral for problems in 2D coupled with thermal effects.'
     issues = '#3807 #10232'
+    capabilities = 'method!=dbg'
   []
   [test_iithermal]
     type = 'CSVDiff'
@@ -22,6 +24,7 @@
     csvdiff = 'interaction_integral_2d_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the interaction integral for problems in 2D coupled with thermal effects.'
     issues = '#7527 #9966'
+    capabilities = 'method!=dbg'
   []
   [test_iithermal_generic]
     type = 'CSVDiff'
@@ -29,6 +32,7 @@
     csvdiff = 'interaction_integral_2d_thermal_generic_out.csv'
     requirement = 'The domain integral action shall compute the stress intensity factor using the interaction integral approach for a problem dominated by thermal strains using an approach that integrates eigenstrain gradients in a general manner.'
     issues = '#26452'
+    capabilities = 'method!=dbg'
   []
   [test_ii_arb_eig_grad]
     type = 'CSVDiff'
@@ -84,6 +88,7 @@
     csvdiff = 'interaction_integral_2d_rot_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the interaction integral for problems in any plane for 2D.'
     issues = '#7527 #9966'
+    capabilities = 'method!=dbg'
   []
   [interaction_integral_2d_c]
     type = 'Exodiff'
@@ -92,6 +97,7 @@
     custom_cmp = 'interaction_integral_2d_c.cmp'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the C(t) integral for problems in 2D.'
     issues = '#7527 #9966'
+    capabilities = 'method!=dbg'
   []
   [test_jthermal_ctefunc]
     type = 'CSVDiff'
@@ -99,6 +105,7 @@
     csvdiff = 'j_integral_2d_ctefunc_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D using the thermal expansion function eigenstrain.'
     issues = '#3807 #10232'
+    capabilities = 'method!=dbg'
   []
   [test_jthermal_mean_ctefunc]
     type = 'CSVDiff'
@@ -106,6 +113,7 @@
     csvdiff = 'j_integral_2d_mean_ctefunc_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D using the mean thermal expansion function eigenstrain.'
     issues = '#3807 #10232'
+    capabilities = 'method!=dbg'
   []
   [test_jthermal_inst_ctefunc]
     type = 'CSVDiff'
@@ -113,5 +121,6 @@
     csvdiff = 'j_integral_2d_inst_ctefunc_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D using the instantaneous thermal expansion function eigenstrain.'
     issues = '#3807 #10232'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/dynamics/acceleration_bc/tests
+++ b/modules/solid_mechanics/test/tests/dynamics/acceleration_bc/tests
@@ -9,6 +9,7 @@
                   " acceleration at the given boundary."
     design = "Dynamics.md PresetAcceleration.md"
     issues = "#7642"
+    capabilities = 'method!=dbg'
   [../]
   [./acceleration_bc_ti]
     type = 'Exodiff'
@@ -22,5 +23,6 @@
     design = "Dynamics.md PresetAcceleration.md"
     issues = "#12185"
     prereq = "acceleration_bc"
+    capabilities = 'method!=dbg'
   [../]
 []

--- a/modules/solid_mechanics/test/tests/dynamics/wave_1D/tests
+++ b/modules/solid_mechanics/test/tests/dynamics/wave_1D/tests
@@ -10,6 +10,7 @@
     requirement = "The mechanics system shall correctly predict 1D wave propagation in a linear "
                   "elastic material with numerical damping resulting from Hilber-Hughes-Taylor (HHT) "
                   "time integration."
+    capabilities = 'method!=dbg'
   []
   [newmark]
     type = 'Exodiff'
@@ -19,6 +20,7 @@
 
     requirement = "The mechanics system shall correctly predict 1D wave propagation in a linear "
                   "elastic material with no numerical or structural damping."
+    capabilities = 'method!=dbg'
   []
   [rayleigh_hht]
     type = 'Exodiff'
@@ -29,6 +31,7 @@
     requirement = "The mechanics system shall correctly predict 1D wave propagation in a linear "
                   "elastic material with both Rayleigh damping and numerical damping resulting from "
                   "Hilber-Hughes-Taylor (HHT) time integration."
+    capabilities = 'method!=dbg'
   []
   [rayleigh_hht_ad]
     type = 'Exodiff'
@@ -41,6 +44,7 @@
                   "Hilber-Hughes-Taylor (HHT) time integration when automatic differentiation is "
                   "used."
     prereq = "rayleigh_hht"
+    capabilities = 'method!=dbg'
   []
   [rayleigh_hht_ad_jac]
     type = 'PetscJacobianTester'
@@ -64,6 +68,7 @@
                   "acceleration computed using the Newmark-Beta time integrator."
     issues = "#12185"
     prereq = "rayleigh_hht_ad"
+    capabilities = 'method!=dbg'
   []
   [rayleigh_newmark]
     type = 'Exodiff'
@@ -73,6 +78,7 @@
 
     requirement = "The mechanics system shall correctly predict 1D wave propagation in a linear "
                   "elastic material with Rayleigh damping."
+    capabilities = 'method!=dbg'
   []
   [rayleigh_newmark_action]
     type = 'Exodiff'
@@ -83,5 +89,6 @@
     requirement = "The mechanics system shall correctly predict 1D wave propagation in a linear "
                   "elastic material with Rayleigh damping when using the dynamic tensor mechanics "
                   "parent action."
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/elem_prop_read_user_object/tests
+++ b/modules/solid_mechanics/test/tests/elem_prop_read_user_object/tests
@@ -16,5 +16,6 @@
     design = 'PropertyReadFile.md'
     requirement = 'The system shall provide an object to read values from a file and map them onto a mesh based on grain IDs determined by a random Voronoi tessellation'
     allow_warnings = true # CSV has more rows than number of grains
+    capabilities = 'method!=dbg'
   [../]
 []

--- a/modules/solid_mechanics/test/tests/finite_strain_elastic_anisotropy/tests
+++ b/modules/solid_mechanics/test/tests/finite_strain_elastic_anisotropy/tests
@@ -7,6 +7,7 @@
     design = '/ComputeFiniteStrainElasticStress.md'
     requirement = 'Finite strain methods in Tensor Mechanics should be able to adequately simulate a
                    complex strain state simulation in 3D using an orhotropic filling with isotropic properties.'
+    capabilities = 'method!=dbg'
   []
   [3d_orthotropic_isotropic]
     type = 'Exodiff'
@@ -29,6 +30,7 @@
     requirement = 'Finite strain methods in Tensor Mechanics should be able to rotate an orthotropic beam-like element 90 degrees and retrieve
                    the proper displacement after being solicited by a pressure boundary condition.'
     custom_cmp = ortho.cmp
+    capabilities = 'method!=dbg'
   []
   [3d_bar_orthotropic_90deg_rotation_ad]
     type = 'Exodiff'
@@ -39,6 +41,7 @@
     requirement = 'Finite strain methods in Tensor Mechanics should be able to rotate an orthotropic beam-like element 90 degrees and retrieve
                    the proper displacement after being solicited by a pressure boundary condition when automatic differentiation is used.'
     custom_cmp = ortho.cmp
+    capabilities = 'method!=dbg'
   []
 
   [3d_bar_orthotropic_full_rotation]
@@ -51,6 +54,7 @@
                    the proper displacement after being solicited by a pressure boundary condition.'
     heavy = true
     custom_cmp = ortho.cmp
+    capabilities = 'method!=dbg'
   []
   [3d_bar_orthotropic_full_rotation_ad]
     type = 'Exodiff'
@@ -62,6 +66,7 @@
                    the proper displacement after being solicited by a pressure boundary condition when automatic differentiation is used.'
     heavy = true
     custom_cmp = ortho.cmp
+    capabilities = 'method!=dbg'
   []
 
 []

--- a/modules/solid_mechanics/test/tests/finite_strain_jacobian/tests
+++ b/modules/solid_mechanics/test/tests/finite_strain_jacobian/tests
@@ -27,6 +27,7 @@
     design = '/ComputeFiniteStrain.md'
     requirement = 'Finite strain methods in Tensor Mechanics should be able to adequately simulate a
                    tensile test simulation in 3D'
+    capabilities = 'method!=dbg'
   [../]
   [./3d_bar_Bbar]
     type = 'Exodiff'
@@ -38,5 +39,6 @@
     design = '/ComputeFiniteStrain.md'
     requirement = 'Finite strain methods in Tensor Mechanics should be able to adequately simulate a
                    tensile test simulation in 3D using a volumetric locking correction'
+    capabilities = 'method!=dbg'
   [../]
 []

--- a/modules/solid_mechanics/test/tests/gravity/tests
+++ b/modules/solid_mechanics/test/tests/gravity/tests
@@ -48,5 +48,6 @@
                   'use of auxiliary kernels and postprocessors. This test verifies that a body falls '
                   'at the right acceleration under the action of gravity and that the computed '
                   'kinetic energy matches the analytical expression.'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/hyperelastic_viscoplastic/tests
+++ b/modules/solid_mechanics/test/tests/hyperelastic_viscoplastic/tests
@@ -4,23 +4,27 @@
     input = 'one_elem.i'
     exodiff = 'one_elem.e'
     allow_warnings = true
+    capabilities = 'method!=dbg'
   [../]
   [./one_elem_multi]
     type = 'Exodiff'
     input = 'one_elem_multi.i'
     exodiff = 'one_elem_multi.e'
     allow_warnings = true
+    capabilities = 'method!=dbg'
   [../]
   [./one_elem_base]
     type = 'Exodiff'
     input = 'one_elem_base.i'
     exodiff = 'one_elem_base.e'
     allow_warnings = true
+    capabilities = 'method!=dbg'
   [../]
   [./one_elem_linear_harden]
     type = 'Exodiff'
     input = 'one_elem_linear_harden.i'
     exodiff = 'one_elem_linear_harden.e'
     allow_warnings = true
+    capabilities = 'method!=dbg'
   [../]
 []

--- a/modules/solid_mechanics/test/tests/ics/volume_weighted_weibull/tests
+++ b/modules/solid_mechanics/test/tests/ics/volume_weighted_weibull/tests
@@ -14,6 +14,7 @@
     cli_args = 'Mesh/nx=200 Mesh/ny=200 Outputs/initial/file_base=volume_weighted_weibull_finer_initial ICs/u_vww/reference_volume=0.000025'
     csvdiff = 'volume_weighted_weibull_finer_initial_histo_0000.csv'
     requirement = 'VolumeWeightedWeibull shall generate a randomly distributed field that approaches the analytic expression for the Weibull distribution when the mesh is uniform and the reference volume is set equal to the element size as the mesh density is increased'
+    capabilities = 'method!=dbg'
   [../]
   [./test_ref_vol]
     prereq = test_finer

--- a/modules/solid_mechanics/test/tests/inclined_bc/tests
+++ b/modules/solid_mechanics/test/tests/inclined_bc/tests
@@ -21,9 +21,9 @@
     type = Exodiff
     input = 'ad_inclined_bc_3d.i'
     exodiff = 'ad_inclined_bc_3d_out.e'
-    capabilities = 'superlu'
     issues = '#24910'
     design = 'PenaltyInclinedNoDisplacementBC.md InclinedNoDisplacementBCAction.md'
     requirement = 'The SolidMechanics module shall have the capabilty to enforce inclined boundary conditions while using automatic differentiation.'
+    capabilities = 'superlu & method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/interaction_integral/tests
+++ b/modules/solid_mechanics/test/tests/interaction_integral/tests
@@ -7,6 +7,7 @@ issues = '#3705'
    csvdiff = 'interaction_integral_2d_out.csv'
    max_parallel = 1           # nl_its and lin_its will not be the same in parallel and serial
    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the interaction integral for problems in 2D.'
+   capabilities = 'method!=dbg'
  [../]
  [./ii_2d_rot]
    type = 'CSVDiff'
@@ -14,6 +15,7 @@ issues = '#3705'
    csvdiff = 'interaction_integral_2d_rot_out.csv'
    max_parallel = 1           # nl_its and lin_its will not be the same in parallel and serial
    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the interaction integral for problems for all planes in 2D.'
+   capabilities = 'method!=dbg'
  [../]
  [./ii_3d_as_2d]
    type = 'CSVDiff'
@@ -21,6 +23,7 @@ issues = '#3705'
    csvdiff = 'interaction_integral_3d_as_2d_out.csv'
    max_parallel = 1           # nl_its and lin_its will not be the same in parallel and serial
    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the interaction integral for problems in 3d evaluated as 2D.'
+   capabilities = 'method!=dbg'
  [../]
  [./ii_3d]
    type = 'CSVDiff'
@@ -29,6 +32,7 @@ issues = '#3705'
    max_parallel = 1           # nl_its and lin_its will not be the same in parallel and serial
    abs_zero = 1e-8
    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the interaction integral for problems in 3D.'
+   capabilities = 'method!=dbg'
  [../]
  [./ii_3d_noq]
    type = 'CSVDiff'
@@ -39,6 +43,7 @@ issues = '#3705'
    abs_zero = 1e-8
    prereq = ii_3d
    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the interaction integral for problems in 3D while supressing the output of q function values.'
+   capabilities = 'method!=dbg'
  [../]
  [./ii_3d_points]
    type = 'CSVDiff'
@@ -47,6 +52,7 @@ issues = '#3705'
    abs_zero = 1e-8
    max_parallel = 1           # nl_its and lin_its will not be the same in parallel and serial
    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the interaction integral for problems in 3D at specified points.'
+   capabilities = 'method!=dbg'
  [../]
  [./ii_3d_rot]
    type = 'CSVDiff'
@@ -55,6 +61,7 @@ issues = '#3705'
    abs_zero = 2e-8
    max_parallel = 1           # nl_its and lin_its will not be the same in parallel and serial
    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the interaction integral for problems in any plane in 3D.'
+   capabilities = 'method!=dbg'
  [../]
  [./ii_2d_chk_q]
    type = 'Exodiff'
@@ -63,7 +70,8 @@ issues = '#3705'
    exodiff = 'interaction_integral_2d_out.e'
    max_parallel = 1           # nl_its and lin_its will not be the same in parallel and serial
    prereq = 'ii_2d'
-   requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the interaction integral for problems in 2D while outputting q vlaues.'
+   requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the interaction integral for problems in 2D while outputting q values.'
+   capabilities = 'method!=dbg'
  [../]
  [./ii_2d_rot_chk_q]
    type = 'Exodiff'

--- a/modules/solid_mechanics/test/tests/j_integral/tests
+++ b/modules/solid_mechanics/test/tests/j_integral/tests
@@ -6,6 +6,7 @@
     input = 'j_integral_2d.i'
     csvdiff = 'j_integral_2d_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D.'
+    capabilities = 'method!=dbg'
   []
   [j_2d_block_restrict]
     type = 'CSVDiff'
@@ -13,6 +14,7 @@
     input = 'j_integral_2d_block_restrict.i'
     csvdiff = 'j_integral_2d_block_restrict_out.csv'
     requirement = 'The domain integral action shall compute the fracture domain integrals including the J integral for problems in which the fracture domains of interest represent a subset of all the domains in the system.'
+    capabilities = 'method!=dbg'
   []
   [j_2d_block_restrict_error]
     type = 'RunException'
@@ -31,6 +33,7 @@
     check_not_exists = 'j_integral_2d_output_vpp_out_*VPP*.csv'
     cli_args = "DomainIntegral/output_vpp=false Outputs/file_base=j_integral_2d_output_vpp_out"
     requirement = 'The domain integral action shall suppress the vector postprocessor output and stop generating a csv file for each integration ring at each time step.'
+    capabilities = 'method!=dbg'
   []
   [j_2d_output_pp]
     type = 'CSVDiff'
@@ -39,30 +42,35 @@
     csvdiff = 'j_integral_2d_output_pp_out.csv'
     cli_args = "DomainIntegral/output_vpp=false Outputs/file_base=j_integral_2d_output_pp_out"
     requirement = 'The domain integral action shall suppress the vector postprocessor output while the postprocessor outputs are not affected.'
+    capabilities = 'method!=dbg'
   []
   [j_2d_small_strain]
     type = 'CSVDiff'
     input = 'j_integral_2d_small_strain.i'
     csvdiff = 'j_integral_2d_small_strain_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D using small strain.'
+    capabilities = 'method!=dbg'
   []
   [j_2d_points]
     type = 'CSVDiff'
     input = 'j_integral_2d_points.i'
     csvdiff = 'j_integral_2d_points_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D at specified points.'
+    capabilities = 'method!=dbg'
   []
   [j_2d_mouth_dir]
     type = 'CSVDiff'
     input = 'j_integral_2d_mouth_dir.i'
     csvdiff = 'j_integral_2d_mouth_dir_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D given a mouth direction.'
+    capabilities = 'method!=dbg'
   []
   [j_2d_topo_q]
     type = 'CSVDiff'
     input = 'j_integral_2d_topo_q_func.i'
     csvdiff = 'j_integral_2d_topo_q_func_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D using the topology type q function.'
+    capabilities = 'method!=dbg'
   []
   [j_3d_as_2d]
     type = 'CSVDiff'
@@ -81,6 +89,7 @@
     input = 'j_integral_3d.i'
     csvdiff = 'j_integral_3d_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 3D.'
+    capabilities = 'method!=dbg'
   []
   [j_3d_noq]
     type = 'CSVDiff'
@@ -88,30 +97,35 @@
     csvdiff = 'j_integral_3d_out.csv'
     prereq = j_3d
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 3D with the q function turned off.'
+    capabilities = 'method!=dbg'
   []
   [j_3d_points]
     type = 'CSVDiff'
     input = 'j_integral_3d_points.i'
     csvdiff = 'j_integral_3d_points_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 3D with specified points.'
+    capabilities = 'method!=dbg'
   []
   [j_3d_mouth_dir]
     type = 'CSVDiff'
     input = 'j_integral_3d_mouth_dir.i'
     csvdiff = 'j_integral_3d_mouth_dir_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 3D given a crack mouth direction.'
+    capabilities = 'method!=dbg'
   []
   [j_3d_mouth_dir_end_dir_vec]
     type = 'CSVDiff'
     input = 'j_integral_3d_mouth_dir_end_dir_vec.i'
     csvdiff = 'j_integral_3d_mouth_dir_end_dir_vec_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 3D given a crack mouth direction and end direction vector.'
+    capabilities = 'method!=dbg'
   []
   [j_3d_topo_q]
     type = 'CSVDiff'
     input = 'j_integral_3d_topo_q_func.i'
     csvdiff = 'j_integral_3d_topo_q_func_out.csv'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 3D with a topology type q function.'
+    capabilities = 'method!=dbg'
   []
   [j_2d_noq]
     type = 'CSVDiff'
@@ -119,6 +133,7 @@
     csvdiff = 'j_integral_2d_out.csv'
     prereq = 'j_2d'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D while supressing the output of the q function values.'
+    capabilities = 'method!=dbg'
   []
   [j_2d_chk_q]
     type = 'Exodiff'
@@ -128,6 +143,7 @@
     prereq = 'j_2d_noq'
     rel_err = 1e-5
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D while outputting the q function values.'
+    capabilities = 'method!=dbg'
   []
   [j_2d_topo_chk_q]
     type = 'Exodiff'
@@ -137,6 +153,7 @@
     prereq = 'j_2d_topo_q'
     rel_err = 1e-5
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 2D with the topology type q function and outputting the values.'
+    capabilities = 'method!=dbg'
   []
   [j_3d_chk_q]
     type = 'Exodiff'
@@ -145,6 +162,7 @@
     exodiff = 'j_integral_3d_out.e'
     prereq = 'j_3d_noq'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 3D while supressing the output of the q values.'
+    capabilities = 'method!=dbg'
   []
   [j_3d_topo_chk_q]
     type = 'Exodiff'
@@ -153,5 +171,6 @@
     exodiff = 'j_integral_3d_topo_q_func_out.e'
     prereq = 'j_3d_topo_q'
     requirement = 'The domain integral action shall compute all of the fracture domain integrals including the J integral for problems in 3D with the topology type q function and outputting the values.'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/j_integral_vtest/tests
+++ b/modules/solid_mechanics/test/tests/j_integral_vtest/tests
@@ -10,6 +10,7 @@
     max_parallel = 1
     requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
                   'including the J integral for surface breaking elliptical cracks.'
+    capabilities = 'method!=dbg'
   []
   [J_ellip_cm]
     type = 'CSVDiff'
@@ -21,6 +22,7 @@
     requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
                   'including the J integral for surface breaking elliptical cracks using the crack '
                   'mouth specification.'
+    capabilities = 'method!=dbg'
   []
   [J_ellip_cm_ad]
     type = 'CSVDiff'
@@ -30,10 +32,10 @@
               'j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_3_0001.csv'
     max_parallel = 1
     valgrind = 'none'
-    capabilities = 'method=opt'
     requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
                   'including the J integral for surface breaking elliptical cracks using the crack '
                   'mouth specification computing the system Jacobian via automatic differentiation.'
+    capabilities = 'method!=dbg'
   []
   [j_ellip_cfp]
     type = 'CSVDiff'
@@ -45,6 +47,7 @@
     requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
                   'including the J integral for surface breaking elliptical cracks with crack face '
                   'pressure.'
+    capabilities = 'method!=dbg'
   []
   [J_ellip_cm_cfp]
     type = 'CSVDiff'
@@ -56,6 +59,7 @@
     requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
                   'including the J integral for surface breaking elliptical cracks with crack face '
                   'pressure and crack mouth boundary specified.'
+    capabilities = 'method!=dbg'
   []
   [c_int_surfbreak_ellip_crack_sym_mm]
     design = 'syntax/DomainIntegral/index.md'
@@ -68,6 +72,7 @@
     heavy = true
     requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
                   'including the C integral for surface breaking elliptical cracks.'
+    capabilities = 'method!=dbg'
   []
 
   [c_int_surfbreak_ellip_crack_sym_mm_ad]
@@ -83,6 +88,7 @@
                   'including the C integral for surface breaking elliptical cracks using automatic '
                   'differentiation.'
     rel_err = 1.0e-4
+    capabilities = 'method!=dbg'
   []
   [j_int_fgm_sif]
     type = 'CSVDiff'
@@ -93,6 +99,7 @@
     requirement = 'The Domain Integral Action shall compute stress intensity factors from the '
                   'interaction integral for a crack perpendicular to a bi-material interface, '
                   'treating the interface as a functionally-graded material.'
+    capabilities = 'method!=dbg'
   []
   [j_int_fgm_sif_error]
     type = 'RunException'
@@ -101,6 +108,7 @@
     requirement = "The Domain Integral shall error out if the user input does not consistently "
                   "define the required material properties to consider extra interaction integral "
                   "terms for functionally graded materials."
+    capabilities = 'method!=dbg'
   []
   [fgm_5]
     issues = '#23313'
@@ -111,6 +119,7 @@
                   'interaction integral, with an added term stemming for spatially varying '
                   'properties, that accounts for the crack perpendicularity to the property grading '
                   'and yield verified results.'
+    capabilities = 'method!=dbg'
   []
   [axisymmetric_solution_tran]
     issues = '#23631'
@@ -119,5 +128,6 @@
     csvdiff = 'axisymmetric_solution_tran_out.csv'
     requirement = 'The Domain Integral Action shall compute verified stress intensity factors from the '
                   'interaction integral for axisymmetric geometries and circumferential cracks.'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/action/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/action/tests
@@ -6,6 +6,7 @@
     design = 'source/actions/TensorMechanicsAction.md'
     requirement = "Can run second order problem without stabilization"
     cli_args = "Physics/SolidMechanics/QuasiStatic/all/volumetric_locking_correction=false"
+    capabilities = 'method!=dbg'
   [../]
   [./with_correction]
     issues = '#20281'

--- a/modules/solid_mechanics/test/tests/lagrangian/axisymmetric_cylindrical/total/analytical/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/axisymmetric_cylindrical/total/analytical/tests
@@ -8,5 +8,6 @@
     requirement = "Small strain solution in 2D axisymmetric RZ coordinates matches analytical "
                   "solution"
     abs_zero = 1e-6
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/action/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/action/tests
@@ -42,6 +42,7 @@
                "Physics/SolidMechanics/QuasiStatic/all/formulation=TOTAL "
                "Physics/SolidMechanics/QuasiStatic/all/volumetric_locking_correction=true"
     design = 'source/actions/TensorMechanicsAction.md'
+    heavy = true
   []
   [action_small_no_stab]
     type = Exodiff
@@ -55,6 +56,7 @@
                "Physics/SolidMechanics/QuasiStatic/all/formulation=TOTAL "
                "Physics/SolidMechanics/QuasiStatic/all/volumetric_locking_correction=false"
     design = 'source/actions/TensorMechanicsAction.md'
+    heavy = true
   []
   [action_1D]
     type = Exodiff

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/convergence/3D/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/convergence/3D/tests
@@ -7,6 +7,7 @@
     csvdiff = 'dirichlet_out.csv'
     requirement = "Quadratic convergence in 3D for DirichletBCs with the total Lagrangian "
                   "formulation, SMP matches FDP."
+    capabilities = 'method!=dbg'
   []
   [neumann]
     type = CSVDiff
@@ -14,5 +15,6 @@
     csvdiff = 'neumann_out.csv'
     requirement = "Quadratic convergence in 3D for NeumannBCs with the total Lagrangian formulation, "
                   "SMP matches FDP."
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/convergence/L/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/convergence/L/tests
@@ -9,6 +9,7 @@
                   "complicated geometry for small deformations with the total Lagrangian "
                   "formulation, SMP matches FDP."
     valgrind = HEAVY
+    capabilities = 'method!=dbg'
   []
   [L-small]
     type = CSVDiff
@@ -18,5 +19,6 @@
                   "complicated geometry for large deformations with the total Lagrangian "
                   "formulation, SMP matches FDP."
     valgrind = HEAVY
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/cross_material/correctness/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/cross_material/correctness/tests
@@ -7,5 +7,6 @@
     csvdiff = 'plastic_j2_out.csv'
     requirement = "Resulting flow curve matches analytic calculation with the total Lagrangian "
                   "formulation"
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/action/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/action/tests
@@ -8,6 +8,7 @@
     requirement = "Action produces identical results for a 3D, large deformation problem with mixed "
                   "constraints compared to a case where the components are specified manually."
     abs_zero = 1e-6
+    heavy = true
   []
   [compare_2d]
     type = Exodiff
@@ -16,5 +17,6 @@
     requirement = "Action produces identical results for a 2D, small deformation problem with mixed "
                   "constraints compared to a case where the components are specific manually."
     abs_zero = 1e-6
+    heavy = true
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/large-tests/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/large-tests/tests
@@ -26,6 +26,7 @@
                "none none none none' targets='strain11 strain21 strain12 strain22'"
     requirement = "Homogenization with strain constraints hits the targets in 2D using large "
                   "kinematics"
+    capabilities = 'method!=dbg'
   []
   [2d-stress]
     type = CSVDiff
@@ -35,6 +36,7 @@
                "none none none none' targets='stress11 stress21 0 stress22'"
     requirement = "Homogenization with stress constraints hits the targets in 2D using large "
                   "kinematics"
+    capabilities = 'method!=dbg'
   []
 
   [3d-strain]
@@ -46,6 +48,7 @@
                "strain32 strain13 strain23 strain33'"
     requirement = "Homogenization with strain constraints hits the targets in 3D using large "
                   "kinematics"
+    capabilities = 'method!=dbg'
   []
   [3d-stress]
     type = CSVDiff
@@ -56,5 +59,6 @@
                "stress23 stress33'"
     requirement = "Homogenization with stress constraints hits the targets in 3D using large "
                   "kinematics"
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/small-tests/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/small-tests/tests
@@ -51,6 +51,7 @@
                "none strain strain strain' targets='strain11 strain12 strain22 strain13 strain23 "
                "strain33'"
     requirement = "Homogenization with strain constraints hits the targets in 3D"
+    capabilities = 'method!=dbg'
   []
   [3d-stress]
     type = CSVDiff
@@ -60,6 +61,7 @@
                "none stress stress stress' targets='stress11 stress12 stress22 stress13 stress23 "
                "stress33'"
     requirement = "Homogenization with stress constraints hits the targets in 3D"
+    capabilities = 'method!=dbg'
   []
   [3d-mixed]
     type = CSVDiff
@@ -69,5 +71,6 @@
                "stress stress stress' targets='stress11 strain12 strain22 stress13 stress23 "
                "stress33'"
     requirement = "Homogenization with mixed stress and strain constraints hits the targets in 3D"
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/planar/generalized_plane_strain/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/planar/generalized_plane_strain/tests
@@ -8,5 +8,6 @@
     issues = '#21757'
     design = 'source/kernels/lagrangian/TotalLagrangianWeakPlaneStress.md'
     requirement = '2D generalized plane strain solution shall match the 3D results in the limit of infinite thickness.'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/rates/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/rates/tests
@@ -8,6 +8,7 @@
     csvdiff = 'truesdell_shear_out.csv'
     requirement = "Classical Truesdell response to pure shear matches known solution"
     abs_zero = 1e-6
+    capabilities = 'method!=dbg'
   []
   [jaumann_shear]
     type = CSVDiff
@@ -16,6 +17,7 @@
     csvdiff = 'jaumann_shear_out.csv'
     requirement = "Classical Jaumann response to pure shear matches known solution"
     abs_zero = 1e-6
+    capabilities = 'method!=dbg'
   []
   [green_naghdi_shear]
     type = CSVDiff
@@ -24,6 +26,7 @@
     csvdiff = 'green_naghdi_shear_out.csv'
     requirement = "Classical Green-Naghdi response to pure shear matches known solution"
     abs_zero = 1e-6
+    capabilities = 'method!=dbg'
   []
   [truesdell_rotation]
     type = CSVDiff

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/special/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/special/tests
@@ -15,6 +15,7 @@
     requirement = "Stress state correctly rotates from step 10 to the final step"
     issues = '#17472'
     design = 'source/materials/lagrangian/ComputeLagrangianObjectiveStress.md'
+    capabilities = 'method!=dbg'
   []
   [truesdell]
     type = Exodiff

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/updated/action/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/updated/action/tests
@@ -41,6 +41,7 @@
                "Physics/SolidMechanics/QuasiStatic/all/strain=SMALL "
                "Physics/SolidMechanics/QuasiStatic/all/formulation=UPDATED "
                "Physics/SolidMechanics/QuasiStatic/all/volumetric_locking_correction=true"
+    capabilities = 'method!=dbg'
   []
   [action_small_no_stab]
     type = Exodiff
@@ -53,6 +54,7 @@
                "Physics/SolidMechanics/QuasiStatic/all/strain=SMALL "
                "Physics/SolidMechanics/QuasiStatic/all/formulation=UPDATED "
                "Physics/SolidMechanics/QuasiStatic/all/volumetric_locking_correction=false"
+    capabilities = 'method!=dbg'
   []
   [action_1D]
     type = Exodiff

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/updated/convergence/3D/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/updated/convergence/3D/tests
@@ -7,6 +7,7 @@
     csvdiff = 'dirichlet_out.csv'
     requirement = "Quadratic convergence in 3D for DirichletBCs with the updated Lagrangian "
                   "formulation, SMP matches FDP."
+    heavy = true
   []
   [neumann]
     type = CSVDiff
@@ -14,5 +15,6 @@
     csvdiff = 'neumann_out.csv'
     requirement = "Quadratic convergence in 3D for NeumannBCs with the updated Lagrangian "
                   "formulation, SMP matches FDP."
+    heavy = true
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/updated/convergence/L/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/updated/convergence/L/tests
@@ -21,5 +21,6 @@
                   "displacement boundary conditions for large deformation, and the preconditioning "
                   "for a single matrix shall match finite-difference preconditioning results."
     valgrind = HEAVY
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/updated/cross_material/correctness/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/updated/cross_material/correctness/tests
@@ -7,5 +7,6 @@
     csvdiff = 'plastic_j2_out.csv'
     requirement = "Resulting flow curve matches analytic calculation with the updated Lagrangian "
                   "formulation"
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/updated/special/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/updated/special/tests
@@ -14,6 +14,7 @@
     csvdiff = 'rotate_out.csv'
     requirement = "Stress state correctly rotates from step 10 to the final step with the updated "
                   "Lagrangian formulation"
+    capabilities = 'method!=dbg'
   []
   [truesdell]
     type = Exodiff

--- a/modules/solid_mechanics/test/tests/lagrangian/materials/correctness/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/materials/correctness/tests
@@ -57,6 +57,7 @@
     abs_zero = 1e-9
     requirement = 'Stress matches exact analytic solution for elastoplasticity with linear hardening'
     design = 'source/materials/lagrangian/ComputeSimoHughesJ2PlasticityStress.md'
+    capabilities = 'method!=dbg'
   []
   [elastoplastic_powerlaw_hardening]
     type = CSVDiff
@@ -67,5 +68,6 @@
     abs_zero = 1e-9
     requirement = 'Stress matches exact analytic solution for elastoplasticity with power-law hardening'
     design = 'source/materials/lagrangian/ComputeSimoHughesJ2PlasticityStress.md'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/line_material_rank_two_sampler/tests
+++ b/modules/solid_mechanics/test/tests/line_material_rank_two_sampler/tests
@@ -8,6 +8,7 @@
     requirement = "The system shall allow sampling of material properties derived
                    from rank two tensors along a line and output those
                    quantities via a vectorpostprocessor."
+    capabilities = 'method!=dbg'
   [../]
   [./rank_two_scalar_sampler]
     type = 'CSVDiff'
@@ -16,5 +17,6 @@
     design = 'source/vectorpostprocessors/LineMaterialRankTwoScalarSampler.md'
     requirement = "The system shall allow sampling of scalar material properties along a
                    line and output those quantities via a vectorpostprocessor."
+    capabilities = 'method!=dbg'
   [../]
 []

--- a/modules/solid_mechanics/test/tests/mandel_notation/tests
+++ b/modules/solid_mechanics/test/tests/mandel_notation/tests
@@ -27,6 +27,7 @@
       input = finite_elastic.i
       exodiff = finite_elastic_out.e
       detail = 'with full tensors'
+      capabilities = 'method!=dbg'
     []
     [symmetric_tensor]
       type = Exodiff

--- a/modules/solid_mechanics/test/tests/material_limit_time_step/creep/tests
+++ b/modules/solid_mechanics/test/tests/material_limit_time_step/creep/tests
@@ -6,9 +6,9 @@
     exodiff = 'nafems_test5a_lim_out.e'
     rel_err = 4e-5
     abs_zero = 1e-8
-    capabilities = 'superlu'
     issues = '#8553'
     requirement = 'The system shall compute a timestep size that is limited by a power law creep model and a specified maximum inelastic strain increment.'
+    capabilities = 'superlu & method!=dbg'
   [../]
   [./test5a_lim_on_initial]
     type = 'CSVDiff'
@@ -16,11 +16,11 @@
     cli_args = 'Postprocessors/matl_ts_min/execute_on="initial timestep_end"
     Outputs/file_base=nafems_test5a_lim_on_initial_out'
     csvdiff = 'nafems_test5a_lim_on_initial_out.csv'
-    capabilities = 'superlu'
     override_columns = '_dt elas_str_yy matl_ts_min'
     override_rel_err = '4e-5 4e-5 4e-5'
     override_abs_zero = '1e-8 1e-10 1e-10'
     issues = '#10382'
     requirement = 'The system shall not impose a limit on the time step during the initial evaluation when the creep limiting time step option is used.'
+    capabilities = 'superlu & method!=dbg'
   [../]
 []

--- a/modules/solid_mechanics/test/tests/mohr_coulomb/tests
+++ b/modules/solid_mechanics/test/tests/mohr_coulomb/tests
@@ -26,6 +26,7 @@
     csvdiff = 'small_deform2.csv'
     rel_err = 1.0E-5
     abs_zero = 1.0E-5
+    capabilities = 'method!=dbg'
   [../]
   [./small2_small_strain]
     type = 'CSVDiff'
@@ -33,6 +34,7 @@
     csvdiff = 'small_deform2_small_strain.csv'
     rel_err = 1.0E-5
     abs_zero = 1.0E-5
+    capabilities = 'method!=dbg'
   [../]
   [./small3]
     type = 'CSVDiff'

--- a/modules/solid_mechanics/test/tests/multi_power_law/tests
+++ b/modules/solid_mechanics/test/tests/multi_power_law/tests
@@ -8,6 +8,7 @@
     valgrind = HEAVY
     requirement = "The AD multiple power law creep must reproduce the results of the AD single power "
                   "law creep: Reference results."
+    capabilities = 'method!=dbg'
   []
   [multipowerlaw]
     type = 'Exodiff'
@@ -19,6 +20,7 @@
     valgrind = HEAVY
     requirement = "The AD multiple power law creep must reproduce the results of the AD single power "
                   "law creep when a single stress increment is provided by the user."
+    capabilities = 'method!=dbg'
   []
   [multipowerlaw_two_intervals]
     type = 'Exodiff'
@@ -30,6 +32,7 @@
     valgrind = HEAVY
     requirement = "The AD multiple power law creep must reproduce the results of the AD single power "
                   "law creep with multiple stress intervals with same power law material parameters."
+    capabilities = 'method!=dbg'
   []
   [multipowerlaw_two_intervals_no_continuity]
     type = 'Exodiff'
@@ -41,6 +44,7 @@
     abs_zero = 1.0e-4
     rel_err = 5.0e-4
     requirement = "The AD multiple power law creep must avoid regression for a simple few-element problem whose solution has stress levels encompassing two different sets of power law parameters"
+    capabilities = 'method!=dbg'
   []
   [multipowerlaw_user_input_error]
     type = 'RunException'
@@ -51,5 +55,6 @@
               Outputs/file_base=multi_power_law_creep_two_intervals_different_no_continuity_out"
 
     requirement = "Stress thresholds must be provided in increasing order, otherwise an error will inform the user of such a requirement. "
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/power_law_creep/tests
+++ b/modules/solid_mechanics/test/tests/power_law_creep/tests
@@ -87,6 +87,7 @@
       input = 'ad_power_law_creep.i'
       exodiff = 'ad_power_law_creep_out.e'
       detail = 'that works with a finite strain formulation.'
+      capabilities = 'method!=dbg'
     []
     [restart1]
       type = 'RunApp'
@@ -134,6 +135,7 @@
     design = 'CompositePowerLawCreepStressUpdate.md'
     requirement = "The system shall provide a phase-dependent power law creep that computes the strain with different material properties."
     issues = '#28368'
+    capabilities = 'method!=dbg'
   []
   [composite_power_law_creep_single_material]
     type = 'CSVDiff'
@@ -142,6 +144,7 @@
     design = 'CompositePowerLawCreepStressUpdate.md'
     requirement = "The system shall provide a phase-dependent power law creep that gives the same output as power_law_creep.i if given the same materials to all the phases."
     issues = '#28368'
+    capabilities = 'method!=dbg'
   []
   [composite_power_law_creep_small_strain]
     type = 'CSVDiff'
@@ -150,6 +153,7 @@
     design = 'CompositePowerLawCreepStressUpdate.md'
     requirement = "The system shall provide a phase-dependent power law creep that works with small strain."
     issues = '#28368'
+    capabilities = 'method!=dbg'
   []
   [composite_power_law_creep_plasticity]
     type = 'CSVDiff'
@@ -158,6 +162,7 @@
     design = 'CompositePowerLawCreepStressUpdate.md'
     requirement = "The system shall provide a phase-dependent power law creep that works with plasticity."
     issues = '#28368'
+    capabilities = 'method!=dbg'
   []
   [composite_power_law_creep_onePhaseMulti]
     type = 'CSVDiff'
@@ -166,6 +171,7 @@
     design = 'CompositePowerLawCreepStressUpdate.md'
     requirement = "The system shall provide a phase-dependent power law creep that works for when one phase has multiple plasticity rule, and another phase does not have plasticity"
     issues = '#28368'
+    capabilities = 'method!=dbg'
   []
   [except_composite_power_law_activation_energy]
     type = 'RunException'

--- a/modules/solid_mechanics/test/tests/preconditioner_reuse/tests
+++ b/modules/solid_mechanics/test/tests/preconditioner_reuse/tests
@@ -7,6 +7,7 @@
     csvdiff = base_case.csv
     requirement = 'Convergence matches previous version of MOOSE without the '
                   'preconditioner reuse system'
+    capabilities = 'method!=dbg'
   []
   [with_reuse]
     type = CSVDiff
@@ -16,5 +17,6 @@
     requirement = 'Preconditioner is reused until the linear iterations exceed '
                   'the value of reuse_preconditioner_max_its upon which the '
                   'system recalculates the preconditioner'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/radial_disp_aux/tests
+++ b/modules/solid_mechanics/test/tests/radial_disp_aux/tests
@@ -20,6 +20,7 @@
     exodiff = 'cylinder_3d_cartesian_out.e'
     design = 'RadialDisplacementCylinderAux.md'
     requirement = 'The system shall compute the radial component of displacement for 3D Cartesian cylindrical models'
+    capabilities = 'method!=dbg'
   [../]
   [./sphere_1d_spherical]
     type = 'Exodiff'
@@ -41,6 +42,7 @@
     exodiff = 'sphere_3d_cartesian_out.e'
     design = 'RadialDisplacementSphereAux.md'
     requirement = 'The system shall compute the radial component of displacement for 3D Cartesian spherical models'
+    capabilities = 'method!=dbg'
   [../]
 
   [./sphere_1d_spherical_except_1]

--- a/modules/solid_mechanics/test/tests/rate_independent_cyclic_hardening/tests
+++ b/modules/solid_mechanics/test/tests/rate_independent_cyclic_hardening/tests
@@ -7,6 +7,7 @@
     input = 'linear_kinharden_nonsymmetric_strain_controlled.i'
     csvdiff = 'linear_kinharden_nonsymmetric_strain_controlled_out.csv'
     requirement = 'The system shall compute the J2 linear kinematic plasticity stress based on the imposed cyclic nonsymmetric strain'
+    capabilities = 'method!=dbg'
   []
   [linear_kinharden_symmetric_strain_controlled]
     type = CSVDiff
@@ -14,6 +15,7 @@
     input = 'linear_kinharden_symmetric_strain_controlled.i'
     csvdiff = 'linear_kinharden_symmetric_strain_controlled_out.csv'
     requirement = 'The system shall compute the J2 linear kinematic plasticity stress based on the imposedcyclic symmetric strain'
+    capabilities = 'method!=dbg'
   []
   [nonlin_isoharden_symmetric_strain_controlled]
     type = CSVDiff
@@ -21,6 +23,7 @@
     input = 'nonlin_isoharden_symmetric_strain_controlled.i'
     csvdiff = 'nonlin_isoharden_symmetric_strain_controlled_out.csv'
     requirement = 'The system shall compute the J2 nonlinear isotropic plasticity stress based on the imposedcyclic symmetric strain'
+    capabilities = 'method!=dbg'
   []
   [nonlin_isokinharden_symmetric_strain_controlled]
     type = CSVDiff
@@ -28,6 +31,7 @@
     input = 'nonlin_isokinharden_symmetric_strain_controlled.i'
     csvdiff = 'nonlin_isokinharden_symmetric_strain_controlled_out.csv'
     requirement = 'The system shall compute the J2 nonlinear combined plasticity stress based on the imposed cyclic symmetric strain'
+    capabilities = 'method!=dbg'
   []
   [nonlin_kinharden_nonsymmetric_strain_controlled]
     type = CSVDiff
@@ -35,6 +39,7 @@
     input = 'nonlin_kinharden_nonsymmetric_strain_controlled.i'
     csvdiff = 'nonlin_kinharden_nonsymmetric_strain_controlled_out.csv'
     requirement = 'The system shall compute the J2 nonlinear kinematic plasticity stress based on the imposed cyclic nonsymmetric strain'
+    capabilities = 'method!=dbg'
   []
   [nonlin_kinharden_symmetric_strain_controlled]
     type = CSVDiff
@@ -42,6 +47,7 @@
     input = 'nonlin_kinharden_symmetric_strain_controlled.i'
     csvdiff = 'nonlin_kinharden_symmetric_strain_controlled_out.csv'
     requirement = 'The system shall compute the J2 nonlinear kinematic plasticity stress based on the imposed cyclic symmetric strain'
+    capabilities = 'method!=dbg'
   []
   [1D_ratcheting_nonlin_kinharden_stress_controlled]
     type = CSVDiff
@@ -49,6 +55,7 @@
     input = '1D_ratcheting_nonlin_kinharden_stress_controlled.i'
     csvdiff = '1D_ratcheting_nonlin_kinharden_stress_controlled_out.csv'
     requirement = 'The system shall compute the J2 nonlinear kinematic plasticity strain based on the imposed cyclic nonsymmetric loading'
+    capabilities = 'method!=dbg'
   []
   [linear_kinharden_nonsymmetric_stress_controlled]
     type = CSVDiff
@@ -56,5 +63,6 @@
     input = 'linear_kinharden_nonsymmetric_stress_controlled.i'
     csvdiff = 'linear_kinharden_nonsymmetric_stress_controlled_out.csv'
     requirement = 'The system shall compute the J2 linear kinematic plasticity strain based on the imposed cyclic nonsymmetric loading'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/rom_stress_update/tests
+++ b/modules/solid_mechanics/test/tests/rom_stress_update/tests
@@ -119,6 +119,7 @@
       csvdiff = creep_ramp_sub_false_more_steps_out.csv
       allow_test_objects = true
       detail = 'when substepping is off and the time step size guarantees accurate results.'
+      capabilities = 'method!=dbg'
     []
     [creep_ramp_sub_true]
       type = 'CSVDiff'
@@ -136,6 +137,7 @@
       allow_test_objects = true
       allow_warnings = true
       detail = 'when substepping is on and the numerical integration error selected by the user guarantees accurate results but substepping settings require a system-wise time step cut because the computed number of substeps exceeds the maximum_number_substeps parameter.'
+      capabilities = 'method!=dbg'
     []
 
     [3tile]
@@ -185,6 +187,7 @@
       cli_args = 'Outputs/file_base=3d_out'
       detail = 'in 3D.'
       allow_test_objects = true
+      capabilities = 'method!=dbg'
     []
     [3d_MPA]
       type = 'CSVDiff'
@@ -194,6 +197,7 @@
       csvdiff = '3d_out.csv'
       detail = 'with units of stress other than Pascal.'
       allow_test_objects = true
+      capabilities = 'method!=dbg'
     []
     [3d-jac]
       type = 'PetscJacobianTester'
@@ -215,6 +219,7 @@
       cli_args = 'Outputs/file_base=2drz_out'
       detail = 'in 2DRz.'
       allow_test_objects = true
+      capabilities = 'method!=dbg'
     []
     [2drz-jac]
       type = 'PetscJacobianTester'

--- a/modules/solid_mechanics/test/tests/scalar_material_damage/tests
+++ b/modules/solid_mechanics/test/tests/scalar_material_damage/tests
@@ -189,6 +189,7 @@
     recover = false
     requirement = "The system shall calculate the effect of damage on the stress of a nonlocal damage model."
     issues = '#21786'
+    capabilities = 'method!=dbg'
   []
   [ad_nonlocal_damage_model]
     type = 'CSVDiff'
@@ -199,5 +200,6 @@
     requirement = "The system shall calculate the effect of damage on the stress of a nonlocal damage model. "
     "When using automatic differentiation."
     issues = '#21786'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/shell/dynamics/tests
+++ b/modules/solid_mechanics/test/tests/shell/dynamics/tests
@@ -39,5 +39,6 @@
     requirement = "The mechanics system shall accurately predict the dynamic behavior of a shell "
                   "element."
     issues = "#15067"
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/shell/static/tests
+++ b/modules/solid_mechanics/test/tests/shell/static/tests
@@ -20,6 +20,7 @@
     input = 'large_strain_m_40_AD.i'
     exodiff = 'large_strain_m_40_AD_out.e'
     requirement = "The mechanics system shall accurately compute the deflection of a cantilever beam when it is modeled using shell elements under large strain and rotations are included."
+    capabilities = 'method!=dbg'
   []
   [beam_bending_jacobian]
     type = 'PetscJacobianTester'
@@ -53,6 +54,7 @@
     input = pinched_cylinder_symm.i
     csvdiff = 'pinched_cylinder_symm_out.csv'
     requirement = "The mechanics system shall converge to the analytic displacement of a cylinder modeled with shell elements, with point loading applied in the x direction."
+    capabilities = 'method!=dbg'
   []
   [pinched_cylinder_y]
     type = 'CSVDiff'
@@ -60,6 +62,7 @@
     cli_args = "DiracKernels/point/variable=disp_y DiracKernels/point/point='0 1 1' Outputs/file_base=pinched_cylinder_symm_y_out"
     csvdiff = 'pinched_cylinder_symm_y_out.csv'
     requirement = "The mechanics system shall converge to the analytic displacement of a cylinder modeled with shell elements, with point loading applied in the y direction."
+    capabilities = 'method!=dbg'
   []
   [inclined_plane]
     type = 'Exodiff'
@@ -110,18 +113,21 @@
     input = pinched_cylinder_symm_unstructured.i
     exodiff = 'pinched_cylinder_symm_unstructured_out.e'
     requirement = "Shell elements should have compatible stresses even for unstructured meshes."
+    capabilities = 'method!=dbg'
   []
   [pinched_cylinder_symm_local_stress]
     type = 'Exodiff'
     input = pinched_cylinder_symm_local_stress.i
     exodiff = 'pinched_cylinder_symm_local_stress_out.e'
     requirement = "Shell elements should have compatible local coordinates."
+    capabilities = 'method!=dbg'
   []
   [plate_concentrated_loads]
     type = 'Exodiff'
     input = plate_concentrated_loads.i
     exodiff = 'plate_concentrated_loads_out.e'
     requirement = "Local force and bending moments should be calculated correctly on the shell element"
+    capabilities = 'method!=dbg'
   []
   [inclined_straintest_local_stress]
     type = 'Exodiff'
@@ -139,12 +145,14 @@
     type = 'Exodiff'
     input = tank_shell.i
     exodiff = 'tank_shell_out.e'
+    capabilities = 'method!=dbg'
     requirement = "The mechanics system shall correctly apply pressure loads to a curved geometry represented by shell elements."
   []
   [tank_shell_rotated]
     type = 'Exodiff'
     input = tank_shell_rotated.i
     exodiff = 'tank_shell_rotated_out.e'
+    capabilities = 'method!=dbg'
     requirement = "The mechanics system shall correctly apply pressure loads to a curved geometry represented by shell elements, in a rotated configuration."
   []
   [scordelis_lo_roof_shell]
@@ -152,6 +160,7 @@
     input = scordelis_lo_roof_shell.i
     exodiff = 'scordelis_lo_roof_shell_out.e'
     requirement = "The mechanics system shall correctly model a benchmark problem consisting of a roof-like geometry with a distributed load, modeled with shell elements."
+    capabilities = 'method!=dbg'
   []
   [clamped_plate_flat]
     type = 'Exodiff'

--- a/modules/solid_mechanics/test/tests/smeared_cracking/tests
+++ b/modules/solid_mechanics/test/tests/smeared_cracking/tests
@@ -22,6 +22,7 @@
     exodiff = cracking_function_out.e
     custom_cmp = cracking_function.cmp
     requirement = 'The MOOSE SolidMechanics module shall simulate cracking while the cracking strength is prescribed by an elemental AuxVariable.'
+    capabilities = 'method!=dbg'
   []
   [exponential]
     type = Exodiff
@@ -30,6 +31,7 @@
     custom_cmp = cracking_exponential.cmp
     use_old_floor = true
     requirement = 'The MOOSE SolidMechanics module shall simulate exponential stress release.'
+    capabilities = 'method!=dbg'
   []
   [rz_exponential]
     type = Exodiff
@@ -38,6 +40,7 @@
     custom_cmp = cracking_rz_exp.cmp
     exodiff_opts = '-steps 0:1200:1'
     requirement = 'The MOOSE SolidMechanics module shall simulate exponential stress relase while using the rz coordinate system.'
+    capabilities = 'method!=dbg'
   []
   [power]
     type = Exodiff
@@ -50,6 +53,7 @@
     input = cracking_multiple_softening.i
     exodiff = cracking_multiple_softening_out.e
     requirement = 'The MOOSE SolidMechanics module shall demonstrate the prescribed softening laws in three directions, power law (x), exponential (y), and abrupt (z).'
+    capabilities = 'method!=dbg'
   []
   [xyz]
     type = Exodiff
@@ -58,6 +62,7 @@
     use_old_floor = true
     custom_cmp = cracking_xyz.cmp
     requirement = 'The MOOSE SolidMechanics module shall simulate smeared cracking in the x y and z directions.'
+    capabilities = 'method!=dbg'
   []
   [plane_stress]
     type = Exodiff
@@ -75,6 +80,7 @@
     custom_cmp = cracking_rotation.cmp
     max_parallel = 1
     requirement = 'The MOOSE SolidMechanics module shall demonstrate that the smeared cracking model correctly handles finite rotation of cracked elements.'
+    capabilities = 'method!=dbg'
   []
   [cracking_rotation_pres_dir_x]
     type = Exodiff

--- a/modules/solid_mechanics/test/tests/static_deformations/tests
+++ b/modules/solid_mechanics/test/tests/static_deformations/tests
@@ -15,11 +15,13 @@
     type = 'CSVDiff'
     input = 'cosserat_glide.i'
     csvdiff = 'cosserat_glide_out_soln_0001.csv'
+    capabilities = 'method!=dbg'
   [../]
   [./glide_fake_plastic]
     type = 'CSVDiff'
     input = 'cosserat_glide_fake_plastic.i'
     csvdiff = 'cosserat_glide_fake_plastic_out_soln_0001.csv'
+    capabilities = 'method!=dbg'
   [../]
   [./layered_cosserat_01]
     type = 'CSVDiff'
@@ -43,6 +45,7 @@
     override_columns = 'wc_y'
     override_rel_err = '1e-5'
     override_abs_zero = '5e-6'
+    capabilities = 'method!=dbg'
   [../]
   [./beam_cosserat_01_slippery]
     type = 'CSVDiff'

--- a/modules/solid_mechanics/test/tests/substepping/tests
+++ b/modules/solid_mechanics/test/tests/substepping/tests
@@ -17,6 +17,7 @@
     exodiff = 'ad_power_law_substepping_out.e'
     valgrind = HEAVY
     requirement = 'The system shall converge under large deformation owing to the help of substepping using automatic differentiation'
+    capabilities = 'method!=dbg'
   []
   [ad_power_law_adaptive_substepping_increment]
     # We only check that the simulation converges with adaptive substepping

--- a/modules/solid_mechanics/test/tests/t_stress/tests
+++ b/modules/solid_mechanics/test/tests/t_stress/tests
@@ -8,6 +8,7 @@
     rel_err = 2e-5
     requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
                   'including the T stress for cracks in an infinite plate.'
+    capabilities = 'method!=dbg'
   []
   [t_stress_ellip_crack_3d]
     type = 'CSVDiff'
@@ -21,6 +22,7 @@
     valgrind = 'heavy'
     requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
                   'including the T stress for an elliptical crack in 3D.'
+    capabilities = 'method!=dbg'
   []
   [ad_t_stress_ellip_crack_3d]
     type = 'CSVDiff'

--- a/modules/solid_mechanics/test/tests/temperature_dependent_hardening/tests
+++ b/modules/solid_mechanics/test/tests/temperature_dependent_hardening/tests
@@ -6,6 +6,7 @@
     input = 'temp_dep_hardening.i'
     exodiff = 'temp_dep_hardening_out.e'
     requirement = 'The system shall compute the stress as a function of temperature and plastic strain from user-supplied hardening functions not using automatic differentiation.'
+    capabilities = 'method!=dbg'
   [../]
   [./ADtest]
     issues = '#18454'
@@ -14,5 +15,6 @@
     input = 'ADtemp_dep_hardening.i'
     exodiff = 'temp_dep_hardening_out.e'
     requirement = 'The system shall compute the stress as a function of temperature and plastic strain from user-supplied hardening functions using automatic differentiation.'
+    capabilities = 'method!=dbg'
   [../]
 []

--- a/modules/solid_mechanics/test/tests/thermal_expansion/tests
+++ b/modules/solid_mechanics/test/tests/thermal_expansion/tests
@@ -31,6 +31,7 @@
     requirement = 'The solid mechanics module shall have the capability to combine multiple eigenstrains to correctly calculate an eigenstrain tensor resulting from isotropic thermal expansion when automatic differentiation is requested.'
     design = 'ComputeThermalExpansionEigenstrain.md RankTwoAux.md'
     issues = '#7457'
+    capabilities = 'method!=dbg'
   []
 
   [ad_constant_expansion_coeff]

--- a/modules/solid_mechanics/test/tests/torque/tests
+++ b/modules/solid_mechanics/test/tests/torque/tests
@@ -9,6 +9,7 @@
     requirement = 'The mechanics system shall provide a way to apply a torque to a boundary for small strain simulations.'
     # PR #26848. Clang 16 Apple Si is not compatible.
     machine = X86_64
+    capabilities = 'method!=dbg'
   []
   [ad]
     type = Exodiff
@@ -18,5 +19,6 @@
     requirement = 'The mechanics system shall provide a way to apply a torque to a boundary for small strain simulations with automatic differentiation.'
     # PR #26848. Clang 16 Apple Si is not compatible.
     machine = X86_64
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/torque_reaction/tests
+++ b/modules/solid_mechanics/test/tests/torque_reaction/tests
@@ -24,6 +24,7 @@
     input = 'torque_reaction_cylinder.i'
     exodiff = 'torque_reaction_cylinder_out.e'
     abs_zero = 5.e-7
+    capabilities = 'method!=dbg'
   [../]
   [./disp_about_axis_motion]
     design = DisplacementAboutAxis.md
@@ -34,6 +35,7 @@
     csvdiff = 'disp_about_axis_axial_motion_out.csv'
     rel_err = 1E-5
     abs_zero = 1e-10
+    capabilities = 'method!=dbg'
   [../]
   [./disp_about_axis_motion_incremental]
     design = DisplacementAboutAxis.md
@@ -45,6 +47,7 @@
     rel_err = 1E-5
     abs_zero = 1e-10
     issues = '#15388'
+    capabilities = 'method!=dbg'
   [../]
   [./disp_about_axis_axial_motion_delayed]
     design = DisplacementAboutAxis.md
@@ -55,6 +58,7 @@
     rel_err = 1E-5
     abs_zero = 1e-10
     issues = '#15388'
+    capabilities = 'method!=dbg'
   [../]
   [./disp_about_axis_error1]
     design = DisplacementAboutAxis.md

--- a/modules/solid_mechanics/test/tests/uel/tests
+++ b/modules/solid_mechanics/test/tests/uel/tests
@@ -64,7 +64,7 @@
     requirement = "The system shall be able to solve a simple mechanics problem with small elastic "
                   "deformation with a triangular mesh using MOOSE capabilities."
     # Only test plugins in dbg and opt.
-    capabilities = 'method=dbg | method=opt'
+    capabilities = 'method=opt'
   []
   [small]
     type = Exodiff
@@ -73,8 +73,7 @@
     abs_zero = 5e-12
     requirement = "The system shall be able to solve a simple mechanics problem with small elastic "
                   "deformation with a triangular mesh using a UEL plugin."
-    # Only test plugins in dbg and opt.
-    capabilities = 'method=dbg | method=opt'
+    capabilities = 'method=opt'
     # skip test if test is being run out-of-tree. Issue Ref: #25279
     installation_type = in_tree
   []
@@ -125,8 +124,7 @@
     exodiff = small_test_expanded_umat_out.e
     requirement = 'The Abaqus UMAT interface shall be able to yield the same results for a triangular element as a UEL routine that computes internal forces without calling a UMAT routine or an analogous UEL interface that calls a UMAT routine for computing the stress vector and the Jacobian.'
     abs_zero = 1e-12
-    # Only test plugins in dbg and opt.
-    capabilities = 'method=dbg | method=opt'
+    capabilities = 'method=opt'
     # skip test if test is being run out-of-tree. Issue Ref: #25279
     installation_type = in_tree
   []
@@ -147,8 +145,7 @@
     exodiff = small_test_umat_states_fields_out.e
     requirement = 'The Abaqus UMAT interface shall be able to yield the same results for a triangular element that a UEL routine that computes internal forces, calling a UMAT routine, when the solution depends on system states and two external fields, including temperature.'
     abs_zero = 1e-12
-    # Only test plugins in dbg and opt.
-    capabilities = 'method=dbg | method=opt'
+    capabilities = 'method=opt'
     # skip test if test is being run out-of-tree. Issue Ref: #25279
     installation_type = in_tree
   []
@@ -158,8 +155,7 @@
     exodiff = small_test_umat_states_fields_gradient_out.e
     requirement = 'The Abaqus UMAT interface shall be able to yield the same results for a triangular element that a UEL routine that computes internal forces, calling a UMAT routine, when the solution depends on system states and two external fields, including temperature, which vary significantly with space.'
     abs_zero = 1e-12
-    # Only test plugins in dbg and opt.
-    capabilities = 'method=dbg | method=opt'
+    capabilities = 'method=opt'
     # skip test if test is being run out-of-tree. Issue Ref: #25279
     installation_type = in_tree
   []

--- a/modules/solid_mechanics/test/tests/umat/multiple_blocks/tests
+++ b/modules/solid_mechanics/test/tests/umat/multiple_blocks/tests
@@ -24,6 +24,7 @@
                   'different blocks using distinct interface plug-ins.'
     # skip test if test is being run out-of-tree. Issue Ref: #25279
     installation_type = in_tree
+    capabilities = 'method!=dbg'
   []
   [multiple_blocks_two_materials_parallel]
     type = 'Exodiff'
@@ -36,6 +37,7 @@
                   'different blocks using distinct interface plug-ins in multi processor runs.'
     # skip test if test is being run out-of-tree. Issue Ref: #25279
     installation_type = in_tree
+    capabilities = 'method!=dbg'
   []
   [rve_multimaterial_umat]
     type = 'Exodiff'

--- a/modules/solid_mechanics/test/tests/umat/predef/tests
+++ b/modules/solid_mechanics/test/tests/umat/predef/tests
@@ -23,6 +23,7 @@
     requirement = 'The system shall avoid regression in a simple mechanical problem where a strain field '
                   'modifies the stiffness of the material through CompositeElasticityTensor. This '
                   'test also serves as a reference for UMAT external field verification'
+    capabilities = 'method!=dbg'
   []
   [dpredef]
     type = 'Exodiff'
@@ -61,6 +62,7 @@
                   'two external fields (not temperature) affecting material behavior '
     # skip test if test is being run out-of-tree. Issue Ref: #25279
     installation_type = in_tree
+    capabilities = 'method!=dbg'
   []
   [predef_multiple_reference]
     type = 'Exodiff'
@@ -71,6 +73,7 @@
     requirement = 'The system shall avoid regression in a simple mechanical problem where two strain fields '
                   'modifies the stiffness of the material through CompositeElasticityTensor. This '
                   'test also serves as a reference for UMAT external field verification'
+    capabilities = 'method!=dbg'
   []
   [predef_multiple_mat]
     type = 'Exodiff'
@@ -84,6 +87,7 @@
                   'two external material properties affecting material behavior '
     # skip test if test is being run out-of-tree. Issue Ref: #25279
     installation_type = in_tree
+    capabilities = 'method!=dbg'
   []
   [predef_multiple_reference_mat]
     type = 'Exodiff'
@@ -94,5 +98,6 @@
     requirement = 'The system shall avoid regression in a simple mechanical problem where two strain fields '
                   'modifies the stiffness of the material through CompositeElasticityTensor. This '
                   'test also serves as a reference for UMAT external material property verification'
+    capabilities = 'method!=dbg'
   []
 []

--- a/modules/solid_mechanics/test/tests/volumetric_locking_verification/tests
+++ b/modules/solid_mechanics/test/tests/volumetric_locking_verification/tests
@@ -6,6 +6,7 @@
     exodiff = '42_node_out.e'
     design = 'VolumetricLocking.md'
     requirement = 'The mechanics system shall correctly model the deformation of a 2D membrane with nearly incompressible material when volumetric locking correction is set to true.'
+    capabilities = 'method!=dbg'
   [../]
   [./no_vol_lock_2D]
     type = Exodiff
@@ -15,5 +16,6 @@
     prereq = 'vol_lock_2D'
     design = 'VolumetricLocking.md'
     requirement = 'The mechanics system shall correctly model the locking behavior of a 2D membrane with nearly incompressible material when volumetric locking correction is set to false.'
+    capabilities = 'method!=dbg'
   [../]
 []


### PR DESCRIPTION
Many tests in the solid mechanics run significantly slower in dbg than in opt. This pull request identifies tests that run more than 10x slower in dbg and modify their test spec to be `capabilities = 'method!=dbg'`.

ref #27555