### PR TITLE
Fix git committers argument handling and update tests

### DIFF
--- a/python/mooseutils/gitutils.py
+++ b/python/mooseutils/gitutils.py
@@ -168,7 +168,7 @@ def git_committers(loc=os.getcwd(), *args):
         raise OSError("The supplied location must be a file or directory: {}".format(loc))
     cmd = ['git', 'shortlog', '-s']
     for argument in args:
-      cmd += argument
+        cmd.append(argument)
     cmd += ['--', loc]
     committers = mooseutils.check_output(cmd, encoding='utf-8')
     counts = collections.defaultdict(int)

--- a/python/mooseutils/tests/test_gitutils.py
+++ b/python/mooseutils/tests/test_gitutils.py
@@ -10,7 +10,7 @@
 import os
 import shutil
 import unittest
-import mock
+from unittest import mock
 import tempfile
 import subprocess
 import platform
@@ -163,6 +163,13 @@ class Test(unittest.TestCase):
         with mock.patch('mooseutils.check_output', side_effect=['false']) as mock_check_output:
             self.assertFalse(mooseutils.git_is_branch('main', '/working/dir'))
         mock_check_output.assert_called_once()
+
+    def testGitCommittersArgs(self):
+        with mock.patch('os.path.exists', return_value=True):
+            with mock.patch('mooseutils.check_output', return_value='1\tJohn Doe\n') as mock_co:
+                counts = mooseutils.git_committers('path', '--merges')
+        mock_co.assert_called_with(['git', 'shortlog', '-s', '--merges', '--', 'path'], encoding='utf-8')
+        self.assertEqual(counts['John Doe'], 1)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, buffer=True)

--- a/python/mooseutils/tests/test_mooseMessageDialog.py
+++ b/python/mooseutils/tests/test_mooseMessageDialog.py
@@ -11,14 +11,19 @@
 import sys
 import unittest
 import mooseutils
-from PyQt5 import QtWidgets
 
+try:
+    from PyQt5 import QtWidgets
+except ModuleNotFoundError:
+    QtWidgets = None
+
+@unittest.skipIf(QtWidgets is None, "PyQt5 is not installed")
 class TestMooseMessageDialog(unittest.TestCase):
     """
     Tests the usage of the various messages functions in message package.
     """
 
-    app = QtWidgets.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv) if QtWidgets is not None else None
 
     def testMooseMessageDefault(self):
         """

--- a/python/mooseutils/tests/test_run_executable.py
+++ b/python/mooseutils/tests/test_run_executable.py
@@ -8,7 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 import unittest
-import mock
+from unittest import mock
 import subprocess
 import mooseutils
 

--- a/python/mooseutils/tests/test_yaml_load.py
+++ b/python/mooseutils/tests/test_yaml_load.py
@@ -10,8 +10,13 @@
 import os
 import unittest
 import tempfile
-from mooseutils.yaml_load import yaml_load, yaml_write, IncludeYamlFile
 
+try:
+    from mooseutils.yaml_load import yaml_load, yaml_write, IncludeYamlFile
+except ModuleNotFoundError:
+    yaml_load = None
+
+@unittest.skipIf(yaml_load is None, "PyYAML is not installed")
 class TestYamlLoad(unittest.TestCase):
     """
     Test that the size function returns something.
@@ -48,6 +53,7 @@ class TestYamlLoad(unittest.TestCase):
         self.assertEqual(data['e'], ['Edward', 'Bonnie'])
         self.assertEqual(data['f'], [1906])
 
+@unittest.skipIf(yaml_load is None, "PyYAML is not installed")
 class TestYamlWrite(unittest.TestCase):
     def setUp(self):
         _, self._tmp = tempfile.mkstemp(suffix='.yml', dir=os.path.dirname(__file__), text=True)


### PR DESCRIPTION
## Summary
- Fix git_committers so extra arguments are appended as whole flags
- Add regression test for git_committers argument handling
- Use built-in unittest.mock and skip optional GUI/YAML tests when dependencies missing

## Testing
- `pytest python/mooseutils/tests/test_gitutils.py::Test::testGitCommittersArgs -q`
- `pytest python/mooseutils/tests -q` *(fails: numerous missing components and environment issues, e.g., IndexError and AttributeError across mooseutils tests)*

------
https://chatgpt.com/codex/tasks/task_b_689509a0dd788329a78fbf6d57ec2a4d