### PR TITLE
Fix null pointer dereference when using the functor system with an `ExternalProblem`

### DIFF
--- a/framework/src/problems/ExternalProblem.C
+++ b/framework/src/problems/ExternalProblem.C
@@ -44,6 +44,9 @@ ExternalProblem::ExternalProblem(const InputParameters & parameters) : FEProblem
   }
   _aux = std::make_shared<AuxiliarySystem>(*this, "aux0");
 
+  // Set the current nonlinear system to the null system we created.
+  setCurrentNonlinearSystem(0);
+
   /**
    * We still need to create Assembly objects to hold the data structures for working with Aux
    * Variables, which will be used in the external problem.

--- a/test/tests/problems/external_problem/functors.i
+++ b/test/tests/problems/external_problem/functors.i
@@ -1,0 +1,48 @@
+[Mesh]
+  [m]
+    type = CartesianMeshGenerator
+    dim = 1
+    dx = '10.0'
+    ix = 2
+  []
+[]
+
+[AuxVariables]
+  [test]
+    family = MONOMIAL
+    order = CONSTANT
+  []
+[]
+
+[AuxKernels]
+  [test]
+    type = ParsedAux
+    variable = test
+    expression = 'x'
+    use_xyzt = true
+  []
+[]
+
+[Postprocessors]
+  [no_functor]
+    type = ElementIntegralVariablePostprocessor
+    variable = test
+  []
+  [functor]
+    type = ADElementIntegralFunctorPostprocessor
+    functor = test
+  []
+[]
+
+[Problem]
+  type = DummyExternalProblem
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 2
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/test/tests/problems/external_problem/gold/functors_out.csv
+++ b/test/tests/problems/external_problem/gold/functors_out.csv
@@ -1,0 +1,4 @@
+time,functor,no_functor
+0,0,0
+1,50,50
+2,50,50

--- a/test/tests/problems/external_problem/tests
+++ b/test/tests/problems/external_problem/tests
@@ -38,4 +38,12 @@
       cli_args = "AuxKernels/active='' Postprocessors/copy/variable=heat_source"
     []
   []
+  [external_functors]
+    type = 'CSVDiff'
+    input = 'functors.i'
+    csvdiff = 'functors_out.csv'
+    requirement = "The system shall support the use of functors in a code coupling interface."
+    design = "ExternalProblem.md"
+    issues = "#32185"
+  []
 []


### PR DESCRIPTION
This was a surprisingly easy 1-line fix.

Closes #32185
