### PR TITLE
Use solution invalid to tally warnings from a variety of sources

### DIFF
--- a/framework/include/systems/SolverSystem.h
+++ b/framework/include/systems/SolverSystem.h
@@ -108,9 +108,6 @@ protected:
   Moose::PCSideType _pc_side;
   /// KSP norm type
   Moose::MooseKSPNormType _ksp_norm;
-
-  /// Boolean to see if solution is invalid
-  bool _solution_is_invalid;
 };
 
 inline const NumericVector<Number> * const &

--- a/framework/include/utils/SolutionInvalidity.h
+++ b/framework/include/utils/SolutionInvalidity.h
@@ -68,6 +68,13 @@ public:
    */
   bool hasInvalidSolution() const;
 
+  /**
+   * Whether or not any warning or invalid solution has ever been encountered
+   *
+   * This must be called after a sync.
+   */
+  bool hasEverHadSolutionIssue() const;
+
   /// Reset the number of solution invalid occurrences back to zero for the current time step
   void resetSolutionInvalidTimeStep();
 
@@ -161,6 +168,8 @@ private:
   bool _has_solution_warning;
   /// Whether or not we have an invalid solution (only after a sync)
   bool _has_solution_error;
+  /// Whether or not we have ever had any warning or solution issue during the simulation
+  bool _has_recorded_issue;
 };
 
 // datastore and dataload for recover

--- a/framework/include/utils/SolutionInvalidity.h
+++ b/framework/include/utils/SolutionInvalidity.h
@@ -69,7 +69,7 @@ public:
   bool hasInvalidSolution() const;
 
   /**
-   * Whether or not any warning or invalid solution has ever been encountered
+   * Whether or not any warning or invalid solution has ever been encountered during the simulation
    *
    * This must be called after a sync.
    */
@@ -84,7 +84,7 @@ public:
   /// Pass the number of solution invalid occurrences from current iteration to cumulative counters
   void accumulateIterationIntoTimeStepOccurences();
 
-  /// Pass the number of solution invalid occurrences from current iteration to cumulative time iteration counters
+  /// Pass the number of solution invalid occurrences from current timestep to cumulative timestep counter (e.g. the total)
   void accumulateTimeStepIntoTotalOccurences(const unsigned int timestep_index);
 
   /// Struct used in InvalidCounts for storing the time history of invalid occurrences
@@ -96,12 +96,16 @@ public:
     unsigned int counts = 0;
   };
 
-  /// Struct used in _counts for storing invalid occurrences
+  /// Struct used in _counts for storing warning and invalid-solution occurrences
   struct InvalidCounts
   {
+    /// Counts for the current iteration (depends on the count, but usually linear iteration)
     unsigned int current_counts = 0;
+    /// Counts for the current time step
     unsigned int current_timestep_counts = 0;
+    /// Total counts across the entire simulation
     unsigned int total_counts = 0;
+    /// Keep track of the occurences across all time steps
     std::vector<TimestepCounts> timestep_counts;
   };
 
@@ -127,10 +131,11 @@ public:
 
   /**
    * Sync iteration counts to main processor
+   * Sum across all processors
    */
   void syncIteration();
 
-  /// Whether the solution invalidity has synchronized iteration counts
+  /// Whether the solution invalidity has synchronized iteration counts across MPI processes
   bool hasSynced() const { return _has_synced; }
 
   friend void dataStore(std::ostream &, SolutionInvalidity &, void *);

--- a/framework/include/utils/SolutionInvalidity.h
+++ b/framework/include/utils/SolutionInvalidity.h
@@ -130,6 +130,9 @@ public:
    */
   void syncIteration();
 
+  /// Whether the solution invalidity has synchronized iteration counts
+  bool hasSynced() const { return _has_synced; }
+
   friend void dataStore(std::ostream &, SolutionInvalidity &, void *);
   friend void dataLoad(std::istream &, SolutionInvalidity &, void *);
 

--- a/framework/include/utils/SolutionInvalidity.h
+++ b/framework/include/utils/SolutionInvalidity.h
@@ -87,9 +87,6 @@ public:
   /// Pass the number of solution invalid occurrences from current iteration to cumulative time iteration counters
   void solutionInvalidAccumulationTimeStep(const unsigned int timestep_index);
 
-  /// Compute the total number of solution invalid occurrences
-  void computeTotalCounts();
-
   /// Struct used in InvalidCounts for storing the time history of invalid occurrences
   struct TimestepCounts
   {

--- a/framework/include/utils/SolutionInvalidity.h
+++ b/framework/include/utils/SolutionInvalidity.h
@@ -76,16 +76,16 @@ public:
   bool hasEverHadSolutionIssue() const;
 
   /// Reset the number of solution invalid occurrences back to zero for the current time step
-  void resetSolutionInvalidTimeStep();
+  void resetTimeStepOccurences();
 
   /// Reset the number of solution invalid occurrences back to zero
-  void resetSolutionInvalidCurrentIteration();
+  void resetIterationOccurences();
 
   /// Pass the number of solution invalid occurrences from current iteration to cumulative counters
-  void solutionInvalidAccumulation();
+  void accumulateIterationIntoTimeStepOccurences();
 
   /// Pass the number of solution invalid occurrences from current iteration to cumulative time iteration counters
-  void solutionInvalidAccumulationTimeStep(const unsigned int timestep_index);
+  void accumulateTimeStepIntoTotalOccurences(const unsigned int timestep_index);
 
   /// Struct used in InvalidCounts for storing the time history of invalid occurrences
   struct TimestepCounts

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -396,11 +396,12 @@ FEProblemSolve::initialSetup()
   MultiSystemSolveObject::initialSetup();
   convergenceSetup();
   // Keep track of the solution warnings from the setup
+  // before a count reset at the beginning of the time step
   if (!_app.isRecovering())
   {
     _app.solutionInvalidity().syncIteration();
-    _app.solutionInvalidity().solutionInvalidAccumulation();
-    _app.solutionInvalidity().solutionInvalidAccumulationTimeStep(0);
+    _app.solutionInvalidity().accumulateIterationIntoTimeStepOccurences();
+    _app.solutionInvalidity().accumulateTimeStepIntoTotalOccurences(0);
   }
 }
 

--- a/framework/src/executioners/FixedPointSolve.C
+++ b/framework/src/executioners/FixedPointSolve.C
@@ -445,7 +445,6 @@ FixedPointSolve::solveStep(const std::set<dof_id_type> & transformed_dofs)
     _fixed_point_status = MooseFixedPointConvergenceReason::DIVERGED_NONLINEAR;
 
     // Keep track of the solution warnings from the solve
-    _app.solutionInvalidity().syncIteration();
     _app.solutionInvalidity().accumulateTimeStepIntoTotalOccurences(_problem.timeStep());
 
     // Perform the output of the current, failed time step (this only occurs if desired)

--- a/framework/src/executioners/FixedPointSolve.C
+++ b/framework/src/executioners/FixedPointSolve.C
@@ -443,6 +443,10 @@ FixedPointSolve::solveStep(const std::set<dof_id_type> & transformed_dofs)
   {
     _fixed_point_status = MooseFixedPointConvergenceReason::DIVERGED_NONLINEAR;
 
+    // Keep track of the solution warnings from the TIMESTEP_END phase
+    _app.solutionInvalidity().syncIteration();
+    _app.solutionInvalidity().solutionInvalidAccumulationTimeStep(_problem.timeStep());
+
     // Perform the output of the current, failed time step (this only occurs if desired)
     _problem.outputStep(EXEC_FAILED);
     return false;
@@ -469,8 +473,7 @@ FixedPointSolve::solveStep(const std::set<dof_id_type> & transformed_dofs)
     }
 
     // Start new TIMESTEP_END section for solution invalidity
-    // We have to restart the current iteration count to avoid double counting, but
-    // but we keep the time step count to have it be: solve count + exec_timestep_end count
+    // We have to restart the current iteration count to avoid double counting
     _app.solutionInvalidity().resetSolutionInvalidCurrentIteration();
 
     _problem.onTimestepEnd();
@@ -483,7 +486,7 @@ FixedPointSolve::solveStep(const std::set<dof_id_type> & transformed_dofs)
     // Keep track of the solution warnings from the TIMESTEP_END phase
     _app.solutionInvalidity().syncIteration();
     _app.solutionInvalidity().solutionInvalidAccumulation();
-    // Similarly, don't tally the step counts into the total counts to avoid double counting
+    _app.solutionInvalidity().solutionInvalidAccumulationTimeStep(_problem.timeStep());
   }
 
   if (_fixed_point_status == MooseFixedPointConvergenceReason::DIVERGED_FAILED_MULTIAPP)

--- a/framework/src/outputs/SolutionInvalidityOutput.C
+++ b/framework/src/outputs/SolutionInvalidityOutput.C
@@ -22,7 +22,7 @@ SolutionInvalidityOutput::validParams()
 {
   InputParameters params = Output::validParams();
 
-  params.set<ExecFlagEnum>("execute_on") = {EXEC_FINAL, EXEC_FAILED};
+  params.set<ExecFlagEnum>("execute_on") = {EXEC_FINAL};
 
   params.addParam<unsigned int>("solution_invalidity_timestep_interval",
                                 1,

--- a/framework/src/outputs/SolutionInvalidityOutput.C
+++ b/framework/src/outputs/SolutionInvalidityOutput.C
@@ -27,9 +27,10 @@ SolutionInvalidityOutput::validParams()
   params.addParam<unsigned int>("solution_invalidity_timestep_interval",
                                 1,
                                 "The number of time steps to group together in the table reporting "
-                                "the solution invalidity occurrences.");
+                                "the warnings and solution invalidity occurrences.");
 
-  params.addClassDescription("Controls output of the time history of solution invalidity object");
+  params.addClassDescription("Controls output of the time history of regular warnings and solution "
+                             "invalidity errors and warnings");
 
   return params;
 }
@@ -48,6 +49,11 @@ SolutionInvalidityOutput::shouldOutput()
   // Note: if this happens in other cases, we should just sync if solutionInvalidity is not synced
   if (_problem_ptr->getCurrentExecuteOnFlag() == EXEC_FAILED)
     _solution_invalidity.syncIteration();
+  // At the known end of a simulation, always output the total summary if anything happened
+  if (_problem_ptr->getCurrentExecuteOnFlag() == EXEC_FAILED ||
+      _problem_ptr->getCurrentExecuteOnFlag() == EXEC_FINAL)
+    return Output::shouldOutput() && _solution_invalidity.hasEverHadSolutionIssue();
+  // At other points, we check the current state of the simulation
   return Output::shouldOutput() && _solution_invalidity.hasInvalidSolution();
 }
 
@@ -56,8 +62,7 @@ SolutionInvalidityOutput::output()
 {
   if (isParamSetByUser("solution_invalidity_timestep_interval"))
     mooseInfo("Set Outputs/solution_invalidity_history=false to silence the default Solution "
-              "Invalid Warnings History "
-              "table above.");
+              "Invalid Warnings History table above.");
   _console << '\n';
   _solution_invalidity.printHistory(_console, _timestep_interval);
   _console << std::flush;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -7122,6 +7122,7 @@ FEProblemBase::computeResidualSys(NonlinearImplicitSystem & sys,
   parallel_object_only();
 
   TIME_SECTION("computeResidualSys", 5);
+  _app.solutionInvalidity().resetSolutionInvalidCurrentIteration();
 
   computeResidual(soln, residual, sys.number());
 }
@@ -7528,6 +7529,7 @@ FEProblemBase::computeJacobianSys(NonlinearImplicitSystem & sys,
                                   const NumericVector<Number> & soln,
                                   SparseMatrix<Number> & jacobian)
 {
+  _app.solutionInvalidity().resetSolutionInvalidCurrentIteration();
   computeJacobian(soln, jacobian, sys.number());
 }
 

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -7122,7 +7122,8 @@ FEProblemBase::computeResidualSys(NonlinearImplicitSystem & sys,
   parallel_object_only();
 
   TIME_SECTION("computeResidualSys", 5);
-  _app.solutionInvalidity().resetSolutionInvalidCurrentIteration();
+  // Reset before residual setup, calculation & execution
+  _app.solutionInvalidity().resetIterationOccurences();
 
   computeResidual(soln, residual, sys.number());
 }
@@ -7529,7 +7530,8 @@ FEProblemBase::computeJacobianSys(NonlinearImplicitSystem & sys,
                                   const NumericVector<Number> & soln,
                                   SparseMatrix<Number> & jacobian)
 {
-  _app.solutionInvalidity().resetSolutionInvalidCurrentIteration();
+  // Reset before Jacobian setup, calculation & execution
+  _app.solutionInvalidity().resetIterationOccurences();
   computeJacobian(soln, jacobian, sys.number());
 }
 

--- a/framework/src/reporters/SolutionInvalidityReporter.C
+++ b/framework/src/reporters/SolutionInvalidityReporter.C
@@ -18,6 +18,8 @@ SolutionInvalidityReporter::validParams()
 {
   InputParameters params = GeneralReporter::validParams();
   params.addClassDescription("Reports the Summary Table of Solution Invalid Counts.");
+  // This reporter is simply executed on JSON output
+  params.suppressParameter<ExecFlagEnum>("execute_on");
   return params;
 }
 

--- a/framework/src/reporters/SolutionInvalidityReporter.C
+++ b/framework/src/reporters/SolutionInvalidityReporter.C
@@ -47,7 +47,6 @@ to_json(nlohmann::json & json, const SolutionInvalidity * const & solution_inval
       nlohmann::json entry;
       entry["object_type"] = solution_registry.item(id).object_type;
       entry["message"] = solution_registry.item(id).message;
-      entry["converged_counts"] = counts[id].current_counts;
       entry["timestep_counts"] = counts[id].current_timestep_counts;
       entry["total_counts"] = counts[id].total_counts;
       json.push_back(entry);

--- a/framework/src/systems/LinearSystem.C
+++ b/framework/src/systems/LinearSystem.C
@@ -285,7 +285,7 @@ LinearSystem::computeLinearSystemInternal(const std::set<TagID> & vector_tags,
   // Accumulate the occurrence of solution invalid warnings for the current iteration cumulative
   // counters
   _app.solutionInvalidity().syncIteration();
-  _app.solutionInvalidity().solutionInvalidAccumulation();
+  _app.solutionInvalidity().accumulateIterationIntoTimeStepOccurences();
 }
 
 NumericVector<Number> &

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -18,7 +18,6 @@
 #include "ComputeFDResidualFunctor.h"
 #include "MooseVariableScalar.h"
 #include "MooseTypes.h"
-#include "SolutionInvalidity.h"
 #include "AuxiliarySystem.h"
 #include "Console.h"
 
@@ -148,10 +147,6 @@ NonlinearSystem::solve()
   if (_fe_problem.hasDampers() || _fe_problem.shouldUpdateSolution() ||
       _fe_problem.needsPreviousNewtonIteration())
     _nl_implicit_sys.nonlinear_solver->postcheck = Moose::compute_postcheck;
-
-  // reset solution invalid counter for the time step
-  if (!_time_integrators.empty())
-    _app.solutionInvalidity().resetSolutionInvalidTimeStep();
 
   if (shouldEvaluatePreSMOResidual())
   {

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -207,9 +207,6 @@ NonlinearSystem::solve()
   // store info about the solve
   _final_residual = _nl_implicit_sys.final_nonlinear_residual();
 
-  // Accumulate only the occurence of solution invalid warnings for each time step
-  _app.solutionInvalidity().solutionInvalidAccumulationTimeStep(_fe_problem.timeStep());
-
   // determine whether solution invalid occurs in the converged solution
   checkInvalidSolution();
 

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -338,7 +338,11 @@ NonlinearSystem::converged()
 {
   if (_fe_problem.hasException() || _fe_problem.getFailNextNonlinearConvergenceCheck())
     return false;
-  if (!_fe_problem.acceptInvalidSolution())
+  // When not computing the residual (for example at the beginning of a time step),
+  // we may be in the process of counting invalid solution warnings, so the call to
+  // acceptInvalidSolution() would fail due to lack of parallel synchronization
+  // TODO: think of a better solution
+  if (_app.solutionInvalidity().hasSynced() && !_fe_problem.acceptInvalidSolution())
   {
     mooseWarning("The solution is not converged due to the solution being invalid.");
     return false;

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -1987,7 +1987,7 @@ NonlinearSystemBase::computeResidualInternal(const std::set<TagID> & tags)
   // Accumulate the occurrence of solution invalid warnings for the current iteration cumulative
   // counters
   _app.solutionInvalidity().syncIteration();
-  _app.solutionInvalidity().solutionInvalidAccumulation();
+  _app.solutionInvalidity().accumulateIterationIntoTimeStepOccurences();
 }
 
 void
@@ -3219,7 +3219,7 @@ NonlinearSystemBase::computeJacobianInternal(const std::set<TagID> & tags)
   // Accumulate the occurrence of solution invalid warnings for the current iteration cumulative
   // counters
   _app.solutionInvalidity().syncIteration();
-  _app.solutionInvalidity().solutionInvalidAccumulation();
+  _app.solutionInvalidity().accumulateIterationIntoTimeStepOccurences();
 }
 
 void

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -1763,7 +1763,6 @@ NonlinearSystemBase::residualSetup()
   // Avoid recursion
   if (this == &_fe_problem.currentNonlinearSystem())
     _fe_problem.residualSetup();
-  _app.solutionInvalidity().resetSolutionInvalidCurrentIteration();
 }
 
 void
@@ -2843,7 +2842,6 @@ NonlinearSystemBase::jacobianSetup()
   // Avoid recursion
   if (this == &_fe_problem.currentNonlinearSystem())
     _fe_problem.jacobianSetup();
-  _app.solutionInvalidity().resetSolutionInvalidCurrentIteration();
 }
 
 void

--- a/framework/src/systems/SolverSystem.C
+++ b/framework/src/systems/SolverSystem.C
@@ -21,8 +21,7 @@ SolverSystem::SolverSystem(SubProblem & subproblem,
   : SystemBase(subproblem, fe_problem, name, var_kind),
     _current_solution(nullptr),
     _pc_side(Moose::PCS_DEFAULT),
-    _ksp_norm(Moose::KSPN_UNPRECONDITIONED),
-    _solution_is_invalid(false)
+    _ksp_norm(Moose::KSPN_UNPRECONDITIONED)
 {
 }
 

--- a/framework/src/utils/SolutionInvalidity.C
+++ b/framework/src/utils/SolutionInvalidity.C
@@ -273,7 +273,7 @@ SolutionInvalidity::transientTable(unsigned int & step_interval) const
 {
   mooseAssert(_has_synced, "Has not synced");
 
-  TimeTable vtable({"Object", "Time", "Stepinterval Count", "Total Count"}, 4);
+  TimeTable vtable({"Object", "Step", "Interval Count", "Total Count"}, 4);
 
   vtable.setColumnFormat({
       VariadicTableColumnFormat::AUTO, // Object information

--- a/framework/src/utils/SolutionInvalidity.C
+++ b/framework/src/utils/SolutionInvalidity.C
@@ -112,19 +112,6 @@ SolutionInvalidity::solutionInvalidAccumulationTimeStep(const unsigned int times
 }
 
 void
-SolutionInvalidity::computeTotalCounts()
-{
-  mooseAssert(_has_synced, "Has not synced");
-
-  for (auto & entry : _counts)
-  {
-    entry.total_counts = 0;
-    for (auto & time_counts : entry.timestep_counts)
-      entry.total_counts += time_counts.counts;
-  }
-}
-
-void
 SolutionInvalidity::print(const ConsoleStream & console) const
 {
   console << "\nSolution Invalid Warnings:\n";

--- a/framework/src/utils/SolutionInvalidity.C
+++ b/framework/src/utils/SolutionInvalidity.C
@@ -73,7 +73,7 @@ SolutionInvalidity::hasEverHadSolutionIssue() const
 }
 
 void
-SolutionInvalidity::resetSolutionInvalidCurrentIteration()
+SolutionInvalidity::resetIterationOccurences()
 {
   // Zero current counts
   for (auto & entry : _counts)
@@ -81,7 +81,7 @@ SolutionInvalidity::resetSolutionInvalidCurrentIteration()
 }
 
 void
-SolutionInvalidity::resetSolutionInvalidTimeStep()
+SolutionInvalidity::resetTimeStepOccurences()
 {
   // Reset that we have synced because we're on a new iteration
   _has_synced = false;
@@ -91,14 +91,14 @@ SolutionInvalidity::resetSolutionInvalidTimeStep()
 }
 
 void
-SolutionInvalidity::solutionInvalidAccumulation()
+SolutionInvalidity::accumulateIterationIntoTimeStepOccurences()
 {
   for (auto & entry : _counts)
     entry.current_timestep_counts += entry.current_counts;
 }
 
 void
-SolutionInvalidity::solutionInvalidAccumulationTimeStep(const unsigned int timestep_index)
+SolutionInvalidity::accumulateTimeStepIntoTotalOccurences(const unsigned int timestep_index)
 {
   for (auto & entry : _counts)
     if (entry.current_timestep_counts)

--- a/test/include/userobjects/WarningUserObject.h
+++ b/test/include/userobjects/WarningUserObject.h
@@ -20,13 +20,10 @@ public:
   static InputParameters validParams();
 
   WarningUserObject(const InputParameters & params);
-  // Get the solution invalid warnings to work
-  // usingCombinedWarningSolutionWarnings;
-  // This is not needed, so the trick I did works
 
   virtual void initialSetup() override;
   virtual void initialize() override {};
   virtual void execute() override;
   virtual void finalize() override;
-  virtual void threadJoin(const UserObject &) override;
+  virtual void threadJoin(const UserObject &) override {};
 };

--- a/test/include/userobjects/WarningUserObject.h
+++ b/test/include/userobjects/WarningUserObject.h
@@ -22,8 +22,8 @@ public:
   WarningUserObject(const InputParameters & params);
 
   virtual void initialSetup() override;
-  virtual void initialize() override {};
+  virtual void initialize() override {}
   virtual void execute() override;
   virtual void finalize() override;
-  virtual void threadJoin(const UserObject &) override {};
+  virtual void threadJoin(const UserObject &) override {}
 };

--- a/test/include/userobjects/WarningUserObject.h
+++ b/test/include/userobjects/WarningUserObject.h
@@ -1,0 +1,32 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ThreadedGeneralUserObject.h"
+
+/**
+ * Outputs a warning
+ */
+class WarningUserObject : public ThreadedGeneralUserObject
+{
+public:
+  static InputParameters validParams();
+
+  WarningUserObject(const InputParameters & params);
+  // Get the solution invalid warnings to work
+  // usingCombinedWarningSolutionWarnings;
+  // This is not needed, so the trick I did works
+
+  virtual void initialSetup() override;
+  virtual void initialize() override {};
+  virtual void execute() override;
+  virtual void finalize() override;
+  virtual void threadJoin(const UserObject &) override;
+};

--- a/test/src/userobjects/WarningUserObject.C
+++ b/test/src/userobjects/WarningUserObject.C
@@ -1,0 +1,49 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "WarningUserObject.h"
+
+registerMooseObject("MooseTestApp", WarningUserObject);
+
+InputParameters
+WarningUserObject::validParams()
+{
+  InputParameters params = GeneralUserObject::validParams();
+  return params;
+}
+
+WarningUserObject::WarningUserObject(const InputParameters & params)
+  : ThreadedGeneralUserObject(params)
+{
+  mooseWarning("During construction");
+}
+
+void
+WarningUserObject::initialSetup()
+{
+  mooseWarning("During initialSetup");
+}
+
+void
+WarningUserObject::execute()
+{
+  mooseWarning("During execution");
+}
+
+void
+WarningUserObject::finalize()
+{
+  mooseWarning("During finalize");
+}
+
+void
+WarningUserObject::threadJoin(const UserObject & /*uo*/)
+{
+  mooseWarning("During threadJoin");
+}

--- a/test/src/userobjects/WarningUserObject.C
+++ b/test/src/userobjects/WarningUserObject.C
@@ -41,9 +41,3 @@ WarningUserObject::finalize()
 {
   mooseWarning("During finalize");
 }
-
-void
-WarningUserObject::threadJoin(const UserObject & /*uo*/)
-{
-  mooseWarning("During threadJoin");
-}

--- a/test/tests/misc/solution_invalid/gold/solution_invalid.json
+++ b/test/tests/misc/solution_invalid/gold/solution_invalid.json
@@ -14,14 +14,12 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 16,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 48
                     },
                     {
-                        "converged_counts": 16,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,

--- a/test/tests/misc/solution_invalid/gold/solution_invalid_checkpoint.json
+++ b/test/tests/misc/solution_invalid/gold/solution_invalid_checkpoint.json
@@ -28,14 +28,14 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 16,
+                        "converged_counts": 0,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 48
                     },
                     {
-                        "converged_counts": 16,
+                        "converged_counts": 0,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
@@ -50,14 +50,14 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 16,
+                        "converged_counts": 0,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 96
                     },
                     {
-                        "converged_counts": 16,
+                        "converged_counts": 0,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,

--- a/test/tests/misc/solution_invalid/gold/solution_invalid_checkpoint.json
+++ b/test/tests/misc/solution_invalid/gold/solution_invalid_checkpoint.json
@@ -28,14 +28,12 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 0,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 48
                     },
                     {
-                        "converged_counts": 0,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
@@ -50,14 +48,12 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 0,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 96
                     },
                     {
-                        "converged_counts": 0,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,

--- a/test/tests/misc/solution_invalid/gold/solution_invalid_outside_solve_out.json
+++ b/test/tests/misc/solution_invalid/gold/solution_invalid_outside_solve_out.json
@@ -14,42 +14,36 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 0,
                         "message": "initial: warning",
                         "object_type": "WarningUserObject",
                         "timestep_counts": 0,
                         "total_counts": 4
                     },
                     {
-                        "converged_counts": 0,
                         "message": "tbegin: warning",
                         "object_type": "WarningUserObject",
                         "timestep_counts": 2,
                         "total_counts": 6
                     },
                     {
-                        "converged_counts": 0,
                         "message": "jacobian: warning",
                         "object_type": "WarningUserObject",
                         "timestep_counts": 0,
                         "total_counts": 4
                     },
                     {
-                        "converged_counts": 0,
                         "message": "residual: warning",
                         "object_type": "WarningUserObject",
                         "timestep_counts": 2,
                         "total_counts": 8
                     },
                     {
-                        "converged_counts": 2,
                         "message": "tend: warning",
                         "object_type": "WarningUserObject",
                         "timestep_counts": 2,
                         "total_counts": 6
                     },
                     {
-                        "converged_counts": 2,
                         "message": "final: warning",
                         "object_type": "WarningUserObject",
                         "timestep_counts": 0,

--- a/test/tests/misc/solution_invalid/gold/solution_invalid_outside_solve_out.json
+++ b/test/tests/misc/solution_invalid/gold/solution_invalid_outside_solve_out.json
@@ -1,0 +1,64 @@
+{
+    "reporters": {
+        "solution_invalidity": {
+            "type": "SolutionInvalidityReporter",
+            "values": {
+                "solution_invalidity": {
+                    "type": "SolutionInvalidity const*"
+                }
+            }
+        }
+    },
+    "time_steps": [
+        {
+            "solution_invalidity": {
+                "solution_invalidity": [
+                    {
+                        "converged_counts": 0,
+                        "message": "initial: warning",
+                        "object_type": "WarningUserObject",
+                        "timestep_counts": 0,
+                        "total_counts": 4
+                    },
+                    {
+                        "converged_counts": 0,
+                        "message": "tbegin: warning",
+                        "object_type": "WarningUserObject",
+                        "timestep_counts": 2,
+                        "total_counts": 6
+                    },
+                    {
+                        "converged_counts": 0,
+                        "message": "jacobian: warning",
+                        "object_type": "WarningUserObject",
+                        "timestep_counts": 0,
+                        "total_counts": 4
+                    },
+                    {
+                        "converged_counts": 0,
+                        "message": "residual: warning",
+                        "object_type": "WarningUserObject",
+                        "timestep_counts": 2,
+                        "total_counts": 8
+                    },
+                    {
+                        "converged_counts": 2,
+                        "message": "tend: warning",
+                        "object_type": "WarningUserObject",
+                        "timestep_counts": 2,
+                        "total_counts": 6
+                    },
+                    {
+                        "converged_counts": 2,
+                        "message": "final: warning",
+                        "object_type": "WarningUserObject",
+                        "timestep_counts": 0,
+                        "total_counts": 2
+                    }
+                ]
+            },
+            "time": 2.0,
+            "time_step": 3
+        }
+    ]
+}

--- a/test/tests/misc/solution_invalid/gold/solution_invalid_parallel.json
+++ b/test/tests/misc/solution_invalid/gold/solution_invalid_parallel.json
@@ -14,14 +14,12 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 4,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 12,
                         "total_counts": 12
                     },
                     {
-                        "converged_counts": 4,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 12,

--- a/test/tests/misc/solution_invalid/gold/solution_invalid_recover.json
+++ b/test/tests/misc/solution_invalid/gold/solution_invalid_recover.json
@@ -28,14 +28,12 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 0,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 48
                     },
                     {
-                        "converged_counts": 0,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
@@ -50,14 +48,12 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 0,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 96
                     },
                     {
-                        "converged_counts": 0,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
@@ -72,14 +68,12 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 0,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 144
                     },
                     {
-                        "converged_counts": 0,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,

--- a/test/tests/misc/solution_invalid/gold/solution_invalid_recover.json
+++ b/test/tests/misc/solution_invalid/gold/solution_invalid_recover.json
@@ -28,14 +28,14 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 16,
+                        "converged_counts": 0,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 48
                     },
                     {
-                        "converged_counts": 16,
+                        "converged_counts": 0,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
@@ -50,14 +50,14 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 16,
+                        "converged_counts": 0,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 96
                     },
                     {
-                        "converged_counts": 16,
+                        "converged_counts": 0,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
@@ -72,14 +72,14 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 16,
+                        "converged_counts": 0,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 144
                     },
                     {
-                        "converged_counts": 16,
+                        "converged_counts": 0,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,

--- a/test/tests/misc/solution_invalid/gold/solution_invalid_transient.json
+++ b/test/tests/misc/solution_invalid/gold/solution_invalid_transient.json
@@ -14,14 +14,12 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 16,
                         "message": "The diffusivity is greater than the threshold value!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,
                         "total_counts": 2160
                     },
                     {
-                        "converged_counts": 16,
                         "message": "Extra invalid thing!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,

--- a/test/tests/misc/solution_invalid/gold/solution_invalid_warning.json
+++ b/test/tests/misc/solution_invalid/gold/solution_invalid_warning.json
@@ -14,7 +14,6 @@
             "solution_invalidity": {
                 "solution_invalidity": [
                     {
-                        "converged_counts": 16,
                         "message": "Solution invalid warning!",
                         "object_type": "NonsafeMaterial",
                         "timestep_counts": 48,

--- a/test/tests/misc/solution_invalid/solution_invalid.i
+++ b/test/tests/misc/solution_invalid/solution_invalid.i
@@ -60,7 +60,6 @@
 [Reporters]
   [solution_invalidity]
     type = SolutionInvalidityReporter
-    execute_on = FINAL
   []
 []
 

--- a/test/tests/misc/solution_invalid/solution_invalid_outside_solve.i
+++ b/test/tests/misc/solution_invalid/solution_invalid_outside_solve.i
@@ -1,0 +1,91 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 1
+  xmax = 1
+  ymax = 1
+[]
+
+[UserObjects]
+  [initial]
+    type = WarningUserObject
+    execute_on = INITIAL
+  []
+  [tbegin]
+    type = WarningUserObject
+    execute_on = TIMESTEP_BEGIN
+  []
+  [jacobian]
+    type = WarningUserObject
+    execute_on = NONLINEAR
+  []
+  [residual]
+    type = WarningUserObject
+    execute_on = LINEAR
+  []
+  [tend]
+    type = WarningUserObject
+    execute_on = TIMESTEP_END
+  []
+  [final]
+    type = WarningUserObject
+    execute_on = FINAL
+  []
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diffusion]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 1
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 0
+  []
+[]
+
+[Problem]
+  type = FEProblem
+[]
+
+[Executioner]
+  # type = Steady
+  type = Transient
+  num_steps = 2
+  solve_type = 'NEWTON'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_type'
+  petsc_options_value = 'lu superlu_dist'
+
+  nl_abs_tol = 1e-10
+[]
+
+[Reporters]
+  [solution_invalidity]
+    type = SolutionInvalidityReporter
+  []
+[]
+
+[Outputs]
+  [out]
+    type = JSON
+    execute_on = 'FINAL'
+    execute_system_information_on = none
+  []
+[]

--- a/test/tests/misc/solution_invalid/solution_invalid_recover.i
+++ b/test/tests/misc/solution_invalid/solution_invalid_recover.i
@@ -72,5 +72,8 @@
 
 [Outputs]
   file_base = 'solution_invalid_recover'
-  json = true
+  [out]
+    type = JSON
+    execute_system_information_on = none
+  []
 []

--- a/test/tests/misc/solution_invalid/solution_invalid_recover.i
+++ b/test/tests/misc/solution_invalid/solution_invalid_recover.i
@@ -65,7 +65,6 @@
 []
 
 [Reporters]
-
   [solution_invalidity]
     type = SolutionInvalidityReporter
   []

--- a/test/tests/misc/solution_invalid/solution_invalid_timehistory.i
+++ b/test/tests/misc/solution_invalid/solution_invalid_timehistory.i
@@ -67,7 +67,6 @@
 [Reporters]
   [solution_invalidity]
     type = SolutionInvalidityReporter
-    execute_on = FINAL
   []
 []
 

--- a/test/tests/misc/solution_invalid/tests
+++ b/test/tests/misc/solution_invalid/tests
@@ -83,6 +83,17 @@
     requirement = 'The system shall be able to output detailed information about why a solution is invalid to a file in transient simulations'
   []
 
+  [warning_tracking_json]
+    type = JSONDiff
+    input = solution_invalid_outside_solve.i
+    jsondiff = 'solution_invalid_outside_solve_out.json'
+    design = 'SolutionInvalidity.md'
+    issues = '#32109'
+    requirement = 'The system shall be able to keep track of all warnings generated during a simulation.'
+    allow_warnings = true
+    recover = false
+  []
+
   [solution_invalid_parallel]
     allow_warnings = true
     recover = false

--- a/test/tests/misc/solution_invalid/tests
+++ b/test/tests/misc/solution_invalid/tests
@@ -146,7 +146,7 @@
       delete_output_before_running = false
       type = JSONDiff
       input = solution_invalid_recover.i
-      cli_args = "--recover solution_invalid_checkpoint_cp/0003 Outputs/file_base='solution_invalid_recover' Executioner/num_steps=4 Outputs/json=true"
+      cli_args = "--recover solution_invalid_checkpoint_cp/0003 Outputs/file_base='solution_invalid_recover' Executioner/num_steps=4"
       jsondiff = 'solution_invalid_recover.json'
       prereq = 'test/solution_valid_checkpoint'
       # SolutionInvalidityReporter accumulates values, so repeating a timestep makes the object stateful.

--- a/test/tests/misc/solution_invalid/tests
+++ b/test/tests/misc/solution_invalid/tests
@@ -92,6 +92,11 @@
     requirement = 'The system shall be able to keep track of all warnings generated during a simulation.'
     allow_warnings = true
     recover = false
+    # The counts are not restartable data, we are double counting over the failed step
+    restep = false
+    # The warnings are emitted by all ranks and threads, and the counts are naturally higher
+    max_parallel = 1
+    max_threads = 1
   []
 
   [solution_invalid_parallel]

--- a/test/tests/misc/solution_invalid/tests
+++ b/test/tests/misc/solution_invalid/tests
@@ -154,16 +154,16 @@
       input = 'solution_invalid_timehistory.i'
       detail = "when solution invalid warning is detected and output with default time step interval"
       expect_out = "Solution Invalid Warnings History:
-      -----------------------------------------------------------------------------------------
-      |                   Object                    | Time | Stepinterval Count | Total Count |
-      -----------------------------------------------------------------------------------------
-      | NonsafeMaterial : Solution invalid warning! | 0-1  |                  0 |           0 |
-      | NonsafeMaterial : Solution invalid warning! | 1-2  |                 48 |          48 |
-      | NonsafeMaterial : Solution invalid warning! | 2-3  |                 48 |          96 |
-      | NonsafeMaterial : Solution invalid warning! | 3-4  |                 48 |         144 |
-      | NonsafeMaterial : Solution invalid warning! | 4-5  |                 48 |         192 |
-      | NonsafeMaterial : Solution invalid warning! | 5-6  |                 48 |         240 |
-      -----------------------------------------------------------------------------------------
+      -------------------------------------------------------------------------------------
+      |                   Object                    | Step | Interval Count | Total Count |
+      -------------------------------------------------------------------------------------
+      | NonsafeMaterial : Solution invalid warning! | 0-1  |              0 |           0 |
+      | NonsafeMaterial : Solution invalid warning! | 1-2  |             48 |          48 |
+      | NonsafeMaterial : Solution invalid warning! | 2-3  |             48 |          96 |
+      | NonsafeMaterial : Solution invalid warning! | 3-4  |             48 |         144 |
+      | NonsafeMaterial : Solution invalid warning! | 4-5  |             48 |         192 |
+      | NonsafeMaterial : Solution invalid warning! | 5-6  |             48 |         240 |
+      -------------------------------------------------------------------------------------
   "
     []
     [use_solution_warning_subblock]
@@ -172,13 +172,13 @@
       cli_args = "Outputs/solution_invalidity_history=false Outputs/solution_invalid/type=SolutionInvalidityOutput Outputs/solution_invalid/solution_invalidity_timestep_interval=2"
       detail = "when user provides a SolutionInvalidityOutput subblock under [Outputs]"
       expect_out = "Solution Invalid Warnings History:
------------------------------------------------------------------------------------------
-|                   Object                    | Time | Stepinterval Count | Total Count |
------------------------------------------------------------------------------------------
-| NonsafeMaterial : Solution invalid warning! | 0-2  |                 48 |          48 |
-| NonsafeMaterial : Solution invalid warning! | 1-3  |                 96 |         144 |
-| NonsafeMaterial : Solution invalid warning! | 2-4  |                 96 |         240 |
------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------
+|                   Object                    | Step | Interval Count | Total Count |
+-------------------------------------------------------------------------------------
+| NonsafeMaterial : Solution invalid warning! | 0-2  |             48 |          48 |
+| NonsafeMaterial : Solution invalid warning! | 1-3  |             96 |         144 |
+| NonsafeMaterial : Solution invalid warning! | 2-4  |             96 |         240 |
+-------------------------------------------------------------------------------------
   "
       []
   []


### PR DESCRIPTION
solution invalid was mainly thought for the solves, so all that code was resetting & tallying entirely in the systems. 
I moved the reset on iterations earlier to avoid resetting right after various objects on linear/nonlinear
Kept the tally on iterations where it was
Moved the tally iteration->time step after timestep_end
Moved the reset on time steps before timestep_begin

refs #32109