### PR TITLE
fix logic in building time sequence

### DIFF
--- a/framework/src/timesteppers/TimeSequenceStepperBase.C
+++ b/framework/src/timesteppers/TimeSequenceStepperBase.C
@@ -141,7 +141,7 @@ TimeSequenceStepperBase::updateSequence(const std::vector<Real> & times)
   _time_sequence.push_back(start_time);
   for (unsigned int j = 0; j < times.size(); ++j)
   {
-    if (times[j] > start_time && times[j] < end_time)
+    if (times[j] > start_time && times[j] <= end_time)
       _time_sequence.push_back(times[j]);
   }
 

--- a/test/tests/time_steppers/timesequence_stepper/tests
+++ b/test/tests/time_steppers/timesequence_stepper/tests
@@ -88,7 +88,23 @@
 
       detail = 'use the final time in the sequence as the simulation end time.'
     []
-  []
+
+    [use_last_t_for_end_time_last_value_matches]
+      type = CSVDiff
+      input = timesequence.i
+      csvdiff = timesequence_out.csv
+      # end_time will be ignored since the last time in the sequence will be used
+      # we have to specify the number of steps for a reasonable mid-step in 'restep' mode
+      # Note that we specify the exact number of 'sync steps' to be sure to test for setting the end time
+      prereq = time_sequence/use_last_t_for_end_time
+      cli_args = "Executioner/TimeStepper/use_last_t_for_end_time=true
+                  Executioner/end_time=4
+                  Executioner/num_steps=7
+                  Postprocessors/dt/type=TimestepSize Outputs/csv=true"
+
+      detail = 'use the final time in the sequence as the simulation end time, even when the end_time is set to the last value in the sequence.'
+    []
+[]
 
   [timesequence_failed]
     type = 'Exodiff'


### PR DESCRIPTION
Addresses case where end_time is ignored when setting equal to last value in sequence. Also added a test to cover this case.

closes #31511

@GiudGiud 