### PR TITLE
Our new test is erroring on more than 2 ranks

### DIFF
--- a/test/tests/meshgenerators/file_mesh_generator/tests
+++ b/test/tests/meshgenerators/file_mesh_generator/tests
@@ -221,6 +221,9 @@
     capabilities = 'exodus>=8.0' # This also ensures HDF5 support
     exodiff = 'iga_constraint_hdf5_out.e' # Symlink; this should match the .m based test
 
+    # Workaround for bug at libMesh level
+    max_parallel = 2
+
     # Penalty method boundary conditions
     abs_zero = 1e-08
 


### PR DESCRIPTION
This looks like a libMesh-level bug to me; let's cap at 2 procs until I can get a fix downstream.

Refs #18768

This should unbreak next.