### PR TITLE
Two MooseDocs quality-of-life improvements

### DIFF
--- a/python/MooseDocs/__init__.py
+++ b/python/MooseDocs/__init__.py
@@ -37,8 +37,8 @@ if MOOSE_DIR is None:
     print("The MOOSE_DIR environment must be set, this should be set within moosedocs.py.")
     sys.exit(1)
 
-# Initialize submodule(s)
-mooseutils.git_init_submodule('large_media', MOOSE_DIR)
+# Initialize submodule(s) with progress output
+mooseutils.git_init_submodule('large_media', MOOSE_DIR, True)
 
 # List all files, this is done here to avoid running this command many times
 ls_files = mooseutils.git_ls_files if is_git_repo else mooseutils.list_files

--- a/python/moosesqa/check_syntax.py
+++ b/python/moosesqa/check_syntax.py
@@ -66,8 +66,11 @@ def _check_node(node, file_cache, object_prefix, syntax_prefix, logger):
     # ERROR: object does not have a markdown file and is not removed
     if (not node.removed) and is_missing:
         msg = "{} is missing a markdown file.\n".format(node.fullpath())
-        msg += "  The page should be located at {}\n".format(md_path)
-        msg += "  A stub page can be created using using the './moosedocs.py generate' command"
+        msg += "  The page should be located at {}.\n".format(md_path)
+        msg += "  A stub page can be created using the './moosedocs.py generate' command.\n"
+        msg += "  This error can also be encountered if a new markdown page is not known by git ls-files.\n"
+        msg += "  In this case, please doublecheck that the file has been committed or that a 'git add' has \n"
+        msg += "    been performed for any new documentation files!"
         logger.log('log_missing_markdown', msg)
 
     # ERROR: missing description

--- a/python/moosesqa/check_syntax.py
+++ b/python/moosesqa/check_syntax.py
@@ -66,11 +66,12 @@ def _check_node(node, file_cache, object_prefix, syntax_prefix, logger):
     # ERROR: object does not have a markdown file and is not removed
     if (not node.removed) and is_missing:
         msg = "{} is missing a markdown file.\n".format(node.fullpath())
-        msg += "  The page should be located at {}.\n".format(md_path)
-        msg += "  A stub page can be created using the './moosedocs.py generate' command.\n"
-        msg += "  This error can also be encountered if a new markdown page is not known by git ls-files.\n"
-        msg += "  In this case, please doublecheck that the file has been committed or that a 'git add' has \n"
-        msg += "    been performed for any new documentation files!"
+        if os.path.exists(md_path):
+            msg += "  This page exists locally at the expected location, but it is not yet tracked by git.\n"
+            msg += "  In this case, please track the new markdown page using 'git add {}'.".format(md_path)
+        else:
+            msg += "  The page should be located at {}.\n".format(md_path)
+            msg += "  A stub page can be created using the './moosedocs.py generate' command."
         logger.log('log_missing_markdown', msg)
 
     # ERROR: missing description

--- a/python/mooseutils/gitutils.py
+++ b/python/mooseutils/gitutils.py
@@ -102,14 +102,17 @@ def git_submodule_info(working_dir=os.getcwd(), *args):
         out[match.group('name')] = (match.group('status'), match.group('sha1'), match.group('refs'))
     return out
 
-def git_init_submodule(path, working_dir=os.getcwd()):
+def git_init_submodule(path, working_dir=os.getcwd(), progress=False):
     """
     Check if given path is a submodule and initialize it (unless it already has been) if so.
     """
     status = git_submodule_info(working_dir)
     for submodule, status in status.items():
-        if (submodule == path) and ((status[0] == '-') or ('(null)' in status[2])):
+        if (submodule == path) and ((status[0] == '-') or ('(null)' in status[2])) and (progress == False):
             subprocess.call(['git', 'submodule', 'update', '--init', path], cwd=working_dir)
+            break
+        elif (submodule == path) and ((status[0] == '-') or ('(null)' in status[2])) and (progress == True):
+            subprocess.call(['git', 'submodule', 'update', '--init', '--progress', path], cwd=working_dir)
             break
 
 def git_version():

--- a/python/mooseutils/tests/test_gitutils.py
+++ b/python/mooseutils/tests/test_gitutils.py
@@ -71,10 +71,17 @@ class Test(unittest.TestCase):
         status_func.return_value = {'test':'-'}
 
         root = mooseutils.git_root_dir()
+        # Test default (without progress output)
         mooseutils.git_init_submodule('test', root)
 
         status_func.assert_called_with(root)
         call_func.assert_called_with(['git', 'submodule', 'update', '--init', 'test'], cwd=root)
+
+        # Test with progress output
+        mooseutils.git_init_submodule('test', root, True)
+
+        status_func.assert_called_with(root)
+        call_func.assert_called_with(['git', 'submodule', 'update', '--init', '--progress', 'test'], cwd=root)
 
     def testGitVersion(self):
         ver = mooseutils.git_version()


### PR DESCRIPTION
Closes #31263
Closes #31264

@NamjaeChoi, @bwspenc, @hugary1995 - for the portion of this relevant to our discussion on Slack, sample output for an improved missing markdown file error message reads:

```
/MySystem/MyObject is missing a markdown file.
  The page should be located at framework/doc/content/source/mysystem/MyObject.md.
  A stub page can be created using the './moosedocs.py generate' command.
  This error can also be encountered if a new markdown page is not known by git ls-files.
  In this case, please doublecheck that the file has been committed or that a 'git add' has
    been performed for any new documentation files!"
Control this message using: 'log_missing_markdown'
```

Let me know if you have any comments on this. 

While I am here, I might as well check off another quality-of-life item that has been bugging me for ages - adding some optional progress output to the `git_init_submodule` method.

