### PR TITLE
Libmesh exception handling

### DIFF
--- a/framework/include/loops/ComputeFVFluxThread.h
+++ b/framework/include/loops/ComputeFVFluxThread.h
@@ -329,7 +329,7 @@ ThreadedFaceLoop<RangeType>::operator()(const RangeType & range, bool bypass_thr
       // Continue if we find a libMesh degenerate map exception, but
       // just throw for any real error
       if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
-        throw e;
+        throw;
 
       mooseException("We caught a libMesh exception: ", e.what());
     }

--- a/framework/include/loops/ComputeFVFluxThread.h
+++ b/framework/include/loops/ComputeFVFluxThread.h
@@ -331,7 +331,8 @@ ThreadedFaceLoop<RangeType>::operator()(const RangeType & range, bool bypass_thr
       if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
         throw;
 
-      mooseException("We caught a libMesh exception: ", e.what());
+      mooseException("We caught a libMesh degeneracy exception in ComputeFVFluxThread:\n",
+                     e.what());
     }
   }
   catch (MooseException & e)

--- a/framework/include/loops/ComputeFVFluxThread.h
+++ b/framework/include/loops/ComputeFVFluxThread.h
@@ -24,6 +24,8 @@
 #include "libmesh/libmesh_exceptions.h"
 #include "libmesh/elem.h"
 
+// C++
+#include <cstring> // for "Jacobian" exception test
 #include <set>
 
 class MooseVariableFVBase;
@@ -318,13 +320,18 @@ ThreadedFaceLoop<RangeType>::operator()(const RangeType & range, bool bypass_thr
       // Clear execution printing sets to start printing on every block and boundary again
       resetExecutionPrinting();
     }
-    catch (libMesh::LogicError & e)
-    {
-      mooseException("We caught a libMesh error: ", e.what());
-    }
     catch (MetaPhysicL::LogicError & e)
     {
       moose::translateMetaPhysicLError(e);
+    }
+    catch (std::exception & e)
+    {
+      // Continue if we find a libMesh degenerate map exception, but
+      // just throw for any real error
+      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
+        throw e;
+
+      mooseException("We caught a libMesh exception: ", e.what());
     }
   }
   catch (MooseException & e)

--- a/framework/include/loops/ThreadedElementLoopBase.h
+++ b/framework/include/loops/ThreadedElementLoopBase.h
@@ -307,13 +307,18 @@ ThreadedElementLoopBase<RangeType>::operator()(const RangeType & range, bool byp
       post();
       resetExecPrintedSets();
     }
-    catch (libMesh::LogicError & e)
-    {
-      mooseException("We caught a libMesh error in ThreadedElementLoopBase:", e.what());
-    }
     catch (MetaPhysicL::LogicError & e)
     {
       moose::translateMetaPhysicLError(e);
+    }
+    catch (std::exception & e)
+    {
+      // Continue if we find a libMesh degenerate map exception, but
+      // just re-throw for any real error
+      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
+        throw; // not "throw e;" - that destroys type info!
+
+      mooseException("We caught a libMesh Jacobian exception: ", e.what());
     }
   }
   catch (MooseException & e)

--- a/framework/include/loops/ThreadedElementLoopBase.h
+++ b/framework/include/loops/ThreadedElementLoopBase.h
@@ -318,7 +318,8 @@ ThreadedElementLoopBase<RangeType>::operator()(const RangeType & range, bool byp
       if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
         throw; // not "throw e;" - that destroys type info!
 
-      mooseException("We caught a libMesh Jacobian exception: ", e.what());
+      mooseException("We caught a libMesh degeneracy exception in ThreadedElementLoopBase:\n",
+                     e.what());
     }
   }
   catch (MooseException & e)

--- a/framework/include/loops/ThreadedElementLoopBase.h
+++ b/framework/include/loops/ThreadedElementLoopBase.h
@@ -16,6 +16,9 @@
 #include "libmesh/libmesh_exceptions.h"
 #include "libmesh/elem.h"
 
+// C++
+#include <cstring> // for "Jacobian" exception test
+
 /**
  * Base class for assembly-like calculations.
  */

--- a/framework/include/utils/GreenGaussGradient.h
+++ b/framework/include/utils/GreenGaussGradient.h
@@ -234,8 +234,14 @@ greenGaussGradient(const ElemArg & elem_arg,
           grad(i) = x(i);
       }
     }
-    catch (libMesh::LogicError & e)
+    catch (std::exception & e)
     {
+      // Don't ignore any *real* errors; we only handle matrix
+      // singularity (LogicError in older libMesh, DegenerateMap in
+      // newer) here
+      if (!strstr(e.what(), "singular"))
+        throw;
+
       // Retry without two-term
       if (!two_term_boundary_expansion)
         mooseError(
@@ -501,8 +507,14 @@ greenGaussGradient(const ElemArg & elem_arg,
           "We have not yet implemented the correct translation from gradient to divergence for "
           "spherical coordinates yet.");
     }
-    catch (libMesh::LogicError & e)
+    catch (std::exception & e)
     {
+      // Don't ignore any *real* errors; we only handle matrix
+      // singularity (LogicError in older libMesh, DegenerateMap in
+      // newer) here
+      if (!strstr(e.what(), "singular"))
+        throw;
+
       // Log warning and default to simple green Gauss
       mooseWarning(
           "Singular matrix encountered in least squares gradient computation. Falling back "

--- a/framework/include/utils/GreenGaussGradient.h
+++ b/framework/include/utils/GreenGaussGradient.h
@@ -17,6 +17,9 @@
 #include "ArrayComponentFunctor.h"
 #include "libmesh/elem.h"
 
+// C++
+#include <cstring> // for "Jacobian" exception test
+
 namespace Moose
 {
 namespace FV

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -700,8 +700,7 @@ MooseApp::MooseApp(const InputParameters & parameters)
                  "about adding your debugger.");
 
     // Finish up the command
-    command_stream << "\""
-                   << " & ";
+    command_stream << "\"" << " & ";
     std::string command_string = command_stream.str();
     Moose::out << "Running: " << command_string << std::endl;
 
@@ -2250,12 +2249,12 @@ MooseApp::run()
   catch (Parser::Error & err)
   {
     mooseAssert(_parser->getThrowOnError(), "Should be true");
-    throw err;
+    throw;
   }
   catch (MooseRuntimeError & err)
   {
     mooseAssert(Moose::_throw_on_error, "Should be true");
-    throw err;
+    throw;
   }
   catch (std::exception & err)
   {

--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -213,7 +213,7 @@ findContactPoint(PenetrationInfo & p_info,
       {
         // Make sure this *is* just a bad mapping Jacobian
         if (!strstr(e.what(), "Jacobian"))
-          throw e;
+          throw;
 
         ref_point(0) -= mult * update(0);
         if (dim - 1 == 2)

--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -23,6 +23,9 @@
 #include "libmesh/fe_base.h"
 #include "libmesh/vector_value.h"
 
+// C++
+#include <cstring> // for "Jacobian" exception test
+
 using namespace libMesh;
 
 namespace Moose
@@ -205,8 +208,13 @@ findContactPoint(PenetrationInfo & p_info,
         update_size = update.l2_norm();
         break;
       }
-      catch (libMesh::LogicError & e)
+      // libMesh might throw here if we hit a zero/negative Jacobian
+      catch (std::exception & e)
       {
+        // Make sure this *is* just a bad mapping Jacobian
+        if (!strstr(e.what(), "Jacobian"))
+          throw e;
+
         ref_point(0) -= mult * update(0);
         if (dim - 1 == 2)
           ref_point(1) -= mult * update(1);

--- a/framework/src/loops/ComputeJacobianForScalingThread.C
+++ b/framework/src/loops/ComputeJacobianForScalingThread.C
@@ -13,6 +13,9 @@
 
 #include "libmesh/elem.h"
 
+// C++
+#include <cstring> // for "Jacobian" exception test
+
 using namespace libMesh;
 
 ComputeJacobianForScalingThread::ComputeJacobianForScalingThread(FEProblemBase & fe_problem,

--- a/framework/src/loops/ComputeJacobianForScalingThread.C
+++ b/framework/src/loops/ComputeJacobianForScalingThread.C
@@ -76,8 +76,9 @@ ComputeJacobianForScalingThread::operator()(const ConstElemRange & range,
       if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
         throw;
 
-      mooseException("We caught a libMesh degeneracy in ComputeJacobianForScalingThread: ",
-                     e.what());
+      mooseException(
+          "We caught a libMesh degeneracy exception in ComputeJacobianForScalingThread:\n",
+          e.what());
     }
   }
   catch (MooseException & e)

--- a/framework/src/loops/ComputeMortarFunctor.C
+++ b/framework/src/loops/ComputeMortarFunctor.C
@@ -186,7 +186,9 @@ ComputeMortarFunctor::operator()(const Moose::ComputeType compute_type,
       if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
         throw;
 
-      _fe_problem.setException("We caught a degeneracy from libMesh:" + std::string(e.what()));
+      _fe_problem.setException(
+          "We caught a libMesh degeneracy exception in ComputeMortarFunctor:\n" +
+          std::string(e.what()));
     }
   }
   PARALLEL_CATCH;

--- a/framework/src/loops/ComputeMortarFunctor.C
+++ b/framework/src/loops/ComputeMortarFunctor.C
@@ -24,6 +24,9 @@
 #include "libmesh/point.h"
 #include "libmesh/mesh_base.h"
 
+// C++
+#include <cstring> // for "Jacobian" exception test
+
 ComputeMortarFunctor::ComputeMortarFunctor(
     const std::vector<std::shared_ptr<MortarConstraintBase>> & mortar_constraints,
     const AutomaticMortarGeneration & amg,

--- a/framework/src/loops/ComputeMortarFunctor.C
+++ b/framework/src/loops/ComputeMortarFunctor.C
@@ -173,10 +173,6 @@ ComputeMortarFunctor::operator()(const Moose::ComputeType compute_type,
                                             act_functor,
                                             /*reinit_mortar_user_objects=*/true);
     }
-    catch (libMesh::LogicError & e)
-    {
-      _fe_problem.setException("We caught a libMesh::LogicError: " + std::string(e.what()));
-    }
     catch (MooseException & e)
     {
       _fe_problem.setException(e.what());
@@ -184,6 +180,13 @@ ComputeMortarFunctor::operator()(const Moose::ComputeType compute_type,
     catch (MetaPhysicL::LogicError & e)
     {
       moose::translateMetaPhysicLError(e);
+    }
+    catch (std::exception & e)
+    {
+      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
+        throw;
+
+      _fe_problem.setException("We caught a degeneracy from libMesh:" + std::string(e.what()));
     }
   }
   PARALLEL_CATCH;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -135,6 +135,9 @@
 
 #include "metaphysicl/dualnumber.h"
 
+// C++
+#include <cstring> // for "Jacobian" exception test
+
 using namespace libMesh;
 
 // Anonymous namespace for helper function

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -7376,10 +7376,6 @@ FEProblemBase::handleException(const std::string & calling_method)
   {
     throw;
   }
-  catch (const libMesh::LogicError & e)
-  {
-    setException(create_exception_message("libMesh::LogicError", e));
-  }
   catch (const MooseException & e)
   {
     setException(create_exception_message("MooseException", e));
@@ -7404,11 +7400,17 @@ FEProblemBase::handleException(const std::string & calling_method)
   }
   catch (const std::exception & e)
   {
-    const auto message = create_exception_message("std::exception", e);
-    if (_regard_general_exceptions_as_errors)
-      mooseError(message);
+    // This might be libMesh detecting a degenerate Jacobian or matrix
+    if (strstr(e.what(), "Jacobian") || strstr(e.what(), "singular"))
+      setException(create_exception_message("libMesh DegenerateMap", e));
     else
-      setException(message);
+    {
+      const auto message = create_exception_message("std::exception", e);
+      if (_regard_general_exceptions_as_errors)
+        mooseError(message);
+      else
+        setException(message);
+    }
   }
 
   checkExceptionAndStopSolve();

--- a/framework/src/systems/AuxiliarySystem.C
+++ b/framework/src/systems/AuxiliarySystem.C
@@ -810,7 +810,7 @@ AuxiliarySystem::computeMortarNodalVars(const ExecFlagType type)
             if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
               throw;
 
-            _fe_problem.setException("The following error was raised during mortar "
+            _fe_problem.setException("We caught a libMesh degeneracy exception during mortar "
                                      "nodal Auxiliary variable computation:\n" +
                                      std::string(e.what()));
           }

--- a/framework/src/systems/AuxiliarySystem.C
+++ b/framework/src/systems/AuxiliarySystem.C
@@ -31,6 +31,9 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/fe_interface.h"
 
+// C++
+#include <cstring> // for "Jacobian" exception test
+
 using namespace libMesh;
 
 // AuxiliarySystem ////////

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -3462,7 +3462,7 @@ NonlinearSystemBase::computeDamping(const NumericVector<Number> & solution,
     // Allow the libmesh error/exception on negative jacobian
     const std::string & message = e.what();
     if (message.find("Jacobian") == std::string::npos)
-      throw e;
+      throw;
   }
 
   _communicator.min(damping);

--- a/modules/navier_stokes/include/utils/CellCenteredMapFunctor.h
+++ b/modules/navier_stokes/include/utils/CellCenteredMapFunctor.h
@@ -146,11 +146,8 @@ CellCenteredMapFunctor<T, Map>::evaluate(const ElemArg & elem_arg, const StateAr
 {
   const Elem * const elem = elem_arg.elem;
 
-  try
-  {
-    return libmesh_map_find(*this, elem->id());
-  }
-  catch (libMesh::LogicError &)
+  auto it = this->find(elem->id());
+  if (it == this->end())
   {
     if (!_sub_ids.empty() && !_sub_ids.count(elem->subdomain_id()))
       mooseError("Attempted to evaluate CellCenteredMapFunctor '",
@@ -165,6 +162,8 @@ CellCenteredMapFunctor<T, Map>::evaluate(const ElemArg & elem_arg, const StateAr
                  "' with a key that does not yet exist in the map. Make sure to fill your "
                  "CellCenteredMapFunctor for all elements you will attempt to access later.");
   }
+
+  return it->second;
 }
 
 template <typename T, typename Map>

--- a/modules/navier_stokes/src/utils/FaceCenteredMapFunctor.C
+++ b/modules/navier_stokes/src/utils/FaceCenteredMapFunctor.C
@@ -135,11 +135,8 @@ template <typename T, typename Map>
 typename FaceCenteredMapFunctor<T, Map>::ValueType
 FaceCenteredMapFunctor<T, Map>::evaluate(const FaceInfo * fi) const
 {
-  try
-  {
-    return libmesh_map_find(*this, fi->id());
-  }
-  catch (libMesh::LogicError &)
+  auto it = this->find(fi->id());
+  if (it == this->end())
   {
     if (!_sub_ids.empty() && !_sub_ids.count(fi->elem().subdomain_id()))
     {
@@ -162,6 +159,8 @@ FaceCenteredMapFunctor<T, Map>::evaluate(const FaceInfo * fi) const
 
     return typename FaceCenteredMapFunctor<T, Map>::ValueType();
   }
+
+  return it->second;
 }
 
 template class FaceCenteredMapFunctor<ADRealVectorValue,

--- a/modules/navier_stokes/src/variables/INSFVVelocityVariable.C
+++ b/modules/navier_stokes/src/variables/INSFVVelocityVariable.C
@@ -27,8 +27,10 @@
 #include "libmesh/dense_matrix.h"
 #include "libmesh/libmesh_common.h"
 
-#include <vector>
+// C++
+#include <cstring> // for "Jacobian" exception test
 #include <utility>
+#include <vector>
 
 namespace Moose
 {

--- a/modules/navier_stokes/src/variables/INSFVVelocityVariable.C
+++ b/modules/navier_stokes/src/variables/INSFVVelocityVariable.C
@@ -410,8 +410,13 @@ INSFVVelocityVariable::adGradSln(const Elem * const elem,
     else
       return grad;
   }
-  catch (libMesh::LogicError &)
+  catch (std::exception & e)
   {
+    // Don't ignore any *real* errors; we only handle matrix
+    // singularity here
+    if (!strstr(e.what(), "singular"))
+      throw;
+
     // Retry without two-term
     mooseAssert(_two_term_boundary_expansion,
                 "I believe we should only get singular systems when two-term boundary expansion is "

--- a/modules/solid_mechanics/src/dampers/ElementJacobianDamper.C
+++ b/modules/solid_mechanics/src/dampers/ElementJacobianDamper.C
@@ -15,6 +15,9 @@
 
 #include "libmesh/quadrature.h" // _qrule
 
+// C++
+#include <cstring> // for "Jacobian" exception test
+
 registerMooseObject("SolidMechanicsApp", ElementJacobianDamper);
 
 InputParameters
@@ -130,12 +133,12 @@ ElementJacobianDamper::computeDamping(const NumericVector<Number> & /* solution 
     }
     catch (std::exception & e)
     {
-      // Allow the libmesh error/exception on negative jacobian
-      const std::string & message = e.what();
-      if (message.find("Jacobian") == std::string::npos)
-        throw e;
-      else
-        _fe_problem.setException(message);
+      // Continue if we find a libMesh degenerate map exception, but
+      // just throw for any real error
+      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
+        throw;
+
+      _fe_problem.setException(e.what());
     }
   }
   PARALLEL_CATCH;

--- a/modules/solid_mechanics/src/materials/RadialReturnStressUpdate.C
+++ b/modules/solid_mechanics/src/materials/RadialReturnStressUpdate.C
@@ -444,7 +444,7 @@ RadialReturnStressUpdateTempl<is_ad>::updateStateSubstep(
     {
       // if we are not using adaptive substepping we just rethrow the exception
       if (!_adaptive_substepping)
-        throw e;
+        throw;
 
       // otherwise we double the number of substeps and try again
       num_substeps *= 2;

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/tests
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/tests
@@ -123,8 +123,8 @@
       input = jacobian_test.i
       cli_args = '--mesh-only'
       mesh_mode = replicated
-      expect_out = '(Number of elements with a negative Jacobian: 1|Number of element sides with negative Jacobians: 2)'
-      detail = 'elements with negative Jacobians'
+      expect_out = '(Number of elements with a bad Jacobian: 1|Number of element sides with bad Jacobians: 2)'
+      detail = 'elements with non-positive Jacobians'
     []
   []
 

--- a/test/tests/misc/jacobian/tests
+++ b/test/tests/misc/jacobian/tests
@@ -42,7 +42,7 @@
     input = no_negative_jacobian.i
     prereq = no_negative_jacobian
     cli_args = 'Kernels/diff/use_displaced_mesh=true Executioner/num_steps=2'
-    expect_err = 'ERROR: negative Jacobian 0 at point \(x,y,z\)=\(       0, 0.211325, 0.211325\) in element 0'
+    expect_err = 'Jacobian 0[\w\s]*at point \(x,y,z\)=\( *0, *0\.211325\d*, *0\.211325\d*\)'
     should_crash = False
     issues = '#9740'
     requirement = 'A 3D simulation shall throw an exception if there is a zero element Jacobian, when use_displaced_mesh = true'
@@ -53,7 +53,7 @@
     prereq = no_negative_jacobian
     # num_steps takes precendence over the end_time in the input file.
     cli_args = 'Kernels/diff/use_displaced_mesh=true Executioner/dt=0.8 Executioner/num_steps=2'
-    expect_err = 'ERROR: negative Jacobian -0.0625 at point \(x,y,z\)=\(-0.105662, 0.211325, 0.211325\) in element 0'
+    expect_err = 'Jacobian -0\.0625[\w\s]*at point \(x,y,z\)=\( *-0\.105662\d*, *0\.211325\d*, *0\.211325\d*\)'
     should_crash = False
     issues = '#9740'
     requirement = 'A 3D simulation shall throw an exception if there is a negative element Jacobian, when use_displaced_mesh = true'
@@ -78,7 +78,7 @@
     input = no_negative_jacobian_2D.i
     prereq = zero_jacobian_2D_ok
     cli_args = 'Kernels/diff/use_displaced_mesh=true Executioner/dt=0.5 Executioner/num_steps=2'
-    expect_err = 'ERROR: negative Jacobian 0 at point \(x,y,z\)=\(       0, 0.211325,        0\) in element 0'
+    expect_err = 'Jacobian 0[\w\s]*at point \(x,y,z\)=\( *0, *0\.211325\d*, *0\)'
     should_crash = False
     issues = '#9740 #10229'
     requirement = 'A 2D simulation shall throw an exception if there is a zero element Jacobian, when use_displaced_mesh = true'


### PR DESCRIPTION
Refs #31856 - this is the "medium-term" step need to make MOOSE compatible with future fixes at the libMesh level.

MOOSE will now catch std::exception and check what() for keywords like Jacobian and singular to identify recoverable exceptions from degenerate maps regardless of libMesh exception type.

While I was at it I noticed a `MeshDiagnosticsGenerator` exception-catching issue for which @GiudGiud might want to review my fix, as well as a couple places where we were using a `try`/`catch` as a bit of a hack where an `if()` would do.