### PR TITLE
XYMeshLineCutter bug fix

### DIFF
--- a/framework/include/utils/MooseMeshXYCuttingUtils.h
+++ b/framework/include/utils/MooseMeshXYCuttingUtils.h
@@ -48,6 +48,23 @@ void lineRemoverMoveNode(libMesh::ReplicatedMesh & mesh,
                          const bool side_to_remove = true);
 
 /**
+ * Determines whether a point on XY-plane is on a given line, to within a tolerance
+ * @param px x coordinate of the point
+ * @param py y coordinate of the point
+ * @param param_1 parameter 1 (a) in line formula a*x+b*y+c=0
+ * @param param_2 parameter 2 (b) in line formula a*x+b*y+c=0
+ * @param param_3 parameter 3 (c) in line formula a*x+b*y+c=0
+ * @param dis_tol tolerance used in determining whether the point is on the line
+ * @return whether the point is on the line
+ */
+bool pointOnLine(const Real px,
+                 const Real py,
+                 const Real param_1,
+                 const Real param_2,
+                 const Real param_3,
+                 const Real dis_tol = libMesh::TOLERANCE);
+
+/**
  * Determines whether a point on XY-plane is on the side of a given line that needs to be removed
  * @param px x coordinate of the point
  * @param py y coordinate of the point

--- a/framework/src/utils/MooseMeshXYCuttingUtils.C
+++ b/framework/src/utils/MooseMeshXYCuttingUtils.C
@@ -730,9 +730,8 @@ quadToTriOnLine(ReplicatedMesh & mesh,
                                                        cut_line_params[2],
                                                        true));
       }
-      if (std::accumulate(node_side_rec.begin(), node_side_rec.end(), 0) !=
-              (int)node_side_rec.size() &&
-          std::accumulate(node_side_rec.begin(), node_side_rec.end(), 0) > 0)
+      const auto num_nodes = std::accumulate(node_side_rec.begin(), node_side_rec.end(), 0);
+      if (num_nodes != (int)node_side_rec.size() && num_nodes > 0)
       {
         cross_elems_quad.push_back((*elem_it)->id());
         new_subdomain_ids.emplace((*elem_it)->subdomain_id() + tri_subdomain_id_shift);
@@ -801,11 +800,12 @@ lineRemoverCutElemTri(ReplicatedMesh & mesh,
                                                 cut_line_params[2],
                                                 true);
     }
-    if (std::accumulate(node_side_rec.begin(), node_side_rec.end(), 0) == (int)node_side_rec.size() - n_points_on_line)
+    const auto num_nodes = std::accumulate(node_side_rec.begin(), node_side_rec.end(), 0);
+    if (num_nodes == node_side_rec.size() - n_points_on_line)
     {
       (*elem_it)->subdomain_id() = block_id_to_remove;
     }
-    else if (std::accumulate(node_side_rec.begin(), node_side_rec.end(), 0) > 0)
+    else if (num_nodes > 0)
     {
       if ((*elem_it)->n_vertices() != 3 || (*elem_it)->n_nodes() != 3)
         mooseError("The element across the cutting line is not TRI3, which is not supported.");

--- a/framework/src/utils/MooseMeshXYCuttingUtils.C
+++ b/framework/src/utils/MooseMeshXYCuttingUtils.C
@@ -730,6 +730,12 @@ quadToTriOnLine(ReplicatedMesh & mesh,
                                                        cut_line_params[2],
                                                        true));
       }
+      // This counts the booleans in node_side_rec, which does not include nodes
+      // that are exactly on the line (these nodes are excluded from the
+      // decision). In this case, num_nodes node lie on one side of the line and
+      // node_side_rec.size() - n_nodes lie on the other side. In the case that
+      // there are nodes on both sides of the line, we mark the element for
+      // conversion.
       const auto num_nodes = std::accumulate(node_side_rec.begin(), node_side_rec.end(), 0);
       if (num_nodes != (int)node_side_rec.size() && num_nodes > 0)
       {
@@ -800,6 +806,12 @@ lineRemoverCutElemTri(ReplicatedMesh & mesh,
                                                 cut_line_params[2],
                                                 true);
     }
+    // This counts the booleans in node_side_rec, which does not include nodes
+    // that are exactly on the line (these nodes are excluded from the
+    // decision). In this case, num_nodes node lie on one side of the line and
+    // node_side_rec.size() - n_nodes lie on the other side. In the case that
+    // there are nodes on both sides of the line, we mark the element for
+    // removal.
     const unsigned int num_nodes = std::accumulate(node_side_rec.begin(), node_side_rec.end(), 0);
     if (num_nodes == node_side_rec.size() - n_points_on_line)
     {

--- a/framework/src/utils/MooseMeshXYCuttingUtils.C
+++ b/framework/src/utils/MooseMeshXYCuttingUtils.C
@@ -800,7 +800,7 @@ lineRemoverCutElemTri(ReplicatedMesh & mesh,
                                                 cut_line_params[2],
                                                 true);
     }
-    const auto num_nodes = std::accumulate(node_side_rec.begin(), node_side_rec.end(), 0);
+    const unsigned int num_nodes = std::accumulate(node_side_rec.begin(), node_side_rec.end(), 0);
     if (num_nodes == node_side_rec.size() - n_points_on_line)
     {
       (*elem_it)->subdomain_id() = block_id_to_remove;


### PR DESCRIPTION
Added utility function to determine if point is on line

Given a cut line, the XYMeshCutter deletes elements on one side of the
line.
When the line cuts through quad elements, those elements are converted
to tris and refined to form a new mesh boundary coincident with the cut
line.
To determine whether the cut line cuts through a given element, each
vertex of the element is plugged into the line equation f(x, y) = ax + by + c.
An (x, y) point is on the line if f(x, y) = 0.
Vertices residing on one side of the line have positive f(x, y) and
vertices residing on the other side of the line have negative f(x, y).
If two vertices of an element have differently signed f values, the
element is deemed to be cut by the line and is marked for conversion to
tri elements and further refinement.

This PR patches a bug in the above logic.
Previously, the mesh generator did not check if a given vertex lies on
the cut line.
These vertices were assigned to one side of the line.
In the case of a quad that is not cut by the line, but has an edge
coincident with the line, this can cause those elements to be
incorrectly marked for tri conversion and refinement.
While the final cut mesh was correct, this results in an irrelevant, confusing
warning that quad elements are being converted to tri elements.
This PR adds checks to determine and ignore vertices that lie on the
cut line.
These vertices are no longer used when determining whether an element is cut
by the line.

Closes #31795.