### PR TITLE
Do not add non-existent material in Closures1PhaseTHM

### DIFF
--- a/modules/thermal_hydraulics/doc/content/source/closures/Closures1PhaseTHM.md
+++ b/modules/thermal_hydraulics/doc/content/source/closures/Closures1PhaseTHM.md
@@ -1,11 +1,9 @@
 # Closures1PhaseTHM
 
-!syntax description /Closures/Closures1PhaseTHM
-
 The closures added are:
 
 - a wall friction factor for the pressure drop,
-- a wall heat transfer coefficient for heat transfer.
+- a wall heat transfer coefficient for heat transfer (only if the heat transfer is not a specified heat flux).
 
 The user can choose between a range of correlations for the heat transfer coefficient and friction factor that covers  pipes to rod-bundles. The available correlations for the heat transfer coefficient are listed in [HTC-correlations].
 
@@ -56,7 +54,7 @@ The user can also define the friction factor directly in the component block, ov
 
 In this case, the friction factor for the `Pipe_1` component will be equal to the value defined in the parameter `f`, while for `Pipe_2` the friction factor will given by the correlation chosen in the [Closures1PhaseTHM.md].
 
-Additionally, this object defines:
+If the heat transfer is not a specified heat flux, this object also defines:
 
 - a wall temperature material, to be able to retrieve the wall temperature as a material property for each heat transfer.
 

--- a/modules/thermal_hydraulics/include/closures/Closures1PhaseTHM.h
+++ b/modules/thermal_hydraulics/include/closures/Closures1PhaseTHM.h
@@ -62,14 +62,6 @@ protected:
    */
   void addWallHTCMaterial(const FlowChannel1Phase & flow_channel, unsigned int i) const;
 
-  /**
-   * Adds computation of wall temperature when heat flux is specified
-   *
-   * @param[in] flow_channel   Flow channel component
-   * @param[in] i   Heat transfer index
-   */
-  void addTemperatureWallFromHeatFluxMaterial(const FlowChannel1Phase & flow_channel,
-                                              unsigned int i) const;
   /// Wall heat transfer coefficient closure
   const WallHTCClosureType _wall_htc_closure;
 

--- a/modules/thermal_hydraulics/src/closures/Closures1PhaseTHM.C
+++ b/modules/thermal_hydraulics/src/closures/Closures1PhaseTHM.C
@@ -61,19 +61,15 @@ Closures1PhaseTHM::addMooseObjectsFlowChannel(const FlowChannelBase & flow_chann
     addWallFFMaterial(flow_channel_1phase);
 
   const unsigned int n_ht_connections = flow_channel_1phase.getNumberOfHeatTransferConnections();
-  if (n_ht_connections > 0)
+  if (n_ht_connections > 0 && flow_channel.getTemperatureMode())
   {
-
     for (unsigned int i = 0; i < n_ht_connections; i++)
     {
       // wall heat transfer coefficient material
       addWallHTCMaterial(flow_channel_1phase, i);
 
       // wall temperature material
-      if (flow_channel.getTemperatureMode())
-        addWallTemperatureFromAuxMaterial(flow_channel_1phase, i);
-      else
-        addTemperatureWallFromHeatFluxMaterial(flow_channel_1phase, i);
+      addWallTemperatureFromAuxMaterial(flow_channel_1phase, i);
     }
   }
 }
@@ -303,22 +299,4 @@ Closures1PhaseTHM::addWallHTCMaterial(const FlowChannel1Phase & flow_channel, un
     default:
       mooseError("Invalid WallHTCClosureType");
   }
-}
-void
-Closures1PhaseTHM::addTemperatureWallFromHeatFluxMaterial(const FlowChannel1Phase & flow_channel,
-                                                          unsigned int i) const
-{
-  const std::string class_name = "TemperatureWallFromHeatFlux3EqnTHMMaterial";
-  InputParameters params = _factory.getValidParams(class_name);
-  params.set<std::vector<SubdomainName>>("block") = flow_channel.getSubdomainNames();
-  params.set<MaterialPropertyName>("T_wall") = flow_channel.getWallTemperatureNames()[i];
-  params.set<MaterialPropertyName>("D_h") = FlowModelSinglePhase::HYDRAULIC_DIAMETER;
-  params.set<MaterialPropertyName>("rho") = FlowModelSinglePhase::DENSITY;
-  params.set<MaterialPropertyName>("vel") = FlowModelSinglePhase::VELOCITY;
-  params.set<MaterialPropertyName>("T") = FlowModelSinglePhase::TEMPERATURE;
-  params.set<MaterialPropertyName>("k") = FlowModelSinglePhase::THERMAL_CONDUCTIVITY;
-  params.set<MaterialPropertyName>("mu") = FlowModelSinglePhase::DYNAMIC_VISCOSITY;
-  params.set<MaterialPropertyName>("cp") = FlowModelSinglePhase::SPECIFIC_HEAT_CONSTANT_PRESSURE;
-  params.set<MaterialPropertyName>("q_wall") = flow_channel.getWallHeatFluxNames()[i];
-  _sim.addMaterial(class_name, genName(flow_channel.name(), "T_from_q_wall_mat", i), params);
 }

--- a/modules/thermal_hydraulics/test/tests/closures/THM_1phase/multiple_heat_flux.i
+++ b/modules/thermal_hydraulics/test/tests/closures/THM_1phase/multiple_heat_flux.i
@@ -1,0 +1,71 @@
+D = 0.1
+A = ${fparse 0.25*pi*D^2}
+P_hf = ${fparse pi*D}
+
+[GlobalParams]
+  gravity_vector = '0 0 0'
+[]
+
+[FluidProperties]
+  [fp_air]
+    type = IdealGasFluidProperties
+  []
+[]
+
+[Closures]
+  [thm]
+    type = Closures1PhaseTHM
+    wall_htc_closure = dittus_boelter
+    wall_ff_closure = churchill
+  []
+[]
+
+[Components]
+  [pipe]
+    type = FlowChannel1Phase
+    fp = fp_air
+    position = '0 0 0'
+    orientation = '1 0 0'
+    length = 1
+    n_elems = 1
+    A = ${A}
+    closures = thm
+    initial_vel = 0.003
+    initial_p = 1e5
+    initial_T = 300
+  []
+
+  [left_wall]
+    type = SolidWall1Phase
+    input = 'pipe:in'
+  []
+  [right_wall]
+    type = SolidWall1Phase
+    input = 'pipe:out'
+  []
+  [ht1]
+    type = HeatTransferFromHeatFlux1Phase
+    flow_channel = 'pipe'
+    q_wall = 1000
+    P_hf = ${P_hf}
+  []
+  [ht2]
+    type = HeatTransferFromHeatFlux1Phase
+    flow_channel = 'pipe'
+    q_wall = 2000
+    P_hf = ${P_hf}
+  []
+[]
+
+[Preconditioning]
+  [pc]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+  dt = 0.1
+[]

--- a/modules/thermal_hydraulics/test/tests/closures/THM_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/closures/THM_1phase/tests
@@ -1,6 +1,6 @@
 [Tests]
   design = 'Closures1PhaseTHM.md'
-  issues = '#19909'
+  issues = '#19909 #29651'
   [tests]
     requirement = "The system shall compute the heat transfer coefficient and the friction factor "
                   "when used with:"
@@ -92,5 +92,11 @@
       csvdiff = 'overwriten_f.csv'
       detail = "the friction factor is prescribed by the user"
     []
+  []
+
+  [multiple_heat_flux]
+    type = RunApp
+    input = 'multiple_heat_flux.i'
+    requirement = 'The system shall be able to run with multiple heat fluxes when using THM closures.'
   []
 []


### PR DESCRIPTION
Whenever a heat flux type heat transfer was connected to a flow channel when using `Closures1PhaseTHM`, the closures tried to add a non-existent material. The prior behavior was to always try to create material properties for the wall heat transfer coefficient and wall temperature for each connected heat transfer, even if the heat transfer was a heat flux. Now, these material properties are not created. If the user wants them, they will need to come up with their own way to determine them, since in general, wall heat transfer coefficient depends on wall temperature (so it would be iterative).

Closes #29651
