### PR TITLE
Drop includes of libmesh auto_ptr.h compatibility header

### DIFF
--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -21,7 +21,6 @@
 #include "libmesh/petsc_vector.h"
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/slepc_macro.h"
-#include "libmesh/auto_ptr.h"
 #include "petscsnes.h"
 #include "slepceps.h"
 

--- a/test/src/materials/LinearInterpolationMaterial.C
+++ b/test/src/materials/LinearInterpolationMaterial.C
@@ -11,8 +11,6 @@
 #include "LinearInterpolation.h"
 #include "PolynomialFit.h"
 
-#include "libmesh/auto_ptr.h"
-
 registerMooseObject("MooseTestApp", LinearInterpolationMaterial);
 
 InputParameters


### PR DESCRIPTION
This file is almost empty in current libmesh master, and will soon be completely empty/removed. No files in MOOSE should be including it any longer.

Part of an ongoing deprecated code cleanup, (see also: #31732).

