### PR TITLE
Dont rely on masterMesh pointer to decide whether to modify the mesh for contact

### DIFF
--- a/modules/contact/src/actions/ContactAction.C
+++ b/modules/contact/src/actions/ContactAction.C
@@ -718,7 +718,7 @@ ContactAction::addMortarContact()
     // Don't do mesh generators when recovering or when the user has requested for us not to
     // (presumably because the lower-dimensional blocks are already in the mesh due to manual
     // addition or because we are restarting)
-    if (!(_app.isRecovering() && _app.isUltimateMaster()) && !_app.masterMesh() &&
+    if (!(_app.isRecovering() && _app.isUltimateMaster()) && !_app.useMasterMesh() &&
         _generate_mortar_mesh)
     {
       const MeshGeneratorName primary_name = primary_subdomain_name + "_generator";

--- a/modules/heat_transfer/src/actions/MortarGapHeatTransferAction.C
+++ b/modules/heat_transfer/src/actions/MortarGapHeatTransferAction.C
@@ -157,7 +157,7 @@ MortarGapHeatTransferAction::act()
 void
 MortarGapHeatTransferAction::coreMortarMesh()
 {
-  if (!(_app.isRecovering() && _app.isUltimateMaster()) && !_app.masterMesh())
+  if (!(_app.isRecovering() && _app.isUltimateMaster()) && !_app.useMasterMesh())
   {
     std::string action_name = MooseUtils::shortName(name());
 


### PR DESCRIPTION
This is no longer viable as for partitioning of the sampledOutput, the meshMesh() pointer is always set now