### PR TITLE
Recover boundary elements in zero algebraic range explicit NEML2

### DIFF
--- a/framework/include/neml2/userobjects/NEML2ModelExecutor.h
+++ b/framework/include/neml2/userobjects/NEML2ModelExecutor.h
@@ -41,7 +41,6 @@ public:
   void finalize() override;
 
   void initialSetup() override;
-  void timestepSetup() override;
 
   /// Get the batch index for the given element ID
   std::size_t getBatchIndex(dof_id_type elem_id) const;

--- a/framework/include/neml2/userobjects/NEML2ModelExecutor.h
+++ b/framework/include/neml2/userobjects/NEML2ModelExecutor.h
@@ -92,7 +92,7 @@ protected:
   const NEML2BatchIndexGenerator & _batch_index_generator;
 
   /// Advance state on device (rather than via MOSOE material properties)
-  const bool _advance_step_on_device;
+  const bool _keep_tensors_on_device;
 
   /// Dump input tensor info on failure to aid debugging
   const bool _debug_inputs_on_failure;

--- a/framework/include/neml2/userobjects/NEML2ModelExecutor.h
+++ b/framework/include/neml2/userobjects/NEML2ModelExecutor.h
@@ -41,6 +41,7 @@ public:
   void finalize() override;
 
   void initialSetup() override;
+  void timestepSetup() override;
 
   /// Get the batch index for the given element ID
   std::size_t getBatchIndex(dof_id_type elem_id) const;
@@ -84,8 +85,17 @@ protected:
   /// Expand tensor shapes if necessary to conformal sizes
   virtual void expandInputs();
 
+  /// Update cached inputs/outputs for on-device state advance
+  void advanceDeviceCaches();
+
   /// The NEML2BatchIndexGenerator used to generate the element-to-batch-index map
   const NEML2BatchIndexGenerator & _batch_index_generator;
+
+  /// Advance state on device (rather than via MOSOE material properties)
+  const bool _advance_step_on_device;
+
+  /// Dump input tensor info on failure to aid debugging
+  const bool _debug_inputs_on_failure;
 
   /// flag that indicates if output data has been fully computed
   bool _output_ready;
@@ -98,6 +108,12 @@ protected:
 
   /// The output variables of the material model
   neml2::ValueMap _out;
+
+  /// Cached state outputs from the last successful step (for on-device advance)
+  neml2::ValueMap _device_state_cache;
+
+  /// Cached force inputs from the last successful step (for on-device advance)
+  neml2::ValueMap _device_forces_cache;
 
   /// The derivative of the output variables w.r.t. the input variables
   neml2::DerivMap _dout_din;

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -648,14 +648,10 @@ getUnion(const std::vector<T> & vector1, const std::vector<T> & vector2, std::ve
 {
   std::unordered_set<T> unique_elements;
   unique_elements.reserve(vector1.size() + vector2.size());
-
-  for (const T & entry : vector1)
-    unique_elements.insert(entry);
-  for (const T & entry : vector2)
-    unique_elements.insert(entry);
+  unique_elements.insert(vector1.begin(), vector1.end());
+  unique_elements.insert(vector2.begin(), vector2.end());
 
   // Now populate the common vector with the union
-  common.clear();
   common.assign(unique_elements.begin(), unique_elements.end());
 }
 

--- a/framework/src/neml2/userobjects/NEML2ModelExecutor.C
+++ b/framework/src/neml2/userobjects/NEML2ModelExecutor.C
@@ -194,13 +194,6 @@ NEML2ModelExecutor::initialSetup()
   }
 }
 
-void
-NEML2ModelExecutor::timestepSetup()
-{
-  if (_keep_tensors_on_device)
-    return;
-}
-
 std::size_t
 NEML2ModelExecutor::getBatchIndex(dof_id_type elem_id) const
 {

--- a/modules/solid_mechanics/include/timeintegrators/NEML2CentralDifference.h
+++ b/modules/solid_mechanics/include/timeintegrators/NEML2CentralDifference.h
@@ -36,7 +36,7 @@ protected:
 
 private:
   /// Empty element vector to help zero out the algebraic range
-  std::vector<const Elem *> _no_elem = {};
+  std::vector<const Elem *> _boundary_elements = {};
 
   /// Empty node vector to help zero out the algebraic range
   std::vector<const Node *> _no_node = {};

--- a/modules/solid_mechanics/include/timeintegrators/NEML2CentralDifference.h
+++ b/modules/solid_mechanics/include/timeintegrators/NEML2CentralDifference.h
@@ -36,7 +36,7 @@ protected:
 
 private:
   /// Empty element vector to help zero out the algebraic range
-  std::vector<const Elem *> _boundary_elements = {};
+  std::vector<const Elem *> _boundary_elems = {};
 
   /// Empty node vector to help zero out the algebraic range
   std::vector<const Node *> _no_node = {};

--- a/modules/solid_mechanics/include/timeintegrators/NEML2CentralDifference.h
+++ b/modules/solid_mechanics/include/timeintegrators/NEML2CentralDifference.h
@@ -23,10 +23,12 @@ public:
   NEML2CentralDifference(const InputParameters & parameters);
 
   void initialSetup() override;
+  void meshChanged() override;
   void postSolve() override;
 
 protected:
   void evaluateRHSResidual() override;
+  void rebuildBoundaryElementList();
 
   /// The assembly object with cached assembly information
   NEML2Assembly * _neml2_assembly = nullptr;
@@ -40,6 +42,9 @@ private:
 
   /// Empty node vector to help zero out the algebraic range
   std::vector<const Node *> _no_node = {};
+
+  /// Whether the cached boundary element list needs rebuilding
+  bool _boundary_elems_dirty = true;
 };
 
 #endif // NEML2_ENABLED

--- a/modules/solid_mechanics/src/timeintegrators/NEML2CentralDifference.C
+++ b/modules/solid_mechanics/src/timeintegrators/NEML2CentralDifference.C
@@ -7,6 +7,9 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
+#include "MooseTypes.h"
+#include "IntegratedBCBase.h"
+
 #ifdef NEML2_ENABLED
 
 // MOOSE includes
@@ -35,6 +38,27 @@ NEML2CentralDifference::NEML2CentralDifference(const InputParameters & parameter
 void
 NEML2CentralDifference::initialSetup()
 {
+  // build boundary element list by iterating over all integrated BCs
+  const auto & ibcs = _nl->getIntegratedBCWarehouse();
+  std::unordered_set<BoundaryID> bnds;
+  for (const auto & ibc : ibcs.getObjects())
+    bnds.insert(ibc->boundaryIDs().begin(), ibc->boundaryIDs().end());
+
+  if (!bnds.empty())
+  {
+    mooseInfo("Dectected BCs on ", bnds.size(), " boundaries.");
+
+    // deduplicate elements that have multiple boundaries
+    std::unordered_set<const Elem *> unique_elems;
+    const auto end = _fe_problem.mesh().bndElemsEnd();
+    for (auto it = _fe_problem.mesh().bndElemsBegin(); it != end; ++it)
+      if (bnds.find((*it)->_bnd_id) != bnds.end())
+        unique_elems.insert((*it)->_elem);
+
+    _boundary_elems.assign(unique_elems.begin(), unique_elems.end());
+    mooseInfo("Adding ", _boundary_elems.size(), " elements to the algebraic range.");
+  }
+
   ExplicitMixedOrder::initialSetup();
   _neml2_assembly = &_fe_problem.getUserObject<NEML2Assembly>("assembly", /*tid=*/0);
   _fe = &_fe_problem.getUserObject<NEML2FEInterpolation>("fe", /*tid=*/0);
@@ -52,8 +76,8 @@ NEML2CentralDifference::evaluateRHSResidual()
 {
   if (_fe->contextUpToDate() && _neml2_assembly->upToDate())
   {
-    libMesh::ConstElemRange null_elem_range(&_no_elem);
-    _fe_problem.setCurrentAlgebraicElementRange(&null_elem_range);
+    libMesh::ConstElemRange boundary_elem_range(&_boundary_elems);
+    _fe_problem.setCurrentAlgebraicElementRange(&boundary_elem_range);
 
     libMesh::ConstNodeRange null_node_range(&_no_node);
     _fe_problem.setCurrentAlgebraicNodeRange(&null_node_range);

--- a/modules/solid_mechanics/test/tests/neml2/plasticity/tests
+++ b/modules/solid_mechanics/test/tests/neml2/plasticity/tests
@@ -11,6 +11,19 @@
       capabilities = 'neml2'
       valgrind = heavy
     []
+    [perfect_advance_on_device]
+      detail = 'perfect plasticity with state advanced on the compute device, '
+      type = Exodiff
+      input = 'perfect.i'
+      exodiff = 'perfect_out.e'
+      capabilities = 'neml2'
+      valgrind = heavy
+      cli_args = "NEML2/all/advance_step_on_device=true
+                  NEML2/all/moose_input_types = 'MATERIAL     POSTPROCESSOR'
+                  NEML2/all/moose_inputs = '     neml2_strain time         '
+                  NEML2/all/neml2_inputs = '     forces/E     forces/t     '
+      "
+    []
     [isoharden]
       detail = 'isotropic hardening, '
       type = Exodiff

--- a/modules/solid_mechanics/test/tests/neml2/plasticity/tests
+++ b/modules/solid_mechanics/test/tests/neml2/plasticity/tests
@@ -11,18 +11,14 @@
       capabilities = 'neml2'
       valgrind = heavy
     []
-    [perfect_advance_on_device]
-      detail = 'perfect plasticity with state advanced on the compute device, '
+    [perfect_keep_tensors_on_device]
+      detail = 'perfect plasticity with tensors kept on the compute device, '
       type = Exodiff
       input = 'perfect.i'
       exodiff = 'perfect_out.e'
       capabilities = 'neml2'
       valgrind = heavy
-      cli_args = "NEML2/all/advance_step_on_device=true
-                  NEML2/all/moose_input_types = 'MATERIAL     POSTPROCESSOR'
-                  NEML2/all/moose_inputs = '     neml2_strain time         '
-                  NEML2/all/neml2_inputs = '     forces/E     forces/t     '
-      "
+      cli_args = "NEML2/all/keep_tensors_on_device=true NEML2/all/moose_input_types='MATERIAL POSTPROCESSOR' NEML2/all/moose_inputs='neml2_strain time' NEML2/all/neml2_inputs='forces/E forces/t'"
     []
     [isoharden]
       detail = 'isotropic hardening, '


### PR DESCRIPTION
## Reason
In #30853 we introduced a capability to offload residual calculations to NEML2 for fast explicit dynamics simulations (`NEML2CentralDifference`). This works by clearing the algebraic range (the list of elements initialized and processed by MOOSE). However this effectively disables calculation of integrated boundary conditions.

Also, for stateful materials we should advance the state from current -> old on device, without the roundtrip via MOOSE materials (which we added to ensure correct restepping / failed timestep rollback). We're not going to evaluate the materials with a cleared out algebraic range, and this would add substantial overhead.

## Design
Use the integrated boundary condition warehouse to compile a list of all boundaries which have BCs applied. Then filter the boundary element range to get all elements touching one of those boundaries and add them back to the algebraic range.

Add an option to retain state on device to minimize communication.

## Impact
Integrated BCs are available again with NEML2 residual calculation, stateful property support for `NEML2CentralDifference`.