### PR TITLE
Messages for potential PenetrationThread errors

### DIFF
--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -274,7 +274,6 @@ PenetrationThread::operator()(const NodeIdRange & range)
         (*point_locator)(*closest_node, candidate_elements);
 
         if (candidate_elements.empty())
-        {
           mooseError("No proximate elements found at node ",
                      closest_node->id(),
                      " at ",
@@ -282,7 +281,6 @@ PenetrationThread::operator()(const NodeIdRange & range)
                      " on boundary ",
                      _nearest_node._boundary1,
                      ".  This should never happen.");
-        }
 
         for (const Elem * elem : candidate_elements)
         {
@@ -295,7 +293,6 @@ PenetrationThread::operator()(const NodeIdRange & range)
         }
 
         if (located_elem_ids.empty())
-        {
           mooseError("No proximate elements found at node ",
                      closest_node->id(),
                      " at ",
@@ -304,7 +301,6 @@ PenetrationThread::operator()(const NodeIdRange & range)
                      _nearest_node._boundary1,
                      " share that boundary.  This may happen if the mesh uses the same boundary id "
                      "for a nodeset and an unrelated sideset.");
-        }
 
         closest_elems = &located_elem_ids;
       }

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -272,6 +272,18 @@ PenetrationThread::operator()(const NodeIdRange & range)
       {
         std::set<const Elem *> candidate_elements;
         (*point_locator)(*closest_node, candidate_elements);
+
+        if (candidate_elements.empty())
+        {
+          mooseError("No proximate elements found at node ",
+                     closest_node->id(),
+                     " at ",
+                     static_cast<const Point &>(*closest_node),
+                     " on boundary ",
+                     _nearest_node._boundary1,
+                     ".  This should never happen.");
+        }
+
         for (const Elem * elem : candidate_elements)
         {
           for (auto s : elem->side_index_range())
@@ -281,6 +293,19 @@ PenetrationThread::operator()(const NodeIdRange & range)
               break;
             }
         }
+
+        if (located_elem_ids.empty())
+        {
+          mooseError("No proximate elements found at node ",
+                     closest_node->id(),
+                     " at ",
+                     static_cast<const Point &>(*closest_node),
+                     " on boundary ",
+                     _nearest_node._boundary1,
+                     " share that boundary.  This may happen if the mesh uses the same boundary id "
+                     "for a nodeset and an unrelated sideset.");
+        }
+
         closest_elems = &located_elem_ids;
       }
       else


### PR DESCRIPTION
The symptoms and the fix here only apply to penetration with the `search_method=all_proximate_sides` option.

We may have an issue in large deformation cases that could trigger the first error, though I haven't managed to trigger it yet.  I'm working on that, but in the meantime an error message is better than an inaccurate solution.

Use of a mesh where a nodeset and sideset don't match could trigger the second error.  In the long term we're going to have to entirely dig MOOSE out from under the mistaken assumption that nodesets are just a way to look up whether a node is on a sideset, and in the medium term I'm working on some mesh options to better handle input mesh files with distinct nodesets that share ids with sidesets, but for right now let's at least catch this particular failure case, which otherwise leads to a segfault later.

Refs #18768, because I got that error from a Flex IGA mesh, but really any third-party mesh file could potentially trigger it.

The root problem here is #30385, but this doesn't fix that, it just handles one symptom of it more cleanly.

## Reason
Catch potential `PenetrationThread`-with-`PointLocator` errors or incompatibilities in a friendlier way than a segfault or incorrect results.

## Design
Test for possible unexpected cases, mooseError() if found

## Impact
No impact on users who don't trigger the failures.