### PR TITLE
Add conversion functions of `HeliumFluidProperties` so it works with the thermal hydraulics module

### DIFF
--- a/modules/fluid_properties/include/fluidproperties/HeliumFluidProperties.h
+++ b/modules/fluid_properties/include/fluidproperties/HeliumFluidProperties.h
@@ -184,6 +184,17 @@ public:
    */
   virtual Real k_from_v_e(Real v, Real e) const override;
 
+  /**
+   * Thermal conductivity and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @param[out] k thermal conductivity (W/m.K)
+   * @param[out] dk_dv derivative of thermal conductivity w.r.t. specific volume
+   * @param[out] dk_de derivative of thermal conductivity w.r.t. specific internal energy
+   */
+  virtual void k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const override;
+
   using SinglePhaseFluidProperties::beta_from_p_T;
 
   /**

--- a/modules/fluid_properties/include/fluidproperties/HeliumFluidProperties.h
+++ b/modules/fluid_properties/include/fluidproperties/HeliumFluidProperties.h
@@ -173,6 +173,17 @@ public:
    */
   virtual Real mu_from_v_e(Real v, Real e) const override;
 
+  /**
+   * Dynamic viscosity and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @param[out] mu dynamic viscosity (Pa.s)
+   * @param[out] dmu_dv derivative of dynamic viscosity w.r.t. specific volume
+   * @param[out] dmu_de derivative of dynamic viscosity w.r.t. specific internal energy
+   */
+  virtual void mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const override;
+
   using SinglePhaseFluidProperties::k_from_v_e;
 
   /**
@@ -251,6 +262,26 @@ public:
    * @param[out] de_dT   derivative of specific internal energy w.r.t. temperature
    */
   virtual void e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const override;
+
+  /**
+   * Specific internal energy from specific volume and specific enthalpy
+   *
+   * @param[in] v   specific volume (m^3/kg)
+   * @param[in] h   specific enthalpy (J/kg)
+   * @return specific internal energy (J/kg)
+   */
+  virtual Real e_from_v_h(Real v, Real h) const override;
+
+  /**
+   * Specific internal energy and its derivatives from specific volume and specific enthalpy
+   *
+   * @param[in] v        specific volume (m^3/kg)
+   * @param[in] h        specific enthalpy (J/kg)
+   * @param[out] e       specific internal energy (J/kg)
+   * @param[out] de_dv   derivative of specific internal energy w.r.t. specific volume
+   * @param[out] de_dh   derivative of specific internal energy w.r.t. specific enthalpy
+   */
+  virtual void e_from_v_h(Real v, Real h, Real & e, Real & de_dv, Real & de_dh) const override;
 
   /**
    * Specific enthalpy from pressure and temperature

--- a/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
@@ -304,6 +304,23 @@ HeliumFluidProperties::k_from_v_e(Real v, Real e) const
   return 2.682e-3 * (1.0 + 1.123e-3 * p_in_bar) * std::pow(T, 0.71 * (1.0 - 2.0e-4 * p_in_bar));
 }
 
+void
+HeliumFluidProperties::k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const
+{
+  Real T=0., p=0., dT_dv=0., dT_de=0., dp_dv=0., dp_de=0.;
+  T_from_v_e(v, e, T, dT_dv, dT_de);
+  p_from_v_e(v, e, p dp_dv, dp_de);
+  Real p_in_bar = p * 1.0e-5;
+
+  k = 2.682e-3 * (1.0 + 1.123e-3 * p_in_bar) * std::pow(T, 0.71 * (1.0 - 2.0e-4 * p_in_bar));
+  Real dk_dT = 2.682e-3 * (1.0 + 1.123e-3 * p_in_bar) * 0.71 * (1.0 - 2.0e-4 * p_in_bar) * std::pow(T, 0.71 * (1.0 - 2.0e-4 * p_in_bar) - 1.0);
+  Real dk_dp = 0.;
+
+  dk_dv = dk_dT * dT_dv + dk_dp * dp_dv;
+  dk_de = dk_dT * dT_de + dk_dp * dp_de;
+
+}
+
 Real
 HeliumFluidProperties::beta_from_p_T(Real pressure, Real temperature) const
 {

--- a/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
@@ -307,18 +307,24 @@ HeliumFluidProperties::k_from_v_e(Real v, Real e) const
 void
 HeliumFluidProperties::k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const
 {
-  Real T=0., p=0., dT_dv=0., dT_de=0., dp_dv=0., dp_de=0.;
+  Real T = 0., p = 0., dT_dv = 0., dT_de = 0., dp_dv = 0., dp_de = 0.;
   T_from_v_e(v, e, T, dT_dv, dT_de);
-  p_from_v_e(v, e, p dp_dv, dp_de);
+  p_from_v_e(v, e, p, dp_dv, dp_de);
   Real p_in_bar = p * 1.0e-5;
 
-  k = 2.682e-3 * (1.0 + 1.123e-3 * p_in_bar) * std::pow(T, 0.71 * (1.0 - 2.0e-4 * p_in_bar));
-  Real dk_dT = 2.682e-3 * (1.0 + 1.123e-3 * p_in_bar) * 0.71 * (1.0 - 2.0e-4 * p_in_bar) * std::pow(T, 0.71 * (1.0 - 2.0e-4 * p_in_bar) - 1.0);
-  Real dk_dp = 0.;
+  constexpr Real a = 2.682e-3;
+  constexpr Real b = 1.123e-3;
+  constexpr Real c = 0.71;
+  constexpr Real d = 2.0e-4;
+
+  k = a * (1.0 + b * p_in_bar) * std::pow(T, c * (1.0 - d * p_in_bar));
+  Real dk_dT = a * (1.0 + b * p_in_bar) * c * (1.0 - d * p_in_bar) *
+               std::pow(T, c * (1.0 - d * p_in_bar) - 1.0);
+  Real dk_dp =
+      -a * std::pow(T, a * (1.0 - b * p_in_bar)) * (c * d * (1 + b * p_in_bar) * std::log(T) - b);
 
   dk_dv = dk_dT * dT_dv + dk_dp * dp_dv;
   dk_de = dk_dT * dT_de + dk_dp * dp_de;
-
 }
 
 Real

--- a/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
@@ -405,16 +405,14 @@ Real
 HeliumFluidProperties::e_from_v_h(Real /*v*/, Real h) const
 {
   return _cv * (h / _cp);
-}_cv
+}
 
 void
 HeliumFluidProperties::e_from_v_h(Real v, Real h, Real & e, Real & de_dv, Real & de_dh) const
 {
   e = e_from_v_h(v, h);
-  Real cv = cv_from_v_e(v, e);
-  Real cp = cp_from_v_e(v, e);
-  de_dv = 0.0;
-  de_dh = cv / cp;
+  de_dv = 0.;
+  de_dh = _cv / _cp;
 }
 
 Real

--- a/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
@@ -300,15 +300,9 @@ void
 HeliumFluidProperties::mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const
 {
   mu = mu_from_v_e(v, e);
-
-  Real T = 0, dT_dv = 0., dT_de = 0.;
-  T_from_v_e(v, e, T, dT_dv, dT_de);
-
-  dmu_dv = 0.0; // no dependence on pressure, dT_dv is zero
   const Real dmu_dT = 0.7 * 3.674e-7 * std::pow(T_from_v_e(v, e), -0.3);
-
-  // dmu_dp = 0
-  dmu_de = dmu_dT * dT_de;
+  dmu_dv = 0.0;          // dmu_dp = 0, dT_dv is zero
+  dmu_de = dmu_dT / _cv; // dmu_dp = 0
 }
 
 Real

--- a/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
@@ -296,6 +296,21 @@ HeliumFluidProperties::mu_from_v_e(Real v, Real e) const
   return 3.674e-7 * std::pow(T_from_v_e(v, e), 0.7);
 }
 
+void
+HeliumFluidProperties::mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const
+{
+  mu = mu_from_v_e(v, e);
+
+  Real T = 0, dT_dv = 0., dT_de = 0.;
+  T_from_v_e(v, e, T, dT_dv, dT_de);
+
+  dmu_dv = 0.0; // no dependence on pressure, dT_dv is zero
+  const Real dmu_dT = 0.7 * 3.674e-7 * std::pow(T_from_v_e(v, e), -0.3);
+
+  // dmu_dp = 0
+  dmu_de = dmu_dT * dT_de;
+}
+
 Real
 HeliumFluidProperties::k_from_v_e(Real v, Real e) const
 {
@@ -323,7 +338,7 @@ HeliumFluidProperties::k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real &
   Real dk_dp =
       -a * std::pow(T, a * (1.0 - b * p_in_bar)) * (c * d * (1 + b * p_in_bar) * std::log(T) - b);
 
-  dk_dv = dk_dT * dT_dv + dk_dp * dp_dv;
+  dk_dv = dk_dp * dp_dv; // dT_dv is zero
   dk_de = dk_dT * dT_de + dk_dp * dp_de;
 }
 
@@ -384,6 +399,22 @@ HeliumFluidProperties::e_from_p_T(
   e = e_from_p_T(pressure, temperature);
   de_dp = 0.0;
   de_dT = _cv;
+}
+
+Real
+HeliumFluidProperties::e_from_v_h(Real /*v*/, Real h) const
+{
+  return _cv * (h / _cp);
+}_cv
+
+void
+HeliumFluidProperties::e_from_v_h(Real v, Real h, Real & e, Real & de_dv, Real & de_dh) const
+{
+  e = e_from_v_h(v, h);
+  Real cv = cv_from_v_e(v, e);
+  Real cp = cp_from_v_e(v, e);
+  de_dv = 0.0;
+  de_dh = cv / cp;
 }
 
 Real

--- a/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/HeliumFluidProperties.C
@@ -319,18 +319,16 @@ HeliumFluidProperties::k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real &
   Real T = 0., p = 0., dT_dv = 0., dT_de = 0., dp_dv = 0., dp_de = 0.;
   T_from_v_e(v, e, T, dT_dv, dT_de);
   p_from_v_e(v, e, p, dp_dv, dp_de);
-  Real p_in_bar = p * 1.0e-5;
 
+  // b and d scaled by 1e-5 to account for conversion to bar
   constexpr Real a = 2.682e-3;
-  constexpr Real b = 1.123e-3;
+  constexpr Real b = 1.123e-8;
   constexpr Real c = 0.71;
-  constexpr Real d = 2.0e-4;
+  constexpr Real d = 2.0e-9;
 
-  k = a * (1.0 + b * p_in_bar) * std::pow(T, c * (1.0 - d * p_in_bar));
-  Real dk_dT = a * (1.0 + b * p_in_bar) * c * (1.0 - d * p_in_bar) *
-               std::pow(T, c * (1.0 - d * p_in_bar) - 1.0);
-  Real dk_dp =
-      -a * std::pow(T, a * (1.0 - b * p_in_bar)) * (c * d * (1 + b * p_in_bar) * std::log(T) - b);
+  k = a * (1.0 + b * p) * std::pow(T, c * (1.0 - d * p));
+  Real dk_dT = a * c * (1.0 + b * p) * (1.0 - d * p) * std::pow(T, c * (1.0 - d * p) - 1.0);
+  Real dk_dp = a * std::pow(T, c * (1.0 - d * p)) * (b - c * d * (1 + b * p) * std::log(T));
 
   dk_dv = dk_dp * dp_dv; // dT_dv is zero
   dk_de = dk_dT * dT_de + dk_dp * dp_de;

--- a/modules/fluid_properties/unit/src/HeliumFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/HeliumFluidPropertiesTest.C
@@ -37,6 +37,7 @@ TEST_F(HeliumFluidPropertiesTest, thermalConductivity)
   REL_TEST(_fp->k_from_v_e(v, e), 1.8651584722911332e-01, REL_TOL_SAVED_VALUE);
   REL_TEST(_fp->k_from_p_T(p, T), 1.8651584722911332e-01, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
+  DERIV_TEST(_fp->k_from_v_e, v, e, REL_TOL_DERIVATIVE);
 }
 
 /**
@@ -52,6 +53,7 @@ TEST_F(HeliumFluidPropertiesTest, viscosity)
   REL_TEST(_fp->mu_from_v_e(v, e), 2.4061901685126415e-05, REL_TOL_SAVED_VALUE);
   REL_TEST(_fp->mu_from_p_T(p, T), 2.4061901685126415e-05, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->mu_from_p_T, p, T, REL_TOL_DERIVATIVE);
+  DERIV_TEST(_fp->mu_from_v_e, v, e, REL_TOL_DERIVATIVE);
 }
 
 /**
@@ -110,6 +112,11 @@ TEST_F(HeliumFluidPropertiesTest, specificInternalEnergy)
   ABS_TEST(_fp->e_from_p_T(p, T), 1.2254485499999998e6, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->e_from_p_T, p, T, REL_TOL_DERIVATIVE);
   ABS_TEST(_fp->e_from_p_rho(p, rho), 1.2254485499999998e6, REL_TOL_SAVED_VALUE);
+
+  const Real v = 1. / rho;
+  const Real h = _fp->h_from_p_T(p, T);
+  ABS_TEST(_fp->e_from_v_h(v, h), 1.2254485499999998e6, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->e_from_v_h, v, h, REL_TOL_DERIVATIVE);
 }
 
 /**


### PR DESCRIPTION
Adds functions for `k_from_v_e` and `mu_from_v_e` that return derivatives, so the AD property conversions work properly, which will allow the thermal hydraulics module to work when using Helium property.

Closes #32263 

## Reason
I need to use the Helium in my simulations where there is strong variation of thermal conductivity

## Design
 This should just override existing functions.

## Impact
Should just fix a bug
