### PR TITLE
Tidy up MooseParsed(Vector)Function

### DIFF
--- a/framework/doc/content/source/outputs/formatters/JsonInputFileFormatter.md
+++ b/framework/doc/content/source/outputs/formatters/JsonInputFileFormatter.md
@@ -19,37 +19,44 @@ This is output for every hierarchical level in the syntax.
 [Functions]
 
   [./*]
-    active         = '__all__ '   # "If specified only the blocks named will be visited and made active"
-                                  # Group: ""
-    inactive       = (no_default) # "If specified blocks matching these identifiers will be skipped."
-                                  # Group: ""
-    isObjectAction = 1            # "Indicates that this is a MooseObjectAction."
-                                  # Group: ""
-    type           = (required)   # "A string representing the Moose Object that will be built by this Action"
-                                  # Group: ""
+    active       = '__all__ '   # "If specified only the blocks named will be visited and made active"
+                                # Unit: ""
+                                # Group: ""
+    control_tags = (no_default) # "Adds user-defined labels for accessing object parameters via control
+                                # logic."
+                                # Unit: ""
+                                # Group: "Advanced"
+    inactive     = (no_default) # "If specified blocks matching these identifiers will be skipped."
+                                # Unit: ""
+                                # Group: ""
+    type         = (required)   # "A string representing the Moose Object that will be built by this Action"
+                                # Unit: ""
+                                # Group: ""
 
     [./<types>]
 
-      [./<ADParsedFunction>]
+      [./<ParsedFunction>]
         # "Function created by parsing a string"
-        control_tags = (no_default)     # "Adds user-defined labels for accessing object parameters via
-                                        # control logic."
-                                        # Group: "Advanced"
-        enable       = 1                # "Set the enabled status of the MooseObject."
-                                        # Group: "Advanced"
-        execute_on   = LINEAR           # "The list of flag(s) indicating when this object should be executed,
-                                        # the available options include NONE, INITIAL, LINEAR, NONLINEAR,
-                                        # TIMESTEP_END, TIMESTEP_BEGIN, FINAL, CUSTOM, ALWAYS."
-                                        # Group: ""
-        type         = ADParsedFunction # ""
-                                        # Group: ""
-        vals         = (no_default)     # "Constant numeric values, postprocessor names, or function names
-                                        # for vars."
-                                        # Group: ""
-        value        = (required)       # "The user defined function."
-                                        # Group: ""
-        vars         = (no_default)     # "Variables (excluding t,x,y,z) that are bound to the values provided
-                                        # by the corresponding items in the vals vector."
-                                        # Group: ""
+        control_tags  = (no_default)   # "Adds user-defined labels for accessing object parameters via control
+                                       # logic."
+                                       # Unit: ""
+                                       # Group: "Advanced"
+        enable        = 1              # "Set the enabled status of the MooseObject."
+                                       # Unit: ""
+                                       # Group: "Advanced"
+        expression    = (required)     # "The user defined function."
+                                       # Unit: ""
+                                       # Group: ""
+        symbol_names  = (required)     # "Symbols (excluding t,x,y,z) that are bound to the values provided
+                                       # by the corresponding items in the symbol_values vector."
+                                       # Unit: ""
+                                       # Group: ""
+        symbol_values = (required)     # "Constant numeric values, postprocessor names, function names,
+                                       # and scalar variables corresponding to the symbols in symbol_names."
+                                       # Unit: ""
+                                       # Group: ""
+        type          = ParsedFunction # ""
+                                       # Unit: ""
+                                       # Group: ""
       [../]
 ```

--- a/framework/doc/content/source/outputs/formatters/YAMLFormatter.md
+++ b/framework/doc/content/source/outputs/formatters/YAMLFormatter.md
@@ -14,15 +14,17 @@ block and the [MooseParsedFunction.md]. We can see metadata about each parameter
 C++ type, their default, or their description.
 
 ```
-- name: /Functions/ADParsedFunction
+- name: /Functions/ParsedFunction
   description: |
 
   parameters:
   - name: control_tags
     required: No
     default: !!str
-    cpp_type: std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >
+    cpp_type: std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >
     group_name: 'Advanced'
+    doc_unit:
+    doc_range:
     description: |
       Adds user-defined labels for accessing object parameters via control logic.
   - name: enable
@@ -30,43 +32,45 @@ C++ type, their default, or their description.
     default: !!str 1
     cpp_type: bool
     group_name: 'Advanced'
+    doc_unit:
+    doc_range:
     description: |
       Set the enabled status of the MooseObject.
-  - name: execute_on
-    required: No
-    default: !!str LINEAR
-    cpp_type: ExecFlagEnum
-    group_name:
-    description: |
-      The list of flag(s) indicating when this object should be executed, the available options include NONE, INITIAL, LINEAR, NONLINEAR, TIMESTEP_END, TIMESTEP_BEGIN, FINAL, CUSTOM, ALWAYS.
-  - name: type
-    required: No
-    default: !!str ADParsedFunction
-    cpp_type: std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >
-    group_name:
-    description: |
-
-  - name: vals
-    required: No
-    default: !!str
-    cpp_type: std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >
-    group_name:
-    description: |
-      Constant numeric values, postprocessor names, or function names for vars.
-  - name: value
+  - name: expression
     required: Yes
     default: !!str
     cpp_type: FunctionExpression
     group_name:
+    doc_unit:
+    doc_range:
     description: |
       The user defined function.
-  - name: vars
-    required: No
+  - name: symbol_names
+    required: Yes
     default: !!str
-    cpp_type: std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >
+    cpp_type: std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >
     group_name:
+    doc_unit:
+    doc_range:
     description: |
-      Variables (excluding t,x,y,z) that are bound to the values provided by the corresponding items in the vals vector.
-  subblocks:
+      Symbols (excluding t,x,y,z) that are bound to the values provided by the corresponding items in the symbol_values vector.
+  - name: symbol_values
+    required: Yes
+    default: !!str
+    cpp_type: std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >
+    group_name:
+    doc_unit:
+    doc_range:
+    description: |
+      Constant numeric values, postprocessor names, function names, and scalar variables corresponding to the symbols in symbol_names.
+  - name: type
+    required: No
+    default: !!str ParsedFunction
+    cpp_type: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >
+    group_name:
+    doc_unit:
+    doc_range:
+    description: |
 
+  subblocks:
 ```

--- a/framework/src/functions/MooseParsedFunctionBase.C
+++ b/framework/src/functions/MooseParsedFunctionBase.C
@@ -18,35 +18,21 @@ InputParameters
 MooseParsedFunctionBase::validParams()
 {
   InputParameters params = emptyInputParameters();
-  params.addDeprecatedParam<std::vector<std::string>>(
-      "vars",
-      "Variables (excluding t,x,y,z) that are bound to the values provided by the corresponding "
-      "items in the vals vector.",
-      "Use 'symbol_names' instead.");
-  params.addDeprecatedParam<std::vector<std::string>>(
-      "vals",
-      "Constant numeric values, postprocessor names, "
-      "function names, and scalar variables for vars.",
-      "Use 'symbol_values' instead.");
   params.addParam<std::vector<std::string>>(
       "symbol_names",
       "Symbols (excluding t,x,y,z) that are bound to the values provided by the corresponding "
-      "items in the vals vector.");
-  params.addParam<std::vector<std::string>>("symbol_values",
-                                            "Constant numeric values, postprocessor names, "
-                                            "function names, and scalar variables corresponding to"
-                                            " the symbols in symbol_names.");
+      "items in the symbol_values vector.");
+  params.addParam<std::vector<std::string>>(
+      "symbol_values",
+      "Constant numeric values, postprocessor names, function names, and scalar variables "
+      "corresponding to the symbols in symbol_names.");
   return params;
 }
 
 MooseParsedFunctionBase::MooseParsedFunctionBase(const InputParameters & parameters)
   : _pfb_feproblem(*parameters.getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
-    _vars(parameters.isParamValid("vars")
-              ? parameters.get<std::vector<std::string>>("vars")
-              : parameters.get<std::vector<std::string>>("symbol_names")),
-    _vals(parameters.isParamValid("vals")
-              ? parameters.get<std::vector<std::string>>("vals")
-              : parameters.get<std::vector<std::string>>("symbol_values"))
+    _vars(parameters.get<std::vector<std::string>>("symbol_names")),
+    _vals(parameters.get<std::vector<std::string>>("symbol_values"))
 {
   if (_vars.size() != _vals.size())
     mooseError("Number of symbol_names must match the number of symbol_values!");

--- a/framework/src/functions/MooseParsedVectorFunction.C
+++ b/framework/src/functions/MooseParsedVectorFunction.C
@@ -19,12 +19,6 @@ MooseParsedVectorFunction::validParams()
   params += MooseParsedFunctionBase::validParams();
   params.addClassDescription(
       "Returns a vector function based on string descriptions for each component.");
-  params.addDeprecatedParam<std::string>(
-      "value_x", "x-component of function.", "value_x is deprecated, use expression_x");
-  params.addDeprecatedParam<std::string>(
-      "value_y", "y-component of function.", "value_y is deprecated, use expression_y");
-  params.addDeprecatedParam<std::string>(
-      "value_z", "z-component of function.", "value_z is deprecated, use expression_z");
   params.addParam<std::string>("expression_x", "0", "x-component of function.");
   params.addParam<std::string>("expression_y", "0", "y-component of function.");
   params.addParam<std::string>("expression_z", "0", "z-component of function.");
@@ -38,10 +32,9 @@ MooseParsedVectorFunction::validParams()
 MooseParsedVectorFunction::MooseParsedVectorFunction(const InputParameters & parameters)
   : Function(parameters),
     MooseParsedFunctionBase(parameters),
-    _vector_value(verifyFunction(std::string("{") +
-                                 getRenamedParam<std::string>("value_x", "expression_x") + "}{" +
-                                 getRenamedParam<std::string>("value_y", "expression_y") + "}{" +
-                                 getRenamedParam<std::string>("value_z", "expression_z") + "}")),
+    _vector_value(verifyFunction(std::string("{") + getParam<std::string>("expression_x") + "}{" +
+                                 getParam<std::string>("expression_y") + "}{" +
+                                 getParam<std::string>("expression_z") + "}")),
     _curl_value(verifyFunction(std::string("{") + getParam<std::string>("curl_x") + "}{" +
                                getParam<std::string>("curl_y") + "}{" +
                                getParam<std::string>("curl_z") + "}")),
@@ -76,9 +69,7 @@ MooseParsedVectorFunction::gradient(Real /*t*/, const Point & /*p*/) const
 void
 MooseParsedVectorFunction::initialSetup()
 {
-  THREAD_ID tid = 0;
-  if (isParamValid("_tid"))
-    tid = getParam<THREAD_ID>("_tid");
+  THREAD_ID tid = isParamValid("_tid") ? getParam<THREAD_ID>("_tid") : 0;
 
   if (!_function_ptr)
     _function_ptr = std::make_unique<MooseParsedFunctionWrapper>(

--- a/framework/src/mfem/problem/MFEMProblem.C
+++ b/framework/src/mfem/problem/MFEMProblem.C
@@ -403,12 +403,11 @@ MFEMProblem::addImagComponentToBC(const std::string & kernel_name,
 int
 vectorFunctionDim(const std::string & type, const InputParameters & parameters)
 {
-  if (parameters.isParamSetByUser("expression_z") || parameters.isParamSetByUser("value_z"))
+  if (parameters.isParamSetByUser("expression_z"))
     return 3;
-  if (parameters.isParamSetByUser("expression_y") || parameters.isParamSetByUser("value_y") ||
-      type == "LevelSetOlssonVortex")
+  if (parameters.isParamSetByUser("expression_y") || type == "LevelSetOlssonVortex")
     return 2;
-  if (parameters.isParamSetByUser("expression_x") || parameters.isParamSetByUser("value_x"))
+  if (parameters.isParamSetByUser("expression_x"))
     return 1;
 
   return 3;

--- a/test/tests/bcs/conservative_advection_bc/no_upwinding_2D.i
+++ b/test/tests/bcs/conservative_advection_bc/no_upwinding_2D.i
@@ -16,9 +16,9 @@ nx = 40
 [Functions]
   [beta]
     type = ParsedVectorFunction
-    value_x = ${vx}
-    value_y = ${vy}
-    value_z = 0
+    expression_x = ${vx}
+    expression_y = ${vy}
+    expression_z = 0
   []
   [box_start]
     type = ParsedFunction

--- a/test/tests/functions/linear_combination_function/lcf_vector.i
+++ b/test/tests/functions/linear_combination_function/lcf_vector.i
@@ -24,7 +24,7 @@
     expression_x = '0.2+x*y'
   [../]
   [./conductivity]
-    type = LinearCombinationFunction # yields value_y=0.1, value_x=0.8
+    type = LinearCombinationFunction # yields expression_y=0.1, expression_x=0.8
     functions = 'conductivity_1 conductivity_2'
     w = '2 -1'
   [../]


### PR DESCRIPTION
## Reason
Remove deprecated functionality and fix flawed logic when determining valid inputs.

## Design
Removes deprecated `ADParsedFunction` alias and `value`, `vars` and `vals` parameters.
Simplifies logic to determine if a variable is scalar.

## Impact
Might break people's input files.

Patches

- [x] Sabertooth https://github.inl.gov/ncrc/sabertooth/pull/472
- [x] SAM - re-running
- [x] Marmot https://github.inl.gov/ncrc/marmot/pull/952
- [x] Pronghorn https://github.inl.gov/ncrc/pronghorn/pull/1316
- [x] Mastodon https://github.com/idaholab/mastodon/pull/467
- [x] Falcon https://github.com/idaholab/falcon/pull/164
