### PR TITLE
Macro assisted MooseEnum / C++ enum class pairing

### DIFF
--- a/framework/doc/content/source/utils/MooseEnum.md
+++ b/framework/doc/content/source/utils/MooseEnum.md
@@ -1,0 +1,83 @@
+# MooseEnum
+
+`MooseEnum` and `MultiMooseEnum` are utility types used throughout MOOSE for parameters with a fixed
+set of valid string values. They provide validation, optional defaults, and a convenient way to map
+validated input values back to C++ enums in implementation code.
+
+## `MooseEnum`
+
+`MooseEnum` stores one selected value from a list of valid options. The constructor takes a
+space-delimited list of allowed names and may also take a default value:
+
+```cpp
+MooseEnum point_not_found_behavior("ERROR WARNING IGNORE", "IGNORE");
+params.addParam<MooseEnum>("point_not_found_behavior",
+                           point_not_found_behavior,
+                           "Behavior to use when a point cannot be located.");
+```
+
+Values can optionally include explicit integer IDs using `=`:
+
+```cpp
+MooseEnum constant_on("NONE=0 ELEMENT=1 SUBDOMAIN=2", "NONE");
+```
+
+When a `MooseEnum` parameter is retrieved, it can be compared directly to strings or converted back
+to a C++ enum with `getEnum<T>()`:
+
+```cpp
+if (getParam<MooseEnum>("point_not_found_behavior") == "ERROR")
+  mooseError("Unable to locate point.");
+
+const auto behavior =
+    getParam<MooseEnum>("point_not_found_behavior").getEnum<PointNotFoundBehavior>();
+```
+
+## `MultiMooseEnum`
+
+`MultiMooseEnum` is the multi-select variant. It uses the same valid-name definition, but stores
+zero or more active values:
+
+```cpp
+params.addParam<MultiMooseEnum>("extra_symbols",
+                                MultiMooseEnum("x y z t dt"),
+                                "Special symbols to make available.");
+```
+
+The selected values can then be queried with methods such as `contains()` or iterated over.
+
+## `CreateMooseEnumClass`
+
+When code needs both a C++ `enum class` and a matching `MooseEnum` option string, the
+`CreateMooseEnumClass` macro in [`framework/include/utils/MooseEnum.h`](/framework/include/utils/MooseEnum.h)
+keeps those declarations in one place.
+
+For example:
+
+```cpp
+CreateMooseEnumClass(PointNotFoundBehavior, ERROR, WARNING, IGNORE);
+```
+
+This expands to:
+
+- an `enum class PointNotFoundBehavior`
+- a `getPointNotFoundBehaviorOptions()` helper returning the corresponding option string for
+  `MooseEnum` or `MultiMooseEnum`
+
+That helper can then be used directly in parameter declarations:
+
+```cpp
+params.addParam<MooseEnum>("point_not_found_behavior",
+                           MooseEnum(getPointNotFoundBehaviorOptions(), "IGNORE"),
+                           "Behavior to use when a point cannot be located.");
+```
+
+This pattern prevents the enum declaration and the valid input string from drifting apart during
+maintenance. Explicit integer assignments are also supported:
+
+```cpp
+CreateMooseEnumClass(ConstantTypeEnum, NONE = 0, ELEMENT = 1, SUBDOMAIN = 2);
+```
+
+The generated option helper will preserve those explicit values in the returned `MooseEnum` option
+string.

--- a/framework/include/constraints/EqualValueEmbeddedConstraint.h
+++ b/framework/include/constraints/EqualValueEmbeddedConstraint.h
@@ -11,6 +11,7 @@
 
 // MOOSE includes
 #include "GenericNodeElemConstraint.h"
+#include "MooseEnum.h"
 
 class DisplacedProblem;
 class FEProblemBase;
@@ -53,7 +54,7 @@ protected:
   FEProblem & _fe_problem;
 
   /// Formulations, currently only supports KINEMATIC and PENALTY
-  const enum class Formulation { KINEMATIC, PENALTY } _formulation;
+  CreateMooseEnumClass(Formulation, KINEMATIC, PENALTY) _formulation;
   /// Penalty parameter used in constraint enforcement for kinematic and penalty formulations
   const Real _penalty;
   /// copy of the residual before the constraint is applied

--- a/framework/include/dirackernels/DiracKernelBase.h
+++ b/framework/include/dirackernels/DiracKernelBase.h
@@ -18,6 +18,7 @@
 #include "MooseVariableField.h"
 #include "MooseVariableInterface.h"
 #include "BlockRestrictable.h"
+#include "MooseEnum.h"
 
 /**
  * DiracKernelBase is the base class for all DiracKernel type classes.
@@ -129,12 +130,7 @@ protected:
   const bool _drop_duplicate_points;
 
   // @{ Point-not-found behavior
-  enum class PointNotFoundBehavior
-  {
-    ERROR,
-    WARNING,
-    IGNORE
-  };
+  CreateMooseEnumClass(PointNotFoundBehavior, ERROR, WARNING, IGNORE);
   const PointNotFoundBehavior _point_not_found_behavior;
   // @}
 

--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -12,6 +12,7 @@
 // MOOOSE includes
 #include "MaterialBase.h"
 #include "Coupleable.h"
+#include "MooseEnum.h"
 #include "MaterialPropertyInterface.h"
 #include "FEProblemBase.h"
 
@@ -206,12 +207,7 @@ public:
   }
   virtual void subdomainSetup() override;
 
-  enum class ConstantTypeEnum
-  {
-    NONE,
-    ELEMENT,
-    SUBDOMAIN
-  };
+  CreateMooseEnumClass(ConstantTypeEnum, NONE, ELEMENT, SUBDOMAIN);
 
   bool ghostable() const override final { return _ghostable; }
 

--- a/framework/include/materials/ParsedMaterialHelper.h
+++ b/framework/include/materials/ParsedMaterialHelper.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "MooseEnum.h"
 #include "FunctionMaterialBase.h"
 #include "FunctionParserUtils.h"
 #include "FunctionMaterialPropertyDescriptor.h"
@@ -44,20 +45,8 @@ class ParsedMaterialHelper : public FunctionMaterialBase<is_ad>, public Function
 public:
   typedef DerivativeMaterialPropertyNameInterface::SymbolName SymbolName;
 
-  enum class VariableNameMappingMode
-  {
-    USE_MOOSE_NAMES,
-    USE_PARAM_NAMES
-  };
-
-  enum class ExtraSymbols
-  {
-    x,
-    y,
-    z,
-    t,
-    dt
-  };
+  CreateMooseEnumClass(VariableNameMappingMode, USE_MOOSE_NAMES, USE_PARAM_NAMES);
+  CreateMooseEnumClass(ExtraSymbols, x, y, z, t, dt);
 
   ParsedMaterialHelper(const InputParameters & parameters,
                        const VariableNameMappingMode map_mode,

--- a/framework/include/meshgenerators/ElementOrderConversionGenerator.h
+++ b/framework/include/meshgenerators/ElementOrderConversionGenerator.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "MeshGenerator.h"
+#include "MooseEnum.h"
 
 class ElementOrderConversionGenerator : public MeshGenerator
 {
@@ -20,13 +21,8 @@ public:
 
   virtual std::unique_ptr<MeshBase> generate() override;
 
-  enum class OrderConversionType
-  {
-    FIRST_ORDER,
-    SECOND_ORDER_NONFULL,
-    SECOND_ORDER,
-    COMPLETE_ORDER
-  };
+  CreateMooseEnumClass(
+      OrderConversionType, FIRST_ORDER, SECOND_ORDER_NONFULL, SECOND_ORDER, COMPLETE_ORDER);
 
 protected:
   ///The input mesh

--- a/framework/include/meshmodifiers/ActivateElementsCoupled.h
+++ b/framework/include/meshmodifiers/ActivateElementsCoupled.h
@@ -27,5 +27,5 @@ protected:
   /// variable value to decide wether an element whould be activated
   const Real _activate_value;
   /// type of activation - blow or above
-  const enum class ActivateType { BELOW, EQUAL, ABOVE } _activate_type;
+  CreateMooseEnumClass(ActivateType, BELOW, EQUAL, ABOVE) _activate_type;
 };

--- a/framework/include/utils/MooseEnum.h
+++ b/framework/include/utils/MooseEnum.h
@@ -11,8 +11,29 @@
 
 // MOOSE includes
 #include "MooseEnumBase.h"
+#include "MooseStringUtils.h"
+#include "MooseUtils.h"
 
 #include <optional>
+#include <cctype>
+#include <algorithm>
+
+#define CreateMooseEnumClass(EnumName, /* enumerators */...)                                       \
+  static inline std::string get##EnumName##Options()                                               \
+  {                                                                                                \
+    /* 1) stringify the enumerator list                                               */           \
+    std::string s = #__VA_ARGS__;                                                                  \
+    /* 2) normalize to the format MooseEnum expects: "A B C=3 D ..."                  */           \
+    std::vector<std::string> elements;                                                             \
+    MooseUtils::tokenize(s, elements, 1, ",");                                                     \
+    for (auto & elem : elements)                                                                   \
+      elem.erase(std::remove_if(elem.begin(), elem.end(), isspace), elem.end());                   \
+    return MooseUtils::join(elements, " ");                                                        \
+  }                                                                                                \
+  enum class EnumName                                                                              \
+  {                                                                                                \
+    __VA_ARGS__                                                                                    \
+  }
 
 // Forward declarations
 namespace libMesh

--- a/framework/src/constraints/EqualValueEmbeddedConstraint.C
+++ b/framework/src/constraints/EqualValueEmbeddedConstraint.C
@@ -17,7 +17,6 @@
 #include "Assembly.h"
 #include "MooseMesh.h"
 #include "AddVariableAction.h"
-#include "MooseEnum.h"
 
 #include "libmesh/sparse_matrix.h"
 
@@ -33,7 +32,7 @@ EqualValueEmbeddedConstraintTempl<is_ad>::validParams()
   params.addClassDescription("This is a constraint enforcing overlapping portions of two blocks to "
                              "have the same variable value");
   params.set<bool>("use_displaced_mesh") = false;
-  MooseEnum formulation("kinematic penalty", "kinematic");
+  MooseEnum formulation(getFormulationOptions(), "kinematic");
   params.addParam<MooseEnum>(
       "formulation", formulation, "Formulation used to enforce the constraint");
   params.addRequiredParam<Real>(

--- a/framework/src/dirackernels/DiracKernelBase.C
+++ b/framework/src/dirackernels/DiracKernelBase.C
@@ -37,10 +37,9 @@ DiracKernelBase::validParams()
       "has been added before. If this option is set to false duplicate points are retained"
       "and contribute to residual and Jacobian.");
 
-  MooseEnum point_not_found_behavior("ERROR WARNING IGNORE", "IGNORE");
   params.addParam<MooseEnum>(
       "point_not_found_behavior",
-      point_not_found_behavior,
+      MooseEnum(getPointNotFoundBehaviorOptions(), "IGNORE"),
       "By default (IGNORE), it is ignored if an added point cannot be located in the "
       "specified subdomains. If this option is set to ERROR, this situation will result in an "
       "error. If this option is set to WARNING, then a warning will be issued.");

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -16,10 +16,9 @@ Material::validParams()
 
   InputParameters params = MaterialBase::validParams();
   params += MaterialPropertyInterface::validParams();
-  MooseEnum const_option("NONE=0 ELEMENT=1 SUBDOMAIN=2", "none");
   params.addParam<MooseEnum>(
       "constant_on",
-      const_option,
+      MooseEnum(getConstantTypeEnumOptions(), "none"),
       "When ELEMENT, MOOSE will only call computeQpProperties() for the 0th "
       "quadrature point, and then copy that value to the other qps."
       "When SUBDOMAIN, MOOSE will only call computeQpProperties() for the 0th "

--- a/framework/src/materials/ParsedMaterialHelper.C
+++ b/framework/src/materials/ParsedMaterialHelper.C
@@ -23,10 +23,9 @@ ParsedMaterialHelper<is_ad>::validParams()
                         true,
                         "Throw an error if any explicitly requested material property does not "
                         "exist. Otherwise assume it to be zero.");
-  MultiMooseEnum extra_symbols("x y z t dt");
   params.addParam<MultiMooseEnum>(
       "extra_symbols",
-      extra_symbols,
+      getExtraSymbolsOptions(),
       "Special symbols, like point coordinates, time, and timestep size.");
   params.addParam<std::vector<MaterialName>>(
       "upstream_materials",

--- a/framework/src/materials/ParsedMaterialHelper.C
+++ b/framework/src/materials/ParsedMaterialHelper.C
@@ -25,7 +25,7 @@ ParsedMaterialHelper<is_ad>::validParams()
                         "exist. Otherwise assume it to be zero.");
   params.addParam<MultiMooseEnum>(
       "extra_symbols",
-      getExtraSymbolsOptions(),
+      MultiMooseEnum(getExtraSymbolsOptions()),
       "Special symbols, like point coordinates, time, and timestep size.");
   params.addParam<std::vector<MaterialName>>(
       "upstream_materials",

--- a/framework/src/meshgenerators/ElementOrderConversionGenerator.C
+++ b/framework/src/meshgenerators/ElementOrderConversionGenerator.C
@@ -20,15 +20,11 @@ InputParameters
 ElementOrderConversionGenerator::validParams()
 {
   InputParameters params = MeshGenerator::validParams();
-
-  MooseEnum conversion_type("FIRST_ORDER SECOND_ORDER_NONFULL SECOND_ORDER COMPLETE_ORDER",
-                            "FIRST_ORDER");
-
   params.addClassDescription("Mesh generator which converts orders of elements");
   params.addRequiredParam<MeshGeneratorName>("input", "The mesh we want to modify");
-  params.addParam<MooseEnum>(
-      "conversion_type", conversion_type, "The type of element order conversion to perform");
-
+  params.addParam<MooseEnum>("conversion_type",
+                             MooseEnum(getOrderConversionTypeOptions()),
+                             "The type of element order conversion to perform");
   return params;
 }
 

--- a/framework/src/meshgenerators/ElementOrderConversionGenerator.C
+++ b/framework/src/meshgenerators/ElementOrderConversionGenerator.C
@@ -23,7 +23,7 @@ ElementOrderConversionGenerator::validParams()
   params.addClassDescription("Mesh generator which converts orders of elements");
   params.addRequiredParam<MeshGeneratorName>("input", "The mesh we want to modify");
   params.addParam<MooseEnum>("conversion_type",
-                             MooseEnum(getOrderConversionTypeOptions()),
+                             MooseEnum(getOrderConversionTypeOptions(), "FIRST_ORDER"),
                              "The type of element order conversion to perform");
   return params;
 }

--- a/framework/src/meshmodifiers/ActivateElementsCoupled.C
+++ b/framework/src/meshmodifiers/ActivateElementsCoupled.C
@@ -21,7 +21,7 @@ ActivateElementsCoupled::validParams()
       "coupled_var",
       "The variable value will be used to decide wether an element whould be activated.");
   params.addParam<MooseEnum>("activate_type",
-                             MooseEnum("below equal above", "above"),
+                             MooseEnum(getActivateTypeOptions(), "above"),
                              "Activate element when below or above the activate_value");
   return params;
 }

--- a/modules/contact/include/actions/ContactAction.h
+++ b/modules/contact/include/actions/ContactAction.h
@@ -13,29 +13,16 @@
 #include "MooseTypes.h"
 #include "MooseEnum.h"
 
-enum class ContactModel
-{
-  FRICTIONLESS,
-  GLUED,
-  COULOMB
-};
-
-enum class ContactFormulation
-{
-  RANFS,
-  KINEMATIC,
-  PENALTY,
-  AUGMENTED_LAGRANGE,
-  TANGENTIAL_PENALTY,
-  MORTAR,
-  MORTAR_PENALTY
-};
-
-enum class ProximityMethod
-{
-  NODE,
-  CENTROID
-};
+CreateMooseEnumClass(ContactModel, FRICTIONLESS, GLUED, COULOMB);
+CreateMooseEnumClass(ContactFormulation,
+                     RANFS,
+                     KINEMATIC,
+                     PENALTY,
+                     AUGMENTED_LAGRANGE,
+                     TANGENTIAL_PENALTY,
+                     MORTAR,
+                     MORTAR_PENALTY);
+CreateMooseEnumClass(ProximityMethod, NODE, CENTROID);
 
 /**
  * Action class for creating constraints, kernels, and user objects necessary for mechanical

--- a/modules/contact/src/actions/ContactAction.C
+++ b/modules/contact/src/actions/ContactAction.C
@@ -1578,21 +1578,19 @@ ContactAction::createSidesetPairsFromGeometry()
 MooseEnum
 ContactAction::getModelEnum()
 {
-  return MooseEnum("frictionless glued coulomb", "frictionless");
+  return MooseEnum(getContactModelOptions(), "frictionless");
 }
 
 MooseEnum
 ContactAction::getProximityMethod()
 {
-  return MooseEnum("node centroid");
+  return MooseEnum(getProximityMethodOptions());
 }
 
 MooseEnum
 ContactAction::getFormulationEnum()
 {
-  auto formulations = MooseEnum(
-      "ranfs kinematic penalty augmented_lagrange tangential_penalty mortar mortar_penalty",
-      "kinematic");
+  auto formulations = MooseEnum(getContactFormulationOptions(), "kinematic");
 
   formulations.addDocumentation(
       "ranfs",

--- a/modules/doc/content/framework_development/utils/index.md
+++ b/modules/doc/content/framework_development/utils/index.md
@@ -10,4 +10,6 @@ These objects are documented here.
 
 [MathUtils.md]
 
+[MooseEnum](MooseEnum.md)
+
 [MooseUtils namespace](/MooseUtils.md)

--- a/modules/doc/content/newsletter/2026/2026_03.md
+++ b/modules/doc/content/newsletter/2026/2026_03.md
@@ -7,6 +7,30 @@ for a complete description of all MOOSE changes.
 
 ## MOOSE Improvements
 
+### Single-source enum declarations for `MooseEnum`
+
+MOOSE now provides a `CreateMooseEnumClass` macro for cases where a C++ `enum class` and a corresponding
+`MooseEnum` or `MultiMooseEnum` option list need to stay synchronized. The macro declares the enum and
+generates a matching `get...Options()` helper, so the valid string options no longer need to be repeated
+manually in a separate location.
+
+This removes a common source of maintenance errors where one enum value list could be updated without
+updating the associated parameter options. The new pattern is now used in several framework and module
+classes, including contact formulations, material `constant_on` modes, and parsed material extra symbols.
+
+For example, code that previously required both an `enum class` declaration and a separate string such as
+`"ERROR WARNING IGNORE"` can now be written once as:
+
+```cpp
+CreateMooseEnumClass(PointNotFoundBehavior, ERROR, WARNING, IGNORE);
+```
+
+and used with:
+
+```cpp
+MooseEnum(getPointNotFoundBehaviorOptions(), "IGNORE")
+```
+
 ## MOOSE Bug Fixes
 
 ## MOOSE Modules Changes

--- a/modules/solid_mechanics/include/materials/ComputeFiniteStrain.h
+++ b/modules/solid_mechanics/include/materials/ComputeFiniteStrain.h
@@ -24,13 +24,7 @@ public:
 
   void computeProperties() override;
 
-  enum class DecompMethod
-  {
-    TaylorExpansion,
-    EigenSolution,
-    HughesWinget
-  };
-
+  CreateMooseEnumClass(DecompMethod, TaylorExpansion, EigenSolution, HughesWinget);
   static MooseEnum decompositionType();
 
 protected:

--- a/modules/solid_mechanics/src/materials/ComputeFiniteStrain.C
+++ b/modules/solid_mechanics/src/materials/ComputeFiniteStrain.C
@@ -16,7 +16,7 @@
 MooseEnum
 ComputeFiniteStrain::decompositionType()
 {
-  return MooseEnum("TaylorExpansion EigenSolution HughesWinget", "TaylorExpansion");
+  return MooseEnum(getDecompMethodOptions(), "TaylorExpansion");
 }
 
 registerMooseObject("SolidMechanicsApp", ComputeFiniteStrain);

--- a/unit/src/CreateMooseEnumTest.C
+++ b/unit/src/CreateMooseEnumTest.C
@@ -1,0 +1,49 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest/gtest.h"
+
+#include "MooseEnum.h"
+
+TEST(CreateMooseEnumTest, defaultValues)
+{
+  struct C
+  {
+    CreateMooseEnumClass(DefaultValue, ZERO, ONE, TWO, THREE, FOUR, FIVE, SIX, SEVEN);
+    CreateMooseEnumClass(ExplicitDefaultValue, ZERO = 0, ONE, TWO, THREE, FOUR, FIVE, SIX, SEVEN);
+  };
+  EXPECT_EQ(C::getDefaultValueOptions(), "ZERO ONE TWO THREE FOUR FIVE SIX SEVEN");
+  EXPECT_EQ(C::getExplicitDefaultValueOptions(), "ZERO=0 ONE TWO THREE FOUR FIVE SIX SEVEN");
+}
+
+TEST(CreateMooseEnumTest, explicitIntegers)
+{
+  struct C
+  {
+    CreateMooseEnumClass(Offset, TWO = 2, THREE, FOUR, FIVE, SIX, SEVEN);
+    CreateMooseEnumClass(Bounce, TWO = 2, FOUR = 4, FIVE, THREE = 3, SIX = 6, SEVEN);
+    CreateMooseEnumClass(Skip, ONE, TWO, THREE, FIVE = 5, SIX, SEVEN);
+  };
+  EXPECT_EQ(C::getOffsetOptions(), "TWO=2 THREE FOUR FIVE SIX SEVEN");
+  EXPECT_EQ(C::getBounceOptions(), "TWO=2 FOUR=4 FIVE THREE=3 SIX=6 SEVEN");
+  EXPECT_EQ(C::getSkipOptions(), "ONE TWO THREE FIVE=5 SIX SEVEN");
+
+  EXPECT_EQ(static_cast<int>(C::Offset::FIVE), 5);
+  EXPECT_EQ(static_cast<int>(C::Bounce::THREE), 3);
+  EXPECT_EQ(static_cast<int>(C::Skip::SEVEN), 7);
+}
+
+TEST(CreateMooseEnumTest, member)
+{
+  struct C
+  {
+    CreateMooseEnumClass(Number, THREE = 3, FOUR, FIVE, SIX, SEVEN) number = static_cast<Number>(6);
+  } c;
+  EXPECT_EQ(c.number, C::Number::SIX);
+}


### PR DESCRIPTION
Closes #26278

Our minimum compiler requirements are now recent enough to support this (gee I hope it works with Intel...).

Anyways, this has been requested befor (e.g. by @tophmatthews). With this capability we can automatically create the option lists for `MooseEnum`s so that they are guaranteed to match a given C++ `enum class` (and there is no risk of them getting out of sync, which can introduce subtle errors, where parameter values are not what they seem).

I'll probably prune the magic enum contrib a bit, because we only really need one of the includes currently.