### PR TITLE
Add better name collision checks. 

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4239,7 +4239,8 @@ FEProblemBase::addPostprocessor(const std::string & pp_name,
 {
   // Check for name collision
   if (hasUserObject(name))
-    mooseError("A ", getUserObjectBase(name).typeAndName(),
+    mooseError("A ",
+               getUserObjectBase(name).typeAndName(),
                " already exists. You may not add a Postprocessor by the same name.");
 
   addUserObject(pp_name, name, parameters);
@@ -4252,7 +4253,8 @@ FEProblemBase::addVectorPostprocessor(const std::string & pp_name,
 {
   // Check for name collision
   if (hasUserObject(name))
-    mooseError("A ", getUserObjectBase(name).typeAndName(),
+    mooseError("A ",
+               getUserObjectBase(name).typeAndName(),
                " already exists. You may not add a VectorPostprocessor by the same name.");
 
   addUserObject(pp_name, name, parameters);
@@ -4265,7 +4267,8 @@ FEProblemBase::addReporter(const std::string & type,
 {
   // Check for name collision
   if (hasUserObject(name))
-    mooseError("A ", getUserObjectBase(name).typeAndName(),
+    mooseError("A ",
+               getUserObjectBase(name).typeAndName(),
                " already exists. You may not add a Reporter by the same name.");
 
   addUserObject(type, name, parameters);

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4239,9 +4239,8 @@ FEProblemBase::addPostprocessor(const std::string & pp_name,
 {
   // Check for name collision
   if (hasUserObject(name))
-    mooseError("A UserObject with the name \"",
-               name,
-               "\" already exists.  You may not add a Postprocessor by the same name.");
+    mooseError("A ", getUserObjectBase(name).typeAndName(),
+               " already exists. You may not add a Postprocessor by the same name.");
 
   addUserObject(pp_name, name, parameters);
 }
@@ -4253,9 +4252,8 @@ FEProblemBase::addVectorPostprocessor(const std::string & pp_name,
 {
   // Check for name collision
   if (hasUserObject(name))
-    mooseError("A UserObject with the name \"",
-               name,
-               "\" already exists.  You may not add a VectorPostprocessor by the same name.");
+    mooseError("A ", getUserObjectBase(name).typeAndName(),
+               " already exists. You may not add a VectorPostprocessor by the same name.");
 
   addUserObject(pp_name, name, parameters);
 }
@@ -4267,8 +4265,8 @@ FEProblemBase::addReporter(const std::string & type,
 {
   // Check for name collision
   if (hasUserObject(name))
-    mooseError(std::string("A UserObject with the name \"") + name +
-               "\" already exists.  You may not add a Reporter by the same name.");
+    mooseError("A ", getUserObjectBase(name).typeAndName(),
+               " already exists. You may not add a Reporter by the same name.");
 
   addUserObject(type, name, parameters);
 }

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -712,7 +712,7 @@
   [uo_pps_name_collision_test]
     type = 'RunException'
     input = 'uo_pps_name_collision_test.i'
-    expect_err = 'A UserObject with the name "\w+" already exists'
+    expect_err = 'A MTUserObject "\w+" already exists'
 
     requirement = 'The system shall report an error when a UserObject and a Postprocessor are added with the same names.'
     issues = '#1405'
@@ -721,10 +721,19 @@
   [uo_vector_pps_name_collision_test]
     type = 'RunException'
     input = 'uo_vector_pps_name_collision_test.i'
-    expect_err = 'A UserObject with the name "\w+" already exists'
+    expect_err = 'A MTUserObject "\w+" already exists'
 
     requirement = 'The system shall report and error when a UserObject and a VectorPostprocessor are added with the same names.'
     issues = '#1405'
+  []
+
+  [uo_reporter_name_collision_test]
+    type = 'RunException'
+    input = 'uo_reporter_name_collision_test.i'
+    expect_err = 'A MTUserObject "\w+" already exists'
+
+    requirement = 'The system shall report an error when a UserObject and a Reporter are added with the same names.'
+    issues = '#31231'
   []
 
   [wrong_object_test]

--- a/test/tests/misc/check_error/uo_pps_name_collision_test.i
+++ b/test/tests/misc/check_error/uo_pps_name_collision_test.i
@@ -1,75 +1,30 @@
 [Mesh]
   type = GeneratedMesh
-  dim = 2
+  dim = 1
   xmin = 0
   xmax = 1
-  ymin = 0
-  ymax = 1
   nx = 5
-  ny = 5
-  elem_type = QUAD4
+[]
+
+[Problem]
+  type = FEProblem
+  solve = false
 []
 
 [UserObjects]
-  [./ud]
+  [ud]
     type = MTUserObject
     scalar = 2
     vector = '9 7 5'
-  [../]
-[]
-
-[Functions]
-  [./forcing_fn]
-    type = ParsedFunction
-    expression = -2
-  [../]
-
-  [./exact_fn]
-    type = ParsedFunction
-    expression = x*x
-  [../]
-[]
-
-[Variables]
-  [./u]
-    family = LAGRANGE
-    order = FIRST
-  [../]
-[]
-
-[Kernels]
-  [./diff]
-    type = Diffusion
-    variable = u
-  [../]
-  [./ffn]
-    type = UserObjectKernel
-    variable = u
-    user_object = ud
   []
-[]
-
-[BCs]
-  [./all]
-    type = FunctionDirichletBC
-    variable = u
-    function = exact_fn
-    boundary = '0 1 2 3'
-  [../]
 []
 
 [Executioner]
   type = Steady
-  solve_type = 'PJFNK'
 []
 
 [Postprocessors]
-  [./ud]
+  [ud]
     type = NumDOFs
   []
-[]
-
-[Outputs]
-  execute_on = 'timestep_end'
-  file_base = out
 []

--- a/test/tests/misc/check_error/uo_reporter_name_collision_test.i
+++ b/test/tests/misc/check_error/uo_reporter_name_collision_test.i
@@ -6,6 +6,11 @@
   nx = 5
 []
 
+[Problem]
+  type = FEProblem
+  solve = false
+[]
+
 [UserObjects]
   [ud]
     type = MTUserObject
@@ -14,18 +19,12 @@
   []
 []
 
-[Problem]
-  type = FEProblem
-  solve = false
-[]
-
 [Executioner]
   type = Steady
 []
 
-[VectorPostprocessors]
+[Reporters]
   [ud]
-    type = ConstantVectorPostprocessor
-    value = 1
+    type = ConstantReporter
   []
 []


### PR DESCRIPTION
Closes #31231

I also added coverage for a reporter name collision with a userobject, which was not already covered (as far as I could tell). Much of the tests for this also had extraneous parts not necessary for testing.