### PR TITLE
Spline Utilities

### DIFF
--- a/framework/include/utils/BSpline.h
+++ b/framework/include/utils/BSpline.h
@@ -18,8 +18,9 @@ namespace Moose
 /**
  * Class implementing a uniform clamped B-Spline curve.
  * Reference used for implementation: https://mat.fsv.cvut.cz/gcg/sbornik/prochazkova.pdf
- * The B-Spline is uniform because of the spacing in the knot vector
+ * The B-Spline is uniform because of the spacings in the knot vector
  * The B-Spline is clamped because the knot vector starts (and ends) with (degree + 1) 0s (and 1s)
+ * Clamped means that it passes through the specified start and end points with specified slopes
  */
 class BSpline
 {

--- a/framework/include/utils/BSpline.h
+++ b/framework/include/utils/BSpline.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "libMeshReducedNamespace.h"
 #include "libmesh/point.h"
 #include <vector>
 
@@ -23,7 +24,13 @@ namespace Moose
 class BSpline
 {
 public:
-  BSpline(const unsigned int degree, const std::vector<libMesh::Point> & control_points);
+  BSpline(const unsigned int degree,
+          const libMesh::Point & start_point,
+          const libMesh::Point & end_point,
+          const libMesh::RealVectorValue & start_direction,
+          const libMesh::RealVectorValue & end_direction,
+          const unsigned int cps_per_half,
+          const libMesh::Real sharpness);
 
   /**
    * Evaluate the BSpline interpolation at given value of t.
@@ -33,16 +40,16 @@ public:
    */
   libMesh::Point getPoint(const libMesh::Real t) const;
 
-  /**
-   * Get the built knot vector associated with the degree and control points.
-   */
-  const std::vector<libMesh::Real> & getKnotVector() const { return _knot_vector; }
-
 private:
   /**
    * Internal method for building the knot vector given the degree and control points.
    */
   std::vector<libMesh::Real> buildKnotVector() const;
+
+  /**
+   * Creates a vector control points from the SplineUtils set of functions.
+   */
+  std::vector<libMesh::Point> createControlPoints() const;
 
   /**
    * Evaluates the the basis function for a B-Spline according to the Cox-de-Boor
@@ -74,6 +81,18 @@ private:
 
   /// The polynomial degree of the B-Spline.
   const unsigned int _degree;
+  /// starting point of spline
+  const libMesh::Point _start_point;
+  /// ending point of spline
+  const libMesh::Point _end_point;
+  /// starting direction of spline
+  const libMesh::RealVectorValue _start_dir;
+  /// ending direction of spline
+  const libMesh::RealVectorValue _end_dir;
+  /// number of control points per half of the spline (vertex is auto-included)
+  const unsigned int _cps_per_half;
+  /// sharpness of the curve
+  const libMesh::Real _sharpness;
   /// The control points.
   const std::vector<libMesh::Point> _control_points;
   /// The knot vector.

--- a/framework/include/utils/SplineUtils.h
+++ b/framework/include/utils/SplineUtils.h
@@ -1,0 +1,87 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+// Reference for B-Spline: https://mat.fsv.cvut.cz/gcg/sbornik/prochazkova.pdf
+
+#pragma once
+
+#include "libMeshReducedNamespace.h"
+
+namespace SplineUtils
+{
+/**
+ * Creates control points for the special case of parallel lines using an interpolating circle.
+ * @param start_point start point for spline
+ * @param end_point end point for spline
+ * @param parallel_direction direction of both curves to be connected. must be the same for both
+ * @param num_cps total number of control points to be created
+ */
+std::vector<Point> circularControlPoints(const libMesh::Point & start_point,
+                                         const libMesh::Point & end_point,
+                                         const libMesh::RealVectorValue & parallel_direction,
+                                         const unsigned int num_cps);
+
+/**
+ * Creates control points for an open uniform BSpline
+ * @param start_point start point for spline
+ * @param end_point end point for spline
+ * @param start_direction incoming direction (derivative)
+ * @param end_direction outgoing direction (derivative)
+ * @param cps_per_half number of control points per half of the spline -- will be along extrapolated
+ * line from the point and its direction
+ * @param sharpness number in [0,1] that determines the sharpness of the curve
+ */
+std::vector<Point> bSplineControlPoints(const libMesh::Point & start_point,
+                                        const libMesh::Point & end_point,
+                                        const libMesh::RealVectorValue & start_direction,
+                                        const libMesh::RealVectorValue & end_direction,
+                                        const unsigned int cps_per_half,
+                                        const libMesh::Real sharpness);
+
+/**
+ * Creates control points along an extrapolated line up to a certain intercept.
+ * @param start_point start point for the line
+ * @param end_point end point of the line
+ * @param direction_vector direction of the line
+ * @param sharpness number in [0,1] that determines the sharpness of the future curve. In this
+ * context, it will determine how close to the end point the control points are placed.
+ * @param build_backwards boolean to build the second vector of control points in the correct order
+ */
+std::vector<Point> controlPointsAlongLine(const libMesh::Point & start_point,
+                                          const libMesh::Point & end_point,
+                                          const libMesh::RealVectorValue & direction_vector,
+                                          const libMesh::Real sharpness,
+                                          const unsigned int num_cps,
+                                          const bool build_backwards = false);
+/**
+ * Makes the control point. Subroutine of controlPointsAlongLine
+ * @param start_point start point for the line
+ * @param end_point end point of the line
+ * @param direction_vector direction of the line
+ * @param sharpness number in [0,1] that determines the sharpness of the future curve. In this
+ * context, it will determine how close to the end point the control point is placed.
+ */
+libMesh::Point makeControlPoint(const libMesh::Point & start_point,
+                                const libMesh::Point & end_point,
+                                const libMesh::RealVectorValue & direction_vector,
+                                const libMesh::Real sharpness);
+/**
+ * Determines the two points defining the shortest line segment between two lines in space. If the
+ * lines intersection, the closest points returned will be identical.
+ * @param point_1 starting point of the first line
+ * @param point_2 starting point of the second line
+ * @param direction_1 direction of the first line
+ * @param direction_2 direction of the second line
+ */
+std::vector<Point> closestPoints(const libMesh::Point & point_1,
+                                 const libMesh::Point & point_2,
+                                 const libMesh::RealVectorValue & direction_1,
+                                 const libMesh::RealVectorValue & direction_2);
+
+}

--- a/framework/include/utils/SplineUtils.h
+++ b/framework/include/utils/SplineUtils.h
@@ -7,12 +7,14 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-// Reference for B-Spline: https://mat.fsv.cvut.cz/gcg/sbornik/prochazkova.pdf
-
 #pragma once
 
 #include "libMeshReducedNamespace.h"
 
+/**
+ * Utilities useful for splines in general
+ * Reference for B-Spline implementation: https://mat.fsv.cvut.cz/gcg/sbornik/prochazkova.pdf
+ */
 namespace SplineUtils
 {
 /**
@@ -51,16 +53,17 @@ std::vector<Point> bSplineControlPoints(const libMesh::Point & start_point,
  * @param direction_vector direction of the line
  * @param sharpness number in [0,1] that determines the sharpness of the future curve. In this
  * context, it will determine how close to the end point the control points are placed.
- * @param build_backwards boolean to build the second vector of control points in the correct order
+ * @param reverse_order boolean to return the vector of control points in the reverse order
  */
 std::vector<Point> controlPointsAlongLine(const libMesh::Point & start_point,
                                           const libMesh::Point & end_point,
                                           const libMesh::RealVectorValue & direction_vector,
                                           const libMesh::Real sharpness,
                                           const unsigned int num_cps,
-                                          const bool build_backwards = false);
+                                          const bool reverse_order = false);
+
 /**
- * Makes the control point. Subroutine of controlPointsAlongLine
+ * Creates a control point. Subroutine of controlPointsAlongLine
  * @param start_point start point for the line
  * @param end_point end point of the line
  * @param direction_vector direction of the line
@@ -71,17 +74,17 @@ libMesh::Point makeControlPoint(const libMesh::Point & start_point,
                                 const libMesh::Point & end_point,
                                 const libMesh::RealVectorValue & direction_vector,
                                 const libMesh::Real sharpness);
+
 /**
  * Determines the two points defining the shortest line segment between two lines in space. If the
- * lines intersection, the closest points returned will be identical.
+ * lines intersect, the two points returned will be identical.
  * @param point_1 starting point of the first line
  * @param point_2 starting point of the second line
  * @param direction_1 direction of the first line
  * @param direction_2 direction of the second line
  */
-std::vector<Point> closestPoints(const libMesh::Point & point_1,
-                                 const libMesh::Point & point_2,
-                                 const libMesh::RealVectorValue & direction_1,
-                                 const libMesh::RealVectorValue & direction_2);
-
+std::pair<Point, Point> closestPoints(const libMesh::Point & point_1,
+                                      const libMesh::Point & point_2,
+                                      const libMesh::RealVectorValue & direction_1,
+                                      const libMesh::RealVectorValue & direction_2);
 }

--- a/framework/src/utils/BSpline.C
+++ b/framework/src/utils/BSpline.C
@@ -10,13 +10,28 @@
 #include "BSpline.h"
 #include "libMeshReducedNamespace.h"
 #include "MooseError.h"
+#include "SplineUtils.h"
 
 using namespace libMesh;
 
 namespace Moose
 {
-BSpline::BSpline(const unsigned int degree, const std::vector<libMesh::Point> & control_points)
-  : _degree(degree), _control_points(control_points), _knot_vector(buildKnotVector())
+BSpline::BSpline(const unsigned int degree,
+                 const libMesh::Point & start_point,
+                 const libMesh::Point & end_point,
+                 const libMesh::RealVectorValue & start_direction,
+                 const libMesh::RealVectorValue & end_direction,
+                 const unsigned int cps_per_half,
+                 const libMesh::Real sharpness)
+  : _degree(degree),
+    _start_point(start_point),
+    _end_point(end_point),
+    _start_dir(start_direction),
+    _end_dir(end_direction),
+    _cps_per_half(cps_per_half),
+    _sharpness(sharpness),
+    _control_points(createControlPoints()),
+    _knot_vector(buildKnotVector())
 {
 }
 
@@ -31,6 +46,16 @@ BSpline::getPoint(const libMesh::Real t) const
     returnPoint += BSpline::CdBBasis(t, i, _degree) * _control_points[i];
 
   return returnPoint;
+}
+
+std::vector<libMesh::Point>
+BSpline::createControlPoints() const
+{
+  std::vector<libMesh::Point> cps;
+  /// call SplineUtils function
+  cps = SplineUtils::bSplineControlPoints(
+      _start_point, _end_point, _start_dir, _end_dir, _cps_per_half, _sharpness);
+  return cps;
 }
 
 std::vector<libMesh::Real>

--- a/framework/src/utils/SplineUtils.C
+++ b/framework/src/utils/SplineUtils.C
@@ -1,0 +1,201 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "SplineUtils.h"
+#include "MooseError.h"
+#include "libMeshReducedNamespace.h"
+#include <algorithm>
+
+namespace SplineUtils
+{
+std::vector<Point>
+circularControlPoints(const libMesh::Point & start_point,
+                      const libMesh::Point & end_point,
+                      const libMesh::RealVectorValue & parallel_direction,
+                      const unsigned int num_cps)
+{
+  /// establish the direction vector between the two points
+  libMesh::RealVectorValue orthogonal_direction = start_point - end_point;
+
+  /// circular control points will only honor the derivatives if the points are colinear along the orthogonal direction
+  if (!(std::abs(parallel_direction * orthogonal_direction) < 1e-12))
+    mooseError("Parallel lines cannot be interpolated using points along a circle! Direction "
+               "vectors are incompatible with point locations.");
+
+  /// define the distance between the two points
+  libMesh::Real distance_between = orthogonal_direction.norm();
+
+  /// connecting circle is assumed to be between each point along the orthogonal_direction vector
+  libMesh::Real radius = distance_between / 2.0;
+
+  /// normalize vectors
+  libMesh::RealVectorValue unit_normal = orthogonal_direction / distance_between;
+  libMesh::RealVectorValue unit_parallel = parallel_direction / parallel_direction.norm();
+
+  /// calculate circle center
+  libMesh::Point center_point = end_point + radius * unit_normal;
+
+  /// initialize vector of control points
+  std::vector<Point> control_points;
+
+  /// initialize parameter
+  double t;
+
+  /// loop over the number of control points to generate the contorl points
+  for (const auto i : make_range(num_cps))
+  {
+    t = (double)i / (double)(num_cps - 1);
+    control_points.push_back(center_point + radius * (std::cos(t * M_PI) * unit_normal +
+                                                      std::sin(t * M_PI) * unit_parallel));
+  }
+
+  return control_points;
+}
+
+std::vector<Point>
+bSplineControlPoints(const libMesh::Point & start_point,
+                     const libMesh::Point & end_point,
+                     const libMesh::RealVectorValue & start_direction,
+                     const libMesh::RealVectorValue & end_direction,
+                     const unsigned int cps_per_half,
+                     const libMesh::Real sharpness)
+{
+  ///
+  /// start with a couple of checks to be sure the input is good
+  ///
+  /// check that start_point is different from end_point
+  if ((start_point - end_point).norm() < libMesh::TOLERANCE)
+    mooseError("Start and end points must be unique.");
+  /// check that neither direction is the zero vector
+  if (start_direction.norm() < libMesh::TOLERANCE || end_direction.norm() == 0)
+    mooseError("Direction vectors must have a nonzero magnitude.");
+
+  /// check if directions are parallel
+  const bool parallel = ((start_direction.cross(end_direction)).norm() < libMesh::TOLERANCE);
+  if (parallel)
+    return SplineUtils::circularControlPoints(
+        start_point, end_point, start_direction, 2 * cps_per_half + 1);
+
+  /// find closest points --> these will be identical if the extrapolated lines intersect
+  std::vector<Point> closest_points_vector =
+      SplineUtils::closestPoints(start_point, end_point, start_direction, end_direction);
+  libMesh::Point closest_point_1 = closest_points_vector[0];
+  libMesh::Point closest_point_2 = closest_points_vector[1];
+
+  /// create vertex (average of closest points)
+  libMesh::Point vertex = (closest_point_1 + closest_point_2) / 2;
+  std::vector<Point> first_half = SplineUtils::controlPointsAlongLine(
+      start_point, closest_point_1, start_direction, sharpness, cps_per_half);
+  std::vector<Point> second_half = SplineUtils::controlPointsAlongLine(
+      end_point, closest_point_2, end_direction, sharpness, cps_per_half, true);
+
+  std::vector<Point> control_points;
+
+  /// put it all together
+  for (const auto i : index_range(first_half))
+    control_points.push_back(first_half[i]);
+  control_points.push_back(vertex);
+  for (const auto i : index_range(second_half))
+    control_points.push_back(second_half[i]);
+
+  return control_points;
+}
+
+std::vector<Point>
+controlPointsAlongLine(const libMesh::Point & start_point,
+                       const libMesh::Point & end_point,
+                       const libMesh::RealVectorValue & direction_vector,
+                       const libMesh::Real sharpness,
+                       const unsigned int num_cps,
+                       const bool build_backwards)
+{
+  /// initialize a vector of control points with the starting point inserted
+  std::vector<Point> control_points;
+
+  /// initialize a changing sharpness parameter
+  double point_sharpness;
+
+  mooseAssert(num_cps != 0, "Number of control points cannot be zero!");
+  if (num_cps == 1)
+    control_points.push_back(start_point);
+
+  /// create the control points by varying the sharpness linearly
+  else
+  {
+    for (const auto i : libMesh::make_range(num_cps))
+    {
+      point_sharpness = (double)i / (double)(num_cps - 1) * sharpness;
+      control_points.push_back(
+          SplineUtils::makeControlPoint(start_point, end_point, direction_vector, point_sharpness));
+    }
+
+    /// build_backwards parameter only set to true when required
+    if (build_backwards)
+      std::reverse(control_points.begin(), control_points.end());
+  }
+  return control_points;
+}
+
+libMesh::Point
+makeControlPoint(const libMesh::Point & start_point,
+                 const libMesh::Point & end_point,
+                 const libMesh::RealVectorValue & direction_vector,
+                 const libMesh::Real sharpness)
+{
+  /// check that sharpness value is ok
+  if (!(sharpness <= 1.0 && sharpness >= 0))
+    mooseError("Sharpness must be in [0,1]!");
+
+  /// normalize direction vector
+  libMesh::RealVectorValue unit_direction = direction_vector / direction_vector.norm();
+
+  /// calculate the distance between points
+  double distance = (end_point - start_point).norm();
+
+  /// initialize return quantity
+  libMesh::Point control_point;
+
+  /// attempt to calculate control vector
+  control_point = start_point + sharpness * distance * unit_direction;
+
+  /// check if we went the wrong way...
+  double end_point_distance_to_cp = (end_point - control_point).norm();
+  if (end_point_distance_to_cp > distance)
+    control_point = start_point - sharpness * distance * unit_direction;
+
+  return control_point;
+}
+
+std::vector<Point>
+closestPoints(const libMesh::Point & point_1,
+              const libMesh::Point & point_2,
+              const libMesh::RealVectorValue & direction_1,
+              const libMesh::RealVectorValue & direction_2)
+{
+  libMesh::RealVectorValue n_vec = direction_1.cross(direction_2);
+
+  /// check if n_vec is the zero vector (indicates parallel lines)
+  if (n_vec.norm() < libMesh::TOLERANCE)
+    mooseError("Lines are parallel! Infinitely many closest points exist.");
+
+  libMesh::RealVectorValue n1_vec = direction_1.cross(n_vec);
+  libMesh::RealVectorValue n2_vec = direction_2.cross(n_vec);
+
+  /// calculate closest points
+  libMesh::Point point_a =
+      point_1 + (point_2 - point_1) * n2_vec / (direction_1 * (n2_vec)) * direction_1;
+  libMesh::Point point_b =
+      point_2 + (point_1 - point_2) * n1_vec / (direction_2 * (n1_vec)) * direction_2;
+
+  /// points will be returned as a vector containing two points
+  std::vector<Point> closest_points = {point_a, point_b};
+
+  return closest_points;
+}
+}

--- a/framework/src/utils/SplineUtils.C
+++ b/framework/src/utils/SplineUtils.C
@@ -20,37 +20,41 @@ circularControlPoints(const libMesh::Point & start_point,
                       const libMesh::RealVectorValue & parallel_direction,
                       const unsigned int num_cps)
 {
-  /// establish the direction vector between the two points
-  libMesh::RealVectorValue orthogonal_direction = start_point - end_point;
+  // establish the direction vector between the two points
+  const auto orthogonal_direction = start_point - end_point;
 
-  /// circular control points will only honor the derivatives if the points are colinear along the orthogonal direction
-  if (!(std::abs(parallel_direction * orthogonal_direction) < 1e-12))
+  // circular control points will only honor the derivatives if the points are colinear along the
+  // orthogonal direction
+  if (!(MooseUtils::absoluteFuzzyEqual(parallel_direction.unit() * orthogonal_direction.unit(), 0)))
     mooseError("Parallel lines cannot be interpolated using points along a circle! Direction "
-               "vectors are incompatible with point locations.");
+               "vectors are incompatible with point locations.\nStart point: ",
+               start_point,
+               "\nEnd point: ",
+               end_point,
+               "\nDirection: ",
+               parallel_direction);
 
-  /// define the distance between the two points
-  libMesh::Real distance_between = orthogonal_direction.norm();
+  // define the distance between the two points
+  const auto distance_between = orthogonal_direction.norm();
 
-  /// connecting circle is assumed to be between each point along the orthogonal_direction vector
-  libMesh::Real radius = distance_between / 2.0;
+  // connecting circle is assumed to be between each point along the orthogonal_direction vector
+  const auto radius = distance_between / 2.0;
 
-  /// normalize vectors
-  libMesh::RealVectorValue unit_normal = orthogonal_direction / distance_between;
-  libMesh::RealVectorValue unit_parallel = parallel_direction / parallel_direction.norm();
+  // normalize vectors
+  const auto unit_normal = orthogonal_direction / distance_between;
+  const auto unit_parallel = parallel_direction / parallel_direction.norm();
 
-  /// calculate circle center
-  libMesh::Point center_point = end_point + radius * unit_normal;
+  // calculate circle center
+  const auto center_point = end_point + radius * unit_normal;
 
-  /// initialize vector of control points
+  // initialize vector of control points
   std::vector<Point> control_points;
 
-  /// initialize parameter
-  double t;
-
-  /// loop over the number of control points to generate the contorl points
+  // loop over the number of control points to generate the contorl points
+  mooseAssert(num_cps > 1, "This routine does not support a single control point");
   for (const auto i : make_range(num_cps))
   {
-    t = (double)i / (double)(num_cps - 1);
+    const auto t = (Real)i / (Real)(num_cps - 1);
     control_points.push_back(center_point + radius * (std::cos(t * M_PI) * unit_normal +
                                                       std::sin(t * M_PI) * unit_parallel));
   }
@@ -66,30 +70,28 @@ bSplineControlPoints(const libMesh::Point & start_point,
                      const unsigned int cps_per_half,
                      const libMesh::Real sharpness)
 {
-  ///
-  /// start with a couple of checks to be sure the input is good
-  ///
-  /// check that start_point is different from end_point
-  if ((start_point - end_point).norm() < libMesh::TOLERANCE)
-    mooseError("Start and end points must be unique.");
-  /// check that neither direction is the zero vector
-  if (start_direction.norm() < libMesh::TOLERANCE || end_direction.norm() == 0)
+  // check that start_point is different from end_point
+  if ((start_point - end_point).norm_sq() < libMesh::TOLERANCE)
+    mooseError("Start and end points must be different.");
+  // check that neither direction is the zero vector
+  if (start_direction.norm_sq() < libMesh::TOLERANCE ||
+      end_direction.norm_sq() < libMesh::TOLERANCE)
     mooseError("Direction vectors must have a nonzero magnitude.");
 
-  /// check if directions are parallel
+  // check if directions are parallel, use a special case if so
   const bool parallel = ((start_direction.cross(end_direction)).norm() < libMesh::TOLERANCE);
   if (parallel)
     return SplineUtils::circularControlPoints(
         start_point, end_point, start_direction, 2 * cps_per_half + 1);
 
-  /// find closest points --> these will be identical if the extrapolated lines intersect
-  std::vector<Point> closest_points_vector =
+  // find closest points --> these will be identical if the extrapolated lines intersect
+  const auto closest_points_vector =
       SplineUtils::closestPoints(start_point, end_point, start_direction, end_direction);
-  libMesh::Point closest_point_1 = closest_points_vector[0];
-  libMesh::Point closest_point_2 = closest_points_vector[1];
+  const auto & closest_point_1 = closest_points_vector.first;
+  const auto & closest_point_2 = closest_points_vector.second;
 
-  /// create vertex (average of closest points)
-  libMesh::Point vertex = (closest_point_1 + closest_point_2) / 2;
+  // create vertex (average of closest points)
+  const auto vertex = (closest_point_1 + closest_point_2) / 2;
   std::vector<Point> first_half = SplineUtils::controlPointsAlongLine(
       start_point, closest_point_1, start_direction, sharpness, cps_per_half);
   std::vector<Point> second_half = SplineUtils::controlPointsAlongLine(
@@ -97,7 +99,7 @@ bSplineControlPoints(const libMesh::Point & start_point,
 
   std::vector<Point> control_points;
 
-  /// put it all together
+  // put it all together
   for (const auto i : index_range(first_half))
     control_points.push_back(first_half[i]);
   control_points.push_back(vertex);
@@ -113,30 +115,27 @@ controlPointsAlongLine(const libMesh::Point & start_point,
                        const libMesh::RealVectorValue & direction_vector,
                        const libMesh::Real sharpness,
                        const unsigned int num_cps,
-                       const bool build_backwards)
+                       const bool reverse_order)
 {
-  /// initialize a vector of control points with the starting point inserted
+  // initialize a vector of control points with the starting point inserted
   std::vector<Point> control_points;
-
-  /// initialize a changing sharpness parameter
-  double point_sharpness;
 
   mooseAssert(num_cps != 0, "Number of control points cannot be zero!");
   if (num_cps == 1)
     control_points.push_back(start_point);
 
-  /// create the control points by varying the sharpness linearly
+  // create the control points by varying the sharpness linearly
   else
   {
     for (const auto i : libMesh::make_range(num_cps))
     {
-      point_sharpness = (double)i / (double)(num_cps - 1) * sharpness;
+      const auto point_sharpness = (Real)i / (Real)(num_cps - 1) * sharpness;
       control_points.push_back(
           SplineUtils::makeControlPoint(start_point, end_point, direction_vector, point_sharpness));
     }
 
-    /// build_backwards parameter only set to true when required
-    if (build_backwards)
+    // reverse_order parameter only set to true when required
+    if (reverse_order)
       std::reverse(control_points.begin(), control_points.end());
   }
   return control_points;
@@ -148,53 +147,53 @@ makeControlPoint(const libMesh::Point & start_point,
                  const libMesh::RealVectorValue & direction_vector,
                  const libMesh::Real sharpness)
 {
-  /// check that sharpness value is ok
-  if (!(sharpness <= 1.0 && sharpness >= 0))
-    mooseError("Sharpness must be in [0,1]!");
+  // check that sharpness value is ok
+  mooseAssert(sharpness <= 1.0 && sharpness >= 0, "Sharpness must be in [0,1]!");
 
-  /// normalize direction vector
-  libMesh::RealVectorValue unit_direction = direction_vector / direction_vector.norm();
+  // normalize direction vector
+  const auto unit_direction = direction_vector.unit();
 
-  /// calculate the distance between points
-  double distance = (end_point - start_point).norm();
+  // calculate the distance between points
+  const auto distance = (end_point - start_point).norm();
+  const auto distance_sq = distance * distance;
 
-  /// initialize return quantity
-  libMesh::Point control_point;
+  // initialize return quantity and attempt to calculate control vector
+  libMesh::Point control_point = start_point + sharpness * distance * unit_direction;
 
-  /// attempt to calculate control vector
-  control_point = start_point + sharpness * distance * unit_direction;
-
-  /// check if we went the wrong way...
-  double end_point_distance_to_cp = (end_point - control_point).norm();
-  if (end_point_distance_to_cp > distance)
+  // check if we went the wrong way, further from the end_point
+  if ((end_point - control_point).norm_sq() > distance_sq)
+  {
     control_point = start_point - sharpness * distance * unit_direction;
+    mooseAssert((end_point - control_point).norm_sq() <= distance_sq,
+                "Also going further from end point");
+  }
 
   return control_point;
 }
 
-std::vector<Point>
+std::pair<Point, Point>
 closestPoints(const libMesh::Point & point_1,
               const libMesh::Point & point_2,
               const libMesh::RealVectorValue & direction_1,
               const libMesh::RealVectorValue & direction_2)
 {
-  libMesh::RealVectorValue n_vec = direction_1.cross(direction_2);
+  const auto n_vec = direction_1.cross(direction_2);
 
-  /// check if n_vec is the zero vector (indicates parallel lines)
-  if (n_vec.norm() < libMesh::TOLERANCE)
+  // check if n_vec is the zero vector (indicates parallel lines)
+  if (n_vec.norm_sq() < libMesh::TOLERANCE)
     mooseError("Lines are parallel! Infinitely many closest points exist.");
 
-  libMesh::RealVectorValue n1_vec = direction_1.cross(n_vec);
-  libMesh::RealVectorValue n2_vec = direction_2.cross(n_vec);
+  const auto n1_vec = direction_1.cross(n_vec);
+  const auto n2_vec = direction_2.cross(n_vec);
 
-  /// calculate closest points
+  // calculate closest points
   libMesh::Point point_a =
       point_1 + (point_2 - point_1) * n2_vec / (direction_1 * (n2_vec)) * direction_1;
   libMesh::Point point_b =
       point_2 + (point_1 - point_2) * n1_vec / (direction_2 * (n1_vec)) * direction_2;
 
-  /// points will be returned as a vector containing two points
-  std::vector<Point> closest_points = {point_a, point_b};
+  // points will be returned as a vector containing two points
+  const auto closest_points = std::make_pair(point_a, point_b);
 
   return closest_points;
 }

--- a/framework/src/utils/SplineUtils.C
+++ b/framework/src/utils/SplineUtils.C
@@ -192,10 +192,13 @@ closestPoints(const libMesh::Point & point_1,
   const auto n2_vec = direction_2.cross(n_vec);
 
   // calculate closest points
-  libMesh::Point point_a =
-      point_1 + (point_2 - point_1) * n2_vec / (direction_1 * (n2_vec)) * direction_1;
-  libMesh::Point point_b =
-      point_2 + (point_1 - point_2) * n1_vec / (direction_2 * (n1_vec)) * direction_2;
+  // take absolute value to ensure specified directions are honored
+  libMesh::Real point_a_dir_scalar =
+      std::abs((point_2 - point_1) * n2_vec / (direction_1 * n2_vec));
+  libMesh::Real point_b_dir_scalar =
+      std::abs((point_1 - point_2) * n1_vec / (direction_2 * n1_vec));
+  libMesh::Point point_a = point_1 + point_a_dir_scalar * direction_1;
+  libMesh::Point point_b = point_2 + point_b_dir_scalar * direction_2;
 
   // points will be returned as a vector containing two points
   const auto closest_points = std::make_pair(point_a, point_b);

--- a/framework/src/utils/SplineUtils.C
+++ b/framework/src/utils/SplineUtils.C
@@ -72,11 +72,11 @@ bSplineControlPoints(const libMesh::Point & start_point,
                      const libMesh::Real sharpness)
 {
   // check that start_point is different from end_point
-  if ((start_point - end_point).norm_sq() < libMesh::TOLERANCE)
+  if ((start_point - end_point).norm_sq() < libMesh::TOLERANCE * libMesh::TOLERANCE)
     mooseError("Start and end points must be different.");
   // check that neither direction is the zero vector
-  if (start_direction.norm_sq() < libMesh::TOLERANCE ||
-      end_direction.norm_sq() < libMesh::TOLERANCE)
+  if (start_direction.norm_sq() < libMesh::TOLERANCE * libMesh::TOLERANCE ||
+      end_direction.norm_sq() < libMesh::TOLERANCE * libMesh::TOLERANCE)
     mooseError("Direction vectors must have a nonzero magnitude.");
   mooseAssert(sharpness <= 1.0 && sharpness >= 0, "Sharpness must be in [0,1]!");
 
@@ -186,7 +186,7 @@ closestPoints(const libMesh::Point & point_1,
   const auto n_vec = direction_1.cross(direction_2);
 
   // check if n_vec is the zero vector (indicates parallel lines)
-  if (n_vec.norm_sq() < libMesh::TOLERANCE)
+  if (n_vec.norm_sq() < libMesh::TOLERANCE * libMesh::TOLERANCE)
     mooseError("Lines are parallel! Infinitely many closest points exist.");
 
   const auto n1_vec = direction_1.cross(n_vec);

--- a/framework/src/utils/SplineUtils.C
+++ b/framework/src/utils/SplineUtils.C
@@ -77,6 +77,7 @@ bSplineControlPoints(const libMesh::Point & start_point,
   if (start_direction.norm_sq() < libMesh::TOLERANCE ||
       end_direction.norm_sq() < libMesh::TOLERANCE)
     mooseError("Direction vectors must have a nonzero magnitude.");
+  mooseAssert(sharpness <= 1.0 && sharpness >= 0, "Sharpness must be in [0,1]!");
 
   // check if directions are parallel, use a special case if so
   const bool parallel = ((start_direction.cross(end_direction)).norm() < libMesh::TOLERANCE);
@@ -84,7 +85,7 @@ bSplineControlPoints(const libMesh::Point & start_point,
   {
     mooseWarning("Directions are parallel! Attempting to use circular control points...");
     unsigned int num_cps = 2 * cps_per_half + 1;
-    if (num_cps < 25)
+    if (num_cps < 30)
       mooseWarning("Number of control points required for circular control points is much greater "
                    "than for BSplines. Current num_cps: " +
                    std::to_string(num_cps));

--- a/framework/src/utils/SplineUtils.C
+++ b/framework/src/utils/SplineUtils.C
@@ -10,6 +10,7 @@
 #include "SplineUtils.h"
 #include "MooseError.h"
 #include "libMeshReducedNamespace.h"
+#include "MooseUtils.h"
 #include <algorithm>
 
 namespace SplineUtils

--- a/framework/src/utils/SplineUtils.C
+++ b/framework/src/utils/SplineUtils.C
@@ -50,7 +50,7 @@ circularControlPoints(const libMesh::Point & start_point,
   // initialize vector of control points
   std::vector<Point> control_points;
 
-  // loop over the number of control points to generate the contorl points
+  // loop over the number of control points to generate the control points
   mooseAssert(num_cps > 1, "This routine does not support a single control point");
   for (const auto i : make_range(num_cps))
   {
@@ -81,8 +81,15 @@ bSplineControlPoints(const libMesh::Point & start_point,
   // check if directions are parallel, use a special case if so
   const bool parallel = ((start_direction.cross(end_direction)).norm() < libMesh::TOLERANCE);
   if (parallel)
-    return SplineUtils::circularControlPoints(
-        start_point, end_point, start_direction, 2 * cps_per_half + 1);
+  {
+    mooseWarning("Directions are parallel! Attempting to use circular control points...");
+    unsigned int num_cps = 2 * cps_per_half + 1;
+    if (num_cps < 25)
+      mooseWarning("Number of control points required for circular control points is much greater "
+                   "than for BSplines. Current num_cps: " +
+                   std::to_string(num_cps));
+    return SplineUtils::circularControlPoints(start_point, end_point, start_direction, num_cps);
+  }
 
   // find closest points --> these will be identical if the extrapolated lines intersect
   const auto closest_points_vector =
@@ -90,8 +97,6 @@ bSplineControlPoints(const libMesh::Point & start_point,
   const auto & closest_point_1 = closest_points_vector.first;
   const auto & closest_point_2 = closest_points_vector.second;
 
-  // create vertex (average of closest points)
-  const auto vertex = (closest_point_1 + closest_point_2) / 2;
   std::vector<Point> first_half = SplineUtils::controlPointsAlongLine(
       start_point, closest_point_1, start_direction, sharpness, cps_per_half);
   std::vector<Point> second_half = SplineUtils::controlPointsAlongLine(
@@ -102,7 +107,6 @@ bSplineControlPoints(const libMesh::Point & start_point,
   // put it all together
   for (const auto i : index_range(first_half))
     control_points.push_back(first_half[i]);
-  control_points.push_back(vertex);
   for (const auto i : index_range(second_half))
     control_points.push_back(second_half[i]);
 

--- a/unit/src/BSplineTest.C
+++ b/unit/src/BSplineTest.C
@@ -27,8 +27,8 @@ TEST(BSplineTest, CP_MakerDegree2Test)
   const libMesh::Point end(2, 1, 0);
   const libMesh::RealVectorValue direction1(1, 0, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
-  const double sharpness = 0.5;
-  const unsigned int cps_per_half = 2;
+  const Real sharpness = 0.5;
+  const unsigned int cps_per_half = 3;
 
   const libMesh::Real t0 = 0;
   const libMesh::Real t1 = 0.4;
@@ -47,8 +47,8 @@ TEST(BSplineTest, CP_MakerDegree2Test)
   const libMesh::Point point_3 = b_spline.getPoint(t3);
 
   const libMesh::Point expected_point_0(1, 2, 1);
-  const libMesh::Point expected_point_1(1.84, 1.99, 0.65);
-  const libMesh::Point expected_point_2(2., 1.51, 0.09);
+  const libMesh::Point expected_point_1(1.57, 1.91, 0.82);
+  const libMesh::Point expected_point_2(2., 1.32, 0.);
   const libMesh::Point expected_point_3(2, 1, 0);
 
   EXPECT_NEAR((point_0 - expected_point_0).norm(), 0, libMesh::TOLERANCE);
@@ -65,8 +65,8 @@ TEST(BSplineTest, CP_MakerDegree3Test)
   const libMesh::Point end(2, 1, 0);
   const libMesh::RealVectorValue direction1(1, 0, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
-  const double sharpness = 0.5;
-  const unsigned int cps_per_half = 2;
+  const Real sharpness = 0.5;
+  const unsigned int cps_per_half = 3;
 
   const libMesh::Real t0 = 0;
   const libMesh::Real t1 = 0.4;
@@ -84,8 +84,8 @@ TEST(BSplineTest, CP_MakerDegree3Test)
   const libMesh::Point point_3 = b_spline.getPoint(t3);
 
   const libMesh::Point expected_point_0(1, 2, 1);
-  const libMesh::Point expected_point_1(1.784, 1.936, 0.648);
-  const libMesh::Point expected_point_2(1.992, 1.488, 0.104);
+  const libMesh::Point expected_point_1(1.61, 1.8575, 0.716);
+  const libMesh::Point expected_point_2(1.982, 1.3465, 0.036);
   const libMesh::Point expected_point_3(2, 1, 0);
 
   EXPECT_NEAR((point_0 - expected_point_0).norm(), 0, libMesh::TOLERANCE);
@@ -102,8 +102,8 @@ TEST(BSplineTest, CP_MakerDegree4Test)
   const libMesh::Point end(2, 1, 0);
   const libMesh::RealVectorValue direction1(1, 0, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
-  const double sharpness = 0.5;
-  const unsigned int cps_per_half = 2;
+  const Real sharpness = 0.5;
+  const unsigned int cps_per_half = 3;
 
   const libMesh::Real t0 = 0;
   const libMesh::Real t1 = 0.4;
@@ -122,36 +122,12 @@ TEST(BSplineTest, CP_MakerDegree4Test)
   const libMesh::Point point_3 = b_spline.getPoint(t3);
 
   const libMesh::Point expected_point_0(1, 2, 1);
-  const libMesh::Point expected_point_1(1.6976, 1.8976, 0.648);
-  const libMesh::Point expected_point_2(1.9856, 1.3856, 0.104);
+  const libMesh::Point expected_point_1(1.5888, 1.8336, 0.6928);
+  const libMesh::Point expected_point_2(1.9736, 1.3208, 0.0512);
   const libMesh::Point expected_point_3(2, 1, 0);
 
   EXPECT_NEAR((point_0 - expected_point_0).norm(), 0, libMesh::TOLERANCE);
   EXPECT_NEAR((point_1 - expected_point_1).norm(), 0, libMesh::TOLERANCE);
   EXPECT_NEAR((point_2 - expected_point_2).norm(), 0, libMesh::TOLERANCE);
   EXPECT_NEAR((point_3 - expected_point_3).norm(), 0, libMesh::TOLERANCE);
-}
-
-/**
- * Test for mooseError when the number of control points supplied is
- * insufficient.
- */
-TEST(BSplineTest, ControlPointErrorTest)
-{
-  const unsigned int degree = 5;
-
-  EXPECT_THROW(
-      {
-        try
-        {
-          Moose::BSpline b_spline(degree, control_points);
-        }
-        catch (const std::exception & e)
-        {
-          EXPECT_STREQ(e.what(),
-                       "Number of control points must be greater than or equal to degree + 1!");
-          throw;
-        }
-      },
-      std::exception);
 }

--- a/unit/src/BSplineTest.C
+++ b/unit/src/BSplineTest.C
@@ -15,32 +15,41 @@
 
 //* The following tests check that the BSpline utility and its submethods work as intended.
 //* Degrees 2, 3, and 4 interpolating polynomials will be evaluated at prescribed values of
-//* t, the parameter. In addition, a vector of control points is supplied.
+//* t, the parameter.
 //*
 //* All expected points were independently calculated and verified.
 
-const libMesh::Real t0 = 0;
-const libMesh::Real t1 = 0.4;
-const libMesh::Real t2 = 0.8;
-const libMesh::Real t3 = 1.0;
-const std::vector<libMesh::Point> control_points = {
-    {1, 2, 0}, {1, 2, 0}, {1.5, 2.5, 0}, {3, 1, 0}, {3, 1, 0}};
-
-TEST(BSplineTest, Degree2Test)
+TEST(BSplineTest, CP_MakerDegree2Test)
 {
   const unsigned int degree = 2;
 
-  Moose::BSpline b_spline(degree, control_points);
+  const libMesh::Point start(1, 2, 1);
+  const libMesh::Point end(2, 1, 0);
+  const libMesh::RealVectorValue direction1(1, 0, 0);
+  const libMesh::RealVectorValue direction2(0, 1, 0);
+  const double sharpness = 0.5;
+  const unsigned int cps_per_half = 2;
+
+  const libMesh::Real t0 = 0;
+  const libMesh::Real t1 = 0.4;
+  const libMesh::Real t2 = 0.8;
+  const libMesh::Real t3 = 1.0;
+
+  /// for reference:
+  // const std::vector<libMesh::Point> control_points = {
+  //     {1, 2, 1}, {1.5, 2, 1}, {2, 2, 0.5}, {2, 1.5, 0}, {2, 1, 0}};
+
+  Moose::BSpline b_spline(degree, start, end, direction1, direction2, cps_per_half, sharpness);
 
   const libMesh::Point point_0 = b_spline.getPoint(t0);
   const libMesh::Point point_1 = b_spline.getPoint(t1);
   const libMesh::Point point_2 = b_spline.getPoint(t2);
   const libMesh::Point point_3 = b_spline.getPoint(t3);
 
-  const libMesh::Point expected_point_0(1, 2, 0);
-  const libMesh::Point expected_point_1(1.37, 2.31, 0);
-  const libMesh::Point expected_point_2(2.73, 1.2699999999999996, 0);
-  const libMesh::Point expected_point_3(3, 1, 0);
+  const libMesh::Point expected_point_0(1, 2, 1);
+  const libMesh::Point expected_point_1(1.84, 1.99, 0.65);
+  const libMesh::Point expected_point_2(2., 1.51, 0.09);
+  const libMesh::Point expected_point_3(2, 1, 0);
 
   EXPECT_NEAR((point_0 - expected_point_0).norm(), 0, libMesh::TOLERANCE);
   EXPECT_NEAR((point_1 - expected_point_1).norm(), 0, libMesh::TOLERANCE);
@@ -48,21 +57,36 @@ TEST(BSplineTest, Degree2Test)
   EXPECT_NEAR((point_3 - expected_point_3).norm(), 0, libMesh::TOLERANCE);
 }
 
-TEST(BSplineTest, Degree3Test)
+TEST(BSplineTest, CP_MakerDegree3Test)
 {
   const unsigned int degree = 3;
 
-  Moose::BSpline b_spline(degree, control_points);
+  const libMesh::Point start(1, 2, 1);
+  const libMesh::Point end(2, 1, 0);
+  const libMesh::RealVectorValue direction1(1, 0, 0);
+  const libMesh::RealVectorValue direction2(0, 1, 0);
+  const double sharpness = 0.5;
+  const unsigned int cps_per_half = 2;
 
+  const libMesh::Real t0 = 0;
+  const libMesh::Real t1 = 0.4;
+  const libMesh::Real t2 = 0.8;
+  const libMesh::Real t3 = 1.0;
+
+  /// for reference:
+  // const std::vector<libMesh::Point> control_points = {
+  //     {1, 2, 1}, {1.5, 2, 1}, {2, 2, 0.5}, {2, 1.5, 0}, {2, 1, 0}};
+
+  Moose::BSpline b_spline(degree, start, end, direction1, direction2, cps_per_half, sharpness);
   const libMesh::Point point_0 = b_spline.getPoint(t0);
   const libMesh::Point point_1 = b_spline.getPoint(t1);
   const libMesh::Point point_2 = b_spline.getPoint(t2);
   const libMesh::Point point_3 = b_spline.getPoint(t3);
 
-  const libMesh::Point expected_point_0(1, 2, 0);
-  const libMesh::Point expected_point_1(1.48, 2.0959999999999996, 0);
-  const libMesh::Point expected_point_2(2.7039999999999997, 1.2799999999999998, 0);
-  const libMesh::Point expected_point_3(3, 1, 0);
+  const libMesh::Point expected_point_0(1, 2, 1);
+  const libMesh::Point expected_point_1(1.784, 1.936, 0.648);
+  const libMesh::Point expected_point_2(1.992, 1.488, 0.104);
+  const libMesh::Point expected_point_3(2, 1, 0);
 
   EXPECT_NEAR((point_0 - expected_point_0).norm(), 0, libMesh::TOLERANCE);
   EXPECT_NEAR((point_1 - expected_point_1).norm(), 0, libMesh::TOLERANCE);
@@ -70,21 +94,37 @@ TEST(BSplineTest, Degree3Test)
   EXPECT_NEAR((point_3 - expected_point_3).norm(), 0, libMesh::TOLERANCE);
 }
 
-TEST(BSplineTest, Degree4Test)
+TEST(BSplineTest, CP_MakerDegree4Test)
 {
   const unsigned int degree = 4;
 
-  Moose::BSpline b_spline(degree, control_points);
+  const libMesh::Point start(1, 2, 1);
+  const libMesh::Point end(2, 1, 0);
+  const libMesh::RealVectorValue direction1(1, 0, 0);
+  const libMesh::RealVectorValue direction2(0, 1, 0);
+  const double sharpness = 0.5;
+  const unsigned int cps_per_half = 2;
+
+  const libMesh::Real t0 = 0;
+  const libMesh::Real t1 = 0.4;
+  const libMesh::Real t2 = 0.8;
+  const libMesh::Real t3 = 1.0;
+
+  /// for reference:
+  // const std::vector<libMesh::Point> control_points = {
+  //     {1, 2, 1}, {1.5, 2, 1}, {2, 2, 0.5}, {2, 1.5, 0}, {2, 1, 0}};
+
+  Moose::BSpline b_spline(degree, start, end, direction1, direction2, cps_per_half, sharpness);
 
   const libMesh::Point point_0 = b_spline.getPoint(t0);
   const libMesh::Point point_1 = b_spline.getPoint(t1);
   const libMesh::Point point_2 = b_spline.getPoint(t2);
   const libMesh::Point point_3 = b_spline.getPoint(t3);
 
-  const libMesh::Point expected_point_0(1, 2, 0);
-  const libMesh::Point expected_point_1(1.5312, 1.9936, 0);
-  const libMesh::Point expected_point_2(2.7152000000000003, 1.2576, 0);
-  const libMesh::Point expected_point_3(3, 1, 0);
+  const libMesh::Point expected_point_0(1, 2, 1);
+  const libMesh::Point expected_point_1(1.6976, 1.8976, 0.648);
+  const libMesh::Point expected_point_2(1.9856, 1.3856, 0.104);
+  const libMesh::Point expected_point_3(2, 1, 0);
 
   EXPECT_NEAR((point_0 - expected_point_0).norm(), 0, libMesh::TOLERANCE);
   EXPECT_NEAR((point_1 - expected_point_1).norm(), 0, libMesh::TOLERANCE);

--- a/unit/src/SplineUtilsTest.C
+++ b/unit/src/SplineUtilsTest.C
@@ -1,0 +1,369 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest/gtest.h"
+#include "BSpline.h"
+#include "libMeshReducedNamespace.h"
+#include "MooseError.h"
+#include "SplineUtils.h"
+
+TEST(SplineUtilsTest, SimpleCircularCPTest)
+{
+  const libMesh::Point start(0, 0, 0);
+  const libMesh::Point end(1, 0, 0);
+  const libMesh::RealVectorValue direction(0, 1, 0);
+  const unsigned int cps = 5;
+  const std::vector<Point> expected_cps = {libMesh::Point(0, 0, 0),
+                                           libMesh::Point(1.46446609e-01, 3.53553391e-01, 0),
+                                           libMesh::Point(0.5, 0.5, 0),
+                                           libMesh::Point(8.53553391e-01, 3.53553391e-01, 0),
+                                           libMesh::Point(1.0, 0, 0)};
+  const std::vector<Point> evaluated_points =
+      SplineUtils::circularControlPoints(start, end, direction, cps);
+  for (const auto i : index_range(expected_cps))
+  {
+    EXPECT_NEAR((expected_cps[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
+  }
+}
+
+TEST(SplineUtilsTest, CircularError)
+{
+  const libMesh::Point start(0, 1, 0);
+  const libMesh::Point end(1, 0, 0);
+  const libMesh::RealVectorValue direction(0, 1, 0);
+  const unsigned int cps = 5;
+  EXPECT_THROW(
+      {
+        try
+        {
+          SplineUtils::circularControlPoints(start, end, direction, cps);
+        }
+        catch (const std::exception & e)
+        {
+          EXPECT_STREQ(
+              e.what(),
+              "Parallel lines cannot be interpolated using points along a circle! Direction "
+              "vectors are incompatible with point locations.");
+          throw;
+        }
+      },
+      std::exception);
+}
+
+TEST(SplineUtilsTest, 3DCircularCPTest)
+{
+  const libMesh::Point start(0, 0, 0);
+  const libMesh::Point end(1, 0, 1);
+  const libMesh::RealVectorValue direction(0, 1, 0);
+  const unsigned int cps_per_half = 2;
+  const libMesh::Real sharpness = 1.0; // not used in calculation but needed for function
+  const std::vector<Point> expected_cps = {
+      libMesh::Point(0, 0, 0),
+      libMesh::Point(1.46446609e-01, 5.00000000e-01, 1.46446609e-01),
+      libMesh::Point(5.00000000e-01, 7.07106781e-01, 5.00000000e-01),
+      libMesh::Point(8.53553391e-01, 5.00000000e-01, 8.53553391e-01),
+      libMesh::Point(1.00000000e+00, 8.65956056e-17, 1.00000000e+00)};
+  const std::vector<Point> evaluated_points =
+      SplineUtils::bSplineControlPoints(start, end, direction, direction, cps_per_half, sharpness);
+  for (const auto i : index_range(expected_cps))
+  {
+    EXPECT_NEAR((expected_cps[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
+  }
+}
+
+TEST(SplineUtilsTest, ClosestPoint2DTest)
+{
+  const libMesh::Point start(1, 2, 0);
+  const libMesh::Point end(2, 1, 0);
+  const libMesh::RealVectorValue direction1(1, 0, 0);
+  const libMesh::RealVectorValue direction2(0, 1, 0);
+  const std::vector<Point> evaluated_points =
+      SplineUtils::closestPoints(start, end, direction1, direction2);
+  const std::vector<Point> expected_points = {libMesh::Point(2, 2, 0), libMesh::Point(2, 2, 0)};
+  for (const auto i : index_range(expected_points))
+    EXPECT_NEAR((expected_points[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
+}
+
+TEST(SplineUtilsTest, ClosestPoint3DTest1)
+{
+  const libMesh::Point start(1, 2, 0);
+  const libMesh::Point end(2, 1, 1);
+  const libMesh::RealVectorValue direction1(1, 0, 0);
+  const libMesh::RealVectorValue direction2(0, 1, 0);
+  const std::vector<Point> evaluated_points =
+      SplineUtils::closestPoints(start, end, direction1, direction2);
+  const std::vector<Point> expected_points = {libMesh::Point(2, 2, 0), libMesh::Point(2, 2, 1)};
+  for (const auto i : index_range(expected_points))
+    EXPECT_NEAR((expected_points[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
+}
+
+TEST(SplineUtilsTest, ClosestPoint3DTest2)
+{
+  const libMesh::Point start(1, 2, 0);
+  const libMesh::Point end(2, 1, 1);
+  const libMesh::RealVectorValue direction1(1, 1, 1);
+  const libMesh::RealVectorValue direction2(1, 2, -1);
+  const std::vector<Point> evaluated_points =
+      SplineUtils::closestPoints(start, end, direction1, direction2);
+  const std::vector<Point> expected_points = {libMesh::Point(1.71428571, 2.71428571, 0.71428571),
+                                              libMesh::Point(2.57142857, 2.14285714, 0.42857143)};
+  for (const auto i : index_range(expected_points))
+    EXPECT_NEAR((expected_points[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
+}
+
+TEST(SplineUtilsTest, CPsAlongLineTest)
+{
+  const libMesh::Point start(1, 2, 0);
+  const libMesh::Point end(2, 2, 0);
+  const libMesh::RealVectorValue direction(1, 0, 0);
+  const libMesh::Real sharpness = 1.0;
+  const unsigned int num_cps = 3;
+  const std::vector<Point> evaluated_points =
+      SplineUtils::controlPointsAlongLine(start, end, direction, sharpness, num_cps);
+  const std::vector<Point> expected_points = {
+      libMesh::Point(1, 2, 0), libMesh::Point(1.5, 2, 0), libMesh::Point(2, 2, 0)};
+  for (const auto i : index_range(expected_points))
+  {
+    EXPECT_NEAR((expected_points[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
+  }
+}
+
+TEST(SplineUtilsTest, CPsAlongLineOneTest)
+{
+  const libMesh::Point start(1, 2, 0);
+  const libMesh::Point end(2, 2, 0);
+  const libMesh::RealVectorValue direction(1, 0, 0);
+  const libMesh::Real sharpness = 1.0;
+  const unsigned int num_cps = 1;
+  const std::vector<Point> evaluated_points =
+      SplineUtils::controlPointsAlongLine(start, end, direction, sharpness, num_cps);
+  const std::vector<Point> expected_points = {libMesh::Point(1, 2, 0)};
+  for (const auto i : index_range(expected_points))
+  {
+    EXPECT_NEAR((expected_points[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
+  }
+}
+
+TEST(SplineUtilsTest, MakeControlPointFailTest1)
+{
+  const libMesh::Point start(1, 2, 0);
+  const libMesh::Point end(2, 2, 0);
+  const libMesh::RealVectorValue direction(1, 0, 0);
+  const libMesh::Real sharpness = -1.0;
+  EXPECT_THROW(
+      {
+        try
+        {
+          SplineUtils::makeControlPoint(start, end, direction, sharpness);
+        }
+        catch (const std::exception & e)
+        {
+          EXPECT_STREQ(e.what(), "Sharpness must be in [0,1]!");
+          throw;
+        }
+      },
+      std::exception);
+}
+
+TEST(SplineUtilsTest, MakeControlPointFailTest2)
+{
+  const libMesh::Point start(1, 2, 0);
+  const libMesh::Point end(2, 2, 0);
+  const libMesh::RealVectorValue direction(1, 0, 0);
+  const libMesh::Real sharpness = 1.5;
+  EXPECT_THROW(
+      {
+        try
+        {
+          SplineUtils::makeControlPoint(start, end, direction, sharpness);
+        }
+        catch (const std::exception & e)
+        {
+          EXPECT_STREQ(e.what(), "Sharpness must be in [0,1]!");
+          throw;
+        }
+      },
+      std::exception);
+}
+
+TEST(SplineUtilsTest, TrivialCPsTest)
+{
+  const libMesh::Point start(1, 2, 0);
+  const libMesh::Point end(2, 1, 0);
+  const libMesh::RealVectorValue direction1(1, 0, 0);
+  const libMesh::RealVectorValue direction2(0, 1, 0);
+  const double sharpness = 0;
+  const unsigned int cps_per_half = 2;
+  const std::vector<Point> evaluated_cps = SplineUtils::bSplineControlPoints(
+      start, end, direction1, direction2, cps_per_half, sharpness);
+
+  const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 0),
+                                           libMesh::Point(1, 2, 0),
+                                           libMesh::Point(2, 2, 0),
+                                           libMesh::Point(2, 1, 0),
+                                           libMesh::Point(2, 1, 0)};
+  for (const auto i : index_range(expected_cps))
+    EXPECT_NEAR((expected_cps[i] - evaluated_cps[i]).norm(), 0, libMesh::TOLERANCE);
+}
+
+TEST(SplineUtilsTest, HalfSharpCPsTest)
+{
+  const libMesh::Point start(1, 2, 0);
+  const libMesh::Point end(2, 1, 0);
+  const libMesh::RealVectorValue direction1(1, 0, 0);
+  const libMesh::RealVectorValue direction2(0, 1, 0);
+  const double sharpness = 0.5;
+  const unsigned int cps_per_half = 2;
+  const std::vector<Point> evaluated_cps = SplineUtils::bSplineControlPoints(
+      start, end, direction1, direction2, cps_per_half, sharpness);
+
+  const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 0),
+                                           libMesh::Point(1.5, 2, 0),
+                                           libMesh::Point(2, 2, 0),
+                                           libMesh::Point(2, 1.5, 0),
+                                           libMesh::Point(2, 1, 0)};
+  for (const auto i : index_range(expected_cps))
+    EXPECT_NEAR((expected_cps[i] - evaluated_cps[i]).norm(), 0, libMesh::TOLERANCE);
+}
+
+TEST(SplineUtilsTest, HalfSharpCPs3DTest)
+{
+  const libMesh::Point start(1, 2, 1);
+  const libMesh::Point end(2, 1, 0);
+  const libMesh::RealVectorValue direction1(1, 0, 0);
+  const libMesh::RealVectorValue direction2(0, 1, 0);
+  const double sharpness = 0.5;
+  const unsigned int cps_per_half = 2;
+  const std::vector<Point> evaluated_cps = SplineUtils::bSplineControlPoints(
+      start, end, direction1, direction2, cps_per_half, sharpness);
+
+  const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 1),
+                                           libMesh::Point(1.5, 2, 1),
+                                           libMesh::Point(2, 2, 0.5),
+                                           libMesh::Point(2, 1.5, 0),
+                                           libMesh::Point(2, 1, 0)};
+  for (const auto i : index_range(expected_cps))
+    EXPECT_NEAR((expected_cps[i] - evaluated_cps[i]).norm(), 0, libMesh::TOLERANCE);
+}
+
+TEST(SplineUtilsTest, FullSharpCPs3DTest)
+{
+  const libMesh::Point start(1, 2, 1);
+  const libMesh::Point end(2, 1, 0);
+  const libMesh::RealVectorValue direction1(1, 0, 0);
+  const libMesh::RealVectorValue direction2(0, 1, 0);
+  const double sharpness = 1.0;
+  const unsigned int cps_per_half = 3;
+  const std::vector<Point> evaluated_cps = SplineUtils::bSplineControlPoints(
+      start, end, direction1, direction2, cps_per_half, sharpness);
+
+  const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 1),
+                                           libMesh::Point(1.5, 2, 1),
+                                           libMesh::Point(2, 2, 1),
+                                           libMesh::Point(2, 2, 0.5),
+                                           libMesh::Point(2, 2, 0),
+                                           libMesh::Point(2, 1.5, 0),
+                                           libMesh::Point(2, 1, 0)};
+  for (const auto i : index_range(expected_cps))
+    EXPECT_NEAR((expected_cps[i] - evaluated_cps[i]).norm(), 0, libMesh::TOLERANCE);
+}
+
+TEST(SplineUtilsTest, NonuniquePointError)
+{
+  const libMesh::Point start(1, 0, 0);
+  const libMesh::Point end(1, 0, 0);
+  const libMesh::RealVectorValue direction1(0, 1, 0);
+  const libMesh::RealVectorValue direction2(0, 1, 0);
+  const unsigned int cps_per_half = 2;
+  const double sharpness = 1.0;
+  EXPECT_THROW(
+      {
+        try
+        {
+          SplineUtils::bSplineControlPoints(
+              start, end, direction1, direction2, cps_per_half, sharpness);
+        }
+        catch (const std::exception & e)
+        {
+          EXPECT_STREQ(e.what(), "Start and end points must be unique.");
+          throw;
+        }
+      },
+      std::exception);
+}
+
+TEST(SplineUtilsTest, ZeroDirection1Error)
+{
+  const libMesh::Point start(1, 0, 0);
+  const libMesh::Point end(1, 1, 0);
+  const libMesh::RealVectorValue direction1(0, 0, 0);
+  const libMesh::RealVectorValue direction2(0, 1, 0);
+  const unsigned int cps_per_half = 2;
+  const double sharpness = 1.0;
+  EXPECT_THROW(
+      {
+        try
+        {
+          SplineUtils::bSplineControlPoints(
+              start, end, direction1, direction2, cps_per_half, sharpness);
+        }
+        catch (const std::exception & e)
+        {
+          EXPECT_STREQ(e.what(), "Direction vectors must have a nonzero magnitude.");
+          throw;
+        }
+      },
+      std::exception);
+}
+TEST(SplineUtilsTest, ZeroDirection2Error)
+{
+  const libMesh::Point start(1, 0, 0);
+  const libMesh::Point end(1, 1, 0);
+  const libMesh::RealVectorValue direction1(0, 1, 0);
+  const libMesh::RealVectorValue direction2(0, 0, 0);
+  const unsigned int cps_per_half = 2;
+  const double sharpness = 1.0;
+  EXPECT_THROW(
+      {
+        try
+        {
+          SplineUtils::bSplineControlPoints(
+              start, end, direction1, direction2, cps_per_half, sharpness);
+        }
+        catch (const std::exception & e)
+        {
+          EXPECT_STREQ(e.what(), "Direction vectors must have a nonzero magnitude.");
+          throw;
+        }
+      },
+      std::exception);
+}
+TEST(SplineUtilsTest, ZeroDirectionBothError)
+{
+  const libMesh::Point start(1, 0, 0);
+  const libMesh::Point end(1, 1, 0);
+  const libMesh::RealVectorValue direction1(0, 0, 0);
+  const libMesh::RealVectorValue direction2(0, 0, 0);
+  const unsigned int cps_per_half = 2;
+  const double sharpness = 1.0;
+  EXPECT_THROW(
+      {
+        try
+        {
+          SplineUtils::bSplineControlPoints(
+              start, end, direction1, direction2, cps_per_half, sharpness);
+        }
+        catch (const std::exception & e)
+        {
+          EXPECT_STREQ(e.what(), "Direction vectors must have a nonzero magnitude.");
+          throw;
+        }
+      },
+      std::exception);
+}

--- a/unit/src/SplineUtilsTest.C
+++ b/unit/src/SplineUtilsTest.C
@@ -62,16 +62,19 @@ TEST(SplineUtilsTest, 3DCircularCPTest)
   const libMesh::Point start(0, 0, 0);
   const libMesh::Point end(1, 0, 1);
   const libMesh::RealVectorValue direction(0, 1, 0);
-  const unsigned int cps_per_half = 2;
-  const libMesh::Real sharpness = 1.0; // not used in calculation but needed for function
+  const unsigned int cps = 5;
   const std::vector<Point> expected_cps = {
       libMesh::Point(0, 0, 0),
       libMesh::Point(1.46446609e-01, 5.00000000e-01, 1.46446609e-01),
       libMesh::Point(5.00000000e-01, 7.07106781e-01, 5.00000000e-01),
       libMesh::Point(8.53553391e-01, 5.00000000e-01, 8.53553391e-01),
       libMesh::Point(1.00000000e+00, 8.65956056e-17, 1.00000000e+00)};
+  // Allow warning
+  const auto save_status = Moose::_throw_on_warning;
+  Moose::_throw_on_warning = false;
   const auto evaluated_points =
-      SplineUtils::bSplineControlPoints(start, end, direction, direction, cps_per_half, sharpness);
+      SplineUtils::bSplineControlPoints(start, end, direction, direction, cps / 2, /*sharpness*/ 0);
+  Moose::_throw_on_warning = save_status;
   for (const auto i : index_range(expected_cps))
     EXPECT_NEAR((expected_cps[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
 }
@@ -151,14 +154,14 @@ TEST(SplineUtilsTest, TrivialCPsTest)
   const libMesh::Point end(2, 1, 0);
   const libMesh::RealVectorValue direction1(1, 0, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
-  const Real sharpness = 0;
-  const unsigned int cps_per_half = 2;
+  const unsigned int cps_per_half = 3;
   const auto evaluated_cps = SplineUtils::bSplineControlPoints(
-      start, end, direction1, direction2, cps_per_half, sharpness);
+      start, end, direction1, direction2, cps_per_half, /*sharpness*/ 0);
 
   const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 0),
                                            libMesh::Point(1, 2, 0),
-                                           libMesh::Point(2, 2, 0),
+                                           libMesh::Point(1, 2, 0),
+                                           libMesh::Point(2, 1, 0),
                                            libMesh::Point(2, 1, 0),
                                            libMesh::Point(2, 1, 0)};
   for (const auto i : index_range(expected_cps))
@@ -178,7 +181,6 @@ TEST(SplineUtilsTest, HalfSharpCPsTest)
 
   const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 0),
                                            libMesh::Point(1.5, 2, 0),
-                                           libMesh::Point(2, 2, 0),
                                            libMesh::Point(2, 1.5, 0),
                                            libMesh::Point(2, 1, 0)};
   for (const auto i : index_range(expected_cps))
@@ -198,7 +200,6 @@ TEST(SplineUtilsTest, HalfSharpCPs3DTest)
 
   const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 1),
                                            libMesh::Point(1.5, 2, 1),
-                                           libMesh::Point(2, 2, 0.5),
                                            libMesh::Point(2, 1.5, 0),
                                            libMesh::Point(2, 1, 0)};
   for (const auto i : index_range(expected_cps))
@@ -219,7 +220,6 @@ TEST(SplineUtilsTest, FullSharpCPs3DTest)
   const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 1),
                                            libMesh::Point(1.5, 2, 1),
                                            libMesh::Point(2, 2, 1),
-                                           libMesh::Point(2, 2, 0.5),
                                            libMesh::Point(2, 2, 0),
                                            libMesh::Point(2, 1.5, 0),
                                            libMesh::Point(2, 1, 0)};
@@ -274,6 +274,7 @@ TEST(SplineUtilsTest, ZeroDirection1Error)
       },
       std::exception);
 }
+
 TEST(SplineUtilsTest, ZeroDirection2Error)
 {
   const libMesh::Point start(1, 0, 0);

--- a/unit/src/SplineUtilsTest.C
+++ b/unit/src/SplineUtilsTest.C
@@ -70,11 +70,14 @@ TEST(SplineUtilsTest, 3DCircularCPTest)
       libMesh::Point(8.53553391e-01, 5.00000000e-01, 8.53553391e-01),
       libMesh::Point(1.00000000e+00, 8.65956056e-17, 1.00000000e+00)};
   // Allow warning
-  const auto save_status = Moose::_throw_on_warning;
+  const auto save_tow = Moose::_throw_on_warning;
+  const auto save_wae = Moose::_warnings_are_errors;
   Moose::_throw_on_warning = false;
+  Moose::_warnings_are_errors = false;
   const auto evaluated_points =
       SplineUtils::bSplineControlPoints(start, end, direction, direction, cps / 2, /*sharpness*/ 0);
-  Moose::_throw_on_warning = save_status;
+  Moose::_throw_on_warning = save_tow;
+  Moose::_warnings_are_errors = save_wae;
   for (const auto i : index_range(expected_cps))
     EXPECT_NEAR((expected_cps[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
 }

--- a/unit/src/SplineUtilsTest.C
+++ b/unit/src/SplineUtilsTest.C
@@ -7,11 +7,12 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#include "gtest/gtest.h"
+#include "SplineUtils.h"
 #include "BSpline.h"
 #include "libMeshReducedNamespace.h"
 #include "MooseError.h"
-#include "SplineUtils.h"
+
+#include "gtest/gtest.h"
 
 TEST(SplineUtilsTest, SimpleCircularCPTest)
 {
@@ -24,12 +25,9 @@ TEST(SplineUtilsTest, SimpleCircularCPTest)
                                            libMesh::Point(0.5, 0.5, 0),
                                            libMesh::Point(8.53553391e-01, 3.53553391e-01, 0),
                                            libMesh::Point(1.0, 0, 0)};
-  const std::vector<Point> evaluated_points =
-      SplineUtils::circularControlPoints(start, end, direction, cps);
+  const auto evaluated_points = SplineUtils::circularControlPoints(start, end, direction, cps);
   for (const auto i : index_range(expected_cps))
-  {
     EXPECT_NEAR((expected_cps[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
-  }
 }
 
 TEST(SplineUtilsTest, CircularError)
@@ -49,7 +47,10 @@ TEST(SplineUtilsTest, CircularError)
           EXPECT_STREQ(
               e.what(),
               "Parallel lines cannot be interpolated using points along a circle! Direction "
-              "vectors are incompatible with point locations.");
+              "vectors are incompatible with point locations.\nStart point: "
+              "(x,y,z)=(       0,        1,        0)\nEnd point: "
+              "(x,y,z)=(       1,        0,        0)\nDirection: (x,y,z)=(       0,        1,     "
+              "   0)");
           throw;
         }
       },
@@ -69,12 +70,10 @@ TEST(SplineUtilsTest, 3DCircularCPTest)
       libMesh::Point(5.00000000e-01, 7.07106781e-01, 5.00000000e-01),
       libMesh::Point(8.53553391e-01, 5.00000000e-01, 8.53553391e-01),
       libMesh::Point(1.00000000e+00, 8.65956056e-17, 1.00000000e+00)};
-  const std::vector<Point> evaluated_points =
+  const auto evaluated_points =
       SplineUtils::bSplineControlPoints(start, end, direction, direction, cps_per_half, sharpness);
   for (const auto i : index_range(expected_cps))
-  {
     EXPECT_NEAR((expected_cps[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
-  }
 }
 
 TEST(SplineUtilsTest, ClosestPoint2DTest)
@@ -83,11 +82,11 @@ TEST(SplineUtilsTest, ClosestPoint2DTest)
   const libMesh::Point end(2, 1, 0);
   const libMesh::RealVectorValue direction1(1, 0, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
-  const std::vector<Point> evaluated_points =
-      SplineUtils::closestPoints(start, end, direction1, direction2);
-  const std::vector<Point> expected_points = {libMesh::Point(2, 2, 0), libMesh::Point(2, 2, 0)};
-  for (const auto i : index_range(expected_points))
-    EXPECT_NEAR((expected_points[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
+  const auto evaluated_points = SplineUtils::closestPoints(start, end, direction1, direction2);
+  const std::pair<Point, Point> expected_points = {libMesh::Point(2, 2, 0),
+                                                   libMesh::Point(2, 2, 0)};
+  EXPECT_NEAR((expected_points.first - evaluated_points.first).norm(), 0, libMesh::TOLERANCE);
+  EXPECT_NEAR((expected_points.second - evaluated_points.second).norm(), 0, libMesh::TOLERANCE);
 }
 
 TEST(SplineUtilsTest, ClosestPoint3DTest1)
@@ -96,11 +95,11 @@ TEST(SplineUtilsTest, ClosestPoint3DTest1)
   const libMesh::Point end(2, 1, 1);
   const libMesh::RealVectorValue direction1(1, 0, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
-  const std::vector<Point> evaluated_points =
-      SplineUtils::closestPoints(start, end, direction1, direction2);
-  const std::vector<Point> expected_points = {libMesh::Point(2, 2, 0), libMesh::Point(2, 2, 1)};
-  for (const auto i : index_range(expected_points))
-    EXPECT_NEAR((expected_points[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
+  const auto evaluated_points = SplineUtils::closestPoints(start, end, direction1, direction2);
+  const std::pair<Point, Point> expected_points = {libMesh::Point(2, 2, 0),
+                                                   libMesh::Point(2, 2, 1)};
+  EXPECT_NEAR((expected_points.first - evaluated_points.first).norm(), 0, libMesh::TOLERANCE);
+  EXPECT_NEAR((expected_points.second - evaluated_points.second).norm(), 0, libMesh::TOLERANCE);
 }
 
 TEST(SplineUtilsTest, ClosestPoint3DTest2)
@@ -109,12 +108,12 @@ TEST(SplineUtilsTest, ClosestPoint3DTest2)
   const libMesh::Point end(2, 1, 1);
   const libMesh::RealVectorValue direction1(1, 1, 1);
   const libMesh::RealVectorValue direction2(1, 2, -1);
-  const std::vector<Point> evaluated_points =
-      SplineUtils::closestPoints(start, end, direction1, direction2);
-  const std::vector<Point> expected_points = {libMesh::Point(1.71428571, 2.71428571, 0.71428571),
-                                              libMesh::Point(2.57142857, 2.14285714, 0.42857143)};
-  for (const auto i : index_range(expected_points))
-    EXPECT_NEAR((expected_points[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
+  const auto evaluated_points = SplineUtils::closestPoints(start, end, direction1, direction2);
+  const std::pair<Point, Point> expected_points = {
+      libMesh::Point(1.71428571, 2.71428571, 0.71428571),
+      libMesh::Point(2.57142857, 2.14285714, 0.42857143)};
+  EXPECT_NEAR((expected_points.first - evaluated_points.first).norm(), 0, libMesh::TOLERANCE);
+  EXPECT_NEAR((expected_points.second - evaluated_points.second).norm(), 0, libMesh::TOLERANCE);
 }
 
 TEST(SplineUtilsTest, CPsAlongLineTest)
@@ -124,14 +123,12 @@ TEST(SplineUtilsTest, CPsAlongLineTest)
   const libMesh::RealVectorValue direction(1, 0, 0);
   const libMesh::Real sharpness = 1.0;
   const unsigned int num_cps = 3;
-  const std::vector<Point> evaluated_points =
+  const auto evaluated_points =
       SplineUtils::controlPointsAlongLine(start, end, direction, sharpness, num_cps);
   const std::vector<Point> expected_points = {
       libMesh::Point(1, 2, 0), libMesh::Point(1.5, 2, 0), libMesh::Point(2, 2, 0)};
   for (const auto i : index_range(expected_points))
-  {
     EXPECT_NEAR((expected_points[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
-  }
 }
 
 TEST(SplineUtilsTest, CPsAlongLineOneTest)
@@ -141,55 +138,11 @@ TEST(SplineUtilsTest, CPsAlongLineOneTest)
   const libMesh::RealVectorValue direction(1, 0, 0);
   const libMesh::Real sharpness = 1.0;
   const unsigned int num_cps = 1;
-  const std::vector<Point> evaluated_points =
+  const auto evaluated_points =
       SplineUtils::controlPointsAlongLine(start, end, direction, sharpness, num_cps);
   const std::vector<Point> expected_points = {libMesh::Point(1, 2, 0)};
   for (const auto i : index_range(expected_points))
-  {
     EXPECT_NEAR((expected_points[i] - evaluated_points[i]).norm(), 0, libMesh::TOLERANCE);
-  }
-}
-
-TEST(SplineUtilsTest, MakeControlPointFailTest1)
-{
-  const libMesh::Point start(1, 2, 0);
-  const libMesh::Point end(2, 2, 0);
-  const libMesh::RealVectorValue direction(1, 0, 0);
-  const libMesh::Real sharpness = -1.0;
-  EXPECT_THROW(
-      {
-        try
-        {
-          SplineUtils::makeControlPoint(start, end, direction, sharpness);
-        }
-        catch (const std::exception & e)
-        {
-          EXPECT_STREQ(e.what(), "Sharpness must be in [0,1]!");
-          throw;
-        }
-      },
-      std::exception);
-}
-
-TEST(SplineUtilsTest, MakeControlPointFailTest2)
-{
-  const libMesh::Point start(1, 2, 0);
-  const libMesh::Point end(2, 2, 0);
-  const libMesh::RealVectorValue direction(1, 0, 0);
-  const libMesh::Real sharpness = 1.5;
-  EXPECT_THROW(
-      {
-        try
-        {
-          SplineUtils::makeControlPoint(start, end, direction, sharpness);
-        }
-        catch (const std::exception & e)
-        {
-          EXPECT_STREQ(e.what(), "Sharpness must be in [0,1]!");
-          throw;
-        }
-      },
-      std::exception);
 }
 
 TEST(SplineUtilsTest, TrivialCPsTest)
@@ -198,9 +151,9 @@ TEST(SplineUtilsTest, TrivialCPsTest)
   const libMesh::Point end(2, 1, 0);
   const libMesh::RealVectorValue direction1(1, 0, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
-  const double sharpness = 0;
+  const Real sharpness = 0;
   const unsigned int cps_per_half = 2;
-  const std::vector<Point> evaluated_cps = SplineUtils::bSplineControlPoints(
+  const auto evaluated_cps = SplineUtils::bSplineControlPoints(
       start, end, direction1, direction2, cps_per_half, sharpness);
 
   const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 0),
@@ -218,9 +171,9 @@ TEST(SplineUtilsTest, HalfSharpCPsTest)
   const libMesh::Point end(2, 1, 0);
   const libMesh::RealVectorValue direction1(1, 0, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
-  const double sharpness = 0.5;
+  const Real sharpness = 0.5;
   const unsigned int cps_per_half = 2;
-  const std::vector<Point> evaluated_cps = SplineUtils::bSplineControlPoints(
+  const auto evaluated_cps = SplineUtils::bSplineControlPoints(
       start, end, direction1, direction2, cps_per_half, sharpness);
 
   const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 0),
@@ -238,9 +191,9 @@ TEST(SplineUtilsTest, HalfSharpCPs3DTest)
   const libMesh::Point end(2, 1, 0);
   const libMesh::RealVectorValue direction1(1, 0, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
-  const double sharpness = 0.5;
+  const Real sharpness = 0.5;
   const unsigned int cps_per_half = 2;
-  const std::vector<Point> evaluated_cps = SplineUtils::bSplineControlPoints(
+  const auto evaluated_cps = SplineUtils::bSplineControlPoints(
       start, end, direction1, direction2, cps_per_half, sharpness);
 
   const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 1),
@@ -258,9 +211,9 @@ TEST(SplineUtilsTest, FullSharpCPs3DTest)
   const libMesh::Point end(2, 1, 0);
   const libMesh::RealVectorValue direction1(1, 0, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
-  const double sharpness = 1.0;
+  const Real sharpness = 1.0;
   const unsigned int cps_per_half = 3;
-  const std::vector<Point> evaluated_cps = SplineUtils::bSplineControlPoints(
+  const auto evaluated_cps = SplineUtils::bSplineControlPoints(
       start, end, direction1, direction2, cps_per_half, sharpness);
 
   const std::vector<Point> expected_cps = {libMesh::Point(1, 2, 1),
@@ -281,7 +234,7 @@ TEST(SplineUtilsTest, NonuniquePointError)
   const libMesh::RealVectorValue direction1(0, 1, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
   const unsigned int cps_per_half = 2;
-  const double sharpness = 1.0;
+  const Real sharpness = 1.0;
   EXPECT_THROW(
       {
         try
@@ -291,7 +244,7 @@ TEST(SplineUtilsTest, NonuniquePointError)
         }
         catch (const std::exception & e)
         {
-          EXPECT_STREQ(e.what(), "Start and end points must be unique.");
+          EXPECT_STREQ(e.what(), "Start and end points must be different.");
           throw;
         }
       },
@@ -305,7 +258,7 @@ TEST(SplineUtilsTest, ZeroDirection1Error)
   const libMesh::RealVectorValue direction1(0, 0, 0);
   const libMesh::RealVectorValue direction2(0, 1, 0);
   const unsigned int cps_per_half = 2;
-  const double sharpness = 1.0;
+  const Real sharpness = 1.0;
   EXPECT_THROW(
       {
         try
@@ -328,7 +281,7 @@ TEST(SplineUtilsTest, ZeroDirection2Error)
   const libMesh::RealVectorValue direction1(0, 1, 0);
   const libMesh::RealVectorValue direction2(0, 0, 0);
   const unsigned int cps_per_half = 2;
-  const double sharpness = 1.0;
+  const Real sharpness = 1.0;
   EXPECT_THROW(
       {
         try
@@ -344,6 +297,7 @@ TEST(SplineUtilsTest, ZeroDirection2Error)
       },
       std::exception);
 }
+
 TEST(SplineUtilsTest, ZeroDirectionBothError)
 {
   const libMesh::Point start(1, 0, 0);
@@ -351,7 +305,7 @@ TEST(SplineUtilsTest, ZeroDirectionBothError)
   const libMesh::RealVectorValue direction1(0, 0, 0);
   const libMesh::RealVectorValue direction2(0, 0, 0);
   const unsigned int cps_per_half = 2;
-  const double sharpness = 1.0;
+  const Real sharpness = 1.0;
   EXPECT_THROW(
       {
         try


### PR DESCRIPTION
closes #30928

## Reason
For use with recently-submitted BSpline utility, which relies on the input of control points to be interpolated. Builds on the project of creating a pipe junction component.

## Design
Utility will auto-create interior control points to be used with BSpline.C. Control points are selected so that the derivatives at supplied points to be connected are honored, which allows the connection to be as smooth as possible. Additional parameter of `sharpness` was included to give the user control over the shape of the curve. Users can also vary the control point density.

## Impact
Supplies general utility for B-Splines (or other spline types) which can have a wide application base.
