### PR TITLE
Only print trace and abort from a single thread

### DIFF
--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -87,12 +87,7 @@ operator<<(std::ostream & os, const std::tuple<T...> & tup)
   do                                                                                               \
   {                                                                                                \
     if (err != MPI_SUCCESS)                                                                        \
-    {                                                                                              \
-      if (libMesh::global_n_processors() == 1)                                                     \
-        libMesh::print_trace();                                                                    \
-      libmesh_here();                                                                              \
-      MOOSE_ABORT;                                                                                 \
-    }                                                                                              \
+      moose::internal::mooseErrorRaw("");                                                          \
   } while (0)
 
 #define mooseException(...)                                                                        \
@@ -118,12 +113,7 @@ operator<<(std::ostream & os, const std::tuple<T...> & tup)
       else                                                                                         \
       {                                                                                            \
         Moose::err << _assert_oss_.str() << std::flush;                                            \
-        if (libMesh::global_n_processors() == 1)                                                   \
-          libMesh::print_trace();                                                                  \
-        else                                                                                       \
-          libMesh::write_traceout();                                                               \
-        libmesh_here();                                                                            \
-        MOOSE_ABORT;                                                                               \
+        moose::internal::mooseErrorRaw("");                                                        \
       }                                                                                            \
     }                                                                                              \
   } while (0)

--- a/framework/src/base/MooseError.C
+++ b/framework/src/base/MooseError.C
@@ -65,7 +65,7 @@ mooseErrorRaw(std::string msg,
     // exit
     for (;;)
       // Don't burn cpu
-      sched_yield();
+      pause();
   else
   {
     std::ostringstream oss;


### PR DESCRIPTION
`print_trace` relies on static command line information and this is destroyed by exit handlers triggered by `MPI_Abort`

This is part of the continuing saga to address failures like those on libmesh/libmesh#4236 and libmesh/libmesh#4237