### PR TITLE
Improve Kokkos initialization settings

### DIFF
--- a/framework/src/kokkos/base/KokkosMooseInit.K
+++ b/framework/src/kokkos/base/KokkosMooseInit.K
@@ -27,6 +27,13 @@ MooseInit::initKokkos()
 {
   Kokkos::InitializationSettings settings;
 
+  // Explicitly set the number of threads consistently with MOOSE
+  settings.set_num_threads(libMesh::n_threads());
+
+  // Only print warnings on the head process
+  if (comm().rank())
+    settings.set_disable_warnings(true);
+
 #ifdef MOOSE_ENABLE_KOKKOS_GPU
 
   unsigned int num_kokkos_gpus = Kokkos::num_devices();


### PR DESCRIPTION
Refs #30655.

Kokkos currently prints three types of warnings depending on the configuration:

```
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false

MPI detected: For OpenMP binding to work as intended, MPI ranks must be bound to exclusive CPU sets.

Kokkos::Cuda::initialize WARNING: running kernels compiled for compute capability 8.0 on device with compute capability 8.9 , this will likely reduce potential performance.
```

I don't have a strong opinion on whether to disable those or add environment variable as instructed.