### PR TITLE
Fix time step info for MFEM transient problems

### DIFF
--- a/framework/doc/content/source/mfem/functormaterials/MFEMFunctorMaterial.md
+++ b/framework/doc/content/source/mfem/functormaterials/MFEMFunctorMaterial.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-!syntax description /FunctorMaterials/MFEMFunctorMaterial
+Base class for declaration of material properties to add to MFEM problems.
 
 ## Overview
 
@@ -15,16 +15,6 @@ subdomains in the mesh.
 `MFEMFunctorMaterial` is intended to allow the specification of `mfem::Coefficient`,
 `mfem::VectorCoefficient`, and `mfem::MatrixCoefficient` objects to add to the MFEM problem in a
 manner consistent with the standard MOOSE Materials system.
-
-## Example Input File Syntax
-
-!listing test/tests/mfem/kernels/gravity.i block=/FunctorMaterials
-
-!syntax parameters /FunctorMaterials/MFEMFunctorMaterial
-
-!syntax inputs /FunctorMaterials/MFEMFunctorMaterial
-
-!syntax children /FunctorMaterials/MFEMFunctorMaterial
 
 !if-end!
 

--- a/framework/doc/content/source/mfem/functormaterials/MFEMGenericFunctorMaterial.md
+++ b/framework/doc/content/source/mfem/functormaterials/MFEMGenericFunctorMaterial.md
@@ -13,6 +13,10 @@ one or more subdomains of the mesh, given by the [!param](/FunctorMaterials/MFEM
 entire mesh if missing. The scalar material properties are named according to members in the
 [!param](/FunctorMaterials/MFEMGenericFunctorMaterial/prop_names) parameter, with respective coefficients used to get property values given by the members of [!param](/FunctorMaterials/MFEMGenericFunctorMaterial/prop_values).
 
+## Example Input File Syntax
+
+!listing test/tests/mfem/kernels/gravity.i block=/FunctorMaterials remove=RigidiumWeightDensity BendiumWeightDensity
+
 !syntax parameters /FunctorMaterials/MFEMGenericFunctorMaterial
 
 !syntax inputs /FunctorMaterials/MFEMGenericFunctorMaterial

--- a/framework/doc/content/source/mfem/functormaterials/MFEMGenericFunctorVectorMaterial.md
+++ b/framework/doc/content/source/mfem/functormaterials/MFEMGenericFunctorVectorMaterial.md
@@ -20,6 +20,10 @@ must be vector-valued. Numeric constant vector values can also be
 specified, but must be enclosed in curly braces to mark the start and
 end of the vector, e.g. `{1. 0. 0.}`.
 
+## Example Input File Syntax
+
+!listing test/tests/mfem/kernels/gravity.i block=/FunctorMaterials remove=Rigidium Bendium
+
 !syntax parameters /FunctorMaterials/MFEMGenericFunctorVectorMaterial
 
 !syntax inputs /FunctorMaterials/MFEMGenericFunctorVectorMaterial

--- a/framework/src/mfem/actions/AddMFEMSubMeshAction.C
+++ b/framework/src/mfem/actions/AddMFEMSubMeshAction.C
@@ -17,7 +17,7 @@ InputParameters
 AddMFEMSubMeshAction::validParams()
 {
   InputParameters params = MooseObjectAction::validParams();
-  params.addClassDescription("Add a MFEM SubMesh object to the simulation.");
+  params.addClassDescription("Add an MFEM SubMesh object to the simulation.");
   return params;
 }
 

--- a/framework/src/mfem/executioners/MFEMTransient.C
+++ b/framework/src/mfem/executioners/MFEMTransient.C
@@ -70,7 +70,14 @@ MFEMTransient::takeStep(Real input_dt)
     _dt = input_dt;
 
   _time_stepper->preSolve();
+
+  // Unfortunately, time needs to be temporarily incremented so we get
+  // meaningful console output in timestepSetup(). We decrement it back
+  // immediately after so step() below behaves as expected.
+  _time += _dt;
   _problem.timestepSetup();
+  _time -= _dt;
+
   _problem.onTimestepBegin();
 
   // Advance time step of the MFEM problem. Time is also updated here, and

--- a/framework/src/mfem/functormaterials/MFEMFunctorMaterial.C
+++ b/framework/src/mfem/functormaterials/MFEMFunctorMaterial.C
@@ -12,8 +12,6 @@
 #include "MFEMFunctorMaterial.h"
 #include "MFEMProblem.h"
 
-registerMooseObject("MooseApp", MFEMFunctorMaterial);
-
 InputParameters
 MFEMFunctorMaterial::validParams()
 {


### PR DESCRIPTION
## Reason
Time step information in the console output is currently lagging by one time step.

## Design
Awful.
Set the time step manually in the derived-problem class before calling timestepSetup which sets the Console output step
Undo the setting after

## Impact
Avoid potential confusion due to disparity between the user's requested simulation time and the output they get.
