### PR TITLE
Remove usage of -ksp_snes_ew petsc option

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -924,7 +924,7 @@ MultiMooseEnum
 getCommonSNESFlags()
 {
   return MultiMooseEnum(
-      "-ksp_monitor_snes_lg -snes_ksp_ew -ksp_snes_ew -snes_converged_reason "
+      "-ksp_monitor_snes_lg -snes_ksp_ew -snes_converged_reason "
       "-snes_ksp -snes_linesearch_monitor -snes_mf -snes_mf_operator -snes_monitor "
       "-snes_test_display -snes_view -snes_monitor_cancel",
       "",

--- a/modules/combined/test/tests/axisymmetric_2d3d_solution_function/2d.i
+++ b/modules/combined/test/tests/axisymmetric_2d3d_solution_function/2d.i
@@ -152,7 +152,7 @@
   type = Transient
   solve_type = 'PJFNK'
 
-  petsc_options = '-ksp_snes_ew'
+  petsc_options = '-snes_ksp_ew'
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = ' 201                hypre    boomeramg      4'
   line_search = 'none'

--- a/modules/combined/test/tests/axisymmetric_2d3d_solution_function/3dy.i
+++ b/modules/combined/test/tests/axisymmetric_2d3d_solution_function/3dy.i
@@ -144,7 +144,7 @@
   type = Transient
   solve_type = 'PJFNK'
 
-  petsc_options = '-ksp_snes_ew'
+  petsc_options = '-snes_ksp_ew'
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = ' 201                hypre    boomeramg      4'
   line_search = 'none'

--- a/modules/combined/test/tests/power_law_hardening/ADPowerLawHardening.i
+++ b/modules/combined/test/tests/power_law_hardening/ADPowerLawHardening.i
@@ -101,7 +101,7 @@
   type = Transient
   solve_type = 'NEWTON'
 
-  petsc_options = '-ksp_snes_ew'
+  petsc_options = '-snes_ksp_ew'
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = '201                hypre    boomeramg      4'
 

--- a/modules/combined/test/tests/power_law_hardening/PowerLawHardening.i
+++ b/modules/combined/test/tests/power_law_hardening/PowerLawHardening.i
@@ -101,7 +101,7 @@
   type = Transient
   solve_type = 'PJFNK'
 
-  petsc_options = '-ksp_snes_ew'
+  petsc_options = '-snes_ksp_ew'
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = '201                hypre    boomeramg      4'
 

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg.i
@@ -208,7 +208,6 @@
   type = Transient
   solve_type = 'NEWTON'
 
-  petsc_options = '-ksp_snes_ew'
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = ' 201                hypre    boomeramg      8'
 

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg_bussetta_simple.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg_bussetta_simple.i
@@ -208,7 +208,6 @@
   type = Transient
   solve_type = 'NEWTON'
 
-  petsc_options = '-ksp_snes_ew'
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = ' 201                hypre    boomeramg      8'
 

--- a/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg_tight.i
+++ b/modules/contact/test/tests/pdass_problems/cylinder_friction_penalty_frictional_al_action_amg_tight.i
@@ -214,7 +214,6 @@
   type = Transient
   solve_type = 'NEWTON'
 
-  petsc_options = '-ksp_snes_ew'
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = ' 201                hypre    boomeramg      8'
 

--- a/modules/porous_flow/examples/fluidflower/fluidflower.i
+++ b/modules/porous_flow/examples/fluidflower/fluidflower.i
@@ -862,7 +862,7 @@ inj_rate = 3.06e-7
   [smp]
     type = SMP
     full = true
-    petsc_options = '-ksp_snes_ew'
+    petsc_options = '-snes_ksp_ew'
     petsc_options_iname = '-ksp_type -pc_type -pc_factor_mat_solver_package -sub_pc_factor_shift_type'
     petsc_options_value = 'gmres lu mumps NONZERO'
     # petsc_options_iname = '-ksp_type -pc_type -pc_hypre_type -sub_pc_type -sub_pc_factor_shift_type -sub_pc_factor_levels -ksp_gmres_restart'


### PR DESCRIPTION
This may have been a valid option at one time, but I keep seeing models that give errors because this is not recognized as a valid PETSc option. Replace all instances of its use with -snes_ksp_ew.

## Reason
I keep running into models that use the invalid `-ksp_snes_ew` PETSc option. Getting rid of all usage of this in MOOSE will help avoid this (and get rid of some warnings in our tests).

## Design
Switch usages of `-ksp_snes_ew` to `-snes_ksp_ew` in all MOOSE tests.

## Impact
This will only update the test suite. No impact on code behavior.