### PR TITLE
Rework DG/HDG execution logic to limit warehouse and shoudlExecute calls

### DIFF
--- a/framework/include/loops/NonlinearThread.h
+++ b/framework/include/loops/NonlinearThread.h
@@ -172,4 +172,8 @@ private:
   /// method which checks things like whether the elem id is less than the neighbor id such that we
   /// make sure we do not execute DGKernels twice on the same face
   mutable bool _should_execute_dg;
+  /// Whether the subdomain has DGKernels
+  bool _subdomain_has_dg;
+  /// Whether the subdomain has HDGKernels
+  bool _subdomain_has_hdg;
 };


### PR DESCRIPTION
refs #31459

simple_diffusion -r 7

results
without
Average runtime: 38.401501 seconds
Standard deviation: .308408 seconds

with this opt
Average runtime: 35.320047 seconds
Standard deviation: .300131 seconds

removing all "neighbor" calls
Average runtime: 34.417854 seconds
Standard deviation: .370974 seconds

with a solve time of 20s (rest is setup) -3s is 15% faster

In the profile it's just gone now
```
File: libkrb5support.1.1.dylib
Type: cpu
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top 30
Showing nodes accounting for 26.42s, 69.45% of 38.04s total
Dropped 388 nodes (cum <= 0.19s)
Showing top 30 nodes out of 229
      flat  flat%   sum%        cum   cum%
     8.86s 23.29% 23.29%      9.12s 23.97%  tcmalloc::CentralFreeList::Populate
     1.84s  4.84% 28.13%      2.03s  5.34%  MatSetValues_SeqAIJ
     1.66s  4.36% 32.49%     37.48s 98.53%  [libsasl2.2.dylib]
     1.39s  3.65% 36.15%      2.55s  6.70%  MooseMesh::cacheInfo
     1.39s  3.65% 39.80%      2.45s  6.44%  libMesh::BoundaryInfo::boundary_ids
     1.02s  2.68% 42.48%      1.02s  2.68%  libMesh::fe_lagrange_1D_linear_shape
     0.99s  2.60% 45.08%      0.99s  2.60%  hypre_BoomerAMGRelaxHybridGaussSeidel_core
     0.85s  2.23% 47.32%      0.87s  2.29%  libMesh::Elem::which_child_am_i
     0.76s  2.00% 49.32%      1.24s  3.26%  MooseVariableData::computeValuesInternal
     0.67s  1.76% 51.08%      0.67s  1.76%  libMesh::H1FETransformation::map_dphi
     0.62s  1.63% 52.71%      0.76s  2.00%  libMesh::Elem::contains_vertex_of
     0.54s  1.42% 54.13%     10.50s 27.60%  tc_new
     0.50s  1.31% 55.44%      0.95s  2.50%  Kernel::computeResidual
     0.45s  1.18% 56.62%      0.45s  1.18%  libMesh::Face::dim
     0.41s  1.08% 57.70%      0.41s  1.08%  MooseMesh::getNodeBlockIds
     0.40s  1.05% 58.75%      0.46s  1.21%  PackedCache::TryGet
     0.38s     1% 59.75%      0.83s  2.18%  libMesh::FEMap::compute_affine_map
     0.38s     1% 60.75%      0.38s     1%  libMesh::FEMap::compute_single_point_map
     0.37s  0.97% 61.72%      0.61s  1.60%  libMesh::DofMap::_dof_indices
     0.35s  0.92% 62.64%      1.37s  3.60%  (anonymous namespace)::fe_lagrange_2D_shape
     0.32s  0.84% 63.49%      1.48s  3.89%  tc_delete
     0.32s  0.84% 64.33%      2.37s  6.23%  variant_filter_iterator::Pred::operator()
     0.31s  0.81% 65.14%      0.88s  2.31%  libMesh::UnstructuredMesh::find_neighbors
     0.30s  0.79% 65.93%      0.30s  0.79%  PetscSortIntWithDataArray
     0.28s  0.74% 66.67%      0.38s     1%  libMesh::Predicates::level::operator()
     0.23s   0.6% 67.27%      0.27s  0.71%  tcmalloc::SLL_TryPop
     0.22s  0.58% 67.85%      0.26s  0.68%  VecSetValues_Seq
     0.21s  0.55% 68.40%      0.28s  0.74%  PetscSFSetUpRanks
     0.20s  0.53% 68.93%      0.20s  0.53%  Diffusion::computeQpResidual
     0.20s  0.53% 69.45%      0.20s  0.53%  FEProblemBase::setNeighborSubdomainID
```