### PR TITLE
Write Console output header to Exodus info

### DIFF
--- a/framework/src/outputs/formatters/ExodusFormatter.C
+++ b/framework/src/outputs/formatters/ExodusFormatter.C
@@ -14,6 +14,7 @@
 #include "SystemInfo.h"
 #include "CommandLine.h"
 #include "ActionWarehouse.h"
+#include "ConsoleUtils.h"
 
 #include "libmesh/exodusII.h"
 
@@ -30,24 +31,10 @@ ExodusFormatter::printInputFile(ActionWarehouse & wh)
       << "# Created by MOOSE #\n"
       << "####################\n";
 
-  // Grab the command line arguments first
-  _ss << "### Command Line Arguments ###\n";
-  if (wh.mooseApp().commandLine())
-  {
-    for (const auto & arg : wh.mooseApp().commandLine()->getArguments())
-      _ss << " " << arg;
-  }
-  if (wh.mooseApp().getSystemInfo() != NULL)
-  {
-    _ss << "### Version Info ###\n"
-        << std::setw(25) << "App Version: " << wh.mooseApp().getVersion() << "\n"
-        << wh.mooseApp().getSystemInfo()->getInfo() << "\n";
-  }
+  // write Console output header info
+  _ss << ConsoleUtils::outputFrameworkInformation(wh.mooseApp());
 
-  _ss << std::left << "### Parallelism ###\n"
-      << std::setw(25) << "Num Processors: " << wh.mooseApp().n_processors() << "\n"
-      << std::setw(25) << "Num Threads: " << libMesh::n_threads() << "\n";
-
+  // write input file syntax
   _ss << "### Input File ###" << std::endl;
   wh.printInputFile(_ss);
 }


### PR DESCRIPTION
## Reason
Would be nice to be able to trace an Exodus file to the MOOSE input file(s) it came from.

## Design
Put the input file(s) location(s) in the Exodus header info like we have in MOOSE stdout.

## Impact
New feature

FYI one can access this information using the SEACAS API method `get_info_records()` [docs](https://sandialabs.github.io/seacas-docs/sphinx/html/exodus.html#exodus.exodus.get_info_records)


closes #30892 