### PR TITLE
Remove libmesh dependency for capabilities library and fix test

### DIFF
--- a/framework/build.mk
+++ b/framework/build.mk
@@ -53,6 +53,11 @@ libmesh_LIBS     := $(shell METHOD=$(METHOD) $(libmesh_config) --libs)
 libmesh_HOST     := $(shell METHOD=$(METHOD) $(libmesh_config) --host)
 libmesh_LDFLAGS  := $(shell METHOD=$(METHOD) $(libmesh_config) --ldflags)
 
+# In the event that we're using something like mpicxx, query it for
+# the underlying compiler (like mpicxx -show); otherwise, fallback to
+# whatever libmesh_CXX is
+libmesh_UNDERLYING_CXX := $(shell ($(libmesh_CXX) -show 2>/dev/null || echo "$(libmesh_CXX)") | awk '{print $$1}')
+
 # You can completely disable timing by setting MOOSE_NO_PERF_GRAPH in your environment
 ifneq (x$(MOOSE_NO_PERF_GRAPH), x)
   libmesh_CXXFLAGS += -DMOOSE_NO_PERF_GRAPH

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -240,7 +240,7 @@ capabilities_LDFLAGS      := $(DYNAMIC_LOOKUP)
 
 capabilities $(capabilities_LIB) : $(capabilities_srcfiles)
 	@echo "Building and linking $(capabilities_LIB)..."
-	@bash -c '(cd "$(CAPABILITIES_DIR)" && $(libmesh_CXX) -I$(LIBMESH_DIR)/include -std=c++17 -w -fPIC -lstdc++ -shared $(capabilities_srcfiles) $(capabilities_COMPILEFLAGS) $(capabilities_LDFLAGS) $(libmesh_LIBS) $(LDFLAGS) $(libmesh_LDFLAGS) -o $(capabilities_LIB))'
+	@bash -c '(cd "$(CAPABILITIES_DIR)" && $(libmesh_CXX) -DMOOSESTRINGUTILS_NO_LIBMESH -std=c++17 -w -fPIC -lstdc++ -shared $(capabilities_srcfiles) $(capabilities_COMPILEFLAGS) $(capabilities_LDFLAGS) $(LDFLAGS) -o $(capabilities_LIB))'
 
 #
 # gtest

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -240,7 +240,7 @@ capabilities_LDFLAGS      := $(DYNAMIC_LOOKUP)
 
 capabilities $(capabilities_LIB) : $(capabilities_srcfiles)
 	@echo "Building and linking $(capabilities_LIB)..."
-	@bash -c '(cd "$(CAPABILITIES_DIR)" && $(libmesh_CXX) -DMOOSESTRINGUTILS_NO_LIBMESH -std=c++17 -w -fPIC -lstdc++ -shared $(capabilities_srcfiles) $(capabilities_COMPILEFLAGS) $(capabilities_LDFLAGS) $(LDFLAGS) -o $(capabilities_LIB))'
+	@bash -c '(cd "$(CAPABILITIES_DIR)" && $(libmesh_UNDERLYING_CXX) -DMOOSESTRINGUTILS_NO_LIBMESH -std=c++17 -w -fPIC -lstdc++ -shared $(capabilities_srcfiles) $(capabilities_COMPILEFLAGS) $(capabilities_LDFLAGS) $(LDFLAGS) -o $(capabilities_LIB))'
 
 #
 # gtest

--- a/python/pycapabilities/tests/test_capabilities.py
+++ b/python/pycapabilities/tests/test_capabilities.py
@@ -10,13 +10,10 @@
 
 import os
 import unittest
+import pycapabilities
 
 class TestCapabilities(unittest.TestCase):
     def test(self):
-
-        # Load the packages
-        import pycapabilities
-
         # Dummy capabilities
         cap = {
             'petsc': ['3.9.1', "PETSc doc"],


### PR DESCRIPTION
refs #31394, #31481, #31523, #31546

- Allows for disabling the use of libmesh libraries in `MooseStringUtils.h`
- Removes the libmesh dependency due to the above
- Fixes python test by not building `pycapabilities` within the unit test; something about importing within the test that changes the environment (still not sure why)