### PR TITLE
Fix SQA doco of heat transfer module

### DIFF
--- a/modules/doc/sqa_reports.yml
+++ b/modules/doc/sqa_reports.yml
@@ -94,7 +94,7 @@ Applications:
     heat_transfer:
         exe_directory: modules/combined
         app_types:
-            - HeatConductionApp
+            - HeatTransferApp
         content_directory: modules/heat_transfer/doc/content
         unregister:
             - framework/doc/unregister.yml

--- a/modules/heat_transfer/doc/config.yml
+++ b/modules/heat_transfer/doc/config.yml
@@ -8,7 +8,7 @@ Renderer:
 
 Extensions:
     MooseDocs.extensions.navigation:
-        name: MOOSE Heat Conduction Module
+        name: MOOSE Heat Transfer Module
         repo: https://github.com/idaholab/moose
         home: /modules/heat_transfer/index.md
     MooseDocs.extensions.appsyntax:

--- a/modules/heat_transfer/doc/content/source/bcs/CoupledConvectiveFlux.md
+++ b/modules/heat_transfer/doc/content/source/bcs/CoupledConvectiveFlux.md
@@ -3,7 +3,7 @@
 !syntax description /BCs/CoupledConvectiveFlux
 
 !alert warning
-`CoupledConvectiveFlux` is deprecated.
+`CoupledConvectiveFlux` is deprecated. Please use [CoupledConvectiveHeatFluxBC.md] instead.
 
 This boundary condition models the heat convection flux.
 The residual is computed on the boundary $\delta \Omega$ as:

--- a/modules/heat_transfer/doc/content/source/bcs/CoupledConvectiveFlux.md
+++ b/modules/heat_transfer/doc/content/source/bcs/CoupledConvectiveFlux.md
@@ -1,1 +1,21 @@
-!template load file=stubs/moose_object.md.template name=CoupledConvectiveFlux syntax=/BCs/CoupledConvectiveFlux
+# CoupledConvectiveFlux
+
+!syntax description /BCs/CoupledConvectiveFlux
+
+!alert warning
+`CoupledConvectiveFlux` is deprecated.
+
+This boundary condition models the heat convection flux.
+The residual is computed on the boundary $\delta \Omega$ as:
+
+!equation
+R = \int_{\delta \Omega}  C (T - T_{\infty}) \psi
+
+with $C$ a constant convective heat transfer coefficient, $T$ the temperature variable, $T_{\infty}$ the temperature
+in the bulk, and $\psi$ a test function.
+
+!syntax parameters /BCs/CoupledConvectiveFlux
+
+!syntax inputs /BCs/CoupledConvectiveFlux
+
+!syntax children /BCs/CoupledConvectiveFlux

--- a/modules/heat_transfer/doc/content/source/bcs/HeatConductionBC.md
+++ b/modules/heat_transfer/doc/content/source/bcs/HeatConductionBC.md
@@ -9,11 +9,12 @@ The residual is computed on the boundary $\delta \Omega$ as:
 !equation
 R = \int_{\delta \Omega} k \nabla T \psi
 
-with $k$ a `Real`-valued thermal conductivity, $T$ the solid temperature and $\psi$ a test function.
+with $k$ a `Real`-valued thermal conductivity, $T$ the solid temperature, and $\psi$ a test function.
 
-!alert warning
+!alert! warning
 If the thermal conductivity depends on temperature, the contribution of this boundary condition to the Jacobian
 will be approximate.
+!alert-end!
 
 !syntax parameters /BCs/HeatConductionBC
 

--- a/modules/heat_transfer/doc/content/source/bcs/HeatConductionBC.md
+++ b/modules/heat_transfer/doc/content/source/bcs/HeatConductionBC.md
@@ -1,1 +1,22 @@
-!template load file=stubs/moose_object.md.template name=HeatConductionBC syntax=/BCs/HeatConductionBC
+# HeatConductionBC
+
+!syntax description /BCs/HeatConductionBC
+
+This boundary condition models the heat conduction flux when integrating the
+heat conduction equation by parts when using the [HeatConduction.md] kernel.
+The residual is computed on the boundary $\delta \Omega$ as:
+
+!equation
+R = \int_{\delta \Omega} k \nabla T \psi
+
+with $k$ a `Real`-valued thermal conductivity, $T$ the solid temperature and $\psi$ a test function.
+
+!alert warning
+If the thermal conductivity depends on temperature, the contribution of this boundary condition to the Jacobian
+will be approximate.
+
+!syntax parameters /BCs/HeatConductionBC
+
+!syntax inputs /BCs/HeatConductionBC
+
+!syntax children /BCs/HeatConductionBC

--- a/modules/heat_transfer/doc/content/source/dirackernels/GapHeatPointSourceMaster.md
+++ b/modules/heat_transfer/doc/content/source/dirackernels/GapHeatPointSourceMaster.md
@@ -1,1 +1,13 @@
-!template load file=stubs/moose_object.md.template name=GapHeatPointSourceMaster syntax=/DiracKernels/GapHeatPointSourceMaster
+# GapHeatPointSourceMaster
+
+!syntax description /DiracKernels/GapHeatPointSourceMaster
+
+The [PenetrationLocator.md] is used to find the points of contact between the primary boundary
+(specified with the [!param](/DiracKernels/GapHeatPointSourceMaster/boundary)) and the secondary boundary.
+A heat source is then applied using the local value of the secondary heat flux.
+
+!syntax parameters /DiracKernels/GapHeatPointSourceMaster
+
+!syntax inputs /DiracKernels/GapHeatPointSourceMaster
+
+!syntax children /DiracKernels/GapHeatPointSourceMaster

--- a/modules/heat_transfer/doc/content/source/materials/GapConductance.md
+++ b/modules/heat_transfer/doc/content/source/materials/GapConductance.md
@@ -1,0 +1,59 @@
+# GapConductance
+
+!syntax description /Materials/GapConductance
+
+This material is automatically created by the [ThermalContactAction.md] when the gap conductance
+has not been specified by the user. It captures both conduction across the gap and radiation.
+This material takes care of computing both the conductance and the derivative of conductance with
+regards to temperature.
+
+## Radiative term
+
+Gap conductance due to radiation is based on the diffusion approximation.
+Between surface $1$ and $2$, we define the heat flux as:
+
+!equation
+q_{12} = \sigma*Fe*(T_1^4 - T_2^4) ~ h_r(T_1 - T_2)
+
+where $\sigma$ is the Stefan-Boltzmann constant, $Fe$ is an emissivity
+function, $T_1$ and $T_2$ are the temperatures of the two surfaces, and
+$h_r$ is the radiant gap conductance. Solving for $h_r$,
+
+!equation
+h_r = \sigma*Fe*(T_1^4 - T_2^4) / (T_1 - T_2)
+
+which can be factored to give:
+
+!equation
+h_r = \sigma*Fe*(T_1^2 + T_2^2) * (T_1 + T_2)
+
+Assuming the gap is between infinite parallel planes, the emissivity
+function is given by:
+
+!equation
+Fe = 1 / (1/e_1 + 1/e_2 - 1)
+
+For cylinders and spheres, see [!citep](incropera2002).
+$r_1$ is the radius of surface 1, the primary surface, and
+$r_2$ the radius of the secondary surface.
+For cylinders:
+
+!equation
+Fe = 1 / (1/e_1 + (1/e_2 - 1) * (r_1/r_2))
+
+!equation
+q_{21} = -q_{12} * (r_1/r_2)
+
+For spheres:
+
+!equation
+Fe = 1 / (1/e_1 + (1/e_2 - 1) * (r_1/r_2)^2)
+
+!equation
+q_{21} = -q_{12} * (r_1/r_2)^2
+
+!syntax parameters /Materials/GapConductance
+
+!syntax inputs /Materials/GapConductance
+
+!syntax children /Materials/GapConductance

--- a/modules/heat_transfer/doc/content/source/materials/GapConductance.md
+++ b/modules/heat_transfer/doc/content/source/materials/GapConductance.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_object.md.template name=GapConductance syntax=/Materials/GapConductance

--- a/modules/heat_transfer/doc/content/source/postprocessors/ThermalConductivity.md
+++ b/modules/heat_transfer/doc/content/source/postprocessors/ThermalConductivity.md
@@ -1,1 +1,21 @@
-!template load file=stubs/moose_object.md.template name=ThermalConductivity syntax=/Postprocessors/ThermalConductivity
+# ThermalConductivity
+
+!syntax description /Postprocessors/ThermalConductivity
+
+The effective thermal conductivity is computed from the average value of the temperature variable,
+referred to as $T_{cold}$, as follows:
+
+!equation
+k_{eff} = \dfrac{\Phi dx}{T_{cold} - T_{hot}} \dfrac{1}{L}
+
+where the 'hot' surface temperature $T_{hot}$ (imposed temperature) and the flux $\Phi$ are provided as postprocessors, while $dx$ the size of the gap
+and $L$ the length scale are provided as `Real`-valued parameters.
+
+For the first time step, before the temperature has been computed, the [!param](/Postprocessors/ThermalConductivity/k0)
+parameter value is returned.
+
+!syntax parameters /Postprocessors/ThermalConductivity
+
+!syntax inputs /Postprocessors/ThermalConductivity
+
+!syntax children /Postprocessors/ThermalConductivity

--- a/modules/heat_transfer/doc/content/syntax/Modules/HeatTransfer/ThermalContact/BC/index.md
+++ b/modules/heat_transfer/doc/content/syntax/Modules/HeatTransfer/ThermalContact/BC/index.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_system.md.template name=ThermalContact syntax=/Modules/HeatTransfer/ThermalContact/BC

--- a/modules/heat_transfer/doc/content/syntax/Modules/HeatTransfer/ThermalContact/index.md
+++ b/modules/heat_transfer/doc/content/syntax/Modules/HeatTransfer/ThermalContact/index.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_system.md.template name=ThermalContact syntax=/Modules/HeatTransfer/ThermalContact

--- a/modules/heat_transfer/doc/content/syntax/Modules/HeatTransfer/index.md
+++ b/modules/heat_transfer/doc/content/syntax/Modules/HeatTransfer/index.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_system.md.template name=HeatTransfer syntax=/Modules/HeatTransfer

--- a/modules/heat_transfer/doc/content/syntax/Modules/index.md
+++ b/modules/heat_transfer/doc/content/syntax/Modules/index.md
@@ -1,1 +1,0 @@
-!template load file=stubs/moose_system.md.template name=Modules syntax=/Modules

--- a/modules/heat_transfer/doc/sqa_reports.yml
+++ b/modules/heat_transfer/doc/sqa_reports.yml
@@ -8,7 +8,6 @@ Applications:
             - ${MOOSE_DIR}/framework/doc/unregister.yml
         remove:
             - ${MOOSE_DIR}/framework/doc/remove.yml
-        log_stub_files: WARNING
 
 Documents:
     software_quality_plan: sqa/inl_records.md#software_quality_plan
@@ -34,5 +33,4 @@ Requirements:
     heat_transfer:
         directories:
             - ${MOOSE_DIR}/modules/heat_transfer
-        log_duplicate_requirement: WARNING
         log_testable: WARNING

--- a/modules/heat_transfer/src/base/HeatTransferApp.C
+++ b/modules/heat_transfer/src/base/HeatTransferApp.C
@@ -63,19 +63,6 @@ HeatTransferApp::registerAll(Factory & f, ActionFactory & af, Syntax & syntax)
   registerSyntaxTask("ThermalContactAction", "ThermalContact/*", "add_material");
   registerSyntaxTask("ThermalContactAction", "ThermalContact/*", "add_secondary_flux_vector");
 
-  registerSyntaxTask(
-      "ThermalContactAction", "Modules/HeatTransfer/ThermalContact/BC/*", "add_aux_kernel");
-  registerSyntaxTask(
-      "ThermalContactAction", "Modules/HeatTransfer/ThermalContact/BC/*", "add_aux_variable");
-  registerSyntaxTask("ThermalContactAction", "Modules/HeatTransfer/ThermalContact/BC/*", "add_bc");
-  registerSyntaxTask(
-      "ThermalContactAction", "Modules/HeatTransfer/ThermalContact/BC/*", "add_dirac_kernel");
-  registerSyntaxTask(
-      "ThermalContactAction", "Modules/HeatTransfer/ThermalContact/BC/*", "add_material");
-  registerSyntaxTask("ThermalContactAction",
-                     "Modules/HeatTransfer/ThermalContact/BC/*",
-                     "add_secondary_flux_vector");
-
   registerSyntaxTask("RadiationTransferAction", "GrayDiffuseRadiation/*", "append_mesh_generator");
   registerSyntaxTask("RadiationTransferAction", "GrayDiffuseRadiation/*", "setup_mesh_complete");
   registerSyntaxTask("RadiationTransferAction", "GrayDiffuseRadiation/*", "add_user_object");

--- a/modules/heat_transfer/src/bcs/CoupledConvectiveFlux.C
+++ b/modules/heat_transfer/src/bcs/CoupledConvectiveFlux.C
@@ -19,7 +19,7 @@ CoupledConvectiveFlux::validParams()
   InputParameters params = IntegratedBC::validParams();
   params.addRequiredCoupledVar("T_infinity", "Field holding far-field temperature");
   params.addRequiredParam<Real>("coefficient", "Heat transfer coefficient");
-  params.addClassDescription("Integrated boundary condition for modeling a convective heat flux");
+  params.addClassDescription("Integrated boundary condition for modeling a convective heat flux.");
 
   return params;
 }

--- a/modules/heat_transfer/src/bcs/CoupledConvectiveFlux.C
+++ b/modules/heat_transfer/src/bcs/CoupledConvectiveFlux.C
@@ -19,6 +19,7 @@ CoupledConvectiveFlux::validParams()
   InputParameters params = IntegratedBC::validParams();
   params.addRequiredCoupledVar("T_infinity", "Field holding far-field temperature");
   params.addRequiredParam<Real>("coefficient", "Heat transfer coefficient");
+  params.addClassDescription("Integrated boundary condition for modeling a convective heat flux");
 
   return params;
 }

--- a/modules/heat_transfer/src/bcs/HeatConductionBC.C
+++ b/modules/heat_transfer/src/bcs/HeatConductionBC.C
@@ -15,7 +15,7 @@ InputParameters
 HeatConductionBC::validParams()
 {
   InputParameters params = FluxBC::validParams();
-  params.addClassDescription("Boundary condition for a diffusive heat flux");
+  params.addClassDescription("Boundary condition for a diffusive heat flux.");
 
   return params;
 }

--- a/modules/heat_transfer/src/bcs/HeatConductionBC.C
+++ b/modules/heat_transfer/src/bcs/HeatConductionBC.C
@@ -15,6 +15,7 @@ InputParameters
 HeatConductionBC::validParams()
 {
   InputParameters params = FluxBC::validParams();
+  params.addClassDescription("Boundary condition for a diffusive heat flux");
 
   return params;
 }

--- a/modules/heat_transfer/src/dirackernels/GapHeatPointSourceMaster.C
+++ b/modules/heat_transfer/src/dirackernels/GapHeatPointSourceMaster.C
@@ -33,6 +33,8 @@ GapHeatPointSourceMaster::validParams()
       "Distance from edge in parametric coordinates over which to smooth contact normal");
   params.addParam<std::string>("normal_smoothing_method",
                                "Method to use to smooth normals (edge_based|nodal_normal_based)");
+  params.addClassDescription(
+      "Dirac kernel to create a heat source on the primary contact surface in thermal contact");
 
   return params;
 }

--- a/modules/heat_transfer/src/dirackernels/GapHeatPointSourceMaster.C
+++ b/modules/heat_transfer/src/dirackernels/GapHeatPointSourceMaster.C
@@ -34,7 +34,7 @@ GapHeatPointSourceMaster::validParams()
   params.addParam<std::string>("normal_smoothing_method",
                                "Method to use to smooth normals (edge_based|nodal_normal_based)");
   params.addClassDescription(
-      "Dirac kernel to create a heat source on the primary contact surface in thermal contact");
+      "Dirac kernel to create a heat source on the primary contact surface in thermal contact.");
 
   return params;
 }

--- a/modules/heat_transfer/src/materials/GapConductance.C
+++ b/modules/heat_transfer/src/materials/GapConductance.C
@@ -26,6 +26,9 @@ GapConductance::validParams()
 {
   InputParameters params = Material::validParams();
   params += GapConductance::actionParameters();
+  params.addClassDescription(
+      "Material to compute an effective gap conductance based on the thermal conductivity of the "
+      "gap and diffusive approximation to the radiative heat transfer");
 
   params.addRequiredCoupledVar("variable", "Temperature variable");
 

--- a/modules/heat_transfer/src/materials/GapConductance.C
+++ b/modules/heat_transfer/src/materials/GapConductance.C
@@ -28,7 +28,7 @@ GapConductance::validParams()
   params += GapConductance::actionParameters();
   params.addClassDescription(
       "Material to compute an effective gap conductance based on the thermal conductivity of the "
-      "gap and diffusive approximation to the radiative heat transfer");
+      "gap and diffusive approximation to the radiative heat transfer.");
 
   params.addRequiredCoupledVar("variable", "Temperature variable");
 

--- a/modules/heat_transfer/src/materials/GapConductance.C
+++ b/modules/heat_transfer/src/materials/GapConductance.C
@@ -111,6 +111,12 @@ GapConductance::actionParameters()
   params.addRangeCheckedParam<unsigned int>(
       "min_gap_order", 0, "min_gap_order<=1", "Order of the Taylor expansion below min_gap");
 
+  params.addParamNamesToGroup("appended_property_name", "Material property retrieval");
+  params.addParamNamesToGroup("gap_geometry_type cylinder_axis_point_1 cylinder_axis_point_2",
+                              "Gap geometry");
+  params.addParamNamesToGroup("emissivity_primary emissivity_secondary", "Radiative heat transfer");
+  params.addParamNamesToGroup("min_gap max_gap min_gap_order", "Gap size");
+
   return params;
 }
 

--- a/modules/heat_transfer/src/postprocessors/ThermalConductivity.C
+++ b/modules/heat_transfer/src/postprocessors/ThermalConductivity.C
@@ -21,7 +21,7 @@ ThermalConductivity::validParams()
   params.addRequiredParam<PostprocessorName>("T_hot", "Temperature on 'hot' boundary in K");
   params.addParam<Real>("length_scale", 1e-8, "Length scale of the solution, default is 1e-8");
   params.addParam<Real>("k0", 0.0, "Initial value of the thermal conductivity");
-  params.addClassDescription("Computes the effective thermal conductivity averaged on a boundary");
+  params.addClassDescription("Computes the effective thermal conductivity averaged on a boundary.");
   return params;
 }
 

--- a/modules/heat_transfer/src/postprocessors/ThermalConductivity.C
+++ b/modules/heat_transfer/src/postprocessors/ThermalConductivity.C
@@ -21,6 +21,7 @@ ThermalConductivity::validParams()
   params.addRequiredParam<PostprocessorName>("T_hot", "Temperature on 'hot' boundary in K");
   params.addParam<Real>("length_scale", 1e-8, "Length scale of the solution, default is 1e-8");
   params.addParam<Real>("k0", 0.0, "Initial value of the thermal conductivity");
+  params.addClassDescription("Computes the effective thermal conductivity averaged on a boundary");
   return params;
 }
 

--- a/modules/heat_transfer/test/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_syntax.i
+++ b/modules/heat_transfer/test/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_syntax.i
@@ -45,7 +45,7 @@
   [../]
 []
 
-[Modules/HeatTransfer/ThermalContact/BC]
+[ThermalContact]
   [./thermal_contact]
     type = GapHeatTransfer
     variable = temp

--- a/modules/heat_transfer/test/tests/gap_heat_transfer_htonly/tests
+++ b/modules/heat_transfer/test/tests/gap_heat_transfer_htonly/tests
@@ -24,7 +24,7 @@
     exodiff = 'gap_heat_transfer_htonly_syntax_out.e'
     abs_zero = 1e-6
     requirement = "Thermal contact shall solve plate heat transfer for a constant conductivity gap "
-                  "in 3D using the Thermal contact syntax"
+                  "in 3D using the ThermalContact syntax."
     design = 'source/bcs/GapHeatTransfer.md'
     issues = '#1609'
   []

--- a/modules/heat_transfer/test/tests/gap_heat_transfer_htonly/tests
+++ b/modules/heat_transfer/test/tests/gap_heat_transfer_htonly/tests
@@ -24,7 +24,7 @@
     exodiff = 'gap_heat_transfer_htonly_syntax_out.e'
     abs_zero = 1e-6
     requirement = "Thermal contact shall solve plate heat transfer for a constant conductivity gap "
-                  "in 3D using the Modules/HeatConduction/Thermal contact syntax"
+                  "in 3D using the Thermal contact syntax"
     design = 'source/bcs/GapHeatTransfer.md'
     issues = '#1609'
   []


### PR DESCRIPTION
We saw the failure by adding a new undocumented BC to the heat transfer module.

These changes let the SQA error detection work again for the heat transfer module