### PR TITLE
Restrict distributed rectilinear MG to the element types it actually supports

### DIFF
--- a/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
+++ b/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
@@ -82,7 +82,7 @@ DistributedRectilinearMeshGenerator::validParams()
   params.addParam<MooseEnum>(
       "partition", partition, "Which method (graph linear square) use to partition mesh");
 
-  MooseEnum elem_types(LIST_GEOM_ELEM); // no default
+  MooseEnum elem_types("EDGE2 QUAD4 HEX8"); // no default
   params.addParam<MooseEnum>("elem_type",
                              elem_types,
                              "The type of element from libMesh to "

--- a/modules/doc/content/training/index.md
+++ b/modules/doc/content/training/index.md
@@ -3,9 +3,9 @@
 !style! halign=left
 Upcoming MOOSE related training in chronological order:
 
-- MOOSE Framework Fundamentals (2026 January 6-7, Rensselaer Polytechnic Institute)
+- [MOOSE Framework Fundamentals](https://ncrcaims.inl.gov/Identity/Account/TrainingRegistration) (2026 January 6-7, Rensselaer Polytechnic Institute)
 
-- BISON Fuels Performance (2026 January 8-9, Rensselaer Polytechnic Institute)
+- [BISON Fuels Performance](https://ncrcaims.inl.gov/Identity/Account/TrainingRegistration) (2026 January 8-9, Rensselaer Polytechnic Institute)
 
 - MOOSE Modeling and Simulation User Training (2026 April 16th, Texas A&M)
 


### PR DESCRIPTION
refs https://github.com/idaholab/moose/issues/31864

on top of the training PR which should be merged first