### PR TITLE
Fix newly introduced bug in MFEM auxkernels

### DIFF
--- a/framework/src/mfem/auxkernels/MFEMAuxKernel.C
+++ b/framework/src/mfem/auxkernels/MFEMAuxKernel.C
@@ -29,7 +29,6 @@ MFEMAuxKernel::MFEMAuxKernel(const InputParameters & parameters)
     _result_var_name(getParam<AuxVariableName>("variable")),
     _result_var(*getMFEMProblem().getProblemData().gridfunctions.Get(_result_var_name))
 {
-  _result_var = 0.0;
 }
 
 #endif

--- a/framework/src/mfem/auxkernels/MFEMCurlAux.C
+++ b/framework/src/mfem/auxkernels/MFEMCurlAux.C
@@ -42,7 +42,7 @@ MFEMCurlAux::MFEMCurlAux(const InputParameters & parameters)
 void
 MFEMCurlAux::execute()
 {
-  _curl.AddMult(_source_var, _result_var, _scale_factor);
+  _curl.AddMult(_source_var, _result_var = 0, _scale_factor);
 }
 
 #endif

--- a/framework/src/mfem/auxkernels/MFEMDivAux.C
+++ b/framework/src/mfem/auxkernels/MFEMDivAux.C
@@ -42,7 +42,7 @@ MFEMDivAux::MFEMDivAux(const InputParameters & parameters)
 void
 MFEMDivAux::execute()
 {
-  _div.AddMult(_source_var, _result_var, _scale_factor);
+  _div.AddMult(_source_var, _result_var = 0, _scale_factor);
 }
 
 #endif

--- a/framework/src/mfem/auxkernels/MFEMGradAux.C
+++ b/framework/src/mfem/auxkernels/MFEMGradAux.C
@@ -42,7 +42,7 @@ MFEMGradAux::MFEMGradAux(const InputParameters & parameters)
 void
 MFEMGradAux::execute()
 {
-  _grad.AddMult(_source_var, _result_var, _scale_factor);
+  _grad.AddMult(_source_var, _result_var = 0, _scale_factor);
 }
 
 #endif


### PR DESCRIPTION
## Reason
Fix bug introduced by yours truly in #31164. Reported by @alexanderianblair.

## Design
Zero out the result gridfunction as we used to.

## Impact
Restore the intended behaviour, which is that of a scaled multiplication (without accumulation).
