### PR TITLE
Replace test summary with only failed tests (if any)

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -857,13 +857,6 @@ class TestHarness:
         if not self.finished_jobs:
             print('No tests ran')
 
-        # If something failed or verbosity is requested, print combined results
-        if (self.options.verbose or (self.num_failed != 0 and not self.options.quiet)) and not self.options.dry_run:
-            print(header('Final Test Results'))
-            sorted_jobs = sorted(self.finished_jobs, key=lambda job: job.getJointStatus().sort_value)
-            for job in sorted_jobs:
-                print((util.formatJobResult(job, self.options, caveats=True)))
-
         # Longest jobs and longest folders
         if not self.options.dry_run and self.options.longest_jobs:
             longest_jobs = self.getLongestJobs(self.options.longest_jobs)
@@ -902,6 +895,12 @@ class TestHarness:
             print(header('Parser Errors'))
             for err in self.parse_errors:
                 print(err)
+
+        # Print out failed tests with final status, if any
+        if (failed_jobs := [j for j in self.finished_jobs if j.isFail()]):
+            print(header('Failed Tests'))
+            for job in failed_jobs:
+                print((util.formatJobResult(job, self.options, caveats=True)))
 
         time_total = (datetime.datetime.now() - self.start_time).total_seconds()
         stats = self.getStats(time_total)

--- a/python/TestHarness/tests/test_FailedTests.py
+++ b/python/TestHarness/tests/test_FailedTests.py
@@ -21,12 +21,19 @@ class TestHarnessTester(TestHarnessTestCase):
             args = ['--no-color', '--results-file', 'failed-unittest', '-o', output_dir]
             kwargs = {'tmp_output': False}
 
+            # Has failing tests; failed test is output and so is failed test summary
             out = self.runTests(*args, '-i', 'always_bad', exit_code=128, **kwargs).output
             self.assertRegex(out, r'tests/test_harness.always_ok.*?OK')
             self.assertRegex(out, r'tests/test_harness.always_bad.*?FAILED \(CODE 1\)')
+            self.assertIn('Failed Tests:', out)
 
+            # Re-run failed tests
             out = self.runTests(*args, '--failed-tests', exit_code=128, **kwargs).output
             # Verify the passing test is not present
             self.assertNotRegex(out, r'tests/test_harness.always_ok.*?OK')
             # Verify the caveat represents a previous result
             self.assertRegex(out, r'tests/test_harness.always_bad.*?\[PREVIOUS RESULTS: CODE 1\] FAILED \(CODE 1\)')
+
+            # Does not having failing tests; failed tests summary not printed
+            out = self.runTests(*args, "-i", "always_ok").output
+            self.assertNotIn('Failed Tests:', out)


### PR DESCRIPTION
Closes #32238

Example output now: one failure

```
<live test statuses>

20 Longest Running Jobs:
--------------------------------------------------------------------------------------------------------------------
[7.560s] [ 284MB]       OK hdgkernels/ldg-diffusion.mms/quad
[6.475s] [ 305MB]       OK hdgkernels/ldg-diffusion.rt_mms/quad
[5.170s] [ 157MB]       OK linearfvkernels/diffusion-reaction-advection.mms-adr-1d-dirichlet
[5.149s] [ 207MB]       OK hdgkernels/ldg-diffusion.mms/tri
[5.081s] [ 158MB]       OK linearfvkernels/diffusion.mms-diffusion-1d-cd
[4.779s] [ 186MB]       OK hdgkernels/ip-advection-diffusion.mms/monomial_quad
[4.641s] [ 177MB]       OK fvkernels/mms/skewness-correction/diffusion.average
[4.558s] [ 155MB]       OK linearfvkernels/anisotropic-diffusion.mms-anisotropic-diffusion-2d-orthogonal
[4.526s] [ 169MB]       OK linearfvkernels/diffusion.mms-diffusion-1d-cd_neumann
[4.468s] [ 225MB]       OK hdgkernels/ip-advection-diffusion.mms/lagrange_quad
[4.461s] [ 233MB]       OK hdgkernels/ldg-diffusion.rt_mms/tri
[4.452s] [ 166MB]       OK linearfvkernels/diffusion-reaction-advection.mms-adr-1d-neumann
[4.419s] [ 145MB]       OK linearfvkernels/block-restriction.mms-diffusion
[4.410s] [ 286MB]       OK hdgkernels/ip-advection-diffusion.mms/hierarchic_quad
[4.205s] [ 262MB]       OK kernels/2d_diffusion.matdiffusion_coupled/ad
[4.164s] [ 169MB]       OK linearfvkernels/anisotropic-diffusion.mms-anisotropic-diffusion-2d-nonorthogonal
[4.131s] [ 174MB]       OK fvkernels/mms/skewness-correction/diffusion.skewcorrected
[4.130s] [ 196MB]       OK linearfvkernels/diffusion-reaction-advection.mms-adr-1d-outflow
[4.107s] [ 173MB]       OK hdgkernels/ip-advection-diffusion.mms/monomial_tri
[4.100s] [ 199MB]       OK linearfvkernels/diffusion-reaction-advection.mms-adr-2d-dirichlet

20 Heaviest Jobs (memory/proc):
--------------------------------------------------------------------------------------------------------------------
[6.475s] [ 305MB]       OK hdgkernels/ldg-diffusion.rt_mms/quad
[3.406s] [ 297MB]       OK linearfvkernels/diffusion.mms-diffusion-2d-rz-nonorthogonal
[4.410s] [ 286MB]       OK hdgkernels/ip-advection-diffusion.mms/hierarchic_quad
[7.560s] [ 284MB]       OK hdgkernels/ldg-diffusion.mms/quad
[4.205s] [ 262MB]       OK kernels/2d_diffusion.matdiffusion_coupled/ad
[3.980s] [ 254MB]       OK linearfvkernels/diffusion-reaction-advection.mms-adr-2d-neumann
[3.573s] [ 243MB]       OK linearfvkernels/diffusion.mms-diffusion-2d-rz
[3.609s] [ 235MB]       OK linearfvkernels/diffusion.mms-diffusion-2d-orthogonal_neumann
[4.461s] [ 233MB]       OK hdgkernels/ldg-diffusion.rt_mms/tri
[2.514s] [ 231MB]       OK kernels/2d_diffusion.matdiffusion/ad
[3.705s] [ 226MB]       OK hdgkernels/ip-advection-diffusion.mms/hierarchic_tri
[4.468s] [ 225MB]       OK hdgkernels/ip-advection-diffusion.mms/lagrange_quad
[3.626s] [ 223MB]       OK linearfvkernels/diffusion.mms-diffusion-2d-nonorthogonal_neumann
[3.953s] [ 216MB]       OK linearfvkernels/diffusion-reaction-advection.mms-adr-2d-outflow
[5.149s] [ 207MB]       OK hdgkernels/ldg-diffusion.mms/tri
[3.681s] [ 205MB]       OK linearfvkernels/diffusion.mms-diffusion-2d-nonorthogonal
[3.147s] [ 200MB]       OK fviks/one-var-diffusion.harmonic
[4.100s] [ 199MB]       OK linearfvkernels/diffusion-reaction-advection.mms-adr-2d-dirichlet
[3.551s] [ 199MB]       OK hdgkernels/ip-advection-diffusion.mms/lagrange_tri
[4.130s] [ 196MB]       OK linearfvkernels/diffusion-reaction-advection.mms-adr-1d-outflow

20 Longest Running Folders:
--------------------------------------------------------------------------------------------------------------------
[31.11s] tests/linearfvkernels/diffusion
[27.07s] tests/hdgkernels/ip-advection-diffusion
[25.93s] tests/hdgkernels/ldg-diffusion
[25.78s] tests/linearfvkernels/diffusion-reaction-advection
[19.16s] tests/fviks/one-var-diffusion
[16.12s] tests/kernels/2d_diffusion
[11.69s] tests/linearfvbcs/scalar_symmetry
[10.58s] tests/kernels/simple_transient_diffusion
[10.57s] tests/linearfvbcs/robin
[10.10s] tests/restart/restart_diffusion
[8.772s] tests/fvkernels/mms/skewness-correction/diffusion
[8.722s] tests/linearfvkernels/anisotropic-diffusion
[8.353s] tests/fvkernels/fv_simple_diffusion
[7.448s] tests/kernels/ad_mat_diffusion
[5.627s] tests/dgkernels/2d_diffusion_dg
[4.578s] tests/kernels/array_kernels
[4.419s] tests/linearfvkernels/block-restriction
[4.290s] tests/fvkernels/mms/mass-mom-mat-advection-diffusion
[3.757s] tests/fviks/diffusion
[3.752s] tests/kernels/diffusion_with_hanging_node

Failed Tests:
--------------------------------------------------------------------------------------------------------------------
[0.696s] [  28MB]     DIFF kernels/simple_diffusion.test FAILED (EXODIFF)

--------------------------------------------------------------------------------------------------------------------
Ran 164 tests in 35.8 seconds. Average test time 1.7 seconds, maximum test time 7.6 seconds.
163 passed, 9 skipped, 1 FAILED
```

Note the very bottom - failed tests, separate from everything else.