### PR TITLE
Adjust step interval output in solution invalidity

### DIFF
--- a/framework/src/utils/SolutionInvalidity.C
+++ b/framework/src/utils/SolutionInvalidity.C
@@ -314,7 +314,9 @@ SolutionInvalidity::transientTable(unsigned int & step_interval) const
       for (unsigned int interval_index : index_range(interval_counts))
       {
         std::string interval_index_str =
-            std::to_string(interval_index) + "-" + std::to_string(interval_index + step_interval);
+            (step_interval > 1) ? std::to_string(interval_index) + "-" +
+                                      std::to_string(interval_index + step_interval - 1)
+                                : std::to_string(interval_index);
 
         interval_sum += interval_counts[interval_index];
         vtable.addRow(info.object_type + " : " + info.message, // Object information

--- a/test/tests/misc/solution_invalid/tests
+++ b/test/tests/misc/solution_invalid/tests
@@ -173,12 +173,12 @@
       -------------------------------------------------------------------------------------
       |                   Object                    | Step | Interval Count | Total Count |
       -------------------------------------------------------------------------------------
-      | NonsafeMaterial : Solution invalid warning! | 0-1  |              0 |           0 |
-      | NonsafeMaterial : Solution invalid warning! | 1-2  |             48 |          48 |
-      | NonsafeMaterial : Solution invalid warning! | 2-3  |             48 |          96 |
-      | NonsafeMaterial : Solution invalid warning! | 3-4  |             48 |         144 |
-      | NonsafeMaterial : Solution invalid warning! | 4-5  |             48 |         192 |
-      | NonsafeMaterial : Solution invalid warning! | 5-6  |             48 |         240 |
+      | NonsafeMaterial : Solution invalid warning! | 0    |              0 |           0 |
+      | NonsafeMaterial : Solution invalid warning! | 1    |             48 |          48 |
+      | NonsafeMaterial : Solution invalid warning! | 2    |             48 |          96 |
+      | NonsafeMaterial : Solution invalid warning! | 3    |             48 |         144 |
+      | NonsafeMaterial : Solution invalid warning! | 4    |             48 |         192 |
+      | NonsafeMaterial : Solution invalid warning! | 5    |             48 |         240 |
       -------------------------------------------------------------------------------------
   "
     []
@@ -191,9 +191,9 @@
 -------------------------------------------------------------------------------------
 |                   Object                    | Step | Interval Count | Total Count |
 -------------------------------------------------------------------------------------
-| NonsafeMaterial : Solution invalid warning! | 0-2  |             48 |          48 |
-| NonsafeMaterial : Solution invalid warning! | 1-3  |             96 |         144 |
-| NonsafeMaterial : Solution invalid warning! | 2-4  |             96 |         240 |
+| NonsafeMaterial : Solution invalid warning! | 0-1  |             48 |          48 |
+| NonsafeMaterial : Solution invalid warning! | 1-2  |             96 |         144 |
+| NonsafeMaterial : Solution invalid warning! | 2-3  |             96 |         240 |
 -------------------------------------------------------------------------------------
   "
       []


### PR DESCRIPTION
make it clear events only belong to one step (and or that step + num_intervals - 1)

based on user feedback. I think it looks a tad nicer
refs #29731
