### PR TITLE
Update libmesh submodule, add intel compiler

### DIFF
--- a/apptainer/moose-dev.def
+++ b/apptainer/moose-dev.def
@@ -393,6 +393,17 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     rm -rf ${GOPATH} ${ROOT_BUILD_DIR}/go
 {%- endif %}
 
+    # Build and add pythonfmu only with GCC
+    COMPILER=$(mpicxx -show | awk '{ print $1 }')
+    if [ "$COMPILER" == "g++" ]; then
+        cd ${ROOT_BUILD_DIR}
+        git clone https://github.com/NTNU-IHB/PythonFMU.git
+        cd PythonFMU/
+        bash build_unix.sh
+        cd ${ROOT_BUILD_DIR}/PythonFMU
+        pip install .
+    fi
+
     # Clean up
     conda clean -ya
     dnf clean all

--- a/apptainer/mpi.def
+++ b/apptainer/mpi.def
@@ -41,11 +41,14 @@ Bootstrap: oras
 From: harbor.hpc.inl.gov/moose-base/rocky-x86_64:8.10-5
 {%- elif ALTERNATE_FROM == "cuda" %}
 From: harbor.hpc.inl.gov/moose-hpcbase/rocky-cuda-x86_64:8.10-cuda12.9-0
+{%- elif ALTERNATE_FROM == "intel" %}
+From: harbor.hpc.inl.gov/moose-hpcbase/rocky-intel-x86_64:8.10_0
 {%- else %}
 From: harbor.hpc.inl.gov/moose-hpcbase/rocky-x86_64:8.10-4
 {%- endif %}
 # Logan Harbour
 Fingerprints: 841AF5A51549CAFFFB474F65207184EA34A4BD48
+
 %environment
     # Fix locale warnings
     export LC_ALL=C

--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_mpi:
-  - moose-mpi 2025.08.06
+  - moose-mpi 2025.09.18
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 5 %}
+{% set build = 6 %}
 {% set vtk_version = "9.4.2" %}
 {% set vtk_friendly_version = "9.4" %}
 {% set sha256 = "36c98e0da96bb12a30fe53708097aa9492e7b66d5c3b366e1c8dc251e2856a02" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -3,12 +3,12 @@ mpi:
   - openmpi
 
 moose_petsc:
-  - moose-petsc 3.23.4 mpich_0
-  - moose-petsc 3.23.4 openmpi_0
+  - moose-petsc 3.23.4 mpich_1
+  - moose-petsc 3.23.4 openmpi_1
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.4.2 mpich_5
-  - moose-libmesh-vtk 9.4.2 openmpi_5
+  - moose-libmesh-vtk 9.4.2 mpich_6
+  - moose-libmesh-vtk 9.4.2 openmpi_6
 
 zip_keys:
   - mpi

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2025.08.06" %}
+{% set version = "2025.09.18" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,11 +3,11 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2025.08.06 mpich_0
-  - moose-libmesh 2025.08.06 openmpi_0
+  - moose-libmesh 2025.09.18 mpich_0
+  - moose-libmesh 2025.09.18 openmpi_0
 
 moose_wasp:
-  - moose-wasp 2025.09.04
+  - moose-wasp 2025.09.18
 
 moose_tools:
   - moose-tools 2025.06.26

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.09.15" %}
+{% set version = "2025.09.18" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -2,7 +2,7 @@ mpi:
   - mpich
 
 moose_dev:
-  - moose-dev 2025.09.15
+  - moose-dev 2025.09.18
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/mpi/meta.yaml
+++ b/conda/mpi/meta.yaml
@@ -6,7 +6,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2025.08.06" %}
+{% set version = "2025.09.18" %}
 
 package:
   name: moose-mpi

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_mpi:
-  - moose-mpi 2025.08.06
+  - moose-mpi 2025.09.18
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -7,7 +7,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = "3.23.4" %}
 
 package:

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2025.09.04" %}
+{% set version = "2025.09.18" %}
 
 package:
   name: moose-wasp

--- a/framework/contrib/cpp-peglib/include/peglib.h
+++ b/framework/contrib/cpp-peglib/include/peglib.h
@@ -489,7 +489,7 @@ inline constexpr unsigned int str2tag(std::string_view sv) {
 
 namespace udl {
 
-inline constexpr unsigned int operator"" _(const char *s, size_t l) {
+inline constexpr unsigned int operator""_(const char *s, size_t l) {
   return str2tag_core(s, l, 0);
 }
 

--- a/framework/include/restart/Restartable.h
+++ b/framework/include/restart/Restartable.h
@@ -42,14 +42,14 @@ public:
   class ManagedValue
   {
   public:
-    ManagedValue<T>(RestartableData<T> & value) : _value(value) {}
+    ManagedValue(RestartableData<T> & value) : _value(value) {}
 
     /**
      * Destructor.
      *
      * Destructs the managed restartable data.
      */
-    ~ManagedValue<T>() { _value.reset(); }
+    ~ManagedValue() { _value.reset(); }
 
     /**
      * Get the restartable value.

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1179,7 +1179,9 @@ MooseApp::registerCapabilities()
   // compiler
   {
     const auto doc = "Compiler used to build the MOOSE framework.";
-#if defined(__clang__)
+#if defined(__INTEL_LLVM_COMPILER)
+    addCapability("compiler", "intel", doc);
+#elif defined(__clang__)
     addCapability("compiler", "clang", doc);
 #elif defined(__GNUC__) || defined(__GNUG__)
     addCapability("compiler", "gcc", doc);

--- a/framework/src/utils/ADFParser.C
+++ b/framework/src/utils/ADFParser.C
@@ -33,7 +33,11 @@ ADFParser::JITCompile()
 
   std::string fopenmp;
 #if defined(_OPENMP)
+#if defined(__INTEL_LLVM_COMPILER)
+  fopenmp = "-qopenmp";
+#else
   fopenmp = "-fopenmp";
+#endif
 #endif
 
   const auto include_path_env = std::getenv("MOOSE_ADFPARSER_JIT_INCLUDE");

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1425,3 +1425,31 @@ a62abba3f218c71fadda32d9ca52b828abbbafbb: #31536; update code-server in apptaine
   wasp:
     full_version: 2025.09.04_0
     hash: 41363d4
+cf8fabc2a0944313bb3e5bf720972ba27d1a2a8b: #31560: update libmesh, wasp and add intel compiler, add pythonfmu to moose-dev container
+  libmesh:
+    full_version: 2025.09.18_0
+    hash: 748d6ae
+  libmesh-vtk:
+    full_version: 9.4.2_6
+    hash: d384dc6
+  moose-dev:
+    full_version: 2025.09.18
+    hash: 32e04eb
+  mpi:
+    full_version: 2025.09.18
+    hash: 37fd888
+  petsc:
+    full_version: 3.23.4_1
+    hash: 6c94cfc
+  pprof:
+    full_version: 2025.06.13
+    hash: 3d296db
+  seacas:
+    full_version: 2025.05.22_0
+    hash: '1278418'
+  tools:
+    full_version: 2025.06.26
+    hash: d73012a
+  wasp:
+    full_version: 2025.09.18_0
+    hash: 67c57c5

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -13,7 +13,7 @@ packages:
       conda/tools/meta.yaml.template: conda/tools/meta.yaml
   # dependers: libmesh-vtk, petsc, libmesh, moose-dev
   mpi:
-    version: 2025.08.06
+    version: 2025.09.18
     conda: conda/mpi
     templates:
       conda/mpi/meta.yaml.template: conda/mpi/meta.yaml
@@ -26,7 +26,7 @@ packages:
   # dependers: libmesh, moose-dev
   libmesh-vtk:
     version: 9.4.2
-    build_number: 5
+    build_number: 6
     conda: conda/libmesh-vtk
     templates:
       conda/libmesh-vtk/conda_build_config.yaml.template: conda/libmesh-vtk/conda_build_config.yaml
@@ -38,7 +38,7 @@ packages:
   # dependers: libmesh, moose-dev
   petsc:
     version: 3.23.4
-    build_number: 0
+    build_number: 1
     conda: conda/petsc
     templates:
       conda/petsc/conda_build_config.yaml.template: conda/petsc/conda_build_config.yaml
@@ -56,7 +56,7 @@ packages:
       - scripts/apple-silicon-hdf5-autogen.patch
   # dependers: moose-dev
   libmesh:
-    version: 2025.08.06
+    version: 2025.09.18
     build_number: 0
     conda: conda/libmesh
     templates:
@@ -75,7 +75,7 @@ packages:
       - scripts/update_and_rebuild_libmesh.sh
   # dependers: moose-dev
   wasp:
-    version: 2025.09.04
+    version: 2025.09.18
     build_number: 0
     conda: conda/wasp
     templates:
@@ -93,7 +93,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.09.15
+    version: 2025.09.18
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml


### PR DESCRIPTION
## Reason
Packages need to be updated. Summary below.

## Design
Update packages.

## Impact
New packages could cause issues.

## Summary of changes

- Update WASP submodule
- Update mpi container to support intel 
- Add pythonFMU in moose-dev container

### libMesh Changes

- Limited support for untangling of tangled meshes in `VariationalMeshSmoother`
- Support for smoothing meshes including pyramids with `VariationalMeshSmoother`
- Added `SparseMatrix::read_coreform_hdf5()` method for reading CSR sparse matrix data from an HDF5-based format
- Default to syncing C++ streams for more reliable console output in cases like threaded output
- Made `libMesh::out` and `libMesh::err` thread-safe even when emitting non-ASCII (unicode, color codes) output
- Made `prepare_for_use()` optional after mesh stitching.  This will enable much faster parallel generation of complex meshes in certain MOOSE workflows.
- Added optional parameter to `build_side_list_from_node_list()` to allow only some nodesets to be converted rather than all
- Added `Parameters::Value::type_info()` method
- Updated autotools to their latest versions.  This fixes a linker bug that was preventing libMesh compilation with some newer software stacks.
- Use `MatGetValue` instead of `MatGetRow` in `PetscMatrix::operator()`, to improve compatibility and efficiency
- `PerfLog` performance logging of Netgen tetrahedralization
- Bug fixes for parallel `StaticCondensation` operation
- Bug fix for certain use cases of `PetscVector` constructed directly from PETSc `Vec`
- Bug fix for triangulation of boundaries with quadratic edges
- Bug fix for an adaptive refinement failure case on distributed meshes
- Fixed handling of linearly-dependent data in reduced basis EIM training
- Fixed small `PetscViewer` memory leaks in `print_matlab()` methods