### PR TITLE
Make type hint for StochasticRunner.parallelWorker more explicit [WIP]

### DIFF
--- a/modules/stochastic_tools/python/moose_stochastic_tools/StochasticControl.py
+++ b/modules/stochastic_tools/python/moose_stochastic_tools/StochasticControl.py
@@ -602,7 +602,7 @@ class StochasticRunner:
         self._control: StochasticControl = control
         self._result_cache: Optional[_ResultCache] = None
 
-    def parallelWorker(self, func: Callable, x_iter: Iterable) -> Generator[np.ndarray | float]:
+    def parallelWorker(self, func: Callable, x_iter: Iterable) -> Generator[np.ndarray | float, None, None]:
         """
         Map-like callable to use as `workers` in SciPy optimizers (emulates
         `multiprocessing.Pool.map`).


### PR DESCRIPTION
Closes #32024



## Reason
Improve backwards compatibility and enables testing of `StochasticRunner.parallelWorker`

## Design
Add new test and edit type hint.

## Impact
Improves python support

