### PR TITLE
Add TH adjustments to facilitate fusion blanket modeling in SALAMANDER

### DIFF
--- a/modules/thermal_hydraulics/include/interfaces/DiscreteLineSegmentInterface.h
+++ b/modules/thermal_hydraulics/include/interfaces/DiscreteLineSegmentInterface.h
@@ -102,9 +102,9 @@ protected:
   Real _length;
 
   /// Number of elements in each axial section
-  const std::vector<unsigned int> & _n_elems;
+  std::vector<unsigned int> _n_elems;
   /// Total number of axial elements
-  const unsigned int _n_elem;
+  unsigned int _n_elem;
 
   /// Number of axial sections
   const unsigned int _n_sections;


### PR DESCRIPTION
Closes #31958 

@joshuahansel Could you give this a review? ~Let me know if you want me to expand the new `Nu_scale` parameter to the non-AD version of the Dittus-Boelter material as well for consistency, or take some other approach.~ EDIT: This has been removed from the PR (see discussion below). This is mostly me pulling some Fande changes from the former "fusion module" PR and adding some testing/documentation.

Refs #30122 