### PR TITLE
Allow L2 FE spaces w/ map type integral

### DIFF
--- a/framework/doc/content/source/mfem/fespaces/MFEMVectorFESpace.md
+++ b/framework/doc/content/source/mfem/fespaces/MFEMVectorFESpace.md
@@ -17,7 +17,7 @@ The dimension of the resulting finite element collection/space will be
 the same as the dimension of the mesh. The value of `vdim` (the number
 of degrees of freedom per basis function) will depend on `fec_type`.
 
-- `H1` and `L2` spaces will have `vdim` set to `range_dim`
+- `H1` and `L2(Int)` spaces will have `vdim` set to `range_dim`
 - `ND` and `RT` spaces will always have `vdim` set to 1
 
 Note that Nédélec and Raviart-Thomas shape functions do not support

--- a/framework/src/mfem/fespaces/MFEMScalarFESpace.C
+++ b/framework/src/mfem/fespaces/MFEMScalarFESpace.C
@@ -18,7 +18,7 @@ MFEMScalarFESpace::validParams()
 {
   InputParameters params = MFEMSimplifiedFESpace::validParams();
   params.addClassDescription("Convenience class to construct scalar finite element spaces.");
-  MooseEnum fec_types("H1 L2", "H1");
+  MooseEnum fec_types("H1 L2 L2Int", "H1");
   params.addParam<MooseEnum>("fec_type", fec_types, "Specifies the family of FE shape functions.");
   MooseEnum basis_types("GaussLegendre GaussLobatto Positive OpenUniform ClosedUniform "
                         "OpenHalfUniform Serendipity ClosedGL IntegratedGLL",
@@ -41,7 +41,7 @@ std::string
 MFEMScalarFESpace::getFECName() const
 {
   std::string basis =
-      _fec_type == "L2"
+      _fec_type == "L2" || _fec_type == "L2Int"
           ? "_T" + std::to_string(getParam<MooseEnum>("basis"))
           : "@" + std::string({mfem::BasisType::GetChar(getParam<MooseEnum>("basis"))});
 

--- a/framework/src/mfem/fespaces/MFEMVectorFESpace.C
+++ b/framework/src/mfem/fespaces/MFEMVectorFESpace.C
@@ -20,7 +20,7 @@ MFEMVectorFESpace::validParams()
   params.addClassDescription(
       "Convenience class to construct vector finite element spaces, abstracting away some of the "
       "mathematical complexity of specifying the dimensions.");
-  MooseEnum fec_types("H1 ND RT L2", "H1");
+  MooseEnum fec_types("H1 ND RT L2 L2Int", "H1");
   params.addParam<MooseEnum>("fec_type", fec_types, "Specifies the family of FE shape functions.");
   MooseEnum closed_basis_types("GaussLobatto=1 ClosedUniform=4 Serendipity=6 ClosedGL=7",
                                "GaussLobatto");
@@ -36,8 +36,8 @@ MFEMVectorFESpace::validParams()
   params.addParam<MooseEnum>(
       "basis",
       basis_types,
-      "Specifies the basis used for H1 and L2 vector elements. H1 spaces require a closed basis "
-      "(GaussLobatto Positive ClosedUniform Serendipity ClosedGL)");
+      "Specifies the basis used for H1 and L2(Int) vector elements. H1 spaces require a closed "
+      "basis (GaussLobatto Positive ClosedUniform Serendipity ClosedGL)");
   params.addParam<int>("range_dim",
                        0,
                        "The number of components of the vectors in reference space. Zero "
@@ -68,7 +68,7 @@ MFEMVectorFESpace::getFECName() const
     actual_type += "_R" + std::to_string(pdim) + "D";
   }
 
-  std::string basis = _fec_type == "L2" ? "_T" : "@";
+  std::string basis = _fec_type == "L2" || _fec_type == "L2Int" ? "_T" : "@";
 
   if (_fec_type == "ND" || _fec_type == "RT")
   {
@@ -77,11 +77,11 @@ MFEMVectorFESpace::getFECName() const
     basis += mfem::BasisType::GetChar(getParam<MooseEnum>("closed_basis"));
     basis += mfem::BasisType::GetChar(getParam<MooseEnum>("open_basis"));
   }
-  else if (_fec_type == "H1" || _fec_type == "L2")
+  else if (_fec_type == "H1" || _fec_type == "L2" || _fec_type == "L2Int")
   {
     if (isParamSetByUser("closed_basis") || isParamSetByUser("open_basis"))
       mooseWarning("closed_basis/open_basis parameter ignored, using basis parameter instead");
-    basis += _fec_type == "L2"
+    basis += _fec_type == "L2" || _fec_type == "L2Int"
                  ? std::to_string(getParam<MooseEnum>("basis"))
                  : std::string({mfem::BasisType::GetChar(getParam<MooseEnum>("basis"))});
   }
@@ -95,7 +95,7 @@ MFEMVectorFESpace::getFECName() const
 int
 MFEMVectorFESpace::getVDim() const
 {
-  if (_fec_type == "H1" || _fec_type == "L2")
+  if (_fec_type == "H1" || _fec_type == "L2" || _fec_type == "L2Int")
   {
     return _range_dim == 0 ? getProblemDim() : _range_dim;
   }

--- a/unit/src/MFEMFESpaceTest.C
+++ b/unit/src/MFEMFESpaceTest.C
@@ -142,7 +142,7 @@ class ScalarFESpaceTest : public MFEMFESpaceUnitTest<MFEMScalarFESpace, std::str
     InputParameters params = _factory.getValidParams("MFEMScalarFESpace");
     params.set<MooseEnum>("fec_type") = std::get<0>(raw_params);
     params.set<MooseEnum>("fec_order") = std::get<1>(raw_params);
-    if (params.set<MooseEnum>("fec_type") == "L2")
+    if (params.set<MooseEnum>("fec_type") == "L2" || params.set<MooseEnum>("fec_type") == "L2Int")
       params.set<MooseEnum>("basis") = "GaussLegendre";
     return params;
   }
@@ -157,18 +157,25 @@ TEST_P(ScalarFESpaceTest, TestExpectedScalarFESpace)
 INSTANTIATE_TEST_SUITE_P(
     ScalarFESpaces,
     ScalarFESpaceTest,
-    testing::Values(ScalarFESpaceTest::makeParam("ref-segment.mesh", "H1", 1, "H1_1D_P1", 1, true),
-                    ScalarFESpaceTest::makeParam("ref-square.mesh", "H1", 1, "H1_2D_P1", 1, true),
-                    ScalarFESpaceTest::makeParam("ref-cube.mesh", "H1", 1, "H1_3D_P1", 1, true),
-                    ScalarFESpaceTest::makeParam("ref-segment.mesh", "H1", 2, "H1_1D_P2", 1, true),
-                    ScalarFESpaceTest::makeParam("ref-square.mesh", "H1", 3, "H1_2D_P3", 1, true),
-                    ScalarFESpaceTest::makeParam("ref-cube.mesh", "H1", 4, "H1_3D_P4", 1, true),
-                    ScalarFESpaceTest::makeParam("ref-segment.mesh", "L2", 1, "L2_1D_P1", 1, true),
-                    ScalarFESpaceTest::makeParam("ref-square.mesh", "L2", 1, "L2_2D_P1", 1, true),
-                    ScalarFESpaceTest::makeParam("ref-cube.mesh", "L2", 1, "L2_3D_P1", 1, true),
-                    ScalarFESpaceTest::makeParam("ref-segment.mesh", "L2", 2, "L2_1D_P2", 1, true),
-                    ScalarFESpaceTest::makeParam("ref-square.mesh", "L2", 3, "L2_2D_P3", 1, true),
-                    ScalarFESpaceTest::makeParam("ref-cube.mesh", "L2", 4, "L2_3D_P4", 1, true)));
+    testing::Values(
+        ScalarFESpaceTest::makeParam("ref-segment.mesh", "H1", 1, "H1_1D_P1", 1, true),
+        ScalarFESpaceTest::makeParam("ref-square.mesh", "H1", 1, "H1_2D_P1", 1, true),
+        ScalarFESpaceTest::makeParam("ref-cube.mesh", "H1", 1, "H1_3D_P1", 1, true),
+        ScalarFESpaceTest::makeParam("ref-segment.mesh", "H1", 2, "H1_1D_P2", 1, true),
+        ScalarFESpaceTest::makeParam("ref-square.mesh", "H1", 3, "H1_2D_P3", 1, true),
+        ScalarFESpaceTest::makeParam("ref-cube.mesh", "H1", 4, "H1_3D_P4", 1, true),
+        ScalarFESpaceTest::makeParam("ref-segment.mesh", "L2", 1, "L2_1D_P1", 1, true),
+        ScalarFESpaceTest::makeParam("ref-square.mesh", "L2", 1, "L2_2D_P1", 1, true),
+        ScalarFESpaceTest::makeParam("ref-cube.mesh", "L2", 1, "L2_3D_P1", 1, true),
+        ScalarFESpaceTest::makeParam("ref-segment.mesh", "L2", 2, "L2_1D_P2", 1, true),
+        ScalarFESpaceTest::makeParam("ref-square.mesh", "L2", 3, "L2_2D_P3", 1, true),
+        ScalarFESpaceTest::makeParam("ref-cube.mesh", "L2", 4, "L2_3D_P4", 1, true),
+        ScalarFESpaceTest::makeParam("ref-segment.mesh", "L2Int", 1, "L2Int_1D_P1", 1, true),
+        ScalarFESpaceTest::makeParam("ref-square.mesh", "L2Int", 1, "L2Int_2D_P1", 1, true),
+        ScalarFESpaceTest::makeParam("ref-cube.mesh", "L2Int", 1, "L2Int_3D_P1", 1, true),
+        ScalarFESpaceTest::makeParam("ref-segment.mesh", "L2Int", 2, "L2Int_1D_P2", 1, true),
+        ScalarFESpaceTest::makeParam("ref-square.mesh", "L2Int", 3, "L2Int_2D_P3", 1, true),
+        ScalarFESpaceTest::makeParam("ref-cube.mesh", "L2Int", 4, "L2Int_3D_P4", 1, true)));
 
 class VectorFESpaceTest : public MFEMFESpaceUnitTest<MFEMVectorFESpace, std::string, int, int>
 {
@@ -181,7 +188,7 @@ class VectorFESpaceTest : public MFEMFESpaceUnitTest<MFEMVectorFESpace, std::str
     params.set<MooseEnum>("fec_type") = std::get<0>(raw_params);
     params.set<MooseEnum>("fec_order") = std::get<1>(raw_params);
     params.set<int>("range_dim") = std::get<2>(raw_params);
-    if (params.set<MooseEnum>("fec_type") == "L2")
+    if (params.set<MooseEnum>("fec_type") == "L2" || params.set<MooseEnum>("fec_type") == "L2Int")
       params.set<MooseEnum>("basis") = "GaussLegendre";
     return params;
   }
@@ -221,6 +228,18 @@ INSTANTIATE_TEST_SUITE_P(
         VectorFESpaceTest::makeParam("ref-cube.mesh", "L2", 3, 1, "L2_3D_P3", 1, false),
         VectorFESpaceTest::makeParam("ref-cube.mesh", "L2", 4, 2, "L2_3D_P4", 2, false),
         VectorFESpaceTest::makeParam("ref-cube.mesh", "L2", 3, 3, "L2_3D_P3", 3, false),
+        VectorFESpaceTest::makeParam("ref-segment.mesh", "L2Int", 1, 0, "L2Int_1D_P1", 1, false),
+        VectorFESpaceTest::makeParam("ref-segment.mesh", "L2Int", 2, 1, "L2Int_1D_P2", 1, false),
+        VectorFESpaceTest::makeParam("ref-segment.mesh", "L2Int", 1, 2, "L2Int_1D_P1", 2, false),
+        VectorFESpaceTest::makeParam("ref-segment.mesh", "L2Int", 2, 3, "L2Int_1D_P2", 3, false),
+        VectorFESpaceTest::makeParam("ref-square.mesh", "L2Int", 4, 0, "L2Int_2D_P4", 2, false),
+        VectorFESpaceTest::makeParam("ref-square.mesh", "L2Int", 3, 1, "L2Int_2D_P3", 1, false),
+        VectorFESpaceTest::makeParam("ref-square.mesh", "L2Int", 2, 2, "L2Int_2D_P2", 2, false),
+        VectorFESpaceTest::makeParam("ref-square.mesh", "L2Int", 1, 3, "L2Int_2D_P1", 3, false),
+        VectorFESpaceTest::makeParam("ref-cube.mesh", "L2Int", 1, 0, "L2Int_3D_P1", 3, false),
+        VectorFESpaceTest::makeParam("ref-cube.mesh", "L2Int", 3, 1, "L2Int_3D_P3", 1, false),
+        VectorFESpaceTest::makeParam("ref-cube.mesh", "L2Int", 4, 2, "L2Int_3D_P4", 2, false),
+        VectorFESpaceTest::makeParam("ref-cube.mesh", "L2Int", 3, 3, "L2Int_3D_P3", 3, false),
         VectorFESpaceTest::makeParam("ref-square.mesh", "RT", 2, 0, "RT_2D_P2", 1, false),
         VectorFESpaceTest::makeParam("ref-cube.mesh", "RT", 1, 0, "RT_3D_P1", 1, false),
         VectorFESpaceTest::makeParam("ref-square.mesh", "RT", 2, 2, "RT_2D_P2", 1, false),
@@ -234,9 +253,7 @@ INSTANTIATE_TEST_SUITE_P(
         VectorFESpaceTest::makeParam("ref-segment.mesh", "RT", 2, 3, "RT_R1D_1D_P2", 1, false),
         VectorFESpaceTest::makeParam("ref-square.mesh", "RT", 3, 3, "RT_R2D_2D_P3", 1, false),
         VectorFESpaceTest::makeParam("ref-segment.mesh", "ND", 5, 3, "ND_R1D_1D_P5", 1, false),
-        VectorFESpaceTest::makeParam("ref-square.mesh", "ND", 1, 3, "ND_R2D_2D_P1", 1, false)
-
-            ));
+        VectorFESpaceTest::makeParam("ref-square.mesh", "ND", 1, 3, "ND_R2D_2D_P1", 1, false)));
 
 class InvalidVectorFESpaceTest : public VectorFESpaceTest
 {


### PR DESCRIPTION
## Reason
Addresses concerns in #31969 which removed the ability to construct integral-mapped (as opposed to value-mapped) L2 FE spaces originally introduced in #31613.

## Design
Rather than specifying the map type, the user can just specify a different finite element collection type, eliminating the need for more complicated checks between the chosen space and Piola mapping.

## Impact
Allows L2 basis functions to be scaled by the volume integral of the spanned element, which can be useful when projecting between some spaces.