### PR TITLE
Put libmesh libraries after capabilities sources

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -240,7 +240,7 @@ capabilities_LDFLAGS      := $(DYNAMIC_LOOKUP)
 
 capabilities $(capabilities_LIB) : $(capabilities_srcfiles)
 	@echo "Building and linking $(capabilities_LIB)..."
-	@bash -c '(cd "$(CAPABILITIES_DIR)" && $(libmesh_CXX) -I$(LIBMESH_DIR)/include $(libmesh_LIBS) $(LDFLAGS) $(libmesh_LDFLAGS) -std=c++17 -w -fPIC -lstdc++ -shared $(capabilities_srcfiles) $(capabilities_COMPILEFLAGS) $(capabilities_LDFLAGS) -o $(capabilities_LIB))'
+	@bash -c '(cd "$(CAPABILITIES_DIR)" && $(libmesh_CXX) -I$(LIBMESH_DIR)/include -std=c++17 -w -fPIC -lstdc++ -shared $(capabilities_srcfiles) $(capabilities_COMPILEFLAGS) $(capabilities_LDFLAGS) $(libmesh_LIBS) $(LDFLAGS) $(libmesh_LDFLAGS) -o $(capabilities_LIB))'
 
 #
 # gtest


### PR DESCRIPTION
This is needed for linkers using `--as-needed`

Refs #31481 and #31523