### PR TITLE
Pre-allocate computation arrays for plasticity

### DIFF
--- a/modules/solid_mechanics/include/materials/CappedMohrCoulombCosseratStressUpdate.h
+++ b/modules/solid_mechanics/include/materials/CappedMohrCoulombCosseratStressUpdate.h
@@ -74,4 +74,7 @@ protected:
                                           bool compute_full_tangent_operator,
                                           const std::vector<std::vector<Real>> & dvar_dtrial,
                                           RankFourTensor & cto) override;
+
+private:
+  std::vector<Real> _eigvals_scratch; // used as temporary storage to avoid heap allocation
 };

--- a/modules/solid_mechanics/include/materials/CappedMohrCoulombStressUpdate.h
+++ b/modules/solid_mechanics/include/materials/CappedMohrCoulombStressUpdate.h
@@ -65,9 +65,11 @@ protected:
   void computeStressParams(const RankTwoTensor & stress,
                            std::vector<Real> & stress_params) const override;
 
-  std::vector<RankTwoTensor> dstress_param_dstress(const RankTwoTensor & stress) const override;
+  void dstressparam_dstress(const RankTwoTensor & stress,
+                            std::vector<RankTwoTensor> & dsp) const override;
 
-  std::vector<RankFourTensor> d2stress_param_dstress(const RankTwoTensor & stress) const override;
+  void d2stressparam_dstress(const RankTwoTensor & stress,
+                             std::vector<RankFourTensor> & d2sp) const override;
 
   virtual void setStressAfterReturnV(const RankTwoTensor & stress_trial,
                                      const std::vector<Real> & stress_params,
@@ -119,4 +121,29 @@ protected:
                                           bool compute_full_tangent_operator,
                                           const std::vector<std::vector<Real>> & dvar_dtrial,
                                           RankFourTensor & cto) override;
+
+private:
+  /**
+   * this is d(stress_param[:])/d(stress) which is calculated by dstressparam_dstress.  Using this
+   * mutable means repeated allocation/deallocation is unnecessary.
+   */
+  mutable std::vector<RankTwoTensor> _dsp_trial_scratch;
+
+  /**
+   * eigenvalues of the stress, used in dstressparam_dstress and preReturnMapV.  Using this mutable
+   * means repeated allocation/deallocation is unnecessary.
+   */
+  mutable std::vector<Real> _eigvals_scratch;
+
+  /**
+   * derivative of ga_shear w.r.t. the stress parameters, used in setIntnlDerivativesV.  Using
+   * this mutable means repeated allocation/deallocation is unnecessary.
+   */
+  mutable std::vector<Real> _dga_shear_scratch;
+
+  /**
+   * scratch vector used in setIntnlDerivativesV.  Using
+   * this mutable means repeated allocation/deallocation is unnecessary.
+   */
+  mutable std::vector<Real> _dshear_correction_scratch;
 };

--- a/modules/solid_mechanics/include/materials/TensileStressUpdate.h
+++ b/modules/solid_mechanics/include/materials/TensileStressUpdate.h
@@ -47,9 +47,11 @@ protected:
   void computeStressParams(const RankTwoTensor & stress,
                            std::vector<Real> & stress_params) const override;
 
-  std::vector<RankTwoTensor> dstress_param_dstress(const RankTwoTensor & stress) const override;
+  void dstressparam_dstress(const RankTwoTensor & stress,
+                            std::vector<RankTwoTensor> & dsp) const override;
 
-  std::vector<RankFourTensor> d2stress_param_dstress(const RankTwoTensor & stress) const override;
+  void d2stressparam_dstress(const RankTwoTensor & stress,
+                             std::vector<RankFourTensor> & d2sp) const override;
 
   virtual void setStressAfterReturnV(const RankTwoTensor & stress_trial,
                                      const std::vector<Real> & stress_params,
@@ -101,4 +103,17 @@ protected:
                                           bool compute_full_tangent_operator,
                                           const std::vector<std::vector<Real>> & dvar_dtrial,
                                           RankFourTensor & cto) override;
+
+private:
+  /**
+   * this is d(stress_param[:])/d(stress) which is calculated by dstressparam_dstress.  Using this
+   * mutable means repeated allocation/deallocation is unnecessary.
+   */
+  mutable std::vector<RankTwoTensor> _dsp_trial_scratch;
+
+  /**
+   * eigenvalues of the stress, used in dstressparam_dstress and preReturnMapV.  Using this mutable
+   * means repeated allocation/deallocation is unnecessary.
+   */
+  mutable std::vector<Real> _eigvals_scratch;
 };

--- a/modules/solid_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
+++ b/modules/solid_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
@@ -332,4 +332,23 @@ protected:
    * @return d2(q)/d(stress)/d(stress)
    */
   virtual RankFourTensor d2qdstress2(const RankTwoTensor & stress) const = 0;
+
+private:
+  /**
+   * d(stress_param[:])/d(stress) used in dstressparam_dstress
+   * to avoid repeatedly allocating/deallocating this vector
+   */
+  mutable std::vector<RankTwoTensor> _dsp_scratch;
+
+  /**
+   * d(stress_param[:])/d(stress_trial) used in dstressparam_dstress
+   * to avoid repeatedly allocating/deallocating this vector
+   */
+  mutable std::vector<RankTwoTensor> _dsp_trial_scratch;
+
+  /**
+   * d2(stress_param[:])/d(stress)/d(stress)  used in d2stressparam_dstress
+   * to avoid repeatedly allocating/deallocating this vector
+   */
+  mutable std::vector<RankFourTensor> _d2sp_scratch;
 };

--- a/modules/solid_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
+++ b/modules/solid_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
@@ -248,13 +248,12 @@ protected:
                              const RankFourTensor & Eijkl,
                              RankTwoTensor & stress) const override;
 
-  void
-  setInelasticStrainIncrementAfterReturn(const RankTwoTensor & stress_trial,
-                                         Real gaE,
-                                         const yieldAndFlow & smoothed_q,
-                                         const RankFourTensor & elasticity_tensor,
-                                         const RankTwoTensor & returned_stress,
-                                         RankTwoTensor & inelastic_strain_increment) const override;
+  void setInelasticStrainIncrementAfterReturn(const RankTwoTensor & stress_trial,
+                                              Real gaE,
+                                              const yieldAndFlow & smoothed_q,
+                                              const RankFourTensor & elasticity_tensor,
+                                              const RankTwoTensor & returned_stress,
+                                              RankTwoTensor & inelastic_strain_increment) override;
 
   /**
    * Calculates the consistent tangent operator.
@@ -298,10 +297,10 @@ protected:
                                   const std::vector<std::vector<Real>> & dvar_dtrial,
                                   RankFourTensor & cto) override;
 
-  virtual std::vector<RankTwoTensor>
-  dstress_param_dstress(const RankTwoTensor & stress) const override;
-  virtual std::vector<RankFourTensor>
-  d2stress_param_dstress(const RankTwoTensor & stress) const override;
+  virtual void dstressparam_dstress(const RankTwoTensor & stress,
+                                    std::vector<RankTwoTensor> & dsp) const override;
+  virtual void d2stressparam_dstress(const RankTwoTensor & stress,
+                                     std::vector<RankFourTensor> & d2sp) const override;
   /**
    * d(p)/d(stress)
    * Derived classes must override this

--- a/modules/solid_mechanics/src/materials/CappedMohrCoulombCosseratStressUpdate.C
+++ b/modules/solid_mechanics/src/materials/CappedMohrCoulombCosseratStressUpdate.C
@@ -36,7 +36,8 @@ CappedMohrCoulombCosseratStressUpdate::CappedMohrCoulombCosseratStressUpdate(
     _host_young(getParam<Real>("host_youngs_modulus")),
     _host_poisson(getParam<Real>("host_poissons_ratio")),
     _host_E0011(_host_young * _host_poisson / (1.0 + _host_poisson) / (1.0 - 2.0 * _host_poisson)),
-    _host_E0000(_host_E0011 + _host_young / (1.0 + _host_poisson))
+    _host_E0000(_host_E0011 + _host_young / (1.0 + _host_poisson)),
+    _eigvals_scratch(_tensor_dimensionality)
 {
 }
 
@@ -48,8 +49,10 @@ CappedMohrCoulombCosseratStressUpdate::preReturnMapV(
     const std::vector<Real> & /*yf*/,
     const RankFourTensor & /*Eijkl*/)
 {
-  std::vector<Real> eigvals;
-  stress_trial.symmetricEigenvaluesEigenvectors(eigvals, _eigvecs);
+  mooseAssert(
+      _eigvals_scratch.size() == _tensor_dimensionality,
+      "_eigvals_scratch incorrectly sized in CappedMohCoulombCosseratStressUpdate::preReturnMapV");
+  stress_trial.symmetricEigenvaluesEigenvectors(_eigvals_scratch, _eigvecs);
   _poissons_ratio = _host_poisson;
 }
 

--- a/modules/solid_mechanics/src/materials/CappedMohrCoulombStressUpdate.C
+++ b/modules/solid_mechanics/src/materials/CappedMohrCoulombStressUpdate.C
@@ -93,6 +93,10 @@ void
 CappedMohrCoulombStressUpdate::d2stressparam_dstress(const RankTwoTensor & stress,
                                                      std::vector<RankFourTensor> & d2sp) const
 {
+  /*
+   * This function is not used but is included here in case a derived class needs it.
+   * The reason it is unused is because consistentTangentOperatorV is optimised
+   */
   mooseAssert(d2sp.size() == 3,
               "CappedMohrCoulombStressUpdate: d2sp incorrectly sized in d2stressparam_dstress");
   stress.d2symmetricEigenvalues(d2sp);

--- a/modules/solid_mechanics/src/materials/CappedMohrCoulombStressUpdate.C
+++ b/modules/solid_mechanics/src/materials/CappedMohrCoulombStressUpdate.C
@@ -58,7 +58,11 @@ CappedMohrCoulombStressUpdate::CappedMohrCoulombStressUpdate(const InputParamete
     _perfect_guess(getParam<bool>("perfect_guess")),
     _poissons_ratio(0.0),
     _shifter(_f_tol),
-    _eigvecs(RankTwoTensor())
+    _eigvecs(RankTwoTensor()),
+    _dsp_trial_scratch(3),
+    _eigvals_scratch(_tensor_dimensionality),
+    _dga_shear_scratch(3),
+    _dshear_correction_scratch(3)
 {
   if (_psi.value(0.0) <= 0.0 || _psi.value(0.0) > _phi.value(0.0))
     mooseWarning("Usually the Mohr-Coulomb dilation angle is positive and not greater than the "
@@ -73,21 +77,25 @@ CappedMohrCoulombStressUpdate::computeStressParams(const RankTwoTensor & stress,
   stress.symmetricEigenvalues(stress_params);
 }
 
-std::vector<RankTwoTensor>
-CappedMohrCoulombStressUpdate::dstress_param_dstress(const RankTwoTensor & stress) const
+void
+CappedMohrCoulombStressUpdate::dstressparam_dstress(const RankTwoTensor & stress,
+                                                    std::vector<RankTwoTensor> & dsp) const
 {
-  std::vector<Real> sp;
-  std::vector<RankTwoTensor> dsp;
-  stress.dsymmetricEigenvalues(sp, dsp);
-  return dsp;
+  mooseAssert(dsp.size() == 3,
+              "CappedMohrCoulombStressUpdate: dsp incorrectly sized in dstressparam_dstress");
+  mooseAssert(
+      _eigvals_scratch.size() == _tensor_dimensionality,
+      "_eigvals_scratch incorrectly sized in CappedMohrCoulombStressUpdate:dstressparam_dstress");
+  stress.dsymmetricEigenvalues(_eigvals_scratch, dsp);
 }
 
-std::vector<RankFourTensor>
-CappedMohrCoulombStressUpdate::d2stress_param_dstress(const RankTwoTensor & stress) const
+void
+CappedMohrCoulombStressUpdate::d2stressparam_dstress(const RankTwoTensor & stress,
+                                                     std::vector<RankFourTensor> & d2sp) const
 {
-  std::vector<RankFourTensor> d2;
-  stress.d2symmetricEigenvalues(d2);
-  return d2;
+  mooseAssert(d2sp.size() == 3,
+              "CappedMohrCoulombStressUpdate: d2sp incorrectly sized in d2stressparam_dstress");
+  stress.d2symmetricEigenvalues(d2sp);
 }
 
 void
@@ -97,8 +105,9 @@ CappedMohrCoulombStressUpdate::preReturnMapV(const std::vector<Real> & /*trial_s
                                              const std::vector<Real> & /*yf*/,
                                              const RankFourTensor & Eijkl)
 {
-  std::vector<Real> eigvals;
-  stress_trial.symmetricEigenvaluesEigenvectors(eigvals, _eigvecs);
+  mooseAssert(_eigvals_scratch.size() == _tensor_dimensionality,
+              "_eigvals_scratch incorrectly sized in CappedMohrCoulombStressUpdate:preReturnMapV");
+  stress_trial.symmetricEigenvaluesEigenvectors(_eigvals_scratch, _eigvecs);
   _poissons_ratio = ElasticityTensorTools::getIsotropicPoissonsRatio(Eijkl);
 }
 
@@ -767,11 +776,15 @@ CappedMohrCoulombStressUpdate::setIntnlDerivativesV(const std::vector<Real> & tr
   const Real trial_smax = trial_stress_params[2]; // largest eigenvalue
   const Real trial_smin = trial_stress_params[0]; // smallest eigenvalue
   const Real ga_shear = ((trial_smax - trial_smin) - (smax - smin)) / (_Eij[2][2] - _Eij[0][2]);
-  const std::vector<Real> dga_shear = {
-      1.0 / (_Eij[2][2] - _Eij[0][2]), 0.0, -1.0 / (_Eij[2][2] - _Eij[0][2])};
+  mooseAssert(
+      _dga_shear_scratch.size() == 3,
+      "_dga_shear_scratch incorrectly sized in CappedMohrCoulombStressUpdate:setIntnlDerivativesV");
+  _dga_shear_scratch[0] = 1.0 / (_Eij[2][2] - _Eij[0][2]);
+  _dga_shear_scratch[1] = 0.0;
+  _dga_shear_scratch[2] = -1.0 / (_Eij[2][2] - _Eij[0][2]);
   // intnl[0] = intnl_old[0] + ga_shear;
   for (std::size_t i = 0; i < _num_sp; ++i)
-    dintnl[0][i] = dga_shear[i];
+    dintnl[0][i] = _dga_shear_scratch[i];
 
   const Real sinpsi = std::sin(_psi.value(intnl[0]));
   const Real dsinpsi_di0 = _psi.derivative(intnl[0]) * std::cos(_psi.value(intnl[0]));
@@ -779,15 +792,18 @@ CappedMohrCoulombStressUpdate::setIntnlDerivativesV(const std::vector<Real> & tr
   const Real prefactor = (_Eij[2][2] + _Eij[0][2]) * sinpsi;
   const Real dprefactor_di0 = (_Eij[2][2] + _Eij[0][2]) * dsinpsi_di0;
   // const Real shear_correction = prefactor * ga_shear;
-  std::vector<Real> dshear_correction(_num_sp);
+  mooseAssert(_dshear_correction_scratch.size() == 3,
+              "_dshear_correction_scratch incorrectly sized in "
+              "CappedMohrCoulombStressUpdate:setIntnlDerivativesV");
   for (std::size_t i = 0; i < _num_sp; ++i)
-    dshear_correction[i] = prefactor * dga_shear[i] + dprefactor_di0 * dintnl[0][i] * ga_shear;
+    _dshear_correction_scratch[i] =
+        prefactor * _dga_shear_scratch[i] + dprefactor_di0 * dintnl[0][i] * ga_shear;
   // const Real ga_tensile = (1 - _poissons_ratio) * ((trial_smax + trial_smin) - (smax + smin) -
   // shear_correction) /
   // _Eij[2][2];
   // intnl[1] = intnl_old[1] + ga_tensile;
   for (std::size_t i = 0; i < _num_sp; ++i)
-    dintnl[1][i] = -(1.0 - _poissons_ratio) * dshear_correction[i] / _Eij[2][2];
+    dintnl[1][i] = -(1.0 - _poissons_ratio) * _dshear_correction_scratch[i] / _Eij[2][2];
   dintnl[1][2] += -(1.0 - _poissons_ratio) / _Eij[2][2];
   dintnl[1][0] += -(1.0 - _poissons_ratio) / _Eij[2][2];
 }
@@ -842,7 +858,7 @@ CappedMohrCoulombStressUpdate::consistentTangentOperatorV(
                 drot_dstress(i, a, k, l) * stress_params[a] * eT(a, j) +
                 _eigvecs(i, a) * stress_params[a] * drot_dstress(j, a, k, l);
 
-  const std::vector<RankTwoTensor> dsp_trial = dstress_param_dstress(stress_trial);
+  dstressparam_dstress(stress_trial, _dsp_trial_scratch);
   for (unsigned i = 0; i < _tensor_dimensionality; ++i)
     for (unsigned j = 0; j < _tensor_dimensionality; ++j)
       for (unsigned k = 0; k < _tensor_dimensionality; ++k)
@@ -850,7 +866,7 @@ CappedMohrCoulombStressUpdate::consistentTangentOperatorV(
           for (unsigned a = 0; a < _num_sp; ++a)
             for (unsigned b = 0; b < _num_sp; ++b)
               dstress_dtrial(i, j, k, l) +=
-                  _eigvecs(i, a) * dvar_dtrial[a][b] * dsp_trial[b](k, l) * eT(a, j);
+                  _eigvecs(i, a) * dvar_dtrial[a][b] * _dsp_trial_scratch[b](k, l) * eT(a, j);
 
   cto = dstress_dtrial * elasticity_tensor;
 }

--- a/modules/solid_mechanics/src/materials/TensileStressUpdate.C
+++ b/modules/solid_mechanics/src/materials/TensileStressUpdate.C
@@ -63,6 +63,10 @@ void
 TensileStressUpdate::d2stressparam_dstress(const RankTwoTensor & stress,
                                            std::vector<RankFourTensor> & d2sp) const
 {
+  /*
+   * This function is not used but is included here in case a derived class needs it.
+   * The reason it is unused is because consistentTangentOperatorV is optimised
+   */
   mooseAssert(d2sp.size() == 3,
               "TensileStressUpdate: d2sp incorrectly sized in d2stressparam_dstress");
   stress.d2symmetricEigenvalues(d2sp);

--- a/modules/solid_mechanics/src/materials/TensileStressUpdate.C
+++ b/modules/solid_mechanics/src/materials/TensileStressUpdate.C
@@ -34,7 +34,9 @@ TensileStressUpdate::TensileStressUpdate(const InputParameters & parameters)
   : MultiParameterPlasticityStressUpdate(parameters, 3, 3, 1),
     _strength(getUserObject<SolidMechanicsHardeningModel>("tensile_strength")),
     _perfect_guess(getParam<bool>("perfect_guess")),
-    _eigvecs(RankTwoTensor())
+    _eigvecs(RankTwoTensor()),
+    _dsp_trial_scratch(3),
+    _eigvals_scratch(_tensor_dimensionality)
 {
 }
 
@@ -46,21 +48,24 @@ TensileStressUpdate::computeStressParams(const RankTwoTensor & stress,
   stress.symmetricEigenvalues(stress_params);
 }
 
-std::vector<RankTwoTensor>
-TensileStressUpdate::dstress_param_dstress(const RankTwoTensor & stress) const
+void
+TensileStressUpdate::dstressparam_dstress(const RankTwoTensor & stress,
+                                          std::vector<RankTwoTensor> & dsp) const
 {
-  std::vector<Real> sp;
-  std::vector<RankTwoTensor> dsp;
-  stress.dsymmetricEigenvalues(sp, dsp);
-  return dsp;
+  mooseAssert(dsp.size() == 3,
+              "TensileStressUpdate: dsp incorrectly sized in dstressparam_dstress");
+  mooseAssert(_eigvals_scratch.size() == _tensor_dimensionality,
+              "_eigvals_scratch incorrectly sized in TensileStressUpdate:dstressparam_dstress");
+  stress.dsymmetricEigenvalues(_eigvals_scratch, dsp);
 }
 
-std::vector<RankFourTensor>
-TensileStressUpdate::d2stress_param_dstress(const RankTwoTensor & stress) const
+void
+TensileStressUpdate::d2stressparam_dstress(const RankTwoTensor & stress,
+                                           std::vector<RankFourTensor> & d2sp) const
 {
-  std::vector<RankFourTensor> d2;
-  stress.d2symmetricEigenvalues(d2);
-  return d2;
+  mooseAssert(d2sp.size() == 3,
+              "TensileStressUpdate: d2sp incorrectly sized in d2stressparam_dstress");
+  stress.d2symmetricEigenvalues(d2sp);
 }
 
 void
@@ -70,8 +75,9 @@ TensileStressUpdate::preReturnMapV(const std::vector<Real> & /*trial_stress_para
                                    const std::vector<Real> & /*yf*/,
                                    const RankFourTensor & /*Eijkl*/)
 {
-  std::vector<Real> eigvals;
-  stress_trial.symmetricEigenvaluesEigenvectors(eigvals, _eigvecs);
+  mooseAssert(_eigvals_scratch.size() == _tensor_dimensionality,
+              "_eigvals_scratch incorrectly sized in TensileStressUpdate:preReturnMapV");
+  stress_trial.symmetricEigenvaluesEigenvectors(_eigvals_scratch, _eigvecs);
 }
 
 void
@@ -270,7 +276,7 @@ TensileStressUpdate::consistentTangentOperatorV(const RankTwoTensor & stress_tri
                 drot_dstress(i, a, k, l) * stress_params[a] * eT(a, j) +
                 _eigvecs(i, a) * stress_params[a] * drot_dstress(j, a, k, l);
 
-  const std::vector<RankTwoTensor> dsp_trial = dstress_param_dstress(stress_trial);
+  dstressparam_dstress(stress_trial, _dsp_trial_scratch);
   for (unsigned i = 0; i < _tensor_dimensionality; ++i)
     for (unsigned j = 0; j < _tensor_dimensionality; ++j)
       for (unsigned k = 0; k < _tensor_dimensionality; ++k)
@@ -278,7 +284,7 @@ TensileStressUpdate::consistentTangentOperatorV(const RankTwoTensor & stress_tri
           for (unsigned a = 0; a < _num_sp; ++a)
             for (unsigned b = 0; b < _num_sp; ++b)
               dstress_dtrial(i, j, k, l) +=
-                  _eigvecs(i, a) * dvar_dtrial[a][b] * dsp_trial[b](k, l) * eT(a, j);
+                  _eigvecs(i, a) * dvar_dtrial[a][b] * _dsp_trial_scratch[b](k, l) * eT(a, j);
 
   cto = dstress_dtrial * elasticity_tensor;
 }

--- a/modules/solid_mechanics/src/materials/TwoParameterPlasticityStressUpdate.C
+++ b/modules/solid_mechanics/src/materials/TwoParameterPlasticityStressUpdate.C
@@ -280,26 +280,31 @@ TwoParameterPlasticityStressUpdate::setInelasticStrainIncrementAfterReturn(
     const yieldAndFlow & smoothed_q,
     const RankFourTensor & /*elasticity_tensor*/,
     const RankTwoTensor & returned_stress,
-    RankTwoTensor & inelastic_strain_increment) const
+    RankTwoTensor & inelastic_strain_increment)
 {
   inelastic_strain_increment = (gaE / _Epp) * (smoothed_q.dg[0] * dpdstress(returned_stress) +
                                                smoothed_q.dg[1] * dqdstress(returned_stress));
 }
 
-std::vector<RankTwoTensor>
-TwoParameterPlasticityStressUpdate::dstress_param_dstress(const RankTwoTensor & stress) const
+void
+TwoParameterPlasticityStressUpdate::dstressparam_dstress(const RankTwoTensor & stress,
+                                                         std::vector<RankTwoTensor> & dsp) const
 {
-  std::vector<RankTwoTensor> dsp(_num_pq, RankTwoTensor());
+  // _num_pq = _num_sp
+  mooseAssert(dsp.size() == _num_pq,
+              "TwoParameterPlasticityStressUpdate: dsp incorrectly sized in dstressparam_dstress");
   dsp[0] = dpdstress(stress);
   dsp[1] = dqdstress(stress);
-  return dsp;
 }
 
-std::vector<RankFourTensor>
-TwoParameterPlasticityStressUpdate::d2stress_param_dstress(const RankTwoTensor & stress) const
+void
+TwoParameterPlasticityStressUpdate::d2stressparam_dstress(const RankTwoTensor & stress,
+                                                          std::vector<RankFourTensor> & d2sp) const
 {
-  std::vector<RankFourTensor> d2(_num_pq, RankFourTensor());
-  d2[0] = d2pdstress2(stress);
-  d2[1] = d2qdstress2(stress);
-  return d2;
+  // _num_pq = _num_sp
+  mooseAssert(
+      d2sp.size() == _num_pq,
+      "TwoParameterPlasticityStressUpdate: d2sp incorrectly sized in d2stressparam_dstress");
+  d2sp[0] = d2pdstress2(stress);
+  d2sp[1] = d2qdstress2(stress);
 }

--- a/modules/solid_mechanics/test/include/materials/CappedWeakPlaneStressUpdate_PartiallyImplemented.h
+++ b/modules/solid_mechanics/test/include/materials/CappedWeakPlaneStressUpdate_PartiallyImplemented.h
@@ -1,0 +1,40 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "CappedWeakPlaneStressUpdate.h"
+
+/**
+ * Just like CappedWeakPlaneStressUpdate, but uses the base class,
+ * TwoParameterPlasticityStressUpdate::consistentTangentOperator
+ * instead of the optimised version found in CappedWeakPlaneStressUpdate.
+ * This is just to check that the base class implementation is
+ * correct, if a little compute-heavy.
+ */
+class CappedWeakPlaneStressUpdate_PartiallyImplemented : public CappedWeakPlaneStressUpdate
+{
+public:
+  static InputParameters validParams();
+
+  CappedWeakPlaneStressUpdate_PartiallyImplemented(const InputParameters & parameters);
+
+protected:
+  virtual void consistentTangentOperator(const RankTwoTensor & stress_trial,
+                                         Real p_trial,
+                                         Real q_trial,
+                                         const RankTwoTensor & stress,
+                                         Real p,
+                                         Real q,
+                                         Real gaE,
+                                         const yieldAndFlow & smoothed_q,
+                                         const RankFourTensor & Eijkl,
+                                         bool compute_full_tangent_operator,
+                                         RankFourTensor & cto) const override;
+};

--- a/modules/solid_mechanics/test/include/materials/TensileStressUpdate_PartiallyImplemented.h
+++ b/modules/solid_mechanics/test/include/materials/TensileStressUpdate_PartiallyImplemented.h
@@ -1,0 +1,39 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "TensileStressUpdate.h"
+
+/**
+ * Just like TensileStressUpdate, but uses the base class,
+ * MultiParameterPlasticityStressUpdate::consistentTangentOperatorV
+ * instead of the optimised version found in TensileStressUpdate.
+ * This is just to check that the base class implementation is
+ * correct, if a little compute-heavy.
+ */
+class TensileStressUpdate_PartiallyImplemented : public TensileStressUpdate
+{
+public:
+  static InputParameters validParams();
+
+  TensileStressUpdate_PartiallyImplemented(const InputParameters & parameters);
+
+protected:
+  virtual void consistentTangentOperatorV(const RankTwoTensor & stress_trial,
+                                          const std::vector<Real> & trial_stress_params,
+                                          const RankTwoTensor & stress,
+                                          const std::vector<Real> & stress_params,
+                                          Real gaE,
+                                          const yieldAndFlow & smoothed_q,
+                                          const RankFourTensor & Eijkl,
+                                          bool compute_full_tangent_operator,
+                                          const std::vector<std::vector<Real>> & dvar_dtrial,
+                                          RankFourTensor & cto) override;
+};

--- a/modules/solid_mechanics/test/src/materials/CappedWeakPlaneStressUpdate_PartiallyImplemented.C
+++ b/modules/solid_mechanics/test/src/materials/CappedWeakPlaneStressUpdate_PartiallyImplemented.C
@@ -1,0 +1,59 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "CappedWeakPlaneStressUpdate_PartiallyImplemented.h"
+
+#include "libmesh/utility.h"
+
+registerMooseObject("SolidMechanicsTestApp", CappedWeakPlaneStressUpdate_PartiallyImplemented);
+
+InputParameters
+CappedWeakPlaneStressUpdate_PartiallyImplemented::validParams()
+{
+  InputParameters params = CappedWeakPlaneStressUpdate::validParams();
+  params.addClassDescription(
+      "Physically, this is just CappedWeakPlaneStressUpdate, but the code uses "
+      "TwoParameterPlasticityStressUpdate::consistentTangentOperator instead of the optimised one "
+      "in CappedWeakPlaneStressUpdate.  The purpose is to show that the "
+      "TwoParameterPlasticityStressUpdate algorithm is correct, although slow.");
+  return params;
+}
+
+CappedWeakPlaneStressUpdate_PartiallyImplemented::CappedWeakPlaneStressUpdate_PartiallyImplemented(
+    const InputParameters & parameters)
+  : CappedWeakPlaneStressUpdate(parameters)
+{
+}
+
+void
+CappedWeakPlaneStressUpdate_PartiallyImplemented::consistentTangentOperator(
+    const RankTwoTensor & stress_trial,
+    Real p_trial,
+    Real q_trial,
+    const RankTwoTensor & stress,
+    Real p,
+    Real q,
+    Real gaE,
+    const yieldAndFlow & smoothed_q,
+    const RankFourTensor & Eijkl,
+    bool compute_full_tangent_operator,
+    RankFourTensor & cto) const
+{
+  TwoParameterPlasticityStressUpdate::consistentTangentOperator(stress_trial,
+                                                                p_trial,
+                                                                q_trial,
+                                                                stress,
+                                                                p,
+                                                                q,
+                                                                gaE,
+                                                                smoothed_q,
+                                                                Eijkl,
+                                                                compute_full_tangent_operator,
+                                                                cto);
+}

--- a/modules/solid_mechanics/test/src/materials/TensileStressUpdate_PartiallyImplemented.C
+++ b/modules/solid_mechanics/test/src/materials/TensileStressUpdate_PartiallyImplemented.C
@@ -1,0 +1,55 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "TensileStressUpdate_PartiallyImplemented.h"
+
+registerMooseObject("SolidMechanicsTestApp", TensileStressUpdate_PartiallyImplemented);
+
+InputParameters
+TensileStressUpdate_PartiallyImplemented::validParams()
+{
+  InputParameters params = TensileStressUpdate::validParams();
+  params.addClassDescription(
+      "Physically, this is just TensileStressUpdate, but the code uses "
+      "MultiParameterPlasticityStressUpdate::consistentTangentOperatorV instead of the optimised "
+      "algorithm found in TensileStressUpdate.  The purpose is to show that the "
+      "MultiParameterPlasticityStressUpdate algorithm is correct, although slow.");
+  return params;
+}
+
+TensileStressUpdate_PartiallyImplemented::TensileStressUpdate_PartiallyImplemented(
+    const InputParameters & parameters)
+  : TensileStressUpdate(parameters)
+{
+}
+
+void
+TensileStressUpdate_PartiallyImplemented::consistentTangentOperatorV(
+    const RankTwoTensor & stress_trial,
+    const std::vector<Real> & trial_stress_params,
+    const RankTwoTensor & stress,
+    const std::vector<Real> & stress_params,
+    Real gaE,
+    const yieldAndFlow & smoothed_q,
+    const RankFourTensor & elasticity_tensor,
+    bool compute_full_tangent_operator,
+    const std::vector<std::vector<Real>> & dvar_dtrial,
+    RankFourTensor & cto)
+{
+  MultiParameterPlasticityStressUpdate::consistentTangentOperatorV(stress_trial,
+                                                                   trial_stress_params,
+                                                                   stress,
+                                                                   stress_params,
+                                                                   gaE,
+                                                                   smoothed_q,
+                                                                   elasticity_tensor,
+                                                                   compute_full_tangent_operator,
+                                                                   dvar_dtrial,
+                                                                   cto);
+}

--- a/modules/solid_mechanics/test/tests/jacobian/tests
+++ b/modules/solid_mechanics/test/tests/jacobian/tests
@@ -388,6 +388,107 @@
       detail = 'cwp11'
     []
 
+    [cwp_partially_implemented_01]
+      type = 'PetscJacobianTester'
+      input = 'cwp01.i'
+      ratio_tol = 1E-7
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/mc/type=CappedWeakPlaneStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'cwp01_partially_implemented'
+    []
+    [cwp_partially_implemented_02]
+      type = 'PetscJacobianTester'
+      input = 'cwp02.i'
+      ratio_tol = 1E-7
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/mc/type=CappedWeakPlaneStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'cwp02_partially_implemented'
+    []
+    [cwp_partially_implemented_03]
+      type = 'PetscJacobianTester'
+      input = 'cwp03.i'
+      ratio_tol = 1E-7
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/mc/type=CappedWeakPlaneStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'cwp03_partially_implemented'
+    []
+    [cwp_partially_implemented_04]
+      type = 'PetscJacobianTester'
+      input = 'cwp04.i'
+      ratio_tol = 1E-7
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/mc/type=CappedWeakPlaneStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'cwp04_partially_implemented'
+    []
+    [cwp_partially_implemented_05]
+      type = 'PetscJacobianTester'
+      input = 'cwp05.i'
+      ratio_tol = 1E-7
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/mc/type=CappedWeakPlaneStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'cwp05_partially_implemented'
+    []
+    [cwp_partially_implemented_06]
+      type = 'PetscJacobianTester'
+      input = 'cwp06.i'
+      ratio_tol = 1E-7
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/mc/type=CappedWeakPlaneStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'cwp06_partially_implemented'
+    []
+    [cwp_partially_implemented_07]
+      type = 'PetscJacobianTester'
+      input = 'cwp07.i'
+      ratio_tol = 1E-7
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/mc/type=CappedWeakPlaneStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'cwp07_partially_implemented'
+    []
+    [cwp_partially_implemented_08]
+      type = 'PetscJacobianTester'
+      input = 'cwp08.i'
+      ratio_tol = 1E-7
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/mc/type=CappedWeakPlaneStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'cwp08_partially_implemented'
+    []
+    [cwp_partially_implemented_09]
+      type = 'PetscJacobianTester'
+      input = 'cwp09.i'
+      ratio_tol = 1E-7
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/mc/type=CappedWeakPlaneStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'cwp09_partially_implemented'
+    []
+    [cwp_partially_implemented_10]
+      type = 'PetscJacobianTester'
+      input = 'cwp10.i'
+      ratio_tol = 1E-7
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/mc/type=CappedWeakPlaneStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'cwp10_partially_implemented'
+    []
+    [cwp_partially_implemented_11]
+      type = 'PetscJacobianTester'
+      input = 'cwp11.i'
+      ratio_tol = 1E-7
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/mc/type=CappedWeakPlaneStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'cwp11_partially_implemented'
+    []
+
+
     [cwpc01]
       type = 'PetscJacobianTester'
       input = 'cwpc01.i'
@@ -520,6 +621,78 @@
       difference_tol = 1E10
       cli_args = 'Executioner/num_steps=1'
       detail = 'tensile_update8'
+    []
+    [tensile_partially_implemented_update1]
+      type = 'PetscJacobianTester'
+      input = 'tensile_update1.i'
+      ratio_tol = 1E-5
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/tensile/type=TensileStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'tensile_update1_partially_implemented'
+    []
+    [tensile_partially_implemented_update2]
+      type = 'PetscJacobianTester'
+      input = 'tensile_update2.i'
+      ratio_tol = 1E-5
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/tensile/type=TensileStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'tensile_update2_partially_implemented'
+    []
+    [tensile_partially_implemented_update3]
+      type = 'PetscJacobianTester'
+      input = 'tensile_update3.i'
+      ratio_tol = 1E-4
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/tensile/type=TensileStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'tensile_update3_partially_implemented'
+    []
+    [tensile_partially_implemented_update4]
+      type = 'PetscJacobianTester'
+      input = 'tensile_update4.i'
+      ratio_tol = 1E-4
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/tensile/type=TensileStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'tensile_update4_partially_implemented'
+    []
+    [tensile_partially_implemented_update5]
+      type = 'PetscJacobianTester'
+      input = 'tensile_update5.i'
+      ratio_tol = 1E-5
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/tensile/type=TensileStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'tensile_update5_partially_implemented'
+    []
+    [tensile_partially_implemented_update6]
+      type = 'PetscJacobianTester'
+      input = 'tensile_update5.i'
+      ratio_tol = 1E-5
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/tensile/type=TensileStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'tensile_update6_partially_implemented'
+    []
+    [tensile_partially_implemented_update7]
+      type = 'PetscJacobianTester'
+      input = 'tensile_update7.i'
+      ratio_tol = 1E-5
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/tensile/type=TensileStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'tensile_update7_partially_implemented'
+    []
+    [tensile_partially_implemented_update8]
+      type = 'PetscJacobianTester'
+      input = 'tensile_update8.i'
+      ratio_tol = 1E-4
+      difference_tol = 1E10
+      cli_args = 'Executioner/num_steps=1 Materials/tensile/type=TensileStressUpdate_PartiallyImplemented'
+      allow_test_objects = true
+      detail = 'tensile_update8_partially_implemented'
     []
 
     [mc_update1]


### PR DESCRIPTION
Created some stack variables to replace heap variables in plasticity algorithms.  A number of other heap variables should be put on stack to close the issue: this is a first-pass only.  Refs #32178

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
