### PR TITLE
Enable builds of MFEM at multiple optimisation levels

### DIFF
--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -167,7 +167,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
         export MOOSE_DIR=${MOOSE_DIR_REAL}
     fi
 
-    # Remove the libmesh methods from moose-dev that we do not need
+    # Remove the libmesh, mfem and neml2 methods from moose-dev that we do not need
     for method in opt oprof devel dbg; do
         if [ "$method" == "$METHOD" ]; then
             continue
@@ -177,6 +177,11 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
         find ${LIBMESH_DIR}/lib -name "*_$method.la" -delete -print
         find ${LIBMESH_DIR}/bin -name "*-$method" -delete -print
         find ${LIBMESH_DIR} -name "*-$method.pc" -delete -print
+        # mfem
+        if [ -n "$WITH_MFEM" ]; then
+            find ${MFEM_DIR}/include/mfem/config -name _config-$method.hpp -delete -print
+            find ${MFEM_DIR}/lib -name "libmfem*-$method*" -delete -print
+        fi
         # neml2
         if [ -n "$NEML2_DIR" ]; then
             if [ "$method" == "devel" ]; then

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.09.18" %}
+{% set version = "2025.10.02" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -2,7 +2,7 @@ mpi:
   - mpich
 
 moose_dev:
-  - moose-dev 2025.09.18
+  - moose-dev 2025.10.02
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/framework/include/actions/ActionFactory.h
+++ b/framework/include/actions/ActionFactory.h
@@ -20,8 +20,6 @@
 /**
  * Macros
  */
-#define stringifyName(name) #name
-
 #define registerSyntax(action, action_syntax)                                                      \
   syntax.registerActionSyntax(action, action_syntax, "", __FILE__, __LINE__)
 #define registerSyntaxTask(action, action_syntax, task)                                            \

--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -18,6 +18,9 @@
 #include <set>
 #include <string>
 
+#define QUOTE(macro) stringifyName(macro)
+#define stringifyName(name) #name
+
 namespace libMesh
 {
 template <typename>
@@ -327,3 +330,20 @@ std::string hitMessagePrefix(const hit::Node & node);
 #endif
 
 } // namespace Moose
+
+// If we are using MFEM, in addition to the checks we do as part of the build system in moose.mk,
+// we check at compile time if both MOOSE and MFEM were built in dbg mode or not
+#ifdef MOOSE_MFEM_ENABLED
+#include "libmesh/ignore_warnings.h"
+#include <mfem.hpp>
+#include "libmesh/restore_warnings.h"
+#ifdef MFEM_DEBUG
+static_assert(std::string_view(QUOTE(METHOD)) == "dbg",
+              "MFEM was built in dbg mode, but not MOOSE. Try reinstalling "
+              "MFEM using the scripts/update_and_rebuild_mfem.sh script.");
+#else
+static_assert(std::string_view(QUOTE(METHOD)) != "dbg",
+              "MOOSE was built in dbg mode, but not MFEM. Try reinstalling "
+              "MFEM using the scripts/update_and_rebuild_mfem.sh script.");
+#endif
+#endif

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -163,33 +163,33 @@ endif
 # Conditional parts if the user wants to compile MOOSE with mfem
 #
 ifeq ($(ENABLE_MFEM),true)
-	MFEM_LIB := libmfem.$(lib_suffix)
-	MFEM_COMMON_LIB := libmfem-common.$(lib_suffix)
+  MFEM_LIB := libmfem-$(METHOD).$(lib_suffix)
+  MFEM_COMMON_LIB := libmfem-common-$(METHOD).$(lib_suffix)
 
   ifneq ($(and $(wildcard $(MFEM_DIR)/lib/$(MFEM_LIB)), $(wildcard $(MFEM_DIR)/lib/$(MFEM_COMMON_LIB))),)
     # Adding the include directories
-	  include $(MFEM_DIR)/share/mfem/config.mk
-	  libmesh_CPPFLAGS += $(MFEM_INCFLAGS)
+    include $(MFEM_DIR)/share/mfem/config.mk
+    libmesh_CPPFLAGS += $(MFEM_INCFLAGS) -DMFEM_CONFIG_FILE=\"_config-$(METHOD).hpp\"
 
     # Dynamically linking with the available MFEM library
-	  ifeq ($(shell uname -s),Darwin)
-	  	libmesh_LDFLAGS += -Wl,-rpath,$(MFEM_DIR)/lib
-	  else
-	    libmesh_LDFLAGS += -Wl,--copy-dt-needed-entries,-rpath,$(MFEM_DIR)/lib
-	  endif
+    ifeq ($(shell uname -s),Darwin)
+      libmesh_LDFLAGS += -Wl,-rpath,$(MFEM_DIR)/lib
+    else
+      libmesh_LDFLAGS += -Wl,--copy-dt-needed-entries,-rpath,$(MFEM_DIR)/lib
+    endif
 
-    libmesh_LDFLAGS += -L$(MFEM_DIR)/lib -lmfem -lmfem-common
+    libmesh_LDFLAGS += -L$(MFEM_DIR)/lib -lmfem-$(METHOD) -lmfem-common-$(METHOD)
 
   else
     # No mfem library found
     $(eval $(call check_library_should_error,mfem))
 
     ifeq ($(mfem_should_error),true)
-      $(error ERROR! Cannot locate libmfem and libmfem-common. Make sure to install mfem before compiling MOOSE!)
+      $(error ERROR! Cannot locate libmfem-$(METHOD) and libmfem-common-$(METHOD). Make sure to install mfem before compiling MOOSE!)
     else
       $(info Skipping libmfem error check for targets that don't involve compilation!)
     endif
-	endif
+  endif
 endif
 
 #

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -89,8 +89,6 @@
 
 using namespace libMesh;
 
-#define QUOTE(macro) stringifyName(macro)
-
 void
 MooseApp::addAppParam(InputParameters & params)
 {

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1453,3 +1453,31 @@ cf8fabc2a0944313bb3e5bf720972ba27d1a2a8b: #31560: update libmesh, wasp and add i
   wasp:
     full_version: 2025.09.18_0
     hash: 67c57c5
+05e79fdc1ae205324f9774332c207dc5738086ca:
+  libmesh:
+    full_version: 2025.09.18_0
+    hash: 748d6ae
+  libmesh-vtk:
+    full_version: 9.4.2_6
+    hash: d384dc6
+  moose-dev:
+    full_version: 2025.10.02
+    hash: '9371540'
+  mpi:
+    full_version: 2025.09.18
+    hash: 37fd888
+  petsc:
+    full_version: 3.23.4_1
+    hash: 6c94cfc
+  pprof:
+    full_version: 2025.06.13
+    hash: 3d296db
+  seacas:
+    full_version: 2025.05.22_0
+    hash: '1278418'
+  tools:
+    full_version: 2025.06.26
+    hash: d73012a
+  wasp:
+    full_version: 2025.09.18_0
+    hash: 67c57c5

--- a/scripts/update_and_rebuild_mfem.sh
+++ b/scripts/update_and_rebuild_mfem.sh
@@ -100,18 +100,9 @@ SUPPORTED_METHODS="oprof devel dbg opt"
 # otherwise default to building all supported methods listed above
 : ${METHODS:=${METHOD:-$SUPPORTED_METHODS}}
 
-# oprof is treated differently, as an alias to devel, and not built separately
-[[ $METHODS =~ oprof ]] && OPROF_REQUESTED=TRUE
-
-# If oprof is requested, build devel instead
-if [ -n $OPROF_REQUESTED ]; then
-  [[ $METHODS =~ devel ]] && METHODS=${METHODS/oprof/}
-  METHODS=${METHODS/oprof/devel}
-fi
-
 # Map from the supported libMesh-like methods to CMake's build types
 typeset -A METHOD_TO_CMAKE_BUILD_TYPE_MAP
-METHOD_TO_CMAKE_BUILD_TYPE_MAP=([devel]=RELWITHDEBINFO [dbg]=DEBUG [opt]=RELEASE)
+METHOD_TO_CMAKE_BUILD_TYPE_MAP=([oprof]=PROFILE [devel]=RELWITHDEBINFO [dbg]=DEBUG [opt]=RELEASE)
 
 # The order here, i.e. in METHODS, _is_ important: the libraries for the last
 # of the requested methods will be available for external use (see below)
@@ -134,6 +125,8 @@ do
       -DCMAKE_${CMAKE_BUILD_TYPE}_POSTFIX=-$METHOD \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=YES \
       -DCMAKE_INSTALL_PREFIX="$MFEM_DIR" \
+      -DCMAKE_CXX_FLAGS_PROFILE="-O2 -g -DNDEBUG -fno-omit-frame-pointer" \
+      -DCMAKE_CUDA_FLAGS_PROFILE="-O2 -g -DNDEBUG -fno-omit-frame-pointer" \
       \
       -DMFEM_ENABLE_MINIAPPS=YES \
       \
@@ -174,9 +167,3 @@ do
   ln -sf _config-$METHOD.hpp "$MFEM_DIR/include/mfem/config/_config.hpp"
   for lib in "$MFEM_DIR"/lib/libmfem*-$METHOD*; do ln -sf $(basename "$lib") "${lib/-$METHOD/}"; done
 done
-
-# If oprof is requested, symlink headers/libraries to its devel counterparts
-if [ -n $OPROF_REQUESTED ]; then
-  ln -sf _config-devel.hpp "$MFEM_DIR/include/mfem/config/_config-oprof.hpp"
-  for lib in "$MFEM_DIR"/lib/libmfem*-devel*; do ln -sf $(basename "$lib") "${lib/-devel/-oprof}"; done
-fi

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -93,7 +93,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.09.18
+    version: 2025.10.02
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml


### PR DESCRIPTION
## Reason
We'd like to have (coexisting) `dbg` and `opt` builds of MFEM that MOOSE `dbg` and `opt` binaries can, respectively, link to. Debug builds include debugging info and assertions, which we are otherwise missing on (most notably on CIVET runs).

## Design
We compile from `devel`, `dbg` and `opt` versions of the MFEM library (as requested by the user, but all by default), corresponding respectively to the CMake build types `RelWithDebInfo`, `Debug`, and `Release`. We use `CMAKE_<CONFIG>_POSTFIX` to distinguish the different libraries and manually save different versions of `_config.hpp`, which we then use when building each MOOSE build. We don't compile examples anymore to recover some of the cost of compiling MFEM multiple times (to expedite this further, we could skip `devel` by default, thoughts?). Though irrelevant for MOOSE apps, we also create symlinks to the last built version of the MFEM library (note we can control this by writing the desired method last in `METHOD(S)`) to restore the default library and header names MFEM's `config.mk` and non-MOOSE apps will be expecting.

## Impact
Better debugging and code correctness checks. People will need to rerun `update_and_rebuild_mfem.sh` when this is merged because MOOSE now looks for the postfixed MFEM libraries and config header, which didn't exist before.
