### PR TITLE
Update neml2 submodule

### DIFF
--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2025.12.08" %}
+{% set version = "2026.01.20" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -2,7 +2,7 @@ mpi:
   - mpich
 
 moose_dev:
-  - moose-dev 2025.12.08
+  - moose-dev 2026.01.20
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/framework/contrib/neml2.mk
+++ b/framework/contrib/neml2.mk
@@ -27,28 +27,27 @@ NEML2_LIB_DIR 	 := $(NEML2_DIR)/lib
 else
 $(error Failed to find NEML2 libraries in $(NEML2_DIR)/lib)
 endif
-NEML2_LIBS       := neml2_base$(NEML2_SUFFIX) \
+NEML2_LIBS       := neml2${NEML2_SUFFIX} \
+										neml2_base$(NEML2_SUFFIX) \
 									  neml2_dispatcher$(NEML2_SUFFIX) \
 										neml2_driver$(NEML2_SUFFIX) \
-										neml2_jit$(NEML2_SUFFIX) \
 										neml2_misc$(NEML2_SUFFIX) \
 										neml2_model$(NEML2_SUFFIX) \
 										neml2_solver$(NEML2_SUFFIX) \
 										neml2_tensor$(NEML2_SUFFIX) \
 										neml2_user_tensor$(NEML2_SUFFIX)
-NEML2_LINK_FLAGS := $(addprefix -l,$(NEML2_LIBS))
+NEML2_LIBS       := $(addprefix -l,$(NEML2_LIBS))
 NEML2_LIB_FILES  := $(addprefix $(NEML2_LIB_DIR)/lib,$(addsuffix .$(DYLIB_SUFFIX),$(NEML2_LIBS)))
 
 # Compile flags for NEML2
 neml2_INCLUDES    += $(addprefix -iquote,$(NEML2_INCLUDE))
 neml2_CPPFLAGS    += -DNEML2_ENABLED
-ifeq ($(HAVE_NO_AS_NEEDED),yes)
-  neml2_LDFLAGS += $(NO_AS_NEEDED_FLAG)
-endif
-neml2_LDFLAGS     += -Wl,-rpath,$(NEML2_LIB_DIR) -L$(NEML2_LIB_DIR) $(NEML2_LINK_FLAGS)
+neml2_LDFLAGS     += -Wl,-rpath,$(NEML2_LIB_DIR) -L$(NEML2_LIB_DIR)
+neml2_LIBS        += $(NEML2_LIBS)
 libmesh_CXXFLAGS  += $(neml2_CPPFLAGS)
 libmesh_INCLUDE   += $(neml2_INCLUDES)
-libmesh_LIBS      += $(neml2_LDFLAGS)
+libmesh_LDFLAGS   += $(neml2_LDFLAGS)
+libmesh_LIBS      += $(neml2_LIBS)
 
 endif
 
@@ -63,6 +62,7 @@ ifeq ($(ENABLE_NEML2),true)
 	@echo "NEML2 cppflags: $(neml2_CPPFLAGS)"
 	@echo "NEML2 includes: $(neml2_INCLUDES)"
 	@echo "NEML2 ldflags: $(neml2_LDFLAGS)"
+	@echo "NEML2 libs: $(neml2_LIBS)"
 else
 	@echo "NEML2 is disabled"
 endif

--- a/framework/include/neml2/interfaces/NEML2ModelInterface.h
+++ b/framework/include/neml2/interfaces/NEML2ModelInterface.h
@@ -17,6 +17,7 @@
 
 #ifdef NEML2_ENABLED
 #include <ATen/Parallel.h>
+#include "neml2/neml2.h"
 #include "neml2/models/Model.h"
 #include "neml2/dispatchers/WorkScheduler.h"
 #include "neml2/dispatchers/WorkDispatcher.h"

--- a/framework/include/neml2/userobjects/NEML2ModelExecutor.h
+++ b/framework/include/neml2/userobjects/NEML2ModelExecutor.h
@@ -124,6 +124,12 @@ protected:
   mutable std::map<neml2::VariableName, std::map<std::string, neml2::Tensor>>
       _retrieved_parameter_derivatives;
 
+  /// Whether the model has any state variable
+  bool _has_state = false;
+
+  /// Whether the model has any old state variable
+  bool _has_old_state = false;
+
 private:
   /// Whether an error was encountered
   bool _error;

--- a/framework/src/neml2/actions/NEML2Action.C
+++ b/framework/src/neml2/actions/NEML2Action.C
@@ -15,6 +15,7 @@
 #include "InputParameterWarehouse.h"
 
 #ifdef NEML2_ENABLED
+#include "neml2/neml2.h"
 #include "neml2/base/Parser.h"
 #endif
 

--- a/framework/src/neml2/models/LibtorchModel.C
+++ b/framework/src/neml2/models/LibtorchModel.C
@@ -82,7 +82,7 @@ LibtorchModel::set_value(bool out, bool /*dout_din*/, bool /*d2out_din2*/)
     {
       // assert that all inputs have the same batch dimension
       neml_assert(_inputs[i]->batch_dim() == first_batch_dim);
-      values.push_back(_inputs[i]->value());
+      values.push_back(_inputs[i]->tensor());
     }
 
     auto x = Tensor(torch::transpose(torch::vstack(at::ArrayRef<at::Tensor>(
@@ -97,7 +97,7 @@ LibtorchModel::set_value(bool out, bool /*dout_din*/, bool /*d2out_din2*/)
         (temp.dim() == 1) ? temp.view({temp.size(0), 1}).transpose(0, 1) : temp.transpose(0, 1);
 
     for (size_t i = 0; i < _outputs.size(); ++i)
-      *_outputs[i] = Scalar(y0[i], _inputs[0]->batch_dim());
+      *_outputs[i] = Scalar(y0[i], 0);
   }
 }
 

--- a/modules/solid_mechanics/test/tests/neml2/crystal_plasticity/approx_kinematics_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/crystal_plasticity/approx_kinematics_neml2.i
@@ -4,11 +4,11 @@
     values = '1.0'
   []
   [sdirs]
-    type = FillMillerIndex
+    type = MillerIndex
     values = '1 1 0'
   []
   [splanes]
-    type = FillMillerIndex
+    type = MillerIndex
     values = '1 1 1'
   []
 []

--- a/modules/solid_mechanics/test/tests/neml2/crystal_plasticity/exact_kinematics_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/crystal_plasticity/exact_kinematics_neml2.i
@@ -4,11 +4,11 @@
     values = '1.0'
   []
   [sdirs]
-    type = FillMillerIndex
+    type = MillerIndex
     values = '1 1 0'
   []
   [splanes]
-    type = FillMillerIndex
+    type = MillerIndex
     values = '1 1 1'
   []
 []

--- a/scripts/update_and_rebuild_neml2.sh
+++ b/scripts/update_and_rebuild_neml2.sh
@@ -210,7 +210,8 @@ for METHOD in $(echo "$METHODS" | tr ',' ' '); do
   fi
 
   # Step 3: Configure NEML2
-  source $SCRIPT_DIR/configure_neml2.sh
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/configure_neml2.sh"
   if [[ "${FAST}" != true  ]] ; then
     echo
     echo "****************************************************************************************************"
@@ -223,6 +224,7 @@ for METHOD in $(echo "$METHODS" | tr ',' ' '); do
                     "-DNEML2_CONTRIB_PARALLEL=${NEML2_JOBS}" \
                     "-Dtimpi_BUILD_TYPE=${METHOD}" \
                     "${EXTRA_ARGS[@]}"
+    # shellcheck disable=SC2181
     if [[ $? -ne 0 ]] ; then
       echo "Error: Failed to configure NEML2"
       exit 1
@@ -236,6 +238,7 @@ for METHOD in $(echo "$METHODS" | tr ',' ' '); do
   echo "****************************************************************************************************"
   echo
   build_neml2 "${NEML2_BUILD_DIR}" "${NEML2_JOBS}"
+  # shellcheck disable=SC2181
   if [[ $? -ne 0 ]] ; then
     echo "Error: Failed to build NEML2"
     exit 1
@@ -248,12 +251,14 @@ for METHOD in $(echo "$METHODS" | tr ',' ' '); do
   echo "****************************************************************************************************"
   echo
   install_neml2 "${NEML2_BUILD_DIR}" "${NEML2_DIR}"
+  # shellcheck disable=SC2181
   if [[ $? -ne 0 ]] ; then
     echo "Error: Failed to install NEML2"
     exit 1
   fi
 done
 
+# shellcheck disable=SC2181
 if [[ $? -eq 0 ]]; then
   echo
   echo "****************************************************************************************************"

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -93,7 +93,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2025.12.08
+    version: 2026.01.20
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml

--- a/test/src/neml2/NEML2TestModel.C
+++ b/test/src/neml2/NEML2TestModel.C
@@ -65,8 +65,8 @@ void
 NEML2TestModel::set_value(bool out, bool dout_din, bool /*d2out_din2*/)
 {
   neml_assert(!_error, "Error flag set!");
-  neml_assert(_input_a.value().numel() > 0, "Input A is empty!");
-  neml_assert(_input_b.value().numel() > 0, "Input B is empty!");
+  neml_assert(_input_a.tensor().numel() > 0, "Input A is empty!");
+  neml_assert(_input_b.tensor().numel() > 0, "Input B is empty!");
 
   if (out)
   {


### PR DESCRIPTION
There are some breaking API changes. No regolding needed. Two crystal plasticity neml2 input files need change, basically changing FillMillerIndex -> MillerIndex. All other source code changes are minor, mostly related to batch dimensions versus dynamic dimensions. neml2.mk need to accommodate neml2 library changes: libneml2_jit is removed, and a new libneml2 is added. --no-as-needed is removed as it's no longer required for linking dynamic neml2 libraries.

I want to keep this PR up for at least a week or so to wait for two neml2 PRs that I really want to get in before updating the moose submodule. But @lindsayad please feel free to use this branch or cherry pick my commits.

ref #29579 