### PR TITLE
Make January 2026 news public

### DIFF
--- a/modules/doc/content/newsletter/2026/2026_01.md
+++ b/modules/doc/content/newsletter/2026/2026_01.md
@@ -46,8 +46,6 @@ A mesh generator was added to delete elements from a mesh in the proximity of an
 [ChangeOverTimePostprocessor.md] was modified to allow division of the change in a post-processor value over a time step by the time step size, yielding an approximation of the time derivative. One use case is to use this quantity to check convergence to steady-state conditions (see the new [PostprocessorSteadyStateConvergence.md]).
 ([idaholab/#32242](https://github.com/idaholab/moose/pull/32242))
 
-## MOOSE Bug Fixes
-
 ## MOOSE Modules Changes
 
 ### Added passive scalar transport support in thermal hydraulics module

--- a/modules/doc/content/newsletter/2026/2026_01.md
+++ b/modules/doc/content/newsletter/2026/2026_01.md
@@ -1,10 +1,5 @@
 # MOOSE Newsletter (January 2026)
 
-!alert! construction title=In Progress
-This MOOSE Newsletter edition is in progress. Please check back in February 2026
-for a complete description of all MOOSE changes.
-!alert-end!
-
 ## MOOSE Improvements
 
 - Added the option to pass command line arguments to all `RunApp` testers in the `TestHarness`, via `--append-runapp-cliarg` ([idaholab/moose#31935](https://github.com/idaholab/moose/pull/31935) and [idaholab/moose#32239](https://github.com/idaholab/moose/issues/32239)).
@@ -16,6 +11,8 @@ for a complete description of all MOOSE changes.
 ### UserObject and Postprocessor support in Kokkos-MOOSE
 
 Kokkos-MOOSE now supports GPU-based [UserObjects](syntax/KokkosUserObjects/index.md) and [Postprocessors](syntax/KokkosUserObjects/index.md#reducers). Kokkos-MOOSE postprocessors leverage the reducer concept of Kokkos and have substantially different interface from the original MOOSE postprocessors. The Kokkos-MOOSE `VectorPostprocessors` and `Reporters` will also adopt the same reducer interface and be added soon. See the linked document for details.
+
+## MOOSE Bug Fixes
 
 ## MOOSE Modules Changes
 

--- a/modules/doc/content/newsletter/2026/2026_01.md
+++ b/modules/doc/content/newsletter/2026/2026_01.md
@@ -7,6 +7,21 @@
   - For example, `--append-runapp-cliarg="foo=bar"` will pass the command line option `foo=bar` to all tests that run a MOOSE application.
 
 - The test harness now explicitly checks for a specific exit code on non-zero exits, instead of allowing any non-zero exit codes. The `should_crash` test specification parameter was deprecated and replaced with `expect_exit_code`. Test specifications that set `should_crash = True` now implicitly set `expect_exit_code = 1`. Applications should remove the use of `should_crash` when possible, replacing it with `expect_exit_code`.
+- When assigning a name string to a MooseEnum (perhaps most notably the order parameter), if such name does not exist
+amongst the enumerated items, and if it is plainly parseable as an integer, its existence is also now checked amongst
+the values of the enumerated items, allowing specifications such as `order = 3` instead of `order = THIRD`.
+([idaholab/moose#32164](https://github.com/idaholab/moose/pull/32164))
+- MOOSE now supports hypre AMS and ADS for curl-curl and grad-div problems, respectively, via its well-known PETSc
+interface. A new [DivDivField.md] kernel has been added to allow discretizations of grad-div problems.
+([idaholab/moose#32233](https://github.com/idaholab/moose/pull/32233))
+
+### MFEM Backend improvements
+
+- All hypre AMS problems, including singular problems, are now verified to correctly execute on CUDA GPUs.
+([idaholab/moose#32197](https://github.com/idaholab/moose/pull/32197))
+- Time-dependent problems are now solved in terms of the state of the system at the next timestep, instead of time
+derivatives, using only MFEM's new capabilities.
+([idaholab/moose#32233](https://github.com/idaholab/moose/pull/32233))
 
 ### UserObject and Postprocessor support in Kokkos-MOOSE
 

--- a/modules/doc/content/newsletter/2026/2026_01.md
+++ b/modules/doc/content/newsletter/2026/2026_01.md
@@ -19,10 +19,24 @@ with an equation such as `f(x,y,z) = 0`. See [ProjectSideSetOntoLevelSetGenerato
 
 A mesh generator was added to delete elements from a mesh in the proximity of another mesh. See [DeleteElementsNearMeshGenerator.md]. ([idaholab/moose#32139](https://github.com/idaholab/moose/pull/32139))
 
+### Added ability to detect steady-state conditions using a post-processor
+
+[PostprocessorSteadyStateConvergence.md] was added for detecting steady-state conditions using a post-processor value. This is similar to [PostprocessorConvergence.md] but lacks iteration-count parameters, which are often inappropriate for steady-state detection.
+([idaholab/#32242](https://github.com/idaholab/moose/pull/32242))
+
+### Allowed ChangeOverTimePostprocessor to estimate time derivative
+
+[ChangeOverTimePostprocessor.md] was modified to allow division of the change over time step by the time step size, yielding an approximation of the time derivative. One use case is to use this quantity to check convergence to steady-state conditions (see the new [PostprocessorSteadyStateConvergence.md]).
+([idaholab/#32242](https://github.com/idaholab/moose/pull/32242))
 
 ## MOOSE Bug Fixes
 
 ## MOOSE Modules Changes
+
+### Added passive scalar transport support in thermal hydraulics module
+
+The ability to model the passive transport of quantities like concentrations of molecules has been added to the [Thermal Hydraulics module](https://mooseframework.inl.gov/modules/thermal_hydraulics/index.html). This support has been added to the components [FlowChannel1Phase.md], [SolidWall1Phase.md], [InletMassFlowRateTemperature1Phase.md], and [Outlet1Phase.md].
+([idaholab/#32149](https://github.com/idaholab/moose/pull/32149))
 
 ## libMesh-level Changes
 

--- a/modules/doc/content/newsletter/2026/2026_01.md
+++ b/modules/doc/content/newsletter/2026/2026_01.md
@@ -12,6 +12,14 @@
 
 Kokkos-MOOSE now supports GPU-based [UserObjects](syntax/KokkosUserObjects/index.md) and [Postprocessors](syntax/KokkosUserObjects/index.md#reducers). Kokkos-MOOSE postprocessors leverage the reducer concept of Kokkos and have substantially different interface from the original MOOSE postprocessors. The Kokkos-MOOSE `VectorPostprocessors` and `Reporters` will also adopt the same reducer interface and be added soon. ([idaholab/moose#31858](https://github.com/idaholab/moose/pull/31858))
 
+### Mesh generation capabilities additions
+
+A mesh generator was added to project a sideset onto a level-set surface. Level set surfaces are defined implicitly
+with an equation such as `f(x,y,z) = 0`. See [ProjectSideSetOntoLevelSetGenerator.md]. ([idaholab/moose#32167](https://github.com/idaholab/moose/pull/32167))
+
+A mesh generator was added to delete elements from a mesh in the proximity of another mesh. See [DeleteElementsNearMeshGenerator.md]. ([idaholab/moose#32139](https://github.com/idaholab/moose/pull/32139))
+
+
 ## MOOSE Bug Fixes
 
 ## MOOSE Modules Changes

--- a/modules/doc/content/newsletter/2026/2026_01.md
+++ b/modules/doc/content/newsletter/2026/2026_01.md
@@ -6,31 +6,33 @@
 
   - For example, `--append-runapp-cliarg="foo=bar"` will pass the command line option `foo=bar` to all tests that run a MOOSE application.
 
-- The test harness now explicitly checks for a specific exit code on non-zero exits, instead of allowing any non-zero exit codes. The `should_crash` test specification parameter was deprecated and replaced with `expect_exit_code`. Test specifications that set `should_crash = True` now implicitly set `expect_exit_code = 1`. Applications should remove the use of `should_crash` when possible, replacing it with `expect_exit_code`.
-- When assigning a name string to a MooseEnum (perhaps most notably the order parameter), if such name does not exist
-amongst the enumerated items, and if it is plainly parseable as an integer, its existence is also now checked amongst
-the values of the enumerated items, allowing specifications such as `order = 3` instead of `order = THIRD`.
-([idaholab/moose#32164](https://github.com/idaholab/moose/pull/32164))
-- MOOSE now supports hypre AMS and ADS for curl-curl and grad-div problems, respectively, via its well-known PETSc
-interface. A new [DivDivField.md] kernel has been added to allow discretizations of grad-div problems.
-([idaholab/moose#32233](https://github.com/idaholab/moose/pull/32233))
+- The test harness now explicitly checks for a specific exit code on non-zero exits, instead of allowing any non-zero exit codes. The `should_crash` test
+  specification parameter was deprecated and replaced with `expect_exit_code`. Test specifications that set `should_crash = True` now implicitly set
+  `expect_exit_code = 1`. Applications should remove the use of `should_crash` when possible, replacing it with `expect_exit_code`.
+- When assigning a name string to a MooseEnum (perhaps most notably the order parameter), if such a name does not exist
+  amongst the enumerated items, and if it is plainly parseable as an integer, its existence is also now checked amongst
+  the values of the enumerated items, allowing specifications such as `order = 3` instead of `order = THIRD`.
+  ([idaholab/moose#32164](https://github.com/idaholab/moose/pull/32164))
+- MOOSE now supports hypre the Auxiliary-space Maxwell Solver (AMS) and the Auxiliary-space Divergence Solver (ADS) for curl-curl and grad-div problems,
+  respectively, via its well-known PETSc interface. A new [DivDivField.md] kernel has been added to allow discretizations of grad-div problems.
+  ([idaholab/moose#32233](https://github.com/idaholab/moose/pull/32233))
 
 ### MFEM Backend improvements
 
 - All hypre AMS problems, including singular problems, are now verified to correctly execute on CUDA GPUs.
-([idaholab/moose#32197](https://github.com/idaholab/moose/pull/32197))
+  ([idaholab/moose#32197](https://github.com/idaholab/moose/pull/32197))
 - Time-dependent problems are now solved in terms of the state of the system at the next timestep, instead of time
-derivatives, using only MFEM's new capabilities.
-([idaholab/moose#32233](https://github.com/idaholab/moose/pull/32233))
+  derivatives, using only MFEM's new capabilities.
+  ([idaholab/moose#32233](https://github.com/idaholab/moose/pull/32233))
 
 ### UserObject and Postprocessor support in Kokkos-MOOSE
 
-Kokkos-MOOSE now supports GPU-based [UserObjects](syntax/KokkosUserObjects/index.md) and [Postprocessors](syntax/KokkosUserObjects/index.md#reducers). Kokkos-MOOSE postprocessors leverage the reducer concept of Kokkos and have substantially different interface from the original MOOSE postprocessors. The Kokkos-MOOSE `VectorPostprocessors` and `Reporters` will also adopt the same reducer interface and be added soon. ([idaholab/moose#31858](https://github.com/idaholab/moose/pull/31858))
+Kokkos-MOOSE now supports GPU-based [UserObjects](syntax/KokkosUserObjects/index.md) and [Postprocessors](syntax/KokkosUserObjects/index.md#reducers). Kokkos-MOOSE postprocessors leverage the reducer concept of Kokkos and have substantially different interfaces from the original MOOSE postprocessors. The Kokkos-MOOSE `VectorPostprocessors` and `Reporters` will also adopt the same reducer interface and be added soon. ([idaholab/moose#31858](https://github.com/idaholab/moose/pull/31858))
 
 ### Mesh generation capabilities additions
 
-A mesh generator was added to project a sideset onto a level-set surface. Level set surfaces are defined implicitly
-with an equation such as `f(x,y,z) = 0`. See [ProjectSideSetOntoLevelSetGenerator.md]. ([idaholab/moose#32167](https://github.com/idaholab/moose/pull/32167))
+A mesh generator was added to project a sideset onto a level-set surface. Level-set surfaces are defined implicitly
+with an equation, such as `f(x,y,z) = 0`. See [ProjectSideSetOntoLevelSetGenerator.md]. ([idaholab/moose#32167](https://github.com/idaholab/moose/pull/32167))
 
 A mesh generator was added to delete elements from a mesh in the proximity of another mesh. See [DeleteElementsNearMeshGenerator.md]. ([idaholab/moose#32139](https://github.com/idaholab/moose/pull/32139))
 
@@ -41,7 +43,7 @@ A mesh generator was added to delete elements from a mesh in the proximity of an
 
 ### Allowed ChangeOverTimePostprocessor to estimate time derivative
 
-[ChangeOverTimePostprocessor.md] was modified to allow division of the change over time step by the time step size, yielding an approximation of the time derivative. One use case is to use this quantity to check convergence to steady-state conditions (see the new [PostprocessorSteadyStateConvergence.md]).
+[ChangeOverTimePostprocessor.md] was modified to allow division of the change in a post-processor value over a time step by the time step size, yielding an approximation of the time derivative. One use case is to use this quantity to check convergence to steady-state conditions (see the new [PostprocessorSteadyStateConvergence.md]).
 ([idaholab/#32242](https://github.com/idaholab/moose/pull/32242))
 
 ## MOOSE Bug Fixes
@@ -50,7 +52,7 @@ A mesh generator was added to delete elements from a mesh in the proximity of an
 
 ### Added passive scalar transport support in thermal hydraulics module
 
-The ability to model the passive transport of quantities like concentrations of molecules has been added to the [Thermal Hydraulics module](https://mooseframework.inl.gov/modules/thermal_hydraulics/index.html). This support has been added to the components [FlowChannel1Phase.md], [SolidWall1Phase.md], [InletMassFlowRateTemperature1Phase.md], and [Outlet1Phase.md].
+The ability to model the passive transport of quantities, like concentrations of molecules, has been added to the [Thermal Hydraulics module](https://mooseframework.inl.gov/modules/thermal_hydraulics/index.html). This support has been added to the components [FlowChannel1Phase.md], [SolidWall1Phase.md], [InletMassFlowRateTemperature1Phase.md], and [Outlet1Phase.md].
 ([idaholab/#32149](https://github.com/idaholab/moose/pull/32149))
 
 ## libMesh-level Changes

--- a/modules/doc/content/newsletter/2026/2026_01.md
+++ b/modules/doc/content/newsletter/2026/2026_01.md
@@ -10,7 +10,7 @@
 
 ### UserObject and Postprocessor support in Kokkos-MOOSE
 
-Kokkos-MOOSE now supports GPU-based [UserObjects](syntax/KokkosUserObjects/index.md) and [Postprocessors](syntax/KokkosUserObjects/index.md#reducers). Kokkos-MOOSE postprocessors leverage the reducer concept of Kokkos and have substantially different interface from the original MOOSE postprocessors. The Kokkos-MOOSE `VectorPostprocessors` and `Reporters` will also adopt the same reducer interface and be added soon. See the linked document for details.
+Kokkos-MOOSE now supports GPU-based [UserObjects](syntax/KokkosUserObjects/index.md) and [Postprocessors](syntax/KokkosUserObjects/index.md#reducers). Kokkos-MOOSE postprocessors leverage the reducer concept of Kokkos and have substantially different interface from the original MOOSE postprocessors. The Kokkos-MOOSE `VectorPostprocessors` and `Reporters` will also adopt the same reducer interface and be added soon. ([idaholab/moose#31858](https://github.com/idaholab/moose/pull/31858))
 
 ## MOOSE Bug Fixes
 

--- a/modules/doc/content/newsletter/2026/2026_01.md
+++ b/modules/doc/content/newsletter/2026/2026_01.md
@@ -38,7 +38,8 @@ Kokkos-MOOSE now supports GPU-based [UserObjects](syntax/KokkosUserObjects/index
 
 ## PETSc-level Changes
 
-## Bug Fixes, Minor Changes, and Minor Enhancements
+The PETSc submodule has been updated from `v3.24.2` to `v3.24.3`. Please see the [GitLab changeset listing](https://gitlab.com/petsc/petsc/-/compare/v3.24.3...v3.24.2?from_project_id=13882401)
+for a summary of changes in this minor release update.
 
 ## Package Changes
 

--- a/modules/doc/content/newsletter/2026/2026_02.md
+++ b/modules/doc/content/newsletter/2026/2026_02.md
@@ -1,0 +1,18 @@
+# MOOSE Newsletter (February 2026)
+
+!alert! construction title=In Progress
+This MOOSE Newsletter edition is in progress. Please check back in March 2026
+for a complete description of all MOOSE changes.
+!alert-end!
+
+## MOOSE Improvements
+
+## MOOSE Bug Fixes
+
+## MOOSE Modules Changes
+
+## libMesh-level Changes
+
+## PETSc-level Changes
+
+## Package Changes

--- a/modules/doc/content/newsletter/index.md
+++ b/modules/doc/content/newsletter/index.md
@@ -4,6 +4,10 @@ MOOSE is a dynamic project with changes occurring daily. In order to help users 
 major changes to the project monthly highlights will be produced. These highlights will be posted
 monthly to the [MOOSE discussion forum](contact_us.md) as well as provided below.
 
+## 2026
+
+- [January, 2026](2026_01.md)
+
 ## 2025
 
 - [December, 2025](2025_12.md)


### PR DESCRIPTION
Refs #11446

@idaholab/moose-ccb Please add content from the month of January to the news for yourself and your collaborators! Please ping those who you have reviewed for their input as well. 

A few big notes for this month's update:

- It would be appreciated if we could link the PR in each feature/update we note, for transparency and context. We are working on an extension to make the linking easier, but in the meantime, please manually link to the appropriate PR / Issue (see examples in this month's issue).
- We have merged "minor enhancements" with "MOOSE Improvements". Minor improvements should have a one or two sentence listing under the latter section, and major improvements should have their own subheading under "MOOSE Improvements".
- The bug fixes section has been moved up to make it more visible alongside the improvements section.

