### PR TITLE
Add parameter cache to speed up syntax, add const

### DIFF
--- a/framework/include/parser/Builder.h
+++ b/framework/include/parser/Builder.h
@@ -129,6 +129,14 @@ private:
    */
   const hit::Node * queryGlobalParamsNode() const;
 
+  /**
+   * Build a cache of object type -> parameters from the Factory.
+   *
+   * Used in the syntax builders to avoid building an object's parameters
+   * multiple times.
+   */
+  std::vector<std::pair<std::string, const InputParameters>> buildRegisteredObjectParams() const;
+
   /// The MooseApp this Parser is part of
   MooseApp & _app;
   /// The Factory associated with that MooseApp

--- a/framework/include/utils/JsonSyntaxTree.h
+++ b/framework/include/utils/JsonSyntaxTree.h
@@ -42,7 +42,7 @@ public:
                      bool is_type,
                      const std::string & action,
                      bool is_action,
-                     InputParameters * params,
+                     const InputParameters & params,
                      const FileLineInfo & lineinfo,
                      const std::string & classname);
 
@@ -85,7 +85,7 @@ protected:
                            bool & out_of_range_allowed,
                            std::map<MooseEnumItem, std::string> & docs);
 
-  size_t setParams(InputParameters * params, bool search_match, nlohmann::json & all_params);
+  size_t setParams(const InputParameters & params, bool search_match, nlohmann::json & all_params);
 
   static std::string
   buildOutputString(const std::iterator_traits<InputParameters::iterator>::value_type & p);

--- a/framework/include/utils/SyntaxTree.h
+++ b/framework/include/utils/SyntaxTree.h
@@ -29,7 +29,7 @@ public:
   void insertNode(std::string syntax,
                   const std::string & action,
                   bool is_action_params = true,
-                  InputParameters * params = NULL);
+                  const InputParameters * params = NULL);
 
   std::string print(const std::string & search_string);
 
@@ -46,14 +46,14 @@ protected:
     TreeNode(const std::string & name,
              SyntaxTree & syntax_tree,
              const std::string * action = NULL,
-             InputParameters * params = NULL,
+             const InputParameters * params = NULL,
              TreeNode * parent = NULL);
     ~TreeNode();
 
     void insertNode(std::string & syntax,
                     const std::string & action,
                     bool is_action_params = true,
-                    InputParameters * params = NULL);
+                    const InputParameters * params = NULL);
     std::string print(short depth, const std::string & search_string, bool & found);
 
     std::string getLongName(const std::string & delim = "/") const;
@@ -61,7 +61,7 @@ protected:
   protected:
     void insertParams(const std::string & action,
                       bool is_action_params,
-                      InputParameters * params = NULL);
+                      const InputParameters * params = NULL);
 
     std::map<std::string, std::unique_ptr<TreeNode>> _children;
     std::multimap<std::string, std::unique_ptr<InputParameters>> _action_params;

--- a/framework/src/utils/SyntaxTree.C
+++ b/framework/src/utils/SyntaxTree.C
@@ -27,7 +27,7 @@ void
 SyntaxTree::insertNode(std::string syntax,
                        const std::string & action,
                        bool is_action_params,
-                       InputParameters * params)
+                       const InputParameters * params)
 {
   if (!_root)
     _root = std::make_unique<TreeNode>("", *this);
@@ -68,7 +68,7 @@ SyntaxTree::haveSeenIt(const std::string & prefix, const std::string & item) con
 SyntaxTree::TreeNode::TreeNode(const std::string & name,
                                SyntaxTree & syntax_tree,
                                const std::string * action,
-                               InputParameters * params,
+                               const InputParameters * params,
                                TreeNode * parent)
   : _name(name), _parent(parent), _syntax_tree(syntax_tree)
 {
@@ -82,7 +82,7 @@ void
 SyntaxTree::TreeNode::insertNode(std::string & syntax,
                                  const std::string & action,
                                  bool is_action_params,
-                                 InputParameters * params)
+                                 const InputParameters * params)
 {
   std::string::size_type pos = syntax.find_first_of("/");
   std::string item;
@@ -114,7 +114,7 @@ SyntaxTree::TreeNode::insertNode(std::string & syntax,
 void
 SyntaxTree::TreeNode::insertParams(const std::string & action,
                                    bool is_action_params,
-                                   InputParameters * params)
+                                   const InputParameters * params)
 {
   if (is_action_params)
     _action_params.emplace(action, std::make_unique<InputParameters>(*params));


### PR DESCRIPTION
Closes #31487

We were looping through each action and for each action building _every_ object's parameters over and over. Combined syntax on rod took 24 sec before this, takes 3.5 sec now.

`outputs/format` testing before (38 sec total):

```
outputs/format.hit ..................................................................................................... OK [10.07s]
outputs/format.definition_active_parameter_test ........................................................................ OK [8.253s]
outputs/format.definition_default_types_child_parameter_promotion_test ................................................. OK [8.112s]
outputs/format.definition_childatleastone_test ......................................................................... OK [8.019s]
outputs/format.definition_default_type_test ............................................................................ OK [7.977s]
outputs/format.definition_default_subblock_types_child_parameter_promotion_test ........................................ OK [7.890s]
outputs/format.definition_mesh_file_parameter_requirement_removal_test ................................................. OK [7.881s]
outputs/format.definition_valenum_test ................................................................................. OK [7.875s]
outputs/format.definition_minvalinc_inputdefault_test .................................................................. OK [7.857s]
outputs/format.definition_normal_sub_test .............................................................................. OK [7.839s]
outputs/format.definition_scraping_markers ............................................................................. OK [7.815s]
outputs/format.definition_input_choices_test ........................................................................... OK [7.594s]
outputs/format.definition_type_sub_test ................................................................................ OK [7.435s]
outputs/format.definition_boolean_type_valenum_choices_test ............................................................ OK [7.344s]
outputs/format.json_full ............................................................................................... OK [7.274s]
outputs/format.json_line_info .......................................................................................... OK [6.826s]
outputs/format.json_no_template ........................................................................................ OK [6.674s]
outputs/format.no_double_executioner_output ............................................................................ OK [6.514s]
outputs/format.json_no_test_objects .................................................................................... OK [6.498s]
outputs/format.yaml_dump_test .......................................................................................... OK [6.166s]
outputs/format.hit_search .............................................................................................. OK [5.707s]
outputs/format.json_search ............................................................................................. OK [5.657s]
outputs/format.nemesis_out_test ........................................................................................ OK [1.243s]
outputs/format.gnuplot_gif_out_test .................................................................................... OK [1.184s]
outputs/format.sln_out_test ............................................................................................ OK [1.184s]
outputs/format.tecplot_bin_test_override ............................................................................... OK [1.179s]
outputs/format.pps_screen_out_warn_test ................................................................................ OK [1.175s]
outputs/format.tecplot_out_test ........................................................................................ OK [1.124s]
outputs/format.gmv_out_test ............................................................................................ OK [1.073s]
outputs/format.gnuplot_png_out_test .................................................................................... OK [1.065s]
outputs/format.xdr_output .............................................................................................. OK [0.980s]
outputs/format.gnuplot_ps_out_test ..................................................................................... OK [0.616s]
outputs/format.show_input_test ......................................................................................... OK [0.607s]
```

`outputs/format` testing after (15 sec total):

```
outputs/format.hit ..................................................................................................... OK [4.892s]
outputs/format.definition_childatleastone_test ......................................................................... OK [3.477s]
outputs/format.definition_valenum_test ................................................................................. OK [3.428s]
outputs/format.definition_scraping_markers ............................................................................. OK [3.405s]
outputs/format.definition_boolean_type_valenum_choices_test ............................................................ OK [3.401s]
outputs/format.definition_type_sub_test ................................................................................ OK [3.350s]
outputs/format.definition_minvalinc_inputdefault_test .................................................................. OK [3.313s]
outputs/format.definition_active_parameter_test ........................................................................ OK [3.223s]
outputs/format.definition_default_types_child_parameter_promotion_test ................................................. OK [3.189s]
outputs/format.definition_default_subblock_types_child_parameter_promotion_test ........................................ OK [3.136s]
outputs/format.definition_mesh_file_parameter_requirement_removal_test ................................................. OK [3.123s]
outputs/format.definition_normal_sub_test .............................................................................. OK [3.104s]
outputs/format.definition_input_choices_test ........................................................................... OK [3.098s]
outputs/format.json_full ............................................................................................... OK [2.643s]
outputs/format.definition_default_type_test ............................................................................ OK [2.608s]
outputs/format.json_line_info .......................................................................................... OK [2.147s]
outputs/format.json_no_test_objects .................................................................................... OK [2.147s]
outputs/format.json_no_template ........................................................................................ OK [2.075s]
outputs/format.hit_search .............................................................................................. OK [1.696s]
outputs/format.no_double_executioner_output ............................................................................ OK [1.378s]
outputs/format.json_search ............................................................................................. OK [1.282s]
outputs/format.tecplot_out_test ........................................................................................ OK [1.213s]
outputs/format.pps_screen_out_warn_test ................................................................................ OK [1.143s]
outputs/format.sln_out_test ............................................................................................ OK [1.115s]
outputs/format.gnuplot_gif_out_test .................................................................................... OK [1.111s]
outputs/format.gmv_out_test ............................................................................................ OK [1.109s]
outputs/format.nemesis_out_test ........................................................................................ OK [1.102s]
outputs/format.tecplot_bin_test_override ............................................................................... OK [1.083s]
outputs/format.yaml_dump_test .......................................................................................... OK [1.048s]
outputs/format.gnuplot_ps_out_test ..................................................................................... OK [1.048s]
outputs/format.xdr_output .............................................................................................. OK [1.036s]
outputs/format.gnuplot_png_out_test .................................................................................... OK [0.513s]
outputs/format.show_input_test ......................................................................................... OK [0.472s]
```
