### PR TITLE
use LDFLAGS when compiling capabilities target, 

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -238,7 +238,7 @@ capabilities_LDFLAGS      := $(DYNAMIC_LOOKUP)
 
 capabilities $(capabilities_LIB) : $(capabilities_srcfiles)
 	@echo "Building and linking $(capabilities_LIB)..."
-	@bash -c '(cd "$(CAPABILITIES_DIR)" && $(libmesh_CXX) -I$(LIBMESH_DIR)/include $(libmesh_LIBS) -std=c++17 -w -fPIC -lstdc++ -shared $(capabilities_srcfiles) $(capabilities_COMPILEFLAGS) $(capabilities_LDFLAGS) -o $(capabilities_LIB))'
+	@bash -c '(cd "$(CAPABILITIES_DIR)" && $(libmesh_CXX) -I$(LIBMESH_DIR)/include $(libmesh_LIBS) $(LDFLAGS) $(libmesh_LDFLAGS) -std=c++17 -w -fPIC -lstdc++ -shared $(capabilities_srcfiles) $(capabilities_COMPILEFLAGS) $(capabilities_LDFLAGS) -o $(capabilities_LIB))'
 
 #
 # gtest


### PR DESCRIPTION
Uses LDFLAGS when compiling `capabilities` target. This fixed my issue when needing custom LIBS to build libmesh. Poking around `moose.mk`, it seems common to include `$LDFLAGS` when compiling other targets.

closes #31481