### PR TITLE
Give the option to not copy end-of-FP solution to old solution keep_solution_during_restore in FullSolveMultiApp

### DIFF
--- a/framework/include/multiapps/FullSolveMultiApp.h
+++ b/framework/include/multiapps/FullSolveMultiApp.h
@@ -51,6 +51,8 @@ protected:
 private:
   /// Switch to tell executioner to keep going despite app solve not converging
   const bool _ignore_diverge;
+  /// Switch to tell the systems or not to update the old solution using the unrestored solution (the one we 'kept during restore')
+  const bool _update_old_state_when_keeping_solution_during_restore;
 
   std::vector<Executioner *> _executioners;
 };

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -570,6 +570,11 @@ public:
 
   virtual void copySolutionsBackwards();
 
+  /// Prevents the copy of the solution vector to the old solution vector in each system.
+  /// Old -> Older is still performed
+  /// This is useful for MultiApps fixed point iterations
+  void skipNextForwardSolutionCopyToOld();
+
   /**
    * Advance all of the state holding vectors / datastructures so that we can move to the next
    * timestep.

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -601,6 +601,13 @@ public:
   void needSolutionState(unsigned int oldest_needed, Moose::SolutionIterationType iteration_type);
 
   /**
+   * Whether we need up to old (1) or older (2) solution states for a given type of iteration
+   * @param oldest_needed oldest solution state needed
+   * @param iteration_type the type of iteration for which old/older states are needed
+   */
+  bool hasSolutionState(unsigned int state, Moose::SolutionIterationType iteration_type) const;
+
+  /**
    * Output the current step.
    * Will ensure that everything is in the proper state to be outputted.
    * Then tell the OutputWarehouse to do its thing

--- a/framework/include/systems/SystemBase.h
+++ b/framework/include/systems/SystemBase.h
@@ -972,6 +972,12 @@ public:
    */
   void sizeVariableMatrixData();
 
+  /**
+   * Skip the next copy from the solution vector to the old solution vector
+   * old -> older is still performed
+   */
+  void skipNextSolutionToOldCopy() { _skip_next_solution_to_old_copy = true; }
+
 protected:
   /**
    * Internal getter for solution owned by libMesh.
@@ -1084,6 +1090,8 @@ private:
   std::array<std::vector<NumericVector<Number> *>, 3> _solution_states;
   /// The saved solution states (0 = current, 1 = old, 2 = older, etc)
   std::vector<NumericVector<Number> *> _saved_solution_states;
+  /// Whether to skip the next copy from the solution to the old vector
+  bool _skip_next_solution_to_old_copy;
 };
 
 inline bool

--- a/framework/src/multiapps/FullSolveMultiApp.C
+++ b/framework/src/multiapps/FullSolveMultiApp.C
@@ -11,6 +11,8 @@
 #include "LayeredSideDiffusiveFluxAverage.h"
 #include "Executioner.h"
 #include "TransientBase.h"
+#include "FEProblemBase.h"
+#include "MaterialPropertyStorage.h"
 #include "Console.h"
 
 // libMesh
@@ -105,6 +107,14 @@ FullSolveMultiApp::initialSetup()
       }
 
       ex->init();
+
+      if (!_update_old_state_when_keeping_solution_during_restore &&
+          appProblemBase(_first_local_app + i).getMaterialPropertyStorage().hasStatefulProperties())
+        paramError("update_old_solution_when_keeping_solution_during_restore",
+                   "While we are updating old solutions using the solution from the previous fixed "
+                   "point iteration, we are not updating the old stateful material properties as "
+                   "well. This is not consistent. We recommend you consider using the 'no_restore' "
+                   "parameter instead of 'keep_solution_during_restore'.");
 
       _executioners[i] = ex;
     }

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -377,13 +377,14 @@ TransientMultiApp::solveStep(Real dt, Real target_time, bool auto_advance)
         if ((!at_steady && _detect_steady_state) || !_output_sub_cycles)
           problem.outputStep(EXEC_FORCED);
 
-      } // sub_cycling
+      } // end of sub_cycling
       else if (_tolerate_failure)
       {
         ex->takeStep(dt);
         ex->endStep(target_time - app_time_offset);
         ex->postStep();
       }
+      // matched time steps (no subcycling)
       else
       {
         // ADL: During restart, there is already an FEProblemBase::advanceState that occurs at the

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -745,6 +745,17 @@ FEProblemBase::needSolutionState(unsigned int state, Moose::SolutionIterationTyp
   _aux->needSolutionState(state, iteration_type);
 }
 
+bool
+FEProblemBase::hasSolutionState(unsigned int state,
+                                Moose::SolutionIterationType iteration_type) const
+{
+  bool has_solution_state = false;
+  for (auto & sys : _solver_systems)
+    has_solution_state |= sys->hasSolutionState(state, iteration_type);
+  has_solution_state |= _aux->hasSolutionState(state, iteration_type);
+  return has_solution_state;
+}
+
 void
 FEProblemBase::newAssemblyArray(std::vector<std::shared_ptr<SolverSystem>> & solver_systems)
 {

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6853,6 +6853,14 @@ FEProblemBase::copySolutionsBackwards()
 }
 
 void
+FEProblemBase::skipNextForwardSolutionCopyToOld()
+{
+  for (auto & sys : _solver_systems)
+    sys->skipNextSolutionToOldCopy();
+  _aux->skipNextSolutionToOldCopy();
+}
+
+void
 FEProblemBase::advanceState()
 {
   TIME_SECTION("advanceState", 5, "Advancing State");

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -82,7 +82,8 @@ SystemBase::SystemBase(SubProblem & subproblem,
     _max_var_n_dofs_per_node(0),
     _automatic_scaling(false),
     _verbose(false),
-    _solution_states_initialized(false)
+    _solution_states_initialized(false),
+    _skip_next_solution_to_old_copy(false)
 {
 }
 
@@ -1289,8 +1290,9 @@ SystemBase::copyOldSolutions()
   const auto states =
       _solution_states[static_cast<unsigned short>(Moose::SolutionIterationType::Time)].size();
   if (states > 1)
-    for (unsigned int i = states - 1; i > 0; --i)
+    for (unsigned int i = states - 1; i > uint(_skip_next_solution_to_old_copy); --i)
       solutionState(i) = solutionState(i - 1);
+  _skip_next_solution_to_old_copy = false;
 
   if (solutionUDotOld())
     *solutionUDotOld() = *solutionUDot();

--- a/modules/stochastic_tools/src/actions/ParameterStudyAction.C
+++ b/modules/stochastic_tools/src/actions/ParameterStudyAction.C
@@ -448,7 +448,12 @@ ParameterStudyAction::act()
 
       // batch-keep-solution
       if (_multiapp_mode == 3)
+      {
         params.set<bool>("keep_solution_during_restore") = true;
+        // Conceptually all these runs are not 'sequential in time' (moving along a transient)
+        // but rather simply restarted from the same solution
+        params.set<bool>("update_old_solution_when_keeping_solution_during_restore") = false;
+      }
       // batch-no-restore
       else if (_multiapp_mode == 4)
         params.set<bool>("no_restore") = true;

--- a/test/tests/multiapps/picard_multilevel/2level_picard/mutilevel_app.i
+++ b/test/tests/multiapps/picard_multilevel/2level_picard/mutilevel_app.i
@@ -79,6 +79,8 @@
     input_files = sub_level1.i
     execute_on = 'timestep_end'
     keep_solution_during_restore = true
+    # We update the old solution to be able to compute the time derivative when we start the child app's
+    # transient again at the beginning of the next fixed point iteration
     update_old_solution_when_keeping_solution_during_restore = true
   []
 []

--- a/test/tests/multiapps/picard_multilevel/2level_picard/mutilevel_app.i
+++ b/test/tests/multiapps/picard_multilevel/2level_picard/mutilevel_app.i
@@ -79,6 +79,7 @@
     input_files = sub_level1.i
     execute_on = 'timestep_end'
     keep_solution_during_restore = true
+    update_old_solution_when_keeping_solution_during_restore = true
   []
 []
 

--- a/test/tests/multisystem/restore_multiapp/parent.i
+++ b/test/tests/multisystem/restore_multiapp/parent.i
@@ -82,6 +82,9 @@
     input_files = sub.i
     execute_on = TIMESTEP_END
     keep_solution_during_restore = true
+    # The choice does not matter here, but conceptually there is no need to override
+    # the old solution when the subapp is a Steady solve
+    update_old_solution_when_keeping_solution_during_restore = false
   []
 []
 

--- a/test/tests/problems/eigen_problem/eigensolvers/ne_coupled_picard_subT.i
+++ b/test/tests/problems/eigen_problem/eigensolvers/ne_coupled_picard_subT.i
@@ -58,9 +58,12 @@
 [MultiApps]
   [./sub]
     type = FullSolveMultiApp
-    keep_solution_during_restore = true
     input_files = ne_coupled_picard_subT_sub.i
     execute_on = timestep_end
+    keep_solution_during_restore = true
+    # The choice does not matter here, but conceptually there is no need to override
+    # the old solution when the subapp is an Eigenvalue solve
+    update_old_solution_when_keeping_solution_during_restore = false
   [../]
 []
 


### PR DESCRIPTION
Prevents a bug where the unrestored solution gets copied onto the old state 
Which for transients is totally fine, but for quasi-static with old displacement values used in calculations is not. 

closes #32234

I think there will be test failures. Question is how many
EDIT:
looks like only 1 in the framework
EDIT:
should be fine now

Patches:
- moltres https://github.com/arfc/moltres/pull/335
- blue_crab https://github.inl.gov/ncrc/blue_crab/pull/354
- griffin https://github.inl.gov/ncrc/griffin/pull/2921
