### PR TITLE
Fix out of bounds accesses 

### DIFF
--- a/framework/include/materials/ParsedMaterialHelper.h
+++ b/framework/include/materials/ParsedMaterialHelper.h
@@ -28,6 +28,8 @@
   using ParsedMaterialHelper<T>::_mat_prop_descriptors;                                            \
   using ParsedMaterialHelper<T>::_tol;                                                             \
   using ParsedMaterialHelper<T>::_postprocessor_values;                                            \
+  using ParsedMaterialHelper<T>::_extra_symbols;                                                   \
+  using ParsedMaterialHelper<T>::_functors;                                                        \
   using ParsedMaterialHelper<T>::_map_mode
 
 /**

--- a/framework/src/materials/DerivativeParsedMaterialHelper.C
+++ b/framework/src/materials/DerivativeParsedMaterialHelper.C
@@ -266,7 +266,8 @@ DerivativeParsedMaterialHelperTempl<is_ad>::assembleDerivatives()
     recurseDerivative(i, 1, root);
 
   // increase the parameter buffer to provide storage for the material property derivatives
-  _func_params.resize(_nargs + _mat_prop_descriptors.size() + _postprocessor_values.size());
+  _func_params.resize(_nargs + _mat_prop_descriptors.size() + _postprocessor_values.size() +
+                      _extra_symbols.size() + _functors.size());
 }
 
 template <bool is_ad>

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -550,8 +550,8 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _solver_params.push_back(makeLinearSolverParams());
   }
 
-  _nonlocal_cm.resize(_nl_sys_names.size());
-  _cm.resize(_nl_sys_names.size());
+  _nonlocal_cm.resize(numSolverSystems());
+  _cm.resize(numSolverSystems());
 
   _time = 0.0;
   _time_old = 0.0;

--- a/framework/src/timesteppers/TimeSequenceStepperBase.C
+++ b/framework/src/timesteppers/TimeSequenceStepperBase.C
@@ -135,8 +135,6 @@ TimeSequenceStepperBase::computeInitialDT()
 Real
 TimeSequenceStepperBase::computeDT()
 {
-  const auto standard_dt = _time_sequence[_current_step + 1] - _time_sequence[_current_step];
-
   if (_use_last_dt_after_last_t)
   {
     // last *provided* time value index; actual last index corresponds to end time
@@ -144,10 +142,10 @@ TimeSequenceStepperBase::computeDT()
     if (_current_step + 1 > last_t_index)
       return _time_sequence[last_t_index] - _time_sequence[last_t_index - 1];
     else
-      return standard_dt;
+      return _time_sequence[_current_step + 1] - _time_sequence[_current_step];
   }
   else
-    return standard_dt;
+    return _time_sequence[_current_step + 1] - _time_sequence[_current_step];
 }
 
 Real


### PR DESCRIPTION
## Reason
There were a few places where we were addressing out of bounds memory, which meant several tests (~25 from memory, on my installation) were failing in debug mode now that gcc 15 enables assertions in libstdc++ by default.

## Design
Depending on which of the 3 cases we're talking about, either appropriately resized containers (2/3) or delayed reads till when we're sure they're within bounds (1/3). Some tests were failing due to a bug in libMesh, fixed in libMesh/libmesh#4209.

## Impact
Avoids undefined behaviour, tests pass in debug mode with gcc 15.
