### PR TITLE
Fix bug renumbering in StitchedMG.

### DIFF
--- a/framework/src/meshgenerators/StitchedMeshGenerator.C
+++ b/framework/src/meshgenerators/StitchedMeshGenerator.C
@@ -184,7 +184,8 @@ StitchedMeshGenerator::generate()
 
       if (overlap_found)
       {
-        const auto max_boundary_id = *base_mesh_bids.rbegin();
+        const auto max_boundary_id =
+            std::max(*base_mesh_bids.rbegin(), *stitched_mesh_bids.rbegin());
         BoundaryID new_index = 1;
         for (const auto bid : stitched_mesh_bids)
         {

--- a/test/tests/meshgenerators/stitched_mesh_generator/tests
+++ b/test/tests/meshgenerators/stitched_mesh_generator/tests
@@ -1,7 +1,7 @@
 [Tests]
   [stitched_mesh_generator]
     design = 'meshgenerators/StitchedMeshGenerator.md'
-    issues = '#11640'
+    issues = '#11640 #31191'
     requirement = "The system shall support the creation of a finite element mesh from existing "
                   "meshes"
 
@@ -45,7 +45,7 @@
     input = 'stitch_block_names.i'
     cli_args = '--mesh-only'
     exodiff = 'stitch_block_names_in.e'
-    exodiff_opts = '-match_by_name'
+    exodiff_opts = '-match_by_name -pedantic'
     recover = false
 
     requirement = "The system shall be able to combine subdomain names when stitching meshes"
@@ -57,7 +57,7 @@
     input = 'stitch_block_names.i'
     cli_args = '--mesh-only dont_stitch_block_names_in.e Mesh/stitch/subdomain_remapping=false'
     exodiff = 'dont_stitch_block_names_in.e'
-    exodiff_opts = '-match_by_name'
+    exodiff_opts = '-match_by_name -pedantic'
     recover = false
 
     requirement = "The system shall retain backwards compatibility with older stitching behavior"


### PR DESCRIPTION
IDs in stitched mesh were being combined when max base mesh BID was lower than stitched_mesh max boundary ID.

refs #31191
