### PR TITLE
Fix GNU Makefile dependencies

### DIFF
--- a/framework/build.mk
+++ b/framework/build.mk
@@ -132,26 +132,28 @@ all:
 
 unity_files:
 
+.SECONDEXPANSION:
+
 #
 # C++ rules
 #
-pcre%.$(obj-suffix) : pcre%.cc | $(prebuild)
+pcre%.$(obj-suffix) : pcre%.cc | $$(prebuild)
 	@echo "Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(ADDITIONAL_CPPFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -w -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
-gtest%.$(no-method-obj-suffix) : gtest%.cc | $(prebuild)
+gtest%.$(no-method-obj-suffix) : gtest%.cc | $$(prebuild)
 	@echo "Compiling C++ "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(ADDITIONAL_CPPFLAGS) $(gtest_INCLUDE) $(CXXFLAGS) -w -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
-%.$(obj-suffix) : %.cc | $(prebuild)
+%.$(obj-suffix) : %.cc | $$(prebuild)
 	@echo "Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(ADDITIONAL_CPPFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 define CXX_RULE_TEMPLATE
-%$(1).$(obj-suffix) : %.C $(ADDITIONAL_SRC_DEPS) | $(prebuild)
+%$(1).$(obj-suffix) : %.C $(ADDITIONAL_SRC_DEPS) | $$(prebuild)
 ifeq ($(1),)
 	@echo "Compiling C++ (in "$$(METHOD)" mode) "$$<"..."
 else
@@ -163,7 +165,7 @@ endef
 # Instantiate Rules
 $(eval $(call CXX_RULE_TEMPLATE,))
 
-%.$(obj-suffix) : %.cpp | $(prebuild)
+%.$(obj-suffix) : %.cpp | $$(prebuild)
 	@echo "Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CXX) $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(ADDITIONAL_CPPFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
@@ -184,12 +186,12 @@ $(eval $(call CXX_RULE_TEMPLATE,))
 # C rules
 #
 
-pcre%.$(obj-suffix) : pcre%.c | $(prebuild)
+pcre%.$(obj-suffix) : pcre%.c | $$(prebuild)
 	@echo "Compiling C (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -w -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
-%.$(obj-suffix) : %.c | $(prebuild)
+%.$(obj-suffix) : %.c | $$(prebuild)
 	@echo "Compiling C (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
@@ -337,9 +339,9 @@ endif
 #
 PLUGIN_FLAGS := -shared -fPIC -Wl,-undefined,dynamic_lookup
 
-%-$(METHOD).plugin : %.C | $(prebuild)
+%-$(METHOD).plugin : %.C | $$(prebuild)
 	@$(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(PLUGIN_FLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $< -o $@
-%-$(METHOD).plugin : %.c | $(prebuild)
+%-$(METHOD).plugin : %.c | $$(prebuild)
 	@echo "Compiling C Plugin (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(PLUGIN_FLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $< -o $@
 %-$(METHOD).plugin : %.f

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -517,7 +517,7 @@ endif
 
 # Pre-make for checking current dependency versions and showing useful warnings
 # if things like conda packages are out of date. The variable is such that
-# rules can use $(prebuild), instead of prebuild, as a prerequisite. In those
+# rules can use $$(prebuild), instead of prebuild, as a prerequisite. In those
 # cases, if this file, moose.mk, is not included, the variable expands to the
 # empty string, establishing no dependency, and keeping the rule valid. The
 # order-only prerequisite $(moose_config), guarantees _some_ configuration file


### PR DESCRIPTION
## Reason
Amends #30916.

## Design
Uses secondary expansion to guarantee lazy evaluation of the prebuild prerequisite variable which is only defined in `moose.mk`, usually included _after_ `build.mk`.

## Impact
Hopefully warnings about outdated conda/apptainer environments now print first thing when building.
