### PR TITLE
Fix hdg failure

### DIFF
--- a/framework/include/userobjects/JSONFileReader.h
+++ b/framework/include/userobjects/JSONFileReader.h
@@ -64,7 +64,7 @@ public:
     {
       if (key_index == value_keys.size() - 1)
       {
-        value = current_node->get<T>();
+        value = current_node->template get<T>();
         break;
       }
       current_node = &(*current_node)[value_keys[key_index + 1]];
@@ -113,7 +113,7 @@ public:
                      vector_keys[key_index]);
         vector_to_fill.clear();
         for (const auto & item : *current_node)
-          vector_to_fill.push_back(item.get<T>());
+          vector_to_fill.push_back(item.template get<T>());
         return;
       }
       if (current_node->is_array())

--- a/framework/kokkos.mk
+++ b/framework/kokkos.mk
@@ -77,7 +77,7 @@ ifneq ($(PETSC_HAVE_CUDA),)
   KOKKOS_CXXFLAGS   += --forward-unknown-to-host-compiler --disable-warnings -x cu -ccbin $(word 1, $(libmesh_CXX))
   KOKKOS_CXXFLAGS   += $(filter-out -Werror=return-type,$(CXXFLAGS) $(libmesh_CXXFLAGS)) # Incompatible with NVCC
   KOKKOS_CPPFLAGS    = $(subst -Werror,-Werror=all-warnings,$(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS})
-  KOKKOS_LDFLAGS     = --forward-unknown-to-host-compiler
+  KOKKOS_LDFLAGS     = --forward-unknown-to-host-compiler -arch=sm_$(CUDA_ARCH)
 else ifneq ($(PETSC_HAVE_HIP),) # To be determined for HIP
   KOKKOS_DEVICE     := HIP
   KOKKOS_ARCH       :=

--- a/test/tests/hdgkernels/adapt/2d-advection-diffusion-test.i
+++ b/test/tests/hdgkernels/adapt/2d-advection-diffusion-test.i
@@ -93,6 +93,8 @@
 [Preconditioning]
   [sc]
     type = StaticCondensation
+    petsc_options_iname = '-pc_type -pc_factor_shift_type'
+    petsc_options_value = 'lu       nonzero'
   []
 []
 


### PR DESCRIPTION
Plus a couple hopefully harmless rider commits 😆 

@NamjaeChoi ping for the kokkos LDFLAGS modification. This removes warnings about compiling for old cuda arches