### PR TITLE
Don't add petsc snes options to LinearFVKernels. Ref. #31854

### DIFF
--- a/framework/src/linearfvkernels/LinearFVKernel.C
+++ b/framework/src/linearfvkernels/LinearFVKernel.C
@@ -11,6 +11,7 @@
 #include "Assembly.h"
 #include "SubProblem.h"
 #include "FEProblemBase.h"
+#include "PetscSupport.h"
 
 InputParameters
 LinearFVKernel::validParams()
@@ -39,6 +40,10 @@ LinearFVKernel::LinearFVKernel(const InputParameters & params)
     _sys_num(_sys.number())
 {
   addMooseVariableDependency(&_var);
+
+  // LinearFV does not need SNES options, not adding them will avoid petsc
+  // unused option warnings.
+  Moose::PetscSupport::dontAddCommonSNESOptions(_fv_problem);
 }
 
 void

--- a/framework/src/linearfvkernels/LinearFVKernel.C
+++ b/framework/src/linearfvkernels/LinearFVKernel.C
@@ -43,7 +43,7 @@ LinearFVKernel::LinearFVKernel(const InputParameters & params)
 
   // LinearFV does not need SNES options, not adding them will avoid petsc
   // unused option warnings.
-  Moose::PetscSupport::dontAddCommonSNESOptions(_fv_problem);
+  Moose::PetscSupport::dontAddCommonSNESOptions(_fe_problem);
 }
 
 void


### PR DESCRIPTION
This PR disables common snes petsc options for simulations involving LinearFVKernels. To test the changes, I ran `tests/linearfvkernels/block-restriction/block-restricted-diffusion-react.i` and observed that no unused option warning was emitted after my changes. The change made to `LinearFVKernel` does not seem to be necessary in `LinearFVBoundaryCondition` to avoid warnings.

Closes #31854
Other Refs: #28053 
