### PR TITLE
Make recently updated xfem test pass on valgrind 

### DIFF
--- a/modules/xfem/test/tests/moving_interface/moving_diffusion.i
+++ b/modules/xfem/test/tests/moving_interface/moving_diffusion.i
@@ -133,8 +133,8 @@
   l_max_its = 20
   l_tol = 1e-3
   nl_max_its = 15
-  nl_rel_tol = 1e-12
-  nl_abs_tol = 1e-12
+  nl_rel_tol = 1e-10
+  nl_abs_tol = 1e-10
 
   start_time = 0.0
   dt = 1


### PR DESCRIPTION
closes #31578

It passed everywhere else but failed the valgrind tests because on one step, it didn't quite converge to the 1e-12 tolerance (but it got very close). The test still passes with significantly looser tolerances. This should pass everywhere.
