### PR TITLE
Try a new compiler for conda packages, see if it fixes our mumps issues

### DIFF
--- a/conda/autojump/conda_build_config.yaml
+++ b/conda/autojump/conda_build_config.yaml
@@ -9,7 +9,7 @@ macos_min_version:                                          # [osx]
 
 macos_machine:                                              # [osx]
   - x86_64-apple-darwin13.4.0                               # [not arm64 and osx]
-  - arm64-apple-darwin20.0.0                                # [arm64]
+  - arm64-apple-darwin24.6.0                                # [arm64]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
   - 10.12                                                   # [not arm64 and osx]

--- a/conda/libmesh/build.sh
+++ b/conda/libmesh/build.sh
@@ -9,7 +9,7 @@ function set_libmesh_env(){
           FORTRANFLAGS DEBUG_FFLAGS DEBUG_FORTRANFLAGS
 
     if [[ "$(uname)" == Darwin ]]; then
-        if [[ $HOST == arm64-apple-darwin20.0.0 ]]; then
+        if [[ $HOST == arm64-apple-darwin24.6.0 ]]; then
             CTUNING="-march=armv8.3-a -I${PREFIX:?}/include"
             export LIBRARY_PATH="${PREFIX:?}/lib"
         else
@@ -33,7 +33,7 @@ function set_libmesh_env(){
     export HYDRA_LAUNCHER=fork
     export INSTALL_BINARY="${SRC_DIR:?}/build-aux/install-sh -C"
 
-    if [[ $HOST == arm64-apple-darwin20.0.0 ]]; then
+    if [[ $HOST == arm64-apple-darwin24.6.0 ]]; then
         LDFLAGS="-L${PREFIX:?}/lib -Wl,-S,-rpath,${PREFIX:?}/lib"
     else
         export LDFLAGS="-Wl,-S"

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2025.08.06" %}
+{% set version = "2025.09.08" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2025.08.06 mpich_0
-  - moose-libmesh 2025.08.06 openmpi_0
+  - moose-libmesh 2025.09.08 mpich_0
+  - moose-libmesh 2025.09.08 openmpi_0
 
 moose_wasp:
   - moose-wasp 2025.09.04

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.09.04" %}
+{% set version = "2025.09.08" %}
 
 package:
   name: moose-dev


### PR DESCRIPTION
might need help on that one @loganharbour 

what we are trying to do is update the compilers on conda to see if that fixes our mumps issue
see
https://gitlab.com/petsc/petsc/-/issues/1637#note_2734332973

if it passes without trouble, i ll download the packages, build griffin with it, then try the failing input (CNRS benchmark on VTB for example) with it

kind of a long shot