### PR TITLE
Fix heavy test with gallium solidification and physics that was timing out

### DIFF
--- a/modules/navier_stokes/doc/content/source/functormaterials/INSFVMushyPorousFrictionFunctorMaterial.md
+++ b/modules/navier_stokes/doc/content/source/functormaterials/INSFVMushyPorousFrictionFunctorMaterial.md
@@ -34,7 +34,7 @@ where the Ergun coefficient is $C_F = 0.55$ and $\rho_l$ is the density of the l
 This material is compatible with [PINSFVMomentumFriction.md] for the non standard (simplified) formulation
 which multiplies the incoming Forchheimer coefficient by the velocity magnitude times velocity component;
 it is *incompatible* with the standard Forchheimer formulation which also multiplies with density over two. Thus the user should
-set the parameter "standard_friction_formulation = false"
+set the parameter "standard_friction_formulation = false" in this kernel or the flow physics.
 
 !syntax parameters /FunctorMaterials/INSFVMushyPorousFrictionFunctorMaterial
 

--- a/modules/navier_stokes/examples/solidification/gallium_melting-physics.i
+++ b/modules/navier_stokes/examples/solidification/gallium_melting-physics.i
@@ -81,6 +81,8 @@ Ny = 50
         # Friction
         friction_types = "Darcy Forchheimer"
         friction_coeffs = "Darcy_coefficient Forchheimer_coefficient"
+        # See documentation for INSFVMushyPorousFrictionFunctorMaterial
+        standard_friction_formulation = false
 
         # Boussinesq
         boussinesq_approximation = true
@@ -109,6 +111,7 @@ Ny = 50
         energy_wall_functors = '${T_hot} ${T_cold} 0 0'
 
         energy_advection_interpolation = '${advected_interp_method}'
+        energy_scaling = 1e-4
       []
     []
     [TwoPhaseMixture]
@@ -181,16 +184,20 @@ Ny = 50
 
   [TimeStepper]
     type = IterationAdaptiveDT
-    optimal_iterations = 10
+    # Raise time step often but not by as much
+    # There's a rough spot for convergence near 10% fluid fraction
+    optimal_iterations = 15
+    growth_factor = 1.5
     dt = 0.1
   []
 
   solve_type = 'NEWTON'
   petsc_options_iname = '-pc_type -pc_factor_shift_type'
   petsc_options_value = 'lu NONZERO'
-  nl_rel_tol = 1e-2
-  nl_abs_tol = 1e-4
+  nl_rel_tol = 1e-6
   nl_max_its = 30
+
+  line_search = 'none'
 []
 
 [Postprocessors]

--- a/modules/navier_stokes/examples/solidification/gallium_melting.i
+++ b/modules/navier_stokes/examples/solidification/gallium_melting.i
@@ -357,7 +357,6 @@ Ny = 50
   # Time-stepping parameters
   start_time = 0.0
   end_time = 200.0
-  num_steps = 2
 
   [TimeStepper]
     type = IterationAdaptiveDT

--- a/modules/navier_stokes/examples/solidification/tests
+++ b/modules/navier_stokes/examples/solidification/tests
@@ -4,7 +4,7 @@
   [gallium_melting]
     type = RunApp
     input = 'gallium_melting.i'
-    cli_args = "Nx=20 Ny=10"
+    cli_args = "Nx=20 Ny=10 Executioner/num_steps=10"
     requirement = 'The system shall be able to simulate the melting of gallium.'
     heavy = true
   []

--- a/modules/navier_stokes/include/physics/WCNSFVTwoPhaseMixturePhysics.h
+++ b/modules/navier_stokes/include/physics/WCNSFVTwoPhaseMixturePhysics.h
@@ -29,7 +29,7 @@ public:
 
 private:
   virtual void addFVKernels() override;
-  virtual void addMaterials() override;
+  virtual void addFunctorMaterials() override;
 
   /// Adds the slip velocity parameters
   virtual void setSlipVelocityParams(InputParameters & params) const override;

--- a/modules/navier_stokes/src/fvkernels/PINSFVMomentumFriction.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVMomentumFriction.C
@@ -143,7 +143,7 @@ PINSFVMomentumFriction::computeFrictionWCoefficient(const Moose::ElemArg & elem_
     speed = NS::computeSpeed<ADReal>(superficial_velocity);
     if (_is_porous_medium)
     {
-      speed *= (1 / _epsilon(elem_arg, state));
+      speed *= (1. / _epsilon(elem_arg, state));
     }
   }
 
@@ -166,7 +166,7 @@ PINSFVMomentumFriction::computeFrictionWCoefficient(const Moose::ElemArg & elem_
     if (_use_Darcy_friction_model)
       coefficient += mu * (*_D)(elem_arg, state)(_index);
     if (_use_Forchheimer_friction_model)
-      coefficient += rho / 2 * (*_F)(elem_arg, state)(_index)*speed;
+      coefficient += rho / 2. * (*_F)(elem_arg, state)(_index)*speed;
   }
   else
   {

--- a/modules/navier_stokes/src/physics/PNSFVSolidHeatTransferPhysics.C
+++ b/modules/navier_stokes/src/physics/PNSFVSolidHeatTransferPhysics.C
@@ -345,16 +345,23 @@ PNSFVSolidHeatTransferPhysics::processThermalConductivity()
         if (getProblem().hasFunctorWithType<ADRealVectorValue>(_thermal_conductivity_name[i],
                                                                /*thread_id=*/0))
           have_vector = true;
-        else
+        else if (getProblem().hasFunctor(_thermal_conductivity_name[i],
+                                         /*thread_id=*/0))
           paramError("thermal_conductivity_solid",
                      "We only allow functor of type (AD)Real or (AD)RealVectorValue for thermal "
                      "conductivity! Functor '" +
                          _thermal_conductivity_name[i] + "' is not of the requested type.");
+        else
+          // If another Physics is creating this functor, we could be running into an order of
+          // creation problem
+          paramWarning("thermal_conductivity_solid",
+                       "Functor '" + _thermal_conductivity_name[i] +
+                           "' was not found in the Problem. Did you mispell it?");
       }
     }
   }
 
-  if (have_vector == have_scalar)
+  if (have_vector && (have_vector == have_scalar))
     paramError("thermal_conductivity_solid",
                "The entries on thermal conductivity shall either be scalars or vectors, mixing "
                "them is not supported!");

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysics.C
@@ -608,10 +608,13 @@ WCNSFVFlowPhysics::addMomentumBoussinesqKernels()
 
   for (const auto d : make_range(dimension()))
   {
-    params.set<MooseEnum>("momentum_component") = NS::directions[d];
-    params.set<NonlinearVariableName>("variable") = _velocity_names[d];
+    if (getParam<RealVectorValue>("gravity")(d) != 0)
+    {
+      params.set<MooseEnum>("momentum_component") = NS::directions[d];
+      params.set<NonlinearVariableName>("variable") = _velocity_names[d];
 
-    getProblem().addFVKernel(kernel_type, kernel_name + NS::directions[d], params);
+      getProblem().addFVKernel(kernel_type, kernel_name + NS::directions[d], params);
+    }
   }
 }
 

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
@@ -139,8 +139,8 @@ WCNSFVFlowPhysicsBase::WCNSFVFlowPhysicsBase(const InputParameters & parameters)
                                 ? getParam<NonlinearVariableName>("fluid_temperature_variable")
                                 : NS::T_fluid),
     _density_name(getParam<MooseFunctorName>("density")),
-    _density_gravity_name(isParamValid("density_gravity")
-                              ? getParam<MooseFunctorName>("density_gravity")
+    _density_gravity_name(isParamValid("density_for_gravity_terms")
+                              ? getParam<MooseFunctorName>("density_for_gravity_terms")
                               : getParam<MooseFunctorName>("density")),
     _dynamic_viscosity_name(getParam<MooseFunctorName>("dynamic_viscosity")),
     _include_symmetrized_viscous_stress(getParam<bool>("include_symmetrized_viscous_stress")),

--- a/modules/navier_stokes/src/physics/WCNSFVTwoPhaseMixturePhysics.C
+++ b/modules/navier_stokes/src/physics/WCNSFVTwoPhaseMixturePhysics.C
@@ -13,7 +13,7 @@
 
 registerNavierStokesPhysicsBaseTasks("NavierStokesApp", WCNSFVTwoPhaseMixturePhysics);
 registerWCNSFVScalarTransportBaseTasks("NavierStokesApp", WCNSFVTwoPhaseMixturePhysics);
-registerMooseAction("NavierStokesApp", WCNSFVTwoPhaseMixturePhysics, "add_material");
+registerMooseAction("NavierStokesApp", WCNSFVTwoPhaseMixturePhysics, "add_functor_material");
 
 InputParameters
 WCNSFVTwoPhaseMixturePhysics::validParams()
@@ -381,7 +381,7 @@ WCNSFVTwoPhaseMixturePhysics::addAdvectionSlipTerm()
 }
 
 void
-WCNSFVTwoPhaseMixturePhysics::addMaterials()
+WCNSFVTwoPhaseMixturePhysics::addFunctorMaterials()
 {
   // Add the phase fraction variable, for output purposes mostly
   if (!getProblem().hasFunctor(_phase_1_fraction_name, /*thread_id=*/0))


### PR DESCRIPTION
made the physics test the same as the non-physics, removing differences that were either just numerical / time stepping parameters and an actual mistake

improved some setup messages and ordering in the flow physics

refs https://github.com/idaholab/moose/issues/30827 https://github.com/idaholab/moose/issues/27555

Note:
I got started on using a functor material to avoid lagging the liquid fraction but the convergence is really really bad. If we could get it to work we would then have a fully implicit solve. Since it's not working, I did not include this. 