### PR TITLE
Bump moose-dev and moose-tools to pin coverage

### DIFF
--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -10,7 +10,7 @@ moose_wasp:
   - moose-wasp 2025.09.19_02960f1
 
 moose_tools:
-  - moose-tools 2026.01.27
+  - moose-tools 2026.02.05
 
 zip_keys:
   - mpi

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2026.01.27" %}
+{% set version = "2026.02.05" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -2,7 +2,7 @@ mpi:
   - mpich
 
 moose_dev:
-  - moose-dev 2026.01.27
+  - moose-dev 2026.02.05
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - {{ black }}
     - {{ clang_format }}
     - {{ clang_tools }}
-    - coverage
+    - coverage 7.13.2
     - deepdiff
     - git-lfs <3.5.1
     - gitpython

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,7 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2026.01.27" %}
+{% set version = "2026.02.05" %}
 
 package:
   name: moose-tools

--- a/conda/tools/meta.yaml.template
+++ b/conda/tools/meta.yaml.template
@@ -32,7 +32,7 @@ requirements:
     - {{ black }}
     - {{ clang_format }}
     - {{ clang_tools }}
-    - coverage
+    - coverage 7.13.2
     - deepdiff
     - git-lfs <3.5.1
     - gitpython

--- a/modules/doc/content/newsletter/2026/2026_02.md
+++ b/modules/doc/content/newsletter/2026/2026_02.md
@@ -16,3 +16,15 @@ for a complete description of all MOOSE changes.
 ## PETSc-level Changes
 
 ## Package Changes
+
+#### Conda `moose-tools 2026.02.05`
+
+- Pin python package `coverage` to 7.13.2 (see [#32313](https://github.com/idaholab/moose/issues/32313))
+
+#### Conda `moose-dev 2026.02.05`
+
+- Forced update due to `coverage` pinning in `moose-tools 2026.02.05`
+
+#### Apptainer `moose-dev:2026.02.05`
+
+- Forced update due to `coverage` pinning in `moose-tools 2026.02.05`

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1593,3 +1593,31 @@ fe70eeddb66f8e8f63484fea0d33ed7a67b1d8cb: #31650: update petsc, libmesh, mfem; a
   wasp:
     full_version: 2025.09.19_02960f1_1
     hash: f0e7230
+584097dcae05a38608b1f9787d5186df1dc4f176: # 32312
+  libmesh:
+    full_version: 2026.01.27_502d428_0
+    hash: c72d5c4
+  libmesh-vtk:
+    full_version: 9.5.2_0
+    hash: 6804f54
+  moose-dev:
+    full_version: 2026.02.05
+    hash: 83adebc
+  mpi:
+    full_version: 2026.01.27
+    hash: 8ce4d65
+  petsc:
+    full_version: 3.24.3_0
+    hash: 21e17c6
+  pprof:
+    full_version: 2026.01.11_71be6bf
+    hash: 2e7209c
+  seacas:
+    full_version: 2025.10.14_0
+    hash: a948f18
+  tools:
+    full_version: 2026.02.05
+    hash: 2cb9bc3
+  wasp:
+    full_version: 2025.09.19_02960f1_1
+    hash: f0e7230

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -7,7 +7,7 @@
 packages:
   # dependers: moose-dev
   tools:
-    version: 2026.01.27
+    version: 2026.02.05
     conda: conda/tools
     templates:
       conda/tools/meta.yaml.template: conda/tools/meta.yaml
@@ -92,7 +92,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2026.01.27
+    version: 2026.02.05
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml


### PR DESCRIPTION
Due to issues with the `coverage` python package update, it's being pinned (see github.com/idaholab/moose/issues/32313). This forces a moose-dev update.

## Conda packages

### `moose-tools=2026.02.05`

- Pin python package `coverage` to 7.13.2 (see [#32313](https://github.com/idaholab/moose/issues/32313))

### `moose-dev=2026.02.05`

- Forced update due to `coverage` pinning in `moose-tools 2026.02.05`

## Apptainer packages

### `moose-dev:2026.02.05`

- Forced update due to `coverage` pinning in `moose-tools 2026.02.05`