### PR TITLE
Update conda packages

### DIFF
--- a/apptainer/mpi.def
+++ b/apptainer/mpi.def
@@ -41,11 +41,14 @@ Bootstrap: oras
 From: harbor.hpc.inl.gov/moose-base/rocky-x86_64:8.10-5
 {%- elif ALTERNATE_FROM == "cuda" %}
 From: harbor.hpc.inl.gov/moose-hpcbase/rocky-cuda-x86_64:8.10-cuda12.9-0
+{%- elif ALTERNATE_FROM == "intel" %}
+From: harbor.hpc.inl.gov/moose-hpcbase/rocky-intel-x86_64:8.10_0
 {%- else %}
 From: harbor.hpc.inl.gov/moose-hpcbase/rocky-x86_64:8.10-4
 {%- endif %}
 # Logan Harbour
 Fingerprints: 841AF5A51549CAFFFB474F65207184EA34A4BD48
+
 %environment
     # Fix locale warnings
     export LC_ALL=C

--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_mpi:
-  - moose-mpi 2025.09.10
+  - moose-mpi 2025.09.16
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_mpi:
-  - moose-mpi 2025.08.06
+  - moose-mpi 2025.09.10
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,10 +3,10 @@
 #   libmesh/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 5 %}
-{% set vtk_version = "9.4.2" %}
-{% set vtk_friendly_version = "9.4" %}
-{% set sha256 = "36c98e0da96bb12a30fe53708097aa9492e7b66d5c3b366e1c8dc251e2856a02" %}
+{% set build = 0 %}
+{% set vtk_version = "9.5.1" %}
+{% set vtk_friendly_version = "9.5" %}
+{% set sha256 = "14443661c7b095d05b4e376fb3f40613f173e34fc9d4658234e9ec1d624a618f" %}
 
 package:
   name: moose-libmesh-vtk

--- a/conda/libmesh-vtk/meta.yaml.template
+++ b/conda/libmesh-vtk/meta.yaml.template
@@ -5,8 +5,8 @@
 # As well as any directions pertaining to modifying those files.
 {% set build = __VERSIONER_LIBMESH_VTK_BUILD_NUMBER__ %}
 {% set vtk_version = "__VERSIONER_LIBMESH_VTK_VERSION__" %}
-{% set vtk_friendly_version = "9.4" %}
-{% set sha256 = "36c98e0da96bb12a30fe53708097aa9492e7b66d5c3b366e1c8dc251e2856a02" %}
+{% set vtk_friendly_version = "9.5" %}
+{% set sha256 = "14443661c7b095d05b4e376fb3f40613f173e34fc9d4658234e9ec1d624a618f" %}
 
 package:
   name: moose-libmesh-vtk

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -3,12 +3,12 @@ mpi:
   - openmpi
 
 moose_petsc:
-  - moose-petsc 3.23.4 mpich_0
-  - moose-petsc 3.23.4 openmpi_0
+  - moose-petsc 3.23.4 mpich_1
+  - moose-petsc 3.23.4 openmpi_1
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.4.2 mpich_5
-  - moose-libmesh-vtk 9.4.2 openmpi_5
+  - moose-libmesh-vtk 9.5.1 mpich_0
+  - moose-libmesh-vtk 9.5.1 openmpi_0
 
 zip_keys:
   - mpi

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2025.08.06" %}
+{% set version = "2025.09.10" %}
 
 package:
   name: moose-libmesh

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2025.09.10" %}
+{% set version = "2025.09.16" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,14 +3,14 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2025.08.06 mpich_0
-  - moose-libmesh 2025.08.06 openmpi_0
+  - moose-libmesh 2025.09.10 mpich_0
+  - moose-libmesh 2025.09.10 openmpi_0
 
 moose_wasp:
-  - moose-wasp 2025.09.04
+  - moose-wasp 2025.09.10
 
 moose_tools:
-  - moose-tools 2025.06.26
+  - moose-tools 2025.09.10
 
 zip_keys:
   - mpi

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,14 +3,14 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2025.09.10 mpich_0
-  - moose-libmesh 2025.09.10 openmpi_0
+  - moose-libmesh 2025.09.16 mpich_0
+  - moose-libmesh 2025.09.16 openmpi_0
 
 moose_wasp:
-  - moose-wasp 2025.09.10
+  - moose-wasp 2025.09.16
 
 moose_tools:
-  - moose-tools 2025.09.10
+  - moose-tools 2025.09.16
 
 zip_keys:
   - mpi

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.09.15" %}
+{% set version = "2025.09.16" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -2,7 +2,7 @@ mpi:
   - mpich
 
 moose_dev:
-  - moose-dev 2025.09.15
+  - moose-dev 2025.09.16
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/mpi/conda_build_config.yaml
+++ b/conda/mpi/conda_build_config.yaml
@@ -130,7 +130,7 @@ moose_libclang:
   - libclang-cpp19.1 19.1.7 default_h73dfc95_4              # [arm64]
 
 moose_libxml:
-  - libxml2 2.14.6 h26afc86_1                               # [linux]
+  - libxml2 2.13.8 h04c0eec_1                               # [linux]
   - libxml2 2.13.8 he1bc88e_1                               # [not arm64 and osx]
   - libxml2 2.13.8 h4a9ca0c_1                               # [arm64]
 

--- a/conda/mpi/conda_build_config.yaml
+++ b/conda/mpi/conda_build_config.yaml
@@ -106,7 +106,7 @@ moose_icu:
   - icu 75.1 hfee45f7_0                                     # [arm64]
 
 moose_cctools:                                              # [osx]
-  - cctools_osx-64 1021.4 ha66f10e_0                        # [not arm64 and osx]
+  - cctools_osx-64 1021.4 h508880d_0                        # [not arm64 and osx]
   - cctools_osx-arm64 1021.4 h12580ec_0                     # [arm64]
 
 moose_compiler_rt:                                          # [osx]

--- a/conda/mpi/conda_build_config.yaml
+++ b/conda/mpi/conda_build_config.yaml
@@ -37,23 +37,23 @@ moose_hdf5:
 moose_libexpat:
   - libexpat 2.7.0
 
-### If you change these versions, change also conda/wasp/*, conda/seacas/*
+### If you change these versions, change also conda/wasp/*
 moose_cmake:
   - cmake 3
 
-### If you change these versions, change also conda/wasp/*, conda/seacas/*
+### If you change these versions, change also conda/wasp/*
 moose_cc:
   - gcc 14.3.0 h76bdaa0_5                                   # [linux]
   - clang 18.1.8 default_h1323312_15                        # [not arm64 and osx]
   - clang 18.1.8 default_hf9bcbb7_15                        # [arm64]
 
-### If you change these versions, change also conda/wasps/*, conda/seacas/*
+### If you change these versions, change also conda/wasps/*
 moose_cxx:
   - gxx 14.3.0 he448592_5                                   # [linux]
   - clangxx 18.1.8 default_h1c12a56_15                      # [not arm64 and osx]
   - clangxx 18.1.8 default_h36137df_15                      # [arm64]
 
-### If you change these versions, change also conda/seacas/*
+
 moose_gfortran:
   - gfortran 14.3.0 he448592_5                              # [linux]
   - gfortran 13.4.0 hcc3c99d_0                              # [not arm64 and osx]

--- a/conda/mpi/conda_build_config.yaml
+++ b/conda/mpi/conda_build_config.yaml
@@ -4,10 +4,10 @@ mpi:
 
 mpi_version:
   # MPICH versions
-  - 4.2.1    # [linux]
+  - 4.3.1    # [linux]
   - 4.3.0    # [osx]
   # OpenMPI versions
-  - 4.1.6    # [linux]
+  - 5.0.8    # [linux]
   - 5.0.7    # [osx]
 
 mpi_friendly_name:
@@ -30,8 +30,8 @@ zip_keys:
   - mpi_dev_website
 
 moose_hdf5:
-  - hdf5 1.14.3         # [linux]
-  - hdf5 1.14.4         # [osx]
+  - hdf5 1.14.6         # [linux]
+  - hdf5 1.14.6         # [osx]
 
 moose_libexpat:
   - libexpat 2.7.0
@@ -42,21 +42,21 @@ moose_cmake:
 
 ### If you change these versions, change also conda/wasp/*, conda/seacas/*
 moose_cc:
-  - gcc 12.3.0 h915e2ae_13                                  # [linux]
-  - clang 18.1.8 default_h576c50e_9                         # [not arm64 and osx]
-  - clang 18.1.8 default_h474c9e2_9                         # [arm64]
+  - gcc 14.3.0 h76bdaa0_5                                   # [linux]
+  - clang 18.1.8                                            # [not arm64 and osx]
+  - clang 18.1.8 default_hf9bcbb7_15                        # [arm64]
 
 ### If you change these versions, change also conda/wasps/*, conda/seacas/*
 moose_cxx:
-  - gxx 12.3.0 h915e2ae_13                                  # [linux]
-  - clangxx 18.1.8 default_heb2e8d1_9                       # [not arm64 and osx]
-  - clangxx 18.1.8 default_h1ffe849_9                       # [arm64]
+  - gxx 14.3.0 he448592_5                                   # [linux]
+  - clangxx 18.1.8                                          # [not arm64 and osx]
+  - clangxx 18.1.8 default_h36137df_15                      # [arm64]
 
 ### If you change these versions, change also conda/seacas/*
 moose_gfortran:
-  - gfortran 12.3.0 h915e2ae_13                             # [linux]
-  - gfortran 13.3.0 hcc3c99d_1                              # [not arm64 and osx]
-  - gfortran 13.3.0 h3ef1dbf_1                              # [arm64]
+  - gfortran 14.3.0 he448592_5                              # [linux]
+  - gfortran 13.4.0                                         # [not arm64 and osx]
+  - gfortran 13.4.0 h3ef1dbf_0                              # [arm64]
 
 ### Cmake requires these be installed in order to "find" compilers
 moose_ccompiler:
@@ -70,29 +70,29 @@ moose_cxxcompiler:
   - clangxx_osx-arm64                                       # [arm64]
 
 moose_libgfortran5:
-  - libgfortran5 14.2.0 hf1ad2bd_2                          # [linux]
-  - libgfortran5 14.2.0 h58528f3_105                        # [not arm64 and osx]
-  - libgfortran5 14.2.0 h2c44a93_105                        # [arm64]
+  - libgfortran5 15.1.0 hcea5267_5                          # [linux]
+  - libgfortran5 15.1.0                                     # [not arm64 and osx]
+  - libgfortran5 15.1.0 hb74de2c_1                          # [arm64]
 
 moose_gcc_impl:                                             # [linux]
-  - gcc_impl_linux-64 12.3.0 h58ffeeb_13                    # [linux]
+  - gcc_impl_linux-64 14.3.0 hd9e9e21_5                     # [linux]
 
 moose_gfortran_impl:                                        # [linux]
-  - gfortran_impl_linux-64 12.3.0 h8f2110c_13               # [linux]
+  - gfortran_impl_linux-64 14.3.0 h7db7018_5                # [linux]
 
 ### Below are pinings created at the time of render
 ### based on above content. If any of the above
 ### content changes, modification will be needed below
 moose_libstdcxx:                                            # [linux]
-  - libstdcxx 14.2.0 h8f9b012_2                             # [linux]
+  - libstdcxx 15.1.0 h8f9b012_5                             # [linux]
 
 moose_libstdcxx_devel:                                      # [linux]
-  - libstdcxx-devel_linux-64 12.3.0 h6b66f73_113            # [linux]
+  - libstdcxx-devel_linux-64 14.3.0 h85bb3a7_105            # [linux]
 
 moose_libcxx:
-  - libcxx 20.1.2 ha0f52bf_0                                # [linux]
-  - libcxx 20.1.2 hf95d169_0                                # [not arm64 and osx]
-  - libcxx 20.1.2 ha82da77_0                                # [arm64]
+  - libcxx 21.1.1 ha0f52bf_0                                # [linux]
+  - libcxx 21.1.1 h3d58e20_0                                # [not arm64 and osx]
+  - libcxx 21.1.1 hf598326_0                                # [arm64]
 
 moose_libzlib:
   - libzlib 1.3.1 hb9d3cd8_2                                # [linux]
@@ -105,29 +105,33 @@ moose_icu:
   - icu 75.1 hfee45f7_0                                     # [arm64]
 
 moose_cctools:                                              # [osx]
-  - cctools_osx-64 1010.6 hd19c6af_6                        # [not arm64 and osx]
-  - cctools_osx-arm64 1010.6 h3b4f5d3_6                     # [arm64]
+  - cctools_osx-64 1021.4                                   # [not arm64 and osx]
+  - cctools_osx-arm64 1021.4 h12580ec_0                     # [arm64]
 
 moose_compiler_rt:                                          # [osx]
-  - compiler-rt 18.1.8 h1020d70_1                           # [not arm64 and osx]
-  - compiler-rt 18.1.8 h856b3c1_1                           # [arm64]
+  - compiler-rt 18.1.8                                      # [not arm64 and osx]
+  - compiler-rt 18.1.8 h855ad52_2                           # [arm64]
 
 moose_clang_osx:                                            # [osx]
-  - clangxx_osx-64 18.1.8 h7e5c614_24                       # [not arm64 and osx]
-  - clang_osx-arm64 18.1.8 h07b0088_24                      # [arm64]
+  - clangxx_osx-64 18.1.8                                   # [not arm64 and osx]
+  - clang_osx-arm64 18.1.8 h07b0088_25                      # [arm64]
 
 moose_llvm_openmp:                                          # [osx]
-  - llvm-openmp 20.1.2 ha54dae1_0                           # [not arm64 and osx]
-  - llvm-openmp 20.1.2 hdb05f8b_0                           # [arm64]
+  - llvm-openmp 21.1.0 hf4e0ed4_0                           # [not arm64 and osx]
+  - llvm-openmp 21.1.0 hbb9b287_0                           # [arm64]
 
 moose_llvm_tools:                                           # [osx]
-  - llvm-tools 18.1.8 hc29ff6c_3                            # [not arm64 and osx]
-  - llvm-tools 18.1.8 hc4b4ae8_3                            # [arm64]
+  - llvm-tools 18.1.8                                       # [not arm64 and osx]
+  - llvm-tools 18.1.8 default_h3f49643_9                    # [arm64]
 
 moose_libclang:
-  - libclang13 20.1.2 default_h9c6a7e4_0                    # [linux]
-  - libclang-cpp18.1 18.1.8 default_h3571c67_9              # [not arm64 and osx]
-  - libclang-cpp18.1 18.1.8 default_hf90f093_9              # [arm64]
+  - libclang-cpp19.1 19.1.7 default_hc369343_4              # [not arm64 and osx]
+  - libclang-cpp19.1 19.1.7 default_h73dfc95_4              # [arm64]
+
+moose_libxml:
+  - libxml2 2.14.6 h26afc86_1                               # [linux]
+  - libxml2 2.13.8                                          # [not arm64 and osx]
+  - libxml2 2.13.8 h4a9ca0c_1                               # [arm64]
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/mpi/conda_build_config.yaml
+++ b/conda/mpi/conda_build_config.yaml
@@ -6,7 +6,7 @@ mpi_version:
   # MPICH versions
   - 4.3.1    # [linux]
   - 4.3.1    # [not arm64 and osx]
-  - 4.3.0    # [osx]
+  - 4.3.0    # [arm64]
   # OpenMPI versions
   - 5.0.8    # [linux]
   - 5.0.7    # [osx]

--- a/conda/mpi/conda_build_config.yaml
+++ b/conda/mpi/conda_build_config.yaml
@@ -5,6 +5,7 @@ mpi:
 mpi_version:
   # MPICH versions
   - 4.3.1    # [linux]
+  - 4.3.1    # [not arm64 and osx]
   - 4.3.0    # [osx]
   # OpenMPI versions
   - 5.0.8    # [linux]
@@ -43,19 +44,19 @@ moose_cmake:
 ### If you change these versions, change also conda/wasp/*, conda/seacas/*
 moose_cc:
   - gcc 14.3.0 h76bdaa0_5                                   # [linux]
-  - clang 18.1.8                                            # [not arm64 and osx]
+  - clang 18.1.8 default_h1323312_15                        # [not arm64 and osx]
   - clang 18.1.8 default_hf9bcbb7_15                        # [arm64]
 
 ### If you change these versions, change also conda/wasps/*, conda/seacas/*
 moose_cxx:
   - gxx 14.3.0 he448592_5                                   # [linux]
-  - clangxx 18.1.8                                          # [not arm64 and osx]
+  - clangxx 18.1.8 default_h1c12a56_15                      # [not arm64 and osx]
   - clangxx 18.1.8 default_h36137df_15                      # [arm64]
 
 ### If you change these versions, change also conda/seacas/*
 moose_gfortran:
   - gfortran 14.3.0 he448592_5                              # [linux]
-  - gfortran 13.4.0                                         # [not arm64 and osx]
+  - gfortran 13.4.0 hcc3c99d_0                              # [not arm64 and osx]
   - gfortran 13.4.0 h3ef1dbf_0                              # [arm64]
 
 ### Cmake requires these be installed in order to "find" compilers
@@ -71,7 +72,7 @@ moose_cxxcompiler:
 
 moose_libgfortran5:
   - libgfortran5 15.1.0 hcea5267_5                          # [linux]
-  - libgfortran5 15.1.0                                     # [not arm64 and osx]
+  - libgfortran5 14.2.0 h51e75f0_103                        # [not arm64 and osx]
   - libgfortran5 15.1.0 hb74de2c_1                          # [arm64]
 
 moose_gcc_impl:                                             # [linux]
@@ -105,15 +106,15 @@ moose_icu:
   - icu 75.1 hfee45f7_0                                     # [arm64]
 
 moose_cctools:                                              # [osx]
-  - cctools_osx-64 1021.4                                   # [not arm64 and osx]
+  - cctools_osx-64 1021.4 ha66f10e_0                        # [not arm64 and osx]
   - cctools_osx-arm64 1021.4 h12580ec_0                     # [arm64]
 
 moose_compiler_rt:                                          # [osx]
-  - compiler-rt 18.1.8                                      # [not arm64 and osx]
+  - compiler-rt 18.1.8 he914875_2                           # [not arm64 and osx]
   - compiler-rt 18.1.8 h855ad52_2                           # [arm64]
 
 moose_clang_osx:                                            # [osx]
-  - clangxx_osx-64 18.1.8                                   # [not arm64 and osx]
+  - clangxx_osx-64 18.1.8 h7e5c614_25                       # [not arm64 and osx]
   - clang_osx-arm64 18.1.8 h07b0088_25                      # [arm64]
 
 moose_llvm_openmp:                                          # [osx]
@@ -121,7 +122,7 @@ moose_llvm_openmp:                                          # [osx]
   - llvm-openmp 21.1.0 hbb9b287_0                           # [arm64]
 
 moose_llvm_tools:                                           # [osx]
-  - llvm-tools 18.1.8                                       # [not arm64 and osx]
+  - llvm-tools 18.1.8 default_hd2a208e_9                    # [not arm64 and osx]
   - llvm-tools 18.1.8 default_h3f49643_9                    # [arm64]
 
 moose_libclang:
@@ -130,7 +131,7 @@ moose_libclang:
 
 moose_libxml:
   - libxml2 2.14.6 h26afc86_1                               # [linux]
-  - libxml2 2.13.8                                          # [not arm64 and osx]
+  - libxml2 2.13.8 he1bc88e_1                               # [not arm64 and osx]
   - libxml2 2.13.8 h4a9ca0c_1                               # [arm64]
 
 #### Darwin SDK SYSROOT

--- a/conda/mpi/meta.yaml
+++ b/conda/mpi/meta.yaml
@@ -6,7 +6,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2025.09.10" %}
+{% set version = "2025.09.16" %}
 
 package:
   name: moose-mpi

--- a/conda/mpi/meta.yaml
+++ b/conda/mpi/meta.yaml
@@ -46,6 +46,7 @@ outputs:
         - {{ moose_cc }}
         - {{ moose_cxx }}
         - {{ moose_ccompiler }}
+        - {{ moose_libxml }}
         - {{ moose_cxxcompiler }}
         - {{ moose_clang_osx }}                   # [osx]
         - {{ moose_compiler_rt }}                 # [osx]
@@ -72,6 +73,7 @@ outputs:
         - {{ moose_cxx }}
         - {{ moose_ccompiler }}
         - {{ moose_cxxcompiler }}
+        - {{ moose_libxml }}
         - {{ moose_clang_osx }}                   # [osx]
         - {{ moose_compiler_rt }}                 # [osx]
         - {{ moose_libclang }}                    # [osx]

--- a/conda/mpi/meta.yaml
+++ b/conda/mpi/meta.yaml
@@ -6,7 +6,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2025.08.06" %}
+{% set version = "2025.09.10" %}
 
 package:
   name: moose-mpi

--- a/conda/mpi/meta.yaml.template
+++ b/conda/mpi/meta.yaml.template
@@ -46,6 +46,7 @@ outputs:
         - {{ moose_cc }}
         - {{ moose_cxx }}
         - {{ moose_ccompiler }}
+        - {{ moose_libxml }}
         - {{ moose_cxxcompiler }}
         - {{ moose_clang_osx }}                   # [osx]
         - {{ moose_compiler_rt }}                 # [osx]
@@ -72,6 +73,7 @@ outputs:
         - {{ moose_cxx }}
         - {{ moose_ccompiler }}
         - {{ moose_cxxcompiler }}
+        - {{ moose_libxml }}
         - {{ moose_clang_osx }}                   # [osx]
         - {{ moose_compiler_rt }}                 # [osx]
         - {{ moose_libclang }}                    # [osx]

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_mpi:
-  - moose-mpi 2025.09.10
+  - moose-mpi 2025.09.16
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_mpi:
-  - moose-mpi 2025.08.06
+  - moose-mpi 2025.09.10
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -7,7 +7,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = "3.23.4" %}
 
 package:

--- a/conda/seacas/conda_build_config.yaml
+++ b/conda/seacas/conda_build_config.yaml
@@ -1,4 +1,4 @@
-
+### If you change these versions, change also conda/wasp/*, conda/seacas/*
 moose_cmake:
   - cmake 3
 
@@ -7,13 +7,13 @@ moose_cc:
   - clang 18.1.8 default_h576c50e_9                         # [not arm64 and osx]
   - clang 18.1.8 default_h474c9e2_9                         # [arm64]
 
-
+### If you change these versions, change also conda/wasps/*, conda/seacas/*
 moose_cxx:
   - gxx 12.3.0 h915e2ae_13                                  # [linux]
   - clangxx 18.1.8 default_heb2e8d1_9                       # [not arm64 and osx]
   - clangxx 18.1.8 default_h1ffe849_9                       # [arm64]
 
-
+### If you change these versions, change also conda/mpi/*
 moose_gfortran:
   - gfortran 12.3.0 h915e2ae_13                             # [linux]
   - gfortran 13.3.0 hcc3c99d_1                              # [not arm64 and osx]

--- a/conda/seacas/conda_build_config.yaml
+++ b/conda/seacas/conda_build_config.yaml
@@ -3,21 +3,21 @@ moose_cmake:
   - cmake 3
 
 moose_cc:
-  - gcc 12.3.0 h915e2ae_13                                  # [linux]
-  - clang 18.1.8 default_h576c50e_9                         # [not arm64 and osx]
-  - clang 18.1.8 default_h474c9e2_9                         # [arm64]
+  - gcc 14.3.0 h76bdaa0_5                                   # [linux]
+  - clang 18.1.8                                            # [not arm64 and osx]
+  - clang 18.1.8 default_hf9bcbb7_15                        # [arm64]
 
 ### If you change these versions, change also conda/wasps/*, conda/seacas/*
 moose_cxx:
-  - gxx 12.3.0 h915e2ae_13                                  # [linux]
-  - clangxx 18.1.8 default_heb2e8d1_9                       # [not arm64 and osx]
-  - clangxx 18.1.8 default_h1ffe849_9                       # [arm64]
+  - gxx 14.3.0 he448592_5                                   # [linux]
+  - clangxx 18.1.8                                          # [not arm64 and osx]
+  - clangxx 18.1.8 default_h36137df_15                      # [arm64]
 
 ### If you change these versions, change also conda/mpi/*
 moose_gfortran:
-  - gfortran 12.3.0 h915e2ae_13                             # [linux]
-  - gfortran 13.3.0 hcc3c99d_1                              # [not arm64 and osx]
-  - gfortran 13.3.0 h3ef1dbf_1                              # [arm64]
+  - gfortran 14.3.0 he448592_5                              # [linux]
+  - gfortran 13.4.0                                         # [not arm64 and osx]
+  - gfortran 13.4.0 h3ef1dbf_0                              # [arm64]
 
 ### Cmake requires these be installed in order to "find" compilers
 moose_ccompiler:

--- a/conda/seacas/conda_build_config.yaml
+++ b/conda/seacas/conda_build_config.yaml
@@ -1,23 +1,23 @@
-### If you change these versions, change also conda/wasp/*, conda/seacas/*
+
 moose_cmake:
   - cmake 3
 
 moose_cc:
-  - gcc 14.3.0 h76bdaa0_5                                   # [linux]
-  - clang 18.1.8 default_h1323312_15                        # [not arm64 and osx]
-  - clang 18.1.8 default_hf9bcbb7_15                        # [arm64]
+  - gcc 12.3.0 h915e2ae_13                                  # [linux]
+  - clang 18.1.8 default_h576c50e_9                         # [not arm64 and osx]
+  - clang 18.1.8 default_h474c9e2_9                         # [arm64]
 
-### If you change these versions, change also conda/wasps/*, conda/seacas/*
+
 moose_cxx:
-  - gxx 14.3.0 he448592_5                                   # [linux]
-  - clangxx 18.1.8 default_h1c12a56_15                      # [not arm64 and osx]
-  - clangxx 18.1.8 default_h36137df_15                      # [arm64]
+  - gxx 12.3.0 h915e2ae_13                                  # [linux]
+  - clangxx 18.1.8 default_heb2e8d1_9                       # [not arm64 and osx]
+  - clangxx 18.1.8 default_h1ffe849_9                       # [arm64]
 
-### If you change these versions, change also conda/mpi/*
+
 moose_gfortran:
-  - gfortran 14.3.0 he448592_5                              # [linux]
-  - gfortran 13.4.0 hcc3c99d_0                              # [not arm64 and osx]
-  - gfortran 13.4.0 h3ef1dbf_0                              # [arm64]
+  - gfortran 12.3.0 h915e2ae_13                             # [linux]
+  - gfortran 13.3.0 hcc3c99d_1                              # [not arm64 and osx]
+  - gfortran 13.3.0 h3ef1dbf_1                              # [arm64]
 
 ### Cmake requires these be installed in order to "find" compilers
 moose_ccompiler:

--- a/conda/seacas/conda_build_config.yaml
+++ b/conda/seacas/conda_build_config.yaml
@@ -4,19 +4,19 @@ moose_cmake:
 
 moose_cc:
   - gcc 14.3.0 h76bdaa0_5                                   # [linux]
-  - clang 18.1.8                                            # [not arm64 and osx]
+  - clang 18.1.8 default_h1323312_15                        # [not arm64 and osx]
   - clang 18.1.8 default_hf9bcbb7_15                        # [arm64]
 
 ### If you change these versions, change also conda/wasps/*, conda/seacas/*
 moose_cxx:
   - gxx 14.3.0 he448592_5                                   # [linux]
-  - clangxx 18.1.8                                          # [not arm64 and osx]
+  - clangxx 18.1.8 default_h1c12a56_15                      # [not arm64 and osx]
   - clangxx 18.1.8 default_h36137df_15                      # [arm64]
 
 ### If you change these versions, change also conda/mpi/*
 moose_gfortran:
   - gfortran 14.3.0 he448592_5                              # [linux]
-  - gfortran 13.4.0                                         # [not arm64 and osx]
+  - gfortran 13.4.0 hcc3c99d_0                              # [not arm64 and osx]
   - gfortran 13.4.0 h3ef1dbf_0                              # [arm64]
 
 ### Cmake requires these be installed in order to "find" compilers

--- a/conda/seacas/meta.yaml
+++ b/conda/seacas/meta.yaml
@@ -1,6 +1,6 @@
 # MAKE SURE THAT seacas_version and seacas_git_rev match if performing a version update!
 {% set build = "0" %}
-{% set seacas_version = "2025.05.22" %}
+{% set seacas_version = "2025.09.10" %}
 {% set seacas_git_rev = "v2025-05-22" %}
 {% set strbuild = "build_" + build|string %}
 

--- a/conda/seacas/meta.yaml
+++ b/conda/seacas/meta.yaml
@@ -1,7 +1,7 @@
 # MAKE SURE THAT seacas_version and seacas_git_rev match if performing a version update!
 {% set build = "0" %}
-{% set seacas_version = "2025.09.16" %}
-{% set seacas_git_rev = "v2025-08-28" %}
+{% set seacas_version = "2025.05.22" %}
+{% set seacas_git_rev = "v2025-05-22" %}
 {% set strbuild = "build_" + build|string %}
 
 package:

--- a/conda/seacas/meta.yaml
+++ b/conda/seacas/meta.yaml
@@ -1,6 +1,6 @@
 # MAKE SURE THAT seacas_version and seacas_git_rev match if performing a version update!
 {% set build = "0" %}
-{% set seacas_version = "2025.09.10" %}
+{% set seacas_version = "2025.09.16" %}
 {% set seacas_git_rev = "v2025-05-22" %}
 {% set strbuild = "build_" + build|string %}
 

--- a/conda/seacas/meta.yaml
+++ b/conda/seacas/meta.yaml
@@ -1,7 +1,7 @@
 # MAKE SURE THAT seacas_version and seacas_git_rev match if performing a version update!
 {% set build = "0" %}
 {% set seacas_version = "2025.09.16" %}
-{% set seacas_git_rev = "v2025-05-22" %}
+{% set seacas_git_rev = "v2025-08-28" %}
 {% set strbuild = "build_" + build|string %}
 
 package:

--- a/conda/seacas/meta.yaml.template
+++ b/conda/seacas/meta.yaml.template
@@ -1,7 +1,7 @@
 # MAKE SURE THAT seacas_version and seacas_git_rev match if performing a version update!
 {% set build = "__VERSIONER_SEACAS_BUILD_NUMBER__" %}
 {% set seacas_version = "__VERSIONER_SEACAS_VERSION__" %}
-{% set seacas_git_rev = "v2025-08-28" %}
+{% set seacas_git_rev = "v2025-05-22" %}
 {% set strbuild = "build_" + build|string %}
 
 package:

--- a/conda/seacas/meta.yaml.template
+++ b/conda/seacas/meta.yaml.template
@@ -1,7 +1,7 @@
 # MAKE SURE THAT seacas_version and seacas_git_rev match if performing a version update!
 {% set build = "__VERSIONER_SEACAS_BUILD_NUMBER__" %}
 {% set seacas_version = "__VERSIONER_SEACAS_VERSION__" %}
-{% set seacas_git_rev = "v2025-05-22" %}
+{% set seacas_git_rev = "v2025-08-28" %}
 {% set strbuild = "build_" + build|string %}
 
 package:

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,7 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.09.10" %}
+{% set version = "2025.09.16" %}
 
 package:
   name: moose-tools

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,7 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.06.26" %}
+{% set version = "2025.09.10" %}
 
 package:
   name: moose-tools

--- a/conda/wasp/conda_build_config.yaml
+++ b/conda/wasp/conda_build_config.yaml
@@ -4,7 +4,7 @@ moose_python:
   - python 3.11
   - python 3.10
 
-### If you change these versions, change also conda/mpi/*, conda/seacas/*
+### If you change these versions, change also conda/mpi/*
 moose_cmake:
   - cmake 3
 
@@ -13,7 +13,7 @@ moose_cc:
   - clang 18.1.8 default_h1323312_15                        # [not arm64 and osx]
   - clang 18.1.8 default_hf9bcbb7_15                        # [arm64]
 
-### If you change these versions, change also conda/mpi/*, conda/seacas/*
+### If you change these versions, change also conda/mpi/*
 moose_cxx:
   - gxx 14.3.0 he448592_5                                   # [linux]
   - clangxx 18.1.8 default_h1c12a56_15                      # [not arm64 and osx]

--- a/conda/wasp/conda_build_config.yaml
+++ b/conda/wasp/conda_build_config.yaml
@@ -10,13 +10,13 @@ moose_cmake:
 
 moose_cc:
   - gcc 14.3.0 h76bdaa0_5                                   # [linux]
-  - clang 18.1.8                                            # [not arm64 and osx]
+  - clang 18.1.8 default_h1323312_15                        # [not arm64 and osx]
   - clang 18.1.8 default_hf9bcbb7_15                        # [arm64]
 
 ### If you change these versions, change also conda/mpi/*, conda/seacas/*
 moose_cxx:
   - gxx 14.3.0 he448592_5                                   # [linux]
-  - clangxx 18.1.8                                          # [not arm64 and osx]
+  - clangxx 18.1.8 default_h1c12a56_15                      # [not arm64 and osx]
   - clangxx 18.1.8 default_h36137df_15                      # [arm64]
 
 ### Cmake requires these be installed in order to "find" compilers

--- a/conda/wasp/conda_build_config.yaml
+++ b/conda/wasp/conda_build_config.yaml
@@ -9,15 +9,15 @@ moose_cmake:
   - cmake 3
 
 moose_cc:
-  - gcc 12.3.0 h915e2ae_13                                  # [linux]
-  - clang 18.1.8 default_h576c50e_9                         # [not arm64 and osx]
-  - clang 18.1.8 default_h474c9e2_9                         # [arm64]
+  - gcc 14.3.0 h76bdaa0_5                                   # [linux]
+  - clang 18.1.8                                            # [not arm64 and osx]
+  - clang 18.1.8 default_hf9bcbb7_15                        # [arm64]
 
 ### If you change these versions, change also conda/mpi/*, conda/seacas/*
 moose_cxx:
-  - gxx 12.3.0 h915e2ae_13                                  # [linux]
-  - clangxx 18.1.8 default_heb2e8d1_9                       # [not arm64 and osx]
-  - clangxx 18.1.8 default_h1ffe849_9                       # [arm64]
+  - gxx 14.3.0 he448592_5                                   # [linux]
+  - clangxx 18.1.8                                          # [not arm64 and osx]
+  - clangxx 18.1.8 default_h36137df_15                      # [arm64]
 
 ### Cmake requires these be installed in order to "find" compilers
 moose_ccompiler:

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2025.09.10" %}
+{% set version = "2025.09.16" %}
 
 package:
   name: moose-wasp

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2025.09.04" %}
+{% set version = "2025.09.10" %}
 
 package:
   name: moose-wasp

--- a/framework/contrib/cpp-peglib/include/peglib.h
+++ b/framework/contrib/cpp-peglib/include/peglib.h
@@ -489,7 +489,7 @@ inline constexpr unsigned int str2tag(std::string_view sv) {
 
 namespace udl {
 
-inline constexpr unsigned int operator"" _(const char *s, size_t l) {
+inline constexpr unsigned int operator""_(const char *s, size_t l) {
   return str2tag_core(s, l, 0);
 }
 

--- a/framework/include/restart/Restartable.h
+++ b/framework/include/restart/Restartable.h
@@ -42,14 +42,14 @@ public:
   class ManagedValue
   {
   public:
-    ManagedValue<T>(RestartableData<T> & value) : _value(value) {}
+    ManagedValue(RestartableData<T> & value) : _value(value) {}
 
     /**
      * Destructor.
      *
      * Destructs the managed restartable data.
      */
-    ~ManagedValue<T>() { _value.reset(); }
+    ~ManagedValue() { _value.reset(); }
 
     /**
      * Get the restartable value.

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1179,7 +1179,9 @@ MooseApp::registerCapabilities()
   // compiler
   {
     const auto doc = "Compiler used to build the MOOSE framework.";
-#if defined(__clang__)
+#if defined(__INTEL_LLVM_COMPILER)
+    addCapability("compiler", "intel", doc);
+#elif defined(__clang__)
     addCapability("compiler", "clang", doc);
 #elif defined(__GNUC__) || defined(__GNUG__)
     addCapability("compiler", "gcc", doc);

--- a/framework/src/utils/ADFParser.C
+++ b/framework/src/utils/ADFParser.C
@@ -33,7 +33,11 @@ ADFParser::JITCompile()
 
   std::string fopenmp;
 #if defined(_OPENMP)
+#if defined(__INTEL_LLVM_COMPILER)
+  fopenmp = "-qopenmp";
+#else
   fopenmp = "-fopenmp";
+#endif
 #endif
 
   const auto include_path_env = std::getenv("MOOSE_ADFPARSER_JIT_INCLUDE");

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -135,7 +135,7 @@ packages:
       - conda/pprof/build.sh
   # dependers: none
   seacas:
-    version: 2025.09.16
+    version: 2025.05.22
     build_number: 0
     conda: conda/seacas
     templates:

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -7,13 +7,13 @@
 packages:
   # dependers: moose-dev
   tools:
-    version: 2025.06.26
+    version: 2025.09.16
     conda: conda/tools
     templates:
       conda/tools/meta.yaml.template: conda/tools/meta.yaml
   # dependers: libmesh-vtk, petsc, libmesh, moose-dev
   mpi:
-    version: 2025.08.06
+    version: 2025.09.16
     conda: conda/mpi
     templates:
       conda/mpi/meta.yaml.template: conda/mpi/meta.yaml
@@ -25,8 +25,8 @@ packages:
     apptainer:
   # dependers: libmesh, moose-dev
   libmesh-vtk:
-    version: 9.4.2
-    build_number: 5
+    version: 9.5.1
+    build_number: 0
     conda: conda/libmesh-vtk
     templates:
       conda/libmesh-vtk/conda_build_config.yaml.template: conda/libmesh-vtk/conda_build_config.yaml
@@ -38,7 +38,7 @@ packages:
   # dependers: libmesh, moose-dev
   petsc:
     version: 3.23.4
-    build_number: 0
+    build_number: 1
     conda: conda/petsc
     templates:
       conda/petsc/conda_build_config.yaml.template: conda/petsc/conda_build_config.yaml
@@ -56,7 +56,7 @@ packages:
       - scripts/apple-silicon-hdf5-autogen.patch
   # dependers: moose-dev
   libmesh:
-    version: 2025.08.06
+    version: 2025.09.16
     build_number: 0
     conda: conda/libmesh
     templates:
@@ -75,7 +75,7 @@ packages:
       - scripts/update_and_rebuild_libmesh.sh
   # dependers: moose-dev
   wasp:
-    version: 2025.09.04
+    version: 2025.09.16
     build_number: 0
     conda: conda/wasp
     templates:
@@ -93,7 +93,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.09.15
+    version: 2025.09.16
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml
@@ -135,7 +135,7 @@ packages:
       - conda/pprof/build.sh
   # dependers: none
   seacas:
-    version: 2025.05.22
+    version: 2025.09.16
     build_number: 0
     conda: conda/seacas
     templates:


### PR DESCRIPTION
## Reason
Conda packages need to be updated so that they are not behind.

## Design
Update pins in conda packages and add fixes as needed.

## Impact
Significant; package updates may cause things to break.

## Update summary

- Updated mpi and compilers in conda moose-mpi
- Updated VTK to 9.5.1 in conda moose-libmesh-vtk
- Updated libmesh submodule
