### PR TITLE
Ignore untracked changes in mfem/conduit submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
     url = https://gitlab.com/petsc/petsc.git
 [submodule "modules/chemical_reactions/contrib/thermochimica"]
     path = modules/chemical_reactions/contrib/thermochimica
-    url = https://github.com/ORNL-CEES/thermochimica.git
+    url = ../../ORNL-CEES/thermochimica.git
     update = none
 [submodule "modules/fluid_properties/contrib/saline"]
     path = modules/fluid_properties/contrib/saline
@@ -21,36 +21,38 @@
     url = https://code.ornl.gov/neams-workbench/wasp.git
 [submodule "modules/fluid_properties/contrib/sodium"]
     path = modules/fluid_properties/contrib/sodium
-    url = https://github.com/idaholab/sodium.git
+    url = ../../idaholab/sodium.git
     update = none
 [submodule "modules/fluid_properties/contrib/potassium"]
     path = modules/fluid_properties/contrib/potassium
-    url = https://github.com/idaholab/potassium.git
+    url = ../../idaholab/potassium.git
     update = none
 [submodule "modules/fluid_properties/contrib/nitrogen"]
     path = modules/fluid_properties/contrib/nitrogen
-    url = https://github.com/idaholab/nitrogen.git
+    url = ../../idaholab/nitrogen.git
     update = none
 [submodule "modules/fluid_properties/contrib/helium"]
     path = modules/fluid_properties/contrib/helium
-    url = https://github.com/idaholab/helium.git
+    url = ../../idaholab/helium.git
     update = none
 [submodule "modules/fluid_properties/contrib/air"]
     path = modules/fluid_properties/contrib/air
-    url = https://github.com/idaholab/air.git
+    url = ../../idaholab/air.git
     update = none
 [submodule "modules/fluid_properties/contrib/carbon_dioxide"]
     path = modules/fluid_properties/contrib/carbon_dioxide
-    url = https://github.com/idaholab/carbon_dioxide.git
+    url = ../../idaholab/carbon_dioxide.git
     update = none
 [submodule "framework/contrib/mfem"]
     path = framework/contrib/mfem
     url = ../../mfem/mfem.git
     update = none
+    ignore = untracked
 [submodule "framework/contrib/conduit"]
     path = framework/contrib/conduit
-    url = https://github.com/LLNL/conduit.git
+    url = ../../LLNL/conduit.git
     update = none
+    ignore = untracked
 [submodule "framework/contrib/neml2"]
     path = framework/contrib/neml2
     url = ../../applied-material-modeling/neml2.git


### PR DESCRIPTION
To be stolen by someone who can actually edit `.gitmodules`.

## Reason
When we build and install conduit and mfem with default settings, we populate build and install directories within the respective submodule trees. A `git status`  will then show `modified:   framework/contrib/conduit (untracked content)` which is slightly distracting (so much red!).

## Design
Simply ignore untracked changed in `.gitmodules` for these two submodules. I've also changed the urls for all repos hosted on GitHub for consistency.

## Impact
Fewer git warnings (less red!).
