### PR TITLE
Add kokkos+libceed to all petsc builds, update container mpi, update containers, fix conda zsh on linux

### DIFF
--- a/apptainer/mpi.def
+++ b/apptainer/mpi.def
@@ -31,18 +31,14 @@
 
 {#- The files directory for this definition                                                   -#}
 {%- set FILES_DIR = MOOSE_DIR + '/apptainer/files/mpi' -%}
-{#- Whether or not to enable openmpi                                                          -#}
-{%- set ENABLE_OPENMPI = ALTERNATE_FROM is not defined or ALTERNATE_FROM == "cuda" -%}
-{#- Whether or not to enable mpich                                                            -#}
-{%- set ENABLE_MPICH = ALTERNATE_FROM is not defined or ALTERNATE_FROM != "cuda" -%}
 
 Bootstrap: oras
 {%- if ALTERNATE_FROM == "gcc_min" or ALTERNATE_FROM == "clang" or ALTERNATE_FROM == "clang_min" %}
-From: mooseharbor.hpc.inl.gov/base/rocky-x86_64:8.10-3
+From: mooseharbor.hpc.inl.gov/base/rocky-x86_64:8.10-5
 {%- elif ALTERNATE_FROM == "cuda" %}
-From: mooseharbor.hpc.inl.gov/moose-hpcbase/rocky-cuda-x86_64:8.10-cuda12.4-1
+From: mooseharbor.hpc.inl.gov/moose-hpcbase/rocky-cuda-x86_64:8.10-cuda12.4-3
 {%- else %}
-From: mooseharbor.hpc.inl.gov/moose-hpcbase/rocky-x86_64:8.10-2
+From: mooseharbor.hpc.inl.gov/moose-hpcbase/rocky-x86_64:8.10-3
 {%- endif %}
 # Logan Harbour
 Fingerprints: 841AF5A51549CAFFFB474F65207184EA34A4BD48
@@ -90,14 +86,12 @@ EOF
 
     export MOOSE_JOBS={{ MOOSE_JOBS or "1" }}
 
-{%- if ENABLE_MPICH %}
     # Install prefix for mpich
     export MOOSE_MPICH_DIR=/opt/mpich
-{%- endif %}
-{%- if ENABLE_OPENMPI %}
     # Install prefix for openmpi
-    export MOOSE_OPENMPI_DIR=/opt/openmpi
-{%- endif %}
+    if [ -d "/opt/openmpi" ]; then
+        export MOOSE_OPENMPI_DIR=/opt/openmpi
+    fi
 
 {%- if ALTERNATE_FROM == "clang" or ALTERNATE_FROM == "clang_min" %}
     # Version of GCC needed to complement Clang
@@ -174,12 +168,13 @@ EOF
 
 {%- if ALTERNATE_FROM == "gcc_min" or ALTERNATE_FROM == "clang" or ALTERNATE_FROM == "clang_min" %}
     # Build and install MPICH
+    MPICH_VERSION=4.3.1
     mkdir ${ROOT_BUILD_DIR}/mpich
     cd ${ROOT_BUILD_DIR}/mpich
-    curl -L -O http://www.mpich.org/static/downloads/4.1.2/mpich-4.1.2.tar.gz
-    tar -xf mpich-4.1.2.tar.gz
-    mkdir mpich-4.1.2/build
-    cd mpich-4.1.2/build
+    curl -L -O http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz
+    tar -xf mpich-${MPICH_VERSION}.tar.gz
+    mkdir mpich-${MPICH_VERSION}/build
+    cd mpich-${MPICH_VERSION}/build
     ../configure --prefix=${MOOSE_MPICH_DIR} \
 {%- if ALTERNATE_FROM == "clang" or ALTERNATE_FROM == "clang_min" %}
       --enable-shared \
@@ -209,23 +204,23 @@ export MANPATH=${MOOSE_MPI_DIR}/share/man:${MANPATH}
 export PATH=${MOOSE_MPI_DIR}/bin:${PATH}
 export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77'
 
-{%- if ENABLE_MPICH %}
     # Add script for loading mpich environment
-    cat << EOF > /opt/mpi/use-mpich
+    if [ -n "$MOOSE_MPICH_DIR" ]; then
+        cat << EOF > /opt/mpi/use-mpich
 #!/bin/bash
 export MOOSE_MPI_DIR=${MOOSE_MPICH_DIR}
 ${USE_MPI_SCRIPT}
 EOF
-{%- endif %}
+    fi
 
-{%- if ENABLE_OPENMPI %}
-    # Add script for loading openmpi environment
-    cat << EOF > /opt/mpi/use-openmpi
+    # Add script for loading openmpi environment if available
+    if [ -n "$MOOSE_OPENMPI_DIR" ]; then
+        cat << EOF > /opt/mpi/use-openmpi
 #!/bin/bash
 export MOOSE_MPI_DIR=${MOOSE_OPENMPI_DIR}
 ${USE_MPI_SCRIPT}
 EOF
-{%- endif %}
+    fi
 
     # Clean Up
     rm -rf ${ROOT_BUILD_DIR}

--- a/apptainer/petsc.def
+++ b/apptainer/petsc.def
@@ -66,7 +66,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     IFS=' ' read -r -a PETSC_OPTIONS <<< "{{ PETSC_OPTIONS }}"
     # Additional options with cuda
     if [ -n "$CUDA_DIR" ]; then
-        PETSC_OPTIONS+=("--download-kokkos" "--download-kokkos-kernels" "--with-cuda" "--with-cuda-arch=70" "--download-slate")
+        PETSC_OPTIONS+=("--with-cuda" "--with-cuda-arch=70" "--download-slate")
     fi
 {%- if PROFILING is defined %}
     # Flags needed for profiling

--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_mpi:
-  - moose-mpi 2025.06.13
+  - moose-mpi 2025.07.23
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 3 %}
+{% set build = 4 %}
 {% set vtk_version = "9.4.2" %}
 {% set vtk_friendly_version = "9.4" %}
 {% set sha256 = "36c98e0da96bb12a30fe53708097aa9492e7b66d5c3b366e1c8dc251e2856a02" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -3,12 +3,12 @@ mpi:
   - openmpi
 
 moose_petsc:
-  - moose-petsc 3.23.0.6.gd9d7fd11dca mpich_2
-  - moose-petsc 3.23.0.6.gd9d7fd11dca openmpi_2
+  - moose-petsc 3.23.0.6.gd9d7fd11dca mpich_3
+  - moose-petsc 3.23.0.6.gd9d7fd11dca openmpi_3
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.4.2 mpich_3
-  - moose-libmesh-vtk 9.4.2 openmpi_3
+  - moose-libmesh-vtk 9.4.2 mpich_4
+  - moose-libmesh-vtk 9.4.2 openmpi_4
 
 zip_keys:
   - mpi

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = "2025.06.25" %}
 
 package:

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2025.06.25 mpich_0
-  - moose-libmesh 2025.06.25 openmpi_0
+  - moose-libmesh 2025.06.25 mpich_1
+  - moose-libmesh 2025.06.25 openmpi_1
 
 moose_wasp:
   - moose-wasp 2025.05.13

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.06.26" %}
+{% set version = "2025.07.22" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -2,7 +2,7 @@ mpi:
   - mpich
 
 moose_dev:
-  - moose-dev 2025.06.26
+  - moose-dev 2025.07.22
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/mpi/base_build.sh
+++ b/conda/mpi/base_build.sh
@@ -12,6 +12,7 @@ function baked_flags()
     # support ZSH initializations
     if setopt &>/dev/null; then
         setopt local_options BASH_REMATCH
+        setopt rematchpcre
     fi
 
     # flags that were set during the build process
@@ -60,6 +61,14 @@ function baked_flags()
         b_FFLAGS=\${b_FFLAGS//\${strip_flag}/}
         b_LDFLAGS=\${b_LDFLAGS//\${strip_flag}/}
     done
+
+    # Remove orphaned -Wl, flags
+    # Note we cannot use variable replacement here as it will not work with spaces in zsh
+    b_CXXFLAGS=$(echo "\$b_CXXFLAGS" | sed 's/-Wl,[[:space:]]//g')
+    b_CPPFLAGS=$(echo "\$b_CPPFLAGS" | sed 's/-Wl,[[:space:]]//g')
+    b_CFLAGS=$(echo "\$b_CFLAGS" | sed 's/-Wl,[[:space:]]//g')
+    b_FFLAGS=$(echo "\$b_FFLAGS" | sed 's/-Wl,[[:space:]]//g')
+    b_LDFLAGS=$(echo "\$b_LDFLAGS" | sed 's/-Wl,[[:space:]]//g')
 
     # append necessary std c library
     export CXXFLAGS="\${b_CXXFLAGS} -std=c++17"

--- a/conda/mpi/meta.yaml
+++ b/conda/mpi/meta.yaml
@@ -6,7 +6,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2025.06.13" %}
+{% set version = "2025.07.23" %}
 
 package:
   name: moose-mpi

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_mpi:
-  - moose-mpi 2025.06.13
+  - moose-mpi 2025.07.23
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -7,7 +7,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 2 %}
+{% set build = 3 %}
 {% set version = "3.23.0.6.gd9d7fd11dca" %}
 
 package:

--- a/scripts/configure_petsc.sh
+++ b/scripts/configure_petsc.sh
@@ -128,6 +128,7 @@ function configure_petsc()
       --download-superlu_dist=1 \
       --download-kokkos=1 \
       --download-kokkos-kernels=1 \
+      --download-libceed=1 \
       "${EXTRA_CONFIGURE_OPTIONS[@]}" \
       "$@"
 

--- a/scripts/configure_petsc.sh
+++ b/scripts/configure_petsc.sh
@@ -25,48 +25,22 @@ function configure_petsc()
     exit 1
   fi
 
+  # Whether or not we're building on apple silicon
+  local IS_APPLE_SILICON=
+  if [[ $(uname -p) == 'arm' ]] && [[ $(uname) == 'Darwin' ]] && [[ $PETSC_ARCH == 'arch-moose' ]]; then
+    IS_APPLE_SILICON=1
+  fi
+
+  # Extra configure options to pass to petsc
+  EXTRA_CONFIGURE_OPTIONS=()
+
   # Use --with-make-np if MOOSE_JOBS is given
-  MAKE_NP_STR=''
-  if [ ! -z "$MOOSE_JOBS" ]; then
-    MAKE_NP_STR="--with-make-np=$MOOSE_JOBS"
+  if [ -n "$MOOSE_JOBS" ]; then
+    EXTRA_CONFIGURE_OPTIONS+=("--with-make-np=$MOOSE_JOBS")
   fi
 
-  # Check to see if HDF5 exists using environment variables and expected locations.
-  # If it does, use it.
-  echo 'INFO: Checking for HDF5...'
-
-  # Prioritize user-set environment variables HDF5_DIR, HDF5DIR, and HDF5_ROOT,
-  # with the first taking the greatest priority
-  if [ -n "$HDF5_DIR" ]; then
-    echo "INFO: HDF5 installation location was set using HDF5_DIR=$HDF5_DIR"
-    HDF5_STR="--with-hdf5-dir=$HDF5_DIR"
-  elif [ -n "$HDF5DIR" ]; then
-    echo "INFO: HDF5 installation location was set using HDF5DIR=$HDF5DIR"
-    HDF5_STR="--with-hdf5-dir=$HDF5DIR"
-  elif [ -n "$HDF5_ROOT" ]; then
-    echo "INFO: HDF5 installation location was set using HDF5_ROOT=$HDF5_ROOT"
-    HDF5_STR="--with-hdf5-dir=$HDF5_ROOT"
-  fi
-
-  # If not found using a variable, look at a few common library locations
-  HDF5_PATHS=/usr/lib/hdf5:/usr/local/hdf5:/usr/share/hdf5:/usr/local/hdf5/share:/opt/hdf5:$HOME/.local
-  if [ -z "$HDF5_STR" ]; then
-    # Set path delimiter
-    IFS=:
-    for p in $HDF5_PATHS; do
-      # When first instance of hdf5 header is found, report finding, set HDF5_STR, and break
-      loc=$(find "$p" -name 'hdf5.h' -print -quit 2>/dev/null)
-      if [ ! -z "$loc" ]; then
-        echo "INFO: HDF5 header location was found at: $loc"
-        echo 'INFO: Using this HDF5 installation to configure and build PETSc.'
-        echo 'INFO: If another HDF5 is desired, please set HDF5_DIR and re-run this script.'
-        HDF5_STR="--with-hdf5-dir=$loc/../../"
-        break
-      fi
-    done
-    unset IFS
-  fi
-
+  # Find the location for patches if needed
+  local PATCH_DIR=
   if [ -n "$BASH_VERSION" ]; then
       PATCH_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
   elif [ -n "$ZSH_VERSION" ]; then
@@ -76,25 +50,62 @@ function configure_petsc()
       exit 1
   fi
 
-  # If HDF5 is not found locally, download it via PETSc and patch if on Apple Silicon
-  if [ -z "$HDF5_STR" ]; then
-    HDF5_STR='--download-hdf5=1 --with-hdf5-fortran-bindings=0 --download-hdf5-configure-arguments="--with-zlib"'
+  # Check to see if HDF5 exists using environment variables and expected locations.
+  # If it does, use it.
+  echo 'INFO: Checking for HDF5...'
+
+  # Prioritize user-set environment variables HDF5_DIR, HDF5DIR, and HDF5_ROOT,
+  # with the first taking the greatest priority
+  local FOUND_HDF5_DIR=""
+  if [ -n "$HDF5_DIR" ]; then
+    echo "INFO: HDF5 installation location was set using HDF5_DIR=$HDF5_DIR"
+    FOUND_HDF5_DIR="$HDF5_DIR"
+  elif [ -n "$HDF5DIR" ]; then
+    echo "INFO: HDF5 installation location was set using HDF5DIR=$HDF5DIR"
+    FOUND_HDF5_DIR="$HDF5DIR"
+  elif [ -n "$HDF5_ROOT" ]; then
+    echo "INFO: HDF5 installation location was set using HDF5_ROOT=$HDF5_ROOT"
+    FOUND_HDF5_DIR="$HDF5_ROOT"
+  fi
+  # If not found using a variable, look at a few common library locations
+  if [ -z "$FOUND_HDF5_DIR" ]; then
+    local HDF5_PATHS=/usr/lib/hdf5:/usr/local/hdf5:/usr/share/hdf5:/usr/local/hdf5/share:/opt/hdf5:$HOME/.local
+    # Set path delimiter
+    IFS=:
+    for p in $HDF5_PATHS; do
+      # When first instance of hdf5 header is found, report finding, set HDF5_STR, and break
+      loc=$(find "$p" -name 'hdf5.h' -print -quit 2>/dev/null)
+      if [ -n "$loc" ]; then
+        echo "INFO: HDF5 header location was found at: $loc"
+        echo 'INFO: Using this HDF5 installation to configure and build PETSc.'
+        echo 'INFO: If another HDF5 is desired, please set HDF5_DIR and re-run this script.'
+        FOUND_HDF5_DIR="$loc/../../"
+        break
+      fi
+    done
+    unset IFS
+  fi
+  # Pass whatever we decided from HDF5_STR as an option
+  if [ -n "$FOUND_HDF5_DIR" ]; then
+    EXTRA_CONFIGURE_OPTIONS+=("--with-hdf5-dir=${FOUND_HDF5_DIR}")
+  # Otherwise, download it via PETSc and patch if on apple silicon
+  else
+    EXTRA_CONFIGURE_OPTIONS+=("--download-hdf5=1" "--with-hdf5-fortran-bindings=0" "--download-hdf5-configure-arguments='--with-zlib'")
     echo 'INFO: HDF5 library not detected, opting to download via PETSc...'
-    if [[ `uname -p` == 'arm' ]] && [[ $(uname) == 'Darwin' ]] && [[ $PETSC_ARCH == 'arch-moose' ]]; then
+    if [ -n "$IS_APPLE_SILICON" ]; then
       echo 'INFO: Patching PETSc to support HDF5 download and installation on Apple Silicon...'
-      PATCH=$PATCH_DIR/apple-silicon-hdf5-autogen.patch
-      git apply $PATCH 2>/dev/null || (git apply $PATCH -R --check && echo 'INFO: Apple Silicon HDF5 patch already applied.')
+      local HDF5_PATCH=$PATCH_DIR/apple-silicon-hdf5-autogen.patch
+      git apply "$HDF5_PATCH" 2>/dev/null || (git apply "$HDF5_PATCH" -R --check && echo 'INFO: Apple Silicon HDF5 patch already applied.')
     fi
   fi
 
   # When manually building PETSc on Apple Silicon, set FFLAGS to the proper arch, otherwise MUMPS
   # will fail to find MPI libraries
-  MUMPS_ARM_STR=''
-  if [[ `uname -p` == 'arm' ]] && [[ $(uname) == 'Darwin' ]] && [[ $PETSC_ARCH == 'arch-moose' ]]; then
-    MUMPS_ARM_STR='FFLAGS=-march=armv8.3-a'
+  if [ -n "$IS_APPLE_SILICON" ]; then
+    EXTRA_CONFIGURE_OPTIONS+=("FFLAGS=-march=armv8.3-a")
   fi
 
-  cd $PETSC_DIR
+  cd "$PETSC_DIR" || exit 1
   python3 ./configure --with-64-bit-indices \
       --with-cxx-dialect=C++17 \
       --with-debugging=no \
@@ -115,12 +126,12 @@ function configure_petsc()
       --download-slepc=1 \
       --download-strumpack=1 \
       --download-superlu_dist=1 \
-      $HDF5_STR \
-      $MUMPS_ARM_STR \
-      $MAKE_NP_STR \
+      --download-kokkos=1 \
+      --download-kokkos-kernels=1 \
+      "${EXTRA_CONFIGURE_OPTIONS[@]}" \
       "$@"
 
-  RETURN_CODE=$?
+  local RETURN_CODE=$?
   if [ $RETURN_CODE != 0 ] && [ -f configure.log ]; then
     echo "Configure failed; displaying contents of configure.log:"
     cat configure.log

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1257,4 +1257,31 @@ ca3944140e845b4b8586365397d7fe1110ebeb89: #30791; libMesh submodule update, add 
   wasp:
     full_version: 2025.05.13_1
     hash: 3e37a23
-
+f14118d63adbfcc3d45765c2ba3cac1dfa0ffa7a: #31104; add kokkos to all builds, update apptainer mpi, add libceed, fix conda zsh linux
+  libmesh:
+    full_version: 2025.06.25_1
+    hash: 471ff5e
+  libmesh-vtk:
+    full_version: 9.4.2_4
+    hash: d35235e
+  moose-dev:
+    full_version: 2025.07.22
+    hash: 46da177
+  mpi:
+    full_version: 2025.07.23
+    hash: 0a5dd50
+  petsc:
+    full_version: 3.23.0.6.gd9d7fd11dca_3
+    hash: '4564759'
+  pprof:
+    full_version: 2025.06.13
+    hash: 3d296db
+  seacas:
+    full_version: 2025.05.22_0
+    hash: '1278418'
+  tools:
+    full_version: 2025.06.26
+    hash: d73012a
+  wasp:
+    full_version: 2025.05.13_1
+    hash: 3e37a23

--- a/scripts/update_and_rebuild_mfem.sh
+++ b/scripts/update_and_rebuild_mfem.sh
@@ -111,6 +111,8 @@ if [ -z "$go_fast" ]; then
       -DParMETIS_DIR="$PETSC_DIR/$PETSC_ARCH" \
       -DMFEM_USE_SUPERLU=YES \
       -DSuperLUDist_DIR="$PETSC_DIR/$PETSC_ARCH" \
+      -DMFEM_USE_CEED=YES \
+      -DCEED_DIR="$PETSC_DIR/$PETSC_ARCH" \
       -DBUILD_SHARED_LIBS=ON \
       -DHDF5_DIR="$HDF5_DIR" \
       -DBLAS_DIR="$PETSC_DIR/$PETSC_ARCH" \

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -13,7 +13,7 @@ packages:
       conda/tools/meta.yaml.template: conda/tools/meta.yaml
   # dependers: libmesh-vtk, petsc, libmesh, moose-dev
   mpi:
-    version: 2025.06.13
+    version: 2025.07.23
     conda: conda/mpi
     templates:
       conda/mpi/meta.yaml.template: conda/mpi/meta.yaml
@@ -26,7 +26,7 @@ packages:
   # dependers: libmesh, moose-dev
   libmesh-vtk:
     version: 9.4.2
-    build_number: 3
+    build_number: 4
     conda: conda/libmesh-vtk
     templates:
       conda/libmesh-vtk/conda_build_config.yaml.template: conda/libmesh-vtk/conda_build_config.yaml
@@ -38,7 +38,7 @@ packages:
   # dependers: libmesh, moose-dev
   petsc:
     version: 3.23.0.6.gd9d7fd11dca
-    build_number: 2
+    build_number: 3
     conda: conda/petsc
     templates:
       conda/petsc/conda_build_config.yaml.template: conda/petsc/conda_build_config.yaml
@@ -57,7 +57,7 @@ packages:
   # dependers: moose-dev
   libmesh:
     version: 2025.06.25
-    build_number: 0
+    build_number: 1
     conda: conda/libmesh
     templates:
       conda/libmesh/conda_build_config.yaml.template: conda/libmesh/conda_build_config.yaml
@@ -93,7 +93,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.06.26
+    version: 2025.07.22
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml


### PR DESCRIPTION
- Adds `--download-kokkos` and `--download-kokkos-kernels` to all PETSc builds (including CPU)
- Updates openmpi in all containers to openmpi 5.0.8
- Updates mpich in all containers to mpich 4.3.1
- Updates base container (system packages)
- Adds `--download-libceed` to all PETSc builds and uses it in MFEM (closes https://github.com/idaholab/moose/issues/31089)
- Fixes conda zsh prompt on linux (closes https://github.com/idaholab/moose/issues/31041)