### PR TITLE
Use CRTP in nodal loops

### DIFF
--- a/framework/include/base/MaxVarNDofsPerNode.h
+++ b/framework/include/base/MaxVarNDofsPerNode.h
@@ -15,7 +15,11 @@
 
 class SolverSystem;
 
-class MaxVarNDofsPerNode : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
+/**
+ * Computes the maximum number of DoFs on any node for all variables
+ */
+class MaxVarNDofsPerNode final
+  : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator, MaxVarNDofsPerNode>
 {
 public:
   MaxVarNDofsPerNode(FEProblemBase & feproblem, SolverSystem & sys);
@@ -25,7 +29,7 @@ public:
 
   virtual ~MaxVarNDofsPerNode();
 
-  virtual void onNode(ConstNodeRange::const_iterator & node_it) override;
+  virtual void onNode(ConstNodeRange::const_iterator & node_it);
 
   void join(const MaxVarNDofsPerNode &);
 

--- a/framework/include/loops/AllNodesSendListThread.h
+++ b/framework/include/loops/AllNodesSendListThread.h
@@ -20,8 +20,8 @@ template <typename T>
 class NumericVector;
 }
 
-class AllNodesSendListThread
-  : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
+class AllNodesSendListThread final
+  : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator, AllNodesSendListThread>
 {
 public:
   AllNodesSendListThread(FEProblemBase & fe_problem,
@@ -31,7 +31,7 @@ public:
 
   AllNodesSendListThread(AllNodesSendListThread & x, Threads::split split);
 
-  virtual void onNode(ConstNodeRange::const_iterator & nd) override;
+  void onNode(ConstNodeRange::const_iterator & nd);
 
   void join(const AllNodesSendListThread & y);
 

--- a/framework/include/loops/BoundaryNodeIntegrityCheckThread.h
+++ b/framework/include/loops/BoundaryNodeIntegrityCheckThread.h
@@ -21,8 +21,10 @@ class MooseObjectTagWarehouse;
 template <typename>
 class ExecuteMooseObjectWarehouse;
 
-class BoundaryNodeIntegrityCheckThread
-  : public ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>
+class BoundaryNodeIntegrityCheckThread final
+  : public ThreadedNodeLoop<ConstBndNodeRange,
+                            ConstBndNodeRange::const_iterator,
+                            BoundaryNodeIntegrityCheckThread>
 {
 public:
   BoundaryNodeIntegrityCheckThread(FEProblemBase & fe_problem, const TheWarehouse::Query & query);
@@ -30,7 +32,7 @@ public:
   // Splitting Constructor
   BoundaryNodeIntegrityCheckThread(BoundaryNodeIntegrityCheckThread & x, Threads::split split);
 
-  virtual void onNode(ConstBndNodeRange::const_iterator & node_it) override;
+  void onNode(ConstBndNodeRange::const_iterator & node_it);
 
   void join(const BoundaryNodeIntegrityCheckThread & /*y*/);
 

--- a/framework/include/loops/ComputeBoundaryInitialConditionThread.h
+++ b/framework/include/loops/ComputeBoundaryInitialConditionThread.h
@@ -17,8 +17,10 @@
 // Forward declarations
 class FEProblemBase;
 
-class ComputeBoundaryInitialConditionThread
-  : public ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>
+class ComputeBoundaryInitialConditionThread final
+  : public ThreadedNodeLoop<ConstBndNodeRange,
+                            ConstBndNodeRange::const_iterator,
+                            ComputeBoundaryInitialConditionThread>
 {
 public:
   // Set IC on all variables

--- a/framework/include/loops/ComputeMortarNodalAuxBndThread.h
+++ b/framework/include/loops/ComputeMortarNodalAuxBndThread.h
@@ -20,8 +20,10 @@ class AuxiliarySystem;
  * This class evaluates a single mortar nodal aux kernel
  */
 template <typename AuxKernelType>
-class ComputeMortarNodalAuxBndThread
-  : public ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>
+class ComputeMortarNodalAuxBndThread final
+  : public ThreadedNodeLoop<ConstBndNodeRange,
+                            ConstBndNodeRange::const_iterator,
+                            ComputeMortarNodalAuxBndThread<AuxKernelType>>
 {
 public:
   ComputeMortarNodalAuxBndThread(FEProblemBase & fe_problem,
@@ -31,7 +33,7 @@ public:
   // Splitting Constructor
   ComputeMortarNodalAuxBndThread(ComputeMortarNodalAuxBndThread & x, Threads::split split);
 
-  void onNode(ConstBndNodeRange::const_iterator & node_it) override;
+  void onNode(ConstBndNodeRange::const_iterator & node_it);
   void join(const ComputeMortarNodalAuxBndThread & /*y*/);
 
 protected:

--- a/framework/include/loops/ComputeNodalAuxBcsThread.h
+++ b/framework/include/loops/ComputeNodalAuxBcsThread.h
@@ -18,8 +18,10 @@ template <typename T>
 class MooseObjectWarehouse;
 
 template <typename AuxKernelType>
-class ComputeNodalAuxBcsThread
-  : public ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>
+class ComputeNodalAuxBcsThread final
+  : public ThreadedNodeLoop<ConstBndNodeRange,
+                            ConstBndNodeRange::const_iterator,
+                            ComputeNodalAuxBcsThread<AuxKernelType>>
 {
 public:
   ComputeNodalAuxBcsThread(FEProblemBase & fe_problem,
@@ -28,14 +30,14 @@ public:
   // Splitting Constructor
   ComputeNodalAuxBcsThread(ComputeNodalAuxBcsThread & x, Threads::split split);
 
-  virtual void onNode(ConstBndNodeRange::const_iterator & node_it) override;
+  void onNode(ConstBndNodeRange::const_iterator & node_it);
 
   void join(const ComputeNodalAuxBcsThread & /*y*/);
 
-protected:
   /// Print information about the loop, mostly order of execution of objects
-  void printGeneralExecutionInformation() const override;
+  void printGeneralExecutionInformation() const;
 
+protected:
   AuxiliarySystem & _aux_sys;
 
   /// Storage object containing active AuxKernel objects

--- a/framework/include/loops/ComputeNodalAuxVarsThread.h
+++ b/framework/include/loops/ComputeNodalAuxVarsThread.h
@@ -21,8 +21,10 @@ template <typename T>
 class MooseObjectWarehouse;
 
 template <typename AuxKernelType>
-class ComputeNodalAuxVarsThread
-  : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
+class ComputeNodalAuxVarsThread final
+  : public ThreadedNodeLoop<ConstNodeRange,
+                            ConstNodeRange::const_iterator,
+                            ComputeNodalAuxVarsThread<AuxKernelType>>
 {
 public:
   ComputeNodalAuxVarsThread(FEProblemBase & fe_problem,
@@ -31,18 +33,18 @@ public:
   // Splitting Constructor
   ComputeNodalAuxVarsThread(ComputeNodalAuxVarsThread & x, Threads::split split);
 
-  void onNode(ConstNodeRange::const_iterator & nd) override;
+  void onNode(ConstNodeRange::const_iterator & nd);
 
   void join(const ComputeNodalAuxVarsThread & /*y*/);
 
   void subdomainChanged();
 
-  void post() override;
+  void post();
+
+  /// Print information about the loop, mostly order of execution of objects
+  void printGeneralExecutionInformation() const;
 
 protected:
-  /// Print information about the loop, mostly order of execution of objects
-  void printGeneralExecutionInformation() const override;
-
   AuxiliarySystem & _aux_sys;
 
   /// Storage object containing active AuxKernel objects

--- a/framework/include/loops/ComputeNodalDampingThread.h
+++ b/framework/include/loops/ComputeNodalDampingThread.h
@@ -20,8 +20,9 @@ class MooseObjectWarehouse;
 class NodalDamper;
 class NonlinearSystemBase;
 
-class ComputeNodalDampingThread
-  : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
+class ComputeNodalDampingThread final : public ThreadedNodeLoop<ConstNodeRange,
+                                                                ConstNodeRange::const_iterator,
+                                                                ComputeNodalDampingThread>
 {
 public:
   ComputeNodalDampingThread(FEProblemBase & feproblem, NonlinearSystemBase & nl);
@@ -31,16 +32,16 @@ public:
 
   virtual ~ComputeNodalDampingThread();
 
-  virtual void onNode(ConstNodeRange::const_iterator & node_it) override;
+  void onNode(ConstNodeRange::const_iterator & node_it);
 
   void join(const ComputeNodalDampingThread & y);
 
   Real damping();
 
-protected:
   /// Print information about the loop, mostly order of execution of objects
-  void printGeneralExecutionInformation() const override;
+  void printGeneralExecutionInformation() const;
 
+protected:
   Real _damping;
   NonlinearSystemBase & _nl;
   const MooseObjectWarehouse<NodalDamper> & _nodal_dampers;

--- a/framework/include/loops/ComputeNodalKernelBCJacobiansThread.h
+++ b/framework/include/loops/ComputeNodalKernelBCJacobiansThread.h
@@ -17,8 +17,10 @@ class NonlinearSystemBase;
 class AuxiliarySystem;
 class NodalKernelBase;
 
-class ComputeNodalKernelBCJacobiansThread
-  : public ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>
+class ComputeNodalKernelBCJacobiansThread final
+  : public ThreadedNodeLoop<ConstBndNodeRange,
+                            ConstBndNodeRange::const_iterator,
+                            ComputeNodalKernelBCJacobiansThread>
 {
 public:
   ComputeNodalKernelBCJacobiansThread(FEProblemBase & fe_problem,
@@ -30,16 +32,16 @@ public:
   ComputeNodalKernelBCJacobiansThread(ComputeNodalKernelBCJacobiansThread & x,
                                       Threads::split split);
 
-  virtual void pre() override;
+  void pre();
 
-  virtual void onNode(ConstBndNodeRange::const_iterator & node_it) override;
+  void onNode(ConstBndNodeRange::const_iterator & node_it);
 
   void join(const ComputeNodalKernelBCJacobiansThread & /*y*/);
 
-protected:
   /// Print information about the loop, mostly order of execution of objects
-  void printGeneralExecutionInformation() const override;
+  void printGeneralExecutionInformation() const;
 
+protected:
   FEProblemBase & _fe_problem;
   NonlinearSystemBase & _nl;
   AuxiliarySystem & _aux_sys;

--- a/framework/include/loops/ComputeNodalKernelBcsThread.h
+++ b/framework/include/loops/ComputeNodalKernelBcsThread.h
@@ -16,8 +16,9 @@
 class AuxiliarySystem;
 class NodalKernelBase;
 
-class ComputeNodalKernelBcsThread
-  : public ThreadedNodeLoop<ConstBndNodeRange, ConstBndNodeRange::const_iterator>
+class ComputeNodalKernelBcsThread final : public ThreadedNodeLoop<ConstBndNodeRange,
+                                                                  ConstBndNodeRange::const_iterator,
+                                                                  ComputeNodalKernelBcsThread>
 {
 public:
   ComputeNodalKernelBcsThread(FEProblemBase & fe_problem,
@@ -26,16 +27,16 @@ public:
   // Splitting Constructor
   ComputeNodalKernelBcsThread(ComputeNodalKernelBcsThread & x, Threads::split split);
 
-  virtual void pre() override;
+  void pre();
 
-  virtual void onNode(ConstBndNodeRange::const_iterator & node_it) override;
+  void onNode(ConstBndNodeRange::const_iterator & node_it);
 
   void join(const ComputeNodalKernelBcsThread & /*y*/);
 
-protected:
   /// Print information about the loop, mostly order of execution of objects
-  void printGeneralExecutionInformation() const override;
+  void printGeneralExecutionInformation() const;
 
+protected:
   FEProblemBase & _fe_problem;
 
   AuxiliarySystem & _aux_sys;

--- a/framework/include/loops/ComputeNodalKernelJacobiansThread.h
+++ b/framework/include/loops/ComputeNodalKernelJacobiansThread.h
@@ -27,8 +27,10 @@ template <typename T>
 class SparseMatrix;
 }
 
-class ComputeNodalKernelJacobiansThread
-  : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
+class ComputeNodalKernelJacobiansThread final
+  : public ThreadedNodeLoop<ConstNodeRange,
+                            ConstNodeRange::const_iterator,
+                            ComputeNodalKernelJacobiansThread>
 {
 public:
   ComputeNodalKernelJacobiansThread(FEProblemBase & fe_problem,
@@ -39,16 +41,16 @@ public:
   // Splitting Constructor
   ComputeNodalKernelJacobiansThread(ComputeNodalKernelJacobiansThread & x, Threads::split split);
 
-  virtual void pre() override;
+  void pre();
 
-  virtual void onNode(ConstNodeRange::const_iterator & node_it) override;
+  void onNode(ConstNodeRange::const_iterator & node_it);
 
   void join(const ComputeNodalKernelJacobiansThread & /*y*/);
 
-protected:
   /// Print information about the loop, mostly order of execution of objects
-  void printGeneralExecutionInformation() const override;
+  void printGeneralExecutionInformation() const;
 
+protected:
   FEProblemBase & _fe_problem;
   NonlinearSystemBase & _nl;
   AuxiliarySystem & _aux_sys;

--- a/framework/include/loops/ComputeNodalKernelsThread.h
+++ b/framework/include/loops/ComputeNodalKernelsThread.h
@@ -19,8 +19,9 @@ class FEProblemBase;
 class AuxiliarySystem;
 class NodalKernelBase;
 
-class ComputeNodalKernelsThread
-  : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
+class ComputeNodalKernelsThread final : public ThreadedNodeLoop<ConstNodeRange,
+                                                                ConstNodeRange::const_iterator,
+                                                                ComputeNodalKernelsThread>
 {
 public:
   ComputeNodalKernelsThread(FEProblemBase & fe_problem,
@@ -30,16 +31,16 @@ public:
   // Splitting Constructor
   ComputeNodalKernelsThread(ComputeNodalKernelsThread & x, Threads::split split);
 
-  virtual void pre() override;
+  void pre();
 
-  virtual void onNode(ConstNodeRange::const_iterator & node_it) override;
+  void onNode(ConstNodeRange::const_iterator & node_it);
 
   void join(const ComputeNodalKernelsThread & /*y*/);
 
-protected:
   /// Print execution order of object types in the loop
-  void printGeneralExecutionInformation() const override;
+  void printGeneralExecutionInformation() const;
 
+protected:
   FEProblemBase & _fe_problem;
 
   AuxiliarySystem & _aux_sys;

--- a/framework/include/loops/ComputeNodalUserObjectsThread.h
+++ b/framework/include/loops/ComputeNodalUserObjectsThread.h
@@ -16,8 +16,9 @@
 // Forward declarations
 class SubProblem;
 
-class ComputeNodalUserObjectsThread
-  : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
+class ComputeNodalUserObjectsThread final : public ThreadedNodeLoop<ConstNodeRange,
+                                                                    ConstNodeRange::const_iterator,
+                                                                    ComputeNodalUserObjectsThread>
 {
 public:
   ComputeNodalUserObjectsThread(FEProblemBase & fe_problem, const TheWarehouse::Query & query);
@@ -28,12 +29,12 @@ public:
 
   void subdomainChanged();
 
-  virtual void onNode(ConstNodeRange::const_iterator & node_it) override;
+  void onNode(ConstNodeRange::const_iterator & node_it);
 
   void join(const ComputeNodalUserObjectsThread & /*y*/);
 
   /// Print information about the loop, mostly order of execution of objects
-  void printGeneralExecutionInformation() const override;
+  void printGeneralExecutionInformation() const;
 
 private:
   const TheWarehouse::Query _query;

--- a/framework/include/loops/ResetDisplacedMeshThread.h
+++ b/framework/include/loops/ResetDisplacedMeshThread.h
@@ -20,7 +20,8 @@ class DisplacedProblem;
 class FEProblemBase;
 class MooseMesh;
 
-class ResetDisplacedMeshThread : public ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>
+class ResetDisplacedMeshThread final
+  : public ThreadedNodeLoop<NodeRange, NodeRange::const_iterator, ResetDisplacedMeshThread>
 {
 public:
   ResetDisplacedMeshThread(FEProblemBase & fe_problem, DisplacedProblem & displaced_problem);

--- a/framework/include/problems/DisplacedProblem.h
+++ b/framework/include/problems/DisplacedProblem.h
@@ -407,14 +407,15 @@ protected:
 
   GeometricSearchData _geometric_search_data;
 
-  class UpdateDisplacedMeshThread : public ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>
+  class UpdateDisplacedMeshThread final
+    : public ThreadedNodeLoop<NodeRange, NodeRange::const_iterator, UpdateDisplacedMeshThread>
   {
   public:
     UpdateDisplacedMeshThread(FEProblemBase & fe_problem, DisplacedProblem & displaced_problem);
 
     UpdateDisplacedMeshThread(UpdateDisplacedMeshThread & x, Threads::split split);
 
-    virtual void onNode(NodeRange::const_iterator & nd) override;
+    void onNode(NodeRange::const_iterator & nd);
 
     void join(const UpdateDisplacedMeshThread & y)
     {

--- a/framework/src/base/MaxVarNDofsPerNode.C
+++ b/framework/src/base/MaxVarNDofsPerNode.C
@@ -16,7 +16,7 @@
 #include "libmesh/threads.h"
 
 MaxVarNDofsPerNode::MaxVarNDofsPerNode(FEProblemBase & feproblem, SolverSystem & sys)
-  : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>(feproblem),
+  : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator, MaxVarNDofsPerNode>(feproblem),
     _system(sys),
     _max(0),
     _dof_map(_system.dofMap())
@@ -25,7 +25,7 @@ MaxVarNDofsPerNode::MaxVarNDofsPerNode(FEProblemBase & feproblem, SolverSystem &
 
 // Splitting Constructor
 MaxVarNDofsPerNode::MaxVarNDofsPerNode(MaxVarNDofsPerNode & x, Threads::split split)
-  : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>(x, split),
+  : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator, MaxVarNDofsPerNode>(x, split),
     _system(x._system),
     _max(0),
     _dof_map(x._dof_map)

--- a/framework/src/loops/AllNodesSendListThread.C
+++ b/framework/src/loops/AllNodesSendListThread.C
@@ -16,7 +16,8 @@ AllNodesSendListThread::AllNodesSendListThread(FEProblemBase & fe_problem,
                                                const MooseMesh & mesh,
                                                const std::vector<unsigned int> & var_nums,
                                                const libMesh::System & system)
-  : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>(fe_problem),
+  : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator, AllNodesSendListThread>(
+        fe_problem),
     _ref_mesh(mesh),
     _var_nums(var_nums),
     _system(system),
@@ -36,7 +37,8 @@ AllNodesSendListThread::AllNodesSendListThread(FEProblemBase & fe_problem,
 }
 
 AllNodesSendListThread::AllNodesSendListThread(AllNodesSendListThread & x, Threads::split split)
-  : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>(x, split),
+  : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator, AllNodesSendListThread>(x,
+                                                                                             split),
     _ref_mesh(x._ref_mesh),
     _var_nums(x._var_nums),
     _system(x._system),

--- a/framework/src/loops/ResetDisplacedMeshThread.C
+++ b/framework/src/loops/ResetDisplacedMeshThread.C
@@ -15,7 +15,7 @@
 
 ResetDisplacedMeshThread::ResetDisplacedMeshThread(FEProblemBase & fe_problem,
                                                    DisplacedProblem & displaced_problem)
-  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>(fe_problem),
+  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator, ResetDisplacedMeshThread>(fe_problem),
     _displaced_problem(displaced_problem),
     _ref_mesh(_displaced_problem.refMesh())
 {
@@ -23,7 +23,7 @@ ResetDisplacedMeshThread::ResetDisplacedMeshThread(FEProblemBase & fe_problem,
 
 ResetDisplacedMeshThread::ResetDisplacedMeshThread(ResetDisplacedMeshThread & x,
                                                    Threads::split split)
-  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>(x, split),
+  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator, ResetDisplacedMeshThread>(x, split),
     _displaced_problem(x._displaced_problem),
     _ref_mesh(x._ref_mesh)
 {

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -1417,7 +1417,7 @@ DisplacedProblem::checkNonlocalCouplingRequirement() const
 
 DisplacedProblem::UpdateDisplacedMeshThread::UpdateDisplacedMeshThread(
     FEProblemBase & fe_problem, DisplacedProblem & displaced_problem)
-  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>(fe_problem),
+  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator, UpdateDisplacedMeshThread>(fe_problem),
     _displaced_problem(displaced_problem),
     _ref_mesh(_displaced_problem.refMesh()),
     _nl_soln(_displaced_problem._nl_solution),
@@ -1429,7 +1429,7 @@ DisplacedProblem::UpdateDisplacedMeshThread::UpdateDisplacedMeshThread(
 
 DisplacedProblem::UpdateDisplacedMeshThread::UpdateDisplacedMeshThread(
     UpdateDisplacedMeshThread & x, Threads::split split)
-  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator>(x, split),
+  : ThreadedNodeLoop<NodeRange, NodeRange::const_iterator, UpdateDisplacedMeshThread>(x, split),
     _displaced_problem(x._displaced_problem),
     _ref_mesh(x._ref_mesh),
     _nl_soln(x._nl_soln),

--- a/framework/src/vectorpostprocessors/WorkBalance.C
+++ b/framework/src/vectorpostprocessors/WorkBalance.C
@@ -239,11 +239,12 @@ private:
   }
 };
 
-class WBNodeLoop : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
+class WBNodeLoop final
+  : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator, WBNodeLoop>
 {
 public:
   WBNodeLoop(FEProblemBase & fe_problem, int system)
-    : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>(fe_problem),
+    : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator, WBNodeLoop>(fe_problem),
       _system(system),
       _local_num_nodes(0),
       _local_num_dofs(0)
@@ -251,14 +252,14 @@ public:
   }
 
   WBNodeLoop(WBNodeLoop & x, Threads::split split)
-    : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>(x, split),
+    : ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator, WBNodeLoop>(x, split),
       _system(x._system),
       _local_num_nodes(0),
       _local_num_dofs(0)
   {
   }
 
-  virtual void onNode(ConstNodeRange::const_iterator & node_it)
+  void onNode(ConstNodeRange::const_iterator & node_it)
   {
     auto & node = *(*node_it);
 


### PR DESCRIPTION
refs #31420 

The comparisons I did, running an input 10 times

Base input test/tests/nodalkernels/constant_rate/constant_rate.i -r 4
```
Without change
Average runtime: 32.410 seconds

With change
Average runtime: 32.049 seconds
```

1000x1000 only nodal variables, added std deviation output
```
without
Average runtime: 58.843401 seconds
Standard deviation: .453407 seconds

with change
Average runtime: 57.653081 seconds
Standard deviation: 2.232744 seconds
```

Nodal only 100x100 (running 20 times)
```
Without
Average runtime: 4.637448 seconds
Standard deviation: .214261 seconds

With
Average runtime: 4.602328 seconds
Standard deviation: .159781 seconds
```

Nodal only 700x700 100 runs
```
Nodal only 700x700 100 runs
without
Average runtime: 26.825499 seconds
Standard deviation: .561516 seconds

with
Average runtime: 26.678414 seconds
Standard deviation: .709921 seconds
```

so overall, about 1-2% faster at most
This input has only 1 nodal loop.

I did nodal loops instead of elemental loops because it was faster (less loops) and easier (less inheritance). I can do elemental loops next if this is accepted. 

It's actually hard to get out of the uncertainty. ~~Maybe running 100s of runs might do it~~
The variation from run to run is larger than the improvement. But averaging we still see it
