### PR TITLE
Alternative take on "Make the number of threads an app parameter"

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1005,6 +1005,17 @@ public:
   const std::shared_ptr<libMesh::Parallel::Communicator> getCommunicator() const { return _comm; }
 
   /**
+   * Returns the number of threads used by this application
+   */
+  unsigned int getNumThreads() const { return _num_threads; }
+
+  /**
+   * Sets the number of threads used by this application, for both libMesh and MOOSE
+   * @param num_threads number of threads to use
+   */
+  void setNumThreads(unsigned int num_threads);
+
+  /**
    * Return the container of relationship managers
    */
   const std::set<std::shared_ptr<RelationshipManager>> & relationshipManagers() const
@@ -1140,6 +1151,9 @@ protected:
 
   /// The MPI communicator this App is going to use
   const std::shared_ptr<libMesh::Parallel::Communicator> _comm;
+
+  /// Number of threads
+  unsigned int _num_threads;
 
   /// The output file basename
   std::string _output_file_base;

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1152,9 +1152,6 @@ protected:
   /// The MPI communicator this App is going to use
   const std::shared_ptr<libMesh::Parallel::Communicator> _comm;
 
-  /// Number of threads
-  unsigned int _num_threads;
-
   /// The output file basename
   std::string _output_file_base;
 
@@ -1203,6 +1200,9 @@ protected:
 
   /// Builder for building app related parser tree
   Moose::Builder _builder;
+
+  /// Number of threads
+  unsigned int _num_threads;
 
   /// Where the restartable data is held (indexed on tid)
   std::vector<RestartableDataMap> _restartable_data;

--- a/framework/include/utils/InputParameterWarehouse.h
+++ b/framework/include/utils/InputParameterWarehouse.h
@@ -36,7 +36,7 @@ public:
   /**
    * Class constructor
    */
-  InputParameterWarehouse();
+  InputParameterWarehouse(unsigned int num_threads);
 
   /**
    * Destruction
@@ -157,6 +157,8 @@ private:
   /// pointers. The ControllableItem objects are not designed and will not be used directly in
   /// user code. All user level access goes through the ControllableParameter object.
   std::vector<std::vector<std::shared_ptr<ControllableItem>>> _controllable_items;
+
+  unsigned int _num_threads;
 
   /**
    * Returns a ControllableParameter object that contains all matches to ControllableItem objects

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -454,7 +454,7 @@ MooseApp::MooseApp(const InputParameters & parameters)
     _start_time(0.0),
     _global_time_offset(0.0),
     _input_parameter_warehouse(std::make_unique<InputParameterWarehouse>((isParamValid("_multiapp_level") ? getParam<unsigned int>("_multiapp_level")
-                                                    : 0) ? 3 : 2)),
+                                                    : 0) ? /*sub_th*/10 : 1)),
     _action_factory(*this),
     _action_warehouse(*this, _syntax, _action_factory),
     _output_warehouse(*this),
@@ -462,7 +462,7 @@ MooseApp::MooseApp(const InputParameters & parameters)
     _command_line(getCheckedPointerParam<std::shared_ptr<CommandLine>>("_command_line")),
     _builder(*this, _action_warehouse, *_parser),
     _num_threads((isParamValid("_multiapp_level") ? getParam<unsigned int>("_multiapp_level")
-                                                    : 0) ? 3 : 2), //getParam<unsigned int>("n_threads")),
+                                                    : 0) ? /*sub_th*/10 : 1), //getParam<unsigned int>("n_threads")),
     _restartable_data(_num_threads),
     _perf_graph(createRecoverablePerfGraph()),
     _solution_invalidity(createRecoverableSolutionInvalidity()),

--- a/framework/src/multiapps/FullSolveMultiApp.C
+++ b/framework/src/multiapps/FullSolveMultiApp.C
@@ -65,6 +65,7 @@ FullSolveMultiApp::initialSetup()
     for (unsigned int i = 0; i < _my_num_apps; i++)
     {
       auto & app = _apps[i];
+      _apps[i]->setNumThreads(_apps[i]->getNumThreads());
       Executioner * ex = app->getExecutioner();
 
       if (!ex)
@@ -84,6 +85,8 @@ FullSolveMultiApp::initialSetup()
       _executioners[i] = ex;
     }
   }
+  // Restore number of threads of the parent
+  _app.setNumThreads(_app.getNumThreads());
 }
 
 bool
@@ -107,6 +110,7 @@ FullSolveMultiApp::solveStep(Real /*dt*/, Real /*target_time*/, bool auto_advanc
   bool last_solve_converged = true;
   for (unsigned int i = 0; i < _my_num_apps; i++)
   {
+    _apps[i]->setNumThreads(_apps[i]->getNumThreads());
     // reset output system if desired
     if (!getParam<bool>("keep_full_output_history"))
       _apps[i]->getOutputWarehouse().reset();
@@ -118,6 +122,8 @@ FullSolveMultiApp::solveStep(Real /*dt*/, Real /*target_time*/, bool auto_advanc
 
     showStatusMessage(i);
   }
+  // Restore number of threads of the parent
+  _app.setNumThreads(_app.getNumThreads());
 
   return last_solve_converged || _ignore_diverge;
 }

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -166,8 +166,13 @@ TransientMultiApp::initialSetup()
     _transient_executioners.resize(_my_num_apps);
     // Grab Transient Executioners from each app
     for (unsigned int i = 0; i < _my_num_apps; i++)
+    {
+      _apps[i]->setNumThreads(_apps[i]->getNumThreads());
       setupApp(i);
+    }
   }
+  // Restore number of threads of the parent
+  _app.setNumThreads(_app.getNumThreads());
 }
 
 bool
@@ -202,6 +207,7 @@ TransientMultiApp::solveStep(Real dt, Real target_time, bool auto_advance)
     for (unsigned int i = 0; i < _my_num_apps; i++)
     {
       FEProblemBase & problem = appProblemBase(_first_local_app + i);
+      _apps[i]->setNumThreads(_apps[i]->getNumThreads());
 
       TransientBase * ex = _transient_executioners[i];
 
@@ -540,7 +546,8 @@ TransientMultiApp::solveStep(Real dt, Real target_time, bool auto_advance)
   }
 
   _transferred_vars.clear();
-
+  // Restore number of threads of the parent
+  _app.setNumThreads(_app.getNumThreads());
   return return_value;
 }
 
@@ -552,6 +559,7 @@ TransientMultiApp::incrementTStep(Real target_time)
     for (unsigned int i = 0; i < _my_num_apps; i++)
     {
       TransientBase * ex = _transient_executioners[i];
+      _apps[i]->setNumThreads(_apps[i]->getNumThreads());
 
       // The App might have a different local time from the rest of the problem
       Real app_time_offset = _apps[i]->getGlobalTimeOffset();
@@ -562,6 +570,8 @@ TransientMultiApp::incrementTStep(Real target_time)
         ex->incrementStepOrReject();
     }
   }
+  // Restore number of threads of the parent
+  _app.setNumThreads(_app.getNumThreads());
 }
 
 void
@@ -572,6 +582,7 @@ TransientMultiApp::finishStep(bool recurse_through_multiapp_levels)
     for (unsigned int i = 0; i < _my_num_apps; i++)
     {
       TransientBase * ex = _transient_executioners[i];
+      _apps[i]->setNumThreads(_apps[i]->getNumThreads());
       ex->endStep();
       ex->postStep();
       if (recurse_through_multiapp_levels)
@@ -583,6 +594,8 @@ TransientMultiApp::finishStep(bool recurse_through_multiapp_levels)
       }
     }
   }
+  // Restore number of threads of the parent
+  _app.setNumThreads(_app.getNumThreads());
 }
 
 Real
@@ -600,6 +613,7 @@ TransientMultiApp::computeDT()
     for (unsigned int i = 0; i < _my_num_apps; i++)
     {
       TransientBase * ex = _transient_executioners[i];
+      _apps[i]->setNumThreads(_apps[i]->getNumThreads());
       ex->computeDT();
       Real dt = ex->getDT();
 
@@ -613,6 +627,8 @@ TransientMultiApp::computeDT()
     return std::numeric_limits<Real>::max();
 
   _communicator.min(smallest_dt);
+  // Restore number of threads of the parent
+  _app.setNumThreads(_app.getNumThreads());
   return smallest_dt;
 }
 

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5611,7 +5611,10 @@ FEProblemBase::backupMultiApps(ExecFlagType type)
                << std::endl;
 
     for (const auto & multi_app : multi_apps)
+    {
+      multi_app->getMooseApp().setNumThreads(multi_app->getMooseApp().getNumThreads());
       multi_app->backup();
+    }
 
     MooseUtils::parallelBarrierNotify(_communicator, _parallel_barrier_messaging);
 
@@ -5619,6 +5622,7 @@ FEProblemBase::backupMultiApps(ExecFlagType type)
       _console << COLOR_CYAN << "Finished Backing Up MultiApps on " << type.name() << "\n"
                << COLOR_DEFAULT << std::endl;
   }
+  _app.setNumThreads(_app.getNumThreads());
 }
 
 void
@@ -5639,7 +5643,10 @@ FEProblemBase::restoreMultiApps(ExecFlagType type, bool force)
     }
 
     for (const auto & multi_app : multi_apps)
+    {
+      multi_app->getMooseApp().setNumThreads(multi_app->getMooseApp().getNumThreads());
       multi_app->restore(force);
+    }
 
     MooseUtils::parallelBarrierNotify(_communicator, _parallel_barrier_messaging);
 
@@ -5647,6 +5654,7 @@ FEProblemBase::restoreMultiApps(ExecFlagType type, bool force)
       _console << COLOR_CYAN << "Finished Restoring MultiApps on " << type.name() << "\n"
                << COLOR_DEFAULT << std::endl;
   }
+  _app.setNumThreads(_app.getNumThreads());
 }
 
 Real

--- a/framework/src/utils/InputParameterWarehouse.C
+++ b/framework/src/utils/InputParameterWarehouse.C
@@ -11,8 +11,8 @@
 #include "InputParameterWarehouse.h"
 #include "InputParameters.h"
 
-InputParameterWarehouse::InputParameterWarehouse()
-  : _input_parameters(libMesh::n_threads()), _controllable_items(libMesh::n_threads())
+InputParameterWarehouse::InputParameterWarehouse(unsigned int num_threads)
+  : _input_parameters(num_threads), _controllable_items(num_threads), _num_threads(num_threads)
 {
 }
 
@@ -176,7 +176,7 @@ InputParameterWarehouse::addControllableParameterConnection(
     const MooseObjectParameterName & secondary,
     bool error_on_empty /*=true*/)
 {
-  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
+  for (THREAD_ID tid = 0; tid < _num_threads; ++tid)
   {
     std::vector<ControllableItem *> primaries = getControllableItems(primary, tid);
     if (primaries.empty() && error_on_empty && tid == 0) // some objects only exist on tid 0
@@ -207,7 +207,7 @@ void
 InputParameterWarehouse::addControllableObjectAlias(const MooseObjectName & alias,
                                                     const MooseObjectName & secondary)
 {
-  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
+  for (THREAD_ID tid = 0; tid < _num_threads; ++tid)
   {
     std::vector<ControllableItem *> secondaries =
         getControllableItems(MooseObjectParameterName(secondary, "*"), tid);
@@ -224,7 +224,7 @@ void
 InputParameterWarehouse::addControllableParameterAlias(const MooseObjectParameterName & alias,
                                                        const MooseObjectParameterName & secondary)
 {
-  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
+  for (THREAD_ID tid = 0; tid < _num_threads; ++tid)
   {
     std::vector<ControllableItem *> secondaries = getControllableItems(secondary, tid);
     if (secondaries.empty() && tid == 0) // some objects only exist on tid 0
@@ -251,7 +251,7 @@ ControllableParameter
 InputParameterWarehouse::getControllableParameter(const MooseObjectParameterName & input) const
 {
   ControllableParameter cparam;
-  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
+  for (THREAD_ID tid = 0; tid < _num_threads; ++tid)
     for (auto it = _controllable_items[tid].begin(); it != _controllable_items[tid].end(); ++it)
       if ((*it)->name() == input)
         cparam.add(it->get());
@@ -278,7 +278,7 @@ std::vector<MooseObjectParameterName>
 InputParameterWarehouse::getControllableParameterNames(const MooseObjectParameterName & input) const
 {
   std::vector<MooseObjectParameterName> names;
-  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
+  for (THREAD_ID tid = 0; tid < _num_threads; ++tid)
     for (auto it = _controllable_items[tid].begin(); it != _controllable_items[tid].end(); ++it)
       if ((*it)->name() == input)
         names.push_back((*it)->name());


### PR DESCRIPTION
This is playing with the global variable in libMesh instead

The impact on setup is much much lower! Do not need to change all the warehouses to keep the thread count around. 
But as you can see we need to switch back and forth every time we call multiapp code, to update the global variable. 