### PR TITLE
Swap MFEM_ASSERT by mooseAssert

### DIFF
--- a/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
@@ -179,7 +179,7 @@ MFEMCutTransitionSubMesh::labelMesh(mfem::ParMesh & parent_mesh)
 mfem::Vector
 MFEMCutTransitionSubMesh::findFaceNormal(const mfem::ParMesh & mesh, const int & face)
 {
-  MFEM_ASSERT(mesh.SpaceDimension() == 3,
+  mooseAssert(mesh.SpaceDimension() == 3,
               "MFEMCutTransitionSubMesh only works in 3-dimensional meshes!");
   mfem::Vector normal;
   mfem::Array<int> face_verts;


### PR DESCRIPTION
I think you're absolutely right @loganharbour, let's get it out of the way. This is the _only_ occurrence of `MFEM_ASSERT` in MOOSE, we just let it slip in.