### PR TITLE
Universally adopt ParsedFunction's expression, symbol_names and symbol_values params

### DIFF
--- a/framework/src/functions/MooseParsedFunctionBase.C
+++ b/framework/src/functions/MooseParsedFunctionBase.C
@@ -55,7 +55,7 @@ MooseParsedFunctionBase::MooseParsedFunctionBase(const InputParameters & paramet
   for (const auto & var : _vars)
     if (var.find_first_of("xyzt") != std::string::npos && var.size() == 1)
       mooseError("The variables \"x, y, z, and t\" in the ParsedFunction are pre-declared for use "
-                 "and must not be declared in \"vars\"");
+                 "and must not be declared in \"symbol_names\"");
 }
 
 MooseParsedFunctionBase::~MooseParsedFunctionBase() {}

--- a/modules/combined/test/tests/optimization/invOpt_nonlinear/simulation.i
+++ b/modules/combined/test/tests/optimization/invOpt_nonlinear/simulation.i
@@ -51,9 +51,9 @@
 [Functions]
   [volumetric_heat_func]
     type = ParsedFunction
-    value = q
-    vars = 'q'
-    vals = 'heat_source_pp'
+    expression = q
+    symbol_names = 'q'
+    symbol_values = 'heat_source_pp'
   []
 []
 [Postprocessors]

--- a/modules/contact/test/tests/fieldsplit/frictionless_mortar_FS.i
+++ b/modules/contact/test/tests/fieldsplit/frictionless_mortar_FS.i
@@ -31,11 +31,11 @@ refine = 1
 [Functions]
   [horizontal_movement]
     type = ParsedFunction
-    value = 'if(t<0.5,${vx}*t-${offset},${vx}-${offset})'
+    expression = 'if(t<0.5,${vx}*t-${offset},${vx}-${offset})'
   []
   [vertical_movement]
     type = ParsedFunction
-    value = 'if(t<0.5,${offset},${vy}*(t-0.5)+${offset})'
+    expression = 'if(t<0.5,${offset},${vy}*(t-0.5)+${offset})'
   []
 []
 

--- a/modules/doc/content/getting_started/examples_and_tutorials/tutorial03_verification/step03_analytical_solution.md
+++ b/modules/doc/content/getting_started/examples_and_tutorials/tutorial03_verification/step03_analytical_solution.md
@@ -142,8 +142,8 @@ that is added in the `[Functions]` block.
 
 !listing tutorial03_verification/app/test/tests/step03_analytical/1d_analytical.i link=False block=Functions
 
-The "vars" and "vals" have a one-to-one relationship, e.g., $k=80.2$. If defined in this manner
-then the names in "vars" can be used in the definition of the equation in the "value" parameter.
+The "symbol_names" and "symbol_values" items have a one-to-one relationship, e.g., $k=80.2$. If defined in this manner
+then the names in "symbol_names" can be used in the definition of the equation in the "expression" parameter.
 
 The error is a single value for each time step. Since the exact solution is known the $L_2$-norm
 can be computed using the [postprocessors/NodalL2Error.md] object within the `[Postprocessors]` block,

--- a/modules/doc/content/getting_started/examples_and_tutorials/tutorial03_verification/step04_mms.md
+++ b/modules/doc/content/getting_started/examples_and_tutorials/tutorial03_verification/step04_mms.md
@@ -75,7 +75,7 @@ in the `[ICs]` block. In this case a constant value throughout the domain is pro
 The volumetric heat source, $\dot{q}$, is defined using the
 [Function System](syntax/Functions/index.md) using the `[Functions]` block. The function, as defined
 in [tutorial03_heat_source] can be defined directly in the input file using the parsed function
-capability. The "vars" and "vals" parameters are used to define named constants within the
+capability. The "symbol_names" and "symbol_values" parameters are used to define named constants within the
 equation. The variables "x", "y", "z", and "t" are always available and represent the
 corresponding spatial location and time.
 
@@ -207,16 +207,16 @@ Executing this script, assuming a name of `spatial_function.py` results in the f
 $ python spatial_function.py
 [mms_force]
   type = ParsedFunction
-  value = 'cp*rho*sin(x*pi)*sin(5*y*pi) + 26*pi^2*k*t*sin(x*pi)*sin(5*y*pi) - shortwave*exp(y*kappa)*sin((1/2)*x*pi)*sin((1/3600)*pi*t/hours)'
-  vars = 'hours rho shortwave k cp kappa'
-  vals = '1.0 1.0 1.0 1.0 1.0 1.0'
+  expression = 'cp*rho*sin(x*pi)*sin(5*y*pi) + 26*pi^2*k*t*sin(x*pi)*sin(5*y*pi) - shortwave*exp(y*kappa)*sin((1/2)*x*pi)*sin((1/3600)*pi*t/hours)'
+  symbol_names = 'hours rho shortwave k cp kappa'
+  symbol_values = '1.0 1.0 1.0 1.0 1.0 1.0'
 []
 [mms_exact]
   type = ParsedFunction
-  value = 't*sin(x*pi)*sin(5*y*pi)'
+  expression = 't*sin(x*pi)*sin(5*y*pi)'
 []
 
-Obviously, when adding to the input file the "vals" must be updated to the correct values for the
+Obviously, when adding to the input file the "symbol_values" must be updated to the correct values for the
 desired simulation.
 
 [!ac](MOOSE) allows for multiple input files to be supplied to an executable, when this is done
@@ -294,13 +294,13 @@ Executing this script, assuming a name of `temporal_function.py` results in the 
 $ python temporal_function.py
 [mms_force]
   type = ParsedFunction
-  value = '-3.08641975308642e-5*x*y*cp*rho*exp(-3.08641975308642e-5*t) - shortwave*exp(y*kappa)*sin((1/2)*x*pi)*sin((1/3600)*pi*t/hours)'
-  vars = 'kappa rho shortwave cp hours'
-  vals = '1.0 1.0 1.0 1.0 1.0'
+  expression = '-3.08641975308642e-5*x*y*cp*rho*exp(-3.08641975308642e-5*t) - shortwave*exp(y*kappa)*sin((1/2)*x*pi)*sin((1/3600)*pi*t/hours)'
+  symbol_names = 'kappa rho shortwave cp hours'
+  symbol_values = '1.0 1.0 1.0 1.0 1.0'
 []
 [mms_exact]
   type = ParsedFunction
-  value = 'x*y*exp(-3.08641975308642e-5*t)'
+  expression = 'x*y*exp(-3.08641975308642e-5*t)'
 []
 
 A third input file, `~/projects/problems/verification/2d_mms_temporal.i` is created. The content

--- a/modules/doc/content/newsletter/2018/2018_10.md
+++ b/modules/doc/content/newsletter/2018/2018_10.md
@@ -22,13 +22,13 @@ a scalar value or a `Postprocessor` value. An example syntax follows:
 ```
 [./a_fn]
   type = ParsedFunction
-  value = sin(x)
+  expression = sin(x)
 [../]
 [./parsed_fn]
   type = ParsedFunction
-  value = '4*sqrt(a)'
-  vars = 'a'
-  vals = 'a_fn'
+  expression = '4*sqrt(a)'
+  symbol_names = 'a'
+  symbol_values = 'a_fn'
 [../]
 ```
 

--- a/modules/geochemistry/test/tests/kinetics/bio_arsenate1.i
+++ b/modules/geochemistry/test/tests/kinetics/bio_arsenate1.i
@@ -85,9 +85,9 @@
 [Functions]
   [rate]
     type = ParsedFunction
-    vars = 'dt reaction_rate_times_dt'
-    vals = 'dt reaction_rate_times_dt'
-    value = 'reaction_rate_times_dt / dt'
+    symbol_names = 'dt reaction_rate_times_dt'
+    symbol_values = 'dt reaction_rate_times_dt'
+    expression = 'reaction_rate_times_dt / dt'
   []
 []
 [Postprocessors]

--- a/modules/navier_stokes/test/tests/finite_volume/cns/mms/1d-with-bcs/free-flow-hllc.i
+++ b/modules/navier_stokes/test/tests/finite_volume/cns/mms/1d-with-bcs/free-flow-hllc.i
@@ -196,15 +196,15 @@ diff_coeff = 0.1
   []
   [rho_bc]
     type = ParsedFunction
-    value = '-diff_coeff*3.48788261470924*sin(x)'
-    vars = 'diff_coeff'
-    vals = '${diff_coeff}'
+    expression = '-diff_coeff*3.48788261470924*sin(x)'
+    symbol_names = 'diff_coeff'
+    symbol_values = '${diff_coeff}'
   []
   [minus_rho_bc]
     type = ParsedFunction
-    value = 'diff_coeff*3.48788261470924*sin(x)'
-    vars = 'diff_coeff'
-    vals = '${diff_coeff}'
+    expression = 'diff_coeff*3.48788261470924*sin(x)'
+    symbol_names = 'diff_coeff'
+    symbol_values = '${diff_coeff}'
   []
   [forcing_rho]
     type = ParsedFunction
@@ -216,15 +216,15 @@ diff_coeff = 0.1
   []
   [rho_u_bc]
     type = ParsedFunction
-    value = '-diff_coeff*3.48788261470924*1.1*sin(1.1*x)'
-    vars = 'diff_coeff'
-    vals = '${diff_coeff}'
+    expression = '-diff_coeff*3.48788261470924*1.1*sin(1.1*x)'
+    symbol_names = 'diff_coeff'
+    symbol_values = '${diff_coeff}'
   []
   [minus_rho_u_bc]
     type = ParsedFunction
-    value = 'diff_coeff*3.48788261470924*1.1*sin(1.1*x)'
-    vars = 'diff_coeff'
-    vals = '${diff_coeff}'
+    expression = 'diff_coeff*3.48788261470924*1.1*sin(1.1*x)'
+    symbol_names = 'diff_coeff'
+    symbol_values = '${diff_coeff}'
   []
   [forcing_rho_u]
     type = ParsedFunction
@@ -236,15 +236,15 @@ diff_coeff = 0.1
   []
   [rho_et_bc]
     type = ParsedFunction
-    value = '-diff_coeff*26.7439413073546*1.2*sin(1.2*x)'
-    vars = 'diff_coeff'
-    vals = '${diff_coeff}'
+    expression = '-diff_coeff*26.7439413073546*1.2*sin(1.2*x)'
+    symbol_names = 'diff_coeff'
+    symbol_values = '${diff_coeff}'
   []
   [minus_rho_et_bc]
     type = ParsedFunction
-    value = 'diff_coeff*26.7439413073546*1.2*sin(1.2*x)'
-    vars = 'diff_coeff'
-    vals = '${diff_coeff}'
+    expression = 'diff_coeff*26.7439413073546*1.2*sin(1.2*x)'
+    symbol_names = 'diff_coeff'
+    symbol_values = '${diff_coeff}'
   []
   [forcing_rho_et]
     type = ParsedFunction

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/linear-segregated/2d-symmetric/channel.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/linear-segregated/2d-symmetric/channel.i
@@ -177,11 +177,11 @@ half_width = 0.2
 [Functions]
   [u_parabolic_profile]
     type = ParsedFunction
-    value = '3/2*${u_inlet}*(1 - pow(y/${half_width}, 2))' # Poiseuille profile
+    expression = '3/2*${u_inlet}*(1 - pow(y/${half_width}, 2))' # Poiseuille profile
   []
   [u_parabolic_profile_rz]
     type = ParsedFunction
-    value = '2*${u_inlet}*(1 - pow(y/${half_width}, 2))' # Cylindrical profile
+    expression = '2*${u_inlet}*(1 - pow(y/${half_width}, 2))' # Cylindrical profile
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/materials/mixture_material/mixture.i
+++ b/modules/navier_stokes/test/tests/finite_volume/materials/mixture_material/mixture.i
@@ -68,19 +68,19 @@
 
 [Functions]
   [cp_solid]
-    type = ADParsedFunction
+    type = ParsedFunction
     expression = '1 - x'
   []
   [cp_liquid]
-    type = ADParsedFunction
+    type = ParsedFunction
     expression = 'x'
   []
   [k_solid]
-    type = ADParsedFunction
+    type = ParsedFunction
     expression = '2 - 3*x'
   []
   [k_liquid]
-    type = ADParsedFunction
+    type = ParsedFunction
     expression = '3*x'
   []
 []

--- a/modules/optimization/doc/content/source/functions/ParsedOptimizationFunction.md
+++ b/modules/optimization/doc/content/source/functions/ParsedOptimizationFunction.md
@@ -15,7 +15,7 @@ f(x,y,z,t; \vec{v}) = xv_1 + yv_2^2 + zv_3^3 + tv_4^4
 
 !listing parsed_function/parsed_function.i block=Functions
 
-`params/vals` is the name of a vector reporter value, define as:
+`params/vals` is the name of a vector reporter value, defined as:
 
 !listing parsed_function/parsed_function.i block=Reporters
 

--- a/modules/optimization/examples/simpleTransient/forward.i
+++ b/modules/optimization/examples/simpleTransient/forward.i
@@ -61,7 +61,7 @@
 [Functions]
   [exact]
     type = ParsedFunction
-    value = '2*exp(-2.0*(x - sin(2*pi*t))^2)*exp(-2.0*(y - cos(2*pi*t))^2)*cos((1/2)*x*pi)*cos((1/2)*y*pi)/pi'
+    expression = '2*exp(-2.0*(x - sin(2*pi*t))^2)*exp(-2.0*(y - cos(2*pi*t))^2)*cos((1/2)*x*pi)*cos((1/2)*y*pi)/pi'
   []
   [source]
     type = NearestReporterCoordinatesFunction

--- a/modules/optimization/examples/simpleTransient/forward_and_adjoint.i
+++ b/modules/optimization/examples/simpleTransient/forward_and_adjoint.i
@@ -61,7 +61,7 @@
 [Functions]
   [exact]
     type = ParsedFunction
-    value = '2*exp(-2.0*(x - sin(2*pi*t))^2)*exp(-2.0*(y - cos(2*pi*t))^2)*cos((1/2)*x*pi)*cos((1/2)*y*pi)/pi'
+    expression = '2*exp(-2.0*(x - sin(2*pi*t))^2)*exp(-2.0*(y - cos(2*pi*t))^2)*cos((1/2)*x*pi)*cos((1/2)*y*pi)/pi'
   []
   [source]
     type = NearestReporterCoordinatesFunction

--- a/modules/optimization/examples/simpleTransient/forward_mesh.i
+++ b/modules/optimization/examples/simpleTransient/forward_mesh.i
@@ -52,7 +52,7 @@
 [Functions]
   [exact]
     type = ParsedFunction
-    value = '2*exp(-2.0*(x - sin(2*pi*t))^2)*exp(-2.0*(y - cos(2*pi*t))^2)*cos((1/2)*x*pi)*cos((1/2)*y*pi)/pi'
+    expression = '2*exp(-2.0*(x - sin(2*pi*t))^2)*exp(-2.0*(y - cos(2*pi*t))^2)*cos((1/2)*x*pi)*cos((1/2)*y*pi)/pi'
   []
   [source]
     type = ParameterMeshFunction

--- a/modules/optimization/examples/simpleTransient/nonlinear_forward_and_adjoint.i
+++ b/modules/optimization/examples/simpleTransient/nonlinear_forward_and_adjoint.i
@@ -71,7 +71,7 @@
 [Functions]
   [exact]
     type = ParsedFunction
-    value = '2*exp(-2.0*(x - sin(2*pi*t))^2)*exp(-2.0*(y - cos(2*pi*t))^2)*cos((1/2)*x*pi)*cos((1/2)*y*pi)/pi'
+    expression = '2*exp(-2.0*(x - sin(2*pi*t))^2)*exp(-2.0*(y - cos(2*pi*t))^2)*cos((1/2)*x*pi)*cos((1/2)*y*pi)/pi'
   []
   [source]
     type = NearestReporterCoordinatesFunction

--- a/modules/optimization/test/tests/functions/param_mesh_closest/create_mesh_1d.i
+++ b/modules/optimization/test/tests/functions/param_mesh_closest/create_mesh_1d.i
@@ -25,7 +25,7 @@
 [Functions]
   [params_fun]
     type = ParsedFunction
-    value = '0.5 + x + y + x*y'
+    expression = '0.5 + x + y + x*y'
   []
 []
 

--- a/modules/optimization/test/tests/functions/param_mesh_closest/create_mesh_2d.i
+++ b/modules/optimization/test/tests/functions/param_mesh_closest/create_mesh_2d.i
@@ -26,7 +26,7 @@
 [Functions]
   [params_fun]
     type = ParsedFunction
-    value = '0.5 + x + y + x*y'
+    expression = '0.5 + x + y + x*y'
   []
 []
 

--- a/modules/optimization/test/tests/functions/param_mesh_closest/create_mesh_3d.i
+++ b/modules/optimization/test/tests/functions/param_mesh_closest/create_mesh_3d.i
@@ -28,7 +28,7 @@
 [Functions]
   [params_fun]
     type = ParsedFunction
-    value = '0.5 + x + y + x*y'
+    expression = '0.5 + x + y + x*y'
   []
 []
 

--- a/modules/optimization/test/tests/functions/parameter_mesh/create_mesh.i
+++ b/modules/optimization/test/tests/functions/parameter_mesh/create_mesh.i
@@ -20,7 +20,7 @@
 [Functions]
   [params_fun]
     type = ParsedFunction
-    value = 'x*(x-1)*y*(y-1)'
+    expression = 'x*(x-1)*y*(y-1)'
   []
 []
 

--- a/modules/optimization/test/tests/functions/parameter_mesh/create_mesh_dg.i
+++ b/modules/optimization/test/tests/functions/parameter_mesh/create_mesh_dg.i
@@ -22,7 +22,7 @@
 [Functions]
   [params_fun]
     type = ParsedFunction
-    value = 'x*(x-1)*y*(y-1)'
+    expression = 'x*(x-1)*y*(y-1)'
   []
 []
 

--- a/modules/optimization/test/tests/functions/parameter_mesh/create_mesh_second.i
+++ b/modules/optimization/test/tests/functions/parameter_mesh/create_mesh_second.i
@@ -23,7 +23,7 @@
 [Functions]
   [params_fun]
     type = ParsedFunction
-    value = 'x*(x-1)*y*(y-1)'
+    expression = 'x*(x-1)*y*(y-1)'
   []
 []
 

--- a/modules/optimization/test/tests/optimizationreporter/material/adjoint_explicit.i
+++ b/modules/optimization/test/tests/optimizationreporter/material/adjoint_explicit.i
@@ -136,9 +136,9 @@
 [Functions]
   [thermo_conduct]
     type = ParsedFunction
-    value = alpha
-    vars = 'alpha'
-    vals = 'p1'
+    expression = alpha
+    symbol_names = 'alpha'
+    symbol_values = 'p1'
   []
 []
 

--- a/modules/phase_field/examples/multiphase/GrandPotential3Phase_AD.i
+++ b/modules/phase_field/examples/multiphase/GrandPotential3Phase_AD.i
@@ -47,16 +47,16 @@
 
 [Functions]
   [ic_func_etaa0]
-    type = ADParsedFunction
-    value = '0.9*0.5*(1.0-tanh((x)/sqrt(2.0)))'
+    type = ParsedFunction
+    expression = '0.9*0.5*(1.0-tanh((x)/sqrt(2.0)))'
   []
   [ic_func_etab0]
-    type = ADParsedFunction
-    value = '0.9*0.5*(1.0+tanh((x)/sqrt(2.0)))'
+    type = ParsedFunction
+    expression = '0.9*0.5*(1.0+tanh((x)/sqrt(2.0)))'
   []
   [ic_func_w]
-    type = ADParsedFunction
-    value = 0
+    type = ParsedFunction
+    expression = 0
   []
 []
 

--- a/modules/phase_field/test/tests/GrandPotentialPFM/GrandPotentialMultiphase_AD.i
+++ b/modules/phase_field/test/tests/GrandPotentialPFM/GrandPotentialMultiphase_AD.i
@@ -58,16 +58,16 @@
 
 [Functions]
   [ic_func_etaa0]
-    type = ADParsedFunction
-    value = 'r:=sqrt(x^2+y^2);0.5*(1.0-tanh((r-10.0)/sqrt(2.0)))'
+    type = ParsedFunction
+    expression = 'r:=sqrt(x^2+y^2);0.5*(1.0-tanh((r-10.0)/sqrt(2.0)))'
   []
   [ic_func_etab0]
-    type = ADParsedFunction
-    value = 'r:=sqrt(x^2+y^2);0.5*(1.0+tanh((r-10)/sqrt(2.0)))*0.5*(1.0+tanh((y)/sqrt(2.0)))'
+    type = ParsedFunction
+    expression = 'r:=sqrt(x^2+y^2);0.5*(1.0+tanh((r-10)/sqrt(2.0)))*0.5*(1.0+tanh((y)/sqrt(2.0)))'
   []
   [ic_func_etab1]
-    type = ADParsedFunction
-    value = 'r:=sqrt(x^2+y^2);0.5*(1.0+tanh((r-10)/sqrt(2.0)))*0.5*(1.0-tanh((y)/sqrt(2.0)))'
+    type = ParsedFunction
+    expression = 'r:=sqrt(x^2+y^2);0.5*(1.0+tanh((r-10)/sqrt(2.0)))*0.5*(1.0-tanh((y)/sqrt(2.0)))'
   []
 []
 

--- a/modules/richards/src/actions/Q2PAction.C
+++ b/modules/richards/src/actions/Q2PAction.C
@@ -242,23 +242,23 @@ Q2PAction::act()
     // user wants total masses, so need to build Functions to do this
     InputParameters params = _factory.getValidParams("ParsedFunction");
 
-    params.set<std::string>("value") = "a*b";
+    params.set<std::string>("expression") = "a*b";
 
     std::vector<std::string> vars;
     vars.push_back("a");
     vars.push_back("b");
-    params.set<std::vector<std::string>>("vars") = vars;
+    params.set<std::vector<std::string>>("symbol_names") = vars;
 
     std::vector<std::string> vals_water;
     vals_water.push_back("Q2P_mass_water_divided_by_dt");
     vals_water.push_back("Q2P_dt");
-    params.set<std::vector<std::string>>("vals") = vals_water;
+    params.set<std::vector<std::string>>("symbol_values") = vals_water;
     _problem->addFunction("ParsedFunction", "Q2P_water_mass_fcn", params);
 
     std::vector<std::string> vals_gas;
     vals_gas.push_back("Q2P_mass_gas_divided_by_dt");
     vals_gas.push_back("Q2P_dt");
-    params.set<std::vector<std::string>>("vals") = vals_gas;
+    params.set<std::vector<std::string>>("symbol_values") = vals_gas;
     _problem->addFunction("ParsedFunction", "Q2P_gas_mass_fcn", params);
   }
 

--- a/modules/solid_mechanics/doc/content/modules/solid_mechanics/tutorials/introduction/step02.md
+++ b/modules/solid_mechanics/doc/content/modules/solid_mechanics/tutorials/introduction/step02.md
@@ -44,7 +44,7 @@ pressure action could have instead been written as
 [Functions]
   [applied_pressure_function]
     type = ParsedFunction
-    value = 1e7*t
+    expression = 1e7*t
   []
 []
 

--- a/modules/solid_mechanics/test/tests/central_difference/consistent/3D/3d_consistent_explicit_mass_scaling.i
+++ b/modules/solid_mechanics/test/tests/central_difference/consistent/3D/3d_consistent_explicit_mass_scaling.i
@@ -138,11 +138,11 @@
   []
   [dispy]
     type = ParsedFunction
-    value = 0.1*t*t*sin(10*t)
+    expression = 0.1*t*t*sin(10*t)
   []
   [dispz]
     type = ParsedFunction
-    value = 0.1*t*t*sin(20*t)
+    expression = 0.1*t*t*sin(20*t)
   []
 []
 

--- a/modules/solid_mechanics/test/tests/recompute_radial_return/affine_plasticity.i
+++ b/modules/solid_mechanics/test/tests/recompute_radial_return/affine_plasticity.i
@@ -95,10 +95,10 @@
     # 189.409039923814000, 0.170423791206825, -0.003242011311945, 1.711645501845780E-05 - exact values
     symbol_names = 'timeAtYield stressAtYield expFac a b c d'
     symbol_values = '0.20097635952803425 -95.26279441628823 12.332921390339125 189.409039923814000 0.170423791206825 -0.003242011311945 1.711645501845780E-05'
-    value = '1e6*
-             if(t<=timeAtYield, -474*t,
-             if(t<=1, stressAtYield,
-             (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
+    expression = '1e6*
+                  if(t<=timeAtYield, -474*t,
+                  if(t<=1, stressAtYield,
+                  (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
   [../]
   [./stress_yy]
     type = ParsedFunction
@@ -108,10 +108,10 @@
     # -76.867432297315000, -1.442488120272900, 0.001315697947301, 1.711645501845780E-05 - exact values
     symbol_names = 'timeAtYield stressAtYield expFac a b c d'
     symbol_values = '0.20097635952803425 -95.26279441628823 12.332921390339125 -76.867432297315000 -1.442488120272900 0.001315697947301 1.711645501845780E-05'
-    value = '1e6*
-             if(t<=timeAtYield, -474*t,
-             if(t<=1, stressAtYield,
-             (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
+    expression = '1e6*
+                  if(t<=timeAtYield, -474*t,
+                  if(t<=1, stressAtYield,
+                  (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
   [../]
   [./stress_zz]
     type = ParsedFunction
@@ -121,10 +121,10 @@
     # -112.541607626499000, 1.272064329066080, 0.001926313364644, 1.711645501845780E-05 - exact values
     symbol_names = 'timeAtYield stressAtYield expFac a b c d'
     symbol_values = '0.20097635952803425 190.52558883257645 12.332921390339125 -112.541607626499000 1.272064329066080 0.001926313364644 1.711645501845780E-05'
-    value = '1e6*
-             if(t<=timeAtYield, 948*t,
-             if(t<=1, stressAtYield,
-             (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
+    expression = '1e6*
+                  if(t<=timeAtYield, 948*t,
+                  if(t<=1, stressAtYield,
+                  (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
   [../]
 []
 

--- a/modules/solid_mechanics/test/tests/recompute_radial_return/cp_affine_plasticity.i
+++ b/modules/solid_mechanics/test/tests/recompute_radial_return/cp_affine_plasticity.i
@@ -95,10 +95,10 @@
     # 189.409039923814000, 0.170423791206825, -0.003242011311945, 1.711645501845780E-05 - exact values
     symbol_names = 'timeAtYield stressAtYield expFac a b c d'
     symbol_values = '0.20097635952803425 -95.26279441628823 12.332921390339125 189.409039923814000 0.170423791206825 -0.003242011311945 1.711645501845780E-05'
-    value = '1e6*
-             if(t<=timeAtYield, -474*t,
-             if(t<=1, stressAtYield,
-             (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
+    expression = '1e6*
+                  if(t<=timeAtYield, -474*t,
+                  if(t<=1, stressAtYield,
+                  (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
   []
   [stress_yy]
     type = ParsedFunction
@@ -108,10 +108,10 @@
     # -76.867432297315000, -1.442488120272900, 0.001315697947301, 1.711645501845780E-05 - exact values
     symbol_names = 'timeAtYield stressAtYield expFac a b c d'
     symbol_values = '0.20097635952803425 -95.26279441628823 12.332921390339125 -76.867432297315000 -1.442488120272900 0.001315697947301 1.711645501845780E-05'
-    value = '1e6*
-             if(t<=timeAtYield, -474*t,
-             if(t<=1, stressAtYield,
-             (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
+    expression = '1e6*
+                  if(t<=timeAtYield, -474*t,
+                  if(t<=1, stressAtYield,
+                  (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
   []
   [stress_zz]
     type = ParsedFunction
@@ -121,10 +121,10 @@
     # -112.541607626499000, 1.272064329066080, 0.001926313364644, 1.711645501845780E-05 - exact values
     symbol_names = 'timeAtYield stressAtYield expFac a b c d'
     symbol_values = '0.20097635952803425 190.52558883257645 12.332921390339125 -112.541607626499000 1.272064329066080 0.001926313364644 1.711645501845780E-05'
-    value = '1e6*
-             if(t<=timeAtYield, 948*t,
-             if(t<=1, stressAtYield,
-             (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
+    expression = '1e6*
+                  if(t<=timeAtYield, 948*t,
+                  if(t<=1, stressAtYield,
+                  (a+b*sqrt(exp(expFac*t))+c*exp(expFac*t))/(1.0+d*exp(expFac*t))))' # tends to -a
   []
 []
 

--- a/modules/solid_mechanics/test/tests/umat/multiple_blocks/multiple_blocks.i
+++ b/modules/solid_mechanics/test/tests/umat/multiple_blocks/multiple_blocks.i
@@ -45,17 +45,17 @@
 [Functions]
   [top_pull]
     type = ParsedFunction
-    value = t/100
+    expression = t/100
   []
   # Forced evolution of temperature
   [temperature_load]
     type = ParsedFunction
-    value = '273 + 10*t'
+    expression = '273 + 10*t'
   []
   # Factor to multiply the elasticity tensor in MOOSE
   [elasticity_prefactor]
     type = ParsedFunction
-    value = '273/(273 + 10*t)'
+    expression = '273/(273 + 10*t)'
   []
 []
 

--- a/modules/solid_mechanics/test/tests/umat/multiple_blocks/multiple_blocks_two_materials.i
+++ b/modules/solid_mechanics/test/tests/umat/multiple_blocks/multiple_blocks_two_materials.i
@@ -45,17 +45,17 @@
 [Functions]
   [top_pull]
     type = ParsedFunction
-    value = t/100
+    expression = t/100
   []
   # Forced evolution of temperature
   [temperature_load]
     type = ParsedFunction
-    value = '273'
+    expression = '273'
   []
   # Factor to multiply the elasticity tensor in MOOSE
   [elasticity_prefactor]
     type = ParsedFunction
-    value = '1'
+    expression = '1'
   []
 []
 

--- a/modules/solid_properties/unit/include/ThermalFunctionSolidPropertiesTest.h
+++ b/modules/solid_properties/unit/include/ThermalFunctionSolidPropertiesTest.h
@@ -25,7 +25,7 @@ protected:
   void buildObjects()
   {
     InputParameters rho_pars = _factory.getValidParams("ParsedFunction");
-    rho_pars.set<std::string>("value") = "100.0+t";
+    rho_pars.set<std::string>("expression") = "100.0+t";
     _fe_problem->addFunction("ParsedFunction", "rho", rho_pars);
     Function & rho = _fe_problem->getFunction("rho");
     rho.initialSetup();
@@ -38,7 +38,7 @@ protected:
     cp.initialSetup();
 
     InputParameters k_pars = _factory.getValidParams("ParsedFunction");
-    k_pars.set<std::string>("value") = "12.1+1.e-6*t*t*t+2.0e-4*t*t-0.5*t";
+    k_pars.set<std::string>("expression") = "12.1+1.e-6*t*t*t+2.0e-4*t*t-0.5*t";
     _fe_problem->addFunction("ParsedFunction", "k", k_pars);
     Function & k = _fe_problem->getFunction("k");
     k.initialSetup();

--- a/modules/stochastic_tools/examples/libtorch_drl_control/libtorch_drl_control_sub.i
+++ b/modules/stochastic_tools/examples/libtorch_drl_control/libtorch_drl_control_sub.i
@@ -52,11 +52,11 @@ air_effective_k = 0.5 # W/(m K)
 [Functions]
   [temp_env]
     type = ParsedFunction
-    value = '15.0*sin(t/86400.0*pi) + 273.0'
+    expression = '15.0*sin(t/86400.0*pi) + 273.0'
   []
   [design_function]
     type = ParsedFunction
-    value = '297'
+    expression = '297'
   []
   [reward_function]
     type = ScaledAbsDifferenceDRLRewardFunction

--- a/modules/stochastic_tools/examples/surrogates/combined/trans_diff_2d/trans_diff_main.i
+++ b/modules/stochastic_tools/examples/surrogates/combined/trans_diff_2d/trans_diff_main.i
@@ -41,7 +41,7 @@
     type = MultiAppSamplerControl
     multi_app = runner
     sampler = hypercube
-    param_names = 'Materials/diff_coeff/constant_expressions Functions/src_func/vals Variables/T/initial_condition'
+    param_names = 'Materials/diff_coeff/constant_expressions Functions/src_func/symbol_values Variables/T/initial_condition'
   []
 []
 

--- a/modules/stochastic_tools/examples/surrogates/combined/trans_diff_2d/trans_diff_trainer.i
+++ b/modules/stochastic_tools/examples/surrogates/combined/trans_diff_2d/trans_diff_trainer.i
@@ -41,7 +41,7 @@
     type = MultiAppSamplerControl
     multi_app = runner
     sampler = sample
-    param_names = 'Materials/diff_coeff/constant_expressions Functions/src_func/vals Variables/T/initial_condition'
+    param_names = 'Materials/diff_coeff/constant_expressions Functions/src_func/symbol_values Variables/T/initial_condition'
   []
 []
 

--- a/modules/stochastic_tools/test/tests/controls/libtorch_drl_control/libtorch_drl_control.i
+++ b/modules/stochastic_tools/test/tests/controls/libtorch_drl_control/libtorch_drl_control.i
@@ -45,7 +45,7 @@
 [Functions]
   [temp_env]
     type = ParsedFunction
-    value = '15.0*sin(t/86400.0 *pi) + 273.0'
+    expression = '15.0*sin(t/86400.0 *pi) + 273.0'
   []
 []
 

--- a/modules/stochastic_tools/test/tests/functions/drl_reward/drl_reward.i
+++ b/modules/stochastic_tools/test/tests/functions/drl_reward/drl_reward.i
@@ -39,7 +39,7 @@
 [Functions]
   [design_function]
     type = ParsedFunction
-    value = 't/3600*297'
+    expression = 't/3600*297'
   []
   [reward_function]
     type = ScaledAbsDifferenceDRLRewardFunction

--- a/modules/stochastic_tools/test/tests/reporters/stochastic_matrix/sub.i
+++ b/modules/stochastic_tools/test/tests/reporters/stochastic_matrix/sub.i
@@ -20,9 +20,9 @@
   []
   [fun]
     type = ParsedFunction
-    value = 'a*1000000 + b*10000 + c*100 + d'
-    vars = 'a b c d'
-    vals = 'afun bfun cfun dfun'
+    expression = 'a*1000000 + b*10000 + c*100 + d'
+    symbol_names = 'a b c d'
+    symbol_values = 'afun bfun cfun dfun'
   []
 []
 

--- a/modules/stochastic_tools/test/tests/transfers/libtorch_nn_transfer/libtorch_drl_control_sub.i
+++ b/modules/stochastic_tools/test/tests/transfers/libtorch_nn_transfer/libtorch_drl_control_sub.i
@@ -45,11 +45,11 @@
 [Functions]
   [temp_env]
     type = ParsedFunction
-    value = '15.0*sin(t/86400.0 *pi) + 273.0'
+    expression = '15.0*sin(t/86400.0 *pi) + 273.0'
   []
   [design_function]
     type = ParsedFunction
-    value = '297'
+    expression = '297'
   []
   [reward_function]
     type = ScaledAbsDifferenceDRLRewardFunction

--- a/modules/subchannel/test/tests/SCMTriPower/test_with_pins.i
+++ b/modules/subchannel/test/tests/SCMTriPower/test_with_pins.i
@@ -41,8 +41,8 @@ num_cells = 40
   [axial_heat_rate]
     type = ParsedFunction
     expression = '(pi/2)*sin(pi*z/L)'
-    vars = 'L'
-    vals = '${length}'
+    symbol_names = 'L'
+    symbol_values = '${length}'
   []
 []
 

--- a/modules/subchannel/test/tests/problems/heat_transfer_correlations/XX09_SCM_SS17.i
+++ b/modules/subchannel/test/tests/problems/heat_transfer_correlations/XX09_SCM_SS17.i
@@ -63,9 +63,9 @@ unheated_length_exit = '${fparse 26.9*scale_factor}'
 [Functions]
   [axial_heat_rate]
     type = ParsedFunction
-    value = '(pi/2)*sin(pi*z/L)*exp(-alpha*z)/(1.0/alpha*(1.0 - exp(-alpha*L)))*L'
-    vars = 'L alpha'
-    vals = '${heated_length} 1.8012'
+    expression = '(pi/2)*sin(pi*z/L)*exp(-alpha*z)/(1.0/alpha*(1.0 - exp(-alpha*L)))*L'
+    symbol_names = 'L alpha'
+    symbol_values = '${heated_length} 1.8012'
   []
 []
 

--- a/modules/subchannel/validation/EBR-II/XX09_SCM_SS17.i
+++ b/modules/subchannel/validation/EBR-II/XX09_SCM_SS17.i
@@ -63,9 +63,9 @@ unheated_length_exit = '${fparse 26.9*scale_factor}'
 [Functions]
   [axial_heat_rate]
     type = ParsedFunction
-    value = '(pi/2)*sin(pi*z/L)*exp(-alpha*z)/(1.0/alpha*(1.0 - exp(-alpha*L)))*L'
-    vars = 'L alpha'
-    vals = '${heated_length} 1.8012'
+    expression = '(pi/2)*sin(pi*z/L)*exp(-alpha*z)/(1.0/alpha*(1.0 - exp(-alpha*L)))*L'
+    symbol_names = 'L alpha'
+    symbol_values = '${heated_length} 1.8012'
   []
 []
 

--- a/modules/subchannel/validation/EBR-II/XX09_SCM_SS17_corrected.i
+++ b/modules/subchannel/validation/EBR-II/XX09_SCM_SS17_corrected.i
@@ -63,9 +63,9 @@ unheated_length_exit = '${fparse 26.9*scale_factor}'
 [Functions]
   [axial_heat_rate]
     type = ParsedFunction
-    value = '(pi/2)*sin(pi*z/L)*exp(-alpha*z)/(1.0/alpha*(1.0 - exp(-alpha*L)))*L'
-    vars = 'L alpha'
-    vals = '${heated_length} 1.8012'
+    expression = '(pi/2)*sin(pi*z/L)*exp(-alpha*z)/(1.0/alpha*(1.0 - exp(-alpha*L)))*L'
+    symbol_names = 'L alpha'
+    symbol_values = '${heated_length} 1.8012'
   []
 []
 

--- a/modules/subchannel/validation/EBR-II/XX09_SCM_SS45R.i
+++ b/modules/subchannel/validation/EBR-II/XX09_SCM_SS45R.i
@@ -63,9 +63,9 @@ unheated_length_exit = '${fparse 26.9*scale_factor}'
 [Functions]
   [axial_heat_rate]
     type = ParsedFunction
-    value = '(pi/2)*sin(pi*z/L)*exp(-alpha*z)/(1.0/alpha*(1.0 - exp(-alpha*L)))*L'
-    vars = 'L alpha'
-    vals = '${heated_length} 1.8012'
+    expression = '(pi/2)*sin(pi*z/L)*exp(-alpha*z)/(1.0/alpha*(1.0 - exp(-alpha*L)))*L'
+    symbol_names = 'L alpha'
+    symbol_values = '${heated_length} 1.8012'
   []
 []
 

--- a/modules/subchannel/validation/EBR-II/XX09_SCM_SS45R_corrected.i
+++ b/modules/subchannel/validation/EBR-II/XX09_SCM_SS45R_corrected.i
@@ -63,9 +63,9 @@ unheated_length_exit = '${fparse 26.9*scale_factor}'
 [Functions]
   [axial_heat_rate]
     type = ParsedFunction
-    value = '(pi/2)*sin(pi*z/L)*exp(-alpha*z)/(1.0/alpha*(1.0 - exp(-alpha*L)))*L'
-    vars = 'L alpha'
-    vals = '${heated_length} 1.8012'
+    expression = '(pi/2)*sin(pi*z/L)*exp(-alpha*z)/(1.0/alpha*(1.0 - exp(-alpha*L)))*L'
+    symbol_names = 'L alpha'
+    symbol_values = '${heated_length} 1.8012'
   []
 []
 

--- a/modules/subchannel/verification/enthalpy_mixing_verification/two_channel.i
+++ b/modules/subchannel/verification/enthalpy_mixing_verification/two_channel.i
@@ -19,7 +19,7 @@ P_out = 155e+5 # Pa
 [Functions]
   [T_fn]
     type = ParsedFunction
-    value = if(x>0.0,483.10,473.10)
+    expression = if(x>0.0,483.10,473.10)
   []
 []
 

--- a/modules/subchannel/verification/friction_model_verification/two_channel2.i
+++ b/modules/subchannel/verification/friction_model_verification/two_channel2.i
@@ -20,7 +20,7 @@ P_out = 155e+5 # Pa
 [Functions]
   [S_fn]
     type = ParsedFunction
-    value = if(x>0.0,0.002,0.001)
+    expression = if(x>0.0,0.002,0.001)
   []
 []
 

--- a/modules/thermal_hydraulics/unit/include/CircularAreaHydraulicDiameterFunctionTest.h
+++ b/modules/thermal_hydraulics/unit/include/CircularAreaHydraulicDiameterFunctionTest.h
@@ -29,7 +29,7 @@ protected:
     {
       const std::string class_name = "ParsedFunction";
       InputParameters params = _factory.getValidParams(class_name);
-      params.set<std::string>("value") = "1 + x";
+      params.set<std::string>("expression") = "1 + x";
       _fe_problem->addFunction(class_name, A_name, params);
     }
 

--- a/python/doc/content/python/mms.md
+++ b/python/doc/content/python/mms.md
@@ -71,11 +71,11 @@ exact solution. The complete output for this function is given below.
 8*pi^2*sin(2*x*pi)*sin(2*y*pi)
 [force]
   type = ParsedFunction
-  value = '8*pi^2*sin(2*x*pi)*sin(2*y*pi)'
+  expression = '8*pi^2*sin(2*x*pi)*sin(2*y*pi)'
 []
 [exact]
   type = ParsedFunction
-  value = 'sin(2*x*pi)*sin(2*y*pi)'
+  expression = 'sin(2*x*pi)*sin(2*y*pi)'
 []
 ```
 
@@ -180,11 +180,11 @@ file for the temporal problem is shown in [mms_temporal].
 3*x*y*t^2
 [force]
   type = ParsedFunction
-  value = '3*x*y*t^2'
+  expression = '3*x*y*t^2'
 []
 [exact]
   type = ParsedFunction
-  value = 'x*y*t^3'
+  expression = 'x*y*t^3'
 []
 ```
 

--- a/python/moosesyntax/test/test_get_moose_syntax_tree.py
+++ b/python/moosesyntax/test/test_get_moose_syntax_tree.py
@@ -63,7 +63,7 @@ class TestSyntaxTree(unittest.TestCase):
         self.assertTrue(node.source.endswith('framework/src/functions/MooseParsedFunction.C'))
         self.assertTrue(node.header.endswith('framework/include/functions/MooseParsedFunction.h'))
         self.assertIsInstance(node.parameters, dict)
-        self.assertIn('value', node.parameters)
+        self.assertIn('expression', node.parameters)
 
         # ActionNode
         node = moosetree.find(root, lambda n: n.fullpath() == '/Outputs/CommonOutputAction')

--- a/test/tests/auxkernels/functor_elemental_gradient/functor_gradient.i
+++ b/test/tests/auxkernels/functor_elemental_gradient/functor_gradient.i
@@ -40,7 +40,7 @@
 [Functions]
   [parsed_function]
     type = ParsedFunction
-    value = 'sin(x)-cos(y/2)'
+    expression = 'sin(x)-cos(y/2)'
   []
   [parsed_grad_function]
     type = ParsedVectorFunction
@@ -49,7 +49,7 @@
   []
   [parsed_gradx_function]
     type = ParsedFunction
-    value = 'cos(x)'
+    expression = 'cos(x)'
   []
 []
 

--- a/test/tests/controls/libtorch_nn_control/read_control.i
+++ b/test/tests/controls/libtorch_nn_control/read_control.i
@@ -6,7 +6,7 @@ cp = 1.0
 [Functions]
   [src_func]
     type = ParsedFunction
-    value = "sin(${pi}/${period}*t)"
+    expression = "sin(${pi}/${period}*t)"
   []
 []
 

--- a/test/tests/indicators/laplacian_jump_indicator/biharmonic.i
+++ b/test/tests/indicators/laplacian_jump_indicator/biharmonic.i
@@ -1,7 +1,7 @@
 [GlobalParams]
   # Parameters used by Functions.
-  vars   = 'c'
-  vals   = '50'
+  symbol_names = 'c'
+  symbol_values = '50'
 []
 
 [Mesh]

--- a/test/tests/indicators/laplacian_jump_indicator/biharmonic_transient.i
+++ b/test/tests/indicators/laplacian_jump_indicator/biharmonic_transient.i
@@ -1,7 +1,7 @@
 [GlobalParams]
   # Parameters used by Functions.
-  vars   = 'c'
-  vals   = '50'
+  symbol_names = 'c'
+  symbol_values = '50'
 []
 
 [Mesh]

--- a/test/tests/kernels/ad_flux_divergence/1d_fluxdivergence_transient_test.i
+++ b/test/tests/kernels/ad_flux_divergence/1d_fluxdivergence_transient_test.i
@@ -71,7 +71,7 @@
 [Functions]
   [analytical]
     type = ParsedFunction
-    value = '100*sin(pi*x/80)*exp(-0.95/(0.092*8.92)*pi^2/80^2*t)'
+    expression = '100*sin(pi*x/80)*exp(-0.95/(0.092*8.92)*pi^2/80^2*t)'
   []
 []
 

--- a/test/tests/kernels/ad_scalar_kernel_constraint/diffusion_bipass_scalar.i
+++ b/test/tests/kernels/ad_scalar_kernel_constraint/diffusion_bipass_scalar.i
@@ -13,32 +13,32 @@
 [Functions]
   [exact_fn]
     type = ParsedFunction
-    value = 'x*x+y*y'
+    expression = 'x*x+y*y'
   []
 
   [ffn]
     type = ParsedFunction
-    value = -4
+    expression = -4
   []
 
   [bottom_bc_fn]
     type = ParsedFunction
-    value = -2*y
+    expression = -2*y
   []
 
   [right_bc_fn]
     type = ParsedFunction
-    value =  2*x
+    expression =  2*x
   []
 
   [top_bc_fn]
     type = ParsedFunction
-    value =  2*y
+    expression =  2*y
   []
 
   [left_bc_fn]
     type = ParsedFunction
-    value = -2*x
+    expression = -2*x
   []
 []
 

--- a/test/tests/kernels/ad_scalar_kernel_constraint/diffusion_override_scalar.i
+++ b/test/tests/kernels/ad_scalar_kernel_constraint/diffusion_override_scalar.i
@@ -13,32 +13,32 @@
 [Functions]
   [exact_fn]
     type = ParsedFunction
-    value = 'x*x+y*y'
+    expression = 'x*x+y*y'
   []
 
   [ffn]
     type = ParsedFunction
-    value = -4
+    expression = -4
   []
 
   [bottom_bc_fn]
     type = ParsedFunction
-    value = -2*y
+    expression = -2*y
   []
 
   [right_bc_fn]
     type = ParsedFunction
-    value =  2*x
+    expression =  2*x
   []
 
   [top_bc_fn]
     type = ParsedFunction
-    value =  2*y
+    expression =  2*y
   []
 
   [left_bc_fn]
     type = ParsedFunction
-    value = -2*x
+    expression = -2*x
   []
 []
 

--- a/test/tests/kernels/ad_scalar_kernel_constraint/scalar_constraint_together.i
+++ b/test/tests/kernels/ad_scalar_kernel_constraint/scalar_constraint_together.i
@@ -13,32 +13,32 @@
 [Functions]
   [exact_fn]
     type = ParsedFunction
-    value = 'x*x+y*y'
+    expression = 'x*x+y*y'
   []
 
   [ffn]
     type = ParsedFunction
-    value = -4
+    expression = -4
   []
 
   [bottom_bc_fn]
     type = ParsedFunction
-    value = -2*y
+    expression = -2*y
   []
 
   [right_bc_fn]
     type = ParsedFunction
-    value =  2*x
+    expression =  2*x
   []
 
   [top_bc_fn]
     type = ParsedFunction
-    value =  2*y
+    expression =  2*y
   []
 
   [left_bc_fn]
     type = ParsedFunction
-    value = -2*x
+    expression = -2*x
   []
 []
 

--- a/test/tests/kernels/scalar_kernel_constraint/diffusion_bipass_scalar.i
+++ b/test/tests/kernels/scalar_kernel_constraint/diffusion_bipass_scalar.i
@@ -13,32 +13,32 @@
 [Functions]
   [exact_fn]
     type = ParsedFunction
-    value = 'x*x+y*y'
+    expression = 'x*x+y*y'
   []
 
   [ffn]
     type = ParsedFunction
-    value = -4
+    expression = -4
   []
 
   [bottom_bc_fn]
     type = ParsedFunction
-    value = -2*y
+    expression = -2*y
   []
 
   [right_bc_fn]
     type = ParsedFunction
-    value =  2*x
+    expression =  2*x
   []
 
   [top_bc_fn]
     type = ParsedFunction
-    value =  2*y
+    expression =  2*y
   []
 
   [left_bc_fn]
     type = ParsedFunction
-    value = -2*x
+    expression = -2*x
   []
 []
 

--- a/test/tests/kernels/scalar_kernel_constraint/diffusion_override_scalar.i
+++ b/test/tests/kernels/scalar_kernel_constraint/diffusion_override_scalar.i
@@ -13,32 +13,32 @@
 [Functions]
   [exact_fn]
     type = ParsedFunction
-    value = 'x*x+y*y'
+    expression = 'x*x+y*y'
   []
 
   [ffn]
     type = ParsedFunction
-    value = -4
+    expression = -4
   []
 
   [bottom_bc_fn]
     type = ParsedFunction
-    value = -2*y
+    expression = -2*y
   []
 
   [right_bc_fn]
     type = ParsedFunction
-    value =  2*x
+    expression =  2*x
   []
 
   [top_bc_fn]
     type = ParsedFunction
-    value =  2*y
+    expression =  2*y
   []
 
   [left_bc_fn]
     type = ParsedFunction
-    value = -2*x
+    expression = -2*x
   []
 []
 

--- a/test/tests/kernels/scalar_kernel_constraint/scalar_constraint_kernel.i
+++ b/test/tests/kernels/scalar_kernel_constraint/scalar_constraint_kernel.i
@@ -13,32 +13,32 @@
 [Functions]
   [exact_fn]
     type = ParsedFunction
-    value = 'x*x+y*y'
+    expression = 'x*x+y*y'
   []
 
   [ffn]
     type = ParsedFunction
-    value = -4
+    expression = -4
   []
 
   [bottom_bc_fn]
     type = ParsedFunction
-    value = -2*y
+    expression = -2*y
   []
 
   [right_bc_fn]
     type = ParsedFunction
-    value =  2*x
+    expression =  2*x
   []
 
   [top_bc_fn]
     type = ParsedFunction
-    value =  2*y
+    expression =  2*y
   []
 
   [left_bc_fn]
     type = ParsedFunction
-    value = -2*x
+    expression = -2*x
   []
 []
 

--- a/test/tests/meshmodifiers/element_subdomain_modifier/adaptivity_moving_boundary_3d.i
+++ b/test/tests/meshmodifiers/element_subdomain_modifier/adaptivity_moving_boundary_3d.i
@@ -56,7 +56,7 @@
 [Functions]
   [moving_gauss]
     type = ParsedFunction
-    value = 'exp(-((x+0.5-t)^2+(y)^2)/0.25)'
+    expression = 'exp(-((x+0.5-t)^2+(y)^2)/0.25)'
   []
 []
 

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -126,7 +126,7 @@
   [bad_parsed_function_vars_test]
     type = 'RunException'
     input = 'bad_parsed_function_vars.i'
-    expect_err = 'The variables \"x, y, z, and t\" in the ParsedFunction are pre-declared for use and must not be declared in \"vars\"'
+    expect_err = 'The variables \"x, y, z, and t\" in the ParsedFunction are pre-declared for use and must not be declared in \"symbol_names\"'
 
     requirement = 'The system shall report an error when a previously undeclared variable is used in a parsed function expression.'
     issues = '#4683'

--- a/test/tests/misc/multiple-nl-systems/test-fv.i
+++ b/test/tests/misc/multiple-nl-systems/test-fv.i
@@ -92,7 +92,7 @@
 [Functions]
   [exact]
     type = ParsedFunction
-    value = '-1/6*x*x*x +7/6*x'
+    expression = '-1/6*x*x*x +7/6*x'
   []
 []
 

--- a/tutorials/darcy_thermo_mech/doc/content/workshop/infrastructure/mms.md
+++ b/tutorials/darcy_thermo_mech/doc/content/workshop/infrastructure/mms.md
@@ -68,15 +68,15 @@ cd ~/projects/moose/examples/ex14_pps
 pi^2*a^2*sin(x*pi*a)
 [force]
   type = ParsedFunction
-  value = 'pi^2*a^2*sin(x*pi*a)'
-  vars = 'a'
-  vals = '1.0'
+  expression = 'pi^2*a^2*sin(x*pi*a)'
+  symbol_names = 'a'
+  symbol_values = '1.0'
 []
 [exact]
   type = ParsedFunction
-  value = 'sin(x*pi*a)'
-  vars = 'a'
-  vals = '1.0'
+  expression = 'sin(x*pi*a)'
+  symbol_names = 'a'
+  symbol_values = '1.0'
 []
 ```
 

--- a/tutorials/tutorial03_verification/doc/content/getting_started/examples_and_tutorials/tutorial03_verification/presentation/tutorial03_analytical.md
+++ b/tutorials/tutorial03_verification/doc/content/getting_started/examples_and_tutorials/tutorial03_verification/presentation/tutorial03_analytical.md
@@ -129,8 +129,8 @@ The known solution can be defined using the Function System in the `Functions` b
 
 !listing tutorial03_verification/app/test/tests/step03_analytical/1d_analytical.i link=False block=Functions
 
-The "vars" and "vals" have a one-to-one relationship, e.g., $k=80.2$. If defined in this manner
-then the names in "vars" can be used in the definition of the equation in the "value" parameter.
+The "symbol_names" and "symbol_values" items have a one-to-one relationship, e.g., $k=80.2$. If defined in this manner
+then the names in "symbol_names" can be used in the definition of the equation in the "expression" parameter.
 
 !---
 

--- a/tutorials/tutorial03_verification/doc/content/getting_started/examples_and_tutorials/tutorial03_verification/presentation/tutorial03_mms.md
+++ b/tutorials/tutorial03_verification/doc/content/getting_started/examples_and_tutorials/tutorial03_verification/presentation/tutorial03_mms.md
@@ -222,13 +222,13 @@ Executing this script, assuming a name of `spatial_function.py` results in the f
 $ python spatial_function.py
 [mms_force]
   type = ParsedFunction
-  value = 'cp*rho*sin(x*pi)*sin(5*y*pi) + 26*pi^2*k*t*sin(x*pi)*sin(5*y*pi) - shortwave*exp(y*kappa)*sin((1/2)*x*pi)*sin((1/3600)*pi*t/hours)'
-  vars = 'hours rho shortwave k cp kappa'
-  vals = '1.0 1.0 1.0 1.0 1.0 1.0'
+  expression = 'cp*rho*sin(x*pi)*sin(5*y*pi) + 26*pi^2*k*t*sin(x*pi)*sin(5*y*pi) - shortwave*exp(y*kappa)*sin((1/2)*x*pi)*sin((1/3600)*pi*t/hours)'
+  symbol_names = 'hours rho shortwave k cp kappa'
+  symbol_values = '1.0 1.0 1.0 1.0 1.0 1.0'
 []
 [mms_exact]
   type = ParsedFunction
-  value = 't*sin(x*pi)*sin(5*y*pi)'
+  expression = 't*sin(x*pi)*sin(5*y*pi)'
 []
 
 !---
@@ -331,13 +331,13 @@ Executing this script, assuming a name of `temporal_function.py` results in the 
 $ python temporal_function.py
 [mms_force]
   type = ParsedFunction
-  value = '-3.08641975308642e-5*x*y*cp*rho*exp(-3.08641975308642e-5*t) - shortwave*exp(y*kappa)*sin((1/2)*x*pi)*sin((1/3600)*pi*t/hours)'
-  vars = 'kappa rho shortwave cp hours'
-  vals = '1.0 1.0 1.0 1.0 1.0'
+  expression = '-3.08641975308642e-5*x*y*cp*rho*exp(-3.08641975308642e-5*t) - shortwave*exp(y*kappa)*sin((1/2)*x*pi)*sin((1/3600)*pi*t/hours)'
+  symbol_names = 'kappa rho shortwave cp hours'
+  symbol_values = '1.0 1.0 1.0 1.0 1.0'
 []
 [mms_exact]
   type = ParsedFunction
-  value = 'x*y*exp(-3.08641975308642e-5*t)'
+  expression = 'x*y*exp(-3.08641975308642e-5*t)'
 []
 
 !---

--- a/unit/src/ParsedFunctionTest.C
+++ b/unit/src/ParsedFunctionTest.C
@@ -46,7 +46,7 @@ ParsedFunctionTest::buildFunction(InputParameters & params)
 TEST_F(ParsedFunctionTest, basicConstructor)
 {
   auto params = getParams();
-  params.set<std::string>("value") = std::string("x + 1.5*y + 2 * z + t/4");
+  params.set<std::string>("expression") = std::string("x + 1.5*y + 2 * z + t/4");
   auto & f = buildFunction(params);
   Moose::Functor<Real> f_wrapped(f);
   f.initialSetup();
@@ -161,9 +161,9 @@ TEST_F(ParsedFunctionTest, advancedConstructor)
   one_var[0] = "q";
 
   auto params = getParams();
-  params.set<std::string>("value") = "x + y + q";
-  params.set<std::vector<std::string>>("vars") = one_var;
-  params.set<std::vector<std::string>>("vals") =
+  params.set<std::string>("expression") = "x + y + q";
+  params.set<std::vector<std::string>>("symbol_names") = one_var;
+  params.set<std::vector<std::string>>("symbol_values") =
       std::vector<std::string>(1, "-1"); // Dummy value, will be overwritten in test below
 
   auto & f = buildFunction(params);
@@ -181,9 +181,9 @@ TEST_F(ParsedFunctionTest, advancedConstructor)
   three_vars[2] = "r";
 
   auto params2 = getParams();
-  params2.set<std::string>("value") = "r*x + y/w + q";
-  params2.set<std::vector<std::string>>("vars") = three_vars;
-  params2.set<std::vector<std::string>>("vals") =
+  params2.set<std::string>("expression") = "r*x + y/w + q";
+  params2.set<std::vector<std::string>>("symbol_names") = three_vars;
+  params2.set<std::vector<std::string>>("symbol_values") =
       std::vector<std::string>(3, "-1"); // Dummy values, will be overwritten in test below
 
   auto & f2 = buildFunction(params2);
@@ -199,9 +199,9 @@ TEST_F(ParsedFunctionTest, advancedConstructor)
   one_val[0] = "2.5";
 
   auto params3 = getParams();
-  params3.set<std::string>("value") = "q*x";
-  params3.set<std::vector<std::string>>("vars") = one_var;
-  params3.set<std::vector<std::string>>("vals") = one_val;
+  params3.set<std::string>("expression") = "q*x";
+  params3.set<std::vector<std::string>>("symbol_names") = one_var;
+  params3.set<std::vector<std::string>>("symbol_values") = one_val;
 
   auto & f3 = buildFunction(params3);
   f3.initialSetup();
@@ -214,9 +214,9 @@ TEST_F(ParsedFunctionTest, advancedConstructor)
   three_vals[2] = "0";
 
   auto params4 = getParams();
-  params4.set<std::string>("value") = "q*x + y/r + w";
-  params4.set<std::vector<std::string>>("vars") = three_vars;
-  params4.set<std::vector<std::string>>("vals") = three_vals;
+  params4.set<std::string>("expression") = "q*x + y/r + w";
+  params4.set<std::vector<std::string>>("symbol_names") = three_vars;
+  params4.set<std::vector<std::string>>("symbol_values") = three_vals;
 
   auto & f4 = buildFunction(params4);
   f4.initialSetup();
@@ -236,9 +236,9 @@ TEST_F(ParsedFunctionTest, testVariables)
   one_var[0] = "q";
 
   auto params = getParams();
-  params.set<std::string>("value") = "x + y + q";
-  params.set<std::vector<std::string>>("vars") = one_var;
-  params.set<std::vector<std::string>>("vals") =
+  params.set<std::string>("expression") = "x + y + q";
+  params.set<std::vector<std::string>>("symbol_names") = one_var;
+  params.set<std::vector<std::string>>("symbol_values") =
       std::vector<std::string>(1, "-1"); // Dummy value, will be overwritten in test below
 
   auto & f = buildFunction(params);
@@ -261,9 +261,9 @@ TEST_F(ParsedFunctionTest, testVariables)
   three_vars[2] = "r";
 
   auto params2 = getParams();
-  params2.set<std::string>("value") = "r*x + y/w + q";
-  params2.set<std::vector<std::string>>("vars") = three_vars;
-  params2.set<std::vector<std::string>>("vals") =
+  params2.set<std::string>("expression") = "r*x + y/w + q";
+  params2.set<std::vector<std::string>>("symbol_names") = three_vars;
+  params2.set<std::vector<std::string>>("symbol_values") =
       std::vector<std::string>(3, "-1"); // Dummy values, will be overwritten in test below
 
   auto & f2 = buildFunction(params2);
@@ -290,14 +290,14 @@ TEST_F(ParsedFunctionTest, testConstants)
   // this functions tests that pi and e get correctly substituted
   // it also tests built in functions of the function parser
   auto params = getParams();
-  params.set<std::string>("value") = "log(e) + x";
+  params.set<std::string>("expression") = "log(e) + x";
 
   auto & f = buildFunction(params);
   f.initialSetup();
   EXPECT_NEAR(2, f.value(0, 1), 0.0000001);
 
   auto params2 = getParams();
-  params2.set<std::string>("value") = "sin(pi*x)";
+  params2.set<std::string>("expression") = "sin(pi*x)";
 
   auto & f2 = buildFunction(params2);
   f2.initialSetup();


### PR DESCRIPTION
Assuming all tests pass, this should be a no-brainer @GiudGiud.

## Reason
Spin-off of #31619 that does _not_ remove deprecated functionality, but simply drops its usage.
This covers the vast majority of the commits and file changes in #31619 and is not dependent on changes to 3rd party apps.

## Design
Replaced usages of `ParsedFunction`'s `value`, `vars` and `vals` parameters with `expression`, `symbol_names` and `symbol_values`, respectively, throughout the test suite and documentation.

## Impact
Hopefully stops the propagation of deprecated functionality that sometimes happens when people copy old test input files.
Relieves #31619 of most of its weight, leaving only the breaking changes there.
