### PR TITLE
Simplify test harness argument grouping and remove old arguments

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1134,7 +1134,7 @@ class TestHarness:
         filtergroup.add_argument('--ignore', nargs='?', action='store', metavar='caveat', dest='ignored_caveats', const='all', type=str,
                                  help='Ignore specified caveats when checking if a test should run; using --ignore without a conditional will ignore all caveats')
         filtergroup.add_argument('--no-check-input', action='store_true', help='Do not run check_input (syntax) tests')
-        filtergroup.add_argument('--not_group', action='store', type=str, help='Run only tests NOT in the named group')
+        filtergroup.add_argument('--not-group', action='store', type=str, help='Run only tests NOT in the named group')
         filtergroup.add_argument('--re', action='store', type=str, dest='reg_exp', help='Run tests that match --re=regular_expression')
         filtergroup.add_argument('--run', type=str, default='', dest='run', help='Only run tests of the specified of tag(s)')
         filtergroup.add_argument('--valgrind', action='store_const', dest='valgrind_mode', const='NORMAL', help='Run normal valgrind tests')

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -400,7 +400,7 @@ class TestHarness:
 
         # Override the MESH_MODE option if using the '--distributed-mesh'
         # or (deprecated) '--parallel-mesh' option.
-        if self.options.distributed_mesh == True or self.options.cli_args != None and \
+        if self.options.distributed_mesh or not self.options.cli_args is None and \
                self.options.cli_args.find('--distributed-mesh') != -1:
 
             option_set = set(['ALL', 'DISTRIBUTED'])

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -242,7 +242,7 @@ class RunApp(Tester):
         if specs['capabilities']:
             cli_args.append('--required-capabilities="' + quote(specs['capabilities'])+'"')
 
-        if (options.parallel_mesh or options.distributed_mesh) and ('--parallel-mesh' not in cli_args or '--distributed-mesh' not in cli_args):
+        if options.distributed_mesh and '--distributed-mesh' not in cli_args:
             # The user has passed the parallel-mesh option to the test harness
             # and it is NOT supplied already in the cli-args option
             cli_args.append('--distributed-mesh')


### PR DESCRIPTION
Closes #31287

Old argument listing:

```
$ ./run_tests --help
usage: run_tests [-h] [--opt] [--dbg] [--devel] [--oprof] [--pro] [--run RUN] [--ignore [caveat]] [-j [int]] [-e] [-c] [--color-first-directory] [--heavy]
                 [--all-tests] [-g GROUP] [--not_group NOT_GROUP] [--dbfile [DBFILE]] [-l LOAD] [-t] [--longest-jobs LONGEST_JOBS] [-s] [-i INPUT_FILE_NAME]
                 [--libmesh_dir LIBMESH_DIR] [--no-capabilities] [--parallel [PARALLEL]] [--n-threads NTHREADS] [--recover] [--recoversuffix RECOVERSUFFIX]
                 [--restep] [--valgrind] [--valgrind-heavy] [--valgrind-max-fails VALGRIND_MAX_FAILS] [--max-fails MAX_FAILS] [--re REG_EXP] [--failed-tests]
                 [--check-input] [--no-check-input] [--spec-file SPEC_FILE] [-C dir] [-d] [--capture-perf-graph] [--parallel-mesh] [--distributed-mesh]
                 [--compute-device {cpu,cuda,hip,mps,ceed-cpu,ceed-cuda,ceed-hip}] [--error] [--error-unused] [--error-deprecated] [--allow-unused]
                 [--allow-warnings] [--cli-args [CLI_ARGS]] [--dry-run] [--use-subdir-exe] [-v] [-q] [--no-report] [--show-directory] [-o directory] [-x]
                 [--include-input-file] [--testharness-unittest] [--json] [--yaml] [--dump] [--no-trimmed-output] [--no-trimmed-output-on-error]
                 [--results-file RESULTS_FILE] [--show-last-run] [--hpc {pbs,slurm}] [--hpc-host  [ ...]] [--hpc-pre-source ]
                 [--hpc-file-timeout HPC_FILE_TIMEOUT] [--hpc-scatter-procs HPC_SCATTER_PROCS] [--hpc-apptainer-bindpath HPC_APPTAINER_BINDPATH]
                 [--hpc-apptainer-no-home] [--hpc-project ] [--hpc-no-hold HPC_NO_HOLD] [--pbs-queue ] [--term-cols TERM_COLS] [--term-format TERM_FORMAT]

A tool used to test MOOSE based applications

options:
  -h, --help            show this help message and exit
  --opt                 test the app_name-opt binary
  --dbg                 test the app_name-dbg binary
  --devel               test the app_name-devel binary
  --oprof               test the app_name-oprof binary
  --pro                 test the app_name-pro binary
  --run RUN             only run tests of the specified of tag(s)
  --ignore [caveat]     ignore specified caveats when checking if a test should run: (--ignore "method compiler") Using --ignore with out a conditional will
                        ignore all caveats
  -j, --jobs [int]      run test binaries in parallel
  -e                    Display "extra" information including all caveats and deleted tests
  -c, --no-color        Do not show colored output
  --color-first-directory
                        Color first directory
  --heavy               Run tests marked with HEAVY : True
  --all-tests           Run normal tests and tests marked with HEAVY : True
  -g, --group GROUP     Run only tests in the named group
  --not_group NOT_GROUP
                        Run only tests NOT in the named group
  --dbfile [DBFILE]     Location to timings data base file. If not set, assumes $HOME/timingDB/timing.sqlite
  -l, --load-average LOAD
                        Do not run additional tests if the load average is at least LOAD
  -t, --timing          Report Timing information for passing tests
  --longest-jobs LONGEST_JOBS
                        Print the longest running jobs upon completion
  -s, --scale           Scale problems that have SCALE_REFINE set
  -i INPUT_FILE_NAME    The test specification file to look for (default: tests)
  --libmesh_dir LIBMESH_DIR
                        Currently only needed for bitten code coverage
  --no-capabilities     Do not allow capability checks
  --parallel, -p [PARALLEL]
                        Number of processors to use when running mpiexec
  --n-threads NTHREADS  Number of threads to use when running mpiexec
  --recover             Run a test in recover mode
  --recoversuffix RECOVERSUFFIX
                        Set the file suffix for recover mode
  --restep              Run a test in restep mode
  --valgrind            Run normal valgrind tests
  --valgrind-heavy      Run heavy valgrind tests
  --valgrind-max-fails VALGRIND_MAX_FAILS
                        The number of valgrind tests allowed to fail before any additional valgrind tests will run
  --max-fails MAX_FAILS
                        The number of tests allowed to fail before any additional tests will run
  --re REG_EXP          Run tests that match --re=regular_expression
  --failed-tests        Run tests that previously failed
  --check-input         Run check_input (syntax) tests only
  --no-check-input      Do not run check_input (syntax) tests
  --spec-file SPEC_FILE
                        Supply a path to the tests spec file to run the tests found therein. Or supply a path to a directory in which the TestHarness will search
                        for tests. You can further alter which tests spec files are found through the use of -i and --re
  -C, --test-root dir   Tell the TestHarness to search for test spec files at this location.
  -d, --pedantic-checks
                        Run pedantic checks of the Testers' file writes looking for race conditions.
  --capture-perf-graph  Capture PerfGraph for MOOSE application runs via Outputs/perf_graph_json_file
  --parallel-mesh       Deprecated, use --distributed-mesh instead
  --distributed-mesh    Pass "--distributed-mesh" to executable
  --compute-device {cpu,cuda,hip,mps,ceed-cpu,ceed-cuda,ceed-hip}
                        Run libtorch or MFEM tests with this compute device; device availability depends on library support and compilation settings
  --error               Run the tests with warnings as errors (Pass "--error" to executable)
  --error-unused        Run the tests with errors on unused parameters (Pass "--error-unused" to executable)
  --error-deprecated    Run the tests with errors on deprecations
  --allow-unused        Run the tests without errors on unused parameters (Pass "--allow-unused" to executable)
  --allow-warnings      Run the tests with warnings not as errors (Do not pass "--error" to executable)
  --cli-args [CLI_ARGS]
                        Append the following list of arguments to the command line (Encapsulate the command in quotes)
  --dry-run             Pass --dry-run to print commands to run, but don't actually run them
  --use-subdir-exe      If there are sub directories that contain a new testroot, use that for running tests under that directory.

Output Options:
  These options control the output of the test harness. The sep-files options write output to files named test_name.TEST_RESULT.txt. All file output will
  overwrite old files

  -v, --verbose         show the output of every test
  -q, --quiet           only show the result of every test, don't show test output even if it fails
  --no-report           do not report skipped tests
  --show-directory      Print test directory path in out messages
  -o, --output-dir directory
                        Save all output files in the directory, and create it if necessary
  -x, --sep-files       Write the output of each test to a separate file. Only quiet output to terminal.
  --include-input-file  Include the contents of the input file when writing the results of a test to a file
  --testharness-unittest
                        Run the TestHarness unittests that test the TestHarness.
  --json                Dump the parameters for the testers in JSON Format
  --yaml                Dump the parameters for the testers in Yaml Format
  --dump                Dump the parameters for the testers in GetPot Format
  --no-trimmed-output   Do not trim the output
  --no-trimmed-output-on-error
                        Do not trim output for tests which cause an error
  --results-file RESULTS_FILE
                        Save run_tests results to an alternative json file (default: .previous_test_results.json)
  --show-last-run       Display previous results without executing tests again

HPC Options:
  Options controlling HPC execution

  --hpc {pbs,slurm}     Launch tests using a HPC scheduler
  --hpc-host  [ ...]    The host(s) to use for submitting HPC jobs
  --hpc-pre-source      Source specified file before launching HPC tests
  --hpc-file-timeout HPC_FILE_TIMEOUT
                        The time in seconds to wait for HPC output
  --hpc-scatter-procs HPC_SCATTER_PROCS
                        Set to run HPC jobs with scatter placement when the processor count is this or lower
  --hpc-apptainer-bindpath HPC_APPTAINER_BINDPATH
                        Sets the apptainer bindpath for HPC jobs
  --hpc-apptainer-no-home
                        Passes --no-home to apptainer for HPC jobs
  --hpc-project         Identify your job(s) with this project (default: moose)
  --hpc-no-hold HPC_NO_HOLD
                        Do not pre-create hpc jobs to be held
  --pbs-queue           Submit jobs to the specified queue

Terminal Options:
  Options for controlling the formatting of terminal output

  --term-cols TERM_COLS
                        The number columns to use in output
  --term-format TERM_FORMAT
                        The formatting to use when outputting job status
```

New argument listing:

```
usage: run_tests [-h] [--failed-tests] [--show-last-run] [--dry-run] [-i INPUT_FILE_NAME] [-C dir] [--spec-file SPEC_FILE] [-j [JOBS]] [-l LOAD] [-p [PARALLEL]]
                 [--n-threads NTHREADS] [-g GROUP] [-s] [--all-tests] [--check-input] [--heavy] [--ignore [caveat]] [--no-check-input] [--not_group NOT_GROUP]
                 [--re REG_EXP] [--run RUN] [--valgrind] [--valgrind-heavy] [--capture-perf-graph] [--cli-args [CLI_ARGS]] [--no-capabilities]
                 [--pedantic-checks] [--use-subdir-exe] [--recover] [--restep] [--allow-unused] [--allow-warnings]
                 [--compute-device {cpu,cuda,hip,mps,ceed-cpu,ceed-cuda,ceed-hip}] [--distributed-mesh] [--error] [--error-unused] [--error-deprecated]
                 [--recoversuffix RECOVERSUFFIX] [--opt] [--dbg] [--devel] [--oprof] [-c] [-e] [-q] [-t] [-v] [--color-first-directory]
                 [--longest-jobs LONGEST_JOBS] [--no-report] [--no-trimmed-output] [--no-trimmed-output-on-error] [--term-cols TERM_COLS]
                 [--term-format TERM_FORMAT] [-o directory] [-x] [--results-file RESULTS_FILE] [--max-fails MAX_FAILS] [--valgrind-max-fails VALGRIND_MAX_FAILS]
                 [--hpc {pbs,slurm}] [--hpc-apptainer-bindpath HPC_APPTAINER_BINDPATH] [--hpc-apptainer-no-home] [--hpc-file-timeout HPC_FILE_TIMEOUT]
                 [--hpc-host  [ ...]] [--hpc-no-hold HPC_NO_HOLD] [--hpc-pre-source ] [--hpc-project ] [--hpc-scatter-procs HPC_SCATTER_PROCS] [--pbs-queue ]
                 [--json] [--yaml] [--dump]

A tool used to test MOOSE-based applications

options:
  -h, --help            show this help message and exit
  --failed-tests        Run tests that previously failed
  --show-last-run       Display previous results without executing tests again
  --dry-run             Print the commands to run without running them

Test Specifications:
  Specify which test specification files to load

  -i INPUT_FILE_NAME    The test specification file to look for (default: tests)
  -C, --test-root dir   Search for test spec files in this location
  --spec-file SPEC_FILE
                        Supply a path to the tests spec file to run the tests found therein or supply a path to a directory in which the TestHarness will search
                        for tests

Parallelization:
  Control the parallel execution

  -j, --jobs [JOBS]     Set the number of parallel jobs for tests
  -l, --load-average LOAD
                        Do not run additional tests if the load average is at least LOAD
  -p, --parallel [PARALLEL]
                        Number of MPI processes to use for each job
  --n-threads NTHREADS  Number of threads to use when running mpiexec

Test Filters:
  Filter which tests are ran

  -g, --group GROUP     Run only tests in the named group
  -s, --scale           Run tests that have SCALE_REFINE set
  --all-tests           Run heavy and non-heavy tests
  --check-input         Run check_input (syntax) tests only
  --heavy               Run tests marked with heavy
  --ignore [caveat]     Ignore specified caveats when checking if a test should run; using --ignore without a conditional will ignore all caveats
  --no-check-input      Do not run check_input (syntax) tests
  --not_group NOT_GROUP
                        Run only tests NOT in the named group
  --re REG_EXP          Run tests that match --re=regular_expression
  --run RUN             Only run tests of the specified of tag(s)
  --valgrind            Run normal valgrind tests
  --valgrind-heavy      Run heavy valgrind tests

Additional Capabilities:
  Enable or disable additional TestHarness capabilities

  --capture-perf-graph  Capture PerfGraph for RunApp tests via Outputs/perf_graph_json_file
  --cli-args [CLI_ARGS]
                        Append the following list of arguments to the command line (encapsulate the command in quotes)
  --no-capabilities     Disable Capability checks
  --pedantic-checks     Run pedantic checks of the Testers' file writes looking for race conditions
  --use-subdir-exe      If there are sub directories that contain a new testroot, use that for running tests under that directory
  --recover             Run tests in recover mode
  --restep              Run tests in restep mode

Application Options:
  Options that pass arguments directly to the executable

  --allow-unused        Run the tests without errors on unused parameters (pass --allow-unused)
  --allow-warnings      Run the tests with warnings not as errors (do not pass --error)
  --compute-device {cpu,cuda,hip,mps,ceed-cpu,ceed-cuda,ceed-hip}
                        Run tests that support this compute device; (passes --compute-device=...)
  --distributed-mesh    Run tests that support distributed mesh (pass --distributed-mesh)
  --error               Run the tests with warnings as errors (pass --error)
  --error-unused        Run the tests with errors on unused parameters (pass --error-unused)
  --error-deprecated    Run the tests with errors on deprecations (pass --error-deprecated)
  --recoversuffix RECOVERSUFFIX
                        Set the file suffix for recover mode (pass --recoversuffix)

Application Methods:
  Control which application biunary method is to be ran

  --opt                 Test the <app_name>-opt binary
  --dbg                 Test the <app_name>-dbg binary
  --devel               Test the <app_name>-devel binary
  --oprof               Test the <app_name>-oprof binary

On-screen Output:
  Control the on-screen output

  -c, --no-color        Do not show colored output
  -e                    Display "extra" information including all caveats and deleted tests
  -q, --quiet           Only show the result of every test (even failed output)
  -t, --timing          Report Timing information for passing tests
  -v, --verbose         Show the output of every test
  --color-first-directory
                        Color first directory
  --longest-jobs LONGEST_JOBS
                        Print the longest running jobs upon completion
  --no-report           Do not report skipped tests
  --no-trimmed-output   Do not trim the output
  --no-trimmed-output-on-error
                        Do not trim output for tests which cause an error
  --term-cols TERM_COLS
                        The number columns to use in output
  --term-format TERM_FORMAT
                        The formatting to use when outputting job status

Output:
  Control the file output

  -o, --output-dir directory
                        Save all output files in the directory, and create it if necessary
  -x, --sep-files       Write the output of each test to a separate file. Only quiet output to terminal.
  --results-file RESULTS_FILE
                        Save run_tests results to an alternative json file (default: .previous_test_results.json)

Failure Criteria:
  Control the failure criteria

  --max-fails MAX_FAILS
                        The number of tests allowed to fail before any additional tests will run
  --valgrind-max-fails VALGRIND_MAX_FAILS
                        The number of valgrind tests allowed to fail before any additional valgrind tests will run

HPC:
  Enable and control HPC execution

  --hpc {pbs,slurm}     Launch tests using a HPC scheduler
  --hpc-apptainer-bindpath HPC_APPTAINER_BINDPATH
                        Sets the apptainer bindpath for HPC jobs
  --hpc-apptainer-no-home
                        Passes --no-home to apptainer for HPC jobs
  --hpc-file-timeout HPC_FILE_TIMEOUT
                        The time in seconds to wait for HPC output
  --hpc-host  [ ...]    The host(s) to use for submitting HPC jobs
  --hpc-no-hold HPC_NO_HOLD
                        Do not pre-create hpc jobs to be held
  --hpc-pre-source      Source specified file before launching HPC tests
  --hpc-project         Identify your job(s) with this project (default: moose)
  --hpc-scatter-procs HPC_SCATTER_PROCS
                        Set to run HPC jobs with scatter placement when the processor count is this or lower
  --pbs-queue           Submit jobs to the specified queue

Syntax Dumping:
  Dump the Tester parameters

  --json                Dump Tester parameters in JSON Format
  --yaml                Dump Tester parameters in Yaml Format
  --dump                Dump Tester parameters in HIT Format
```
