### PR TITLE
Fix BMBB distributed mesh segmentation fault and unique ID

### DIFF
--- a/test/tests/constraints/equal_value_boundary_constraint/break_mesh_with_evbc.i
+++ b/test/tests/constraints/equal_value_boundary_constraint/break_mesh_with_evbc.i
@@ -1,28 +1,19 @@
-[Problem]
-  boundary_restricted_node_integrity_check = false
-[]
-
 [Mesh]
-  [fmg]
-    type = FileMeshGenerator
-    file = ../../meshgenerators/break_mesh_by_block_generator/4ElementJunction.e
+  [file]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 1
+    ny = 1
   []
-
-  [breakmesh]
-    type = BreakMeshByBlockGenerator
-    block_pairs = '2 4'
-    input = fmg
+  [mirror]
+    type = SymmetryTransformGenerator
+    input = file
+    mirror_point = "0 1 0"
+    mirror_normal_vector = "0 1 0"
   []
-
-  [add_surfaces]
-    type = SideSetsFromNormalsGenerator
-    input = breakmesh
-    normals = '0  1  0
-               1  0  0
-               0 -1  0
-              -1  0  0'
-    fixed_normal = true
-    new_boundary = 'y1 x1 y0 x0'
+  [cmbn]
+    type = CombinerGenerator
+    inputs = 'file mirror'
   []
 []
 
@@ -52,14 +43,14 @@
     type = DirichletBC
     variable = diffused
     preset = false
-    boundary = 'x0'
-    value = 1.0
+    boundary = 'left'
+    value = 0.0
   []
   [right]
     type = DirichletBC
     variable = diffused
     preset = false
-    boundary = 'x1'
+    boundary = 'right'
     value = 0.0
   []
 []
@@ -68,8 +59,8 @@
   [corner]
     type = EqualValueBoundaryConstraint
     variable = diffused
-    secondary_node_ids = '1 2 3 4 5 6'
-    primary_node_coord = '-0.5 0.5 0'
+    secondary_node_ids = '1 2 3 4 7 8'
+    primary_node_coord = '1 2 0'
     penalty = 10e6
   []
 []

--- a/test/tests/constraints/equal_value_boundary_constraint/tests
+++ b/test/tests/constraints/equal_value_boundary_constraint/tests
@@ -45,7 +45,7 @@
     type = RunException
     input = 'break_mesh_with_evbc.i'
     expect_err = "Multiple nodes found for the specified primary_node_coord."
-    cli_args = "Constraints/corner/primary_node_coord='0.5 0.5 0.0'"
+    cli_args = "Constraints/corner/primary_node_coord='1.0 1.0 0.0'"
     requirement = "The system shall report an error when multiple nodes are found for the specified node coordinates."
   []
 []

--- a/test/tests/meshgenerators/break_mesh_by_block_generator/break_mesh_2DJunction_splittrue.i
+++ b/test/tests/meshgenerators/break_mesh_by_block_generator/break_mesh_2DJunction_splittrue.i
@@ -7,7 +7,6 @@
   [./breakmesh]
     type = BreakMeshByBlockGenerator
     input = fmg
-    split_interface = true
   []
 []
 

--- a/test/tests/meshgenerators/break_mesh_by_block_generator/break_mesh_block_pairs_restricted.i
+++ b/test/tests/meshgenerators/break_mesh_by_block_generator/break_mesh_block_pairs_restricted.i
@@ -13,6 +13,5 @@
     type = BreakMeshByBlockGenerator
     block_pairs = '0 1;
                    2 3'
-    split_interface = true
   []
 []


### PR DESCRIPTION
* Fixed the segmentation fault caused by empty boundary ID on a processor
* Ensured unique ID consistency for the newly added nodes

ref #21161
ref #32091