### PR TITLE
Add get functions to FunctionElementAverage postprocesssor

### DIFF
--- a/framework/include/postprocessors/FunctionElementAverage.h
+++ b/framework/include/postprocessors/FunctionElementAverage.h
@@ -27,6 +27,9 @@ public:
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;
 
+  const Real & getVolume() const { return _volume; }
+  const Real & getIntegralValue() const { return _integral_value; }
+
 protected:
   Real _volume;
 };


### PR DESCRIPTION
Added constant get functions to FunctionElementAverage to return the volume and the integral value.

Closes #31049.