### PR TITLE
Fix `next` MeshDiagnosticsGenerator parallel+dbg case

### DIFF
--- a/framework/include/loops/ComputeFVFluxThread.h
+++ b/framework/include/loops/ComputeFVFluxThread.h
@@ -328,7 +328,8 @@ ThreadedFaceLoop<RangeType>::operator()(const RangeType & range, bool bypass_thr
     {
       // Continue if we find a libMesh degenerate map exception, but
       // just throw for any real error
-      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
+      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular") &&
+          !strstr(e.what(), "det != 0"))
         throw;
 
       mooseException("We caught a libMesh degeneracy exception in ComputeFVFluxThread:\n",

--- a/framework/include/loops/ThreadedElementLoopBase.h
+++ b/framework/include/loops/ThreadedElementLoopBase.h
@@ -152,7 +152,7 @@ public:
    * Called if a MooseException is caught anywhere during the computation.
    * The single input parameter taken is a MooseException object.
    */
-  virtual void caughtMooseException(MooseException &){};
+  virtual void caughtMooseException(MooseException &) {};
 
   /**
    * Whether or not the loop should continue.

--- a/framework/include/loops/ThreadedElementLoopBase.h
+++ b/framework/include/loops/ThreadedElementLoopBase.h
@@ -318,7 +318,8 @@ ThreadedElementLoopBase<RangeType>::operator()(const RangeType & range, bool byp
     {
       // Continue if we find a libMesh degenerate map exception, but
       // just re-throw for any real error
-      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
+      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular") &&
+          !strstr(e.what(), "det != 0"))
         throw; // not "throw e;" - that destroys type info!
 
       mooseException("We caught a libMesh degeneracy exception in ThreadedElementLoopBase:\n",

--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -212,7 +212,7 @@ findContactPoint(PenetrationInfo & p_info,
       catch (std::exception & e)
       {
         // Make sure this *is* just a bad mapping Jacobian
-        if (!strstr(e.what(), "Jacobian"))
+        if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "det != 0"))
           throw;
 
         ref_point(0) -= mult * update(0);

--- a/framework/src/loops/ComputeJacobianForScalingThread.C
+++ b/framework/src/loops/ComputeJacobianForScalingThread.C
@@ -76,7 +76,8 @@ ComputeJacobianForScalingThread::operator()(const ConstElemRange & range,
     {
       // Continue if we find a libMesh degenerate map exception, but
       // just re-throw for any real error
-      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
+      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular") &&
+          !strstr(e.what(), "det != 0"))
         throw;
 
       mooseException(

--- a/framework/src/loops/ComputeMortarFunctor.C
+++ b/framework/src/loops/ComputeMortarFunctor.C
@@ -186,7 +186,8 @@ ComputeMortarFunctor::operator()(const Moose::ComputeType compute_type,
     }
     catch (std::exception & e)
     {
-      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
+      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular") &&
+          !strstr(e.what(), "det != 0"))
         throw;
 
       _fe_problem.setException(

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -1438,7 +1438,9 @@ MeshDiagnosticsGenerator::checkLocalJacobians(const std::unique_ptr<MeshBase> & 
       }
       catch (std::exception & e)
       {
-        if (!strstr(e.what(), "Jacobian"))
+        // In 2D dbg/devel modes libMesh could hit
+        // libmesh_assert_not_equal_to on a side reinit
+        if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "det != 0"))
           throw;
 
         num_bad_side_qp_jacobians++;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -7420,7 +7420,8 @@ FEProblemBase::handleException(const std::string & calling_method)
   catch (const std::exception & e)
   {
     // This might be libMesh detecting a degenerate Jacobian or matrix
-    if (strstr(e.what(), "Jacobian") || strstr(e.what(), "singular"))
+    if (strstr(e.what(), "Jacobian") || strstr(e.what(), "singular") ||
+        strstr(e.what(), "det != 0"))
       setException(create_exception_message("libMesh DegenerateMap", e));
     else
     {

--- a/framework/src/systems/AuxiliarySystem.C
+++ b/framework/src/systems/AuxiliarySystem.C
@@ -810,7 +810,8 @@ AuxiliarySystem::computeMortarNodalVars(const ExecFlagType type)
           {
             // Continue if we find a libMesh degenerate map exception, but
             // just re-throw for any real error
-            if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
+            if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular") &&
+                !strstr(e.what(), "det != 0"))
               throw;
 
             _fe_problem.setException("We caught a libMesh degeneracy exception during mortar "

--- a/modules/solid_mechanics/src/dampers/ElementJacobianDamper.C
+++ b/modules/solid_mechanics/src/dampers/ElementJacobianDamper.C
@@ -135,7 +135,8 @@ ElementJacobianDamper::computeDamping(const NumericVector<Number> & /* solution 
     {
       // Continue if we find a libMesh degenerate map exception, but
       // just throw for any real error
-      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular"))
+      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular") &&
+          !strstr(e.what(), "det != 0"))
         throw;
 
       _fe_problem.setException(e.what());


### PR DESCRIPTION
This fixes #31879 for me, and extends the fix to any other code blocks that might be hit by the same issue.