### PR TITLE
Switch from double to real_t and improve support for different FE bases

### DIFF
--- a/framework/doc/content/source/mfem/solvers/MFEMSolverBase.md
+++ b/framework/doc/content/source/mfem/solvers/MFEMSolverBase.md
@@ -17,7 +17,7 @@ preconditioners - can be passed to the `mfem::Solver` at construction time.
 
 Most solvers have the option of being used as Low-Order-Refined (LOR) preconditioner, by setting their respective `low_order_refined` parameter to `true`. LOR solvers work by taking a problem and casting it onto a spectrally equivalent one with lower polynomial order and more refined mesh. Due to the scaling properties of the computing time with respect to polynomial order and mesh size, this change will often result in a significant performance improvement, which tends to be more pronounced at higher polynomial orders. More details can be found [here](https://mfem.org/pdf/workshop21/15_WillPazner_High_Order_Solvers.pdf).
 
-!alert note Solving a problem with vector variables with the LOR method requires a specific choice of quadrature basis for the low-order and the high-order systems to be spectrally equivalent. Therefore, if you are solving an H(Curl) or H(Div) problem with an LOR solver, you must set `closed_basis = GaussLobatto` and `open_basis = IntegratedGLL` in the corresponding `FESpaces` block.
+!alert note Solving a problem with vector variables with the LOR method requires a specific choice of basis for the low-order and the high-order systems to be spectrally equivalent. Therefore, if you are solving an H(Curl) or H(Div) problem with an LOR solver, you must set `closed_basis = GaussLobatto` and `open_basis = IntegratedGLL` in the corresponding `FESpaces` block.
 
 
 !if-end!

--- a/framework/doc/content/source/mfem/solvers/MFEMSolverBase.md
+++ b/framework/doc/content/source/mfem/solvers/MFEMSolverBase.md
@@ -9,15 +9,16 @@ Base class for `mfem::Solver` objects to use in MFEM problems.
 ## Overview
 
 Classes derived from `MFEMSolverBase` can usually be used as preconditioners or linear solvers; the
-`constructSolver` method should be overridden to construct a `shared_ptr` to an `mfem::Solver`
-derived object, and the `getSolver` method should return the `shared_ptr` for use during a solve.
+`constructSolver` method should be overridden to construct a `unique_ptr` to an `mfem::Solver`
+derived object. The `getSolver` method returns a reference to the underlying `mfem::Solver`
+for use during a solve.
 
 Problem-specific information - such as finite element spaces used in the set-up of some
 preconditioners - can be passed to the `mfem::Solver` at construction time.
 
-Most solvers have the option of being used as Low-Order-Refined (LOR) preconditioner, by setting their respective `low_order_refined` parameter to `true`. LOR solvers work by taking a problem and casting it onto a spectrally equivalent one with lower polynomial order and more refined mesh. Due to the scaling properties of the computing time with respect to polynomial order and mesh size, this change will often result in a significant performance improvement, which tends to be more pronounced at higher polynomial orders. More details can be found [here](https://mfem.org/pdf/workshop21/15_WillPazner_High_Order_Solvers.pdf).
+Most solvers have the option of being used as a Low-Order-Refined (LOR) preconditioner, by setting their respective `low_order_refined` parameter to `true`. LOR solvers work by taking a problem and casting it onto a spectrally equivalent one with lower polynomial order and more refined mesh. Due to the scaling properties of the computing time with respect to polynomial order and mesh size, this change will often result in a significant performance improvement, which tends to be more pronounced at higher polynomial orders. More details can be found [here](https://mfem.org/pdf/workshop21/15_WillPazner_High_Order_Solvers.pdf).
 
-!alert note Solving a problem with vector variables with the LOR method requires a specific choice of basis for the low-order and the high-order systems to be spectrally equivalent. Therefore, if you are solving an H(Curl) or H(Div) problem with an LOR solver, you must set `closed_basis = GaussLobatto` and `open_basis = IntegratedGLL` in the corresponding `FESpaces` block.
+!alert note Solving a problem with vector variables with the LOR method requires a specific choice of basis for the low-order and the high-order systems to be spectrally equivalent. Therefore, if you are solving (a) an H1 problem or (b) an H(Curl) or H(Div) problem with an LOR solver, you must set (a) `basis = GaussLobatto` (default) or (b) `closed_basis = GaussLobatto` (default) and `open_basis = IntegratedGLL` in the corresponding `FESpaces` block.
 
 
 !if-end!

--- a/framework/include/mfem/equation_systems/EquationSystem.h
+++ b/framework/include/mfem/equation_systems/EquationSystem.h
@@ -302,7 +302,7 @@ public:
 
   void AddCoupledVariableNameIfMissing(const std::string & coupled_var_name) override;
 
-  virtual void SetTimeStep(double dt);
+  virtual void SetTimeStep(mfem::real_t dt);
   virtual void UpdateEquationSystem();
 
   virtual void AddKernel(std::shared_ptr<MFEMKernel> kernel) override;

--- a/framework/include/mfem/fespaces/MFEMFESpace.h
+++ b/framework/include/mfem/fespaces/MFEMFESpace.h
@@ -65,9 +65,6 @@ protected:
   /// in this finite element space.
   virtual int getVDim() const = 0;
 
-  /// Get the quadrature basis enum associated with the given name.
-  int getBasis(const std::string & basis_name) const;
-
 private:
   /// Constructs the fec from the fec name.
   void buildFEC(const std::string & fec_name) const;

--- a/framework/include/mfem/integrators/ScaleIntegrator.h
+++ b/framework/include/mfem/integrators/ScaleIntegrator.h
@@ -23,7 +23,7 @@ class ScaleIntegrator : public mfem::BilinearFormIntegrator
 {
 private:
   mfem::BilinearFormIntegrator * _integrator{nullptr};
-  double _scale;
+  mfem::real_t _scale;
   bool _own_integrator;
 
 public:
@@ -31,11 +31,11 @@ public:
     : _integrator{integ}, _scale{1}, _own_integrator{true}
   {
   }
-  ScaleIntegrator(mfem::BilinearFormIntegrator * integ, double scale)
+  ScaleIntegrator(mfem::BilinearFormIntegrator * integ, mfem::real_t scale)
     : _integrator{integ}, _scale{scale}, _own_integrator{true}
   {
   }
-  ScaleIntegrator(mfem::BilinearFormIntegrator * integ, double scale, bool own)
+  ScaleIntegrator(mfem::BilinearFormIntegrator * integ, mfem::real_t scale, bool own)
     : _integrator{integ}, _scale{scale}, _own_integrator{own}
   {
   }
@@ -50,7 +50,7 @@ public:
     _integrator = integ;
   }
 
-  void SetScale(double scale) { _scale = scale; }
+  void SetScale(mfem::real_t scale) { _scale = scale; }
 
   void SetOwn(bool own) { _own_integrator = own; }
 

--- a/framework/include/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.h
@@ -30,7 +30,7 @@ public:
 
   void SetGridFunctions() override;
   void Init(mfem::BlockVector & X) override;
-  void ImplicitSolve(const double dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
+  void ImplicitSolve(const mfem::real_t dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
   void Solve() override;
 
   [[nodiscard]] Moose::MFEM::TimeDependentEquationSystem * GetEquationSystem() const override
@@ -44,7 +44,7 @@ public:
   }
 
 protected:
-  void BuildEquationSystemOperator(double dt);
+  void BuildEquationSystemOperator(mfem::real_t dt);
 
 private:
   std::shared_ptr<Moose::MFEM::TimeDependentEquationSystem> _equation_system{nullptr};

--- a/framework/include/mfem/problem_operators/TimeDomainProblemOperator.h
+++ b/framework/include/mfem/problem_operators/TimeDomainProblemOperator.h
@@ -24,7 +24,7 @@ public:
 
   void SetGridFunctions() override;
   void Solve() override {}
-  void ImplicitSolve(const double, const mfem::Vector &, mfem::Vector &) override {}
+  void ImplicitSolve(const mfem::real_t, const mfem::Vector &, mfem::Vector &) override {}
 };
 
 } // namespace Moose::MFEM

--- a/framework/include/mfem/solvers/MFEMSolverBase.h
+++ b/framework/include/mfem/solvers/MFEMSolverBase.h
@@ -45,7 +45,7 @@ protected:
   virtual void constructSolver(const InputParameters & parameters) = 0;
 
   /// Checks for the correct configuration of quadrature bases for LOR spectral equivalence
-  virtual bool checkSpectralEquivalence(mfem::ParBilinearForm & blf) const;
+  virtual void checkSpectralEquivalence(mfem::ParBilinearForm & blf) const;
 
   /// Variable defining whether to use LOR solver
   bool _lor;

--- a/framework/include/mfem/submeshes/MFEMCutTransitionSubMesh.h
+++ b/framework/include/mfem/submeshes/MFEMCutTransitionSubMesh.h
@@ -41,7 +41,7 @@ protected:
   mfem::Vector findFaceNormal(const mfem::ParMesh & mesh, const int & face);
 
   /// Checks whether an element lies on the positive or negative side of the cut plane
-  int sideOfCut(const int & el, const int & el_vertex_on_cut, mfem::ParMesh & mesh);
+  bool isPositiveSideOfCut(const int & el, const int & el_vertex_on_cut, mfem::ParMesh & mesh);
 
   const BoundaryName & _cut_boundary;
   std::shared_ptr<mfem::ParSubMesh> _cut_submesh{nullptr};

--- a/framework/include/mfem/utils/CoefficientManager.h
+++ b/framework/include/mfem/utils/CoefficientManager.h
@@ -173,7 +173,7 @@ public:
   bool scalarPropertyIsDefined(const std::string & name, const std::string & block) const;
   bool vectorPropertyIsDefined(const std::string & name, const std::string & block) const;
   bool matrixPropertyIsDefined(const std::string & name, const std::string & block) const;
-  void setTime(const double time);
+  void setTime(const mfem::real_t time);
 
 private:
   ScalarMap _scalar_coeffs;

--- a/framework/include/mfem/utils/CoefficientMap.h
+++ b/framework/include/mfem/utils/CoefficientMap.h
@@ -140,7 +140,7 @@ public:
     return block_map.count(block) > 0;
   }
 
-  void setTime(const double time)
+  void setTime(const mfem::real_t time)
   {
     for (auto & coef : this->_iterable_coefficients)
       coef->SetTime(time);

--- a/framework/src/mfem/equation_systems/EquationSystem.C
+++ b/framework/src/mfem/equation_systems/EquationSystem.C
@@ -459,7 +459,7 @@ TimeDependentEquationSystem::AddCoupledVariableNameIfMissing(const std::string &
 }
 
 void
-TimeDependentEquationSystem::SetTimeStep(double dt)
+TimeDependentEquationSystem::SetTimeStep(mfem::real_t dt)
 {
   if (fabs(dt - _dt_coef.constant) > 1.0e-12 * dt)
   {

--- a/framework/src/mfem/fespaces/MFEMFESpace.C
+++ b/framework/src/mfem/fespaces/MFEMFESpace.C
@@ -62,34 +62,6 @@ MFEMFESpace::buildFEC(const std::string & fec_name) const
   }
 }
 
-int
-MFEMFESpace::getBasis(const std::string & basis_name) const
-{
-
-  if (!strcmp(basis_name.c_str(), "GaussLegendre"))
-    return mfem::BasisType::GaussLegendre;
-  else if (!strcmp(basis_name.c_str(), "GaussLobatto"))
-    return mfem::BasisType::GaussLobatto;
-  else if (!strcmp(basis_name.c_str(), "Positive"))
-    return mfem::BasisType::Positive;
-  else if (!strcmp(basis_name.c_str(), "OpenUniform"))
-    return mfem::BasisType::OpenUniform;
-  else if (!strcmp(basis_name.c_str(), "ClosedUniform"))
-    return mfem::BasisType::ClosedUniform;
-  else if (!strcmp(basis_name.c_str(), "OpenHalfUniform"))
-    return mfem::BasisType::OpenHalfUniform;
-  else if (!strcmp(basis_name.c_str(), "Serendipity"))
-    return mfem::BasisType::Serendipity;
-  else if (!strcmp(basis_name.c_str(), "ClosedGL"))
-    return mfem::BasisType::ClosedGL;
-  else if (!strcmp(basis_name.c_str(), "IntegratedGLL"))
-    return mfem::BasisType::IntegratedGLL;
-  else if (!strcmp(basis_name.c_str(), "NumBasisTypes"))
-    return mfem::BasisType::NumBasisTypes;
-  else
-    mooseError("Unknown basis type: ", basis_name);
-}
-
 void
 MFEMFESpace::buildFESpace(const int vdim) const
 {

--- a/framework/src/mfem/fespaces/MFEMVectorFESpace.C
+++ b/framework/src/mfem/fespaces/MFEMVectorFESpace.C
@@ -20,14 +20,24 @@ MFEMVectorFESpace::validParams()
   params.addClassDescription(
       "Convenience class to construct vector finite element spaces, abstracting away some of the "
       "mathematical complexity of specifying the dimensions.");
-  MooseEnum fec_types("H1 ND RT L2", "H1", true);
+  MooseEnum fec_types("H1 ND RT L2", "H1");
   params.addParam<MooseEnum>("fec_type", fec_types, "Specifies the family of FE shape functions.");
-  params.addParam<std::string>("closed_basis",
-                               "GaussLobatto",
-                               "Specifies the closed quadrature basis used for vector elements.");
-  params.addParam<std::string>("open_basis",
-                               "GaussLegendre",
-                               "Specifies the open quadrature basis used for vector elements.");
+  MooseEnum closed_basis_types("GaussLobatto=1 ClosedUniform=4 Serendipity=6 ClosedGL=7",
+                               "GaussLobatto");
+  params.addParam<MooseEnum>("closed_basis",
+                             closed_basis_types,
+                             "Specifies the closed basis used for ND and RT elements.");
+  MooseEnum basis_types("GaussLegendre GaussLobatto Positive OpenUniform ClosedUniform "
+                        "OpenHalfUniform Serendipity ClosedGL IntegratedGLL",
+                        "GaussLegendre");
+  params.addParam<MooseEnum>(
+      "open_basis", basis_types, "Specifies the open basis used for ND and RT elements.");
+  basis_types = "GaussLobatto";
+  params.addParam<MooseEnum>(
+      "basis",
+      basis_types,
+      "Specifies the basis used for H1 and L2 vector elements. H1 spaces require a closed basis "
+      "(GaussLobatto Positive ClosedUniform Serendipity ClosedGL)");
   params.addParam<int>("range_dim",
                        0,
                        "The number of components of the vectors in reference space. Zero "
@@ -39,8 +49,8 @@ MFEMVectorFESpace::validParams()
 
 MFEMVectorFESpace::MFEMVectorFESpace(const InputParameters & parameters)
   : MFEMSimplifiedFESpace(parameters),
-    _fec_type(parameters.get<MooseEnum>("fec_type")),
-    _range_dim(parameters.get<int>("range_dim"))
+    _fec_type(getParam<MooseEnum>("fec_type")),
+    _range_dim(getParam<int>("range_dim"))
 {
 }
 
@@ -57,15 +67,26 @@ MFEMVectorFESpace::getFECName() const
     actual_type += "_R" + std::to_string(pdim) + "D";
   }
 
-  const char cb = mfem::BasisType::GetChar(getBasis(getParam<std::string>("closed_basis")));
-  const std::string closed_basis(1, cb);
-  const char ob = mfem::BasisType::GetChar(getBasis(getParam<std::string>("open_basis")));
-  const std::string open_basis(1, ob);
+  std::string basis = _fec_type == "L2" ? "_T" : "@";
 
-  // This is to get around an MFEM bug where if you pass the full name of the default element type,
-  // it crashes
-  const std::string basis =
-      (closed_basis + open_basis == "Gg" ? "" : "@" + closed_basis + open_basis);
+  if (_fec_type == "ND" || _fec_type == "RT")
+  {
+    if (isParamSetByUser("basis"))
+      mooseWarning("basis parameter ignored, using closed_basis/open_basis parameters instead");
+    basis += mfem::BasisType::GetChar(getParam<MooseEnum>("closed_basis"));
+    basis += mfem::BasisType::GetChar(getParam<MooseEnum>("open_basis"));
+  }
+  else if (_fec_type == "H1" || _fec_type == "L2")
+  {
+    if (isParamSetByUser("closed_basis") || isParamSetByUser("open_basis"))
+      mooseWarning("closed_basis/open_basis parameter ignored, using basis parameter instead");
+    basis += _fec_type == "L2"
+                 ? std::to_string(getParam<MooseEnum>("basis"))
+                 : std::string({mfem::BasisType::GetChar(getParam<MooseEnum>("basis"))});
+  }
+
+  // This is to get around an MFEM bug (to be removed in #31525)
+  basis = (basis == "@Gg" || basis == "@G" || basis == "_T0") ? "" : basis;
 
   return actual_type + basis + "_" + std::to_string(pdim) + "D_P" + std::to_string(_fec_order);
 }

--- a/framework/src/mfem/problem/MFEMProblem.C
+++ b/framework/src/mfem/problem/MFEMProblem.C
@@ -365,7 +365,6 @@ MFEMProblem::addPostprocessor(const std::string & type,
                               const std::string & name,
                               InputParameters & parameters)
 {
-  // For some reason this isn't getting called
   ExternalProblem::addPostprocessor(type, name, parameters);
   const PostprocessorValue & val = getPostprocessorValueByName(name);
   getCoefficients().declareScalar<mfem::FunctionCoefficient>(

--- a/framework/src/mfem/problem/MFEMProblem.C
+++ b/framework/src/mfem/problem/MFEMProblem.C
@@ -334,7 +334,7 @@ MFEMProblem::addFunction(const std::string & type,
   {
     getCoefficients().declareScalar<mfem::FunctionCoefficient>(
         name,
-        [&func](const mfem::Vector & p, double t) -> mfem::real_t
+        [&func](const mfem::Vector & p, mfem::real_t t) -> mfem::real_t
         { return func.value(t, pointFromMFEMVector(p)); });
   }
   else if (std::find(VECTOR_FUNCS.begin(), VECTOR_FUNCS.end(), type) != VECTOR_FUNCS.end())
@@ -343,7 +343,7 @@ MFEMProblem::addFunction(const std::string & type,
     getCoefficients().declareVector<mfem::VectorFunctionCoefficient>(
         name,
         dim,
-        [&func, dim](const mfem::Vector & p, double t, mfem::Vector & u)
+        [&func, dim](const mfem::Vector & p, mfem::real_t t, mfem::Vector & u)
         {
           libMesh::RealVectorValue vector_value = func.vectorValue(t, pointFromMFEMVector(p));
           for (int i = 0; i < dim; i++)
@@ -369,7 +369,7 @@ MFEMProblem::addPostprocessor(const std::string & type,
   ExternalProblem::addPostprocessor(type, name, parameters);
   const PostprocessorValue & val = getPostprocessorValueByName(name);
   getCoefficients().declareScalar<mfem::FunctionCoefficient>(
-      name, [&val](const mfem::Vector &, double) -> mfem::real_t { return val; });
+      name, [&val](const mfem::Vector &) -> mfem::real_t { return val; });
 }
 
 InputParameters

--- a/framework/src/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/TimeDomainEquationSystemProblemOperator.C
@@ -46,7 +46,7 @@ TimeDomainEquationSystemProblemOperator::Solve()
 }
 
 void
-TimeDomainEquationSystemProblemOperator::ImplicitSolve(const double dt,
+TimeDomainEquationSystemProblemOperator::ImplicitSolve(const mfem::real_t dt,
                                                        const mfem::Vector & /*X*/,
                                                        mfem::Vector & dX_dt)
 {
@@ -74,7 +74,7 @@ TimeDomainEquationSystemProblemOperator::ImplicitSolve(const double dt,
 }
 
 void
-TimeDomainEquationSystemProblemOperator::BuildEquationSystemOperator(double dt)
+TimeDomainEquationSystemProblemOperator::BuildEquationSystemOperator(mfem::real_t dt)
 {
   GetEquationSystem()->SetTimeStep(dt);
   GetEquationSystem()->UpdateEquationSystem();

--- a/framework/src/mfem/solvers/MFEMCGSolver.C
+++ b/framework/src/mfem/solvers/MFEMCGSolver.C
@@ -61,10 +61,7 @@ MFEMCGSolver::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs)
   }
   else if (_lor)
   {
-    if (!checkSpectralEquivalence(a))
-      mooseError("Low-Order-Refined solver requires the FESpace closed_basis to be GaussLobatto "
-                 "and the open-basis to be IntegratedGLL for ND and RT elements.");
-
+    checkSpectralEquivalence(a);
     auto lor_solver = new mfem::LORSolver<mfem::CGSolver>(a, tdofs);
     lor_solver->GetSolver().SetRelTol(getParam<mfem::real_t>("l_tol"));
     lor_solver->GetSolver().SetAbsTol(getParam<mfem::real_t>("l_abs_tol"));

--- a/framework/src/mfem/solvers/MFEMGMRESSolver.C
+++ b/framework/src/mfem/solvers/MFEMGMRESSolver.C
@@ -61,10 +61,7 @@ MFEMGMRESSolver::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdof
   }
   else if (_lor)
   {
-    if (!checkSpectralEquivalence(a))
-      mooseError("Low-Order-Refined solver requires the FESpace closed_basis to be GaussLobatto "
-                 "and the open-basis to be IntegratedGLL for ND and RT elements.");
-
+    checkSpectralEquivalence(a);
     auto lor_solver = new mfem::LORSolver<mfem::GMRESSolver>(a, tdofs);
     lor_solver->GetSolver().SetRelTol(getParam<mfem::real_t>("l_tol"));
     lor_solver->GetSolver().SetAbsTol(getParam<mfem::real_t>("l_abs_tol"));

--- a/framework/src/mfem/solvers/MFEMHypreADS.C
+++ b/framework/src/mfem/solvers/MFEMHypreADS.C
@@ -45,10 +45,7 @@ MFEMHypreADS::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs)
 {
   if (_lor)
   {
-    if (!checkSpectralEquivalence(a))
-      mooseError("Low-Order-Refined solver requires the FESpace closed_basis to be GaussLobatto "
-                 "and the open-basis to be IntegratedGLL for ND and RT elements.");
-
+    checkSpectralEquivalence(a);
     if (_mfem_fespace.getFESpace()->GetMesh()->GetElement(0)->GetGeometryType() !=
         mfem::Geometry::Type::CUBE)
       mooseError("LOR HypreADS Solver only supports hex meshes.");

--- a/framework/src/mfem/solvers/MFEMHypreAMS.C
+++ b/framework/src/mfem/solvers/MFEMHypreAMS.C
@@ -52,10 +52,7 @@ MFEMHypreAMS::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs)
 {
   if (_lor)
   {
-    if (!checkSpectralEquivalence(a))
-      mooseError("Low-Order-Refined solver requires the FESpace closed_basis to be GaussLobatto "
-                 "and the open-basis to be IntegratedGLL for ND and RT elements.");
-
+    checkSpectralEquivalence(a);
     if (_mfem_fespace.getFESpace()->GetMesh()->GetElement(0)->GetGeometryType() !=
         mfem::Geometry::Type::CUBE)
       mooseError("LOR HypreAMS Solver only supports hex meshes.");

--- a/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
+++ b/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
@@ -62,10 +62,7 @@ MFEMHypreBoomerAMG::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & t
 {
   if (_lor)
   {
-    if (!checkSpectralEquivalence(a))
-      mooseError("Low-Order-Refined solver requires the FESpace closed_basis to be GaussLobatto "
-                 "and the open-basis to be IntegratedGLL for ND and RT elements.");
-
+    checkSpectralEquivalence(a);
     auto lor_solver = new mfem::LORSolver<mfem::HypreBoomerAMG>(a, tdofs);
     lor_solver->GetSolver().SetTol(getParam<mfem::real_t>("l_tol"));
     lor_solver->GetSolver().SetMaxIter(getParam<int>("l_max_its"));

--- a/framework/src/mfem/solvers/MFEMHypreFGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreFGMRES.C
@@ -60,10 +60,7 @@ MFEMHypreFGMRES::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdof
   }
   else if (_lor)
   {
-    if (!checkSpectralEquivalence(a))
-      mooseError("Low-Order-Refined solver requires the FESpace closed_basis to be GaussLobatto "
-                 "and the open-basis to be IntegratedGLL for ND and RT elements.");
-
+    checkSpectralEquivalence(a);
     mfem::ParLORDiscretization lor_disc(a, tdofs);
     auto lor_solver = new mfem::LORSolver<mfem::HypreFGMRES>(
         lor_disc, getMFEMProblem().mesh().getMFEMParMesh().GetComm());

--- a/framework/src/mfem/solvers/MFEMHypreGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreGMRES.C
@@ -63,10 +63,7 @@ MFEMHypreGMRES::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs
   }
   else if (_lor)
   {
-    if (!checkSpectralEquivalence(a))
-      mooseError("Low-Order-Refined solver requires the FESpace closed_basis to be GaussLobatto "
-                 "and the open-basis to be IntegratedGLL for ND and RT elements.");
-
+    checkSpectralEquivalence(a);
     mfem::ParLORDiscretization lor_disc(a, tdofs);
     auto lor_solver = new mfem::LORSolver<mfem::HypreGMRES>(
         lor_disc, getMFEMProblem().mesh().getMFEMParMesh().GetComm());

--- a/framework/src/mfem/solvers/MFEMHyprePCG.C
+++ b/framework/src/mfem/solvers/MFEMHyprePCG.C
@@ -61,10 +61,7 @@ MFEMHyprePCG::updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs)
   }
   else if (_lor)
   {
-    if (!checkSpectralEquivalence(a))
-      mooseError("Low-Order-Refined solver requires the FESpace closed_basis to be GaussLobatto "
-                 "and the open-basis to be IntegratedGLL for ND and RT elements.");
-
+    checkSpectralEquivalence(a);
     mfem::ParLORDiscretization lor_disc(a, tdofs);
     auto lor_solver = new mfem::LORSolver<mfem::HyprePCG>(
         lor_disc, getMFEMProblem().mesh().getMFEMParMesh().GetComm());

--- a/framework/src/mfem/solvers/MFEMOperatorJacobiSmoother.C
+++ b/framework/src/mfem/solvers/MFEMOperatorJacobiSmoother.C
@@ -40,10 +40,7 @@ MFEMOperatorJacobiSmoother::updateSolver(mfem::ParBilinearForm & a, mfem::Array<
 {
   if (_lor)
   {
-    if (!checkSpectralEquivalence(a))
-      mooseError("Low-Order-Refined solver requires the FESpace closed_basis to be GaussLobatto "
-                 "and the open-basis to be IntegratedGLL for ND and RT elements.");
-
+    checkSpectralEquivalence(a);
     _solver.reset(new mfem::LORSolver<mfem::OperatorJacobiSmoother>(a, tdofs));
   }
 }

--- a/framework/src/mfem/solvers/MFEMSolverBase.C
+++ b/framework/src/mfem/solvers/MFEMSolverBase.C
@@ -57,25 +57,29 @@ template void MFEMSolverBase::setPreconditioner(mfem::HypreFGMRES &);
 template void MFEMSolverBase::setPreconditioner(mfem::HypreGMRES &);
 template void MFEMSolverBase::setPreconditioner(mfem::HyprePCG &);
 
-bool
+void
 MFEMSolverBase::checkSpectralEquivalence(mfem::ParBilinearForm & blf) const
 {
-  bool equiv = true;
-
-  if (auto fec = dynamic_cast<const mfem::ND_FECollection *>(blf.FESpace()->FEColl()))
+  if (auto fec = dynamic_cast<const mfem::H1_FECollection *>(blf.FESpace()->FEColl()))
+  {
+    if (fec->GetBasisType() != mfem::BasisType::GaussLobatto)
+      mooseError("Low-Order-Refined solver requires the FESpace basis to be GaussLobatto "
+                 "for H1 elements.");
+  }
+  else if (auto fec = dynamic_cast<const mfem::ND_FECollection *>(blf.FESpace()->FEColl()))
   {
     if (fec->GetClosedBasisType() != mfem::BasisType::GaussLobatto ||
         fec->GetOpenBasisType() != mfem::BasisType::IntegratedGLL)
-      equiv = false;
+      mooseError("Low-Order-Refined solver requires the FESpace closed-basis to be GaussLobatto "
+                 "and the open-basis to be IntegratedGLL for ND elements.");
   }
   else if (auto fec = dynamic_cast<const mfem::RT_FECollection *>(blf.FESpace()->FEColl()))
   {
     if (fec->GetClosedBasisType() != mfem::BasisType::GaussLobatto ||
         fec->GetOpenBasisType() != mfem::BasisType::IntegratedGLL)
-      equiv = false;
+      mooseError("Low-Order-Refined solver requires the FESpace closed-basis to be GaussLobatto "
+                 "and the open-basis to be IntegratedGLL for RT elements.");
   }
-
-  return equiv;
 }
 
 #endif

--- a/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
@@ -89,7 +89,7 @@ MFEMCutTransitionSubMesh::labelMesh(mfem::ParMesh & parent_mesh)
                 getMFEMProblem().mesh().getMFEMParMesh().GetComm());
   MPI_Bcast(_cut_normal.GetData(),
             _cut_normal.Size(),
-            MPI_DOUBLE,
+            MFEM_MPI_REAL_T,
             rank_with_submesh,
             getMFEMProblem().mesh().getMFEMParMesh().GetComm());
   // Iterate over all vertices on cut, find elements with those vertices,

--- a/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
@@ -110,7 +110,7 @@ MFEMCutTransitionSubMesh::labelMesh(mfem::ParMesh & parent_mesh)
     {
       const int el_adj_to_cut = els_adj_to_cut[i];
       if (isInDomain(el_adj_to_cut, getSubdomainAttributes(), parent_mesh) &&
-          sideOfCut(el_adj_to_cut, cut_vert, parent_mesh) == 1)
+          isPositiveSideOfCut(el_adj_to_cut, cut_vert, parent_mesh))
         transition_els.Append(el_adj_to_cut);
     }
   }
@@ -162,7 +162,7 @@ MFEMCutTransitionSubMesh::labelMesh(mfem::ParMesh & parent_mesh)
           {
             const int el_adj_to_cut = els_adj_to_cut[i];
             if (isInDomain(el_adj_to_cut, getSubdomainAttributes(), parent_mesh) &&
-                sideOfCut(el_adj_to_cut, cut_vert, parent_mesh) == 1)
+                isPositiveSideOfCut(el_adj_to_cut, cut_vert, parent_mesh))
               transition_els.Append(el_adj_to_cut);
           }
         }
@@ -203,10 +203,10 @@ MFEMCutTransitionSubMesh::findFaceNormal(const mfem::ParMesh & mesh, const int &
   return normal;
 }
 
-int
-MFEMCutTransitionSubMesh::sideOfCut(const int & el,
-                                    const int & el_vertex_on_cut,
-                                    mfem::ParMesh & parent_mesh)
+bool
+MFEMCutTransitionSubMesh::isPositiveSideOfCut(const int & el,
+                                              const int & el_vertex_on_cut,
+                                              mfem::ParMesh & parent_mesh)
 {
   const int sdim = parent_mesh.SpaceDimension();
   mfem::Vector el_center(3);
@@ -215,11 +215,7 @@ MFEMCutTransitionSubMesh::sideOfCut(const int & el,
   mfem::Vector relative_center(sdim);
   for (int j = 0; j < sdim; j++)
     relative_center[j] = el_center[j] - vertex_coords[j];
-  double side = _cut_normal * relative_center;
-  if (side > 0)
-    return 1;
-  else
-    return -1;
+  return _cut_normal * relative_center > 0;
 }
 
 void

--- a/framework/src/mfem/utils/CoefficientManager.C
+++ b/framework/src/mfem/utils/CoefficientManager.C
@@ -197,7 +197,7 @@ CoefficientManager::matrixPropertyIsDefined(const std::string & name,
 }
 
 void
-CoefficientManager::setTime(const double time)
+CoefficientManager::setTime(const mfem::real_t time)
 {
   this->_scalar_coeffs.setTime(time);
   this->_vector_coeffs.setTime(time);

--- a/test/tests/mfem/auxkernels/projection.i
+++ b/test/tests/mfem/auxkernels/projection.i
@@ -23,6 +23,7 @@
     type = MFEMScalarFESpace
     fec_type = L2
     fec_order = CONSTANT
+    basis = GaussLegendre
   []
 []
 

--- a/test/tests/mfem/ics/scalar_ic.i
+++ b/test/tests/mfem/ics/scalar_ic.i
@@ -18,6 +18,7 @@
     type = MFEMScalarFESpace
     fec_type = L2
     fec_order = CONSTANT
+    basis = GaussLegendre
   []
 []
 

--- a/test/tests/mfem/ics/transient_scalar_ic.i
+++ b/test/tests/mfem/ics/transient_scalar_ic.i
@@ -17,6 +17,7 @@
     type = MFEMScalarFESpace
     fec_type = L2
     fec_order = CONSTANT
+    basis = GaussLegendre
   []
 []
 

--- a/test/tests/mfem/ics/vector_ic.i
+++ b/test/tests/mfem/ics/vector_ic.i
@@ -28,6 +28,7 @@
     type = MFEMVectorFESpace
     fec_type = L2
     fec_order = CONSTANT
+    basis = GaussLegendre
   []
 []
 

--- a/test/tests/mfem/kernels/darcy.i
+++ b/test/tests/mfem/kernels/darcy.i
@@ -34,6 +34,7 @@
     type = MFEMScalarFESpace
     fec_type = L2
     fec_order = SECOND
+    basis = GaussLegendre
   []
 []
 

--- a/test/tests/mfem/kernels/graddiv.i
+++ b/test/tests/mfem/kernels/graddiv.i
@@ -23,6 +23,7 @@
     type = MFEMScalarFESpace
     fec_type = L2
     fec_order = CONSTANT
+    basis = GaussLegendre
   []
 []
 

--- a/unit/src/MFEMEssentialBCTest.C
+++ b/unit/src/MFEMEssentialBCTest.C
@@ -57,9 +57,9 @@ public:
 
   void check_boundary(int /*bound*/,
                       mfem::FiniteElementSpace & fespace,
-                      std::function<double(mfem::ElementTransformation *,
-                                           const mfem::IntegrationPoint &)> error_func,
-                      double tolerance)
+                      std::function<mfem::real_t(mfem::ElementTransformation *,
+                                                 const mfem::IntegrationPoint &)> error_func,
+                      mfem::real_t tolerance)
   {
     for (int be = 0; be < _mfem_mesh_ptr->getMFEMParMeshPtr()->GetNBE(); be++)
     {
@@ -71,12 +71,12 @@ public:
       const mfem::FiniteElement * fe = fespace.GetBE(be);
       const mfem::IntegrationRule & ir =
           mfem::IntRules.Get(fe->GetGeomType(), 2 * fe->GetOrder() + 2);
-      double total_error = 0.0;
+      mfem::real_t total_error = 0.0;
       for (int j = 0; j < ir.GetNPoints(); j++)
       {
         const mfem::IntegrationPoint point = ir.IntPoint(j);
         transform->SetIntPoint(&point);
-        const double error = error_func(transform, point);
+        const mfem::real_t error = error_func(transform, point);
         total_error += error * error;
       }
       EXPECT_LT(total_error, tolerance);

--- a/unit/src/MFEMFESpaceTest.C
+++ b/unit/src/MFEMFESpaceTest.C
@@ -133,6 +133,8 @@ class ScalarFESpaceTest : public MFEMFESpaceUnitTest<MFEMScalarFESpace, std::str
     InputParameters params = _factory.getValidParams("MFEMScalarFESpace");
     params.set<MooseEnum>("fec_type") = std::get<0>(raw_params);
     params.set<MooseEnum>("fec_order") = std::get<1>(raw_params);
+    if (params.set<MooseEnum>("fec_type") == "L2")
+      params.set<MooseEnum>("basis") = "GaussLegendre";
     return params;
   }
 };
@@ -170,6 +172,8 @@ class VectorFESpaceTest : public MFEMFESpaceUnitTest<MFEMVectorFESpace, std::str
     params.set<MooseEnum>("fec_type") = std::get<0>(raw_params);
     params.set<MooseEnum>("fec_order") = std::get<1>(raw_params);
     params.set<int>("range_dim") = std::get<2>(raw_params);
+    if (params.set<MooseEnum>("fec_type") == "L2")
+      params.set<MooseEnum>("basis") = "GaussLegendre";
     return params;
   }
 };

--- a/unit/src/MFEMPostprocessorTest.C
+++ b/unit/src/MFEMPostprocessorTest.C
@@ -91,7 +91,7 @@ TEST_F(MFEMPostprocessorTest, MFEMVectorL2Error)
   pp_params.set<VariableName>("variable") = "vector_var";
   auto & l2_pp = addObject<MFEMVectorL2Error>("MFEMVectorL2Error", "ppl2", pp_params);
 
-  mfem::VectorConstantCoefficient twos(mfem::Vector({2., 2.}));
+  mfem::VectorConstantCoefficient twos(mfem::Vector({2., 2., 2.}));
   _vector_var->ProjectCoefficient(twos);
   EXPECT_GT(l2_pp.getValue(), 1.);
 

--- a/unit/src/MFEMSolverTest.C
+++ b/unit/src/MFEMSolverTest.C
@@ -18,11 +18,9 @@ class MFEMSolverTest : public MFEMObjectUnitTest
 public:
   MFEMSolverTest() : MFEMObjectUnitTest("MooseUnitApp") {}
 
-  static double uexact(const mfem::Vector & x)
+  static mfem::real_t uexact(const mfem::Vector & x)
   {
-    double u;
-    u = x(2) * x(2) * x(2) - 5.0 * x(0) * x(0) * x(1) * x(2);
-    return u;
+    return x(2) * x(2) * x(2) - 5.0 * x(0) * x(0) * x(1) * x(2);
   }
 
   static void gradexact(const mfem::Vector & x, mfem::Vector & grad)
@@ -33,17 +31,14 @@ public:
     grad[2] = 3.0 * x(2) * x(2) - 5.0 * x(0) * x(0) * x(1);
   }
 
-  static double d2uexact(const mfem::Vector & x) // returns \Delta u
+  static mfem::real_t d2uexact(const mfem::Vector & x) // returns \Delta u
   {
-    double d2u;
-    d2u = -10.0 * x(1) * x(2) + 6.0 * x(2);
-    return d2u;
+    return -10.0 * x(1) * x(2) + 6.0 * x(2);
   }
 
-  static double fexact(const mfem::Vector & x) // returns -\Delta u
+  static mfem::real_t fexact(const mfem::Vector & x) // returns -\Delta u
   {
-    double d2u = d2uexact(x);
-    return -d2u;
+    return -d2uexact(x);
   }
 
   // Create a simple 3D mesh for testing


### PR DESCRIPTION
## Reason
We should be able to fully support all of MFEM's floating point formats.
The user should be able to successfully select the basis type for all four supported FE collections.

## Design
Code refactoring, including extra careful parameter checks and processing.

## Impact
Better support for different floating point precisions and FE collections with non-default basis types.
Though this will affect #31525 (as it'll conflict), it's completely orthogonal and separate.
Indeed, I've explicitly commented the code to explicitly mark what needs removing in #31525.