### PR TITLE
Parameter application logic

### DIFF
--- a/python/FactorySystem/Parser.py
+++ b/python/FactorySystem/Parser.py
@@ -182,6 +182,14 @@ class Parser:
                 if key in params.keys():
                     if key == 'cli_args':
                         params[key].append(value)
+                    elif params.type(key) == list:
+                        if isinstance(value, str):
+                            value = value.replace('\n', ' ')
+                            params[key] = re.split(r'\s+', value)
+                        elif isinstance(value, (list, tuple)):
+                            params[key] = list(value)
+                        else:
+                            params[key] = [str(value)]
                     else:
                         params[key] = value
 

--- a/python/TestHarness/tests/test_CapabilitiesPropagation.py
+++ b/python/TestHarness/tests/test_CapabilitiesPropagation.py
@@ -1,0 +1,16 @@
+#* This file is part of the MOOSE framework
+#* https://mooseframework.inl.gov
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testGlobalCapabilitiesPropagated(self):
+        result = self.runTests('-i', 'global_capabilities', '--dry-run')
+        test_results = result.results['tests']['tests/test_harness']['tests']['always_ok']
+        self.assertEqual(test_results['capabilities'], 'foo')

--- a/python/TestHarness/tests/test_CapabilitiesPropagation.py
+++ b/python/TestHarness/tests/test_CapabilitiesPropagation.py
@@ -14,3 +14,8 @@ class TestHarnessTester(TestHarnessTestCase):
         result = self.runTests('-i', 'global_capabilities', '--dry-run')
         test_results = result.results['tests']['tests/test_harness']['tests']['always_ok']
         self.assertEqual(test_results['capabilities'], 'foo')
+
+    def testGlobalPrereqPropagated(self):
+        result = self.runTests('-i', 'global_prereq', '--dry-run')
+        test_results = result.results['tests']['tests/test_harness']['tests']['parent']['tests']['child']
+        self.assertEqual(test_results['prereq'], ['pre'])

--- a/test/tests/test_harness/global_capabilities
+++ b/test/tests/test_harness/global_capabilities
@@ -1,0 +1,7 @@
+[Tests]
+  capabilities = 'foo'
+  [./always_ok]
+    type = RunApp
+    input = good.i
+  [../]
+[]

--- a/test/tests/test_harness/global_prereq
+++ b/test/tests/test_harness/global_prereq
@@ -1,0 +1,13 @@
+[Tests]
+  [parent]
+    prereq = pre
+    [pre]
+      type = RunCommand
+      command = 'true'
+    []
+    [child]
+      type = RunCommand
+      command = 'true'
+    []
+  []
+[]


### PR DESCRIPTION
## Reason
Allow common parameters to be specified at a higher level in the `tests` spec hierarchy.

## Design
Set parent block parameters as defaults for local parameters, cascading down.

## Impact
More compact tests specs.