### PR TITLE
Disable perf graph live in the test harness by default

### DIFF
--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -49,6 +49,7 @@ class RunApp(Tester):
         params.addParam('no_additional_cli_args', False, "A Boolean indicating that no additional CLI args should be added from the TestHarness. Note: This parameter should be rarely used as it will not pass on additional options such as those related to mpi, threads, distributed mesh, errors, etc.")
 
         params.addParam('capture_perf_graph', True, 'Whether or not to enable the capturing of PerfGraph output via Outputs/perf_graph_json_file and --capture-perf-graph')
+        params.addParam("perf_graph_live", False, "Whether to enable perf graph live printing")
 
         # Valgrind
         params.addParam('valgrind', 'NORMAL', "Set to (NONE, NORMAL, HEAVY) to determine which configurations where valgrind will run.")
@@ -249,6 +250,9 @@ class RunApp(Tester):
 
         if specs['restep'] != False and options.enable_restep:
             cli_args.append('--test-restep')
+
+        if not specs['perf_graph_live'] and '--disable-perf-graph-live' not in cli_args:
+            cli_args.append('--disable-perf-graph-live')
 
         if '--error' not in cli_args and (not specs["allow_warnings"] or options.error) and not options.allow_warnings:
             cli_args.append('--error')

--- a/test/tests/utils/perf_graph_live_print/tests
+++ b/test/tests/utils/perf_graph_live_print/tests
@@ -7,6 +7,7 @@
     issues = '#15444'
     design = 'utils/PerfGraph.md'
     requirement = 'The system shall allow for timing sections of code and having automated print-outs when they take too long.'
+    perf_graph_live = true
   []
 
   [nested_sections]
@@ -19,6 +20,7 @@
     issues = '#15444'
     design = 'utils/PerfGraphLivePrint.md'
     requirement = 'The system shall allow for nested code timing sections and having automated print-outs of the code section names when they are taking a long time.'
+    perf_graph_live = true
   []
   [section_interrupted_by_regular_print]
     # this test does not address the warnings 'direct to Moose::out' issue #23750
@@ -30,6 +32,7 @@
     issues = '#23746'
     design = 'utils/PerfGraphLivePrint.md'
     requirement = 'The system shall be able to display the automatic print-out of a timed section even when an external print happened before the threshold for the automatic print-out was met.'
+    perf_graph_live = true
   []
 
   [multiapps]
@@ -41,6 +44,7 @@
     issues = '#19114'
     design = 'utils/PerfGraphLivePrint.md'
     requirement = 'The system shall allow for automatic print-outs of timing sections within multiapps.'
+    perf_graph_live = true
   []
   [multiapps_and_nested]
     type = RunApp
@@ -51,6 +55,7 @@
     issues = '#19114'
     design = 'utils/PerfGraphLivePrint.md'
     requirement = 'The system shall allow for automatic print-outs of nested timing sections within multiapps.'
+    perf_graph_live = true
   []
 
   [nested_multiapps]
@@ -62,5 +67,6 @@
     issues = '#19114'
     design = 'utils/PerfGraphLivePrint.md'
     requirement = 'The system shall allow for automatic print-outs of timing sections within nested multiapps.'
+    perf_graph_live = true
   []
 []


### PR DESCRIPTION
Refs #31344