### PR TITLE
Fix MFEMBoundarySubMesh attributes

### DIFF
--- a/framework/include/mfem/problem/MFEMProblem.h
+++ b/framework/include/mfem/problem/MFEMProblem.h
@@ -186,6 +186,11 @@ public:
   MFEMProblemData & getProblemData() { return _problem_data; }
 
   /**
+   * Return the MPI communicator associated with this FE problem's mesh.
+   */
+  MPI_Comm getComm() { return mesh().getMFEMParMesh().GetComm(); }
+
+  /**
    * Displace the mesh, if mesh displacement is enabled.
    */
   void displaceMesh();

--- a/framework/src/mfem/submeshes/MFEMBoundarySubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMBoundarySubMesh.C
@@ -22,6 +22,7 @@ MFEMBoundarySubMesh::validParams()
 
   params.addClassDescription("Class to construct an MFEMSubMesh formed from the subspace of the "
                              "parent mesh restricted to the set of user-specified boundaries.");
+  params.addParam<BoundaryName>("submesh_boundary", "Name to assign submesh boundary.");
   return params;
 }
 
@@ -36,8 +37,12 @@ MFEMBoundarySubMesh::buildSubMesh()
 {
   _submesh = std::make_shared<mfem::ParSubMesh>(
       mfem::ParSubMesh::CreateFromBoundary(getMesh(), getBoundaryAttributes()));
-  _submesh->attribute_sets.attr_sets = getMesh().attribute_sets.attr_sets;
-  _submesh->bdr_attribute_sets.attr_sets = getMesh().bdr_attribute_sets.attr_sets;
+  _submesh->attribute_sets.attr_sets = getMesh().bdr_attribute_sets.attr_sets;
+
+  if (isParamSetByUser("submesh_boundary"))
+    _submesh->bdr_attribute_sets.SetAttributeSet(
+        getParam<BoundaryName>("submesh_boundary"),
+        mfem::Array<int>({getMesh().bdr_attributes.Max() + 1}));
 }
 
 #endif

--- a/framework/src/mfem/submeshes/MFEMDomainSubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMDomainSubMesh.C
@@ -40,12 +40,9 @@ MFEMDomainSubMesh::buildSubMesh()
   _submesh->bdr_attribute_sets.attr_sets = getMesh().bdr_attribute_sets.attr_sets;
 
   if (isParamSetByUser("submesh_boundary"))
-  {
-    const BoundaryName & submesh_boundary = getParam<BoundaryName>("submesh_boundary");
-    _submesh->bdr_attribute_sets.CreateAttributeSet(submesh_boundary);
-    _submesh->bdr_attribute_sets.AddToAttributeSet(submesh_boundary,
-                                                   getMesh().bdr_attributes.Max() + 1);
-  }
+    _submesh->bdr_attribute_sets.SetAttributeSet(
+        getParam<BoundaryName>("submesh_boundary"),
+        mfem::Array<int>({getMesh().bdr_attributes.Max() + 1}));
 }
 
 #endif


### PR DESCRIPTION
## Reason
For submeshes created from boundaries, the domain attributes are the parent's boundary attributes.
Also, the boundary of the new submesh is also numbered at one plus the parent's max boundary attribute.
I'm trying to document this is mfem/mfem#5068, [bf21910](https://github.com/mfem/mfem/pull/5068/commits/bf21910fe46f59c975dc4ba8b044a0dfb9dff904).

## Design
Minor adjustment in attribute set creation and assignment for this particular case. 

## Impact
Correct names for submesh attributes.