### PR TITLE
Improve documentation for SideDiffusiveFluxAverage

### DIFF
--- a/framework/doc/content/source/postprocessors/SideDiffusiveFluxAverage.md
+++ b/framework/doc/content/source/postprocessors/SideDiffusiveFluxAverage.md
@@ -2,6 +2,21 @@
 
 !syntax description /Postprocessors/SideDiffusiveFluxAverage
 
+## Object Description
+
+This object computes the quantity
+
+!equation
+- \frac{1}{A} \int_{d\Omega} D \nabla u \cdot \mathbf{n}
+
+where:
+
+- $d\Omega$ represents the boundary,
+- $D$ represents the diffusivity,
+- $u$ represents the variable used in the calculation,
+- $\mathbf{n}$ represents the outward-facing normal vector at the boundary, and
+- $A$ represents the area of the selected boundary across which the average is being taken.
+
 !alert warning
 The expression of the diffusive flux in this object is generic, as described, and may differ from the diffusive flux in your specific physics implementation. If so, you may not use this object to compute the diffusive flux.
 

--- a/framework/src/postprocessors/SideDiffusiveFluxAverage.C
+++ b/framework/src/postprocessors/SideDiffusiveFluxAverage.C
@@ -26,7 +26,7 @@ SideDiffusiveFluxAverageTempl<is_ad>::validParams()
 {
   InputParameters params = SideDiffusiveFluxIntegralTempl<is_ad, Real>::validParams();
   params.addClassDescription(
-      "Computes the average of the integral of the diffusive flux over the specified boundary");
+      "Computes the average of the diffusive flux over the specified boundary");
   return params;
 }
 

--- a/framework/src/postprocessors/SideDiffusiveFluxAverage.C
+++ b/framework/src/postprocessors/SideDiffusiveFluxAverage.C
@@ -25,6 +25,8 @@ InputParameters
 SideDiffusiveFluxAverageTempl<is_ad>::validParams()
 {
   InputParameters params = SideDiffusiveFluxIntegralTempl<is_ad, Real>::validParams();
+  params.addClassDescription(
+      "Computes the average of the integral of the diffusive flux over the specified boundary");
   return params;
 }
 


### PR DESCRIPTION
Add equation description of SideDiffusiveFluxAverage as well as better class description (which didn't previously mention the average it was taking).

Closes #31722

CC: @simopier since he noticed it during the TMAP8 Workshop this week.