### PR TITLE
Add `--only-tests-that-require` to TestHarness

### DIFF
--- a/modules/doc/content/newsletter/2025/2025_09.md
+++ b/modules/doc/content/newsletter/2025/2025_09.md
@@ -7,6 +7,27 @@ for a complete description of all MOOSE changes.
 
 ## MOOSE Improvements
 
+### TestHarness `--only-tests-that-require` option
+
+The `capability` parameter for test specifications allows for run-time checking of if a test can or cannot run based on capabilities defined by the application executable. The `--only-tests-that-require` command line option has been added to the [TestHarness.md], which allows filtering of tests based on whether or not they depend on a capability.
+
+For example, take a situation in which `./run_tests --only-tests-that-require cuda` is ran along with the following test specification:
+
+```
+[Tests]
+  [needs_cuda]
+    ...
+    capabilities = 'cuda'
+  []
+  [doesnt_need_cuda]
+    ...
+    capabilities = 'libtorch'
+  []
+[]
+```
+
+In this case, the test `needs_cuda` will be ran beacuse it depends on the `cuda` capability, while the `doesnt_need_cuda` test will not run because it does not depend on the `cuda` capability.
+
 ## MOOSE Modules Changes
 
 ## libMesh-level Changes

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -335,8 +335,8 @@ class TestHarness:
         self.options._required_capabilities = []
         if self.options.no_capabilities:
             self.options._capabilities = None
-            if self.options.require_capability:
-                self.errorExit('Cannot use --require-capability with --no-capabilities')
+            if self.options.only_tests_that_require:
+                self.errorExit('Cannot use --only-tests-that-require with --no-capabilities')
         else:
             assert self.executable
 
@@ -352,8 +352,8 @@ class TestHarness:
             # when temporarily augmenting the capabilities in a Tester
             # to perform a check to see if the capability check in the tester
             # changes if we change these value(s)
-            if self.options.require_capability:
-                required = self.options.require_capability
+            if self.options.only_tests_that_require:
+                required = self.options.only_tests_that_require
                 if isinstance(required, str):
                     required = [required]
                 self.options._required_capabilities = self.buildRequiredCapabilities(
@@ -1153,7 +1153,7 @@ class TestHarness:
         filtergroup.add_argument('--no-check-input', action='store_true', help='Do not run check_input (syntax) tests')
         filtergroup.add_argument('--not-group', action='store', type=str, help='Run only tests NOT in the named group')
         filtergroup.add_argument('--re', action='store', type=str, dest='reg_exp', help='Run tests that match the given regular expression')
-        filtergroup.add_argument('--require-capability', action='extend', nargs=1, type=str, help='Require that a test depend on this capability name; can be negated with "!"')
+        filtergroup.add_argument('--only-tests-that-require', action='extend', nargs=1, type=str, help='Require that a test depend on this capability name; can be negated with "!"')
         filtergroup.add_argument('--valgrind', action='store_const', dest='valgrind_mode', const='NORMAL', help='Run normal valgrind tests')
         filtergroup.add_argument('--valgrind-heavy', action='store_const', dest='valgrind_mode', const='HEAVY', help='Run heavy valgrind tests')
 

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -70,10 +70,15 @@ def findDepApps(dep_names, use_current_only=False):
     apps = []
 
     # First see if we are in a git repo
-    p = subprocess.Popen('git rev-parse --show-cdup', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-    p.wait()
+    p = subprocess.run(
+        ['git', 'rev-parse', '--show-cdup'],
+        text=True,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
     if p.returncode == 0:
-        git_dir = p.communicate()[0].decode('utf-8')
+        git_dir = p.stdout
         root_dir = os.path.abspath(os.path.join(os.getcwd(), git_dir)).rstrip()
 
         # Assume that any application we care about is always a peer

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1148,7 +1148,7 @@ class TestHarness:
         filtergroup.add_argument('--no-check-input', action='store_true', help='Do not run check_input (syntax) tests')
         filtergroup.add_argument('--not-group', action='store', type=str, help='Run only tests NOT in the named group')
         filtergroup.add_argument('--re', action='store', type=str, dest='reg_exp', help='Run tests that match the given regular expression')
-        filtergroup.add_argument('--require-capability', action='append', nargs=1, type=str, help='Require that a test depend on this capability name; can be negated with "!"')
+        filtergroup.add_argument('--require-capability', action='extend', nargs=1, type=str, help='Require that a test depend on this capability name; can be negated with "!"')
         filtergroup.add_argument('--valgrind', action='store_const', dest='valgrind_mode', const='NORMAL', help='Run normal valgrind tests')
         filtergroup.add_argument('--valgrind-heavy', action='store_const', dest='valgrind_mode', const='HEAVY', help='Run heavy valgrind tests')
 
@@ -1347,8 +1347,13 @@ class TestHarness:
         """
         Helper for setting up the required capabilities.
         """
+        assert isinstance(registered, list)
+        assert isinstance(required, list)
+
         result = []
-        for v in [v.strip() for v in required]:
+        for v in required:
+            assert isinstance(v, str)
+            v = v.strip()
             is_false = v[0] == '!'
             capability = v[1:] if is_false else v
             if capability not in registered:

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -352,7 +352,7 @@ class TestHarness:
                 if isinstance(required, str):
                     required = [required]
                 self.options._required_capabilities = self.buildRequiredCapabilities(
-                    self.options._capabilities,
+                    list(self.options._capabilities.keys()),
                     required
                 )
 
@@ -1342,17 +1342,17 @@ class TestHarness:
         return None
 
     @staticmethod
-    def buildRequiredCapabilities(capabilities: dict[str, Tuple[Any, str]],
-                                  required_capabilities: list[str]) -> list[Tuple[str, bool]]:
+    def buildRequiredCapabilities(registered: list[str],
+                                  required: list[str]) -> list[Tuple[str, bool]]:
         """
         Helper for setting up the required capabilities.
         """
         result = []
-        for v in [v.strip() for v in required_capabilities]:
+        for v in [v.strip() for v in required]:
             is_false = v[0] == '!'
             capability = v[1:] if is_false else v
-            if capability not in capabilities:
-                TestHarness.errorExit(f'Require capability "{capability}" is not registered')
+            if capability not in registered:
+                TestHarness.errorExit(f'Required capability "{capability}" is not registered')
             result.append((capability, is_false))
         return result
 

--- a/python/TestHarness/tests/TestHarnessTestCase.py
+++ b/python/TestHarness/tests/TestHarnessTestCase.py
@@ -43,6 +43,7 @@ class TestHarnessTestCase(unittest.TestCase):
                  no_capabilities: bool = True,
                  capture_results: bool = True,
                  exit_code: int = 0,
+                 run: bool = True,
                  tests: Optional[dict[str, dict]] = None) -> RunTestsResult:
         """
         Helper for running tests
@@ -100,10 +101,13 @@ class TestHarnessTestCase(unittest.TestCase):
             try:
                 with redirect_stdout(stdout):
                     result.harness = TestHarness.build(argv, 'moose_test', MOOSE_DIR, **test_harness_build_kwargs)
-                    result.harness.findAndRunTests()
+                    if run:
+                        result.harness.findAndRunTests()
             except SystemExit as e:
-                self.assertEqual(e.code, exit_code)
-                return result
+                if isinstance(e.code, int):
+                    self.assertEqual(e.code, exit_code)
+                    return result
+                raise
             finally:
                 os.chdir(cwd)
                 result.output = stdout.getvalue()

--- a/python/TestHarness/tests/test_OnlyTestsThatRequire.py
+++ b/python/TestHarness/tests/test_OnlyTestsThatRequire.py
@@ -46,16 +46,16 @@ class TestRequireCapability(TestHarnessTestCase):
         Test that the test harness will set the _required_capabilities option
         """
         # No capabilities set, can't run
-        with self.assertRaisesRegex(SystemExit, 'Cannot use --require-capability with --no-capabilities'):
-            self.runTests('--require-capability', 'petsc', no_capabilities=True)
+        with self.assertRaisesRegex(SystemExit, 'Cannot use --only-tests-that-require with --no-capabilities'):
+            self.runTests('--only-tests-that-require', 'petsc', no_capabilities=True)
 
         # Not registered
         with self.assertRaisesRegex(SystemExit, 'Required capability "foo" is not registered'):
-            self.runTests('--require-capability', 'foo', no_capabilities=False)
+            self.runTests('--only-tests-that-require', 'foo', no_capabilities=False)
 
         # Is registered and is set
         res = self.runTests(
-            '--require-capability',
+            '--only-tests-that-require',
             'moosetestapp',
             no_capabilities=False,
             run=False
@@ -64,9 +64,9 @@ class TestRequireCapability(TestHarnessTestCase):
 
         # Multiple
         res = self.runTests(
-            '--require-capability',
+            '--only-tests-that-require',
             'moosetestapp',
-            '--require-capability',
+            '--only-tests-that-require',
             '!compiler',
             no_capabilities=False,
             run=False
@@ -93,7 +93,7 @@ class TestRequireCapability(TestHarnessTestCase):
                 tests[test_name]['capabilities'] = f"'{test_capabilities}'"
             args = []
             for v in require_capabilities:
-                args += ['--require-capability', v]
+                args += ['--only-tests-that-require', v]
             res = self.runTests(*args, tests=tests, no_capabilities=False)
             job = self.getJobWithName(res.harness, test_name)
             if skip:
@@ -112,7 +112,7 @@ class TestRequireCapability(TestHarnessTestCase):
         # Test spec has complex capabilities and still runs
         run_test(False, ['moosetestapp'], 'moosetestapp & compiler')
 
-        # Multiple --require-capability
+        # Multiple --only-tests-that-require
         run_test(False, ['moosetestapp', 'compiler'], 'compiler & moosetestapp')
         run_test(False, ['moosetestapp', 'compiler'], 'compiler & method & moosetestapp')
 

--- a/python/TestHarness/tests/test_Replay.py
+++ b/python/TestHarness/tests/test_Replay.py
@@ -73,6 +73,6 @@ class TestHarnessTester(TestHarnessTestCase):
     def testNoResultsFile(self):
         """ Verify the TestHarness errors correctly when there is no results file to work with """
         with tempfile.TemporaryDirectory() as output_dir:
-            out = self.runTests('--show-last-run', '--results-file', 'non_existent', '-o', output_dir,
-                                tmp_output=False, capture_results=False, exit_code=1).output
-            self.assertIn(f'The previous run {output_dir}/non_existent does not exist', out)
+            with self.assertRaisesRegex(SystemExit, f'The previous run {output_dir}/non_existent does not exist'):
+                self.runTests('--show-last-run', '--results-file', 'non_existent', '-o', output_dir,
+                              tmp_output=False, capture_results=False, exit_code=1)

--- a/python/TestHarness/tests/test_RequireCapability.py
+++ b/python/TestHarness/tests/test_RequireCapability.py
@@ -1,0 +1,120 @@
+#* This file is part of the MOOSE framework
+#* https://mooseframework.inl.gov
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+from TestHarnessTestCase import TestHarnessTestCase
+from TestHarness import TestHarness
+from TestHarness.StatusSystem import StatusSystem
+
+import unittest
+
+class TestRequireCapability(TestHarnessTestCase):
+    def testTestHarnessBuildRequiredCapabilities(self):
+        """
+        Tests TestHarness.buildRequiredCapabilities()
+        """
+        # Not registered
+        with self.assertRaisesRegex(SystemExit, 'Required capability "bar" is not registered'):
+            TestHarness.buildRequiredCapabilities(['foo'], ['bar'])
+
+        # True value -> false augmented value
+        res = TestHarness.buildRequiredCapabilities(['foo'], ['foo'])
+        self.assertEqual(res, [('foo', False)])
+
+        # False value -> true augmented value
+        res = TestHarness.buildRequiredCapabilities(['foo'], ['!foo'])
+        self.assertEqual(res, [('foo', True)])
+
+        # Has stripping
+        res = TestHarness.buildRequiredCapabilities(['foo'], ['  foo '])
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0][0], 'foo')
+
+        # Multiple
+        res = TestHarness.buildRequiredCapabilities(['foo', 'bar'], ['foo', '!bar'])
+        self.assertEqual(len(res), 2)
+        self.assertEqual(res[0], ('foo', False))
+        self.assertEqual(res[1], ('bar', True))
+
+    def testTestHarnessOptions(self):
+        """
+        Test that the test harness will set the _required_capabilities option
+        """
+        # No capabilities set, can't run
+        with self.assertRaisesRegex(SystemExit, 'Cannot use --require-capability with --no-capabilities'):
+            self.runTests('--require-capability', 'petsc', no_capabilities=True)
+
+        # Not registered
+        with self.assertRaisesRegex(SystemExit, 'Required capability "foo" is not registered'):
+            self.runTests('--require-capability', 'foo', no_capabilities=False)
+
+        # Is registered and is set
+        res = self.runTests(
+            '--require-capability',
+            'moosetestapp',
+            no_capabilities=False,
+            run=False
+        )
+        self.assertEqual(res.harness.options._required_capabilities, [('moosetestapp', False)])
+
+        # Multiple
+        res = self.runTests(
+            '--require-capability',
+            'moosetestapp',
+            '--require-capability',
+            '!compiler',
+            no_capabilities=False,
+            run=False
+        )
+        self.assertEqual(
+            res.harness.options._required_capabilities,
+            [('moosetestapp', False), ('compiler', True)]
+        )
+
+    def testTesterSkip(self):
+        """
+        Test the Tester skipping tests based on --required-capabilities
+        """
+        def run_test(skip, require_capabilities, test_capabilities=None):
+            test_name = 'test'
+            tests = {
+                test_name: {
+                    'type': 'RunApp',
+                    'input': 'unused',
+                    'should_execute': False,
+                }
+            }
+            if test_capabilities:
+                tests[test_name]['capabilities'] = f"'{test_capabilities}'"
+            args = []
+            for v in require_capabilities:
+                args += ['--require-capability', v]
+            res = self.runTests(*args, tests=tests, no_capabilities=False)
+            job = self.getJobWithName(res.harness, test_name)
+            if skip:
+                self.assertEqual(job.getStatus(), StatusSystem.skip)
+                self.assertEqual(job.getCaveats(), set(['Missing required capabilities']))
+            else:
+                self.assertEqual(job.getStatus(), StatusSystem.finished)
+
+        # Capability is not in the test spec capabilities
+        run_test(True, ['moosetestapp'])
+        run_test(True, ['moosetestapp'], 'compiler')
+
+        # Capability is in the test spec capabilities
+        run_test(False, ['moosetestapp'], 'moosetestapp')
+
+        # Test spec has complex capabilities and still runs
+        run_test(False, ['moosetestapp'], 'moosetestapp & compiler')
+
+        # Multiple --require-capability
+        run_test(False, ['moosetestapp', 'compiler'], 'compiler & moosetestapp')
+        run_test(False, ['moosetestapp', 'compiler'], 'compiler & method & moosetestapp')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -322,4 +322,10 @@
     requirement = 'The system shall provide the ability to set whether or not a test can run using the capabilities system using properties of the currently running test suite.'
     issues = '#31135'
   []
+  [require_capability]
+    type = PythonUnitTest
+    input = test_RequireCapability.py
+    requirement = 'The system shall provide the ability to filter tests based on whether or not they are dependent on certain capabilities.'
+    issues = '#31310'
+  []
 []

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -322,9 +322,9 @@
     requirement = 'The system shall provide the ability to set whether or not a test can run using the capabilities system using properties of the currently running test suite.'
     issues = '#31135'
   []
-  [require_capability]
+  [only_tests_that_require]
     type = PythonUnitTest
-    input = test_RequireCapability.py
+    input = test_OnlyTestsThatRequire.py
     requirement = 'The system shall provide the ability to filter tests based on whether or not they are dependent on certain capabilities.'
     issues = '#31310'
   []

--- a/python/pycapabilities/__init__.py
+++ b/python/pycapabilities/__init__.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import subprocess
-import mooseutils
 
 """
 First, attempt to import capabilities. If that fails, try adding the capabilities source directory to the path


### PR DESCRIPTION
Closes https://github.com/idaholab/moose/issues/31310

This lets you pass `--required-capability foo` to only run tests that explicitly depend on the capability `foo` given the current configuration. You can also use multiple, i.e., `--only-tests-that-require foo --only-tests-that-require !bar`.

Thus, you can do something like:

```
./run_tests --only-tests-that-require cuda
```

to only run the tests that depend on cuda.