### PR TITLE
Build hwloc topology up front when possible

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -30,7 +30,8 @@ import pyhit
 from FactorySystem.Factory import Factory
 from FactorySystem.Parser import Parser
 from FactorySystem.Warehouse import Warehouse
-from mooseutils import colorText
+
+from .mpi_config import get_mpi_config
 
 if TYPE_CHECKING:
     from pycapabilities import Capabilities
@@ -449,6 +450,9 @@ class TestHarness:
         self.options._checks = checks
         # So that testers can see if we have an application
         self.options._app_name = self.app_name
+
+        # Store the mpi configuration we have discovered
+        self.options._mpi_config = get_mpi_config()
 
         # Initialize the scheduler
         self.initialize()
@@ -1684,6 +1688,16 @@ class TestHarness:
             dest="method",
             const="oprof",
             help="Test the <app_name>-oprof binary",
+        )
+
+        envgroup = parser.add_argument_group(
+            "Environment Options", "Control the runtime environment"
+        )
+        envgroup.add_argument(
+            "--disable-mpi-options",
+            action="store_true",
+            dest="disable_mpi_options",
+            help="Disable automated MPI environment options",
         )
 
         screengroup = parser.add_argument_group(

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -452,7 +452,7 @@ class TestHarness:
         self.options._app_name = self.app_name
 
         # Store the mpi configuration we have discovered
-        self.options._mpi_config = get_mpi_config()
+        self.options.mpi_config = get_mpi_config()
 
         # Initialize the scheduler
         self.initialize()

--- a/python/TestHarness/mpi_config.py
+++ b/python/TestHarness/mpi_config.py
@@ -1,0 +1,90 @@
+# This file is part of the MOOSE framework
+# https://mooseframework.inl.gov
+#
+# All rights reserved, see COPYRIGHT for full restrictions
+# https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#
+# Licensed under LGPL 2.1, please see LICENSE for details
+# https://www.gnu.org/licenses/lgpl-2.1.html
+
+"""Provide capabilities for determining the run-time MPI implementation."""
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from shutil import which
+from socket import gethostname
+from subprocess import CalledProcessError, check_output, run
+from traceback import format_exc
+from typing import Optional
+
+
+class MPIType(Enum):
+    """Enum that represents the MPI implementations that we special case."""
+
+    UNKNOWN = 0
+    OPENMPI = 1
+    MPICH = 2
+
+
+@dataclass
+class MPIConfig:
+    mpi_type: MPIType
+    hwloc: bool
+    hwloc_topo_file: Optional[str]
+
+
+def build_hwloc_topo() -> Optional[str]:
+    """
+    Build the hwloc topology file, if possible.
+
+    If we're able to build this once up front (instead of
+    on every single application execution), we can save a
+    sizeable amount of time on init.
+    """
+
+    if (exe := which("lstopo-no-graphics")) is None and (
+        exe := which("lstopo")
+    ) is None:
+        return None
+
+    try:
+        store_dir = os.path.join(Path.home(), ".local", "share", "moose", "testharness")
+        if not os.path.exists(store_dir):
+            os.makedirs(store_dir, exist_ok=True)
+        store_file = os.path.join(store_dir, f"hwloc_topo_{gethostname()}.xml")
+        cmd = [exe, "--of", "xml", "-f", store_file]
+        run(cmd, check=True)
+        return store_file
+    except Exception:
+        print("WARNING: Failed to build hwloc topology file")
+        print(format_exc())
+
+    return None
+
+
+@staticmethod
+def get_mpi_config() -> MPIConfig:
+    """Get the MPI configuration for the implementations that we special case."""
+    config = MPIConfig(mpi_type=MPIType.UNKNOWN, hwloc=False, hwloc_topo_file=None)
+
+    mpi_command = os.environ.get("MOOSE_MPI_COMMAND", "mpiexec").split()[0]
+    which_mpiexec = which(mpi_command)
+    if which_mpiexec is not None:
+        try:
+            out = check_output([mpi_command, "--version"], text=True)
+        except CalledProcessError:
+            pass
+        else:
+            if "HYDRA" in out:
+                config.mpi_type = MPIType.MPICH
+                if "hwloc" in out:
+                    config.hwloc = True
+            elif "Open MPI" in out:
+                config.mpi_type = MPIType.OPENMPI
+
+    if config.hwloc:
+        config.hwloc_topo_file = build_hwloc_topo()
+
+    return config

--- a/python/TestHarness/mpi_config.py
+++ b/python/TestHarness/mpi_config.py
@@ -63,7 +63,6 @@ def build_hwloc_topo() -> Optional[str]:
     return None
 
 
-@staticmethod
 def get_mpi_config() -> MPIConfig:
     """Get the MPI configuration for the implementations that we special case."""
     config = MPIConfig(mpi_type=MPIType.UNKNOWN, hwloc=False, hwloc_topo_file=None)

--- a/python/TestHarness/mpi_config.py
+++ b/python/TestHarness/mpi_config.py
@@ -51,8 +51,7 @@ def build_hwloc_topo() -> Optional[str]:
 
     try:
         store_dir = os.path.join(Path.home(), ".local", "share", "moose", "testharness")
-        if not os.path.exists(store_dir):
-            os.makedirs(store_dir, exist_ok=True)
+        os.makedirs(store_dir, exist_ok=True)
         store_file = os.path.join(store_dir, f"hwloc_topo_{gethostname()}.xml")
         cmd = [exe, "--of", "xml", "-f", store_file]
         run(cmd, check=True)

--- a/python/TestHarness/runners/HPCRunner.py
+++ b/python/TestHarness/runners/HPCRunner.py
@@ -9,7 +9,7 @@
 
 import re, time, os, subprocess, yaml
 from TestHarness.runners.Runner import Runner
-from TestHarness.mpi_config import MPIConfig
+from TestHarness.mpi_config import MPIConfig, MPIType
 
 
 class HPCRunner(Runner):
@@ -174,7 +174,7 @@ class HPCRunner(Runner):
         #
         # Where <NULL> is there the null character ends up. Thus, in cases
         # where we have a nonzero exit code and a MPI_ABORT, we'll try to remove these.
-        if self.exit_code != 0 and self.options._mpi_config == MPIConfig.OPENMPI:
+        if self.exit_code != 0 and self.options._mpi_config.mpi_type == MPIType.OPENMPI:
             output = self.getRunOutput().getOutput(sanitize=False)
             if "MPI_ABORT" in output:
                 output_changed = False

--- a/python/TestHarness/runners/HPCRunner.py
+++ b/python/TestHarness/runners/HPCRunner.py
@@ -9,7 +9,7 @@
 
 import re, time, os, subprocess, yaml
 from TestHarness.runners.Runner import Runner
-from TestHarness import util
+from TestHarness.mpi_config import MPIConfig
 
 
 class HPCRunner(Runner):
@@ -174,7 +174,7 @@ class HPCRunner(Runner):
         #
         # Where <NULL> is there the null character ends up. Thus, in cases
         # where we have a nonzero exit code and a MPI_ABORT, we'll try to remove these.
-        if self.exit_code != 0 and self.job.getTester().hasOpenMPI():
+        if self.exit_code != 0 and self.options._mpi_config == MPIConfig.OPENMPI:
             output = self.getRunOutput().getOutput(sanitize=False)
             if "MPI_ABORT" in output:
                 output_changed = False

--- a/python/TestHarness/runners/HPCRunner.py
+++ b/python/TestHarness/runners/HPCRunner.py
@@ -174,7 +174,7 @@ class HPCRunner(Runner):
         #
         # Where <NULL> is there the null character ends up. Thus, in cases
         # where we have a nonzero exit code and a MPI_ABORT, we'll try to remove these.
-        if self.exit_code != 0 and self.options._mpi_config.mpi_type == MPIType.OPENMPI:
+        if self.exit_code != 0 and self.options.mpi_config.mpi_type == MPIType.OPENMPI:
             output = self.getRunOutput().getOutput(sanitize=False)
             if "MPI_ABORT" in output:
                 output_changed = False

--- a/python/TestHarness/runners/SubprocessRunner.py
+++ b/python/TestHarness/runners/SubprocessRunner.py
@@ -118,7 +118,7 @@ class SubprocessRunner(Runner):
 
         # Special MPI environment options, if not disabled
         if not self.options.disable_mpi_options:
-            mpi_config: MPIConfig = self.options._mpi_config
+            mpi_config: MPIConfig = self.options.mpi_config
             # OpenMPI
             if mpi_config.mpi_type == MPIType.OPENMPI:
                 # Don't clobber state
@@ -177,7 +177,7 @@ class SubprocessRunner(Runner):
             if (
                 file == self.errfile
                 and self.exit_code != 0
-                and self.options._mpi_config.mpi_type == MPIType.OPENMPI
+                and self.options.mpi_config.mpi_type == MPIType.OPENMPI
                 and len(output) > 2
                 and output[-3:] in ["\n\0\n", "\n\x00\n"]
             ):

--- a/python/TestHarness/runners/SubprocessRunner.py
+++ b/python/TestHarness/runners/SubprocessRunner.py
@@ -19,6 +19,7 @@ from tempfile import SpooledTemporaryFile
 from threading import Lock
 from typing import Optional
 
+from TestHarness.mpi_config import MPIConfig, MPIType
 from TestHarness.runners.Runner import Runner
 from TestHarness.util import findBSDTime, findGNUTime
 
@@ -115,12 +116,22 @@ class SubprocessRunner(Runner):
         # Augment the environment if needed
         process_env = tester.augmentEnvironment(self.options)
 
-        # Special logic for openmpi runs
-        if tester.hasOpenMPI():
-            # Don't clobber state
-            process_env["OMPI_MCA_orte_tmpdir_base"] = self.job.getTempDirectory().name
-            # Allow oversubscription for hosts that don't have a hostfile
-            process_env["PRTE_MCA_rmaps_default_mapping_policy"] = ":oversubscribe"
+        # Special MPI environment options, if not disabled
+        if not self.options.disable_mpi_options:
+            mpi_config: MPIConfig = self.options._mpi_config
+            # OpenMPI
+            if mpi_config.mpi_type == MPIType.OPENMPI:
+                # Don't clobber state
+                process_env["OMPI_MCA_orte_tmpdir_base"] = (
+                    self.job.getTempDirectory().name
+                )
+                # Allow oversubscription for hosts that don't have a hostfile
+                process_env["PRTE_MCA_rmaps_default_mapping_policy"] = ":oversubscribe"
+            # MPICH with hwloc with a prebuilt topology file
+            elif mpi_config.mpi_type == MPIType.MPICH:
+                if mpi_config.hwloc and mpi_config.hwloc_topo_file is not None:
+                    process_env["HWLOC_XMLFILE"] = mpi_config.hwloc_topo_file
+                    process_env["HWLOC_THISSYSTEM"] = "1"
 
         # Add to environment if requested
         if process_env:
@@ -166,7 +177,7 @@ class SubprocessRunner(Runner):
             if (
                 file == self.errfile
                 and self.exit_code != 0
-                and self.job.getTester().hasOpenMPI()
+                and self.options._mpi_config.mpi_type == MPIType.OPENMPI
                 and len(output) > 2
                 and output[-3:] in ["\n\0\n", "\n\x00\n"]
             ):

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -1080,8 +1080,10 @@ class Job(OutputInterface):
             self.timer.start(name, time_now)
             self.timer.stop(name, time_now + total_time)
 
-        # Load the command ran
+        # Load the command and environment ran
         self.__tester.setCommandRan(test_entry["tester"]["command"])
+        if env := test_entry["tester"]["environment"]:
+            self.__tester.setEnvironmentRan(env)
 
         # Load the output
         output_files = test_entry.get("output_files")

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -392,7 +392,7 @@ class RunApp(Tester):
             )
 
             # Need to run mpiexec with containerized openmpi
-            if options.hpc and options._mpi_config.mpi_type == MPIType.OPENMPI:
+            if options.hpc and options.mpi_config.mpi_type == MPIType.OPENMPI:
                 cmd = f"mpiexec -n 1 {cmd}"
 
             return cmd
@@ -516,7 +516,7 @@ class RunApp(Tester):
         if (
             force_mpi
             or ncpus > 1
-            or (options.hpc and options._mpi_config.mpi_type == MPIType.OPENMPI)
+            or (options.hpc and options.mpi_config.mpi_type == MPIType.OPENMPI)
         ):
             command = f"{mpi_command} -n {ncpus} {command}"
 

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -7,13 +7,18 @@
 # Licensed under LGPL 2.1, please see LICENSE for details
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
-import re, os, shutil
-from Tester import Tester
-from TestHarness import util, TestHarness
-from TestHarness.capability_util import addAugmentedCapability
-from shlex import quote
 import json
+import os
+import re
+import shutil
+from shlex import quote
 from typing import Optional, Tuple
+
+from Tester import Tester
+
+from TestHarness import TestHarness, util
+from TestHarness.capability_util import addAugmentedCapability
+from TestHarness.mpi_config import MPIConfig
 
 
 class RunApp(Tester):
@@ -387,7 +392,7 @@ class RunApp(Tester):
             )
 
             # Need to run mpiexec with containerized openmpi
-            if options.hpc and self.hasOpenMPI():
+            if options.hpc and options._mpi_config == MPIConfig.OPENMPI:
                 cmd = f"mpiexec -n 1 {cmd}"
 
             return cmd
@@ -508,7 +513,11 @@ class RunApp(Tester):
 
         # Force mpi, more than 1 core, or containerized openmpi (requires mpiexec serial)
         mpi_command, force_mpi = self.getMPICommand(options)
-        if force_mpi or ncpus > 1 or (options.hpc and self.hasOpenMPI()):
+        if (
+            force_mpi
+            or ncpus > 1
+            or (options.hpc and options._mpi_config == MPIConfig.OPENMPI)
+        ):
             command = f"{mpi_command} -n {ncpus} {command}"
 
         # Arbitrary proxy command; set RUNAPP_COMMAND to the actual command

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -18,7 +18,7 @@ from Tester import Tester
 
 from TestHarness import TestHarness, util
 from TestHarness.capability_util import addAugmentedCapability
-from TestHarness.mpi_config import MPIConfig
+from TestHarness.mpi_config import MPIConfig, MPIType
 
 
 class RunApp(Tester):
@@ -392,7 +392,7 @@ class RunApp(Tester):
             )
 
             # Need to run mpiexec with containerized openmpi
-            if options.hpc and options._mpi_config == MPIConfig.OPENMPI:
+            if options.hpc and options._mpi_config.mpi_type == MPIType.OPENMPI:
                 cmd = f"mpiexec -n 1 {cmd}"
 
             return cmd
@@ -516,7 +516,7 @@ class RunApp(Tester):
         if (
             force_mpi
             or ncpus > 1
-            or (options.hpc and options._mpi_config == MPIConfig.OPENMPI)
+            or (options.hpc and options._mpi_config.mpi_type == MPIType.OPENMPI)
         ):
             command = f"{mpi_command} -n {ncpus} {command}"
 

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -1,11 +1,11 @@
-# * This file is part of the MOOSE framework
-# * https://mooseframework.inl.gov
-# *
-# * All rights reserved, see COPYRIGHT for full restrictions
-# * https://github.com/idaholab/moose/blob/master/COPYRIGHT
-# *
-# * Licensed under LGPL 2.1, please see LICENSE for details
-# * https://www.gnu.org/licenses/lgpl-2.1.html
+# This file is part of the MOOSE framework
+# https://mooseframework.inl.gov
+#
+# All rights reserved, see COPYRIGHT for full restrictions
+# https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#
+# Licensed under LGPL 2.1, please see LICENSE for details
+# https://www.gnu.org/licenses/lgpl-2.1.html
 
 import importlib.util
 import inspect
@@ -15,7 +15,6 @@ import re
 import shutil
 import sys
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Optional, Tuple
 
 import mooseutils
@@ -684,29 +683,6 @@ class Tester(MooseObject, OutputInterface):
                 self.addCaveats(f"slots={min_slots}")
                 return min_slots
         return slots
-
-    def hasOpenMPI(self):
-        """return whether we have openmpi for execution
-
-        The hacky way to do this is look for "ompi_info" (which only comes
-        with openmpi), and then if it does exist make sure that "mpiexec" is
-        in the same directory.
-
-        We could probably move this somewhere so that it's not called multiple
-        times, but I don't think that's a concern because the PATH should be
-        very hot in cache and it's nice to keep this method local to where
-        it's actually used.
-        """
-        which_ompi_info = shutil.which("ompi_info")
-        if which_ompi_info is None:  # no ompi_info
-            return False
-        which_mpiexec = shutil.which("mpiexec")
-        if which_mpiexec is None:  # no mpiexec
-            return False
-        return (
-            Path(which_mpiexec).parent.absolute()
-            == Path(which_ompi_info).parent.absolute()
-        )
 
     def getCommand(self, options):
         """

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -504,6 +504,8 @@ class Tester(MooseObject, OutputInterface):
             ),
             "input_file": self.getInputFile(),
         }
+        if env := self.getEnvironmentRan():
+            results["environment"] = env
         json_metadata = {}
         for key, value in self.json_metadata.items():
             if value.data:


### PR DESCRIPTION
Closes #32252

This decreases runtime for framework tests with `-j 24` from ~400 sec to ~330 sec on rod.