### PR TITLE
Add convexity diagnostics and repair for polygons

### DIFF
--- a/framework/doc/content/source/meshgenerators/MeshRepairGenerator.md
+++ b/framework/doc/content/source/meshgenerators/MeshRepairGenerator.md
@@ -20,6 +20,7 @@ The operations currently implemented are:
 
 - renumbering the nodes and elements to have a contiguous ordering.
 
+- splitting non-convex polygons into convex polygons
 
 !syntax parameters /Mesh/MeshRepairGenerator
 

--- a/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
+++ b/framework/include/meshgenerators/MeshDiagnosticsGenerator.h
@@ -53,8 +53,10 @@ private:
   void checkNonConformalMeshFromAdaptivity(const std::unique_ptr<MeshBase> & mesh) const;
   /// Routine to check whether the Jacobians (elem and side) are not negative
   void checkLocalJacobians(const std::unique_ptr<MeshBase> & mesh) const;
-  //// Routine to check for non matching edges
+  /// Routine to check for non matching edges
   void checkNonMatchingEdges(const std::unique_ptr<MeshBase> & mesh) const;
+  /// Routine to check for non-convex polygons
+  void checkPolygons(const std::unique_ptr<MeshBase> & mesh) const;
 
   /**
    * Utility routine to output the final diagnostics level in the desired mode
@@ -100,6 +102,8 @@ private:
   const MooseEnum _check_adaptivity_non_conformality;
   /// whether to check for negative jacobians in the domain
   const MooseEnum _check_local_jacobian;
+  /// whether to check for non-convex polygons in the mesh
+  const MooseEnum _check_polygons;
   /// number of logs to output at most for each check
   const unsigned int _num_outputs;
 };

--- a/framework/include/meshgenerators/MeshRepairGenerator.h
+++ b/framework/include/meshgenerators/MeshRepairGenerator.h
@@ -42,6 +42,9 @@ private:
   /// Whether to merge boundaries with the same name but different ID
   const bool _boundary_id_merge;
 
+  /// Whether to split non-convex polygons
+  const bool _split_nonconvex_polygons;
+
   /// @brief Removes the elements with an volume value below the user threshold
   /// @param mesh the mesh to modify
   void removeSmallVolumeElements(std::unique_ptr<MeshBase> & mesh) const;
@@ -54,4 +57,8 @@ private:
   ///        do not support mixed element types
   /// @param mesh the mesh to modify
   void separateSubdomainsByElementType(std::unique_ptr<MeshBase> & mesh) const;
+
+  /// @brief Splits non-convex polygonal elements to keep only convex elements
+  /// @param mesh the mesh to modify
+  void splitNonConvexPolygons(std::unique_ptr<MeshBase> & mesh) const;
 };

--- a/framework/src/meshgenerators/MeshRepairGenerator.C
+++ b/framework/src/meshgenerators/MeshRepairGenerator.C
@@ -257,7 +257,7 @@ MeshRepairGenerator::splitNonConvexPolygons(std::unique_ptr<MeshBase> & mesh) co
         mooseAssert(obtuse_angle_nodes.empty(), "Should not be empty");
 
         // Find the normal to the element plane
-        const auto elem_centroid = elem->true_centroid();
+        const auto elem_centroid = elem->vertex_average();
         const auto n_nodes = elem->n_nodes();
         Point plane_normal;
         // Two nodes could be aligned with the centroid in a non-convex polygon
@@ -411,7 +411,10 @@ MeshRepairGenerator::splitNonConvexPolygons(std::unique_ptr<MeshBase> & mesh) co
       // Keep all the cut elements, to be added at the end to avoid invalidating iterators
       if (fixed_it)
         for (auto & elem_uptr : elements_to_add_to_mesh_temp)
+        {
+          elem_uptr->inherit_data_from(*elem);
           elements_to_add_to_mesh.push_back(std::move(elem_uptr));
+        }
 
       // Heuristic did not work, just use a triangulation
       // NOTE: This is not the triangulation of the polygon. It is simple though
@@ -438,6 +441,7 @@ MeshRepairGenerator::splitNonConvexPolygons(std::unique_ptr<MeshBase> & mesh) co
             mooseError("Manual triangulation failed as two consecutive nodes are aligned with the "
                        "centroid");
 
+          new_elem->inherit_data_from(*elem);
           elements_to_add_to_mesh.push_back(std::move(new_elem));
         }
       }

--- a/framework/src/meshgenerators/MeshRepairGenerator.C
+++ b/framework/src/meshgenerators/MeshRepairGenerator.C
@@ -46,6 +46,9 @@ MeshRepairGenerator::validParams()
       false,
       "Whether to renumber the elements of the mesh so the numbering is contiguous");
 
+  params.addParam<bool>(
+      "split_nonconvex_polygons", false, "Split non-convex polygons to form convex ones");
+
   return params;
 }
 
@@ -56,10 +59,11 @@ MeshRepairGenerator::MeshRepairGenerator(const InputParameters & parameters)
     _node_overlap_tol(getParam<Real>("node_overlap_tol")),
     _fix_element_orientation(getParam<bool>("fix_elements_orientation")),
     _elem_type_separation(getParam<bool>("separate_blocks_by_element_types")),
-    _boundary_id_merge(getParam<bool>("merge_boundary_ids_with_same_name"))
+    _boundary_id_merge(getParam<bool>("merge_boundary_ids_with_same_name")),
+    _split_nonconvex_polygons(getParam<bool>("split_nonconvex_polygons"))
 {
   if (!_fix_overlapping_nodes && !_fix_element_orientation && !_elem_type_separation &&
-      !_boundary_id_merge && !getParam<bool>("renumber_contiguously"))
+      !_boundary_id_merge && !getParam<bool>("renumber_contiguously") && !_split_nonconvex_polygons)
     mooseError("No specific item to fix. Are any of the parameters misspelled?");
 }
 
@@ -100,6 +104,10 @@ MeshRepairGenerator::generate()
     mesh->renumber_nodes_and_elements();
     mesh->allow_renumbering(prev_status);
   }
+
+  // Split non-convex polygons to make convex ones
+  if (_split_nonconvex_polygons)
+    splitNonConvexPolygons(mesh);
 
   mesh->unset_is_prepared();
   return mesh;
@@ -222,4 +230,233 @@ MeshRepairGenerator::separateSubdomainsByElementType(std::unique_ptr<MeshBase> &
       }
     }
   }
+}
+
+void
+MeshRepairGenerator::splitNonConvexPolygons(std::unique_ptr<MeshBase> & mesh) const
+{
+  // Counters to keep track of what happened in the splitting
+  unsigned int num_polygons = 0;
+  unsigned int num_nonconvex = 0;
+  unsigned int num_triangulated = 0;
+  std::vector<Elem *> elems_to_delete;
+  std::vector<std::unique_ptr<libMesh::C0Polygon>> elements_to_add_to_mesh;
+
+  for (auto elem : mesh->element_ptr_range())
+  {
+    // We are not splitting non-convex quads. Maybe later.
+    if (elem->type() == libMesh::C0POLYGON)
+    {
+      num_polygons++;
+
+      // Lambda function to determine if an element is convex
+      auto is_convex = [](const Elem * elem,
+                          std::vector<std::pair<int, Real>> & obtuse_angle_nodes) -> bool
+      {
+        mooseAssert(elem, "Should have an elem");
+        mooseAssert(obtuse_angle_nodes.empty(), "Should not be empty");
+
+        // Find the normal to the element plane
+        const auto elem_centroid = elem->true_centroid();
+        const auto n_nodes = elem->n_nodes();
+        Point plane_normal;
+        // Two nodes could be aligned with the centroid in a non-convex polygon
+        for (const auto i : make_range(n_nodes))
+        {
+          const auto v1 = elem_centroid - elem->point(i);
+          const auto v2 = elem_centroid - elem->point((i + 1) % n_nodes);
+          if (!MooseUtils::absoluteFuzzyEqual((v1.cross(v2)).norm_sq(), 0))
+          {
+            plane_normal = v1.cross(v2).unit();
+            break;
+          }
+        }
+
+        // Look for angles > 180 deg with the cross product
+        bool convex = true;
+        for (const auto i : make_range(n_nodes))
+        {
+          const auto n1 = elem->point(i);
+          const auto n2 = elem->point((i + 1) % n_nodes);
+          const auto n3 = elem->point((i + 2) % n_nodes);
+          const auto top_dir = (n2 - n1).cross(n3 - n2);
+
+          if (plane_normal * top_dir <= 0)
+          {
+            convex = false;
+            if (!MooseUtils::absoluteFuzzyEqual(plane_normal * top_dir, 0))
+              obtuse_angle_nodes.push_back(
+                  std::make_pair<int, Real>(i, plane_normal * top_dir / top_dir.norm()));
+            // n1, n2 and n3 are likely aligned
+            else
+              obtuse_angle_nodes.push_back(std::make_pair<int, Real>(i, -1));
+          }
+        }
+        return convex;
+      };
+
+      std::vector<std::pair<int, Real>> parent_obtuse_angles;
+      const auto convex = is_convex(elem, parent_obtuse_angles);
+
+      if (!convex)
+        num_nonconvex++;
+      // Move to next one if it is convex, no need to fix it
+      else
+        continue;
+
+      // Lambda function to split a polygon into two polygons at the specified nodes
+      // TODO: we could try to split a polygon into more than two polygons
+      auto cut_polygon = [&mesh](const Elem * elem, unsigned int node_i_cut1, unsigned node_i_cut2)
+          -> std::pair<std::unique_ptr<libMesh::C0Polygon>, std::unique_ptr<libMesh::C0Polygon>>
+      {
+        const auto cut1 = std::min(node_i_cut1, node_i_cut2);
+        const auto cut2 = std::max(node_i_cut1, node_i_cut2);
+
+        // Count the number of sides on each side of the cut
+        const auto ns1 = cut2 - cut1 + 1;
+        const auto ns2 = elem->n_nodes() - ns1 + 2;
+        mooseAssert(ns1 >= 3, "Should cut at least a triangle");
+        mooseAssert(ns2 >= 3, "Should cut at least a triangle");
+
+        // Create the children and add their nodes
+        auto child1 = std::make_unique<libMesh::C0Polygon>(ns1);
+        for (const auto i_n : make_range(cut1, cut2 + 1))
+          child1->set_node(i_n - cut1, mesh->node_ptr(elem->node_ptr(i_n)->id()));
+
+        auto child2 = std::make_unique<libMesh::C0Polygon>(ns2);
+        for (const auto i_n : make_range(cut2, elem->n_nodes() + cut1 + 1))
+          child2->set_node((i_n - cut2) % child2->n_nodes(),
+                           mesh->node_ptr(elem->node_ptr(i_n % elem->n_nodes())->id()));
+
+        return std::make_pair(std::move(child1), std::move(child2));
+      };
+
+      // If not convex, try to split it.
+      // Let's first try to split it recursively at every large angle
+      // NOTE: These vectors of unique pointer keep the memory ownership of the elements
+      // during the loop attempting to fix the polygon with the heuristic below
+      bool failed = false;
+      std::vector<std::unique_ptr<libMesh::C0Polygon>> elements_to_add_to_mesh_temp;
+      std::vector<std::pair<std::unique_ptr<Elem>, std::vector<std::pair<int, Real>>>> elems_to_cut;
+
+      // Create a clone of the first element to simplify logic
+      std::unique_ptr<libMesh::C0Polygon> base_elem =
+          std::make_unique<libMesh::C0Polygon>(elem->n_nodes());
+      for (const auto i_n : make_range(elem->n_nodes()))
+        base_elem->set_node(i_n, elem->node_ptr(i_n));
+      elems_to_cut.push_back(std::make_pair(std::move(base_elem), parent_obtuse_angles));
+
+      while (!failed && !elems_to_cut.empty())
+      {
+        auto & [current_elem, large_angles] = elems_to_cut.back();
+
+        // Split the element on one side at the node with the worst obtuse angle
+        // TODO: try all of them instead to see if a single cut can fix the element
+        auto worst_angle_it =
+            std::min_element(large_angles.begin(),
+                             large_angles.end(),
+                             [](std::pair<int, Real> lhs, std::pair<int, Real> rhs) -> bool
+                             { return lhs.second < rhs.second; });
+        unsigned int worst_angle_i = (*worst_angle_it).first;
+        const auto n_nodes = current_elem->n_nodes();
+
+        // Split the element on the other side at roughly the opposite node
+        // TODO: we could try all of the 'other' nodes here too to see if a single cut can fix the
+        // element NOTE: if trying multiple cuts (not implemented), we should remove the opposite
+        // from the large_angles
+        const auto opposite = ((worst_angle_i + n_nodes / 2) % n_nodes);
+
+        auto [child1, child2] = cut_polygon(current_elem.get(), worst_angle_i, opposite);
+
+        // Check the two fragments
+        std::vector<std::pair<int, Real>> child1_large_angles;
+        bool is_convex1 = is_convex(child1.get(), child1_large_angles);
+        std::vector<std::pair<int, Real>> child2_large_angles;
+        bool is_convex2 = is_convex(child2.get(), child2_large_angles);
+
+        // Can we keep going?
+        if (child1->n_nodes() < 4 && !is_convex1)
+          failed = true;
+        if (child2->n_nodes() < 4 && !is_convex2)
+          failed = true;
+
+        // We managed to cut the elements into a convex part, but it's flipped
+        // so the element is likely "outside" of the starting element
+        if (is_convex1 && child1->volume() <= 0)
+          failed = true;
+        if (is_convex2 && child2->volume() <= 0)
+          failed = true;
+
+        // Current element is done
+        // NOTE: if trying multiple cuts (not implemented), we should not erase yet, we should
+        // instead only remove the cut we tried from the 'large_angles' vector used to pick cuts
+        large_angles.erase(worst_angle_it);
+        elems_to_cut.pop_back();
+
+        // Add non convex elements to the list of elements to cut
+        if (!is_convex1)
+          elems_to_cut.push_back(std::make_pair(std::move(child1), child1_large_angles));
+        if (!is_convex2)
+          elems_to_cut.push_back(std::make_pair(std::move(child2), child2_large_angles));
+
+        // Add convex elements to the mesh
+        // NOTE: if trying multiple cuts, we should not do this yet
+        if (is_convex1)
+          elements_to_add_to_mesh_temp.push_back(std::move(child1));
+        if (is_convex2)
+          elements_to_add_to_mesh_temp.push_back(std::move(child2));
+      }
+      bool fixed_it = !failed;
+
+      // Keep all the cut elements, to be added at the end to avoid invalidating iterators
+      if (fixed_it)
+        for (auto & elem_uptr : elements_to_add_to_mesh_temp)
+          elements_to_add_to_mesh.push_back(std::move(elem_uptr));
+
+      // Heuristic did not work, just use a triangulation
+      // NOTE: This is not the triangulation of the polygon. It is simple though
+      if (!fixed_it)
+      {
+        const auto centroid_node = mesh->add_point(elem->true_centroid());
+        num_triangulated++;
+        const auto * poly = dynamic_cast<libMesh::C0Polygon *>(elem);
+        const auto n_sides = poly->n_sides();
+        for (const auto i_tr : make_range(n_sides))
+        {
+          auto new_elem = std::make_unique<libMesh::C0Polygon>(3);
+          new_elem->set_node(0, mesh->node_ptr(elem->node_ptr(i_tr)->id()));
+          new_elem->set_node(1, centroid_node);
+          new_elem->set_node(2, mesh->node_ptr(elem->node_ptr((i_tr + 1) % n_sides)->id()));
+
+          // Check for degenerate case
+          if (MooseUtils::absoluteFuzzyEqual(
+                  (*(Point *)centroid_node - *(Point *)elem->node_ptr(i_tr))
+                      .cross(*(Point *)centroid_node -
+                             *(Point *)elem->node_ptr((i_tr + 1) % n_sides))
+                      .norm_sq(),
+                  0))
+            mooseError("Manual triangulation failed as two consecutive nodes are aligned with the "
+                       "centroid");
+
+          elements_to_add_to_mesh.push_back(std::move(new_elem));
+        }
+      }
+      // Element got fixed, can be deleted after (can't while using the range)
+      elems_to_delete.push_back(elem);
+    }
+  }
+  // Delete the original element
+  for (auto elem : elems_to_delete)
+    mesh->delete_elem(elem);
+  // Add the new ones
+  for (auto & new_elem_ptr : elements_to_add_to_mesh)
+    mesh->add_elem(std::move(new_elem_ptr));
+
+  _console << "Number of non-convex polygons which got split into convex polygons: "
+           << num_nonconvex << std::endl;
+  if (num_triangulated)
+    _console << "Number of non-convex polygons split using a triangulation: " << num_triangulated
+             << ", using heuristic: " << num_nonconvex - num_triangulated << std::endl;
+  if (!num_polygons)
+    mooseWarning("No C0 polygons in mesh: the polyon convexity fix did nothing");
 }

--- a/framework/src/meshgenerators/MeshRepairGenerator.C
+++ b/framework/src/meshgenerators/MeshRepairGenerator.C
@@ -13,6 +13,7 @@
 
 #include "libmesh/mesh_tools.h"
 #include "libmesh/mesh_modification.h"
+#include "libmesh/face_c0polygon.h"
 
 registerMooseObject("MooseApp", MeshRepairGenerator);
 
@@ -241,6 +242,11 @@ MeshRepairGenerator::splitNonConvexPolygons(std::unique_ptr<MeshBase> & mesh) co
   unsigned int num_triangulated = 0;
   std::vector<Elem *> elems_to_delete;
   std::vector<std::unique_ptr<libMesh::C0Polygon>> elements_to_add_to_mesh;
+
+  // Missing parallel packing for polys
+  if (!mesh->is_serial())
+    mooseError("MeshRepairGenerator requires a serial mesh for this operation. "
+               "The mesh should not be distributed.");
 
   for (auto elem : mesh->element_ptr_range())
   {

--- a/test/tests/meshgenerators/mesh_repair_generator/nonconvex_polygon.i
+++ b/test/tests/meshgenerators/mesh_repair_generator/nonconvex_polygon.i
@@ -1,0 +1,76 @@
+dx = 2
+
+[Mesh]
+  [hex_one_nonconvex_dent]
+    type = ElementGenerator
+    nodal_positions = "0 -0.8 0
+                       -1 -1 0
+                       -1 1 0
+                       0 2 0
+                       1 1 0
+                       1 -1 0"
+
+    element_connectivity = '0 1 2 3 4 5'
+    elem_type = "C0POLYGON"
+  []
+  [hex_two_nonconvex_dents]
+    type = ElementGenerator
+    input = hex_one_nonconvex_dent
+    nodal_positions = "${fparse 2*dx + 0} -0.8 0
+                       ${fparse 2*dx + -1} -1 0
+                       ${fparse 2*dx + 0.01} 1 0
+                       ${fparse 2*dx + 0} 2 0
+                       ${fparse 2*dx + 1} 1 0
+                       ${fparse 2*dx + 1} -1 0"
+
+    element_connectivity = '0 1 2 3 4 5'
+    elem_type = "C0POLYGON"
+  []
+  # looks like a 3-branch star
+  [hex_three_nonconvex_dents]
+    type = ElementGenerator
+    input = hex_two_nonconvex_dents
+    nodal_positions = "${fparse 2*dx + 0} -1 0
+                       ${fparse 2*dx + -2} -1.5 0
+                       ${fparse 2*dx - 0.01} 1 0
+                       ${fparse 2*dx + 0} 2 0
+                       ${fparse 2*dx + 0.01} 1 0
+                       ${fparse 2*dx + 2} -1.5 0"
+
+    element_connectivity = '0 1 2 3 4 5'
+    elem_type = "C0POLYGON"
+  []
+  [hex_two_nodes_in_a_single_nonconvex_dent]
+    type = ElementGenerator
+    input = hex_three_nonconvex_dents
+    nodal_positions = "${fparse 2*dx + 0} -2 0
+                       ${fparse 2*dx + 0.01} -1 0
+                       ${fparse 2*dx + 0.01} 1 0
+                       ${fparse 2*dx + 0} 2 0
+                       ${fparse 2*dx + 1} 1 0
+                       ${fparse 2*dx + 1} -1 0"
+
+    element_connectivity = '0 1 2 3 4 5'
+    elem_type = "C0POLYGON"
+  []
+
+  [check]
+    type = MeshDiagnosticsGenerator
+    input = hex_two_nodes_in_a_single_nonconvex_dent
+    check_polygons = INFO
+  []
+  [repair]
+    type = MeshRepairGenerator
+    input = 'check'
+    split_nonconvex_polygons = true
+  []
+  [check_after_repair]
+    type = MeshDiagnosticsGenerator
+    input = repair
+    check_polygons = ERROR
+  []
+  [convert]
+    type = ElementsToSimplicesConverter
+    input = 'check_after_repair'
+  []
+[]

--- a/test/tests/meshgenerators/mesh_repair_generator/tests
+++ b/test/tests/meshgenerators/mesh_repair_generator/tests
@@ -1,12 +1,12 @@
 [Tests]
   design = 'MeshRepairGenerator.md'
-  issues = '#25107'
   [node_overlap]
     type = JSONDiff
     input = overlapping_fix_test.i
     jsondiff = overlapping_fix_test_json.json
     requirement = 'The system shall be able to merge overlapping nodes.'
     mesh_mode = 'replicated'
+    issues = '#25107'
   []
   [element_flip]
     type = CSVDiff
@@ -14,6 +14,7 @@
     csvdiff = flip_element_out.csv
     requirement = 'The system shall be able to flip the orientation of negative-volume elements.'
     mesh_mode = 'replicated'
+    issues = '#25107'
   []
   [separate_element_types]
     type = JSONDiff
@@ -21,6 +22,7 @@
     jsondiff = mixed_elements_json.json
     requirement = "The system shall be able to split blocks across their element's type."
     mesh_mode = 'replicated'
+    issues = '#25107'
   []
   [boundary_merge]
     type = JSONDiff
@@ -28,5 +30,15 @@
     jsondiff = merge_boundaries_json.json
     requirement = "The system shall be able to merge boundaries with the same names but different boundary IDs."
     mesh_mode = 'replicated'
+    issues = '#25107'
+  []
+  [fix_nonconvex_polygons]
+    type = RunApp
+    input = 'nonconvex_polygon.i'
+    cli_args = '--mesh-only'
+    recover = false
+    expect_out = "Number of non convex polygons: 0"
+    requirement = "The system shall be able to split nonconvex polygons to turn them into convex ones."
+    issues = '#32159'
   []
 []

--- a/test/tests/meshgenerators/mesh_repair_generator/tests
+++ b/test/tests/meshgenerators/mesh_repair_generator/tests
@@ -40,5 +40,7 @@
     expect_out = "Number of non convex polygons: 0"
     requirement = "The system shall be able to split nonconvex polygons to turn them into convex ones."
     issues = '#32159'
+    # parallel packing not implemented for polys
+    mesh_mode = 'replicated'
   []
 []


### PR DESCRIPTION
based on #32141 , should likely wait for that one to be merged before reviewing to avoid double reviewing the same content
EDIT: previous PR merged

Both the check and the split could be in libmesh utils instead. This is a recurring situation with mesh utils tbh