### PR TITLE
Mesh preparedness fixes

### DIFF
--- a/framework/src/actions/SplitMeshAction.C
+++ b/framework/src/actions/SplitMeshAction.C
@@ -32,7 +32,7 @@ SplitMeshAction::act()
 {
   auto mesh = _app.actionWarehouse().mesh();
 
-  // Keep the mesh unpartitioned until right before the split 
+  // Keep the mesh unpartitioned until right before the split
   mesh->getMesh().skip_partitioning(false);
 
   const std::string split_file_arg = _app.parameters().isParamSetByUser("split_file")

--- a/framework/src/actions/SplitMeshAction.C
+++ b/framework/src/actions/SplitMeshAction.C
@@ -32,6 +32,7 @@ SplitMeshAction::act()
 {
   auto mesh = _app.actionWarehouse().mesh();
 
+  // Keep the mesh unpartitioned until right before the split 
   mesh->getMesh().skip_partitioning(false);
 
   const std::string split_file_arg = _app.parameters().isParamSetByUser("split_file")

--- a/framework/src/actions/SplitMeshAction.C
+++ b/framework/src/actions/SplitMeshAction.C
@@ -31,6 +31,9 @@ void
 SplitMeshAction::act()
 {
   auto mesh = _app.actionWarehouse().mesh();
+
+  mesh->getMesh().skip_partitioning(false);
+
   const std::string split_file_arg = _app.parameters().isParamSetByUser("split_file")
                                          ? _app.parameters().get<std::string>("split_file")
                                          : "";

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2960,10 +2960,6 @@ MooseMesh::init()
       getMesh().skip_partitioning(true);
     buildMesh();
 
-    // Re-enable partitioning so the splitter can partition!
-    if (_app.isSplitMesh())
-      getMesh().skip_partitioning(false);
-
     if (getParam<bool>("build_all_side_lowerd_mesh"))
       buildLowerDMesh();
   }

--- a/framework/src/meshgenerators/MeshGenerator.C
+++ b/framework/src/meshgenerators/MeshGenerator.C
@@ -331,6 +331,9 @@ MeshGenerator::generateInternal()
 
   if (getParam<bool>("show_info"))
   {
+    if (!mesh->is_prepared())
+      mesh->prepare_for_use();
+
     const auto mesh_info = mesh->get_info(/* verbosity = */ 2);
 
     // We will prefix all information with "type() 'name()':" because this could potentially

--- a/modules/peridynamics/src/meshgenerators/MeshGeneratorPD.C
+++ b/modules/peridynamics/src/meshgenerators/MeshGeneratorPD.C
@@ -135,6 +135,11 @@ MeshGeneratorPD::generate()
   // get the MeshBase object this generator will be working on
   std::unique_ptr<MeshBase> old_mesh = std::move(_input);
 
+  // If it's not prepared, we need it to be, to access caches like
+  // mesh_dimension() and spatial_dimension()
+  if (!old_mesh->is_prepared())
+    old_mesh->prepare_for_use();
+
   // STEP 1: obtain FE block(s) and elements to be converted to PD mesh
 
   // get the IDs of all available blocks in the input FE mesh


### PR DESCRIPTION
## Reason
Some of the additional error checking in https://github.com/libMesh/libmesh/pull/3759 has exposed issues in MOOSE code; those need to be fixed before we can be confident the libMesh PR is ready to merge.

## Design
1. In places where MOOSE is relying on cached data from an unprepared mesh, test `is_prepared()` first and prepare if necessary.
2. When MOOSE is doing mesh splitting, keep repartitioning disabled until *right before* splitting the mesh; otherwise when libMesh starts correctly noting that unpartitioned meshes are unprepared, earlier MOOSE prepare_for_use() calls can trigger partitioning before the split, when a split-detail-dependent partitioner like a manual GridPartitioner setting may be unable to handle it.

## Impact
In theory no impact.  When we merge the next libMesh submodule there may be other similar errors exposed downstream.