### PR TITLE
Fix mistake in a test involving a moving mesh + mortar + distributed parallel

### DIFF
--- a/test/tests/mortar/mesh_modification/displaced_and_modifying_meshes.i
+++ b/test/tests/mortar/mesh_modification/displaced_and_modifying_meshes.i
@@ -74,7 +74,7 @@
     threshold = 0.5
     block = '10000 10001'
     # subdomain 10002 is inactive, no variables defined on it
-    subdomain_id = 10001
+    subdomain_id = 10002
     execute_on = 'INITIAL TIMESTEP_BEGIN'
     execution_order_group = '2'
   []
@@ -204,6 +204,9 @@
     type = SMP
     full = true
     solve_type = 'NEWTON'
+    # Default PC fails at 14 MPI
+    petsc_options_iname = '-pc_type -pc_factor_shift_type'
+    petsc_options_value = 'lu NONZERO'
   []
 []
 

--- a/test/tests/mortar/mesh_modification/tests
+++ b/test/tests/mortar/mesh_modification/tests
@@ -7,5 +7,9 @@
     csvdiff = 'displaced_and_modifying_meshes_out.csv'
     abs_zero = 1e-8
     requirement = 'The system shall be able to use mortar constraints while modifying element subdomains in the reference mesh and the displaced mesh.'
+    # See #31305
+    max_parallel = 4
+    # #30630 fixes distributed
+    mesh_mode = 'replicated'
   []
 []


### PR DESCRIPTION
limit it to 4 procs
refs #31305

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
