### PR TITLE
Add ReactionForceAux

### DIFF
--- a/framework/include/auxkernels/TagAuxBase.h
+++ b/framework/include/auxkernels/TagAuxBase.h
@@ -50,10 +50,12 @@ TagAuxBase<T>::validParams()
                                "The coupled variable whose components are coupled to AuxVariable");
   params.set<ExecFlagEnum>("execute_on", true) = {EXEC_TIMESTEP_END};
   params.suppressParameter<ExecFlagEnum>("execute_on");
-  params.addParam<bool>("scaled",
-                        true,
-                        "Return value depending on the variable scaling/autoscaling. Set this to "
-                        "false to obtain unscaled physical reaction forces.");
+  params.addDeprecatedParam<bool>(
+      "scaled",
+      true,
+      "Return value depending on the variable scaling/autoscaling. Set this to "
+      "false to obtain unscaled physical reaction forces.",
+      "This parameter has been deprecated.");
   return params;
 }
 

--- a/framework/include/auxkernels/TagVectorAux.h
+++ b/framework/include/auxkernels/TagVectorAux.h
@@ -26,7 +26,7 @@ protected:
   virtual Real computeValue() override;
 
   /// Whether to remove variable scaling from the returned value
-  const bool _unscaled;
+  const bool _remove_variable_scaling;
   const VariableValue & _v;
   const MooseVariableBase & _v_var;
 };

--- a/framework/include/auxkernels/TagVectorAux.h
+++ b/framework/include/auxkernels/TagVectorAux.h
@@ -25,6 +25,7 @@ public:
 protected:
   virtual Real computeValue() override;
 
+  /// Whether to remove variable scaling from the returned value
   const bool _unscaled;
   const VariableValue & _v;
   const MooseVariableBase & _v_var;

--- a/framework/src/auxkernels/TagVectorAux.C
+++ b/framework/src/auxkernels/TagVectorAux.C
@@ -15,9 +15,14 @@ InputParameters
 TagVectorAux::validParams()
 {
   InputParameters params = TagAuxBase<AuxKernel>::validParams();
-  params.addClassDescription("Couple a tagged vector, and return its DOF value");
-  params.addRequiredParam<TagName>("vector_tag", "Name of the vector tag");
-  params.addParam<bool>("remove_variable_scaling", false, "Remove variable scaling from DOF value");
+  params.addClassDescription("Extract DOF values from a tagged vector into an AuxVariable");
+  params.addRequiredParam<TagName>("vector_tag", "Name of the vector tag to extract values from");
+  params.addParam<bool>(
+      "remove_variable_scaling",
+      false,
+      "Whether to remove variable scaling from DOF value. If false, values are directly extracted "
+      "from the tag vector, and potentially with scaling applied. If true, any scaling of "
+      "variables is undone in the reported values.");
   return params;
 }
 
@@ -31,8 +36,13 @@ TagVectorAux::TagVectorAux(const InputParameters & parameters)
   checkCoupledVariable(&_v_var, &_var);
 
   if (isParamSetByUser("scaled"))
+  {
     mooseDeprecated("The 'scaled' parameter has been deprecated. Please use the "
                     "'remove_variable_scaling' parameter instead.");
+    if (isParamSetByUser("remove_variable_scaling"))
+      paramError("You cannot set both the 'scaled' and 'remove_variable_scaling' parameters. "
+                 "Please use only the 'remove_variable_scaling' parameter.");
+  }
 }
 
 Real

--- a/framework/src/auxkernels/TagVectorAux.C
+++ b/framework/src/auxkernels/TagVectorAux.C
@@ -15,21 +15,28 @@ InputParameters
 TagVectorAux::validParams()
 {
   InputParameters params = TagAuxBase<AuxKernel>::validParams();
-  params.addRequiredParam<TagName>("vector_tag", "Tag Name this Aux works on");
-  params.addClassDescription("Couple a tag vector, and return its nodal value");
+  params.addClassDescription("Couple a tagged vector, and return its DOF value");
+  params.addRequiredParam<TagName>("vector_tag", "Name of the vector tag");
+  params.addParam<bool>("remove_variable_scaling", false, "Remove variable scaling from DOF value");
   return params;
 }
 
 TagVectorAux::TagVectorAux(const InputParameters & parameters)
   : TagAuxBase<AuxKernel>(parameters),
+    _unscaled(isParamSetByUser("scaled") ? !getParam<bool>("scaled")
+                                         : getParam<bool>("remove_variable_scaling")),
     _v(coupledVectorTagValue("v", "vector_tag")),
     _v_var(*getFieldVar("v", 0))
 {
   checkCoupledVariable(&_v_var, &_var);
+
+  if (isParamSetByUser("scaled"))
+    mooseDeprecated("The 'scaled' parameter has been deprecated. Please use the "
+                    "'remove_variable_scaling' parameter instead.");
 }
 
 Real
 TagVectorAux::computeValue()
 {
-  return _scaled ? _v[_qp] : _v[_qp] / _v_var.scalingFactor();
+  return _unscaled ? _v[_qp] / _v_var.scalingFactor() : _v[_qp];
 }

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty.i
@@ -157,13 +157,13 @@
     block = '1 2 3 4 5 6 7'
   []
   [react_x]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_x'
     variable = 'react_x'
   []
   [react_y]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_y'
     variable = 'react_y'
@@ -256,10 +256,8 @@
   solve_type = 'PJFNK'
 
   petsc_options = '-snes_ksp_ew'
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_type -pc_factor_shift_type '
-                        '-pc_factor_shift_amount -mat_mffd_err'
-  petsc_options_value = 'lu       superlu_dist                  NONZERO               1e-15          '
-                        '         1e-5'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_type -pc_factor_shift_type -pc_factor_shift_amount -mat_mffd_err'
+  petsc_options_value = 'lu       superlu_dist                  NONZERO               1e-15                   1e-5'
 
   line_search = 'none'
 

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_adaptivity.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_adaptivity.i
@@ -111,13 +111,13 @@
     contact_quantity = normal_gap
   []
   [react_x]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_x'
     variable = 'react_x'
   []
   [react_y]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_y'
     variable = 'react_y'

--- a/modules/contact/test/tests/verification/patch_tests/mindlin/cylinder_friction_node_face.i
+++ b/modules/contact/test/tests/verification/patch_tests/mindlin/cylinder_friction_node_face.i
@@ -134,13 +134,13 @@
     paired_boundary = 2
   []
   [react_x]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_x'
     variable = 'react_x'
   []
   [react_y]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_y'
     variable = 'react_y'
@@ -278,10 +278,8 @@
   solve_type = 'PJFNK'
 
   petsc_options = '-snes_ksp_ew'
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_type -pc_factor_shift_type '
-                        '-pc_factor_shift_amount -mat_mffd_err'
-  petsc_options_value = 'lu       superlu_dist                  NONZERO               1e-15          '
-                        '         1e-5'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_type -pc_factor_shift_type -pc_factor_shift_amount -mat_mffd_err'
+  petsc_options_value = 'lu       superlu_dist                  NONZERO               1e-15                   1e-5'
 
   line_search = 'none'
 

--- a/modules/solid_mechanics/doc/content/source/auxkernels/ReactionForceAux.md
+++ b/modules/solid_mechanics/doc/content/source/auxkernels/ReactionForceAux.md
@@ -1,0 +1,29 @@
+# ReactionForceAux
+
+Save the reaction force corresponding to the variable DOFs into this AuxVariable.
+
+!syntax parameters /AuxKernels/ReactionForceAux
+
+# Usage
+
+First declare a tagged vector to save the residual contribution, i.e.
+
+!listing /test/tests/plane_stress/3D_finite_tension_pull.i block=Problem
+
+Then, inform the solid mechanics Physics about the declared vector tag. The Physics will automatically accumulate the residual contribution into the tagged vector.
+
+!listing /test/tests/plane_stress/3D_finite_tension_pull.i block=Physics
+
+Next, use the ReactionForceAux to read the accumulated residual contribution into an AuxVariable, i.e.
+
+!listing /test/tests/plane_stress/3D_finite_tension_pull.i block=AuxKernels
+
+This would save the residual contribution in the $x$ direction into the AuxVariable named "react_x". Upon convergence of each time step, residual will be close to zero (up to the tolerances you set) everywhere in the domain except where strongly enforced constraints are applied. Examples of these constraints are Dirichlet boundary conditions and contact. The final, accumulated residual contribution on the constrained degrees of freedom can then be interpreted as the distributed "reaction force".
+
+Finally, the distributed reaction force can be summed up on a boundary to obtain the total reaction force. In the following example, the distributed reaction force is summed up on the "right" boundary where the displacement control is applied.
+
+!listing /test/tests/plane_stress/3D_finite_tension_pull.i block=Postprocessors/react_x
+
+# Example input files
+
+!syntax inputs /AuxKernels/ReactionForceAux

--- a/modules/solid_mechanics/doc/content/source/auxkernels/ReactionForceAux.md
+++ b/modules/solid_mechanics/doc/content/source/auxkernels/ReactionForceAux.md
@@ -10,7 +10,7 @@ First declare a tagged vector to save the residual contribution, i.e.
 
 !listing /test/tests/plane_stress/3D_finite_tension_pull.i block=Problem
 
-Then, inform the solid mechanics Physics about the declared vector tag. The Physics will automatically accumulate the residual contribution into the tagged vector.
+Then, inform the SolidMechanics Physics about the declared vector tag. The Physics will automatically accumulate the residual contribution into the tagged vector. Importantly, this should only be done for the Kernels (which are set up by the SolidMechanics Physics), and not for other objects such as boundary conditions.
 
 !listing /test/tests/plane_stress/3D_finite_tension_pull.i block=Physics
 
@@ -18,9 +18,9 @@ Next, use the ReactionForceAux to read the accumulated residual contribution int
 
 !listing /test/tests/plane_stress/3D_finite_tension_pull.i block=AuxKernels
 
-This would save the residual contribution in the $x$ direction into the AuxVariable named "react_x". Upon convergence of each time step, residual will be close to zero (up to the tolerances you set) everywhere in the domain except where strongly enforced constraints are applied. Examples of these constraints are Dirichlet boundary conditions and contact. The final, accumulated residual contribution on the constrained degrees of freedom can then be interpreted as the distributed "reaction force".
+In this example, this would save the residual contribution in the $x$ direction into the AuxVariable named "react_x". Upon convergence of each time step, the residual contribution from the kernels will be close to zero (up to the tolerances you set) everywhere in the domain except where constraints or boundary conditions are applied. Examples of these constraints are Dirichlet/Neumann boundary conditions, pressure, applied torque, and contact, etc.. The final, accumulated residual contribution on the constrained degrees of freedom can then be interpreted as the distributed "reaction force".
 
-Finally, the distributed reaction force can be summed up on a boundary to obtain the total reaction force. In the following example, the distributed reaction force is summed up on the "right" boundary where the displacement control is applied.
+Finally, if desired, the distributed reaction force can be summed up on a boundary to obtain the total reaction force. In the following example, the distributed reaction force is summed up on the "right" boundary where the displacement control is applied.
 
 !listing /test/tests/plane_stress/3D_finite_tension_pull.i block=Postprocessors/react_x
 

--- a/modules/solid_mechanics/include/auxkernels/ReactionForceAux.h
+++ b/modules/solid_mechanics/include/auxkernels/ReactionForceAux.h
@@ -12,7 +12,7 @@
 #include "TagVectorAux.h"
 
 /**
- * ReactionForceAux returns the reaction force corresponds to each DOF.
+ * ReactionForceAux returns the reaction force corresponding to each DOF.
  */
 class ReactionForceAux : public TagVectorAux
 {

--- a/modules/solid_mechanics/include/auxkernels/ReactionForceAux.h
+++ b/modules/solid_mechanics/include/auxkernels/ReactionForceAux.h
@@ -9,23 +9,15 @@
 
 #pragma once
 
-#include "AuxKernel.h"
-#include "TagAuxBase.h"
+#include "TagVectorAux.h"
 
 /**
- * TagVectorAux returns the coupled DOF value of a tagged vector.
+ * ReactionForceAux returns the reaction force corresponds to each DOF.
  */
-class TagVectorAux : public TagAuxBase<AuxKernel>
+class ReactionForceAux : public TagVectorAux
 {
 public:
   static InputParameters validParams();
 
-  TagVectorAux(const InputParameters & parameters);
-
-protected:
-  virtual Real computeValue() override;
-
-  const bool _unscaled;
-  const VariableValue & _v;
-  const MooseVariableBase & _v_var;
+  ReactionForceAux(const InputParameters & parameters);
 };

--- a/modules/solid_mechanics/src/auxkernels/ReactionForceAux.C
+++ b/modules/solid_mechanics/src/auxkernels/ReactionForceAux.C
@@ -15,8 +15,9 @@ InputParameters
 ReactionForceAux::validParams()
 {
   InputParameters params = TagVectorAux::validParams();
-  params.addClassDescription("Couple a tagged residual, and return its DOF value. The returned "
-                             "value has units consistent with the simulation setup.");
+  params.addClassDescription("Extract the value of the residual from an appropriately formed tag "
+                             "vector and save those values as reaction forces in an AuxVariable");
+
   params.set<bool>("remove_variable_scaling") = true;
   params.suppressParameter<bool>("remove_variable_scaling");
   params.suppressParameter<bool>("scaled");

--- a/modules/solid_mechanics/src/auxkernels/ReactionForceAux.C
+++ b/modules/solid_mechanics/src/auxkernels/ReactionForceAux.C
@@ -1,0 +1,32 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ReactionForceAux.h"
+
+registerMooseObject("SolidMechanicsApp", ReactionForceAux);
+
+InputParameters
+ReactionForceAux::validParams()
+{
+  InputParameters params = TagVectorAux::validParams();
+  params.addClassDescription("Couple a tagged residual, and return its DOF value. The returned "
+                             "value has units consistent with the simulation setup.");
+  params.set<bool>("remove_variable_scaling") = true;
+  params.suppressParameter<bool>("remove_variable_scaling");
+  params.suppressParameter<bool>("scaled");
+  return params;
+}
+
+ReactionForceAux::ReactionForceAux(const InputParameters & parameters) : TagVectorAux(parameters)
+{
+  const auto tag_id = _subproblem.getVectorTagID(getParam<TagName>("vector_tag"));
+  const auto tag_type = _subproblem.vectorTagType(tag_id);
+  if (tag_type != Moose::VECTOR_TAG_RESIDUAL)
+    paramError("vector_tag", "The provided tag does not correspond to a residual vector.");
+}

--- a/modules/solid_mechanics/src/auxkernels/ReactionForceAux.C
+++ b/modules/solid_mechanics/src/auxkernels/ReactionForceAux.C
@@ -24,10 +24,4 @@ ReactionForceAux::validParams()
   return params;
 }
 
-ReactionForceAux::ReactionForceAux(const InputParameters & parameters) : TagVectorAux(parameters)
-{
-  const auto tag_id = _subproblem.getVectorTagID(getParam<TagName>("vector_tag"));
-  const auto tag_type = _subproblem.vectorTagType(tag_id);
-  if (tag_type != Moose::VECTOR_TAG_RESIDUAL)
-    paramError("vector_tag", "The provided tag does not correspond to a residual vector.");
-}
+ReactionForceAux::ReactionForceAux(const InputParameters & parameters) : TagVectorAux(parameters) {}

--- a/modules/solid_mechanics/test/tests/free_expansion_abs_ref/free_expansion_abs_ref.i
+++ b/modules/solid_mechanics/test/tests/free_expansion_abs_ref/free_expansion_abs_ref.i
@@ -47,13 +47,13 @@
     use_displaced_mesh = false
   []
   [ref_x]
-    type = TagVectorAux
+    type = ReactionForceAux
     variable = 'ref_x'
     vector_tag = 'ref'
     v = 'disp_x'
   []
   [ref_y]
-    type = TagVectorAux
+    type = ReactionForceAux
     variable = 'ref_y'
     vector_tag = 'ref'
     v = 'disp_y'

--- a/modules/solid_mechanics/test/tests/generalized_plane_strain/generalized_plane_strain_ref_resid.i
+++ b/modules/solid_mechanics/test/tests/generalized_plane_strain/generalized_plane_strain_ref_resid.i
@@ -75,13 +75,13 @@
     use_displaced_mesh = false
   []
   [saved_x]
-    type = TagVectorAux
+    type = ReactionForceAux
     variable = 'saved_x'
     vector_tag = 'ref'
     v = 'disp_x'
   []
   [saved_y]
-    type = TagVectorAux
+    type = ReactionForceAux
     variable = 'saved_y'
     vector_tag = 'ref'
     v = 'disp_y'

--- a/modules/solid_mechanics/test/tests/plane_stress/3D_finite_tension_pull.i
+++ b/modules/solid_mechanics/test/tests/plane_stress/3D_finite_tension_pull.i
@@ -52,7 +52,7 @@
 
 [AuxKernels]
   [react_x]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_x'
     variable = 'react_x'

--- a/modules/solid_mechanics/test/tests/plane_stress/weak_plane_stress_finite_tension_pull.i
+++ b/modules/solid_mechanics/test/tests/plane_stress/weak_plane_stress_finite_tension_pull.i
@@ -61,7 +61,7 @@
 
 [AuxKernels]
   [react_x]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_x'
     variable = 'react_x'

--- a/modules/solid_mechanics/test/tests/torque_reaction/torque_reaction.i
+++ b/modules/solid_mechanics/test/tests/torque_reaction/torque_reaction.i
@@ -29,21 +29,21 @@
 []
 
 [AuxVariables]
-  [./saved_x]
-  [../]
-  [./saved_y]
-  [../]
+  [saved_x]
+  []
+  [saved_y]
+  []
 []
 
 [AuxKernels]
   [saved_x]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_x'
     variable = 'saved_x'
   []
   [saved_y]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_y'
     variable = 'saved_y'
@@ -60,35 +60,35 @@
 []
 
 [BCs]
-  [./left_x]
+  [left_x]
     type = DirichletBC
     variable = disp_x
     boundary = left
     value = 0.0
-  [../]
-  [./left_y]
+  []
+  [left_y]
     type = DirichletBC
     variable = disp_y
     boundary = left
     value = 0.0
-  [../]
-  [./right_shear_y]
+  []
+  [right_shear_y]
     type = FunctionDirichletBC
     variable = disp_y
     boundary = right
     function = '0.001*t'
-  [../]
+  []
 []
 
 [Materials]
-  [./elasticity_tensor]
+  [elasticity_tensor]
     type = ComputeIsotropicElasticityTensor
     youngs_modulus = 207000
     poissons_ratio = 0.3
-  [../]
-  [./elastic_stress]
+  []
+  [elastic_stress]
     type = ComputeLinearElasticStress
-  [../]
+  []
 []
 
 [Executioner]
@@ -110,15 +110,15 @@
 []
 
 [Postprocessors]
-  [./_dt]
+  [_dt]
     type = TimestepSize
-  [../]
-  [./torque]
+  []
+  [torque]
     type = TorqueReaction
     boundary = right
     reaction_force_variables = 'saved_x saved_y'
     direction_vector = '0. 0. 1.'
-  [../]
+  []
 []
 
 [Outputs]

--- a/modules/solid_mechanics/test/tests/torque_reaction/torque_reaction_3D.i
+++ b/modules/solid_mechanics/test/tests/torque_reaction/torque_reaction_3D.i
@@ -28,33 +28,33 @@
 []
 
 [GlobalParams]
-  volumetric_locking_correction=true
+  volumetric_locking_correction = true
 []
 
 [AuxVariables]
-  [./saved_x]
-  [../]
-  [./saved_y]
-  [../]
-  [./saved_z]
-  [../]
+  [saved_x]
+  []
+  [saved_y]
+  []
+  [saved_z]
+  []
 []
 
 [AuxKernels]
   [saved_x]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_x'
     variable = 'saved_x'
   []
   [saved_y]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_y'
     variable = 'saved_y'
   []
   [saved_z]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_z'
     variable = 'saved_z'
@@ -71,47 +71,47 @@
 []
 
 [BCs]
-  [./bottom_x]
+  [bottom_x]
     type = DirichletBC
     variable = disp_x
     boundary = bottom
     value = 0.0
-  [../]
-  [./bottom_y]
+  []
+  [bottom_y]
     type = DirichletBC
     variable = disp_y
     boundary = bottom
     value = 0.0
-  [../]
-  [./bottom_z]
+  []
+  [bottom_z]
     type = DirichletBC
     variable = disp_z
     boundary = bottom
     value = 0.0
-  [../]
-  [./top_shear_z]
+  []
+  [top_shear_z]
     type = FunctionDirichletBC
     variable = disp_z
     boundary = top
     function = '0.01*t'
-  [../]
-  [./top_shear_x]
+  []
+  [top_shear_x]
     type = FunctionDirichletBC
     variable = disp_x
     boundary = top
     function = '0.01*t'
-  [../]
+  []
 []
 
 [Materials]
-  [./elasticity_tensor]
+  [elasticity_tensor]
     type = ComputeIsotropicElasticityTensor
     youngs_modulus = 207000
     poissons_ratio = 0.3
-  [../]
-  [./elastic_stress]
+  []
+  [elastic_stress]
     type = ComputeLinearElasticStress
-  [../]
+  []
 []
 
 [Executioner]
@@ -140,16 +140,16 @@
 []
 
 [Postprocessors]
-  [./_dt]
+  [_dt]
     type = TimestepSize
-  [../]
-  [./torque]
+  []
+  [torque]
     type = TorqueReaction
     boundary = top
     reaction_force_variables = 'saved_x saved_y saved_z'
     axis_origin = '0.5 0. 0.5'
     direction_vector = '-1. 0. 1.'
-  [../]
+  []
 []
 
 [Outputs]

--- a/modules/solid_mechanics/test/tests/torque_reaction/torque_reaction_cylinder.i
+++ b/modules/solid_mechanics/test/tests/torque_reaction/torque_reaction_cylinder.i
@@ -19,33 +19,33 @@
 []
 
 [GlobalParams]
-  volumetric_locking_correction=true
+  volumetric_locking_correction = true
 []
 
 [AuxVariables]
-  [./saved_x]
-  [../]
-  [./saved_y]
-  [../]
-  [./saved_z]
-  [../]
+  [saved_x]
+  []
+  [saved_y]
+  []
+  [saved_z]
+  []
 []
 
 [AuxKernels]
   [saved_x]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_x'
     variable = 'saved_x'
   []
   [saved_y]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_y'
     variable = 'saved_y'
   []
   [saved_z]
-    type = TagVectorAux
+    type = ReactionForceAux
     vector_tag = 'ref'
     v = 'disp_z'
     variable = 'saved_z'
@@ -62,25 +62,25 @@
 []
 
 [BCs]
-  [./bottom_x]
+  [bottom_x]
     type = DirichletBC
     variable = disp_x
     boundary = 1
     value = 0.0
-  [../]
-  [./bottom_y]
+  []
+  [bottom_y]
     type = DirichletBC
     variable = disp_y
     boundary = 1
     value = 0.0
-  [../]
-  [./bottom_z]
+  []
+  [bottom_z]
     type = DirichletBC
     variable = disp_z
     boundary = 1
     value = 0.0
-  [../]
-  [./top_x]
+  []
+  [top_x]
     type = DisplacementAboutAxis
     boundary = 2
     function = '0.1*t'
@@ -89,8 +89,8 @@
     axis_direction = '0 -1.0 1.0'
     component = 0
     variable = disp_x
-  [../]
-  [./top_y]
+  []
+  [top_y]
     type = DisplacementAboutAxis
     boundary = 2
     function = '0.1*t'
@@ -99,8 +99,8 @@
     axis_direction = '0 -1.0 1.0'
     component = 1
     variable = disp_y
-  [../]
-  [./top_z]
+  []
+  [top_z]
     type = DisplacementAboutAxis
     boundary = 2
     function = '0.1*t'
@@ -109,18 +109,18 @@
     axis_direction = '0 -1.0 1.0'
     component = 2
     variable = disp_z
-  [../]
+  []
 []
 
 [Materials]
-  [./elasticity_tensor]
+  [elasticity_tensor]
     type = ComputeIsotropicElasticityTensor
     youngs_modulus = 207000
     poissons_ratio = 0.3
-  [../]
-  [./elastic_stress]
+  []
+  [elastic_stress]
     type = ComputeFiniteStrainElasticStress
-  [../]
+  []
 []
 
 [Executioner]
@@ -147,13 +147,13 @@
 []
 
 [Postprocessors]
-  [./torque]
+  [torque]
     type = TorqueReaction
     boundary = 2
     reaction_force_variables = 'saved_x saved_y saved_z'
     axis_origin = '10. 10. 10.'
     direction_vector = '0 -1.0 1.0'
-  [../]
+  []
 []
 
 [Outputs]

--- a/test/tests/tag/tests
+++ b/test/tests/tag/tests
@@ -74,6 +74,13 @@
     requirement = 'The system shall throw an error when the variable orders and families for the '
                   'tagged and the auxiliary output variables do not match.'
   []
+  [tag_vector_error]
+    type = 'RunException'
+    input = 'wrong_tag_type.i'
+    expect_err = 'The provided vector tag does not correspond to a tagged residual vector'
+    requirement = 'The system shall throw an error when the user attempts to remove variable scaling '
+                  'from a tagged vector that is not affected by variable scaling.'
+  []
 
   [call_residual]
     type = RunApp

--- a/test/tests/tag/tests
+++ b/test/tests/tag/tests
@@ -74,7 +74,7 @@
     requirement = 'The system shall throw an error when the variable orders and families for the '
                   'tagged and the auxiliary output variables do not match.'
   []
-  [tag_vector_error]
+  [wrong_tag_type]
     type = 'RunException'
     input = 'wrong_tag_type.i'
     expect_err = 'The provided vector tag does not correspond to a tagged residual vector'

--- a/test/tests/tag/wrong_tag_type.i
+++ b/test/tests/tag/wrong_tag_type.i
@@ -1,0 +1,47 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 1
+    nx = 10
+  []
+[]
+
+[Problem]
+  solve = false
+  extra_tag_vectors = 'vec_tag1'
+  extra_tag_solutions = 'vec_tag2'
+[]
+
+[Variables]
+  [u]
+    initial_condition = 1
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+    extra_vector_tags = 'vec_tag1'
+  []
+  [react]
+    type = Reaction
+    variable = u
+    extra_vector_tags = 'vec_tag1 vec_tag2'
+  []
+[]
+
+[AuxVariables]
+  [tag_value]
+    [AuxKernel]
+      type = TagVectorAux
+      v = u
+      vector_tag = vec_tag2
+      remove_variable_scaling = true
+    []
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]


### PR DESCRIPTION
Deprecate the `scaled` parameter in `TagAuxBase`. The deprecated parameter is replaced by `remove_variable_scaling` in `TagVectorAux`.

In solid mechanics, a new AuxKernel named `ReactionForceAux` is added where `remove_variable_scaling` is always set to true.

`ReactionForceAux.md` discusses the example usage to get reaction force.

ref #20482
ref #31357