### PR TITLE
Avoid redundancy between  MooseConfig.h and moose.mk

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -295,10 +295,10 @@ LIBRARY_SUFFIX :=
 ifeq ($(MOOSE_HEADER_SYMLINKS),true)
 
 # If we are compiling with header symlinks, we don't want to start compiling any
-# object files until all symlinking is completed. The first dependency in the
+# object files until all symlinking is completed. The second dependency in the
 # list below ensures this.
 
-$(all_app_objects) : | $(app_LINKS) $(moose_config_symlink)
+$(all_app_objects) : $(moose_config_symlink) | $(app_LINKS)
 
 else
 

--- a/framework/build.mk
+++ b/framework/build.mk
@@ -121,23 +121,23 @@ unity_files:
 #
 # C++ rules
 #
-pcre%.$(obj-suffix) : pcre%.cc | prebuild
+pcre%.$(obj-suffix) : pcre%.cc | $(prebuild)
 	@echo "Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(ADDITIONAL_CPPFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -w -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
-gtest%.$(no-method-obj-suffix) : gtest%.cc | prebuild
+gtest%.$(no-method-obj-suffix) : gtest%.cc | $(prebuild)
 	@echo "Compiling C++ "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(ADDITIONAL_CPPFLAGS) $(gtest_INCLUDE) $(CXXFLAGS) -w -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
-%.$(obj-suffix) : %.cc
+%.$(obj-suffix) : %.cc | $(prebuild)
 	@echo "Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(ADDITIONAL_CPPFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 define CXX_RULE_TEMPLATE
-%$(1).$(obj-suffix) : %.C $(ADDITIONAL_SRC_DEPS)
+%$(1).$(obj-suffix) : %.C $(ADDITIONAL_SRC_DEPS) | $(prebuild)
 ifeq ($(1),)
 	@echo "Compiling C++ (in "$$(METHOD)" mode) "$$<"..."
 else
@@ -149,7 +149,7 @@ endef
 # Instantiate Rules
 $(eval $(call CXX_RULE_TEMPLATE,))
 
-%.$(obj-suffix) : %.cpp
+%.$(obj-suffix) : %.cpp | $(prebuild)
 	@echo "Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CXX) $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(ADDITIONAL_CPPFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
@@ -170,12 +170,12 @@ $(eval $(call CXX_RULE_TEMPLATE,))
 # C rules
 #
 
-pcre%.$(obj-suffix) : pcre%.c | prebuild
+pcre%.$(obj-suffix) : pcre%.c | $(prebuild)
 	@echo "Compiling C (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -w -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
-%.$(obj-suffix) : %.c
+%.$(obj-suffix) : %.c | $(prebuild)
 	@echo "Compiling C (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
@@ -315,10 +315,9 @@ endif
 #
 PLUGIN_FLAGS := -shared -fPIC -Wl,-undefined,dynamic_lookup
 
-# we add include/base so that MooseConfig.h can be found, which is absent from the symlink dirs
-%-$(METHOD).plugin : %.C
-	@$(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(PLUGIN_FLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -I $(FRAMEWORK_DIR)/include/base $< -o $@
-%-$(METHOD).plugin : %.c
+%-$(METHOD).plugin : %.C | $(prebuild)
+	@$(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(PLUGIN_FLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $< -o $@
+%-$(METHOD).plugin : %.c | $(prebuild)
 	@echo "Compiling C Plugin (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(PLUGIN_FLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $< -o $@
 %-$(METHOD).plugin : %.f

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 // Libtorch includes
 #include <torch/types.h>
 #include <torch/mps.h>
@@ -88,7 +88,7 @@ class MooseApp : public ConsoleStreamInterface,
                  public MooseBase
 {
 public:
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
   /// Get the device torch is supposed to be running on.
   torch::DeviceType getLibtorchDevice() const { return _libtorch_device; }
 #endif
@@ -1002,7 +1002,7 @@ private:
    */
   void removeRelationshipManager(std::shared_ptr<RelationshipManager> relationship_manager);
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
   /**
    * Function to determine the device which should be used by libtorch on this
    * application. We use this function to decide what is available on different
@@ -1556,7 +1556,7 @@ private:
   /// the backup will not be filled yet.
   std::unique_ptr<Backup> * const _initial_backup;
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
   /// The libtorch device this app is using.
   const torch::DeviceType _libtorch_device;
 #endif

--- a/framework/include/libtorch/controls/LibtorchNeuralNetControl.h
+++ b/framework/include/libtorch/controls/LibtorchNeuralNetControl.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/framework/include/libtorch/materials/TorchScriptMaterial.h
+++ b/framework/include/libtorch/materials/TorchScriptMaterial.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/framework/include/libtorch/postprocessors/LibtorchControlValuePostprocessor.h
+++ b/framework/include/libtorch/postprocessors/LibtorchControlValuePostprocessor.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/framework/include/libtorch/reporters/LibtorchArtificialNeuralNetParameters.h
+++ b/framework/include/libtorch/reporters/LibtorchArtificialNeuralNetParameters.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/framework/include/libtorch/userobjects/TorchScriptUserObject.h
+++ b/framework/include/libtorch/userobjects/TorchScriptUserObject.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/framework/include/libtorch/utils/LibtorchArtificialNeuralNet.h
+++ b/framework/include/libtorch/utils/LibtorchArtificialNeuralNet.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/framework/include/libtorch/utils/LibtorchArtificialNeuralNetTrainer.h
+++ b/framework/include/libtorch/utils/LibtorchArtificialNeuralNetTrainer.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/framework/include/libtorch/utils/LibtorchDataset.h
+++ b/framework/include/libtorch/utils/LibtorchDataset.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/framework/include/libtorch/utils/LibtorchNeuralNetBase.h
+++ b/framework/include/libtorch/utils/LibtorchNeuralNetBase.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/framework/include/libtorch/utils/LibtorchUtils.h
+++ b/framework/include/libtorch/utils/LibtorchUtils.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/framework/include/libtorch/utils/TorchScriptModule.h
+++ b/framework/include/libtorch/utils/TorchScriptModule.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/actions/AddMFEMFESpaceAction.h
+++ b/framework/include/mfem/actions/AddMFEMFESpaceAction.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/actions/AddMFEMPreconditionerAction.h
+++ b/framework/include/mfem/actions/AddMFEMPreconditionerAction.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/actions/AddMFEMProblemOperatorAction.h
+++ b/framework/include/mfem/actions/AddMFEMProblemOperatorAction.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/actions/AddMFEMSolverAction.h
+++ b/framework/include/mfem/actions/AddMFEMSolverAction.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/actions/AddMFEMSubMeshAction.h
+++ b/framework/include/mfem/actions/AddMFEMSubMeshAction.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/actions/SetMFEMMeshFESpaceAction.h
+++ b/framework/include/mfem/actions/SetMFEMMeshFESpaceAction.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/auxkernels/MFEMAuxKernel.h
+++ b/framework/include/mfem/auxkernels/MFEMAuxKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/auxkernels/MFEMCurlAux.h
+++ b/framework/include/mfem/auxkernels/MFEMCurlAux.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "libmesh/ignore_warnings.h"

--- a/framework/include/mfem/auxkernels/MFEMDivAux.h
+++ b/framework/include/mfem/auxkernels/MFEMDivAux.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "libmesh/ignore_warnings.h"

--- a/framework/include/mfem/auxkernels/MFEMGradAux.h
+++ b/framework/include/mfem/auxkernels/MFEMGradAux.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "libmesh/ignore_warnings.h"

--- a/framework/include/mfem/bcs/MFEMBoundaryCondition.h
+++ b/framework/include/mfem/bcs/MFEMBoundaryCondition.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/bcs/MFEMBoundaryIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMBoundaryIntegratedBC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMIntegratedBC.h"

--- a/framework/include/mfem/bcs/MFEMBoundaryNormalIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMBoundaryNormalIntegratedBC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMIntegratedBC.h"

--- a/framework/include/mfem/bcs/MFEMConvectiveHeatFluxBC.h
+++ b/framework/include/mfem/bcs/MFEMConvectiveHeatFluxBC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMIntegratedBC.h"

--- a/framework/include/mfem/bcs/MFEMEssentialBC.h
+++ b/framework/include/mfem/bcs/MFEMEssentialBC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMBoundaryCondition.h"

--- a/framework/include/mfem/bcs/MFEMIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMIntegratedBC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMBoundaryCondition.h"

--- a/framework/include/mfem/bcs/MFEMScalarDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMScalarDirichletBC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMEssentialBC.h"

--- a/framework/include/mfem/bcs/MFEMVectorBoundaryIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorBoundaryIntegratedBC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMIntegratedBC.h"

--- a/framework/include/mfem/bcs/MFEMVectorDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorDirichletBC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/bcs/MFEMVectorDirichletBCBase.h
+++ b/framework/include/mfem/bcs/MFEMVectorDirichletBCBase.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/bcs/MFEMVectorNormalDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorNormalDirichletBC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/bcs/MFEMVectorTangentialDirichletBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorTangentialDirichletBC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/containers/MFEMContainers.h
+++ b/framework/include/mfem/containers/MFEMContainers.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include <map>

--- a/framework/include/mfem/equation_systems/EquationSystem.h
+++ b/framework/include/mfem/equation_systems/EquationSystem.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "libmesh/ignore_warnings.h"

--- a/framework/include/mfem/executioners/MFEMExecutioner.h
+++ b/framework/include/mfem/executioners/MFEMExecutioner.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "Executioner.h"

--- a/framework/include/mfem/executioners/MFEMSteady.h
+++ b/framework/include/mfem/executioners/MFEMSteady.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMExecutioner.h"

--- a/framework/include/mfem/executioners/MFEMTransient.h
+++ b/framework/include/mfem/executioners/MFEMTransient.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMExecutioner.h"

--- a/framework/include/mfem/fespaces/MFEMFESpace.h
+++ b/framework/include/mfem/fespaces/MFEMFESpace.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "libmesh/ignore_warnings.h"

--- a/framework/include/mfem/fespaces/MFEMGenericFESpace.h
+++ b/framework/include/mfem/fespaces/MFEMGenericFESpace.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMFESpace.h"

--- a/framework/include/mfem/fespaces/MFEMScalarFESpace.h
+++ b/framework/include/mfem/fespaces/MFEMScalarFESpace.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSimplifiedFESpace.h"

--- a/framework/include/mfem/fespaces/MFEMSimplifiedFESpace.h
+++ b/framework/include/mfem/fespaces/MFEMSimplifiedFESpace.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMFESpace.h"

--- a/framework/include/mfem/fespaces/MFEMVectorFESpace.h
+++ b/framework/include/mfem/fespaces/MFEMVectorFESpace.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSimplifiedFESpace.h"

--- a/framework/include/mfem/functormaterials/MFEMFunctorMaterial.h
+++ b/framework/include/mfem/functormaterials/MFEMFunctorMaterial.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/functormaterials/MFEMGenericFunctorMaterial.h
+++ b/framework/include/mfem/functormaterials/MFEMGenericFunctorMaterial.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMFunctorMaterial.h"

--- a/framework/include/mfem/functormaterials/MFEMGenericFunctorVectorMaterial.h
+++ b/framework/include/mfem/functormaterials/MFEMGenericFunctorVectorMaterial.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMFunctorMaterial.h"

--- a/framework/include/mfem/ics/MFEMInitialCondition.h
+++ b/framework/include/mfem/ics/MFEMInitialCondition.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMGeneralUserObject.h"

--- a/framework/include/mfem/ics/MFEMScalarIC.h
+++ b/framework/include/mfem/ics/MFEMScalarIC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMInitialCondition.h"

--- a/framework/include/mfem/ics/MFEMVectorIC.h
+++ b/framework/include/mfem/ics/MFEMVectorIC.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMInitialCondition.h"

--- a/framework/include/mfem/integrators/ScaleIntegrator.h
+++ b/framework/include/mfem/integrators/ScaleIntegrator.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMGeneralUserObject.h"

--- a/framework/include/mfem/interfaces/MFEMBlockRestrictable.h
+++ b/framework/include/mfem/interfaces/MFEMBlockRestrictable.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "GeneralUserObject.h"

--- a/framework/include/mfem/interfaces/MFEMBoundaryRestrictable.h
+++ b/framework/include/mfem/interfaces/MFEMBoundaryRestrictable.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "GeneralUserObject.h"

--- a/framework/include/mfem/kernels/MFEMCurlCurlKernel.h
+++ b/framework/include/mfem/kernels/MFEMCurlCurlKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMKernel.h"

--- a/framework/include/mfem/kernels/MFEMDiffusionKernel.h
+++ b/framework/include/mfem/kernels/MFEMDiffusionKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMKernel.h"

--- a/framework/include/mfem/kernels/MFEMDivDivKernel.h
+++ b/framework/include/mfem/kernels/MFEMDivDivKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMKernel.h"

--- a/framework/include/mfem/kernels/MFEMDomainLFKernel.h
+++ b/framework/include/mfem/kernels/MFEMDomainLFKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMKernel.h"

--- a/framework/include/mfem/kernels/MFEMKernel.h
+++ b/framework/include/mfem/kernels/MFEMKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/kernels/MFEMLinearElasticityKernel.h
+++ b/framework/include/mfem/kernels/MFEMLinearElasticityKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMKernel.h"

--- a/framework/include/mfem/kernels/MFEMMassKernel.h
+++ b/framework/include/mfem/kernels/MFEMMassKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMKernel.h"

--- a/framework/include/mfem/kernels/MFEMMixedBilinearFormKernel.h
+++ b/framework/include/mfem/kernels/MFEMMixedBilinearFormKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMKernel.h"

--- a/framework/include/mfem/kernels/MFEMMixedScalarCurlKernel.h
+++ b/framework/include/mfem/kernels/MFEMMixedScalarCurlKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMMixedBilinearFormKernel.h"

--- a/framework/include/mfem/kernels/MFEMMixedVectorGradientKernel.h
+++ b/framework/include/mfem/kernels/MFEMMixedVectorGradientKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMMixedBilinearFormKernel.h"

--- a/framework/include/mfem/kernels/MFEMTimeDerivativeMassKernel.h
+++ b/framework/include/mfem/kernels/MFEMTimeDerivativeMassKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMMassKernel.h"

--- a/framework/include/mfem/kernels/MFEMVectorDomainLFKernel.h
+++ b/framework/include/mfem/kernels/MFEMVectorDomainLFKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMKernel.h"

--- a/framework/include/mfem/kernels/MFEMVectorFEDomainLFKernel.h
+++ b/framework/include/mfem/kernels/MFEMVectorFEDomainLFKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMKernel.h"

--- a/framework/include/mfem/kernels/MFEMVectorFEMassKernel.h
+++ b/framework/include/mfem/kernels/MFEMVectorFEMassKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMKernel.h"

--- a/framework/include/mfem/kernels/MFEMVectorFEWeakDivergenceKernel.h
+++ b/framework/include/mfem/kernels/MFEMVectorFEWeakDivergenceKernel.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMKernel.h"

--- a/framework/include/mfem/mesh/MFEMMesh.h
+++ b/framework/include/mfem/mesh/MFEMMesh.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 //* This file is part of the MOOSE framework
 //* https://mooseframework.inl.gov

--- a/framework/include/mfem/outputs/MFEMConduitDataCollection.h
+++ b/framework/include/mfem/outputs/MFEMConduitDataCollection.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMDataCollection.h"

--- a/framework/include/mfem/outputs/MFEMDataCollection.h
+++ b/framework/include/mfem/outputs/MFEMDataCollection.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "FileOutput.h"

--- a/framework/include/mfem/outputs/MFEMParaViewDataCollection.h
+++ b/framework/include/mfem/outputs/MFEMParaViewDataCollection.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMDataCollection.h"

--- a/framework/include/mfem/outputs/MFEMVisItDataCollection.h
+++ b/framework/include/mfem/outputs/MFEMVisItDataCollection.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMDataCollection.h"

--- a/framework/include/mfem/postprocessors/MFEML2Error.h
+++ b/framework/include/mfem/postprocessors/MFEML2Error.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMPostprocessor.h"

--- a/framework/include/mfem/postprocessors/MFEMPostprocessor.h
+++ b/framework/include/mfem/postprocessors/MFEMPostprocessor.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "Postprocessor.h"

--- a/framework/include/mfem/postprocessors/MFEMVectorL2Error.h
+++ b/framework/include/mfem/postprocessors/MFEMVectorL2Error.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMPostprocessor.h"

--- a/framework/include/mfem/problem/MFEMProblem.h
+++ b/framework/include/mfem/problem/MFEMProblem.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "ExternalProblem.h"

--- a/framework/include/mfem/problem/MFEMProblemData.h
+++ b/framework/include/mfem/problem/MFEMProblemData.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "EquationSystem.h"

--- a/framework/include/mfem/problem_operators/EquationSystemInterface.h
+++ b/framework/include/mfem/problem_operators/EquationSystemInterface.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMProblemData.h"

--- a/framework/include/mfem/problem_operators/EquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/EquationSystemProblemOperator.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "ProblemOperator.h"

--- a/framework/include/mfem/problem_operators/ProblemOperator.h
+++ b/framework/include/mfem/problem_operators/ProblemOperator.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMProblemData.h"

--- a/framework/include/mfem/problem_operators/ProblemOperatorInterface.h
+++ b/framework/include/mfem/problem_operators/ProblemOperatorInterface.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMProblemData.h"

--- a/framework/include/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "TimeDomainProblemOperator.h"

--- a/framework/include/mfem/problem_operators/TimeDomainProblemOperator.h
+++ b/framework/include/mfem/problem_operators/TimeDomainProblemOperator.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMProblemData.h"

--- a/framework/include/mfem/solvers/MFEMCGSolver.h
+++ b/framework/include/mfem/solvers/MFEMCGSolver.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSolverBase.h"

--- a/framework/include/mfem/solvers/MFEMGMRESSolver.h
+++ b/framework/include/mfem/solvers/MFEMGMRESSolver.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSolverBase.h"

--- a/framework/include/mfem/solvers/MFEMHypreADS.h
+++ b/framework/include/mfem/solvers/MFEMHypreADS.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSolverBase.h"

--- a/framework/include/mfem/solvers/MFEMHypreAMS.h
+++ b/framework/include/mfem/solvers/MFEMHypreAMS.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSolverBase.h"

--- a/framework/include/mfem/solvers/MFEMHypreBoomerAMG.h
+++ b/framework/include/mfem/solvers/MFEMHypreBoomerAMG.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSolverBase.h"

--- a/framework/include/mfem/solvers/MFEMHypreFGMRES.h
+++ b/framework/include/mfem/solvers/MFEMHypreFGMRES.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSolverBase.h"

--- a/framework/include/mfem/solvers/MFEMHypreGMRES.h
+++ b/framework/include/mfem/solvers/MFEMHypreGMRES.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSolverBase.h"

--- a/framework/include/mfem/solvers/MFEMHyprePCG.h
+++ b/framework/include/mfem/solvers/MFEMHyprePCG.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSolverBase.h"

--- a/framework/include/mfem/solvers/MFEMOperatorJacobiSmoother.h
+++ b/framework/include/mfem/solvers/MFEMOperatorJacobiSmoother.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSolverBase.h"

--- a/framework/include/mfem/solvers/MFEMSolverBase.h
+++ b/framework/include/mfem/solvers/MFEMSolverBase.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMGeneralUserObject.h"

--- a/framework/include/mfem/solvers/MFEMSuperLU.h
+++ b/framework/include/mfem/solvers/MFEMSuperLU.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSolverBase.h"

--- a/framework/include/mfem/submeshes/MFEMBoundarySubMesh.h
+++ b/framework/include/mfem/submeshes/MFEMBoundarySubMesh.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSubMesh.h"

--- a/framework/include/mfem/submeshes/MFEMDomainSubMesh.h
+++ b/framework/include/mfem/submeshes/MFEMDomainSubMesh.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMSubMesh.h"

--- a/framework/include/mfem/submeshes/MFEMSubMesh.h
+++ b/framework/include/mfem/submeshes/MFEMSubMesh.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include "MFEMGeneralUserObject.h"

--- a/framework/include/mfem/transfers/MFEMSubMeshTransfer.h
+++ b/framework/include/mfem/transfers/MFEMSubMeshTransfer.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/transfers/MultiAppMFEMCopyTransfer.h
+++ b/framework/include/mfem/transfers/MultiAppMFEMCopyTransfer.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include <vector>

--- a/framework/include/mfem/userobjects/MFEMGeneralUserObject.h
+++ b/framework/include/mfem/userobjects/MFEMGeneralUserObject.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/mfem/utils/CoefficientManager.h
+++ b/framework/include/mfem/utils/CoefficientManager.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include <map>

--- a/framework/include/mfem/utils/CoefficientMap.h
+++ b/framework/include/mfem/utils/CoefficientMap.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 #include <map>

--- a/framework/include/mfem/variables/MFEMVariable.h
+++ b/framework/include/mfem/variables/MFEMVariable.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/framework/include/outputs/png/PNGOutput.h
+++ b/framework/include/outputs/png/PNGOutput.h
@@ -8,7 +8,6 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 #pragma once
 
-#include "MooseConfig.h"
 #ifdef MOOSE_HAVE_LIBPNG
 
 // pnglib includes

--- a/framework/include/utils/ADRealForward.h
+++ b/framework/include/utils/ADRealForward.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include "MooseConfig.h"
 #include "libmesh/libmesh_common.h"
 #include "metaphysicl/metaphysicl_version.h"
 

--- a/framework/include/utils/ADUtils.h
+++ b/framework/include/utils/ADUtils.h
@@ -11,7 +11,6 @@
 
 #include "MooseError.h"
 #include "MooseTypes.h"
-#include "MooseConfig.h"
 
 class SubProblem;
 class SystemBase;

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -2318,7 +2318,7 @@ getNullptrExample()
   return nullptr;
 }
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 template <typename T>
 constexpr bool
@@ -2342,7 +2342,7 @@ constexpr bool
 isScalarFunctorNameTypeHelper(T *)
 {
   return std::is_same_v<T, MooseFunctorName>
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
          || std::is_same_v<T, MFEMScalarCoefficientName>
 #endif
       ;
@@ -2359,7 +2359,7 @@ template <typename T>
 constexpr bool
 isVectorFunctorNameTypeHelper(T *)
 {
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
   return std::is_same_v<T, MFEMVectorCoefficientName>;
 #else
   return false;
@@ -2410,7 +2410,7 @@ InputParameters::appendFunctorDescription(const std::string & doc_string) const
 
   return MooseUtils::trim(doc_string, ". ") + ". A functor is any of the following: a variable, " +
          (
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
              Moose::internal::isMFEMFunctorNameTypeHelper(Moose::internal::getNullptrExample<T>())
                  ? "an MFEM"
                  :

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -1175,7 +1175,7 @@ DerivativeStringClass(SolverSystemName);
 /// Command line argument, specialized to handle quotes in vector arguments
 DerivativeStringClass(CLIArgString);
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 /**
  * Coefficients used in input for MFEM residual objects
  */

--- a/framework/include/utils/NumberArrayOps.h
+++ b/framework/include/utils/NumberArrayOps.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include "MooseConfig.h"
 #include "MooseError.h"
 #include "metaphysicl/dualnumberarray.h"
 

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -110,9 +110,6 @@ ifeq ($(ENABLE_LIBTORCH),true)
 	LIBTORCH_LIB := libtorch.$(lib_suffix)
 
   ifneq ($(wildcard $(LIBTORCH_DIR)/lib/$(LIBTORCH_LIB)),)
-    # Enabling parts that have pytorch dependencies
-    libmesh_CXXFLAGS += -DLIBTORCH_ENABLED
-
     # Adding the include directories, we use -isystem to silence the warning coming from
     # libtorch (which would cause errors in the testing phase)
     libmesh_CXXFLAGS += -isystem $(LIBTORCH_DIR)/include/torch/csrc/api/include
@@ -158,9 +155,6 @@ ifeq ($(ENABLE_MFEM),true)
 	MFEM_COMMON_LIB := libmfem-common.$(lib_suffix)
 
   ifneq ($(and $(wildcard $(MFEM_DIR)/lib/$(MFEM_LIB)), $(wildcard $(MFEM_DIR)/lib/$(MFEM_COMMON_LIB))),)
-    # Enabling parts that have MFEM dependencies
-    libmesh_CXXFLAGS += -DMFEM_ENABLED
-
     # Adding the include directories
 	  include $(MFEM_DIR)/share/mfem/config.mk
 	  libmesh_CXXFLAGS += $(MFEM_INCFLAGS)
@@ -250,9 +244,11 @@ gtest_INCLUDE := -I$(gtest_DIR)
 moose_config := $(FRAMEWORK_DIR)/include/base/MooseConfig.h
 moose_default_config := $(FRAMEWORK_DIR)/include/base/MooseDefaultConfig.h
 
-$(moose_config): | prebuild
+$(moose_config):
 	@echo "Copying default MOOSE configuration to: "$@"..."
 	@cp $(moose_default_config) $(moose_config)
+
+libmesh_CPPFLAGS += -imacros $(moose_config)
 
 #
 # header symlinks
@@ -260,7 +256,6 @@ $(moose_config): | prebuild
 ifeq ($(MOOSE_HEADER_SYMLINKS),true)
 
 all_header_dir := $(FRAMEWORK_DIR)/build/header_symlinks
-moose_all_header_dir := $(all_header_dir)
 
 define all_header_dir_rule
 $(1): | prebuild
@@ -293,8 +288,8 @@ endef
 $(eval $(call all_header_dir_rule, $(all_header_dir)))
 $(call symlink_rules, $(all_header_dir), $(include_files))
 
-moose_config_symlink := $(moose_all_header_dir)/MooseConfig.h
-$(moose_config_symlink): $(moose_config) | $(moose_all_header_dir) prebuild
+moose_config_symlink := $(all_header_dir)/MooseConfig.h
+$(moose_config_symlink): $(moose_config) | $(all_header_dir) prebuild
 	@echo "Symlinking MOOSE configure "$(moose_config_symlink)
 	@ln -sf $(moose_config) $(moose_config_symlink)
 
@@ -444,7 +439,7 @@ ifeq (x$(moose_HEADER_deps),x)
   moose_HEADER_deps := $(realpath $(moose_GIT_DIR)/HEAD $(moose_GIT_DIR)/index)
 endif
 
-$(moose_revision_header): $(moose_HEADER_deps) | $(moose_all_header_dir)
+$(moose_revision_header): $(moose_HEADER_deps) | $(all_header_dir)
 	@echo "Checking if header needs updating: "$@"..."
 	$(shell REPO_LOCATION="$(FRAMEWORK_DIR)" \
 	        HEADER_FILE="$(moose_revision_header)" \
@@ -455,8 +450,8 @@ $(moose_revision_header): $(moose_HEADER_deps) | $(moose_all_header_dir)
 	@if [ $(.SHELLSTATUS) -ne 0 ]; then \
 	echo "\nFailed to generate MooseRevision.h\n"; exit $(.SHELLSTATUS); \
 	fi
-	@if [ ! -e "$(moose_all_header_dir)/MooseRevision.h" ]; then \
-		ln -sf $(moose_revision_header) $(moose_all_header_dir); \
+	@if [ ! -e "$(all_header_dir)/MooseRevision.h" ]; then \
+		ln -sf $(moose_revision_header) $(all_header_dir); \
 	fi
 
 # libmesh submodule status
@@ -476,10 +471,19 @@ wasp_submodule_status:
 	@if [ x$(wasp_submodule_message) != "x" ]; then printf $(wasp_submodule_message); exit 1; fi
 
 # Pre-make for checking current dependency versions and showing useful warnings
-# if things like conda packages are out of date. The "-" in "@-" means that
-# it is allowed to not exit 0. "::" means that the rule can be appended by
-# applications that require prebuild steps.
-prebuild::
+# if things like conda packages are out of date. The variable is such that
+# rules can use $(prebuild), instead of prebuild, as a prerequisite. In those
+# cases, if this file, moose.mk, is not included, the variable expands to the
+# empty string, establishing no dependency, and keeping the rule valid. The
+# order-only prerequisite $(moose_config), guarantees _some_ configuration file
+# exists prior to execution of any recipe whose rule depends on prebuild. The
+# responsibility to trigger a rebuild on an update of the configuration file,
+# e.g. via the configure command, lies with normal prerequisites for the rules
+# of targets that actually depend on the contents of the configuration file.
+# The "-" in "@-" means that it is allowed to not exit 0. "::" means that
+# the rule can be appended by applications that require prebuild steps.
+prebuild = prebuild
+prebuild:: | $(moose_config)
 	@-python3 $(FRAMEWORK_DIR)/../scripts/premake.py
 
 wasp_submodule_status $(moose_revision_header) $(moose_LIB): | prebuild
@@ -512,7 +516,6 @@ $(moose_LIB): $(moose_objects) $(pcre_LIB) $(gtest_LIB) $(hit_LIB) $(pyhit_LIB) 
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $(moose_LIB) $(FRAMEWORK_DIR)
 
 ifeq ($(MOOSE_HEADER_SYMLINKS),true)
-
 
 $(moose_objects): $(moose_config_symlink) | moose_header_symlinks
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -807,7 +807,7 @@ MooseApp::registerCapabilities()
 
   {
     const auto doc = "MFEM finite element library";
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
     haveCapability("mfem", doc);
 #else
     missingCapability("mfem",

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -72,7 +72,7 @@
 #include <sys/utsname.h> // utsname
 #endif
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 #include <torch/version.h>
 #endif
 
@@ -501,7 +501,7 @@ MooseApp::MooseApp(const InputParameters & parameters)
     _output_buffer_cache(nullptr),
     _automatic_automatic_scaling(getParam<bool>("automatic_automatic_scaling")),
     _initial_backup(getParam<std::unique_ptr<Backup> *>("_initial_backup"))
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
     ,
     _libtorch_device(determineLibtorchDeviceType(getParam<MooseEnum>("libtorch_device")))
 #endif
@@ -793,7 +793,7 @@ MooseApp::registerCapabilities()
 
   {
     const auto doc = "LibTorch machine learning and parallel tensor algebra library";
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
     addCapability("libtorch", TORCH_VERSION, doc);
 #else
     missingCapability("libtorch",
@@ -3466,7 +3466,7 @@ MooseApp::constructingMeshGenerators() const
          _mesh_generator_system.appendingMeshGenerators();
 }
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 torch::DeviceType
 MooseApp::determineLibtorchDeviceType(const MooseEnum & device_enum) const
 {

--- a/framework/src/libtorch/controls/LibtorchNeuralNetControl.C
+++ b/framework/src/libtorch/controls/LibtorchNeuralNetControl.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchNeuralNetControl.h"
 #include "TorchScriptModule.h"

--- a/framework/src/libtorch/materials/TorchScriptMaterial.C
+++ b/framework/src/libtorch/materials/TorchScriptMaterial.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "TorchScriptMaterial.h"
 

--- a/framework/src/libtorch/postprocessors/LibtorchControlValuePostprocessor.C
+++ b/framework/src/libtorch/postprocessors/LibtorchControlValuePostprocessor.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchControlValuePostprocessor.h"
 

--- a/framework/src/libtorch/reporters/LibtorchArtificialNeuralNetParameters.C
+++ b/framework/src/libtorch/reporters/LibtorchArtificialNeuralNetParameters.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchNeuralNetControl.h"
 #include "LibtorchArtificialNeuralNetParameters.h"

--- a/framework/src/libtorch/userobjects/TorchScriptUserObject.C
+++ b/framework/src/libtorch/userobjects/TorchScriptUserObject.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "TorchScriptUserObject.h"
 

--- a/framework/src/libtorch/utils/LibtorchArtificialNeuralNet.C
+++ b/framework/src/libtorch/utils/LibtorchArtificialNeuralNet.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchArtificialNeuralNet.h"
 #include "MooseError.h"

--- a/framework/src/libtorch/utils/LibtorchArtificialNeuralNetTrainer.C
+++ b/framework/src/libtorch/utils/LibtorchArtificialNeuralNetTrainer.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchArtificialNeuralNetTrainer.h"
 

--- a/framework/src/libtorch/utils/LibtorchUtils.C
+++ b/framework/src/libtorch/utils/LibtorchUtils.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchUtils.h"
 

--- a/framework/src/libtorch/utils/TorchScriptModule.C
+++ b/framework/src/libtorch/utils/TorchScriptModule.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include <torch/torch.h>
 #include "TorchScriptModule.h"

--- a/framework/src/mfem/actions/AddMFEMFESpaceAction.C
+++ b/framework/src/mfem/actions/AddMFEMFESpaceAction.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "AddMFEMFESpaceAction.h"
 

--- a/framework/src/mfem/actions/AddMFEMPreconditionerAction.C
+++ b/framework/src/mfem/actions/AddMFEMPreconditionerAction.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "AddMFEMPreconditionerAction.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/actions/AddMFEMProblemOperatorAction.C
+++ b/framework/src/mfem/actions/AddMFEMProblemOperatorAction.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "AddMFEMProblemOperatorAction.h"
 

--- a/framework/src/mfem/actions/AddMFEMSolverAction.C
+++ b/framework/src/mfem/actions/AddMFEMSolverAction.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "AddMFEMSolverAction.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/actions/AddMFEMSubMeshAction.C
+++ b/framework/src/mfem/actions/AddMFEMSubMeshAction.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "AddMFEMSubMeshAction.h"
 

--- a/framework/src/mfem/actions/SetMFEMMeshFESpaceAction.C
+++ b/framework/src/mfem/actions/SetMFEMMeshFESpaceAction.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "SetMFEMMeshFESpaceAction.h"
 

--- a/framework/src/mfem/auxkernels/MFEMAuxKernel.C
+++ b/framework/src/mfem/auxkernels/MFEMAuxKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMAuxKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/auxkernels/MFEMCurlAux.C
+++ b/framework/src/mfem/auxkernels/MFEMCurlAux.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMCurlAux.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/auxkernels/MFEMDivAux.C
+++ b/framework/src/mfem/auxkernels/MFEMDivAux.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMDivAux.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/auxkernels/MFEMGradAux.C
+++ b/framework/src/mfem/auxkernels/MFEMGradAux.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMGradAux.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/bcs/MFEMBoundaryCondition.C
+++ b/framework/src/mfem/bcs/MFEMBoundaryCondition.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMBoundaryCondition.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/bcs/MFEMBoundaryIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMBoundaryIntegratedBC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMBoundaryIntegratedBC.h"
 

--- a/framework/src/mfem/bcs/MFEMBoundaryNormalIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMBoundaryNormalIntegratedBC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMBoundaryNormalIntegratedBC.h"
 

--- a/framework/src/mfem/bcs/MFEMConvectiveHeatFluxBC.C
+++ b/framework/src/mfem/bcs/MFEMConvectiveHeatFluxBC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMConvectiveHeatFluxBC.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/bcs/MFEMEssentialBC.C
+++ b/framework/src/mfem/bcs/MFEMEssentialBC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMEssentialBC.h"
 

--- a/framework/src/mfem/bcs/MFEMIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMIntegratedBC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMIntegratedBC.h"
 

--- a/framework/src/mfem/bcs/MFEMScalarDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMScalarDirichletBC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMScalarDirichletBC.h"
 

--- a/framework/src/mfem/bcs/MFEMVectorBoundaryIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorBoundaryIntegratedBC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorBoundaryIntegratedBC.h"
 

--- a/framework/src/mfem/bcs/MFEMVectorDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorDirichletBC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorDirichletBC.h"
 

--- a/framework/src/mfem/bcs/MFEMVectorDirichletBCBase.C
+++ b/framework/src/mfem/bcs/MFEMVectorDirichletBCBase.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorDirichletBCBase.h"
 

--- a/framework/src/mfem/bcs/MFEMVectorNormalDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorNormalDirichletBC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorNormalDirichletBC.h"
 

--- a/framework/src/mfem/bcs/MFEMVectorTangentialDirichletBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorTangentialDirichletBC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorTangentialDirichletBC.h"
 

--- a/framework/src/mfem/equation_systems/EquationSystem.C
+++ b/framework/src/mfem/equation_systems/EquationSystem.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "EquationSystem.h"
 #include "libmesh/int_range.h"

--- a/framework/src/mfem/executioners/MFEMExecutioner.C
+++ b/framework/src/mfem/executioners/MFEMExecutioner.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMExecutioner.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/executioners/MFEMSteady.C
+++ b/framework/src/mfem/executioners/MFEMSteady.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMSteady.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/executioners/MFEMTransient.C
+++ b/framework/src/mfem/executioners/MFEMTransient.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMTransient.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/fespaces/MFEMFESpace.C
+++ b/framework/src/mfem/fespaces/MFEMFESpace.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMFESpace.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/fespaces/MFEMGenericFESpace.C
+++ b/framework/src/mfem/fespaces/MFEMGenericFESpace.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMGenericFESpace.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/fespaces/MFEMScalarFESpace.C
+++ b/framework/src/mfem/fespaces/MFEMScalarFESpace.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMScalarFESpace.h"
 

--- a/framework/src/mfem/fespaces/MFEMSimplifiedFESpace.C
+++ b/framework/src/mfem/fespaces/MFEMSimplifiedFESpace.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMSimplifiedFESpace.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/fespaces/MFEMVectorFESpace.C
+++ b/framework/src/mfem/fespaces/MFEMVectorFESpace.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorFESpace.h"
 

--- a/framework/src/mfem/functormaterials/MFEMFunctorMaterial.C
+++ b/framework/src/mfem/functormaterials/MFEMFunctorMaterial.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMFunctorMaterial.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/functormaterials/MFEMGenericFunctorMaterial.C
+++ b/framework/src/mfem/functormaterials/MFEMGenericFunctorMaterial.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMGenericFunctorMaterial.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/functormaterials/MFEMGenericFunctorVectorMaterial.C
+++ b/framework/src/mfem/functormaterials/MFEMGenericFunctorVectorMaterial.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMGenericFunctorVectorMaterial.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/ics/MFEMInitialCondition.C
+++ b/framework/src/mfem/ics/MFEMInitialCondition.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMInitialCondition.h"
 #include <mfem.hpp>

--- a/framework/src/mfem/ics/MFEMScalarIC.C
+++ b/framework/src/mfem/ics/MFEMScalarIC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMScalarIC.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/ics/MFEMVectorIC.C
+++ b/framework/src/mfem/ics/MFEMVectorIC.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorIC.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/integrators/ScaleIntegrator.C
+++ b/framework/src/mfem/integrators/ScaleIntegrator.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "ScaleIntegrator.h"
 

--- a/framework/src/mfem/interfaces/MFEMBlockRestrictable.C
+++ b/framework/src/mfem/interfaces/MFEMBlockRestrictable.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMBlockRestrictable.h"
 

--- a/framework/src/mfem/interfaces/MFEMBoundaryRestrictable.C
+++ b/framework/src/mfem/interfaces/MFEMBoundaryRestrictable.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMBoundaryRestrictable.h"
 

--- a/framework/src/mfem/kernels/MFEMCurlCurlKernel.C
+++ b/framework/src/mfem/kernels/MFEMCurlCurlKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMCurlCurlKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMDiffusionKernel.C
+++ b/framework/src/mfem/kernels/MFEMDiffusionKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMDiffusionKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMDivDivKernel.C
+++ b/framework/src/mfem/kernels/MFEMDivDivKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMDivDivKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMDomainLFKernel.C
+++ b/framework/src/mfem/kernels/MFEMDomainLFKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMDomainLFKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMKernel.C
+++ b/framework/src/mfem/kernels/MFEMKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMLinearElasticityKernel.C
+++ b/framework/src/mfem/kernels/MFEMLinearElasticityKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMLinearElasticityKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMMassKernel.C
+++ b/framework/src/mfem/kernels/MFEMMassKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMMassKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMMixedBilinearFormKernel.C
+++ b/framework/src/mfem/kernels/MFEMMixedBilinearFormKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMMixedBilinearFormKernel.h"
 

--- a/framework/src/mfem/kernels/MFEMMixedScalarCurlKernel.C
+++ b/framework/src/mfem/kernels/MFEMMixedScalarCurlKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMMixedScalarCurlKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMMixedVectorGradientKernel.C
+++ b/framework/src/mfem/kernels/MFEMMixedVectorGradientKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMMixedVectorGradientKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMTimeDerivativeMassKernel.C
+++ b/framework/src/mfem/kernels/MFEMTimeDerivativeMassKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMTimeDerivativeMassKernel.h"
 

--- a/framework/src/mfem/kernels/MFEMVectorDomainLFKernel.C
+++ b/framework/src/mfem/kernels/MFEMVectorDomainLFKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorDomainLFKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMVectorFEDomainLFKernel.C
+++ b/framework/src/mfem/kernels/MFEMVectorFEDomainLFKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorFEDomainLFKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMVectorFEMassKernel.C
+++ b/framework/src/mfem/kernels/MFEMVectorFEMassKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorFEMassKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/kernels/MFEMVectorFEWeakDivergenceKernel.C
+++ b/framework/src/mfem/kernels/MFEMVectorFEWeakDivergenceKernel.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorFEWeakDivergenceKernel.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/mesh/MFEMMesh.C
+++ b/framework/src/mfem/mesh/MFEMMesh.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 //* This file is part of the MOOSE framework
 //* https://mooseframework.inl.gov

--- a/framework/src/mfem/outputs/MFEMConduitDataCollection.C
+++ b/framework/src/mfem/outputs/MFEMConduitDataCollection.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMConduitDataCollection.h"
 

--- a/framework/src/mfem/outputs/MFEMDataCollection.C
+++ b/framework/src/mfem/outputs/MFEMDataCollection.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMDataCollection.h"
 

--- a/framework/src/mfem/outputs/MFEMParaViewDataCollection.C
+++ b/framework/src/mfem/outputs/MFEMParaViewDataCollection.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMParaViewDataCollection.h"
 

--- a/framework/src/mfem/outputs/MFEMVisItDataCollection.C
+++ b/framework/src/mfem/outputs/MFEMVisItDataCollection.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVisItDataCollection.h"
 

--- a/framework/src/mfem/postprocessors/MFEML2Error.C
+++ b/framework/src/mfem/postprocessors/MFEML2Error.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEML2Error.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/postprocessors/MFEMPostprocessor.C
+++ b/framework/src/mfem/postprocessors/MFEMPostprocessor.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMPostprocessor.h"
 

--- a/framework/src/mfem/postprocessors/MFEMVectorL2Error.C
+++ b/framework/src/mfem/postprocessors/MFEMVectorL2Error.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVectorL2Error.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/problem/MFEMProblem.C
+++ b/framework/src/mfem/problem/MFEMProblem.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMProblem.h"
 #include "MFEMInitialCondition.h"

--- a/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "EquationSystemProblemOperator.h"
 

--- a/framework/src/mfem/problem_operators/ProblemOperator.C
+++ b/framework/src/mfem/problem_operators/ProblemOperator.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "ProblemOperator.h"
 

--- a/framework/src/mfem/problem_operators/ProblemOperatorInterface.C
+++ b/framework/src/mfem/problem_operators/ProblemOperatorInterface.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "ProblemOperatorInterface.h"
 

--- a/framework/src/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "TimeDomainEquationSystemProblemOperator.h"
 

--- a/framework/src/mfem/problem_operators/TimeDomainProblemOperator.C
+++ b/framework/src/mfem/problem_operators/TimeDomainProblemOperator.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "TimeDomainProblemOperator.h"
 

--- a/framework/src/mfem/solvers/MFEMCGSolver.C
+++ b/framework/src/mfem/solvers/MFEMCGSolver.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMCGSolver.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/solvers/MFEMGMRESSolver.C
+++ b/framework/src/mfem/solvers/MFEMGMRESSolver.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMGMRESSolver.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/solvers/MFEMHypreADS.C
+++ b/framework/src/mfem/solvers/MFEMHypreADS.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMHypreADS.h"
 

--- a/framework/src/mfem/solvers/MFEMHypreAMS.C
+++ b/framework/src/mfem/solvers/MFEMHypreAMS.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMHypreAMS.h"
 

--- a/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
+++ b/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMHypreBoomerAMG.h"
 #include "MFEMFESpace.h"

--- a/framework/src/mfem/solvers/MFEMHypreFGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreFGMRES.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMHypreFGMRES.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/solvers/MFEMHypreGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreGMRES.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMHypreGMRES.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/solvers/MFEMHyprePCG.C
+++ b/framework/src/mfem/solvers/MFEMHyprePCG.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMHyprePCG.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/solvers/MFEMOperatorJacobiSmoother.C
+++ b/framework/src/mfem/solvers/MFEMOperatorJacobiSmoother.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMOperatorJacobiSmoother.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/solvers/MFEMSolverBase.C
+++ b/framework/src/mfem/solvers/MFEMSolverBase.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMSolverBase.h"
 

--- a/framework/src/mfem/solvers/MFEMSuperLU.C
+++ b/framework/src/mfem/solvers/MFEMSuperLU.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMSuperLU.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/submeshes/MFEMBoundarySubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMBoundarySubMesh.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMBoundarySubMesh.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/submeshes/MFEMDomainSubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMDomainSubMesh.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMDomainSubMesh.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/submeshes/MFEMSubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMSubMesh.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMSubMesh.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/transfers/MFEMSubMeshTransfer.C
+++ b/framework/src/mfem/transfers/MFEMSubMeshTransfer.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMSubMeshTransfer.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/transfers/MultiAppMFEMCopyTransfer.C
+++ b/framework/src/mfem/transfers/MultiAppMFEMCopyTransfer.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MultiAppMFEMCopyTransfer.h"
 #include "FEProblemBase.h"

--- a/framework/src/mfem/userobjects/MFEMGeneralUserObject.C
+++ b/framework/src/mfem/userobjects/MFEMGeneralUserObject.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMGeneralUserObject.h"
 #include "MFEMProblem.h"

--- a/framework/src/mfem/utils/CoefficientManager.C
+++ b/framework/src/mfem/utils/CoefficientManager.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MooseStringUtils.h"
 #include "CoefficientManager.h"

--- a/framework/src/mfem/utils/CoefficientMap.C
+++ b/framework/src/mfem/utils/CoefficientMap.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 #include "CoefficientMap.h"
 
 namespace Moose::MFEM

--- a/framework/src/mfem/variables/MFEMVariable.C
+++ b/framework/src/mfem/variables/MFEMVariable.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMVariable.h"
 #include "MooseVariableBase.h"

--- a/framework/src/outputs/png/PNGOutput.C
+++ b/framework/src/outputs/png/PNGOutput.C
@@ -7,7 +7,6 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#include "MooseConfig.h"
 #ifdef MOOSE_HAVE_LIBPNG
 
 #include <fstream>

--- a/framework/src/parser/Builder.C
+++ b/framework/src/parser/Builder.C
@@ -1071,7 +1071,7 @@ Builder::extractParams(const std::string & prefix, InputParameters & p)
         setscalar(LinearSystemName, string);
         setscalar(SolverSystemName, string);
         setscalar(CLIArgString, string);
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
         setscalar(MFEMScalarCoefficientName, string);
         setscalar(MFEMVectorCoefficientName, string);
         setscalar(MFEMMatrixCoefficientName, string);
@@ -1158,7 +1158,7 @@ Builder::extractParams(const std::string & prefix, InputParameters & p)
         setvector(NonlinearSystemName, string);
         setvector(LinearSystemName, string);
         setvector(SolverSystemName, string);
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
         setvector(MFEMScalarCoefficientName, string);
         setvector(MFEMVectorCoefficientName, string);
         setvector(MFEMMatrixCoefficientName, string);
@@ -1216,7 +1216,7 @@ Builder::extractParams(const std::string & prefix, InputParameters & p)
         setvectorvector(DistributionName);
         setvectorvector(SamplerName);
         setvectorvector(TagName);
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
         setvectorvector(MFEMScalarCoefficientName);
         setvectorvector(MFEMVectorCoefficientName);
         setvectorvector(MFEMMatrixCoefficientName);

--- a/framework/src/restart/DataIO.C
+++ b/framework/src/restart/DataIO.C
@@ -8,7 +8,6 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "DenseMatrix.h"
-#include "MooseConfig.h"
 #include "DataIO.h"
 #include "MooseMesh.h"
 #include "FEProblemBase.h"

--- a/framework/src/utils/ADFParser.C
+++ b/framework/src/utils/ADFParser.C
@@ -50,8 +50,10 @@ ADFParser::JITCompile()
           JITCompileHelper("ADReal", fopenmp, "#include \"" + include_path + "\"\n", type_hash);
     else
       // otherwise use the compiled in location from the source tree
-      result = JITCompileHelper(
-          "ADReal", fopenmp + " " + ADFPARSER_INCLUDES, "#include \"ADReal.h\"\n", type_hash);
+      result = JITCompileHelper("ADReal",
+                                fopenmp + " " + ADFPARSER_INCLUDES,
+                                "#include \"MooseConfig.h\"\n#include \"ADReal.h\"\n",
+                                type_hash);
   }
 
   if (!result)

--- a/framework/src/utils/SystemInfo.C
+++ b/framework/src/utils/SystemInfo.C
@@ -20,7 +20,7 @@
 #include <locale>
 #endif
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 #include <torch/version.h>
 #endif
 
@@ -43,7 +43,7 @@ SystemInfo::getInfo() const
       << LIBMESH_DETECTED_SLEPC_VERSION_MINOR << '.' << LIBMESH_DETECTED_SLEPC_VERSION_SUBMINOR
       << '\n';
 #endif
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
   oss << std::setw(25) << "Libtorch Version: " << TORCH_VERSION << '\n';
 #endif
 

--- a/modules/contact/include/utils/MortarContactUtils.h
+++ b/modules/contact/include/utils/MortarContactUtils.h
@@ -9,8 +9,6 @@
 
 #pragma once
 
-#include "MooseConfig.h"
-
 #include "FEProblemBase.h"
 #include "ADReal.h"
 #include "RankTwoTensor.h"

--- a/modules/stochastic_tools/include/libtorch/controls/LibtorchDRLControl.h
+++ b/modules/stochastic_tools/include/libtorch/controls/LibtorchDRLControl.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/modules/stochastic_tools/include/libtorch/postprocessors/LibtorchDRLLogProbabilityPostprocessor.h
+++ b/modules/stochastic_tools/include/libtorch/postprocessors/LibtorchDRLLogProbabilityPostprocessor.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/modules/stochastic_tools/include/libtorch/reporters/DRLControlNeuralNetParameters.h
+++ b/modules/stochastic_tools/include/libtorch/reporters/DRLControlNeuralNetParameters.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/modules/stochastic_tools/include/libtorch/reporters/DRLRewardReporter.h
+++ b/modules/stochastic_tools/include/libtorch/reporters/DRLRewardReporter.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/modules/stochastic_tools/include/libtorch/surrogates/LibtorchANNSurrogate.h
+++ b/modules/stochastic_tools/include/libtorch/surrogates/LibtorchANNSurrogate.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/modules/stochastic_tools/include/libtorch/surrogates/LibtorchANNTrainer.h
+++ b/modules/stochastic_tools/include/libtorch/surrogates/LibtorchANNTrainer.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/modules/stochastic_tools/include/libtorch/surrogates/LibtorchDRLControlTrainer.h
+++ b/modules/stochastic_tools/include/libtorch/surrogates/LibtorchDRLControlTrainer.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/modules/stochastic_tools/include/libtorch/transfers/LibtorchNeuralNetControlTransfer.h
+++ b/modules/stochastic_tools/include/libtorch/transfers/LibtorchNeuralNetControlTransfer.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/modules/stochastic_tools/src/base/StochasticToolsApp.C
+++ b/modules/stochastic_tools/src/base/StochasticToolsApp.C
@@ -106,12 +106,12 @@ StochasticToolsApp::registerApps()
 
 void
 StochasticToolsApp::requiresTorch(const MooseObject &
-#ifndef LIBTORCH_ENABLED
+#ifndef MOOSE_LIBTORCH_ENABLED
                                       obj
 #endif
 )
 {
-#ifndef LIBTORCH_ENABLED
+#ifndef MOOSE_LIBTORCH_ENABLED
   obj.mooseError("PyTorch C++ API (libtorch) must be installed to use this object, see "
                  "https://mooseframework.inl.gov/modules/stochastic_tools/install_pytorch.html for "
                  "instruction.");

--- a/modules/stochastic_tools/src/libtorch/controls/LibtorchDRLControl.C
+++ b/modules/stochastic_tools/src/libtorch/controls/LibtorchDRLControl.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchDRLControl.h"
 #include "TorchScriptModule.h"

--- a/modules/stochastic_tools/src/libtorch/postprocessors/LibtorchDRLLogProbabilityPostprocessor.C
+++ b/modules/stochastic_tools/src/libtorch/postprocessors/LibtorchDRLLogProbabilityPostprocessor.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchDRLLogProbabilityPostprocessor.h"
 

--- a/modules/stochastic_tools/src/libtorch/reporters/DRLControlNeuralNetParameters.C
+++ b/modules/stochastic_tools/src/libtorch/reporters/DRLControlNeuralNetParameters.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "DRLControlNeuralNetParameters.h"
 #include "LibtorchDRLControlTrainer.h"

--- a/modules/stochastic_tools/src/libtorch/reporters/DRLRewardReporter.C
+++ b/modules/stochastic_tools/src/libtorch/reporters/DRLRewardReporter.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "DRLRewardReporter.h"
 

--- a/modules/stochastic_tools/src/libtorch/surrogates/LibtorchANNSurrogate.C
+++ b/modules/stochastic_tools/src/libtorch/surrogates/LibtorchANNSurrogate.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchANNSurrogate.h"
 

--- a/modules/stochastic_tools/src/libtorch/trainers/LibtorchANNTrainer.C
+++ b/modules/stochastic_tools/src/libtorch/trainers/LibtorchANNTrainer.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchANNTrainer.h"
 #include "LibtorchDataset.h"

--- a/modules/stochastic_tools/src/libtorch/trainers/LibtorchDRLControlTrainer.C
+++ b/modules/stochastic_tools/src/libtorch/trainers/LibtorchDRLControlTrainer.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchDataset.h"
 #include "LibtorchArtificialNeuralNetTrainer.h"

--- a/modules/stochastic_tools/src/libtorch/transfers/LibtorchNeuralNetControlTransfer.C
+++ b/modules/stochastic_tools/src/libtorch/transfers/LibtorchNeuralNetControlTransfer.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "LibtorchNeuralNetControlTransfer.h"
 #include "LibtorchNeuralNetControl.h"

--- a/test/include/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTest.h
+++ b/test/include/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTest.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 #include <torch/types.h>

--- a/test/include/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTrainerTest.h
+++ b/test/include/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTrainerTest.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/test/include/libtorch/vectorpostprocessors/TorchScriptModuleTest.h
+++ b/test/include/libtorch/vectorpostprocessors/TorchScriptModuleTest.h
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #pragma once
 

--- a/test/src/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTest.C
+++ b/test/src/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTest.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include <torch/torch.h>
 #include "LibtorchArtificialNeuralNet.h"

--- a/test/src/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTrainerTest.C
+++ b/test/src/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTrainerTest.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include <torch/torch.h>
 #include "LibtorchArtificialNeuralNet.h"

--- a/test/src/libtorch/vectorpostprocessors/TorchScriptModuleTest.C
+++ b/test/src/libtorch/vectorpostprocessors/TorchScriptModuleTest.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include <torch/torch.h>
 #include "TorchScriptModule.h"

--- a/unit/include/MFEMObjectUnitTest.h
+++ b/unit/include/MFEMObjectUnitTest.h
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #pragma once
 

--- a/unit/src/FunctionTest.C
+++ b/unit/src/FunctionTest.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMObjectUnitTest.h"
 

--- a/unit/src/LibtorchUtilsTest.C
+++ b/unit/src/LibtorchUtilsTest.C
@@ -7,7 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifdef LIBTORCH_ENABLED
+#ifdef MOOSE_LIBTORCH_ENABLED
 
 #include "gtest/gtest.h"
 #include "LibtorchUtils.h"

--- a/unit/src/MFEMEssentialBCTest.C
+++ b/unit/src/MFEMEssentialBCTest.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "libmesh/ignore_warnings.h"
 #include "mfem/miniapps/common/mfem-common.hpp"

--- a/unit/src/MFEMFESpaceTest.C
+++ b/unit/src/MFEMFESpaceTest.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "gtest/gtest.h"
 

--- a/unit/src/MFEMIntegratedBCTest.C
+++ b/unit/src/MFEMIntegratedBCTest.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "libmesh/ignore_warnings.h"
 #include "mfem/miniapps/common/mfem-common.hpp"

--- a/unit/src/MFEMKernelTest.C
+++ b/unit/src/MFEMKernelTest.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMObjectUnitTest.h"
 #include "MFEMCurlCurlKernel.h"

--- a/unit/src/MFEMMaterialTest.C
+++ b/unit/src/MFEMMaterialTest.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMObjectUnitTest.h"
 #include "MFEMGenericFunctorMaterial.h"

--- a/unit/src/MFEMMeshTest.C
+++ b/unit/src/MFEMMeshTest.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "gtest/gtest.h"
 #include "MFEMMesh.h"

--- a/unit/src/MFEMPostprocessorTest.C
+++ b/unit/src/MFEMPostprocessorTest.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMObjectUnitTest.h"
 #include "MFEML2Error.h"

--- a/unit/src/MFEMSolverTest.C
+++ b/unit/src/MFEMSolverTest.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "MFEMObjectUnitTest.h"
 #include "MFEMHypreGMRES.h"

--- a/unit/src/TestCoefficientManager.C
+++ b/unit/src/TestCoefficientManager.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include <algorithm>
 

--- a/unit/src/TestCoefficientMap.C
+++ b/unit/src/TestCoefficientMap.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include <algorithm>
 

--- a/unit/src/TestNLDiffusionIntegrator.C
+++ b/unit/src/TestNLDiffusionIntegrator.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "gtest/gtest.h"
 #include "libmesh/ignore_warnings.h"

--- a/unit/src/TestNonLinearIntegrators.C
+++ b/unit/src/TestNonLinearIntegrators.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "gtest/gtest.h"
 #include "libmesh/ignore_warnings.h"

--- a/unit/src/TestScaleIntegrator.C
+++ b/unit/src/TestScaleIntegrator.C
@@ -1,4 +1,4 @@
-#ifdef MFEM_ENABLED
+#ifdef MOOSE_MFEM_ENABLED
 
 #include "gtest/gtest.h"
 #include "libmesh/ignore_warnings.h"


### PR DESCRIPTION
## Reason
Avoid redundancy between macros in `MooseConfig.h` and variables in `moose.mk`.

## Design
Include `MooseConfig.h` everywhere so that its macro definitions are visible universally.

## Impact
Hopefully minimal.