### PR TITLE
Add partitioner directly when setting a custom partitioner

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -3779,6 +3779,10 @@ void
 MooseMesh::setCustomPartitioner(Partitioner * partitioner)
 {
   _custom_partitioner = partitioner->clone();
+  setIsCustomPartitionerRequested(true);
+  if (_mesh)
+    _mesh->partitioner() = _custom_partitioner->clone();
+  _partitioner_name = "custom";
 }
 
 bool
@@ -3977,8 +3981,8 @@ MooseMesh::computeFiniteVolumeCoords() const
 MooseEnum
 MooseMesh::partitioning()
 {
-  MooseEnum partitioning("default=-3 metis=-2 parmetis=-1 linear=0 centroid hilbert_sfc morton_sfc",
-                         "default");
+  MooseEnum partitioning(
+      "default=-3 metis=-2 parmetis=-1 linear=0 centroid hilbert_sfc morton_sfc custom", "default");
   return partitioning;
 }
 


### PR DESCRIPTION
if possible,
if not, we are storing it in an attribute to be set later when the MeshBase is actually built

refs #31978

This is to accomodate the workflow in SAM for building the partitioner