### PR TITLE
Fix CIVET repo parsing

### DIFF
--- a/python/TestHarness/resultsstore/civetstore.py
+++ b/python/TestHarness/resultsstore/civetstore.py
@@ -143,7 +143,7 @@ class CIVETStore:
             search = re.search(r'^git@([a-zA-Z._\-]+):([a-zA-Z0-9._\-]+)\/([a-zA-Z0-9._\-]+)$',
                                 repo)
         if search is None:
-            raise ValueError(f'Failed to parse SSH repo from {"value"}')
+            raise ValueError(f'Failed to parse SSH repo from {repo}')
         return search.group(1), search.group(2), search.group(3)
 
     @staticmethod
@@ -156,9 +156,17 @@ class CIVETStore:
         """
         assert isinstance(env, dict)
 
-        ssh_repo = env.get('CIVET_BASE_SSH_URL', env.get('APPLICATION_REPO'))
-        if ssh_repo is None:
-            raise ValueError('Failed to obtain repo from CIVET_BASE_SSH_URL or APPLICATION_REPO')
+        ssh_repo = None
+        base_ssh_url = env.get('CIVET_BASE_SSH_URL')
+        if base_ssh_url is None:
+            raise KeyError('Environment variable CIVET_BASE_SSH_URL not set')
+        if base_ssh_url:
+            ssh_repo = base_ssh_url
+        else:
+            if (application_repo := env.get('APPLICATION_REPO')):
+                ssh_repo = application_repo
+            else:
+                raise ValueError('Failed to obtain repo from CIVET_BASE_SSH_URL or APPLICATION_REPO')
 
         server, org, repo = CIVETStore.parse_ssh_repo(ssh_repo)
         return f'{server}/{org}/{repo}'

--- a/python/TestHarness/resultsstore/civetstore.py
+++ b/python/TestHarness/resultsstore/civetstore.py
@@ -157,11 +157,17 @@ class CIVETStore:
         assert isinstance(env, dict)
 
         ssh_repo = None
+
+        # This variable will always be set, but will be empty in the
+        # case of a scheduled event
         base_ssh_url = env.get('CIVET_BASE_SSH_URL')
         if base_ssh_url is None:
             raise KeyError('Environment variable CIVET_BASE_SSH_URL not set')
+        # Is set, so we're on a push or a pull request
         if base_ssh_url:
             ssh_repo = base_ssh_url
+        # Base repo is not set, so use APPLICATION_REPO, which
+        # should be set on a scheduled event
         else:
             if (application_repo := env.get('APPLICATION_REPO')):
                 ssh_repo = application_repo

--- a/python/TestHarness/tests/test_resultsstore_civetstore.py
+++ b/python/TestHarness/tests/test_resultsstore_civetstore.py
@@ -120,20 +120,29 @@ class TestCIVETStore(TestHarnessTestCase):
         """
         Tests get_civet_repo_url()
         """
+        # Normal PR or push event
         env = {'CIVET_BASE_SSH_URL': APPLICATION_REPO}
         self.assertEqual(
             CIVETStore.get_civet_repo_url(env),
             'github.com/idaholab/moose'
         )
 
-        env = {'APPLICATION_REPO': APPLICATION_REPO}
+        # Base will be empty on a scheduled event
+        env = {'CIVET_BASE_SSH_URL': '',
+               'APPLICATION_REPO': APPLICATION_REPO}
         self.assertEqual(
             CIVETStore.get_civet_repo_url(env),
             'github.com/idaholab/moose'
         )
 
-        with self.assertRaises(ValueError):
+        # Base not set at all
+        with self.assertRaisesRegex(KeyError, 'CIVET_BASE_SSH_URL not set'):
             CIVETStore.get_civet_repo_url({})
+
+        # Empty base and no APPLICATION_REPO
+        env = {'CIVET_BASE_SSH_URL': ''}
+        with self.assertRaisesRegex(ValueError, 'Failed to obtain repo'):
+            CIVETStore.get_civet_repo_url(env)
 
     def testGetCIVETServer(self):
         """


### PR DESCRIPTION
The logic was bad. CIVET_BASE_SSH_URL is always available, but will just be empty.

Fixes the issue in https://civet.inl.gov/job/3290024/.

Closes #31704