### PR TITLE
Add ceed-* devices to test harness

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1143,7 +1143,7 @@ class TestHarness:
         # Options that pass straight through to the executable
         parser.add_argument('--parallel-mesh', action='store_true', dest='parallel_mesh', help='Deprecated, use --distributed-mesh instead')
         parser.add_argument('--distributed-mesh', action='store_true', dest='distributed_mesh', help='Pass "--distributed-mesh" to executable')
-        parser.add_argument('--device', action='store', dest='device', type=str, choices=TestHarness.validDevices(), default='cpu', help='Run libtorch or MFEM tests with this device')
+        parser.add_argument('--device', action='store', dest='device', type=str, choices=TestHarness.validDevices(), default='cpu', help='Run libtorch or MFEM tests with this device; device availability depends on library support and compilation settings')
         parser.add_argument('--libtorch-device', action='store', dest='device', type=str, choices=['cpu', 'cuda', 'mps'], help='Run libtorch tests with this device')
         parser.add_argument('--error', action='store_true', help='Run the tests with warnings as errors (Pass "--error" to executable)')
         parser.add_argument('--error-unused', action='store_true', help='Run the tests with errors on unused parameters (Pass "--error-unused" to executable)')

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -252,6 +252,10 @@ class TestHarness:
         harness.findAndRunTests()
         sys.exit(harness.error_code)
 
+    @staticmethod
+    def validDevices():
+        return ['cpu', 'cuda', 'hip', 'mps', 'ceed-cpu', 'ceed-cuda', 'ceed-hip']
+
     def __init__(self, argv: list, moose_dir: str, moose_python: str, test_root: TestRoot):
         self.moose_python_dir = moose_python
         self._rootdir = test_root.root_dir
@@ -1139,7 +1143,7 @@ class TestHarness:
         # Options that pass straight through to the executable
         parser.add_argument('--parallel-mesh', action='store_true', dest='parallel_mesh', help='Deprecated, use --distributed-mesh instead')
         parser.add_argument('--distributed-mesh', action='store_true', dest='distributed_mesh', help='Pass "--distributed-mesh" to executable')
-        parser.add_argument('--device', action='store', dest='device', type=str, choices=['cpu', 'cuda', 'hip', 'mps'], default='cpu', help='Run libtorch or MFEM tests with this device')
+        parser.add_argument('--device', action='store', dest='device', type=str, choices=TestHarness.validDevices(), default='cpu', help='Run libtorch or MFEM tests with this device')
         parser.add_argument('--libtorch-device', action='store', dest='device', type=str, choices=['cpu', 'cuda', 'mps'], help='Run libtorch tests with this device')
         parser.add_argument('--error', action='store_true', help='Run the tests with warnings as errors (Pass "--error" to executable)')
         parser.add_argument('--error-unused', action='store_true', help='Run the tests with errors on unused parameters (Pass "--error-unused" to executable)')

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -55,7 +55,7 @@ class RunApp(Tester):
 
         params.addParam('libtorch_devices', "The devices to use for this libtorch test ('CPU', 'CUDA', 'MPS')")
         device_list_str = "', '".join(d.upper() for d in TestHarness.validDevices())
-        device_param_doc = f"The devices to use for this libtorch or MFEM test ('{device_list_str}'); default ('CPU')"
+        device_param_doc = f"The devices to use for this libtorch or MFEM test ('{device_list_str}'); device availability depends on library support and compilation settings; default ('CPU')"
         params.addParam('devices', ['CPU'], device_param_doc)
 
         return params
@@ -86,7 +86,7 @@ class RunApp(Tester):
 
         for value in params['devices']:
             if value.lower() not in TestHarness.validDevices():
-                raise Exception(f'Unknown device "{value}')
+                raise Exception(f'Unknown device "{value}"')
 
     def getInputFile(self):
         if self.specs.isValid('input'):

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -9,7 +9,7 @@
 
 import re, os, shutil
 from Tester import Tester
-from TestHarness import util
+from TestHarness import util, TestHarness
 from shlex import quote
 
 class RunApp(Tester):
@@ -54,7 +54,10 @@ class RunApp(Tester):
         params.addParam('valgrind', 'NORMAL', "Set to (NONE, NORMAL, HEAVY) to determine which configurations where valgrind will run.")
 
         params.addParam('libtorch_devices', "The devices to use for this libtorch test ('CPU', 'CUDA', 'MPS')")
-        params.addParam('devices', ['CPU'], "The devices to use for this libtorch or MFEM test ('CPU', 'CUDA', 'HIP', 'MPS'); default ('CPU')")
+        device_list_str = "', '".join(d.upper() for d in TestHarness.validDevices())
+        device_param_doc = f"The devices to use for this libtorch or MFEM test ('{device_list_str}'); default ('CPU')"
+        params.addParam('devices', ['CPU'], device_param_doc)
+
         return params
 
     def __init__(self, name, params):
@@ -79,10 +82,10 @@ class RunApp(Tester):
         if params.isValid('libtorch_devices'):
             for value in params['libtorch_devices']:
                 if value.lower() not in ['cpu', 'cuda', 'mps']:
-                    raise Exception(f'Unknown libtorch_device "{value}')
+                    raise Exception(f'Unknown libtorch_device "{value}"')
 
         for value in params['devices']:
-            if value.lower() not in ['cpu', 'cuda', 'hip', 'mps']:
+            if value.lower() not in TestHarness.validDevices():
                 raise Exception(f'Unknown device "{value}')
 
     def getInputFile(self):


### PR DESCRIPTION
Refs #30915 and #31126

If/when this is merged I think I'll add `ceed-cpu` and `ceed-cuda` steps to some civet recipe. The latter can certainly go in our CUDA GPU recipe, but I'd have to think about where `ceed-cpu` should go. Currently both will be empty, but `ceed-cpu` will have a couple of associated tests after #31126 