### PR TITLE
Remove accidently checked in exodiff symlink

### DIFF
--- a/test/exodiff
+++ b/test/exodiff
@@ -1,1 +1,0 @@
-../framework/contrib/exodiff/exodiff


### PR DESCRIPTION
## Reason
A symlink to exodiff was accidently checked in.

## Design
Remove the symlink.

## Impact
No impact.