### PR TITLE
Ensuring there are no python files in MooseDocs output

### DIFF
--- a/python/MooseDocs/base/executioners.py
+++ b/python/MooseDocs/base/executioners.py
@@ -338,7 +338,8 @@ class Executioner(mixins.ConfigObject, mixins.TranslatorObject):
         """Complete copying of non-source (e.g., images) files."""
         start = time.time()
         for node in other_nodes:
-            self.translator.renderer.write(node)
+            if node.attributes.get('active', True) and node.attributes.get('write', True):
+                self.translator.renderer.write(node)
         return time.time() - start
 
     def _clear_progress(self):

--- a/python/MooseDocs/commands/verify.py
+++ b/python/MooseDocs/commands/verify.py
@@ -135,7 +135,18 @@ def main(options):
     for root, _, files in os.walk(out_dir):
         for fname in files:
             _, ext = os.path.splitext(fname)
-            if ext in extensions:
+
+            # Ensure there are no python files
+            if ext == ".py":
+                print(
+                    mooseutils.colorText(
+                        f"There should not be python files in output, but {fname} exists.",
+                        'RED',
+                    )
+                )
+                errno += 1
+
+            elif ext in extensions:
                 errno += compare(os.path.join(root, fname), out_dir, gold_dir, options.update_gold)
 
     return errno

--- a/python/MooseDocs/common/get_content.py
+++ b/python/MooseDocs/common/get_content.py
@@ -131,7 +131,7 @@ def create_file_page(name, filename, in_ext):
     if ext in in_ext:
         return pages.Source(name, source=filename)
     else:
-        return pages.File(name, source=filename)
+        return pages.File(name, source=filename, write=ext != ".py")
 
 def get_files(items, in_ext):
     """

--- a/python/MooseDocs/test/common/test_get_pages.py
+++ b/python/MooseDocs/test/common/test_get_pages.py
@@ -13,7 +13,7 @@ import unittest
 import mock
 
 from MooseDocs import ROOT_DIR
-from MooseDocs.common.get_content import _build_regex, _find_files, _doc_import, get_content
+from MooseDocs.common.get_content import _build_regex, _find_files, _doc_import, get_content, create_file_page
 from MooseDocs.tree import pages
 
 class TestBuildRegex(unittest.TestCase):
@@ -161,6 +161,32 @@ class TestDocTree(unittest.TestCase):
                 self.assertEqual(p.local, 'getting_started')
                 self.assertEqual(p.source,
                                  os.path.join(ROOT_DIR, 'framework/doc/content/getting_started'))
+
+class TestCreateFilePage(unittest.TestCase):
+    def testCreateFile(self):
+        file = "foo.txt"
+        page = create_file_page("foo", file, [".md"])
+        self.assertIsInstance(page, pages.File)
+        self.assertEqual(page.name, "foo")
+        self.assertEqual(page.source, file)
+        self.assertEqual(page.attributes.get("write", True), True)
+
+    def testCreateInFile(self):
+        file = "foo.md"
+        page = create_file_page("foo", file, [".md"])
+        self.assertIsInstance(page, pages.Source)
+        self.assertEqual(page.name, "foo")
+        self.assertEqual(page.source, file)
+        self.assertEqual(page.attributes.get("write", True), True)
+
+    def testCreatePythonFile(self):
+        file = "foo.py"
+        page = create_file_page("foo", file, [".md"])
+        self.assertIsInstance(page, pages.File)
+        self.assertEqual(page.name, "foo")
+        self.assertEqual(page.source, file)
+        self.assertEqual(page.attributes.get("write", True), False)
+
 
 if __name__ == '__main__':
     import logging


### PR DESCRIPTION
Closes #31655

Implemenation is very simple, when discovering content pages, we set the `write` attribute to `False` if the file extension is `.py`. The executioner also needed an if statement to respect this attribute. The rest is just testing.
