### PR TITLE
Squeeze a bit more performance from the test harness

### DIFF
--- a/modules/solid_mechanics/examples/cframe_iga/tests
+++ b/modules/solid_mechanics/examples/cframe_iga/tests
@@ -4,7 +4,6 @@
     input = 'cframe_iga.i'
     max_parallel = 1 # number of VTK output files changes with num processes, so we are sticking w/ one for now
     xmldiff = 'cframe_iga_out_001.pvtu cframe_iga_out_001_0.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     # See #24187, set vtk to >=9.0 once #21449 is resolved
     capabilities = 'petsc>=3.12.0 & method!=dbg & exodus>=8.0 & vtk>=9.1'
     valgrind = none

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1135,8 +1135,7 @@ class TestHarness:
                                  help='Ignore specified caveats when checking if a test should run; using --ignore without a conditional will ignore all caveats')
         filtergroup.add_argument('--no-check-input', action='store_true', help='Do not run check_input (syntax) tests')
         filtergroup.add_argument('--not-group', action='store', type=str, help='Run only tests NOT in the named group')
-        filtergroup.add_argument('--re', action='store', type=str, dest='reg_exp', help='Run tests that match --re=regular_expression')
-        filtergroup.add_argument('--run', type=str, default='', dest='run', help='Only run tests of the specified of tag(s)')
+        filtergroup.add_argument('--re', action='store', type=str, dest='reg_exp', help='Run tests that match the given regular expression')
         filtergroup.add_argument('--valgrind', action='store_const', dest='valgrind_mode', const='NORMAL', help='Run normal valgrind tests')
         filtergroup.add_argument('--valgrind-heavy', action='store_const', dest='valgrind_mode', const='HEAVY', help='Run heavy valgrind tests')
 
@@ -1220,8 +1219,6 @@ class TestHarness:
             if hpc_config is not None:
                 self.options.hpc = hpc_config.scheduler
                 print(f'INFO: Setting --hpc={self.options.hpc} for known host {hpc_host}')
-
-        self.options.runtags = [tag for tag in self.options.run.split(',') if tag != '']
 
         # Convert all list based options of length one to scalars
         for key, value in list(vars(self.options).items()):

--- a/python/TestHarness/testers/SchemaDiff.py
+++ b/python/TestHarness/testers/SchemaDiff.py
@@ -67,10 +67,6 @@ class SchemaDiff(RunApp):
             else:
                 gold = os.path.join(self.getTestDir(), specs['gold_dir'], gold_file)
                 test = os.path.join(self.getTestDir(), file)
-                # We always ignore the header_type attribute, since it was
-                # introduced in VTK 7 and doesn't seem to be important as
-                # far as Paraview is concerned.
-                specs['ignored_items'].append('header_type')
 
                 gold_dict = self.try_load(gold)
                 test_dict = self.try_load(test)
@@ -150,7 +146,13 @@ class SchemaDiff(RunApp):
                         return True #if the values in the pseudo-list are different, but all fall within the accepted rel_err, the list is skipped for diffing.
                     except ValueError:
                         return False
-        exclude_paths = []
+
+        # We always ignore the header_type attribute, since it was
+        # introduced in VTK 7 and doesn't seem to be important as
+        # far as Paraview is concerned.
+        # We always ignore the version attribute, since there seems
+        # to be (enough) backward compatibility.
+        exclude_paths = ["root['VTKFile']['@header_type']", "root['VTKFile']['@version']"]
         if exclude_values:
             for value in exclude_values:
                 search = orig | deepdiff.search.grep(value, case_sensitive=True)

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -44,7 +44,6 @@ class Tester(MooseObject, OutputInterface):
         params.addParam('allow_test_objects', False, "Allow the use of test objects by adding --allow-test-objects to the command line.")
 
         params.addParam('valgrind', 'NONE', "Set to (NONE, NORMAL, HEAVY) to determine which configurations where valgrind will run.")
-        params.addParam('tags',      [], "A list of strings")
         params.addParam('max_buffer_size', None, "Bytes allowed in stdout/stderr before it is subjected to being trimmed. Set to -1 to ignore output size restrictions. "
                                                  "If 'max_buffer_size' is not set, the default value of 'None' triggers a reasonable value (e.g. 100 kB)")
         params.addParam('parallel_scheduling', False, "Allow all tests in test spec file to run in parallel (adheres to prereq rules).")
@@ -196,7 +195,6 @@ class Tester(MooseObject, OutputInterface):
         self.specs = params
         self.joined_out = ''
         self.process = None
-        self.tags = params['tags']
         self.__caveats = set([])
 
         # Alternate text we want to print as part of our status instead of the
@@ -595,15 +593,6 @@ class Tester(MooseObject, OutputInterface):
             augment('compute_device', [options.compute_device, 'Compute device'])
         else:
             capabilities = None
-
-        tag_match = False
-        for t in self.tags:
-            if t in options.runtags:
-                tag_match = True
-                break
-        if len(options.runtags) > 0 and not tag_match:
-            self.setStatus(self.silent)
-            return False
 
         # If something has already deemed this test a failure
         if self.isFail():

--- a/test/tests/meshgenerators/file_mesh_generator/tests
+++ b/test/tests/meshgenerators/file_mesh_generator/tests
@@ -95,7 +95,6 @@
     # when a spline control node is at a finite element's centroid.
     max_parallel = 1
     xmldiff = '3d_steady_diffusion_iga_out_001.pvtu 3d_steady_diffusion_iga_out_001_0.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to read IsoGeometric Analysis meshes with 3D elements and sidesets in ExodusII format.'
     design = 'meshgenerators/FileMeshGenerator.md'
     issues = '#18768'

--- a/test/tests/mfem/auxkernels/tests
+++ b/test/tests/mfem/auxkernels/tests
@@ -4,7 +4,6 @@
     input = projection.i
     xmldiff = 'OutputData/Projection/Run0/Run0.pvd
                 OutputData/Projection/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     design = 'MFEMScalarProjectionAux.md MFEMVectorProjectionAux.md'
     issues = '#31153'
     requirement = 'The system shall have the ability to project scalar and vector coefficients onto appropriate MFEM auxvariables.'
@@ -22,7 +21,6 @@
                'Outputs/ParaViewDataCollection/file_base=OutputData/HeatTransferTimeAverage'
     xmldiff = 'OutputData/HeatTransferTimeAverage/Run0/Run0.pvd
                 OutputData/HeatTransferTimeAverage/Run0/Cycle000003/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     design = 'MFEMScalarTimeAverageAux.md'
     issues = '#31163'
     requirement = 'The system shall have the ability to take a running time average of an MFEM variable.'

--- a/test/tests/mfem/ics/tests
+++ b/test/tests/mfem/ics/tests
@@ -6,7 +6,6 @@
     input = scalar_ic.i
     xmldiff = 'OutputData/ScalarIC/Run0/Run0.pvd
                 OutputData/ScalarIC/Run0/Cycle000000/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to set initial conditions on a scalar variable.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -18,7 +17,6 @@
     input = vector_ic.i
     xmldiff = 'OutputData/VectorIC/Run0/Run0.pvd
                 OutputData/VectorIC/Run0/Cycle000000/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to set initial conditions on a vector MFEM variable.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -31,7 +29,6 @@
     xmldiff = 'OutputData/TransientScalarIC/Run0/Run0.pvd
                 OutputData/TransientScalarIC/Run0/Cycle000000/proc000000.vtu
                 OutputData/TransientScalarIC/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to set initial conditions on a scalar variable in transient simulations.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'

--- a/test/tests/mfem/kernels/tests
+++ b/test/tests/mfem/kernels/tests
@@ -6,7 +6,6 @@
     input = curlcurl.i
     xmldiff = 'OutputData/CurlCurl/Run0/Run0.pvd
                 OutputData/CurlCurl/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a definite Maxwell problem with Nedelec elements of the first kind using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu' # schemadiff with cuda
@@ -20,7 +19,6 @@
     input = curlcurl.i
     xmldiff = 'OutputData/CurlCurlLOR/Run0/Run0.pvd
                 OutputData/CurlCurlLOR/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     cli_args = 'FESpaces/HCurlFESpace/fec_order=THIRD '
                'FESpaces/HCurlFESpace/closed_basis=GaussLobatto '
                'FESpaces/HCurlFESpace/open_basis=IntegratedGLL '
@@ -42,7 +40,6 @@
     input = diffusion.i
     xmldiff = 'OutputData/Diffusion/Run0/Run0.pvd
                 OutputData/Diffusion/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a diffusion problem using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -57,7 +54,6 @@
               'OutputData/Diffusion/Run0/Cycle000001/proc000000.vtu'
     cli_args = 'Solver/type=MFEMCGSolver Solver/preconditioner=jacobi '
                'Executioner/assembly_level=partial'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a diffusion problem with partial assembly using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -73,7 +69,6 @@
                'Executioner/device=ceed-cpu '
                'Executioner/assembly_level=none'
     compute_devices = 'ceed-cpu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a diffusion problem with matrix-free assembly using MFEM.'
     capabilities = 'mfem'
     max_parallel = 1
@@ -84,7 +79,6 @@
     input = diffusion.i
     xmldiff = 'OutputData/DiffusionLOR/Run0/Run0.pvd '
               'OutputData/DiffusionLOR/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     cli_args = 'FESpaces/H1FESpace/fec_order=SECOND '
                'Solver/type=MFEMCGSolver Solver/preconditioner=jacobi '
                'Preconditioner/jacobi/low_order_refined=true '
@@ -101,7 +95,6 @@
     input = graddiv.i
     xmldiff = 'OutputData/GradDiv/Run0/Run0.pvd
                 OutputData/GradDiv/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a grad-div problem with Raviart-Thomas elements using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -114,7 +107,6 @@
     input = graddiv.i
     xmldiff = 'OutputData/GradDivLOR/Run0/Run0.pvd
                 OutputData/GradDivLOR/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     cli_args = 'Mesh/file=../mesh/beam-hex.mesh FESpaces/HDivFESpace/fec_order=THIRD '
                'FESpaces/HDivFESpace/closed_basis=GaussLobatto '
                'FESpaces/HDivFESpace/open_basis=IntegratedGLL '
@@ -137,7 +129,6 @@
     cli_args = 'BCs/active="bottom top_dirichlet" '
                'Executioner/dt=0.25 Executioner/end_time=1.0 '
                'Outputs/ParaViewDataCollection/file_base=OutputData/HeatConduction'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a transient heat conduction problem using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -156,7 +147,6 @@
                'Outputs/ParaViewDataCollection/file_base=OutputData/HeatConduction '
                'Solver/type=MFEMCGSolver Solver/preconditioner=jacobi '
                'Executioner/assembly_level=element'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a transient heat conduction problem with element assembly using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -178,7 +168,6 @@
                'Executioner/assembly_level=none '
                'Executioner/device=ceed-cpu'
     compute_devices = 'ceed-cpu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a transient heat conduction problem with matrix-free assembly using MFEM.'
     capabilities = 'mfem'
     valgrind = none
@@ -192,7 +181,6 @@
     xmldiff = 'OutputData/HeatConductionLOR/Run0/Run0.pvd
                 OutputData/HeatConductionLOR/Run0/Cycle000001/proc000000.vtu
                 OutputData/HeatConductionLOR/Run0/Cycle000004/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     cli_args = 'BCs/active="bottom top_dirichlet" '
                'Executioner/dt=0.25 Executioner/end_time=1.0 '
                'FESpaces/H1FESpace/fec_order=SECOND '
@@ -211,7 +199,6 @@
     input = heattransfer.i
     xmldiff = 'OutputData/HeatTransfer/Run0/Run0.pvd
                 OutputData/HeatTransfer/Run0/Cycle000003/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a transient heat conduction problem with a heat transfer coefficient on one boundary using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -224,7 +211,6 @@
     input = linearelasticity.i
     xmldiff = 'OutputData/LinearElasticity/Run0/Run0.pvd
                 OutputData/LinearElasticity/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a linear elasticity problem using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -236,7 +222,6 @@
     input = gravity.i
     xmldiff = 'OutputData/Gravity/Run0/Run0.pvd
                 OutputData/Gravity/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to solve a linear elasticity problem for a beam deformed under gravitational loads using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu' # schemadiff with cuda

--- a/test/tests/mfem/submeshes/tests
+++ b/test/tests/mfem/submeshes/tests
@@ -6,7 +6,6 @@
     input = domain_submesh.i
     xmldiff = 'OutputData/DomainPotential/Run0/Run0.pvd
                 OutputData/DomainPotential/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'MOOSE shall have the ability to solve a diffusion problem defined on an MFEM domain restricted submesh.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -18,7 +17,6 @@
     input = boundary_submesh.i
     xmldiff = 'OutputData/BoundaryPotential/Run0/Run0.pvd
                 OutputData/BoundaryPotential/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'MOOSE shall have the ability to solve an FE problem defined on an MFEM boundary restricted submesh.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -30,7 +28,6 @@
     input = domain_submesh_transfer.i
     xmldiff = 'OutputData/DomainPotentialTransfer/Run0/Run0.pvd
                 OutputData/DomainPotentialTransfer/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'MOOSE shall have the ability to transfer a domain restricted submesh variable data to a corresponding variable defined on the parent mesh.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -42,7 +39,6 @@
     input = magnetostatic.i
     xmldiff = 'OutputData/Magnetostatic/Run0/Run0.pvd
                 OutputData/Magnetostatic/Run0/Cycle000001/proc000000.vtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'MOOSE shall have the ability to support source terms arising from the elimination of coupled MFEM variables external to the equation system.'
     capabilities = 'mfem'
     max_parallel = 1

--- a/test/tests/mfem/variables/tests
+++ b/test/tests/mfem/variables/tests
@@ -6,7 +6,6 @@
     input = mfem_variables_from_moose.i
     xmldiff = 'OutputData/VariableSetupTest/Run0/Cycle000000/data.pvtu
                 OutputData/VariableSetupTest/Run0/Cycle000001/data.pvtu'
-    ignored_items = "root['VTKFile']['@version']"
     requirement = 'The system shall have the ability to add an MFEM variable from a user specification of a MOOSE variable, inferring the finite element space.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'


### PR DESCRIPTION
## Reason
Better test harness performance.

## Design
Removed unused options and now avoiding grepping when we know the match a priori.

## Impact
(Slightly) faster tests. SchemaDiff for `tests/mfem` is ~17% faster on my machine.