### PR TITLE
Make sure we fetch boundaryIDs from all sides when preparing the maps for turbulence routines.

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -799,7 +799,7 @@ public:
   /**
    * Return the name of the boundary given the id.
    */
-  const std::string & getBoundaryName(BoundaryID boundary_id);
+  const std::string & getBoundaryName(BoundaryID boundary_id) const;
 
   /**
    * This routine builds a multimap of boundary ids to matching boundary ids across all periodic

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1827,9 +1827,9 @@ MooseMesh::setBoundaryName(BoundaryID boundary_id, BoundaryName name)
 }
 
 const std::string &
-MooseMesh::getBoundaryName(BoundaryID boundary_id)
+MooseMesh::getBoundaryName(BoundaryID boundary_id) const
 {
-  BoundaryInfo & boundary_info = getMesh().get_boundary_info();
+  const BoundaryInfo & boundary_info = getMesh().get_boundary_info();
 
   // We need to figure out if this boundary is a sideset or nodeset
   if (boundary_info.get_side_boundary_ids().count(boundary_id))

--- a/modules/navier_stokes/src/base/NavierStokesMethods.C
+++ b/modules/navier_stokes/src/base/NavierStokesMethods.C
@@ -252,7 +252,7 @@ getWallBoundedElements(const std::vector<BoundaryName> & wall_boundary_names,
   // processors.
   auto gather_functor = [&subproblem, &wall_bounded](const processor_id_type libmesh_dbg_var(pid),
                                                      const std::vector<dof_id_type> & elem_ids,
-                                                     std::vector<dof_id_type> & data_to_fill)
+                                                     std::vector<unsigned char> & data_to_fill)
   {
     mooseAssert(pid != subproblem.processor_id(), "We shouldn't be gathering from ourselves.");
     data_to_fill.resize(elem_ids.size());
@@ -268,7 +268,7 @@ getWallBoundedElements(const std::vector<BoundaryName> & wall_boundary_names,
 
   auto action_functor = [&subproblem, &wall_bounded](const processor_id_type libmesh_dbg_var(pid),
                                                      const std::vector<dof_id_type> & elem_ids,
-                                                     const std::vector<dof_id_type> & filled_data)
+                                                     const std::vector<unsigned char> & filled_data)
   {
     mooseAssert(pid != subproblem.processor_id(),
                 "The request filler shouldn't have been ourselves");
@@ -317,7 +317,7 @@ getWallBoundedElements(const std::vector<BoundaryName> & wall_boundary_names,
           }
       }
 
-  dof_id_type * bool_ex = nullptr;
+  unsigned char * bool_ex = nullptr;
   TIMPI::pull_parallel_vector_data(
       subproblem.comm(), elem_ids_requested, gather_functor, action_functor, bool_ex);
 }


### PR DESCRIPTION
Refs #29847

This popped up on the ATR assemby mesh.