### PR TITLE
Added ADVolumeJunctionBaseUserObject::getFlowChannelVariables()

### DIFF
--- a/modules/thermal_hydraulics/include/userobjects/ADVolumeJunction1PhaseUserObject.h
+++ b/modules/thermal_hydraulics/include/userobjects/ADVolumeJunction1PhaseUserObject.h
@@ -38,6 +38,8 @@ public:
 
 protected:
   virtual void computeFluxesAndResiduals(const unsigned int & c) override;
+  virtual std::vector<const MooseVariableBase *> getFlowChannelVariables() const override;
+  virtual std::vector<const MooseVariableBase *> getJunctionVariables() const override;
 
   /// Cross-sectional area of connected flow channels
   const ADVariableValue & _A;

--- a/modules/thermal_hydraulics/include/userobjects/ADVolumeJunctionBaseUserObject.h
+++ b/modules/thermal_hydraulics/include/userobjects/ADVolumeJunctionBaseUserObject.h
@@ -61,6 +61,11 @@ protected:
   virtual void computeFluxesAndResiduals(const unsigned int & c) = 0;
 
   /**
+   * Gets the flow channel variables
+   */
+  virtual std::vector<const MooseVariableBase *> getFlowChannelVariables() const;
+
+  /**
    * Gets the junction variables
    */
   virtual std::vector<const MooseVariableBase *> getJunctionVariables() const;

--- a/modules/thermal_hydraulics/src/userobjects/ADVolumeJunction1PhaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/ADVolumeJunction1PhaseUserObject.C
@@ -293,3 +293,27 @@ ADVolumeJunction1PhaseUserObject::finalize()
   for (unsigned int i = 0; i < _n_scalar_eq; i++)
     comm().sum(_residual[i]);
 }
+
+std::vector<const MooseVariableBase *>
+ADVolumeJunction1PhaseUserObject::getFlowChannelVariables() const
+{
+  std::vector<const MooseVariableBase *> vars(THMVACE1D::N_FLUX_OUTPUTS);
+  vars[THMVACE1D::RHOA] = getVar("rhoA", 0);
+  vars[THMVACE1D::RHOUA] = getVar("rhouA", 0);
+  vars[THMVACE1D::RHOEA] = getVar("rhoEA", 0);
+
+  return vars;
+}
+
+std::vector<const MooseVariableBase *>
+ADVolumeJunction1PhaseUserObject::getJunctionVariables() const
+{
+  std::vector<const MooseVariableBase *> vars(VolumeJunction1Phase::N_EQ);
+  vars[VolumeJunction1Phase::RHOV_INDEX] = getJunctionVar("rhoV");
+  vars[VolumeJunction1Phase::RHOUV_INDEX] = getJunctionVar("rhouV");
+  vars[VolumeJunction1Phase::RHOVV_INDEX] = getJunctionVar("rhovV");
+  vars[VolumeJunction1Phase::RHOWV_INDEX] = getJunctionVar("rhowV");
+  vars[VolumeJunction1Phase::RHOEV_INDEX] = getJunctionVar("rhoEV");
+
+  return vars;
+}

--- a/modules/thermal_hydraulics/src/userobjects/ADVolumeJunctionBaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/ADVolumeJunctionBaseUserObject.C
@@ -195,6 +195,17 @@ ADVolumeJunctionBaseUserObject::getFlux(const unsigned int & connection_index) c
 }
 
 std::vector<const MooseVariableBase *>
+ADVolumeJunctionBaseUserObject::getFlowChannelVariables() const
+{
+  // TODO: This default implementation should be deleted and made pure virtual
+  // after apps update.
+  std::vector<const MooseVariableBase *> vars(_flow_variable_names.size());
+  for (const auto i : index_range(_flow_variable_names))
+    vars[i] = getVar(_flow_variable_names[i], 0);
+  return vars;
+}
+
+std::vector<const MooseVariableBase *>
 ADVolumeJunctionBaseUserObject::getJunctionVariables() const
 {
   std::vector<const MooseVariableBase *> vars(_scalar_variable_names.size());


### PR DESCRIPTION
This adds a new virtual method `ADVolumeJunctionBaseUserObject::getFlowChannelVariables()`. This was broken out of https://github.com/idaholab/moose/pull/32271 to avoid breaking RELAP-7. After this is merged, the method needs to be implemented in RELAP-7, and then https://github.com/idaholab/moose/pull/32271 can proceed.

Refs #31847
