### PR TITLE
Fix garbage results from NodalValueSampler

### DIFF
--- a/framework/include/postprocessors/ExtremeValueBase.h
+++ b/framework/include/postprocessors/ExtremeValueBase.h
@@ -9,7 +9,11 @@
 
 #pragma once
 
+#include "libmesh/libmesh_common.h"
 #include <utility>
+
+class UserObject;
+class InputParameters;
 
 template <class T>
 class ExtremeValueBase : public T
@@ -20,12 +24,12 @@ public:
   ExtremeValueBase(const InputParameters & parameters);
 
   virtual void initialize() override;
-  virtual Real getValue() const override;
+  virtual libMesh::Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;
 
 protected:
-  virtual std::pair<Real, Real> getProxyValuePair() = 0;
+  virtual std::pair<libMesh::Real, libMesh::Real> getProxyValuePair() = 0;
 
   /// Get the extreme value with a functor element argument
   virtual void computeExtremeValue();
@@ -39,5 +43,5 @@ protected:
   } _type;
 
   /// Extreme value and proxy value at the same point
-  std::pair<Real, Real> _proxy_value;
+  std::pair<libMesh::Real, libMesh::Real> _proxy_value;
 };

--- a/framework/include/postprocessors/NodalExtremeValue.h
+++ b/framework/include/postprocessors/NodalExtremeValue.h
@@ -19,7 +19,7 @@ public:
   static InputParameters validParams();
 
   NodalExtremeValue(const InputParameters & parameters);
-  virtual void execute() override { computeExtremeValue(); }
+  virtual void execute() override;
 
 protected:
   virtual std::pair<Real, Real> getProxyValuePair() override;
@@ -29,6 +29,7 @@ protected:
    * which to evaluate the variable. If not provided, defaults to the variable.
    */
   const VariableValue & _proxy_variable;
+  const MooseVariable * const _proxy_var;
 
   /// Extreme value of the proxy variable
   Real _proxy_value;

--- a/framework/src/postprocessors/NodalExtremeValue.C
+++ b/framework/src/postprocessors/NodalExtremeValue.C
@@ -29,8 +29,20 @@ NodalExtremeValue::validParams()
 
 NodalExtremeValue::NodalExtremeValue(const InputParameters & parameters)
   : ExtremeValueBase<NodalVariablePostprocessor>(parameters),
-    _proxy_variable(isParamValid("proxy_variable") ? coupledValue("proxy_variable") : _u)
+    _proxy_variable(isParamValid("proxy_variable") ? coupledValue("proxy_variable") : _u),
+    _proxy_var(isParamValid("proxy_variable") ? getVar("proxy_variable", 0) : nullptr)
 {
+}
+
+void
+NodalExtremeValue::execute()
+{
+  const bool have_dofs = _var->dofIndices().size();
+  if (_proxy_var)
+    mooseAssert(static_cast<bool>(_proxy_var->dofIndices().size()) == have_dofs,
+                "Should not use variables that don't have coincident dof maps");
+  if (have_dofs)
+    computeExtremeValue();
 }
 
 std::pair<Real, Real>

--- a/framework/src/vectorpostprocessors/NodalValueSampler.C
+++ b/framework/src/vectorpostprocessors/NodalValueSampler.C
@@ -72,10 +72,12 @@ NodalValueSampler::execute()
   // separate NodalValueSampler objects to get their values.
   for (unsigned int i = 0; i < _coupled_standard_moose_vars.size(); i++)
   {
-    const VariableValue & nodal_solution = _coupled_standard_moose_vars[i]->dofValues();
+    const auto & dof_indices = _coupled_standard_moose_vars[i]->dofIndices();
 
-    if (nodal_solution.size() > 0)
+    if (dof_indices.size() > 0)
     {
+      const VariableValue & nodal_solution = _coupled_standard_moose_vars[i]->dofValues();
+      mooseAssert(nodal_solution.size() == dof_indices.size(), "These must be the same length");
       _values[i] = nodal_solution[_qp];
       _has_values[i] = 1;
     }


### PR DESCRIPTION
Querying the size of `dofValues()` is a horrible idea because it may be non-zero sized from some previous reinitialization (perhaps not even associated with nodes) in which there *were* dof indices. The right thing to do is to check the actual dof indices container

Closes #31185