### PR TITLE
Minor code cleanup in variable data

### DIFF
--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -1449,8 +1449,7 @@ MooseVariableData<OutputType>::reinitAux()
     _dof_map.dof_indices(_elem, _dof_indices, _var_num);
     if (_elem->n_dofs(_sys.number(), _var_num) > 0)
     {
-      // FIXME: check if the following is equivalent with '_nodal_dof_index = _dof_indices[0];'?
-      _nodal_dof_index = _elem->dof_number(_sys.number(), _var_num, 0);
+      _nodal_dof_index = _dof_indices[0];
 
       fetchDoFValues();
 

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -578,7 +578,7 @@ MooseVariableData<OutputType>::computeValuesInternal()
   // Curl
   if (_need_curl)
     fill(_curl_u, *_current_curl_phi, _vector_tags_dof_u[_solution_tag]);
-  if (_need_curl_old)
+  if (is_transient && _need_curl_old)
     fill(_curl_u_old, *_current_curl_phi, _vector_tags_dof_u[_old_solution_tag]);
 
   // Div
@@ -597,9 +597,10 @@ MooseVariableData<OutputType>::computeValuesInternal()
   // Vector tags
   for (auto tag : _required_vector_tags)
   {
-    if (_need_vector_tag_u[tag] && _sys.hasVector(tag) && _sys.getVector(tag).closed())
+    mooseAssert(_sys.getVector(tag).closed(), "Should be closed");
+    if (_need_vector_tag_u[tag] && _sys.hasVector(tag))
       fill(_vector_tag_u[tag], *_current_phi, _vector_tags_dof_u[tag]);
-    if (_need_vector_tag_grad[tag] && _sys.hasVector(tag) && _sys.getVector(tag).closed())
+    if (_need_vector_tag_grad[tag] && _sys.hasVector(tag))
       fill(_vector_tag_grad[tag], *_current_grad_phi, _vector_tags_dof_u[tag]);
   }
 
@@ -627,8 +628,6 @@ MooseVariableData<OutputType>::computeValuesInternal()
     if (_need_du_dot_du)
     {
       _du_dot_du.resize(nqp);
-      for (const auto qp : make_range(nqp))
-        _du_dot_du[qp] = 0.;
       for (const auto i : make_range(num_dofs))
         for (const auto qp : make_range(nqp))
           _du_dot_du[qp] = _dof_du_dot_du[i];
@@ -636,8 +635,6 @@ MooseVariableData<OutputType>::computeValuesInternal()
     if (_need_du_dotdot_du)
     {
       _du_dotdot_du.resize(nqp);
-      for (const auto qp : make_range(nqp))
-        _du_dotdot_du[qp] = 0.;
       for (const auto i : make_range(num_dofs))
         for (const auto qp : make_range(nqp))
           _du_dotdot_du[qp] = _dof_du_dotdot_du[i];

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -597,11 +597,16 @@ MooseVariableData<OutputType>::computeValuesInternal()
   // Vector tags
   for (auto tag : _required_vector_tags)
   {
-    mooseAssert(_sys.getVector(tag).closed(), "Should be closed");
     if (_need_vector_tag_u[tag] && _sys.hasVector(tag))
+    {
+      mooseAssert(_sys.getVector(tag).closed(), "Vector should be closed");
       fill(_vector_tag_u[tag], *_current_phi, _vector_tags_dof_u[tag]);
+    }
     if (_need_vector_tag_grad[tag] && _sys.hasVector(tag))
+    {
+      mooseAssert(_sys.getVector(tag).closed(), "Vector should be closed");
       fill(_vector_tag_grad[tag], *_current_grad_phi, _vector_tags_dof_u[tag]);
+    }
   }
 
   // Matrix tags

--- a/framework/src/variables/MooseVariableDataBase.C
+++ b/framework/src/variables/MooseVariableDataBase.C
@@ -575,6 +575,7 @@ MooseVariableDataBase<OutputType>::fetchDoFValues()
         // tag is defined on problem but may not be used by a system
         // the grain tracker requires being able to read from solution vectors that we are also in
         // the process of writing :-/
+        // Note: the extra vector tags are also still not closed when a TagVectorAux uses them
         if (_sys.hasVector(tag) /* && _sys.getVector(tag).closed()*/)
         {
           auto & vec = _sys.getVector(tag);
@@ -592,8 +593,10 @@ MooseVariableDataBase<OutputType>::fetchDoFValues()
     {
       _matrix_tags_dof_u[tag].resize(n);
       if (_need_matrix_tag_dof_u[tag] || _need_matrix_tag_u[tag])
-        if (_sys.hasMatrix(tag) && _sys.matrixTagActive(tag) && _sys.getMatrix(tag).closed())
+        if (_sys.hasMatrix(tag) && _sys.matrixTagActive(tag))
         {
+          mooseAssert(_sys.getMatrix(tag).closed(),
+                      "Matrix with tag '" + std::to_string(tag) + "' should be closed");
           auto & mat = _sys.getMatrix(tag);
           for (unsigned i = 0; i < n; i++)
             _matrix_tags_dof_u[tag][i] = mat(_dof_indices[i], _dof_indices[i]);
@@ -685,8 +688,12 @@ MooseVariableDataBase<RealEigenVector>::fetchDoFValues()
          _subproblem.safeAccessTaggedVectors()) ||
         _subproblem.vectorTagType(tag) == Moose::VECTOR_TAG_SOLUTION)
       // tag is defined on problem but may not be used by a system
-      if (_sys.hasVector(tag) && _sys.getVector(tag).closed())
+      if (_sys.hasVector(tag))
+      {
+        mooseAssert(_sys.getVector(tag).closed(),
+                    "Vector with tag '" + std::to_string(tag) + "' should be closed");
         getArrayDoFValues(_sys.getVector(tag), n, _vector_tags_dof_u[tag]);
+      }
 
   if (_subproblem.safeAccessTaggedMatrices())
   {
@@ -696,8 +703,10 @@ MooseVariableDataBase<RealEigenVector>::fetchDoFValues()
     {
       _matrix_tags_dof_u[tag].resize(n);
       if (_need_matrix_tag_dof_u[tag] || _need_matrix_tag_u[tag])
-        if (_sys.hasMatrix(tag) && _sys.matrixTagActive(tag) && _sys.getMatrix(tag).closed())
+        if (_sys.hasMatrix(tag) && _sys.matrixTagActive(tag))
         {
+          mooseAssert(_sys.getMatrix(tag).closed(),
+                      "Matrix with tag '" + std::to_string(tag) + "' should be closed");
           auto & mat = _sys.getMatrix(tag);
           for (unsigned i = 0; i < n; i++)
             for (unsigned j = 0; j < _count; j++)

--- a/framework/src/variables/MooseVariableDataBase.C
+++ b/framework/src/variables/MooseVariableDataBase.C
@@ -596,10 +596,7 @@ MooseVariableDataBase<OutputType>::fetchDoFValues()
         {
           auto & mat = _sys.getMatrix(tag);
           for (unsigned i = 0; i < n; i++)
-          {
-            Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
             _matrix_tags_dof_u[tag][i] = mat(_dof_indices[i], _dof_indices[i]);
-          }
         }
     }
   }
@@ -703,11 +700,8 @@ MooseVariableDataBase<RealEigenVector>::fetchDoFValues()
         {
           auto & mat = _sys.getMatrix(tag);
           for (unsigned i = 0; i < n; i++)
-          {
-            Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
             for (unsigned j = 0; j < _count; j++)
               _matrix_tags_dof_u[tag][i](j) = mat(_dof_indices[i] + j, _dof_indices[i] + j);
-          }
         }
     }
   }


### PR DESCRIPTION
I don't think it makes a difference performance wise.
You'd need to try transients + AD and something with threads to be sure

AD simple diffusion r7
with
Average runtime: 26.330144 seconds
Standard deviation: .296015 seconds

without
Average runtime: 26.418131 seconds
Standard deviation: .348839 seconds
