### PR TITLE
Catch when the server is shutting down

### DIFF
--- a/python/moosecontrol/runners/baserunner.py
+++ b/python/moosecontrol/runners/baserunner.py
@@ -19,7 +19,7 @@ from typing import Callable, Optional
 from requests import Session
 from requests.exceptions import ConnectionError
 
-from moosecontrol.exceptions import InitializeTimeout
+from moosecontrol.exceptions import InitializeTimeout, WebServerControlError
 from moosecontrol.validation import WebServerControlResponse, process_response
 
 from .utils import Poker, TimedPoller
@@ -158,6 +158,10 @@ class BaseRunner(ABC):
             response = self.get("check")
         except ConnectionError:
             return False
+        except WebServerControlError as e:
+            if e.error == "Control is no longer available":
+                return False
+            raise
         return response.response.status_code == 200
 
     def initialize_start(self):


### PR DESCRIPTION
## Reason
See https://civet.inl.gov/job/3397863/ for an example; we could catch the server just as it's shutting down. This should be considered the server not listening.

## Design
Catch the error "Control is no longer available" and consider it not listening.

## Impact
Catches an edge case. Will result in more consistent testing.

