### PR TITLE
Support index type selection and optimize index calculation in Kokkos arrays

### DIFF
--- a/framework/doc/content/syntax/Kokkos/index.md
+++ b/framework/doc/content/syntax/Kokkos/index.md
@@ -26,12 +26,15 @@ Standard containers such as `std::vector`, `std::set`, `std::map` and others are
 Basically, it is safe to assume that any dynamically-allocated data on CPU cannot be accessed on GPU.
 Therefore, we provide alternative data containers to be used on GPU: `Moose::Kokkos::Array`, `Moose::Kokkos::JaggedArray`, and `Moose::Kokkos::Map`.
 
-`Moose::Kokkos::Array` is a template class and designed to hold arbitrary type of data.
-It receives three template arguments: data type, dimension, and layout type.
+`Moose::Kokkos::Array` is a template class designed to hold arbitrary type of data.
+It receives up to four template arguments: data type, dimension, index type, and layout type.
 It supports multi-dimensional indexing, and up to five-dimensional arrays are supported.
 The dimension can either be specified through the second template argument with the default being one-dimension or using type aliases: for instance, a three-dimensional array of type `double` can be declared either by `Array<double, 3>` or `Array3D<double>`.
 The entries of an array can be accessed with either `operator()` with multi-dimensional indices or `operator[]` with a flattened, dimensionless index, where the flattening follows a layout in which the innermost dimension varies the fastest.
-If having the outermost dimension run the fastest is desired for multi-dimensional arrays, the third layout template argument can be optionally set to `Moose::Kokkos::LayoutType::RIGHT` (default is `LEFT`).
+The index type template argument is set to 8-byte integer by default to accomodate large arrays.
+However, 8-byte integer computation is significantly more expensive than 4-byte integer computation.
+If your array size is small enough, consider using 4-byte indices to optimize index calculations.
+If having the outermost dimension run the fastest is desired for multi-dimensional arrays, the fourth layout template argument can be optionally set to `Moose::Kokkos::LayoutType::RIGHT` (default is `LEFT`).
 They automatically return either CPU or GPU data depending on where they are being accessed.
 Arrays can be allocated through the following APIs: `create()`, `createHost()`, and `createDevice()`.
 `create()` allocates memories on both CPU and GPU, while `createHost()` or `createDevice()` only allocates memory on either CPU or GPU.
@@ -135,7 +138,7 @@ Therefore, `Moose::Kokkos::JaggedArray` stores the data of a jagged array sequen
 It is divided into inner and outer arrays.
 The outer array is the regular part of a jagged array.
 Each entry of the outer array is the inner array, whose size can vary with each other.
-As a result, it is defined with four template arguments: the data type, inner array dimension size, outer array dimension size, and inner array layout type (defaults to `Moose::Kokkos::LayoutType::LEFT`).
+As a result, it is defined with up to five template arguments: the data type, inner array dimension size, outer array dimension size, outer array index type (defaults to 8-byte integer; inner arrays always use 4-byte integer), and inner array layout type (defaults to `Moose::Kokkos::LayoutType::LEFT`).
 Both inner and outer arrays can be up to three-dimensional.
 However, it is not possible to have inner arrays with different dimensions in a single jagged array.
 

--- a/framework/src/kokkos/base/KokkosArray.K
+++ b/framework/src/kokkos/base/KokkosArray.K
@@ -23,25 +23,24 @@ free(void * ptr)
   ::Kokkos::kokkos_free<ExecSpace::memory_space>(ptr);
 }
 
-template <>
-template <>
+template <typename T, typename index_type>
 void
-Array<Real, 1, LayoutType::LEFT>::axby<Real>(const Real a,
-                                             const Array<Real, 1, LayoutType::LEFT> & x,
-                                             const char op,
-                                             const Real b,
-                                             const Array<Real, 1, LayoutType::LEFT> & y,
-                                             const bool accumulate)
+Array<T, 1, index_type, LayoutType::LEFT>::axby(const T a,
+                                                const Array<T, 1, index_type, LayoutType::LEFT> & x,
+                                                const char op,
+                                                const T b,
+                                                const Array<T, 1, index_type, LayoutType::LEFT> & y,
+                                                const bool accumulate)
 {
-  if (!isDeviceAlloc() || !x.isDeviceAlloc() || !y.isDeviceAlloc())
+  if (!this->isDeviceAlloc() || !x.isDeviceAlloc() || !y.isDeviceAlloc())
     mooseError("Kokkos array error: all arrays for axby() should be on device.");
 
-  if (!(size() == x.size() && (x.size() == y.size())))
+  if (!(this->size() == x.size() && (x.size() == y.size())))
     mooseError("Kokkos array error: all arrays for axby() should have the same size.");
 
-  ::Kokkos::RangePolicy<ExecSpace, ::Kokkos::IndexType<ThreadID>> policy(0, size());
+  ::Kokkos::RangePolicy<ExecSpace, ::Kokkos::IndexType<ThreadID>> policy(0, this->size());
 
-  auto data = deviceData();
+  auto data = this->deviceData();
 
   switch (op)
   {
@@ -88,68 +87,67 @@ Array<Real, 1, LayoutType::LEFT>::axby<Real>(const Real a,
   ::Kokkos::fence();
 }
 
-template <>
-template <>
+template <typename T, typename index_type>
 void
-Array<Real, 1, LayoutType::LEFT>::scal<Real>(const Real a,
-                                             const Array<Real, 1, LayoutType::LEFT> & x)
+Array<T, 1, index_type, LayoutType::LEFT>::scal(const T a,
+                                                const Array<T, 1, index_type, LayoutType::LEFT> & x)
 {
-  if (!isDeviceAlloc() || !x.isDeviceAlloc())
+  if (!this->isDeviceAlloc() || !x.isDeviceAlloc())
     mooseError("Kokkos array error: all arrays for scal() should be on device.");
 
-  if (size() != x.size())
+  if (this->size() != x.size())
     mooseError("Kokkos array error: all arrays for scal() should have the same size.");
 
-  ::Kokkos::View<Real *, MemSpace, ::Kokkos::MemoryTraits<::Kokkos::Unmanaged>> self(deviceData(),
-                                                                                     size());
-  ::Kokkos::View<Real *, MemSpace, ::Kokkos::MemoryTraits<::Kokkos::Unmanaged>> other(
-      x.deviceData(), x.size());
+  ::Kokkos::View<T *, MemSpace, ::Kokkos::MemoryTraits<::Kokkos::Unmanaged>> self(
+      this->deviceData(), this->size());
+  ::Kokkos::View<T *, MemSpace, ::Kokkos::MemoryTraits<::Kokkos::Unmanaged>> other(x.deviceData(),
+                                                                                   x.size());
 
   KokkosBlas::scal(self, a, other);
 }
 
-template <>
-template <>
+template <typename T, typename index_type>
 void
-Array<Real, 1, LayoutType::LEFT>::scal<Real>(const Real a)
+Array<T, 1, index_type, LayoutType::LEFT>::scal(const T a)
 {
   return scal(a, *this);
 }
 
-template <>
-template <>
-Real
-Array<Real, 1, LayoutType::LEFT>::dot<Real>(const Array<Real, 1, LayoutType::LEFT> & x)
+template <typename T, typename index_type>
+T
+Array<T, 1, index_type, LayoutType::LEFT>::dot(const Array<T, 1, index_type, LayoutType::LEFT> & x)
 {
-  if (!isDeviceAlloc() || !x.isDeviceAlloc())
+  if (!this->isDeviceAlloc() || !x.isDeviceAlloc())
     mooseError("Kokkos array error: all arrays for dot() should be on device.");
 
-  if (size() != x.size())
+  if (this->size() != x.size())
     mooseError("Kokkos array error: all arrays for dot() should have the same size.");
 
-  ::Kokkos::View<Real *, MemSpace, ::Kokkos::MemoryTraits<::Kokkos::Unmanaged>> self(deviceData(),
-                                                                                     size());
-  ::Kokkos::View<Real *, MemSpace, ::Kokkos::MemoryTraits<::Kokkos::Unmanaged>> other(
-      x.deviceData(), x.size());
+  ::Kokkos::View<T *, MemSpace, ::Kokkos::MemoryTraits<::Kokkos::Unmanaged>> self(
+      this->deviceData(), this->size());
+  ::Kokkos::View<T *, MemSpace, ::Kokkos::MemoryTraits<::Kokkos::Unmanaged>> other(x.deviceData(),
+                                                                                   x.size());
 
   return KokkosBlas::dot(self, other);
 }
 
-template <>
-template <>
-Real
-Array<Real, 1>::nrm2<Real>()
+template <typename T, typename index_type>
+T
+Array<T, 1, index_type, LayoutType::LEFT>::nrm2()
 {
-  if (!isDeviceAlloc())
+  if (!this->isDeviceAlloc())
     mooseError("Kokkos array error: array for nrm2() should be on device.");
 
-  ::Kokkos::View<Real *, MemSpace, ::Kokkos::MemoryTraits<::Kokkos::Unmanaged>> self(deviceData(),
-                                                                                     size());
+  ::Kokkos::View<T *, MemSpace, ::Kokkos::MemoryTraits<::Kokkos::Unmanaged>> self(
+      this->deviceData(), this->size());
 
   return KokkosBlas::nrm2(self);
 }
 
-template class Array<Real, 1, LayoutType::LEFT>;
+template class Array<Real, 1, uint8_t, LayoutType::LEFT>;
+template class Array<Real, 1, uint16_t, LayoutType::LEFT>;
+template class Array<Real, 1, uint32_t, LayoutType::LEFT>;
+template class Array<Real, 1, uint64_t, LayoutType::LEFT>;
 
 } // namespace Kokkos
 } // namespace Moose

--- a/unit/include/KokkosArrayTest.h
+++ b/unit/include/KokkosArrayTest.h
@@ -13,48 +13,52 @@
 
 #include "gtest_include.h"
 
-template <unsigned int dimension, Moose::Kokkos::LayoutType layout>
+template <unsigned int dimension, typename index_type, Moose::Kokkos::LayoutType layout>
 class KokkosArrayTestObjectBase
 {
 public:
-  KokkosArrayTestObjectBase(Moose::Kokkos::Array<unsigned int, dimension, layout> array)
+  KokkosArrayTestObjectBase(Moose::Kokkos::Array<unsigned int, dimension, index_type, layout> array)
     : _array(array)
   {
   }
 
 protected:
-  Moose::Kokkos::Array<unsigned int, dimension, layout> _array;
+  Moose::Kokkos::Array<unsigned int, dimension, index_type, layout> _array;
 };
 
-class KokkosArrayTestObject1D : public KokkosArrayTestObjectBase<1, Moose::Kokkos::LayoutType::LEFT>
+template <typename index_type = dof_id_type>
+class KokkosArrayTestObject1D
+  : public KokkosArrayTestObjectBase<1, index_type, Moose::Kokkos::LayoutType::LEFT>
 {
 public:
-  KokkosArrayTestObject1D(Moose::Kokkos::Array<unsigned int, 1> array)
-    : KokkosArrayTestObjectBase<1, Moose::Kokkos::LayoutType::LEFT>(array)
+  KokkosArrayTestObject1D(Moose::Kokkos::Array<unsigned int, 1, index_type> array)
+    : KokkosArrayTestObjectBase<1, index_type, Moose::Kokkos::LayoutType::LEFT>(array)
   {
   }
 
   KOKKOS_FUNCTION void operator()(const int i) const { this->_array(i) = i; }
 };
 
-template <Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
-class KokkosArrayTestObject2D : public KokkosArrayTestObjectBase<2, layout>
+template <typename index_type = dof_id_type,
+          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+class KokkosArrayTestObject2D : public KokkosArrayTestObjectBase<2, index_type, layout>
 {
 public:
-  KokkosArrayTestObject2D(Moose::Kokkos::Array<unsigned int, 2, layout> array)
-    : KokkosArrayTestObjectBase<2, layout>(array)
+  KokkosArrayTestObject2D(Moose::Kokkos::Array<unsigned int, 2, index_type, layout> array)
+    : KokkosArrayTestObjectBase<2, index_type, layout>(array)
   {
   }
 
   KOKKOS_FUNCTION void operator()(const int i, const int j) const { this->_array(i, j) = i + j; }
 };
 
-template <Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
-class KokkosArrayTestObject3D : public KokkosArrayTestObjectBase<3, layout>
+template <typename index_type = dof_id_type,
+          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+class KokkosArrayTestObject3D : public KokkosArrayTestObjectBase<3, index_type, layout>
 {
 public:
-  KokkosArrayTestObject3D(Moose::Kokkos::Array<unsigned int, 3, layout> array)
-    : KokkosArrayTestObjectBase<3, layout>(array)
+  KokkosArrayTestObject3D(Moose::Kokkos::Array<unsigned int, 3, index_type, layout> array)
+    : KokkosArrayTestObjectBase<3, index_type, layout>(array)
   {
   }
 
@@ -64,12 +68,13 @@ public:
   }
 };
 
-template <Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
-class KokkosArrayTestObject4D : public KokkosArrayTestObjectBase<4, layout>
+template <typename index_type = dof_id_type,
+          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+class KokkosArrayTestObject4D : public KokkosArrayTestObjectBase<4, index_type, layout>
 {
 public:
-  KokkosArrayTestObject4D(Moose::Kokkos::Array<unsigned int, 4, layout> array)
-    : KokkosArrayTestObjectBase<4, layout>(array)
+  KokkosArrayTestObject4D(Moose::Kokkos::Array<unsigned int, 4, index_type, layout> array)
+    : KokkosArrayTestObjectBase<4, index_type, layout>(array)
   {
   }
 
@@ -79,12 +84,13 @@ public:
   }
 };
 
-template <Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
-class KokkosArrayTestObject5D : public KokkosArrayTestObjectBase<5, layout>
+template <typename index_type = dof_id_type,
+          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+class KokkosArrayTestObject5D : public KokkosArrayTestObjectBase<5, index_type, layout>
 {
 public:
-  KokkosArrayTestObject5D(Moose::Kokkos::Array<unsigned int, 5, layout> array)
-    : KokkosArrayTestObjectBase<5, layout>(array)
+  KokkosArrayTestObject5D(Moose::Kokkos::Array<unsigned int, 5, index_type, layout> array)
+    : KokkosArrayTestObjectBase<5, index_type, layout>(array)
   {
   }
 
@@ -95,19 +101,22 @@ public:
   }
 };
 
-template <unsigned int inner, unsigned int outer, Moose::Kokkos::LayoutType layout>
+template <unsigned int inner,
+          unsigned int outer,
+          typename index_type,
+          Moose::Kokkos::LayoutType layout>
 class KokkosJaggedArrayTestObjectBase
 {
 public:
   KokkosJaggedArrayTestObjectBase(
-      Moose::Kokkos::JaggedArray<unsigned int, inner, outer, layout> array)
+      Moose::Kokkos::JaggedArray<unsigned int, inner, outer, index_type, layout> array)
     : _array(array)
   {
   }
 
 protected:
   KOKKOS_FUNCTION void
-  fillInner(const Moose::Kokkos::JaggedArrayInnerData<unsigned int, inner> data) const
+  fillInner(const Moose::Kokkos::JaggedArrayInnerData<unsigned int, inner, layout> data) const
   {
     if constexpr (inner == 1)
       for (dof_id_type i = 0; i < data.n(0); ++i)
@@ -125,27 +134,35 @@ protected:
             data(i, j, k) = i + j + k;
   }
 
-  Moose::Kokkos::JaggedArray<unsigned int, inner, outer, layout> _array;
+  Moose::Kokkos::JaggedArray<unsigned int, inner, outer, index_type, layout> _array;
 };
 
-template <unsigned int inner, Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
-class KokkosJaggedArrayTestObject1D : public KokkosJaggedArrayTestObjectBase<inner, 1, layout>
+template <unsigned int inner,
+          typename index_type = dof_id_type,
+          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+class KokkosJaggedArrayTestObject1D
+  : public KokkosJaggedArrayTestObjectBase<inner, 1, index_type, layout>
 {
 public:
-  KokkosJaggedArrayTestObject1D(Moose::Kokkos::JaggedArray<unsigned int, inner, 1, layout> array)
-    : KokkosJaggedArrayTestObjectBase<inner, 1, layout>(array)
+  KokkosJaggedArrayTestObject1D(
+      Moose::Kokkos::JaggedArray<unsigned int, inner, 1, index_type, layout> array)
+    : KokkosJaggedArrayTestObjectBase<inner, 1, index_type, layout>(array)
   {
   }
 
   KOKKOS_FUNCTION void operator()(const int i) const { this->fillInner(this->_array(i)); }
 };
 
-template <unsigned int inner, Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
-class KokkosJaggedArrayTestObject2D : public KokkosJaggedArrayTestObjectBase<inner, 2, layout>
+template <unsigned int inner,
+          typename index_type = dof_id_type,
+          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+class KokkosJaggedArrayTestObject2D
+  : public KokkosJaggedArrayTestObjectBase<inner, 2, index_type, layout>
 {
 public:
-  KokkosJaggedArrayTestObject2D(Moose::Kokkos::JaggedArray<unsigned int, inner, 2, layout> array)
-    : KokkosJaggedArrayTestObjectBase<inner, 2, layout>(array)
+  KokkosJaggedArrayTestObject2D(
+      Moose::Kokkos::JaggedArray<unsigned int, inner, 2, index_type, layout> array)
+    : KokkosJaggedArrayTestObjectBase<inner, 2, index_type, layout>(array)
   {
   }
 
@@ -155,12 +172,16 @@ public:
   }
 };
 
-template <unsigned int inner, Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
-class KokkosJaggedArrayTestObject3D : public KokkosJaggedArrayTestObjectBase<inner, 3, layout>
+template <unsigned int inner,
+          typename index_type = dof_id_type,
+          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+class KokkosJaggedArrayTestObject3D
+  : public KokkosJaggedArrayTestObjectBase<inner, 3, index_type, layout>
 {
 public:
-  KokkosJaggedArrayTestObject3D(Moose::Kokkos::JaggedArray<unsigned int, inner, 3, layout> array)
-    : KokkosJaggedArrayTestObjectBase<inner, 3, layout>(array)
+  KokkosJaggedArrayTestObject3D(
+      Moose::Kokkos::JaggedArray<unsigned int, inner, 3, index_type, layout> array)
+    : KokkosJaggedArrayTestObjectBase<inner, 3, index_type, layout>(array)
   {
   }
 

--- a/unit/src/KokkosArrayTest.K
+++ b/unit/src/KokkosArrayTest.K
@@ -9,7 +9,7 @@
 
 #include "KokkosArrayTest.h"
 
-TEST_F(KokkosArrayTest, Array1)
+TEST_F(KokkosArrayTest, Array1D)
 {
   Moose::Kokkos::Array<unsigned int, 1> array(3);
 
@@ -23,7 +23,7 @@ TEST_F(KokkosArrayTest, Array1)
     EXPECT_EQ(array[i], i);
 }
 
-TEST_F(KokkosArrayTest, Array2)
+TEST_F(KokkosArrayTest, Array2D)
 {
   Moose::Kokkos::Array<unsigned int, 2> array(3, 4);
 
@@ -41,7 +41,7 @@ TEST_F(KokkosArrayTest, Array2)
     }
 }
 
-TEST_F(KokkosArrayTest, Array3)
+TEST_F(KokkosArrayTest, Array3D)
 {
   Moose::Kokkos::Array<unsigned int, 3> array(3, 4, 5);
 
@@ -60,7 +60,7 @@ TEST_F(KokkosArrayTest, Array3)
       }
 }
 
-TEST_F(KokkosArrayTest, Array4)
+TEST_F(KokkosArrayTest, Array4D)
 {
   Moose::Kokkos::Array<unsigned int, 4> array(3, 4, 5, 6);
 
@@ -80,7 +80,7 @@ TEST_F(KokkosArrayTest, Array4)
         }
 }
 
-TEST_F(KokkosArrayTest, Array5)
+TEST_F(KokkosArrayTest, Array5D)
 {
   Moose::Kokkos::Array<unsigned int, 5> array(3, 4, 5, 6, 7);
 
@@ -101,12 +101,104 @@ TEST_F(KokkosArrayTest, Array5)
           }
 }
 
-TEST_F(KokkosArrayTest, Array2RightLayout)
+TEST_F(KokkosArrayTest, Array1D4ByteIndex)
 {
-  Moose::Kokkos::Array<unsigned int, 2, Moose::Kokkos::LayoutType::RIGHT> array(3, 4);
+  Moose::Kokkos::Array<unsigned int, 1, unsigned int> array(3);
+
+  Kokkos::RangePolicy<> policy(0, 3);
+  KokkosArrayTestObject1D<unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int i = 0; i < 3; ++i)
+    EXPECT_EQ(array[i], i);
+}
+
+TEST_F(KokkosArrayTest, Array2D4ByteIndex)
+{
+  Moose::Kokkos::Array<unsigned int, 2, unsigned int> array(3, 4);
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 4});
-  KokkosArrayTestObject2D<Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosArrayTestObject2D<unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int i = 0; i < 3; ++i)
+    for (unsigned int j = 0; j < 4; ++j)
+    {
+      unsigned int idx = i + j * 3;
+      EXPECT_EQ(array[idx], i + j);
+    }
+}
+
+TEST_F(KokkosArrayTest, Array3D4ByteIndex)
+{
+  Moose::Kokkos::Array<unsigned int, 3, unsigned int> array(3, 4, 5);
+
+  Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 4, 5});
+  KokkosArrayTestObject3D<unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int i = 0; i < 3; ++i)
+    for (unsigned int j = 0; j < 4; ++j)
+      for (unsigned int k = 0; k < 5; ++k)
+      {
+        unsigned int idx = i + j * 3 + k * 3 * 4;
+        EXPECT_EQ(array[idx], i + j + k);
+      }
+}
+
+TEST_F(KokkosArrayTest, Array4D4ByteIndex)
+{
+  Moose::Kokkos::Array<unsigned int, 4, unsigned int> array(3, 4, 5, 6);
+
+  Kokkos::MDRangePolicy<Kokkos::Rank<4>> policy({0, 0, 0, 0}, {3, 4, 5, 6});
+  KokkosArrayTestObject4D<unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int i = 0; i < 3; ++i)
+    for (unsigned int j = 0; j < 4; ++j)
+      for (unsigned int k = 0; k < 5; ++k)
+        for (unsigned int l = 0; l < 6; ++l)
+        {
+          unsigned int idx = i + j * 3 + k * 3 * 4 + l * 3 * 4 * 5;
+          EXPECT_EQ(array[idx], i + j + k + l);
+        }
+}
+
+TEST_F(KokkosArrayTest, Array5D4ByteIndex)
+{
+  Moose::Kokkos::Array<unsigned int, 5, unsigned int> array(3, 4, 5, 6, 7);
+
+  Kokkos::MDRangePolicy<Kokkos::Rank<5>> policy({0, 0, 0, 0, 0}, {3, 4, 5, 6, 7});
+  KokkosArrayTestObject5D<unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int i = 0; i < 3; ++i)
+    for (unsigned int j = 0; j < 4; ++j)
+      for (unsigned int k = 0; k < 5; ++k)
+        for (unsigned int l = 0; l < 6; ++l)
+          for (unsigned int m = 0; m < 7; ++m)
+          {
+            unsigned int idx = i + j * 3 + k * 3 * 4 + l * 3 * 4 * 5 + m * 3 * 4 * 5 * 6;
+            EXPECT_EQ(array[idx], i + j + k + l + m);
+          }
+}
+
+TEST_F(KokkosArrayTest, Array2DRightLayout)
+{
+  Moose::Kokkos::Array<unsigned int, 2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> array(3, 4);
+
+  Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 4});
+  KokkosArrayTestObject2D<dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -119,12 +211,13 @@ TEST_F(KokkosArrayTest, Array2RightLayout)
     }
 }
 
-TEST_F(KokkosArrayTest, Array3RightLayout)
+TEST_F(KokkosArrayTest, Array3DRightLayout)
 {
-  Moose::Kokkos::Array<unsigned int, 3, Moose::Kokkos::LayoutType::RIGHT> array(3, 4, 5);
+  Moose::Kokkos::Array<unsigned int, 3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> array(
+      3, 4, 5);
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 4, 5});
-  KokkosArrayTestObject3D<Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosArrayTestObject3D<dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -138,12 +231,13 @@ TEST_F(KokkosArrayTest, Array3RightLayout)
       }
 }
 
-TEST_F(KokkosArrayTest, Array4RightLayout)
+TEST_F(KokkosArrayTest, Array4DRightLayout)
 {
-  Moose::Kokkos::Array<unsigned int, 4, Moose::Kokkos::LayoutType::RIGHT> array(3, 4, 5, 6);
+  Moose::Kokkos::Array<unsigned int, 4, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> array(
+      3, 4, 5, 6);
 
   Kokkos::MDRangePolicy<Kokkos::Rank<4>> policy({0, 0, 0, 0}, {3, 4, 5, 6});
-  KokkosArrayTestObject4D<Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosArrayTestObject4D<dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -158,12 +252,13 @@ TEST_F(KokkosArrayTest, Array4RightLayout)
         }
 }
 
-TEST_F(KokkosArrayTest, Array5RightLayout)
+TEST_F(KokkosArrayTest, Array5DRightLayout)
 {
-  Moose::Kokkos::Array<unsigned int, 5, Moose::Kokkos::LayoutType::RIGHT> array(3, 4, 5, 6, 7);
+  Moose::Kokkos::Array<unsigned int, 5, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> array(
+      3, 4, 5, 6, 7);
 
   Kokkos::MDRangePolicy<Kokkos::Rank<5>> policy({0, 0, 0, 0, 0}, {3, 4, 5, 6, 7});
-  KokkosArrayTestObject5D<Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosArrayTestObject5D<dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -179,7 +274,7 @@ TEST_F(KokkosArrayTest, Array5RightLayout)
           }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray11)
+TEST_F(KokkosArrayTest, jaggedArray1D1D)
 {
   Moose::Kokkos::JaggedArray<unsigned int, 1, 1> array(3);
 
@@ -199,7 +294,7 @@ TEST_F(KokkosArrayTest, jaggedArray11)
       EXPECT_EQ(array(I)[i], i);
 }
 
-TEST_F(KokkosArrayTest, jaggedArray21)
+TEST_F(KokkosArrayTest, jaggedArray2D1D)
 {
   Moose::Kokkos::JaggedArray<unsigned int, 2, 1> array(3);
 
@@ -223,7 +318,7 @@ TEST_F(KokkosArrayTest, jaggedArray21)
       }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray31)
+TEST_F(KokkosArrayTest, jaggedArray3D1D)
 {
   Moose::Kokkos::JaggedArray<unsigned int, 3, 1> array(3);
 
@@ -248,7 +343,7 @@ TEST_F(KokkosArrayTest, jaggedArray31)
         }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray12)
+TEST_F(KokkosArrayTest, jaggedArray1D2D)
 {
   Moose::Kokkos::JaggedArray<unsigned int, 1, 2> array(3, 3);
 
@@ -270,7 +365,7 @@ TEST_F(KokkosArrayTest, jaggedArray12)
         EXPECT_EQ(array(I, J)[i], i);
 }
 
-TEST_F(KokkosArrayTest, jaggedArray22)
+TEST_F(KokkosArrayTest, jaggedArray2D2D)
 {
   Moose::Kokkos::JaggedArray<unsigned int, 2, 2> array(3, 3);
 
@@ -296,7 +391,7 @@ TEST_F(KokkosArrayTest, jaggedArray22)
         }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray32)
+TEST_F(KokkosArrayTest, jaggedArray3D2D)
 {
   Moose::Kokkos::JaggedArray<unsigned int, 3, 2> array(3, 3);
 
@@ -323,7 +418,7 @@ TEST_F(KokkosArrayTest, jaggedArray32)
           }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray13)
+TEST_F(KokkosArrayTest, jaggedArray1D3D)
 {
   Moose::Kokkos::JaggedArray<unsigned int, 1, 3> array(3, 3, 3);
 
@@ -347,7 +442,7 @@ TEST_F(KokkosArrayTest, jaggedArray13)
           EXPECT_EQ(array(I, J, K)[i], i);
 }
 
-TEST_F(KokkosArrayTest, jaggedArray23)
+TEST_F(KokkosArrayTest, jaggedArray2D3D)
 {
   Moose::Kokkos::JaggedArray<unsigned int, 2, 3> array(3, 3, 3);
 
@@ -375,7 +470,7 @@ TEST_F(KokkosArrayTest, jaggedArray23)
           }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray33)
+TEST_F(KokkosArrayTest, jaggedArray3D3D)
 {
   Moose::Kokkos::JaggedArray<unsigned int, 3, 3> array(3, 3, 3);
 
@@ -404,9 +499,9 @@ TEST_F(KokkosArrayTest, jaggedArray33)
             }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray11RightLayout)
+TEST_F(KokkosArrayTest, jaggedArray1D1D4ByteIndex)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 1, 1, Moose::Kokkos::LayoutType::RIGHT> array(3);
+  Moose::Kokkos::JaggedArray<unsigned int, 1, 1, unsigned int> array(3);
 
   for (unsigned int I = 0; I < 3; ++I)
     array.reserve({I}, {I + 1});
@@ -414,7 +509,7 @@ TEST_F(KokkosArrayTest, jaggedArray11RightLayout)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<1, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject1D<1, unsigned int> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -424,9 +519,9 @@ TEST_F(KokkosArrayTest, jaggedArray11RightLayout)
       EXPECT_EQ(array(I)[i], i);
 }
 
-TEST_F(KokkosArrayTest, jaggedArray21RightLayout)
+TEST_F(KokkosArrayTest, jaggedArray2D1D4ByteIndex)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 2, 1, Moose::Kokkos::LayoutType::RIGHT> array(3);
+  Moose::Kokkos::JaggedArray<unsigned int, 2, 1, unsigned int> array(3);
 
   for (unsigned int I = 0; I < 3; ++I)
     array.reserve({I}, {I + 1, I + 1});
@@ -434,7 +529,234 @@ TEST_F(KokkosArrayTest, jaggedArray21RightLayout)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<2, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject1D<2, unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int i = 0; i < I + 1; ++i)
+      for (unsigned int j = 0; j < I + 1; ++j)
+      {
+        unsigned int idx = i + j * (I + 1);
+        EXPECT_EQ(array(I)[idx], i + j);
+      }
+}
+
+TEST_F(KokkosArrayTest, jaggedArray3D1D4ByteIndex)
+{
+  Moose::Kokkos::JaggedArray<unsigned int, 3, 1, unsigned int> array(3);
+
+  for (unsigned int I = 0; I < 3; ++I)
+    array.reserve({I}, {I + 1, I + 1, I + 1});
+
+  array.finalize();
+
+  Kokkos::RangePolicy<> policy(0, 3);
+  KokkosJaggedArrayTestObject1D<3, unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int i = 0; i < I + 1; ++i)
+      for (unsigned int j = 0; j < I + 1; ++j)
+        for (unsigned int k = 0; k < I + 1; ++k)
+        {
+          unsigned int idx = i + j * (I + 1) + k * (I + 1) * (I + 1);
+          EXPECT_EQ(array(I)[idx], i + j + k);
+        }
+}
+
+TEST_F(KokkosArrayTest, jaggedArray1D2D4ByteIndex)
+{
+  Moose::Kokkos::JaggedArray<unsigned int, 1, 2, unsigned int> array(3, 3);
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      array.reserve({I, J}, {I + 1});
+
+  array.finalize();
+
+  Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
+  KokkosJaggedArrayTestObject2D<1, unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      for (unsigned int i = 0; i < I + 1; ++i)
+        EXPECT_EQ(array(I, J)[i], i);
+}
+
+TEST_F(KokkosArrayTest, jaggedArray2D2D4ByteIndex)
+{
+  Moose::Kokkos::JaggedArray<unsigned int, 2, 2, unsigned int> array(3, 3);
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      array.reserve({I, J}, {I + 1, J + 1});
+
+  array.finalize();
+
+  Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
+  KokkosJaggedArrayTestObject2D<2, unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      for (unsigned int i = 0; i < I + 1; ++i)
+        for (unsigned int j = 0; j < J + 1; ++j)
+        {
+          unsigned int idx = i + j * (I + 1);
+          EXPECT_EQ(array(I, J)[idx], i + j);
+        }
+}
+
+TEST_F(KokkosArrayTest, jaggedArray3D2D4ByteIndex)
+{
+  Moose::Kokkos::JaggedArray<unsigned int, 3, 2, unsigned int> array(3, 3);
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      array.reserve({I, J}, {I + 1, J + 1, J + 1});
+
+  array.finalize();
+
+  Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
+  KokkosJaggedArrayTestObject2D<3, unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      for (unsigned int i = 0; i < I + 1; ++i)
+        for (unsigned int j = 0; j < J + 1; ++j)
+          for (unsigned int k = 0; k < J + 1; ++k)
+          {
+            unsigned int idx = i + j * (I + 1) + k * (I + 1) * (J + 1);
+            EXPECT_EQ(array(I, J)[idx], i + j + k);
+          }
+}
+
+TEST_F(KokkosArrayTest, jaggedArray1D3D4ByteIndex)
+{
+  Moose::Kokkos::JaggedArray<unsigned int, 1, 3, unsigned int> array(3, 3, 3);
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      for (unsigned int K = 0; K < 3; ++K)
+        array.reserve({I, J, K}, {I + 1});
+
+  array.finalize();
+
+  Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
+  KokkosJaggedArrayTestObject3D<1, unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      for (unsigned int K = 0; K < 3; ++K)
+        for (unsigned int i = 0; i < I + 1; ++i)
+          EXPECT_EQ(array(I, J, K)[i], i);
+}
+
+TEST_F(KokkosArrayTest, jaggedArray2D3D4ByteIndex)
+{
+  Moose::Kokkos::JaggedArray<unsigned int, 2, 3, unsigned int> array(3, 3, 3);
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      for (unsigned int K = 0; K < 3; ++K)
+        array.reserve({I, J, K}, {I + 1, J + 1});
+
+  array.finalize();
+
+  Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
+  KokkosJaggedArrayTestObject3D<2, unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      for (unsigned int K = 0; K < 3; ++K)
+        for (unsigned int i = 0; i < I + 1; ++i)
+          for (unsigned int j = 0; j < J + 1; ++j)
+          {
+            unsigned int idx = i + j * (I + 1);
+            EXPECT_EQ(array(I, J, K)[idx], i + j);
+          }
+}
+
+TEST_F(KokkosArrayTest, jaggedArray3D3D4ByteIndex)
+{
+  Moose::Kokkos::JaggedArray<unsigned int, 3, 3, unsigned int> array(3, 3, 3);
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      for (unsigned int K = 0; K < 3; ++K)
+        array.reserve({I, J, K}, {I + 1, J + 1, K + 1});
+
+  array.finalize();
+
+  Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
+  KokkosJaggedArrayTestObject3D<3, unsigned int> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int J = 0; J < 3; ++J)
+      for (unsigned int K = 0; K < 3; ++K)
+        for (unsigned int i = 0; i < I + 1; ++i)
+          for (unsigned int j = 0; j < J + 1; ++j)
+            for (unsigned int k = 0; k < K + 1; ++k)
+            {
+              unsigned int idx = i + j * (I + 1) + k * (I + 1) * (J + 1);
+              EXPECT_EQ(array(I, J, K)[idx], i + j + k);
+            }
+}
+
+TEST_F(KokkosArrayTest, jaggedArray1D1DRightLayout)
+{
+  Moose::Kokkos::JaggedArray<unsigned int, 1, 1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
+      array(3);
+
+  for (unsigned int I = 0; I < 3; ++I)
+    array.reserve({I}, {I + 1});
+
+  array.finalize();
+
+  Kokkos::RangePolicy<> policy(0, 3);
+  KokkosJaggedArrayTestObject1D<1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  Kokkos::parallel_for(policy, object);
+
+  array.copyToHost();
+
+  for (unsigned int I = 0; I < 3; ++I)
+    for (unsigned int i = 0; i < I + 1; ++i)
+      EXPECT_EQ(array(I)[i], i);
+}
+
+TEST_F(KokkosArrayTest, jaggedArray2D1DRightLayout)
+{
+  Moose::Kokkos::JaggedArray<unsigned int, 2, 1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
+      array(3);
+
+  for (unsigned int I = 0; I < 3; ++I)
+    array.reserve({I}, {I + 1, I + 1});
+
+  array.finalize();
+
+  Kokkos::RangePolicy<> policy(0, 3);
+  KokkosJaggedArrayTestObject1D<2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -448,9 +770,10 @@ TEST_F(KokkosArrayTest, jaggedArray21RightLayout)
       }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray31RightLayout)
+TEST_F(KokkosArrayTest, jaggedArray3D1DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 3, 1, Moose::Kokkos::LayoutType::RIGHT> array(3);
+  Moose::Kokkos::JaggedArray<unsigned int, 3, 1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
+      array(3);
 
   for (unsigned int I = 0; I < 3; ++I)
     array.reserve({I}, {I + 1, I + 1, I + 1});
@@ -458,7 +781,7 @@ TEST_F(KokkosArrayTest, jaggedArray31RightLayout)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<3, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject1D<3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -473,9 +796,10 @@ TEST_F(KokkosArrayTest, jaggedArray31RightLayout)
         }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray12RightLayout)
+TEST_F(KokkosArrayTest, jaggedArray1D2DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 1, 2, Moose::Kokkos::LayoutType::RIGHT> array(3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 1, 2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
+      array(3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -484,7 +808,7 @@ TEST_F(KokkosArrayTest, jaggedArray12RightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<1, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject2D<1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -495,9 +819,10 @@ TEST_F(KokkosArrayTest, jaggedArray12RightLayout)
         EXPECT_EQ(array(I, J)[i], i);
 }
 
-TEST_F(KokkosArrayTest, jaggedArray22RightLayout)
+TEST_F(KokkosArrayTest, jaggedArray2D2DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 2, 2, Moose::Kokkos::LayoutType::RIGHT> array(3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 2, 2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
+      array(3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -506,7 +831,7 @@ TEST_F(KokkosArrayTest, jaggedArray22RightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<2, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject2D<2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -521,9 +846,10 @@ TEST_F(KokkosArrayTest, jaggedArray22RightLayout)
         }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray32RightLayout)
+TEST_F(KokkosArrayTest, jaggedArray3D2DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 3, 2, Moose::Kokkos::LayoutType::RIGHT> array(3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 3, 2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
+      array(3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -532,7 +858,7 @@ TEST_F(KokkosArrayTest, jaggedArray32RightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<3, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject2D<3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -548,9 +874,10 @@ TEST_F(KokkosArrayTest, jaggedArray32RightLayout)
           }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray13RightLayout)
+TEST_F(KokkosArrayTest, jaggedArray1D3DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 1, 3, Moose::Kokkos::LayoutType::RIGHT> array(3, 3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 1, 3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
+      array(3, 3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -560,7 +887,7 @@ TEST_F(KokkosArrayTest, jaggedArray13RightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<1, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject3D<1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -572,9 +899,10 @@ TEST_F(KokkosArrayTest, jaggedArray13RightLayout)
           EXPECT_EQ(array(I, J, K)[i], i);
 }
 
-TEST_F(KokkosArrayTest, jaggedArray23RightLayout)
+TEST_F(KokkosArrayTest, jaggedArray2D3DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 2, 3, Moose::Kokkos::LayoutType::RIGHT> array(3, 3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 2, 3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
+      array(3, 3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -584,7 +912,7 @@ TEST_F(KokkosArrayTest, jaggedArray23RightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<2, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject3D<2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -600,9 +928,10 @@ TEST_F(KokkosArrayTest, jaggedArray23RightLayout)
           }
 }
 
-TEST_F(KokkosArrayTest, jaggedArray33RightLayout)
+TEST_F(KokkosArrayTest, jaggedArray3D3DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 3, 3, Moose::Kokkos::LayoutType::RIGHT> array(3, 3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 3, 3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
+      array(3, 3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -612,7 +941,7 @@ TEST_F(KokkosArrayTest, jaggedArray33RightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<3, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject3D<3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();


### PR DESCRIPTION
Refs #30655.

Users can choose the index type instead of being stuck at 8-byte integers. 4-byte indices have significant performance advantage over 8-byte indices on GPUs. Sorry for a messy change, but this seems to improve the performance of our application by ~25%.