### PR TITLE
Update Kokkos nodal kernel interface for AuxKernel implementation

### DIFF
--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -1845,9 +1845,10 @@ public:
                                                                        unsigned int comp = 0);
   Moose::Kokkos::VariableGradient
   kokkosCoupledVectorTagGradientsByName(const std::string & var_name, const std::string & tag_name);
-  Moose::Kokkos::VariableNodalValue kokkosCoupledVectorTagNodalValueByName(
-      const std::string & var_name, const std::string & tag_name, unsigned int comp = 0);
-  Moose::Kokkos::VariableNodalValue
+  Moose::Kokkos::VariableValue kokkosCoupledVectorTagNodalValueByName(const std::string & var_name,
+                                                                      const std::string & tag_name,
+                                                                      unsigned int comp = 0);
+  Moose::Kokkos::VariableValue
   kokkosCoupledVectorTagNodalValuesByName(const std::string & var_name,
                                           const std::string & tag_name);
 
@@ -1861,9 +1862,10 @@ public:
                                                                  unsigned int comp = 0);
   Moose::Kokkos::VariableGradient
   kokkosCoupledVectorTagGradients(const std::string & var_name, const std::string & tag_param_name);
-  Moose::Kokkos::VariableNodalValue kokkosCoupledVectorTagNodalValue(
-      const std::string & var_name, const std::string & tag_param_name, unsigned int comp = 0);
-  Moose::Kokkos::VariableNodalValue
+  Moose::Kokkos::VariableValue kokkosCoupledVectorTagNodalValue(const std::string & var_name,
+                                                                const std::string & tag_param_name,
+                                                                unsigned int comp = 0);
+  Moose::Kokkos::VariableValue
   kokkosCoupledVectorTagNodalValues(const std::string & var_name,
                                     const std::string & tag_param_name);
 
@@ -1873,9 +1875,9 @@ public:
   Moose::Kokkos::VariableGradient kokkosCoupledGradient(const std::string & var_name,
                                                         unsigned int comp = 0);
   Moose::Kokkos::VariableGradient kokkosCoupledGradients(const std::string & var_name);
-  Moose::Kokkos::VariableNodalValue kokkosCoupledNodalValue(const std::string & var_name,
-                                                            unsigned int comp = 0);
-  Moose::Kokkos::VariableNodalValue kokkosCoupledNodalValues(const std::string & var_name);
+  Moose::Kokkos::VariableValue kokkosCoupledNodalValue(const std::string & var_name,
+                                                       unsigned int comp = 0);
+  Moose::Kokkos::VariableValue kokkosCoupledNodalValues(const std::string & var_name);
 
   Moose::Kokkos::VariableValue kokkosCoupledValueOld(const std::string & var_name,
                                                      unsigned int comp = 0);
@@ -1883,9 +1885,9 @@ public:
   Moose::Kokkos::VariableGradient kokkosCoupledGradientOld(const std::string & var_name,
                                                            unsigned int comp = 0);
   Moose::Kokkos::VariableGradient kokkosCoupledGradientsOld(const std::string & var_name);
-  Moose::Kokkos::VariableNodalValue kokkosCoupledNodalValueOld(const std::string & var_name,
-                                                               unsigned int comp = 0);
-  Moose::Kokkos::VariableNodalValue kokkosCoupledNodalValuesOld(const std::string & var_name);
+  Moose::Kokkos::VariableValue kokkosCoupledNodalValueOld(const std::string & var_name,
+                                                          unsigned int comp = 0);
+  Moose::Kokkos::VariableValue kokkosCoupledNodalValuesOld(const std::string & var_name);
 
   Moose::Kokkos::VariableValue kokkosCoupledValueOlder(const std::string & var_name,
                                                        unsigned int comp = 0);
@@ -1893,23 +1895,23 @@ public:
   Moose::Kokkos::VariableGradient kokkosCoupledGradientOlder(const std::string & var_name,
                                                              unsigned int comp = 0);
   Moose::Kokkos::VariableGradient kokkosCoupledGradientsOlder(const std::string & var_name);
-  Moose::Kokkos::VariableNodalValue kokkosCoupledNodalValueOlder(const std::string & var_name,
-                                                                 unsigned int comp = 0);
-  Moose::Kokkos::VariableNodalValue kokkosCoupledNodalValuesOlder(const std::string & var_name);
+  Moose::Kokkos::VariableValue kokkosCoupledNodalValueOlder(const std::string & var_name,
+                                                            unsigned int comp = 0);
+  Moose::Kokkos::VariableValue kokkosCoupledNodalValuesOlder(const std::string & var_name);
 
   Moose::Kokkos::VariableValue kokkosCoupledDot(const std::string & var_name,
                                                 unsigned int comp = 0);
   Moose::Kokkos::VariableValue kokkosCoupledDots(const std::string & var_name);
-  Moose::Kokkos::VariableNodalValue kokkosCoupledNodalDot(const std::string & var_name,
-                                                          unsigned int comp = 0);
-  Moose::Kokkos::VariableNodalValue kokkosCoupledNodalDots(const std::string & var_name);
+  Moose::Kokkos::VariableValue kokkosCoupledNodalDot(const std::string & var_name,
+                                                     unsigned int comp = 0);
+  Moose::Kokkos::VariableValue kokkosCoupledNodalDots(const std::string & var_name);
 
   Moose::Kokkos::Scalar<const Real> kokkosCoupledDotDu(const std::string & var_name,
                                                        unsigned int comp = 0);
 
   Moose::Kokkos::VariableValue kokkosZeroValue();
   Moose::Kokkos::VariableGradient kokkosZeroGradient();
-  Moose::Kokkos::VariableNodalValue kokkosZeroNodalValue();
+  Moose::Kokkos::VariableValue kokkosZeroNodalValue();
 #endif
 };
 

--- a/framework/include/kokkos/base/KokkosAssembly.h
+++ b/framework/include/kokkos/base/KokkosAssembly.h
@@ -48,6 +48,11 @@ public:
    */
   unsigned int getFETypeID(FEType type) const { return libmesh_map_find(_fe_type_map, type); }
   /**
+   * Get the mesh dimension
+   * @returns The mesh dimension
+   */
+  KOKKOS_FUNCTION unsigned int getDimension() const { return _dimension; }
+  /**
    * Get the maximum number of quadrature points per element in the current partition
    * @returns The maximum number of quadrature points per element
    */

--- a/framework/include/kokkos/base/KokkosTypes.h
+++ b/framework/include/kokkos/base/KokkosTypes.h
@@ -55,6 +55,13 @@ struct Real33
       for (unsigned int j = 0; j < 3; ++j)
         a[i][j] += tensor.a[i][j];
   }
+  KOKKOS_INLINE_FUNCTION void identity(const unsigned int dim = 3)
+  {
+    *this = 0;
+
+    for (unsigned int i = 0; i < dim; ++i)
+      a[i][i] = 1;
+  }
   KOKKOS_INLINE_FUNCTION Real determinant(const unsigned int dim = 3)
   {
     Real det = 0;

--- a/framework/include/kokkos/base/KokkosVariable.h
+++ b/framework/include/kokkos/base/KokkosVariable.h
@@ -82,6 +82,11 @@ public:
    */
   KOKKOS_FUNCTION bool coupled() const { return _coupled; }
   /**
+   * Get whether the variable is nodal
+   * @returns Whether the variable is nodal
+   */
+  KOKKOS_FUNCTION bool nodal() const { return _nodal; }
+  /**
    * Get the number of components
    * @returns The number of components
    */
@@ -120,6 +125,10 @@ private:
    * Whether the variable is coupled
    */
   bool _coupled = false;
+  /**
+   * Whether the variable is nodal
+   */
+  bool _nodal = false;
   /**
    * Number of components
    */

--- a/framework/include/kokkos/bcs/KokkosDirichletBC.h
+++ b/framework/include/kokkos/bcs/KokkosDirichletBC.h
@@ -21,7 +21,10 @@ public:
 
   KokkosDirichletBC(const InputParameters & parameters);
 
-  KOKKOS_FUNCTION Real computeValue(const ContiguousNodeID /* node */) const { return _value; }
+  KOKKOS_FUNCTION Real computeValue(const unsigned int /* qp */, ResidualDatum & /* datum */) const
+  {
+    return _value;
+  }
 
 protected:
   const Moose::Kokkos::Scalar<const Real> _value;

--- a/framework/include/kokkos/bcs/KokkosMatchedValueBC.h
+++ b/framework/include/kokkos/bcs/KokkosMatchedValueBC.h
@@ -21,12 +21,13 @@ public:
 
   KokkosMatchedValueBC(const InputParameters & parameters);
 
-  KOKKOS_FUNCTION Real computeQpResidual(const ContiguousNodeID node) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, ResidualDatum & datum) const;
   KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int jvar,
-                                                const ContiguousNodeID node) const;
+                                                const unsigned int qp,
+                                                ResidualDatum & datum) const;
 
 protected:
-  const Moose::Kokkos::VariableNodalValue _v;
+  const Moose::Kokkos::VariableValue _v;
 
   /// The id of the coupled variable
   const unsigned int _v_num;
@@ -37,14 +38,15 @@ protected:
 };
 
 KOKKOS_FUNCTION inline Real
-KokkosMatchedValueBC::computeQpResidual(const ContiguousNodeID node) const
+KokkosMatchedValueBC::computeQpResidual(const unsigned int qp, ResidualDatum & datum) const
 {
-  return _u_coeff * _u(node) - _v_coeff * _v(node);
+  return _u_coeff * _u(datum, qp) - _v_coeff * _v(datum, qp);
 }
 
 KOKKOS_FUNCTION inline Real
 KokkosMatchedValueBC::computeQpOffDiagJacobian(const unsigned int jvar,
-                                               const ContiguousNodeID /* node */) const
+                                               const unsigned int /* qp */,
+                                               ResidualDatum & /* datum */) const
 {
   if (jvar == _v_num)
     return -_v_coeff;

--- a/framework/include/kokkos/kernels/KokkosKernel.h
+++ b/framework/include/kokkos/kernels/KokkosKernel.h
@@ -181,7 +181,12 @@ Kernel::operator()(ResidualLoop, const ThreadID tid, const Derived & kernel) con
 {
   auto elem = kokkosBlockElementID(tid);
 
-  ResidualDatum datum(elem, kokkosAssembly(), kokkosSystems(), _kokkos_var, _kokkos_var.var());
+  ResidualDatum datum(elem,
+                      libMesh::invalid_uint,
+                      kokkosAssembly(),
+                      kokkosSystems(),
+                      _kokkos_var,
+                      _kokkos_var.var());
 
   kernel.computeResidualInternal(kernel, datum);
 }
@@ -192,7 +197,12 @@ Kernel::operator()(JacobianLoop, const ThreadID tid, const Derived & kernel) con
 {
   auto elem = kokkosBlockElementID(tid);
 
-  ResidualDatum datum(elem, kokkosAssembly(), kokkosSystems(), _kokkos_var, _kokkos_var.var());
+  ResidualDatum datum(elem,
+                      libMesh::invalid_uint,
+                      kokkosAssembly(),
+                      kokkosSystems(),
+                      _kokkos_var,
+                      _kokkos_var.var());
 
   kernel.computeJacobianInternal(kernel, datum);
 }
@@ -209,7 +219,8 @@ Kernel::operator()(OffDiagJacobianLoop, const ThreadID tid, const Derived & kern
   if (!sys.isVariableActive(jvar, kokkosMesh().getElementInfo(elem).subdomain))
     return;
 
-  ResidualDatum datum(elem, kokkosAssembly(), kokkosSystems(), _kokkos_var, jvar);
+  ResidualDatum datum(
+      elem, libMesh::invalid_uint, kokkosAssembly(), kokkosSystems(), _kokkos_var, jvar);
 
   kernel.computeOffDiagJacobianInternal(kernel, datum);
 }

--- a/framework/include/kokkos/materials/KokkosMaterial.h
+++ b/framework/include/kokkos/materials/KokkosMaterial.h
@@ -228,7 +228,7 @@ Material::operator()(ElementInit, const ThreadID tid, const Derived & material) 
 {
   auto elem = kokkosElementID(tid);
 
-  Datum datum(elem, kokkosAssembly(), kokkosSystems());
+  Datum datum(elem, libMesh::invalid_uint, kokkosAssembly(), kokkosSystems());
 
   for (unsigned int qp = 0; qp < datum.n_qps(); qp++)
   {
@@ -273,7 +273,7 @@ Material::operator()(ElementCompute, const ThreadID tid, const Derived & materia
 {
   auto elem = kokkosElementID(tid);
 
-  Datum datum(elem, kokkosAssembly(), kokkosSystems());
+  Datum datum(elem, libMesh::invalid_uint, kokkosAssembly(), kokkosSystems());
 
   for (unsigned int qp = 0; qp < datum.n_qps(); qp++)
   {

--- a/framework/include/kokkos/mesh/KokkosMesh.h
+++ b/framework/include/kokkos/mesh/KokkosMesh.h
@@ -37,15 +37,15 @@ struct ElementInfo
   /**
    * Element type ID
    */
-  unsigned int type;
+  unsigned int type = libMesh::invalid_uint;
   /**
    * Contiguous element ID
    */
-  ContiguousElementID id;
+  ContiguousElementID id = libMesh::DofObject::invalid_id;
   /**
    * Contiguous subdomain ID
    */
-  ContiguousSubdomainID subdomain;
+  ContiguousSubdomainID subdomain = std::numeric_limits<ContiguousSubdomainID>::max();
 };
 
 /**

--- a/framework/include/kokkos/nodalkernels/KokkosBoundNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosBoundNodalKernel.h
@@ -19,17 +19,18 @@ public:
 
   KokkosBoundNodalKernel(const InputParameters & parameters);
 
-  KOKKOS_FUNCTION Real computeQpResidual(const ContiguousNodeID node) const;
-  KOKKOS_FUNCTION Real computeQpJacobian(const ContiguousNodeID node) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, ResidualDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int qp, ResidualDatum & datum) const;
   KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int jvar,
-                                                const ContiguousNodeID node) const;
+                                                const unsigned int qp,
+                                                ResidualDatum & datum) const;
 
 protected:
   /// The number of the coupled variable
   const unsigned int _v_var;
 
   /// The value of the coupled variable
-  const Moose::Kokkos::VariableNodalValue _v;
+  const Moose::Kokkos::VariableValue _v;
 
 private:
   KOKKOS_FUNCTION bool skipOnBoundary(const ContiguousNodeID node) const;
@@ -83,31 +84,34 @@ KokkosBoundNodalKernel<Derived>::skipOnBoundary(const ContiguousNodeID node) con
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosBoundNodalKernel<Derived>::computeQpResidual(const ContiguousNodeID node) const
+KokkosBoundNodalKernel<Derived>::computeQpResidual(const unsigned int qp,
+                                                   ResidualDatum & datum) const
 {
-  if (skipOnBoundary(node))
-    return _u(node);
+  if (skipOnBoundary(datum.node()))
+    return _u(datum, qp);
 
-  return static_cast<const Derived *>(this)->getResidual(node);
+  return static_cast<const Derived *>(this)->getResidual(qp, datum);
 }
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosBoundNodalKernel<Derived>::computeQpJacobian(const ContiguousNodeID node) const
+KokkosBoundNodalKernel<Derived>::computeQpJacobian(const unsigned int qp,
+                                                   ResidualDatum & datum) const
 {
-  if (skipOnBoundary(node))
+  if (skipOnBoundary(datum.node()))
     return 1;
 
-  return static_cast<const Derived *>(this)->getJacobian(node);
+  return static_cast<const Derived *>(this)->getJacobian(qp, datum);
 }
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
 KokkosBoundNodalKernel<Derived>::computeQpOffDiagJacobian(const unsigned int jvar,
-                                                          const ContiguousNodeID node) const
+                                                          const unsigned int qp,
+                                                          ResidualDatum & datum) const
 {
-  if (skipOnBoundary(node))
+  if (skipOnBoundary(datum.node()))
     return 0;
 
-  return static_cast<const Derived *>(this)->getOffDiagJacobian(jvar, node);
+  return static_cast<const Derived *>(this)->getOffDiagJacobian(jvar, qp, datum);
 }

--- a/framework/include/kokkos/nodalkernels/KokkosConstantRate.h
+++ b/framework/include/kokkos/nodalkernels/KokkosConstantRate.h
@@ -18,14 +18,15 @@ public:
 
   KokkosConstantRate(const InputParameters & parameters);
 
-  KOKKOS_FUNCTION Real computeQpResidual(const ContiguousNodeID node) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, ResidualDatum & datum) const;
 
 protected:
   const Moose::Kokkos::Scalar<const Real> _rate;
 };
 
 KOKKOS_FUNCTION inline Real
-KokkosConstantRate::computeQpResidual(const ContiguousNodeID /* node */) const
+KokkosConstantRate::computeQpResidual(const unsigned int /* qp */,
+                                      ResidualDatum & /* datum */) const
 {
   return -_rate;
 }

--- a/framework/include/kokkos/nodalkernels/KokkosCoupledForceNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosCoupledForceNodalKernel.h
@@ -18,30 +18,32 @@ public:
 
   KokkosCoupledForceNodalKernel(const InputParameters & parameters);
 
-  KOKKOS_FUNCTION Real computeQpResidual(const ContiguousNodeID node) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, ResidualDatum & datum) const;
   KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int jvar,
-                                                const ContiguousNodeID node) const;
+                                                const unsigned int qp,
+                                                ResidualDatum & datum) const;
 
 private:
   /// The number of the coupled variable
   const unsigned int _v_var;
 
   /// The value of the coupled variable
-  const Moose::Kokkos::VariableNodalValue _v;
+  const Moose::Kokkos::VariableValue _v;
 
   /// A multiplicative factor for computing the coupled force
   const Real _coef;
 };
 
 KOKKOS_FUNCTION inline Real
-KokkosCoupledForceNodalKernel::computeQpResidual(const ContiguousNodeID node) const
+KokkosCoupledForceNodalKernel::computeQpResidual(const unsigned int qp, ResidualDatum & datum) const
 {
-  return -_coef * _v(node);
+  return -_coef * _v(datum, qp);
 }
 
 KOKKOS_FUNCTION inline Real
 KokkosCoupledForceNodalKernel::computeQpOffDiagJacobian(const unsigned int jvar,
-                                                        const ContiguousNodeID /* node */) const
+                                                        const unsigned int /* qp */,
+                                                        ResidualDatum & /* datum */) const
 {
   if (jvar == _v_var)
     return -_coef;

--- a/framework/include/kokkos/nodalkernels/KokkosLowerBoundNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosLowerBoundNodalKernel.h
@@ -21,10 +21,11 @@ public:
 
   KokkosLowerBoundNodalKernel(const InputParameters & parameters);
 
-  KOKKOS_FUNCTION Real getResidual(const ContiguousNodeID node) const;
-  KOKKOS_FUNCTION Real getJacobian(const ContiguousNodeID node) const;
+  KOKKOS_FUNCTION Real getResidual(const unsigned int qp, ResidualDatum & datum) const;
+  KOKKOS_FUNCTION Real getJacobian(const unsigned int qp, ResidualDatum & datum) const;
   KOKKOS_FUNCTION Real getOffDiagJacobian(const unsigned int jvar,
-                                          const ContiguousNodeID node) const;
+                                          const unsigned int qp,
+                                          ResidualDatum & datum) const;
 
 private:
   /// The lower bound on the coupled variable
@@ -32,15 +33,15 @@ private:
 };
 
 KOKKOS_FUNCTION inline Real
-KokkosLowerBoundNodalKernel::getResidual(const ContiguousNodeID node) const
+KokkosLowerBoundNodalKernel::getResidual(const unsigned int qp, ResidualDatum & datum) const
 {
-  return ::Kokkos::min(_u(node), _v(node) - _lower_bound);
+  return ::Kokkos::min(_u(datum, qp), _v(datum, qp) - _lower_bound);
 }
 
 KOKKOS_FUNCTION inline Real
-KokkosLowerBoundNodalKernel::getJacobian(const ContiguousNodeID node) const
+KokkosLowerBoundNodalKernel::getJacobian(const unsigned int qp, ResidualDatum & datum) const
 {
-  if (_u(node) <= _v(node) - _lower_bound)
+  if (_u(datum, qp) <= _v(datum, qp) - _lower_bound)
     return 1;
 
   return 0;
@@ -48,10 +49,11 @@ KokkosLowerBoundNodalKernel::getJacobian(const ContiguousNodeID node) const
 
 KOKKOS_FUNCTION inline Real
 KokkosLowerBoundNodalKernel::getOffDiagJacobian(const unsigned int jvar,
-                                                const ContiguousNodeID node) const
+                                                const unsigned int qp,
+                                                ResidualDatum & datum) const
 {
   if (jvar == _v_var)
-    if (_v(node) - _lower_bound < _u(node))
+    if (_v(datum, qp) - _lower_bound < _u(datum, qp))
       return 1;
 
   return 0;

--- a/framework/include/kokkos/nodalkernels/KokkosReactionNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosReactionNodalKernel.h
@@ -18,21 +18,22 @@ public:
 
   KokkosReactionNodalKernel(const InputParameters & parameters);
 
-  KOKKOS_FUNCTION Real computeQpResidual(const ContiguousNodeID node) const;
-  KOKKOS_FUNCTION Real computeQpJacobian(const ContiguousNodeID node) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, ResidualDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int qp, ResidualDatum & datum) const;
 
 protected:
   const Real _coeff;
 };
 
 KOKKOS_FUNCTION inline Real
-KokkosReactionNodalKernel::computeQpResidual(const ContiguousNodeID node) const
+KokkosReactionNodalKernel::computeQpResidual(const unsigned int qp, ResidualDatum & datum) const
 {
-  return _coeff * _u(node);
+  return _coeff * _u(datum, qp);
 }
 
 KOKKOS_FUNCTION inline Real
-KokkosReactionNodalKernel::computeQpJacobian(const ContiguousNodeID /* node */) const
+KokkosReactionNodalKernel::computeQpJacobian(const unsigned int /* qp */,
+                                             ResidualDatum & /* datum */) const
 {
   return _coeff;
 }

--- a/framework/include/kokkos/nodalkernels/KokkosTimeDerivativeNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosTimeDerivativeNodalKernel.h
@@ -18,18 +18,20 @@ public:
 
   KokkosTimeDerivativeNodalKernel(const InputParameters & parameters);
 
-  KOKKOS_FUNCTION Real computeQpResidual(const ContiguousNodeID node) const;
-  KOKKOS_FUNCTION Real computeQpJacobian(const ContiguousNodeID node) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, ResidualDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int qp, ResidualDatum & datum) const;
 };
 
 KOKKOS_FUNCTION inline Real
-KokkosTimeDerivativeNodalKernel::computeQpResidual(const ContiguousNodeID node) const
+KokkosTimeDerivativeNodalKernel::computeQpResidual(const unsigned int qp,
+                                                   ResidualDatum & datum) const
 {
-  return _u_dot(node);
+  return _u_dot(datum, qp);
 }
 
 KOKKOS_FUNCTION inline Real
-KokkosTimeDerivativeNodalKernel::computeQpJacobian(const ContiguousNodeID /* node */) const
+KokkosTimeDerivativeNodalKernel::computeQpJacobian(const unsigned int /* qp */,
+                                                   ResidualDatum & /* datum */) const
 {
   return _du_dot_du;
 }

--- a/framework/include/kokkos/nodalkernels/KokkosTimeNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosTimeNodalKernel.h
@@ -33,7 +33,7 @@ protected:
   /**
    * Time derivative of the current solution at nodes
    */
-  const VariableNodalValue _u_dot;
+  const VariableValue _u_dot;
   /**
    * Derivative of u_dot with respect to u
    */

--- a/framework/include/kokkos/nodalkernels/KokkosUpperBoundNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosUpperBoundNodalKernel.h
@@ -21,10 +21,11 @@ public:
 
   KokkosUpperBoundNodalKernel(const InputParameters & parameters);
 
-  KOKKOS_FUNCTION Real getResidual(const ContiguousNodeID node) const;
-  KOKKOS_FUNCTION Real getJacobian(const ContiguousNodeID node) const;
+  KOKKOS_FUNCTION Real getResidual(const unsigned int qp, ResidualDatum & datum) const;
+  KOKKOS_FUNCTION Real getJacobian(const unsigned int qp, ResidualDatum & datum) const;
   KOKKOS_FUNCTION Real getOffDiagJacobian(const unsigned int jvar,
-                                          const ContiguousNodeID node) const;
+                                          const unsigned int qp,
+                                          ResidualDatum & datum) const;
 
 private:
   /// The upper bound on the coupled variable
@@ -32,15 +33,15 @@ private:
 };
 
 KOKKOS_FUNCTION inline Real
-KokkosUpperBoundNodalKernel::getResidual(const ContiguousNodeID node) const
+KokkosUpperBoundNodalKernel::getResidual(const unsigned int qp, ResidualDatum & datum) const
 {
-  return ::Kokkos::min(_u(node), _upper_bound - _v(node));
+  return ::Kokkos::min(_u(datum, qp), _upper_bound - _v(datum, qp));
 }
 
 KOKKOS_FUNCTION inline Real
-KokkosUpperBoundNodalKernel::getJacobian(const ContiguousNodeID node) const
+KokkosUpperBoundNodalKernel::getJacobian(const unsigned int qp, ResidualDatum & datum) const
 {
-  if (_u(node) <= _upper_bound - _v(node))
+  if (_u(datum, qp) <= _upper_bound - _v(datum, qp))
     return 1;
 
   return 0;
@@ -48,10 +49,11 @@ KokkosUpperBoundNodalKernel::getJacobian(const ContiguousNodeID node) const
 
 KOKKOS_FUNCTION inline Real
 KokkosUpperBoundNodalKernel::getOffDiagJacobian(const unsigned int jvar,
-                                                const ContiguousNodeID node) const
+                                                const unsigned int qp,
+                                                ResidualDatum & datum) const
 {
   if (jvar == _v_var)
-    if (_upper_bound - _v(node) < _u(node))
+    if (_upper_bound - _v(datum, qp) < _u(datum, qp))
       return -1;
 
   return 0;

--- a/framework/src/kokkos/base/KokkosVariable.K
+++ b/framework/src/kokkos/base/KokkosVariable.K
@@ -27,6 +27,7 @@ void
 Variable::init(const MooseVariableBase & variable, const TagID tag)
 {
   _coupled = true;
+  _nodal = variable.isNodal();
   _components = variable.count();
   _tag = tag;
 
@@ -49,6 +50,7 @@ Variable::init(const std::vector<const MooseVariableBase *> & variables,
                CoupleableKey)
 {
   _coupled = true;
+  _nodal = true;
   _components = variables.size();
   _tag = tag;
 
@@ -57,6 +59,8 @@ Variable::init(const std::vector<const MooseVariableBase *> & variables,
 
   for (unsigned int comp = 0; comp < _components; ++comp)
   {
+    _nodal = _nodal && variables[comp]->isNodal();
+
     _var[comp] = variables[comp]->number();
     _sys[comp] = variables[comp]->sys().number();
   }
@@ -69,6 +73,7 @@ void
 Variable::init(const std::vector<Real> & values, CoupleableKey)
 {
   _coupled = false;
+  _nodal = true;
   _components = values.size();
 
   _default_value = values;

--- a/framework/src/kokkos/bcs/KokkosNodalBC.K
+++ b/framework/src/kokkos/bcs/KokkosNodalBC.K
@@ -22,7 +22,8 @@ NodalBC::validParams()
 }
 
 NodalBC::NodalBC(const InputParameters & parameters)
-  : NodalBCBase(parameters, Moose::VarFieldType::VAR_FIELD_STANDARD), _u(kokkosSystems(), _var)
+  : NodalBCBase(parameters, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    _u(_var, Moose::SOLUTION_TAG, true)
 {
   addMooseVariableDependency(&_var);
 }

--- a/framework/src/kokkos/interfaces/KokkosCoupleable.K
+++ b/framework/src/kokkos/interfaces/KokkosCoupleable.K
@@ -134,23 +134,23 @@ Coupleable::kokkosCoupledVectorTagGradientsByName(const std::string & var_name,
   return Moose::Kokkos::VariableGradient(variable);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledVectorTagNodalValueByName(const std::string & var_name,
                                                    const std::string & tag_name,
                                                    unsigned int comp)
 {
   auto variable = kokkosCoupledVectorTagVariable(var_name, tag_name, comp);
 
-  return Moose::Kokkos::VariableNodalValue(_c_fe_problem.getKokkosSystems(), variable);
+  return Moose::Kokkos::VariableValue(variable, true);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledVectorTagNodalValuesByName(const std::string & var_name,
                                                     const std::string & tag_name)
 {
   auto variable = kokkosCoupledVectorTagVariables(var_name, tag_name);
 
-  return Moose::Kokkos::VariableNodalValue(_c_fe_problem.getKokkosSystems(), variable);
+  return Moose::Kokkos::VariableValue(variable, true);
 }
 
 Moose::Kokkos::VariableValue
@@ -203,7 +203,7 @@ Coupleable::kokkosCoupledVectorTagGradients(const std::string & var_name,
   return kokkosCoupledVectorTagGradientsByName(var_name, tag_name);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledVectorTagNodalValue(const std::string & var_name,
                                              const std::string & tag_param_name,
                                              unsigned int comp)
@@ -216,7 +216,7 @@ Coupleable::kokkosCoupledVectorTagNodalValue(const std::string & var_name,
   return kokkosCoupledVectorTagNodalValueByName(var_name, tag_name, comp);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledVectorTagNodalValues(const std::string & var_name,
                                               const std::string & tag_param_name)
 {
@@ -252,13 +252,13 @@ Coupleable::kokkosCoupledGradients(const std::string & var_name)
   return kokkosCoupledVectorTagGradientsByName(var_name, Moose::SOLUTION_TAG);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledNodalValue(const std::string & var_name, unsigned int comp)
 {
   return kokkosCoupledVectorTagNodalValueByName(var_name, Moose::SOLUTION_TAG, comp);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledNodalValues(const std::string & var_name)
 {
   return kokkosCoupledVectorTagNodalValuesByName(var_name, Moose::SOLUTION_TAG);
@@ -288,13 +288,13 @@ Coupleable::kokkosCoupledGradientsOld(const std::string & var_name)
   return kokkosCoupledVectorTagGradientsByName(var_name, Moose::OLD_SOLUTION_TAG);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledNodalValueOld(const std::string & var_name, unsigned int comp)
 {
   return kokkosCoupledVectorTagNodalValueByName(var_name, Moose::OLD_SOLUTION_TAG, comp);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledNodalValuesOld(const std::string & var_name)
 {
   return kokkosCoupledVectorTagNodalValuesByName(var_name, Moose::OLD_SOLUTION_TAG);
@@ -324,13 +324,13 @@ Coupleable::kokkosCoupledGradientsOlder(const std::string & var_name)
   return kokkosCoupledVectorTagGradientsByName(var_name, Moose::OLDER_SOLUTION_TAG);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledNodalValueOlder(const std::string & var_name, unsigned int comp)
 {
   return kokkosCoupledVectorTagNodalValueByName(var_name, Moose::OLDER_SOLUTION_TAG, comp);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledNodalValuesOlder(const std::string & var_name)
 {
   return kokkosCoupledVectorTagNodalValuesByName(var_name, Moose::OLDER_SOLUTION_TAG);
@@ -348,13 +348,13 @@ Coupleable::kokkosCoupledDots(const std::string & var_name)
   return kokkosCoupledVectorTagValuesByName(var_name, Moose::SOLUTION_DOT_TAG);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledNodalDot(const std::string & var_name, unsigned int comp)
 {
   return kokkosCoupledVectorTagNodalValueByName(var_name, Moose::SOLUTION_DOT_TAG, comp);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosCoupledNodalDots(const std::string & var_name)
 {
   return kokkosCoupledVectorTagNodalValuesByName(var_name, Moose::SOLUTION_DOT_TAG);
@@ -387,10 +387,10 @@ Coupleable::kokkosZeroGradient()
   return Moose::Kokkos::VariableGradient(variable);
 }
 
-Moose::Kokkos::VariableNodalValue
+Moose::Kokkos::VariableValue
 Coupleable::kokkosZeroNodalValue()
 {
   auto variable = kokkosZeroVariable();
 
-  return Moose::Kokkos::VariableNodalValue(_c_fe_problem.getKokkosSystems(), variable);
+  return Moose::Kokkos::VariableValue(variable, true);
 }

--- a/framework/src/kokkos/nodalkernels/KokkosNodalKernel.K
+++ b/framework/src/kokkos/nodalkernels/KokkosNodalKernel.K
@@ -23,7 +23,7 @@ NodalKernel::validParams()
 
 NodalKernel::NodalKernel(const InputParameters & parameters)
   : NodalKernelBase(parameters, Moose::VarFieldType::VAR_FIELD_STANDARD),
-    _u(kokkosSystems(), _var),
+    _u(_var, Moose::SOLUTION_TAG, true),
     _boundary_restricted(boundaryRestricted())
 {
 }

--- a/framework/src/kokkos/nodalkernels/KokkosTimeNodalKernel.K
+++ b/framework/src/kokkos/nodalkernels/KokkosTimeNodalKernel.K
@@ -27,7 +27,7 @@ TimeNodalKernel::validParams()
 
 TimeNodalKernel::TimeNodalKernel(const InputParameters & parameters)
   : NodalKernel(parameters),
-    _u_dot(kokkosSystems(), _var, Moose::SOLUTION_DOT_TAG),
+    _u_dot(_var, Moose::SOLUTION_DOT_TAG, true),
     _du_dot_du(_var.sys().duDotDu(_var.number()))
 {
 }

--- a/test/include/kokkos/bcs/KokkosCoupledDirichletBC.h
+++ b/test/include/kokkos/bcs/KokkosCoupledDirichletBC.h
@@ -25,14 +25,15 @@ public:
 
   KokkosCoupledDirichletBC(const InputParameters & parameters);
 
-  KOKKOS_FUNCTION Real computeQpResidual(const ContiguousNodeID node) const;
-  KOKKOS_FUNCTION Real computeQpJacobian(const ContiguousNodeID node) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, ResidualDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int qp, ResidualDatum & datum) const;
   KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int jvar,
-                                                const ContiguousNodeID node) const;
+                                                const unsigned int qp,
+                                                ResidualDatum & datum) const;
 
 protected:
   // The coupled variable
-  const Moose::Kokkos::VariableNodalValue _v;
+  const Moose::Kokkos::VariableValue _v;
 
   /// The id of the coupled variable
   const unsigned int _v_num;
@@ -42,23 +43,25 @@ protected:
 };
 
 KOKKOS_FUNCTION inline Real
-KokkosCoupledDirichletBC::computeQpResidual(const ContiguousNodeID node) const
+KokkosCoupledDirichletBC::computeQpResidual(const unsigned int qp, ResidualDatum & datum) const
 {
-  return _c * _u(node) + _u(node) * _u(node) + _v(node) * _v(node) - _value;
+  return _c * _u(datum, qp) + _u(datum, qp) * _u(datum, qp) + _v(datum, qp) * _v(datum, qp) -
+         _value;
 }
 
 KOKKOS_FUNCTION inline Real
-KokkosCoupledDirichletBC::computeQpJacobian(const ContiguousNodeID node) const
+KokkosCoupledDirichletBC::computeQpJacobian(const unsigned int qp, ResidualDatum & datum) const
 {
-  return _c + 2 * _u(node);
+  return _c + 2 * _u(datum, qp);
 }
 
 KOKKOS_FUNCTION inline Real
 KokkosCoupledDirichletBC::computeQpOffDiagJacobian(const unsigned int jvar,
-                                                   const ContiguousNodeID node) const
+                                                   const unsigned int qp,
+                                                   ResidualDatum & datum) const
 {
   if (jvar == _v_num)
-    return 2 * _v(node);
+    return 2 * _v(datum, qp);
   else
     return 0;
 }

--- a/test/include/kokkos/nodalkernels/KokkosJacobianCheck.h
+++ b/test/include/kokkos/nodalkernels/KokkosJacobianCheck.h
@@ -21,18 +21,19 @@ public:
 
   KokkosJacobianCheck(const InputParameters & parameters);
 
-  KOKKOS_FUNCTION Real computeQpResidual(const ContiguousNodeID node) const;
-  KOKKOS_FUNCTION Real computeQpJacobian(const ContiguousNodeID node) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, ResidualDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int qp, ResidualDatum & datum) const;
 };
 
 KOKKOS_FUNCTION inline Real
-KokkosJacobianCheck::computeQpResidual(const ContiguousNodeID node) const
+KokkosJacobianCheck::computeQpResidual(const unsigned int qp, ResidualDatum & datum) const
 {
-  return -5.0 * _u(node);
+  return -5.0 * _u(datum, qp);
 }
 
 KOKKOS_FUNCTION inline Real
-KokkosJacobianCheck::computeQpJacobian(const ContiguousNodeID /* node */) const
+KokkosJacobianCheck::computeQpJacobian(const unsigned int /* qp */,
+                                       ResidualDatum & /* datum */) const
 {
   return -5.0;
 }


### PR DESCRIPTION
Refs #30655.

Realized that MOOSE AuxKernels serve as both nodal and elemental kernels with a single interface. Updating Kokkos nodal kernel interface accordingly to be prepared for Kokkos AuxKernel implementation.