### PR TITLE
Add the ability to define the fluid properties user object in the flow physics

### DIFF
--- a/modules/navier_stokes/include/physics/WCNSFVFlowPhysicsBase.h
+++ b/modules/navier_stokes/include/physics/WCNSFVFlowPhysicsBase.h
@@ -126,6 +126,8 @@ protected:
   void addPorousMediumSpeedMaterial();
   /// Add material to define the local speed with no porous medium treatment
   void addNonPorousMediumSpeedMaterial();
+  /// Function which adds the general functor fluid properties functor material to define fluid functor material property
+  void addFluidPropertiesFunctorMaterial();
 
   /// Function which adds the RhieChow interpolator user objects for weakly and incompressible formulations
   virtual void addRhieChowUserObjects() = 0;

--- a/modules/navier_stokes/src/base/NSFVBase.C
+++ b/modules/navier_stokes/src/base/NSFVBase.C
@@ -65,6 +65,12 @@ NSFVBase::commonMomentumEquationParams()
   params.addParam<bool>("solve_for_dynamic_pressure",
                         false,
                         "Whether to solve for the dynamic pressure instead of the total pressure");
+  params.addParam<Point>("reference_pressure_point",
+                         Point(0, 0, 0),
+                         "Point at which the gravity term for the static pressure is zero");
+  params.addParam<Real>("reference_pressure", 1e5, "Total pressure at the reference point");
+  params.addParamNamesToGroup(
+      "solve_for_dynamic_pressure reference_pressure_point reference_pressure", "Dynamic pressure");
 
   // Pressure pin parameters
   params.addParam<bool>(

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
@@ -335,6 +335,7 @@ WCNSFVFlowPhysicsBase::addFluidPropertiesFunctorMaterial()
     params.set<MooseFunctorName>("characteristic_length") = "1";
   }
   else
+    // not implemented yet
     paramWarning(
         NS::fluid,
         "Specifying the fluid properties user object does not define the GeneralFunctorFluidProps "
@@ -353,7 +354,8 @@ WCNSFVFlowPhysicsBase::addFluidPropertiesFunctorMaterial()
   }
   params.set<Point>("gravity") = getParam<RealVectorValue>("gravity");
 
-  getProblem().addFunctorMaterial(class_name, prefix() + "functor_fluidprops", params);
+  if (!_porous_medium_treatment)
+    getProblem().addFunctorMaterial(class_name, prefix() + "functor_fluidprops", params);
 }
 
 void

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "WCNSFVFlowPhysicsBase.h"
+#include "WCNSLinearFVFlowPhysics.h"
 #include "WCNSFVTurbulencePhysics.h"
 #include "NSFVBase.h"
 #include "MapConversionUtils.h"
@@ -70,6 +71,10 @@ WCNSFVFlowPhysicsBase::validParams()
   params.addParam<MooseEnum>("mu_interp_method",
                              coeff_interp_method,
                              "Switch that can select face interpolation method for the viscosity.");
+
+  // Fluid properties
+  params.addParam<UserObjectName>(NS::fluid, "Fluid properties userobject");
+  params.addParamNamesToGroup(NS::fluid, "Material properties");
 
   // Parameter groups
   params.addParamNamesToGroup(
@@ -268,6 +273,9 @@ WCNSFVFlowPhysicsBase::addMaterials()
     addPorousMediumSpeedMaterial();
   else
     addNonPorousMediumSpeedMaterial();
+
+  if (isParamValid(NS::fluid))
+    addFluidPropertiesFunctorMaterial();
 }
 
 void
@@ -284,7 +292,8 @@ WCNSFVFlowPhysicsBase::addPorousMediumSpeedMaterial()
     params.set<MooseFunctorName>(NS::porosity) = "1";
   params.set<bool>("define_interstitial_velocity_components") = _porous_medium_treatment;
 
-  getProblem().addMaterial("PINSFVSpeedFunctorMaterial", prefix() + "pins_speed_material", params);
+  getProblem().addFunctorMaterial(
+      "PINSFVSpeedFunctorMaterial", prefix() + "pins_speed_material", params);
 }
 
 void
@@ -299,7 +308,51 @@ WCNSFVFlowPhysicsBase::addNonPorousMediumSpeedMaterial()
     params.set<MooseFunctorName>(param_names[dim_i]) = _velocity_names[dim_i];
   params.set<MooseFunctorName>("vector_magnitude_name") = NS::speed;
 
-  getProblem().addMaterial(class_name, prefix() + "ins_speed_material", params);
+  getProblem().addFunctorMaterial(class_name, prefix() + "ins_speed_material", params);
+}
+
+void
+WCNSFVFlowPhysicsBase::addFluidPropertiesFunctorMaterial()
+{
+  // Not very future-proof but it works
+  const bool use_ad = !dynamic_cast<WCNSLinearFVFlowPhysics *>(this);
+  const std::string class_name =
+      use_ad ? "GeneralFunctorFluidProps" : "NonADGeneralFunctorFluidProps";
+  InputParameters params = getFactory().getValidParams(class_name);
+  assignBlocks(params, _blocks);
+
+  params.set<UserObjectName>(NS::fluid) = getParam<UserObjectName>(NS::fluid);
+  params.set<MooseFunctorName>(NS::pressure) = _pressure_name;
+  params.set<MooseFunctorName>(NS::T_fluid) = _fluid_temperature_name;
+  params.set<MooseFunctorName>(NS::speed) = NS::speed;
+  params.set<MooseFunctorName>(NS::density) = _density_name;
+  if (!MooseUtils::parsesToReal(_density_name))
+    params.set<bool>("force_define_density") = true;
+  if (!_porous_medium_treatment)
+  {
+    params.set<MooseFunctorName>(NS::porosity) = "1";
+    params.set<MooseFunctorName>("characteristic_length") = "1";
+  }
+  else
+    paramWarning(
+        NS::fluid,
+        "Specifying the fluid properties user object does not define the GeneralFunctorFluidProps "
+        "when using the porous medium treatment. You have to define this object in the input");
+
+  // Dynamic pressure
+  params.set<bool>("solving_for_dynamic_pressure") = _solve_for_dynamic_pressure;
+  if (_solve_for_dynamic_pressure)
+  {
+    params.set<Point>("reference_pressure_point") = getParam<Point>("reference_pressure_point");
+    if (!isParamSetByUser("reference_pressure_point"))
+      paramWarning("reference_pressure_point",
+                   "Default value of (0,0,0) used. If this point is outside the flow domain, the "
+                   "simulation will error");
+    params.set<Real>("reference_pressure") = getParam<Real>("reference_pressure");
+  }
+  params.set<Point>("gravity") = getParam<RealVectorValue>("gravity");
+
+  getProblem().addFunctorMaterial(class_name, prefix() + "functor_fluidprops", params);
 }
 
 void

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
@@ -74,7 +74,9 @@ WCNSFVFlowPhysicsBase::validParams()
 
   // Fluid properties
   params.addParam<UserObjectName>(NS::fluid, "Fluid properties userobject");
-  params.addParamNamesToGroup(NS::fluid, "Material properties");
+  params.addParam<FunctionName>(
+      "mu_rampdown", 1, "A function describing a ramp down of viscosity over time");
+  params.addParamNamesToGroup(NS::fluid + " mu_rampdown", "Material properties");
 
   // Parameter groups
   params.addParamNamesToGroup(
@@ -321,11 +323,10 @@ WCNSFVFlowPhysicsBase::addFluidPropertiesFunctorMaterial()
   InputParameters params = getFactory().getValidParams(class_name);
   assignBlocks(params, _blocks);
 
-  params.set<UserObjectName>(NS::fluid) = getParam<UserObjectName>(NS::fluid);
   params.set<MooseFunctorName>(NS::pressure) = _pressure_name;
   params.set<MooseFunctorName>(NS::T_fluid) = _fluid_temperature_name;
   params.set<MooseFunctorName>(NS::speed) = NS::speed;
-  params.set<MooseFunctorName>(NS::density) = _density_name;
+  params.applySpecificParameters(parameters(), {NS::fluid, NS::density, "mu_rampdown"});
   if (!MooseUtils::parsesToReal(_density_name))
     params.set<bool>("force_define_density") = true;
   if (!_porous_medium_treatment)

--- a/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFluidHeatTransferPhysics.C
@@ -518,6 +518,7 @@ WCNSFVFluidHeatTransferPhysics::addMaterials()
     {
       params.set<bool>("assumed_constant_cp") = false;
       params.set<UserObjectName>(NS::fluid) = getParam<UserObjectName>(NS::fluid);
+      params.set<MooseFunctorName>(NS::pressure) = _flow_equations_physics->getPressureName();
     }
   }
   if (_solve_for_enthalpy)

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/2d-transient-physics.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/2d-transient-physics.i
@@ -94,7 +94,7 @@ inlet_v = 0.001
   []
 []
 
-[Materials]
+[FunctorMaterials]
   [const_functor]
     type = ADGenericFunctorMaterial
     prop_names = 'cp k mu'

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/tests
@@ -32,6 +32,18 @@
     recover = false # see #19126
     valgrind = HEAVY
   []
+  [transient-physics-defines-fp]
+    type = 'Exodiff'
+    input = 2d-transient-physics.i
+    cli_args = "FunctorMaterials/active='' Physics/NavierStokes/Flow/flow/fp=fp"
+    exodiff = 2d-transient-physics_out.e
+    prereq = 'transient-physics'
+    capabilities = 'method!=dbg'
+    requirement = 'The system shall be able to solve for a transient 2D channel case with a weakly compressible formulation using the shorthand WCNSFV Physics syntax, and using this syntax for the flow equations to define the fluid material properties from the fluid properties object.'
+    abs_zero = 1e-9
+    recover = false # see #19126
+    valgrind = HEAVY
+  []
   [turbulence]
     type = 'Exodiff'
     input = 2d-transient.i

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/tests
@@ -32,18 +32,6 @@
     recover = false # see #19126
     valgrind = HEAVY
   []
-  [transient-physics-defines-fp]
-    type = 'Exodiff'
-    input = 2d-transient-physics.i
-    cli_args = "FunctorMaterials/active='' Physics/NavierStokes/Flow/flow/fp=fp"
-    exodiff = 2d-transient-physics_out.e
-    prereq = 'transient-physics'
-    capabilities = 'method!=dbg'
-    requirement = 'The system shall be able to solve for a transient 2D channel case with a weakly compressible formulation using the shorthand WCNSFV Physics syntax, and using this syntax for the flow equations to define the fluid material properties from the fluid properties object.'
-    abs_zero = 1e-9
-    recover = false # see #19126
-    valgrind = HEAVY
-  []
   [turbulence]
     type = 'Exodiff'
     input = 2d-transient.i

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/materials/2d-transient-physics.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/materials/2d-transient-physics.i
@@ -1,0 +1,142 @@
+l = 10
+advected_interp_method = 'average'
+
+# Operating conditions
+inlet_temp = 300
+outlet_pressure = 1e5
+inlet_v = 0.001
+
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    xmin = 0
+    xmax = ${l}
+    ymin = 0
+    ymax = 1
+    nx = 20
+    ny = 10
+  []
+[]
+
+[Physics]
+  [NavierStokes]
+    [Flow]
+      [flow]
+        compressibility = 'weakly-compressible'
+        fp = 'fp'
+
+        velocity_variable = 'u v'
+        fluid_temperature_variable = 'T'
+
+        density = 'rho'
+        dynamic_viscosity = 'mu'
+        mu_rampdown = 'mu_rampdown'
+
+        initial_velocity = '${inlet_v} 1e-15 0'
+        initial_pressure = '${outlet_pressure}'
+
+        inlet_boundaries = 'left'
+        momentum_inlet_types = 'fixed-velocity'
+        momentum_inlet_functors = '${inlet_v} 0'
+
+        wall_boundaries = 'top bottom'
+        momentum_wall_types = 'noslip noslip'
+
+        outlet_boundaries = 'right'
+        momentum_outlet_types = 'fixed-pressure'
+        pressure_functors = '${outlet_pressure}'
+
+        mass_advection_interpolation = ${advected_interp_method}
+        momentum_advection_interpolation = ${advected_interp_method}
+      []
+    []
+    [FluidHeatTransfer]
+      [energy]
+        coupled_flow_physics = flow
+        fluid_temperature_variable = 'T'
+
+        fp = 'fp'
+        thermal_conductivity = 'k'
+        specific_heat = 'cp'
+
+        initial_temperature = '${inlet_temp}'
+
+        energy_inlet_types = 'fixed-temperature'
+        energy_inlet_functors = '${inlet_temp}'
+        energy_wall_types = 'heatflux heatflux'
+        energy_wall_functors = '0 0'
+
+        external_heat_source = 'power_density'
+        energy_advection_interpolation = 'average'
+      []
+    []
+    [Turbulence]
+      [turbulence]
+        coupled_flow_physics = flow
+        fluid_heat_transfer_physics = energy
+      []
+    []
+  []
+[]
+
+[AuxVariables]
+  [velocity_norm]
+    type = MooseVariableFVReal
+  []
+  [power_density]
+    type = MooseVariableFVReal
+    initial_condition = 1e4
+  []
+[]
+
+[FluidProperties]
+  [fp]
+    type = FlibeFluidProperties
+    # AD-version of h_from_p_T(p, T, h, dh_dp, dh_dT) not implemented
+    allow_imperfect_jacobians = true
+  []
+[]
+
+[AuxKernels]
+  [speed]
+    type = VectorMagnitudeAux
+    variable = 'velocity_norm'
+    x = u
+    y = v
+  []
+[]
+
+[Functions]
+  [mu_rampdown]
+    type = PiecewiseLinear
+    x = '1 2 3 4'
+    y = '1e3 1e2 1e1 1'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'NEWTON'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type'
+  petsc_options_value = 'lu       NONZERO'
+
+  [TimeStepper]
+    type = IterationAdaptiveDT
+    dt = 1e-3
+    optimal_iterations = 6
+  []
+  end_time = 15
+
+  nl_abs_tol = 1e-12
+  nl_max_its = 50
+  line_search = 'none'
+
+  automatic_scaling = true
+  off_diagonals_in_auto_scaling = true
+  compute_scaling_once = false
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/materials/2d-transient-physics.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/materials/2d-transient-physics.i
@@ -33,7 +33,7 @@ inlet_v = 0.001
         dynamic_viscosity = 'mu'
         mu_rampdown = 'mu_rampdown'
 
-        initial_velocity = '${inlet_v} 1e-15 0'
+        initial_velocity = '${inlet_v} 0 0'
         initial_pressure = '${outlet_pressure}'
 
         inlet_boundaries = 'left'

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/materials/gold/2d-transient-physics_out.e
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/materials/gold/2d-transient-physics_out.e
@@ -1,0 +1,1 @@
+2d-transient_out.e

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/materials/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/materials/tests
@@ -28,6 +28,20 @@
     # Warning from setting AD derivatives to 0 in h_from_p_T(p, T, h, dh_dp, dh_dT)
     allow_warnings = true
   []
+  [transient_using_h-physics-defines-functormats]
+    type = 'Exodiff'
+    input = 2d-transient-physics.i
+    exodiff = 2d-transient-physics_out.e
+    capabilities = 'method!=dbg'
+    requirement = 'The system shall be able to use realistic fluid properties in a weakly compressible flow simulation and define the functor properties automatically within the shorthand syntax.'
+    rel_err = 7e-5
+    # The non-linear tolerance is actually fairly tight, but the variable values
+    # are small at the no-slip boundary conditions, and this leads to absolute diffs of around 1e-15,
+    # triggering the default relative tolerance error criterion
+    valgrind = HEAVY
+    # Warning from setting AD derivatives to 0 in h_from_p_T(p, T, h, dh_dp, dh_dT)
+    allow_warnings = true
+  []
   [fluidprops]
     type = 'Exodiff'
     input = functorfluidprops.i

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/materials/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/materials/tests
@@ -34,7 +34,8 @@
     exodiff = 2d-transient-physics_out.e
     capabilities = 'method!=dbg'
     requirement = 'The system shall be able to use realistic fluid properties in a weakly compressible flow simulation and define the functor properties automatically within the shorthand syntax.'
-    rel_err = 7e-5
+    rel_err = 1e-5
+    abs_zero = 1e-6
     # The non-linear tolerance is actually fairly tight, but the variable values
     # are small at the no-slip boundary conditions, and this leads to absolute diffs of around 1e-15,
     # triggering the default relative tolerance error criterion


### PR DESCRIPTION
This was requested quite a bit. While the input is shorter, I think we do lose some flexiblity there. Maybe it s fine. time will tell

build on top of the nonlinear enthalpy-variable PR
will need to be merged after

EDIT: it was merged

refs https://github.com/idaholab/moose/issues/31218