### PR TITLE
Extend LinearFVAdvectionDiffusionFunctorRobinBC to override coefficients in derived classes

### DIFF
--- a/framework/include/linearfvbcs/LinearFVAdvectionDiffusionFunctorRobinBC.h
+++ b/framework/include/linearfvbcs/LinearFVAdvectionDiffusionFunctorRobinBC.h
@@ -14,6 +14,7 @@
 /**
  * Class implementing a Robin boundary condition for linear finite
  * volume variables. This is only applicable for advection-diffusion problems.
+ * alpha, beta, gamma are provided as functors and may vary in space/time.
  */
 class LinearFVAdvectionDiffusionFunctorRobinBC : public LinearFVAdvectionDiffusionBC
 {
@@ -39,6 +40,11 @@ public:
   virtual Real computeBoundaryGradientRHSContribution() const override;
 
 protected:
+  /// Getter functions (consistent entry point for all derived classes)
+  virtual Real getAlpha(Moose::FaceArg face, Moose::StateArg state) const;
+  virtual Real getBeta(Moose::FaceArg face, Moose::StateArg state) const;
+  virtual Real getGamma(Moose::FaceArg face, Moose::StateArg state) const;
+
   /// Functor giving the alpha coefficient (multiplying normal gradient)
   const Moose::Functor<Real> & _alpha;
   /// Functor giving the beta coefficient (multiplying value)


### PR DESCRIPTION
Close #31848 