### PR TITLE
Drop support for calling deprecated BoundaryInfo::build_side_list()

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -278,16 +278,8 @@ public:
   void buildNodeListFromSideList();
 
   /**
-   * Calls BoundaryInfo::build_side_list().
-   * Fills in the three passed vectors with list logical (element, side, id) tuples.
-   * This function will eventually be deprecated in favor of the one below, which
-   * returns a single std::vector of (elem-id, side-id, bc-id) tuples instead.
-   */
-  void buildSideList(std::vector<dof_id_type> & el,
-                     std::vector<unsigned short int> & sl,
-                     std::vector<boundary_id_type> & il);
-  /**
-   * As above, but uses the non-deprecated std::tuple interface.
+   * Calls BoundaryInfo::build_side_list(), returns a std::vector of
+   * (elem-id, side-id, bc-id) tuples.
    */
   std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> buildSideList();
 

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -3026,19 +3026,6 @@ MooseMesh::buildNodeListFromSideList()
     getMesh().get_boundary_info().build_node_list_from_side_list();
 }
 
-void
-MooseMesh::buildSideList(std::vector<dof_id_type> & el,
-                         std::vector<unsigned short int> & sl,
-                         std::vector<boundary_id_type> & il)
-{
-  libmesh_ignore(el);
-  libmesh_ignore(sl);
-  libmesh_ignore(il);
-  mooseError("The version of MooseMesh::buildSideList() taking three "
-             "arguments is not available in your version of libmesh, call the "
-             "version that returns a vector of tuples instead.");
-}
-
 std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
 MooseMesh::buildSideList()
 {

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -3031,18 +3031,12 @@ MooseMesh::buildSideList(std::vector<dof_id_type> & el,
                          std::vector<unsigned short int> & sl,
                          std::vector<boundary_id_type> & il)
 {
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  mooseDeprecated("The version of MooseMesh::buildSideList() taking three arguments is "
-                  "deprecated, call the version that returns a vector of tuples instead.");
-  getMesh().get_boundary_info().build_side_list(el, sl, il);
-#else
   libmesh_ignore(el);
   libmesh_ignore(sl);
   libmesh_ignore(il);
   mooseError("The version of MooseMesh::buildSideList() taking three "
              "arguments is not available in your version of libmesh, call the "
              "version that returns a vector of tuples instead.");
-#endif
 }
 
 std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>


### PR DESCRIPTION
The deprecated version of this function will be removed in libMesh/libmesh#4276, so let's see if any MOOSE apps are still calling it.

cc: @roystgnr 