### PR TITLE
Fix dropped arguments bug

### DIFF
--- a/apptainer/files/mpi/.singularity.d/env/89-user-overrides.sh
+++ b/apptainer/files/mpi/.singularity.d/env/89-user-overrides.sh
@@ -15,7 +15,7 @@ if test -f "${HOME}/.bashrc_apptainer" ; then
         ;;
     exec)
         export BASH_ENV="${user_override}"
-        set -- /bin/bash --noprofile --rcfile "${user_override}" -c "$*"
+        set -- /bin/bash --noprofile --rcfile "${user_override}" -c "$@"
         ;;
     run)
         set -- /bin/bash --noprofile --rcfile "${user_override}"

--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_mpi:
-  - moose-mpi 2025.09.18
+  - moose-mpi 2025.10.13
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 6 %}
+{% set build = 7 %}
 {% set vtk_version = "9.4.2" %}
 {% set vtk_friendly_version = "9.4" %}
 {% set sha256 = "36c98e0da96bb12a30fe53708097aa9492e7b66d5c3b366e1c8dc251e2856a02" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -3,12 +3,12 @@ mpi:
   - openmpi
 
 moose_petsc:
-  - moose-petsc 3.23.4 mpich_1
-  - moose-petsc 3.23.4 openmpi_1
+  - moose-petsc 3.23.4 mpich_2
+  - moose-petsc 3.23.4 openmpi_2
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.4.2 mpich_6
-  - moose-libmesh-vtk 9.4.2 openmpi_6
+  - moose-libmesh-vtk 9.4.2 mpich_7
+  - moose-libmesh-vtk 9.4.2 openmpi_7
 
 zip_keys:
   - mpi

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = "2025.09.18" %}
 
 package:

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2025.09.18 mpich_0
-  - moose-libmesh 2025.09.18 openmpi_0
+  - moose-libmesh 2025.09.18 mpich_1
+  - moose-libmesh 2025.09.18 openmpi_1
 
 moose_wasp:
   - moose-wasp 2025.09.18

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.09.18" %}
+{% set version = "2025.10.13" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -2,7 +2,7 @@ mpi:
   - mpich
 
 moose_dev:
-  - moose-dev 2025.09.18
+  - moose-dev 2025.10.13
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/mpi/meta.yaml
+++ b/conda/mpi/meta.yaml
@@ -6,7 +6,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2025.09.18" %}
+{% set version = "2025.10.13" %}
 
 package:
   name: moose-mpi

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -3,7 +3,7 @@ mpi:
   - openmpi
 
 moose_mpi:
-  - moose-mpi 2025.09.18
+  - moose-mpi 2025.10.13
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -7,7 +7,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 1 %}
+{% set build = 2 %}
 {% set version = "3.23.4" %}
 
 package:

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1453,3 +1453,31 @@ cf8fabc2a0944313bb3e5bf720972ba27d1a2a8b: #31560: update libmesh, wasp and add i
   wasp:
     full_version: 2025.09.18_0
     hash: 67c57c5
+4ce995026805816dbc0c272d66c7b8b6633a9958: #31632: Fix dropped arguments bug
+  libmesh:
+    full_version: 2025.09.18_1
+    hash: 70cf981
+  libmesh-vtk:
+    full_version: 9.4.2_7
+    hash: 3d548b7
+  moose-dev:
+    full_version: 2025.10.13
+    hash: 40ac75b
+  mpi:
+    full_version: 2025.10.13
+    hash: 0ead4e3
+  petsc:
+    full_version: 3.23.4_2
+    hash: 3aeaa84
+  pprof:
+    full_version: 2025.06.13
+    hash: 3d296db
+  seacas:
+    full_version: 2025.05.22_0
+    hash: '1278418'
+  tools:
+    full_version: 2025.06.26
+    hash: d73012a
+  wasp:
+    full_version: 2025.09.18_0
+    hash: 67c57c5

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -13,7 +13,7 @@ packages:
       conda/tools/meta.yaml.template: conda/tools/meta.yaml
   # dependers: libmesh-vtk, petsc, libmesh, moose-dev
   mpi:
-    version: 2025.09.18
+    version: 2025.10.13
     conda: conda/mpi
     templates:
       conda/mpi/meta.yaml.template: conda/mpi/meta.yaml
@@ -26,7 +26,7 @@ packages:
   # dependers: libmesh, moose-dev
   libmesh-vtk:
     version: 9.4.2
-    build_number: 6
+    build_number: 7
     conda: conda/libmesh-vtk
     templates:
       conda/libmesh-vtk/conda_build_config.yaml.template: conda/libmesh-vtk/conda_build_config.yaml
@@ -38,7 +38,7 @@ packages:
   # dependers: libmesh, moose-dev
   petsc:
     version: 3.23.4
-    build_number: 1
+    build_number: 2
     conda: conda/petsc
     templates:
       conda/petsc/conda_build_config.yaml.template: conda/petsc/conda_build_config.yaml
@@ -57,7 +57,7 @@ packages:
   # dependers: moose-dev
   libmesh:
     version: 2025.09.18
-    build_number: 0
+    build_number: 1
     conda: conda/libmesh
     templates:
       conda/libmesh/conda_build_config.yaml.template: conda/libmesh/conda_build_config.yaml
@@ -93,7 +93,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.09.18
+    version: 2025.10.13
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml


### PR DESCRIPTION
## Reason
A `.bashrc_apptainer` file in the user's home directory triggers a bug which leads to all but the first arguments in an apptainer exec call to be dropped. This for example breaks `moose-dev-exec`.

## Design
Turns out that a typo in `apptainer/files/mpi/.singularity.d/env/89-user-overrides.sh` is responsible for this. 

## Impact
Fixing this will enable the currently broken override capability.