### PR TITLE
Mark some MFEM tests as valgrind heavy

### DIFF
--- a/test/tests/mfem/submeshes/tests
+++ b/test/tests/mfem/submeshes/tests
@@ -55,6 +55,7 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     recover = false
+    valgrind = heavy
   []
   [MFEMVacuumCutTransitionSubMesh]
     design = 'syntax/MFEM/ClosedCoilMagnetostatic.md'
@@ -78,5 +79,6 @@
     compute_devices = 'cpu cuda'
     recover = false
     restep = false
+    valgrind = heavy
   []  
 []


### PR DESCRIPTION
## Reason
The following MFEM Valgrind tests fail deterministically due to timeout:

```
[603.6s]  TIMEOUT mfem/submeshes.MFEMDomainSubMeshBoundary FAILED (TIMEOUT) [previous results: TIMEOUT]
[603.4s]  TIMEOUT mfem/submeshes.MFEMGeometryCutTransitionSubMesh FAILED (TIMEOUT) [previous results: TIMEOUT]
```

They need to be marked as Valgrind-heavy.

## Design
Mark the tests as Valgrind-heavy.

## Impact
Avoid Valgrind failure.