### PR TITLE
Avoid redundant add/remove of GhostingFunctors

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -3147,7 +3147,10 @@ MooseApp::attachRelationshipManagers(MeshBase & mesh, MooseMesh & moose_mesh)
     if (rm->isType(Moose::RelationshipManagerType::GEOMETRIC))
     {
       if (rm->attachGeometricEarly())
+      {
         mesh.add_ghosting_functor(createRMFromTemplateAndInit(*rm, moose_mesh, mesh));
+        _attached_relationship_managers[Moose::RelationshipManagerType::GEOMETRIC].insert(rm.get());
+      }
       else
       {
         // If we have a geometric ghosting functor that can't be attached early, then we have to

--- a/framework/src/problems/SubProblem.C
+++ b/framework/src/problems/SubProblem.C
@@ -1068,13 +1068,14 @@ SubProblem::removeAlgebraicGhostingFunctor(GhostingFunctor & algebraic_gf)
 {
   EquationSystems & eq = es();
   const auto n_sys = eq.n_systems();
+  DofMap & nl_dof_map = eq.get_system(0).get_dof_map();
 
-#ifndef NDEBUG
-  const DofMap & nl_dof_map = eq.get_system(0).get_dof_map();
   const bool found_in_root_sys =
       std::find(nl_dof_map.algebraic_ghosting_functors_begin(),
                 nl_dof_map.algebraic_ghosting_functors_end(),
                 &algebraic_gf) != nl_dof_map.algebraic_ghosting_functors_end();
+
+#ifndef NDEBUG
   const bool found_in_our_map =
       _root_alg_gf_to_sys_clones.find(&algebraic_gf) != _root_alg_gf_to_sys_clones.end();
   mooseAssert(found_in_root_sys == found_in_our_map,
@@ -1082,7 +1083,9 @@ SubProblem::removeAlgebraicGhostingFunctor(GhostingFunctor & algebraic_gf)
               "it in our gf to clones map");
 #endif
 
-  eq.get_system(0).get_dof_map().remove_algebraic_ghosting_functor(algebraic_gf);
+  if (found_in_root_sys) // libMesh yells if we try to remove
+                         // something that's not there
+    nl_dof_map.remove_algebraic_ghosting_functor(algebraic_gf);
 
   auto it = _root_alg_gf_to_sys_clones.find(&algebraic_gf);
   if (it == _root_alg_gf_to_sys_clones.end())
@@ -1111,11 +1114,12 @@ SubProblem::removeCouplingGhostingFunctor(GhostingFunctor & coupling_gf)
   if (!num_nl_sys)
     return;
 
-#ifndef NDEBUG
-  const DofMap & nl_dof_map = eq.get_system(0).get_dof_map();
+  DofMap & nl_dof_map = eq.get_system(0).get_dof_map();
   const bool found_in_root_sys = std::find(nl_dof_map.coupling_functors_begin(),
                                            nl_dof_map.coupling_functors_end(),
                                            &coupling_gf) != nl_dof_map.coupling_functors_end();
+
+#ifndef NDEBUG
   const bool found_in_our_map =
       _root_coupling_gf_to_sys_clones.find(&coupling_gf) != _root_coupling_gf_to_sys_clones.end();
   mooseAssert(found_in_root_sys == found_in_our_map,
@@ -1123,7 +1127,9 @@ SubProblem::removeCouplingGhostingFunctor(GhostingFunctor & coupling_gf)
               "it in our gf to clones map");
 #endif
 
-  eq.get_system(0).get_dof_map().remove_coupling_functor(coupling_gf);
+  if (found_in_root_sys) // libMesh yells if we try to remove
+                         // something that's not there
+    nl_dof_map.remove_coupling_functor(coupling_gf);
 
   auto it = _root_coupling_gf_to_sys_clones.find(&coupling_gf);
   if (it == _root_coupling_gf_to_sys_clones.end())

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -26,7 +26,6 @@
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/string_to_enum.h"
-#include "libmesh/default_coupling.h"
 
 // TIMPI includes
 #include "timpi/parallel_sync.h"
@@ -102,10 +101,6 @@ MultiAppProjectionTransfer::initialSetup()
                          .feType();
 
     LinearImplicitSystem & proj_sys = to_es.add_system<LinearImplicitSystem>("proj-sys-" + name());
-
-    proj_sys.get_dof_map().add_coupling_functor(
-        proj_sys.get_dof_map().default_coupling(),
-        false); // The false keeps it from getting added to the mesh
 
     _proj_var_num = proj_sys.add_variable("var", fe_type);
     proj_sys.attach_assemble_function(assemble_l2);


### PR DESCRIPTION
Refs #31069

## Reason
This should avoid soon-to-be-deprecated calls to the libMesh add/remove methods

## Design
Fixing the tracking of `_attached_relationship_managers` fixes one to-be-deprecated redundant add.  Avoiding a manually-reattached `default_coupling()` object fixes the second.  Manually checking for attempted removals of non-attached functors fixes that problem.

## Impact
If any apps are directly removing GhostingFunctors independent of the MOOSE RelationshipManager system, then that `default_coupling()` add might have been a necessary re-add.  Otherwise we should see no impact other than forwards compatibility.