### PR TITLE
Optimize linearFV setup

### DIFF
--- a/framework/include/mesh/FaceInfo.h
+++ b/framework/include/mesh/FaceInfo.h
@@ -37,7 +37,11 @@ class Node;
 class FaceInfo
 {
 public:
-   FaceInfo(const ElemInfo * elem_info, unsigned int side, const dof_id_type id, libMesh::ElemSideBuilder & side_builder);
+  FaceInfo(const ElemInfo * elem_info,
+           unsigned int side,
+           const dof_id_type id,
+           libMesh::ElemSideBuilder & side_builder,
+           libMesh::FEBase * fe);
 
   /// This enum is used to indicate which side(s) of a face a particular
   /// variable is defined on.  This is important for certain BC-related finite

--- a/framework/include/mesh/FaceInfo.h
+++ b/framework/include/mesh/FaceInfo.h
@@ -15,6 +15,7 @@
 
 #include "libmesh/vector_value.h"
 #include "libmesh/remote_elem.h"
+#include "libmesh/elem_side_builder.h"
 
 #include <map>
 #include <set>
@@ -36,7 +37,7 @@ class Node;
 class FaceInfo
 {
 public:
-  FaceInfo(const ElemInfo * const elem_info, const unsigned int side, const dof_id_type id);
+   FaceInfo(const ElemInfo * elem_info, unsigned int side, const dof_id_type id, libMesh::ElemSideBuilder & side_builder);
 
   /// This enum is used to indicate which side(s) of a face a particular
   /// variable is defined on.  This is important for certain BC-related finite

--- a/framework/include/mesh/FaceInfo.h
+++ b/framework/include/mesh/FaceInfo.h
@@ -44,7 +44,7 @@ public:
            unsigned int side,
            const dof_id_type id,
            libMesh::ElemSideBuilder & side_builder,
-           libMesh::FEBase * fe);
+           libMesh::FEBase & fe);
 
   /// This enum is used to indicate which side(s) of a face a particular
   /// variable is defined on.  This is important for certain BC-related finite

--- a/framework/include/mesh/FaceInfo.h
+++ b/framework/include/mesh/FaceInfo.h
@@ -37,14 +37,10 @@ class Node;
 class FaceInfo
 {
 public:
-  // Simple constructor for unit tests
-  FaceInfo(const ElemInfo * elem_info, unsigned int side, const dof_id_type id);
-  // Optimized constructor for the MooseMesh to use
   FaceInfo(const ElemInfo * elem_info,
            unsigned int side,
            const dof_id_type id,
-           libMesh::ElemSideBuilder & side_builder,
-           libMesh::FEBase & fe);
+           libMesh::ElemSideBuilder & side_builder);
 
   /// This enum is used to indicate which side(s) of a face a particular
   /// variable is defined on.  This is important for certain BC-related finite

--- a/framework/include/mesh/FaceInfo.h
+++ b/framework/include/mesh/FaceInfo.h
@@ -37,6 +37,9 @@ class Node;
 class FaceInfo
 {
 public:
+  // Simple constructor for unit tests
+  FaceInfo(const ElemInfo * elem_info, unsigned int side, const dof_id_type id);
+  // Optimized constructor for the MooseMesh to use
   FaceInfo(const ElemInfo * elem_info,
            unsigned int side,
            const dof_id_type id,

--- a/framework/src/mesh/FaceInfo.C
+++ b/framework/src/mesh/FaceInfo.C
@@ -45,7 +45,7 @@ FaceInfo::FaceInfo(const ElemInfo * elem_info,
                    unsigned int side,
                    const dof_id_type id,
                    libMesh::ElemSideBuilder & side_builder,
-                   libMesh::FEBase * fe)
+                   libMesh::FEBase & fe)
   : _elem_info(elem_info),
     _neighbor_info(nullptr),
     _id(id),
@@ -58,12 +58,12 @@ FaceInfo::FaceInfo(const ElemInfo * elem_info,
   auto & face = side_builder(*_elem_info->elem(), side);
   _face_area = face.volume();
   _face_centroid = face.vertex_average();
-  const std::vector<Point> & normals = fe->get_normals();
+  const std::vector<Point> & normals = fe.get_normals();
   Point pt0(0, 0, 0);
   std::vector<Point> pts = {pt0};
   // We pass this point to avoid the re-init caching that fails when
   // the same FE is used for a boundary and a volume element (of the same dimension here)
-  fe->reinit(_elem_info->elem(), _elem_side_id, libMesh::TOLERANCE, &pts);
+  fe.reinit(_elem_info->elem(), _elem_side_id, libMesh::TOLERANCE, &pts);
   mooseAssert(normals.size() == 1, "FaceInfo construction broken w.r.t. computing face normals");
   _normal = normals[0];
 }

--- a/framework/src/mesh/FaceInfo.C
+++ b/framework/src/mesh/FaceInfo.C
@@ -16,7 +16,11 @@
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/remote_elem.h"
 
-FaceInfo::FaceInfo(const ElemInfo * elem_info, unsigned int side, const dof_id_type id, libMesh::ElemSideBuilder & side_builder)
+FaceInfo::FaceInfo(const ElemInfo * elem_info,
+                   unsigned int side,
+                   const dof_id_type id,
+                   libMesh::ElemSideBuilder & side_builder,
+                   libMesh::FEBase * fe)
   : _elem_info(elem_info),
     _neighbor_info(nullptr),
     _id(id),
@@ -26,12 +30,7 @@ FaceInfo::FaceInfo(const ElemInfo * elem_info, unsigned int side, const dof_id_t
     _gc(0.5)
 {
   // Compute face-related quantities
-  unsigned int dim = _elem_info->elem()->dim();
   const auto & face = side_builder(*_elem_info->elem(), side);
-  std::unique_ptr<libMesh::FEBase> fe(
-      libMesh::FEBase::build(dim, libMesh::FEType(_elem_info->elem()->default_order())));
-  libMesh::QGauss qface(dim - 1, libMesh::CONSTANT);
-  fe->attach_quadrature_rule(&qface);
   const std::vector<Point> & normals = fe->get_normals();
   fe->reinit(_elem_info->elem(), _elem_side_id);
   mooseAssert(normals.size() == 1, "FaceInfo construction broken w.r.t. computing face normals");

--- a/framework/src/mesh/FaceInfo.C
+++ b/framework/src/mesh/FaceInfo.C
@@ -16,7 +16,7 @@
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/remote_elem.h"
 
-FaceInfo::FaceInfo(const ElemInfo * elem_info, unsigned int side, const dof_id_type id)
+FaceInfo::FaceInfo(const ElemInfo * elem_info, unsigned int side, const dof_id_type id, libMesh::ElemSideBuilder & side_builder)
   : _elem_info(elem_info),
     _neighbor_info(nullptr),
     _id(id),
@@ -27,7 +27,7 @@ FaceInfo::FaceInfo(const ElemInfo * elem_info, unsigned int side, const dof_id_t
 {
   // Compute face-related quantities
   unsigned int dim = _elem_info->elem()->dim();
-  const std::unique_ptr<const Elem> face = _elem_info->elem()->build_side_ptr(_elem_side_id);
+  const auto & face = side_builder(*_elem_info->elem(), side);
   std::unique_ptr<libMesh::FEBase> fe(
       libMesh::FEBase::build(dim, libMesh::FEType(_elem_info->elem()->default_order())));
   libMesh::QGauss qface(dim - 1, libMesh::CONSTANT);
@@ -37,8 +37,8 @@ FaceInfo::FaceInfo(const ElemInfo * elem_info, unsigned int side, const dof_id_t
   mooseAssert(normals.size() == 1, "FaceInfo construction broken w.r.t. computing face normals");
   _normal = normals[0];
 
-  _face_area = face->volume();
-  _face_centroid = face->vertex_average();
+  _face_area = face.volume();
+  _face_centroid = face.vertex_average();
 }
 
 void

--- a/framework/src/mesh/FaceInfo.C
+++ b/framework/src/mesh/FaceInfo.C
@@ -16,36 +16,10 @@
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/remote_elem.h"
 
-FaceInfo::FaceInfo(const ElemInfo * elem_info, unsigned int side, const dof_id_type id)
-  : _elem_info(elem_info),
-    _neighbor_info(nullptr),
-    _id(id),
-    _processor_id(_elem_info->elem()->processor_id()),
-    _elem_side_id(side),
-    _neighbor_side_id(libMesh::invalid_uint),
-    _gc(0.5)
-{
-  // Compute face-related quantities
-  unsigned int dim = _elem_info->elem()->dim();
-  const std::unique_ptr<const Elem> face = _elem_info->elem()->build_side_ptr(_elem_side_id);
-  std::unique_ptr<libMesh::FEBase> fe(
-      libMesh::FEBase::build(dim, libMesh::FEType(_elem_info->elem()->default_order())));
-  libMesh::QGauss qface(dim - 1, libMesh::CONSTANT);
-  fe->attach_quadrature_rule(&qface);
-  const std::vector<Point> & normals = fe->get_normals();
-  fe->reinit(_elem_info->elem(), _elem_side_id);
-  mooseAssert(normals.size() == 1, "FaceInfo construction broken w.r.t. computing face normals");
-  _normal = normals[0];
-
-  _face_area = face->volume();
-  _face_centroid = face->vertex_average();
-}
-
 FaceInfo::FaceInfo(const ElemInfo * elem_info,
                    unsigned int side,
                    const dof_id_type id,
-                   libMesh::ElemSideBuilder & side_builder,
-                   libMesh::FEBase & fe)
+                   libMesh::ElemSideBuilder & side_builder)
   : _elem_info(elem_info),
     _neighbor_info(nullptr),
     _id(id),
@@ -58,14 +32,7 @@ FaceInfo::FaceInfo(const ElemInfo * elem_info,
   auto & face = side_builder(*_elem_info->elem(), side);
   _face_area = face.volume();
   _face_centroid = face.vertex_average();
-  const std::vector<Point> & normals = fe.get_normals();
-  Point pt0(0, 0, 0);
-  std::vector<Point> pts = {pt0};
-  // We pass this point to avoid the re-init caching that fails when
-  // the same FE is used for a boundary and a volume element (of the same dimension here)
-  fe.reinit(_elem_info->elem(), _elem_side_id, libMesh::TOLERANCE, &pts);
-  mooseAssert(normals.size() == 1, "FaceInfo construction broken w.r.t. computing face normals");
-  _normal = normals[0];
+  _normal = _elem_info->elem()->side_vertex_average_normal(side);
 }
 
 void

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -3906,7 +3906,7 @@ MooseMesh::buildFiniteVolumeInfo() const
                                     side,
                                     face_index++,
                                     side_builder,
-                                    fe_at_dim[elem_dim - 1][elem->default_order()].get());
+                                    *fe_at_dim[elem_dim - 1][elem->default_order()]);
 
         auto & fi = _all_face_info.back();
 

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -3864,13 +3864,28 @@ MooseMesh::buildFiniteVolumeInfo() const
     num_sides += elem->n_sides();
   }
 
-  // Used to speed up FaceInfo creation
+  // Used to speed up FaceInfo creation:
+  // - element side builder that caches per type of element
+  // - prebuild side quadratures and element FEs (to get normals, volume, centroid )
   libMesh::ElemSideBuilder side_builder;
+  std::vector<std::vector<std::unique_ptr<libMesh::FEBase>>> fe_at_dim(getMesh().mesh_dimension());
+  std::vector<libMesh::QGauss> q_faces;
+  for (const auto d : make_range(1, int(getMesh().mesh_dimension() + 1)))
+  {
+    q_faces.emplace_back(libMesh::QGauss(d - 1, libMesh::CONSTANT));
+    for (const auto o : make_range(/*max_elem_order + 1*/ 4))
+    {
+      fe_at_dim[d - 1].emplace_back(
+          libMesh::FEBase::build(d, libMesh::FEType(/*order*/ o, libMesh::MONOMIAL)));
+      fe_at_dim[d - 1][o]->attach_quadrature_rule(&q_faces[d - 1]);
+    }
+  }
 
   _all_face_info.reserve(num_sides / 2);
   dof_id_type face_index = 0;
   for (const Elem * elem : as_range(begin, end))
   {
+    const auto elem_dim = elem->dim();
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
       // get the neighbor element
@@ -3886,7 +3901,12 @@ MooseMesh::buildFiniteVolumeInfo() const
                     "be active.");
 
         // We construct the faceInfo using the elementinfo and side index
-        _all_face_info.emplace_back(&_elem_to_elem_info[elem->id()], side, face_index++, side_builder);
+        mooseAssert(elem->default_order() < 4, "Did not expect such high element orders in FV");
+        _all_face_info.emplace_back(&_elem_to_elem_info[elem->id()],
+                                    side,
+                                    face_index++,
+                                    side_builder,
+                                    fe_at_dim[elem_dim - 1][elem->default_order()].get());
 
         auto & fi = _all_face_info.back();
 

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -3856,7 +3856,7 @@ MooseMesh::buildFiniteVolumeInfo() const
 
   // We prepare a map connecting the Elem* and the corresponding ElemInfo
   // for the active elements.
-  _elem_to_elem_info.reserve(nActiveElem());
+  _elem_to_elem_info.reserve(nActiveLocalElem());
   unsigned int num_sides = 0;
   for (const Elem * elem : as_range(begin, end))
   {
@@ -3925,7 +3925,7 @@ MooseMesh::buildFiniteVolumeInfo() const
   // references if ever the new size exceeds capacity
   _elem_side_to_face_info.reserve(_all_face_info.size());
   // heuristic to avoid resizing too much
-  _face_info.reserve(_all_face_info.size() * (nActiveLocalElem() + 1e-8) / nActiveElem());
+  _face_info.reserve(_all_face_info.size());
   for (auto & fi : _all_face_info)
   {
     const Elem * const elem = &fi.elem();

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -61,6 +61,7 @@
 #include "libmesh/ghost_point_neighbors.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/enum_to_string.h"
+#include "libmesh/elem_side_builder.h"
 
 static const int GRAIN_SIZE =
     1; // the grain_size does not have much influence on our execution speed
@@ -3863,6 +3864,9 @@ MooseMesh::buildFiniteVolumeInfo() const
     num_sides += elem->n_sides();
   }
 
+  // Used to speed up FaceInfo creation
+  libMesh::ElemSideBuilder side_builder;
+
   _all_face_info.reserve(num_sides / 2);
   dof_id_type face_index = 0;
   for (const Elem * elem : as_range(begin, end))
@@ -3882,7 +3886,7 @@ MooseMesh::buildFiniteVolumeInfo() const
                     "be active.");
 
         // We construct the faceInfo using the elementinfo and side index
-        _all_face_info.emplace_back(&_elem_to_elem_info[elem->id()], side, face_index++);
+        _all_face_info.emplace_back(&_elem_to_elem_info[elem->id()], side, face_index++, side_builder);
 
         auto & fi = _all_face_info.back();
 

--- a/unit/src/LimitersTest.C
+++ b/unit/src/LimitersTest.C
@@ -36,12 +36,13 @@ TEST(LimitersTest, limitVector)
   ReplicatedMesh mesh(app->comm(), /*dim=*/2);
   MeshTools::Generation::build_square(mesh, 2, 2);
   ElemInfo ei(mesh.elem_ptr(0));
+  libMesh::ElemSideBuilder side_builder;
 
   dof_id_type counter = 0;
   for (const auto s : ei.elem()->side_index_range())
     if (ei.elem()->neighbor_ptr(s))
     {
-      FaceInfo fi(&ei, s, counter++);
+      FaceInfo fi(&ei, s, counter++, side_builder);
       ElemInfo ni(ei.elem()->neighbor_ptr(s));
       fi.computeInternalCoefficients(&ni);
       auto result = interpolate(limiter, upwind, downwind, &grad, fi, true);

--- a/unit/src/MooseFunctorTest.C
+++ b/unit/src/MooseFunctorTest.C
@@ -126,7 +126,8 @@ TEST(MooseFunctorTest, testArgs)
 
   ElemInfo ei(elem.get());
   ElemInfo ni(neighbor.get());
-  FaceInfo fi(&ei, 1, 0);
+  libMesh::ElemSideBuilder side_builder;
+  FaceInfo fi(&ei, 1, 0, side_builder);
   fi.computeInternalCoefficients(&ni);
 
   QGauss qrule(1, CONSTANT);


### PR DESCRIPTION
see #31554 for before
now
```
Showing top 30 nodes out of 176
      flat  flat%   sum%        cum   cum%
     6.21s 19.73% 19.73%      6.57s 20.87%  tcmalloc::CentralFreeList::Populate
     5.76s 18.30% 38.02%      5.96s 18.93%  FaceInfo::FaceInfo
     1.75s  5.56% 43.58%      3.43s 10.90%  MooseMesh::cacheInfo
     1.57s  4.99% 48.57%      1.77s  5.62%  libMesh::DofMap::_dof_indices
     0.79s  2.51% 51.08%      8.66s 27.51%  tc_new
     0.70s  2.22% 53.30%      7.20s 22.87%  MooseMesh::buildFiniteVolumeInfo
     0.68s  2.16% 55.46%      0.68s  2.16%  hypre_BoomerAMGRelaxHybridGaussSeidel_core
     0.52s  1.65% 57.12%      1.23s  3.91%  libMesh::UnstructuredMesh::find_neighbors
     0.44s  1.40% 58.51%      0.44s  1.40%  MooseMesh::getNodeBlockIds
     0.44s  1.40% 59.91%      4.79s 15.22%  libMesh::SparsityPattern::Build::handle_vi_vj
     0.43s  1.37% 61.28%      0.49s  1.56%  PackedCache::TryGet
     0.41s  1.30% 62.58%     30.63s 97.30%  [libsasl2.2.dylib]
     0.39s  1.24% 63.82%      2.08s  6.61%  tc_delete
     0.38s  1.21% 65.03%      0.38s  1.21%  libMesh::Predicates::not_null::operator()
     0.36s  1.14% 66.17%      0.41s  1.30%  MatSetValues_SeqAIJ
     0.36s  1.14% 67.31%      0.36s  1.14%  std::__1::__cxx_atomic_load[abi:ne180100]
     0.36s  1.14% 68.46%      0.79s  2.51%  variant_filter_iterator::Pred::operator()
     0.34s  1.08% 69.54%      4.07s 12.93%  std::__1::vector::__insert_with_size[abi:ne180100]
     0.30s  0.95% 70.49%      1.03s  3.27%  std::__1::__hash_table::__emplace_unique_key_args
     0.29s  0.92% 71.41%      0.30s  0.95%  hypre_BoomerAMGBuildCoarseOperatorKT.omp_outlined.10
     0.26s  0.83% 72.24%      0.51s  1.62%  libMesh::StoredRange::reset
     0.24s  0.76% 73.00%      0.24s  0.76%  tcmalloc::Span::Span
     0.23s  0.73% 73.73%      0.32s  1.02%  tcmalloc::SLL_TryPop
     0.21s  0.67% 74.40%      0.55s  1.75%  ComputeLinearFVElementalThread::operator()
     0.19s   0.6% 75.00%      0.31s  0.98%  MooseMesh::updateActiveSemiLocalNodeRange
     0.19s   0.6% 75.60%      0.49s  1.56%  tcmalloc::ThreadCache::FreeList::Push
     0.17s  0.54% 76.14%      0.17s  0.54%  hypre_BoomerAMGBuildInterp.omp_outlined.9
     0.17s  0.54% 76.68%      0.30s  0.95%  tcmalloc::SLL_Push
     0.16s  0.51% 77.19%      0.16s  0.51%  tcmalloc::Sampler::TryRecordAllocationFast
     0.15s  0.48% 77.67%      0.25s  0.79%  std::__1::__hash_table::__do_rehash
```

I have a libMesh PR open to address 
```
     1.75s  5.56% 43.58%      3.43s 10.90%  MooseMesh::cacheInfo
```

The first commit in this PR addresses this item
```
    0.33s  0.82% 77.28%      0.36s   0.9%  std::__1::vector::__emplace_back_slow_path
```
The rest this item
```
    12.09s 30.22% 30.22%     12.86s 32.14%  FaceInfo::FaceInfo
```
