### PR TITLE
Allow interchangeability of int names and values in MooseEnum

### DIFF
--- a/framework/doc/content/source/mfem/fespaces/MFEMFESpace.md
+++ b/framework/doc/content/source/mfem/fespaces/MFEMFESpace.md
@@ -13,8 +13,8 @@ MFEM which one or more `MFEMVariable`s can be defined with respect to.
 
 This class has pure virtual methods `MFEMFESpace::getFECName()` and
 `MFEMFESpace::getVDim()`, which child classes must implement. The
-first should return a name to be passed to [MFEM factory method
-`FiniteElementCollection::New()`](https://docs.mfem.org/html/classmfem_1_1FiniteElementCollection.html#a15fcfa553d4949eb08f9926ac74d1e80).
+first should return a name to be passed to
+[MFEM factory method `FiniteElementCollection::New()`](https://docs.mfem.org/html/classmfem_1_1FiniteElementCollection.html#a15fcfa553d4949eb08f9926ac74d1e80).
 The second should specify the number of degrees of freedom per basis
 function in the finite element space and will be passed as the
 argument `vdim` in the

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -35,15 +35,13 @@ AddVariableAction::validParams()
   params.set<std::string>("type") = "MooseVariableBase";
 
   // The below is for backwards compatibility
-  MooseEnum families(AddVariableAction::getNonlinearVariableFamilies());
-  MooseEnum orders(AddVariableAction::getNonlinearVariableOrders());
-  params.addParam<MooseEnum>(
-      "family", families, "Specifies the family of FE shape functions to use for this variable");
+  params.addParam<MooseEnum>("family",
+                             AddVariableAction::getNonlinearVariableFamilies(),
+                             "Specifies the family of FE shape functions to use for this variable");
   params.addParam<MooseEnum>("order",
-                             orders,
-                             "Specifies the order of the FE shape function to use "
-                             "for this variable (additional orders not listed are "
-                             "allowed)");
+                             AddVariableAction::getNonlinearVariableOrders(),
+                             "Specifies the order of the FE shape function to use for this "
+                             "variable (additional orders not listed are allowed)");
   params.addParam<std::vector<Real>>("scaling",
                                      "Specifies a scaling factor to apply to this variable");
   params.addParam<std::vector<Real>>("initial_condition",
@@ -74,7 +72,15 @@ AddVariableAction::getNonlinearVariableFamilies()
 MooseEnum
 AddVariableAction::getNonlinearVariableOrders()
 {
-  return MooseEnum("CONSTANT FIRST SECOND THIRD FOURTH", "FIRST", true);
+  return MooseEnum(
+      "CONSTANT FIRST SECOND THIRD FOURTH FIFTH SIXTH SEVENTH EIGHTH NINTH TENTH ELEVENTH TWELFTH "
+      "THIRTEENTH FOURTEENTH FIFTEENTH SIXTEENTH SEVENTEENTH EIGHTTEENTH NINETEENTH TWENTIETH "
+      "TWENTYFIRST TWENTYSECOND TWENTYTHIRD TWENTYFOURTH TWENTYFIFTH TWENTYSIXTH TWENTYSEVENTH "
+      "TWENTYEIGHTH TWENTYNINTH THIRTIETH THIRTYFIRST THIRTYSECOND THIRTYTHIRD THIRTYFOURTH "
+      "THIRTYFIFTH THIRTYSIXTH THIRTYSEVENTH THIRTYEIGHTH THIRTYNINTH FORTIETH FORTYFIRST "
+      "FORTYSECOND FORTYTHIRD",
+      "FIRST",
+      true);
 }
 
 FEType

--- a/framework/src/mfem/fespaces/MFEMSimplifiedFESpace.C
+++ b/framework/src/mfem/fespaces/MFEMSimplifiedFESpace.C
@@ -11,6 +11,7 @@
 
 #include "MFEMSimplifiedFESpace.h"
 #include "MFEMProblem.h"
+#include "AddVariableAction.h"
 
 InputParameters
 MFEMSimplifiedFESpace::validParams()
@@ -18,15 +19,9 @@ MFEMSimplifiedFESpace::validParams()
   InputParameters params = MFEMFESpace::validParams();
   params.addClassDescription("Base class for the simplified interfaces to build MFEM finite "
                              "element spaces. It provides the common parameters.");
-  MooseEnum fec_order(
-      "CONSTANT FIRST SECOND THIRD FOURTH FIFTH SIXTH SEVENTH EIGHTH NINTH TENTH ELEVENTH TWELFTH "
-      "THIRTEENTH FOURTEENTH FIFTEENTH SIXTEENTH SEVENTEENTH EIGHTTEENTH NINETEENTH TWENTIETH "
-      "TWENTYFIRST TWENTYSECOND TWENTYTHIRD TWENTYFOURTH TWENTYFIFTH TWENTYSIXTH TWENTYSEVENTH "
-      "TWENTYEIGHTH TWENTYNINTH THIRTIETH THIRTYFIRST THIRTYSECOND THIRTYTHIRD THIRTYFOURTH "
-      "THIRTYFIFTH THIRTYSIXTH THIRTYSEVENTH THIRTYEIGHTH THIRTYNINTH FORTIETH FORTYFIRST "
-      "FORTYSECOND FORTYTHIRD",
-      "FIRST");
-  params.addParam<MooseEnum>("fec_order", fec_order, "Order of the FE shape function to use.");
+  params.addParam<MooseEnum>("fec_order",
+                             AddVariableAction::getNonlinearVariableOrders(),
+                             "Order of the FE shape function to use.");
   return params;
 }
 

--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -35,32 +35,15 @@ MooseVariableBase::validParams()
   params += BlockRestrictable::validParams();
   params += OutputInterface::validParams();
 
-  MooseEnum order(
-      "CONSTANT FIRST SECOND THIRD FOURTH FIFTH SIXTH SEVENTH EIGHTH NINTH TENTH ELEVENTH TWELFTH "
-      "THIRTEENTH FOURTEENTH FIFTEENTH SIXTEENTH SEVENTEENTH EIGHTTEENTH NINETEENTH TWENTIETH "
-      "TWENTYFIRST TWENTYSECOND TWENTYTHIRD TWENTYFOURTH TWENTYFIFTH TWENTYSIXTH TWENTYSEVENTH "
-      "TWENTYEIGHTH TWENTYNINTH THIRTIETH THIRTYFIRST THIRTYSECOND THIRTYTHIRD THIRTYFOURTH "
-      "THIRTYFIFTH THIRTYSIXTH THIRTYSEVENTH THIRTYEIGHTH THIRTYNINTH FORTIETH FORTYFIRST "
-      "FORTYSECOND FORTYTHIRD",
-      "FIRST",
-      true);
-  params.addParam<MooseEnum>("order",
-                             order,
-                             "Order of the FE shape function to use for this variable (additional "
-                             "orders not listed here are allowed, depending on the family).");
-
-  MooseEnum family{AddVariableAction::getNonlinearVariableFamilies()};
-
-  params.addParam<MooseEnum>(
-      "family", family, "Specifies the family of FE shape functions to use for this variable.");
+  params.transferParam<MooseEnum>(AddVariableAction::validParams(), "order");
+  params.transferParam<MooseEnum>(AddVariableAction::validParams(), "family");
 
   // ArrayVariable capability
   params.addRangeCheckedParam<unsigned int>(
       "components", 1, "components>0", "Number of components for an array variable");
 
   // Advanced input options
-  params.addParam<std::vector<Real>>("scaling",
-                                     "Specifies a scaling factor to apply to this variable");
+  params.transferParam<std::vector<Real>>(AddVariableAction::validParams(), "scaling");
   params.addParam<bool>("eigen", false, "True to make this variable an eigen variable");
   params.addParam<bool>("fv", false, "True to make this variable a finite volume variable");
   params.addParam<bool>("array",


### PR DESCRIPTION
## Reason
It'd be beneficial if users could specify the order of variables/spaces using plain digits, e.g. `order = 3`, instead of spelled-out ordinals, e.g. `order = THIRD`.

## Design
When assigning a name string to a `MooseEnum` (like the `order` parameter) we now:
a) check its existence amongst the names of the enumerated items (just as before);
b) if that search is unsuccessful, and if the name string is plainly parseable as an integer, we check its existence amongst the values of the enumerated items;
c) if that fails and we don't allow out of range extensions, we error (as before), if do allow extensions we enumerate a new item, with the passed in name (as before), but whose value is either i) the next valid id (as before) or ii) if the name string is plainly parseable as an integer, that very integer.

~This would be enough for the intents here, but for completeness and symmetry, I changed the way we assign an integer value too. We now:
a) check its existence amongst the values of the enumerated items (just as before);
b) if that search is unsuccessful, we check the existence of a string holding that integer value amongst the names of the enumerated items;
c) if that fails and we don't allow out of range extensions, we error (as we would unconditionally before), if we do allow extensions we enumerate a new item with the given value and whose name is a string holding the integer value.~

## Impact
Users can now specify `order = 18` instead of `order = EIGHTTEENTH`. For MFEM-backed problems, the user can continue to use the spelled-out ordinals till `order = FORTYTHIRD` but is now free to ask for `order = 77`.
If the user is trying to maintain a `MooseEnum` whose names are strings holding plain integer values, things may get confusing in weird corner cases allowing out of range extensions. In MOOSE, of this kind, I can only see trivial enumerations that do not allow out of range extensions, e.g. `MooseEnum dims("1=1 2 3");`, which are unaffected.