### PR TITLE
Kokkos Multivariable Kernels

### DIFF
--- a/framework/include/kokkos/base/KokkosDatum.h
+++ b/framework/include/kokkos/base/KokkosDatum.h
@@ -343,7 +343,8 @@ public:
       _ife(systems[ivar.sys(comp)].getFETypeID(_ivar)),
       _jfe(systems[ivar.sys(comp)].getFETypeID(_jvar)),
       _n_idofs(assembly.getNumDofs(_elem.type, _ife)),
-      _n_jdofs(assembly.getNumDofs(_elem.type, _jfe))
+      _n_jdofs(assembly.getNumDofs(_elem.type, _jfe)),
+      _comp(comp)
   {
   }
   /**
@@ -367,7 +368,8 @@ public:
       _ivar(ivar.var(comp)),
       _jvar(jvar),
       _ife(systems[ivar.sys(comp)].getFETypeID(_ivar)),
-      _jfe(systems[ivar.sys(comp)].getFETypeID(_jvar))
+      _jfe(systems[ivar.sys(comp)].getFETypeID(_jvar)),
+      _comp(comp)
   {
   }
 
@@ -416,6 +418,11 @@ public:
    * @returns The variable FE type ID
    */
   KOKKOS_FUNCTION unsigned int jfe() const { return _jfe; }
+  /**
+   * Get the variable component
+   * @returns The variable component
+   */
+  KOKKOS_FUNCTION unsigned int comp() const { return _comp; }
 
 protected:
   /**
@@ -434,6 +441,10 @@ protected:
    * Number of local DOFs
    */
   const unsigned int _n_idofs = 1, _n_jdofs = 1;
+  /**
+   * Variable component
+   */
+  const unsigned int _comp;
 };
 
 } // namespace Moose::Kokkos

--- a/framework/include/kokkos/base/KokkosVariable.h
+++ b/framework/include/kokkos/base/KokkosVariable.h
@@ -12,7 +12,7 @@
 #include "KokkosTypes.h"
 
 #include "MooseTypes.h"
-#include "MooseVariableBase.h"
+#include "MooseVariableFieldBase.h"
 #include "MoosePassKey.h"
 
 class Coupleable;
@@ -38,36 +38,85 @@ public:
    * @param variable The MOOSE variable
    * @param tag The vector tag ID
    */
-  Variable(const MooseVariableBase & variable, const TagID tag) { init(variable, tag); }
+  Variable(const MooseVariableFieldBase & variable, const TagID tag) { init(variable, tag); }
   /**
    * Constructor
    * Initialize the variable with a MOOSE variable and vector tag name
    * @param variable The MOOSE variable
    * @param tag_name The vector tag name
    */
-  Variable(const MooseVariableBase & variable, const TagName & tag_name = Moose::SOLUTION_TAG)
+  Variable(const MooseVariableFieldBase & variable, const TagName & tag_name = Moose::SOLUTION_TAG)
   {
     init(variable, tag_name);
   }
+  /**
+   * Constructor
+   * Initialize the variable with multiple MOOSE variables and vector tag ID
+   * @param variables The MOOSE variables
+   * @param tag The vector tag ID
+   */
+  ///@{
+  Variable(const std::vector<const MooseVariableFieldBase *> & variables, const TagID tag)
+  {
+    init(variables, tag);
+  }
+  Variable(const std::vector<MooseVariableFieldBase *> & variables, const TagID tag)
+  {
+    init(variables, tag);
+  }
+  ///@}
+  /**
+   * Constructor
+   * Initialize the variable with multiple MOOSE variables and vector tag name
+   * @param variables The MOOSE variables
+   * @param tag The vector tag ID
+   */
+  ///@{
+  Variable(const std::vector<const MooseVariableFieldBase *> & variables,
+           const TagName & tag_name = Moose::SOLUTION_TAG)
+  {
+    init(variables, tag_name);
+  }
+  Variable(const std::vector<MooseVariableFieldBase *> & variables,
+           const TagName & tag_name = Moose::SOLUTION_TAG)
+  {
+    init(variables, tag_name);
+  }
+  ///@}
+
   /**
    * Initialize the variable with a MOOSE variable and vector tag ID
    * @param variable The MOOSE variable
    * @param tag The vector tag ID
    */
-  void init(const MooseVariableBase & variable, const TagID tag);
+  void init(const MooseVariableFieldBase & variable, const TagID tag);
   /**
    * Initialize the variable with a MOOSE variable and vector tag name
    * @param variable The MOOSE variable
    * @param tag_name The vector tag name
    */
-  void init(const MooseVariableBase & variable, const TagName & tag_name = Moose::SOLUTION_TAG);
+  void init(const MooseVariableFieldBase & variable,
+            const TagName & tag_name = Moose::SOLUTION_TAG);
   /**
-   * Initialize the variable with coupled MOOSE variables
-   * @param variables The coupled MOOSE variables
+   * Initialize the variable with multiple MOOSE variables and vector tag ID
+   * @param variables The MOOSE variables
    * @param tag The vector tag ID
    */
-  void
-  init(const std::vector<const MooseVariableBase *> & variables, const TagID tag, CoupleableKey);
+  ///@{
+  void init(const std::vector<const MooseVariableFieldBase *> & variables, const TagID tag);
+  void init(const std::vector<MooseVariableFieldBase *> & variables, const TagID tag);
+  ///@}
+  /**
+   * Initialize the variable with multiple MOOSE variables and vector tag name
+   * @param variables The MOOSE variables
+   * @param tag_name The vector tag name
+   */
+  ///@{
+  void init(const std::vector<const MooseVariableFieldBase *> & variables,
+            const TagName & tag_name = Moose::SOLUTION_TAG);
+  void init(const std::vector<MooseVariableFieldBase *> & variables,
+            const TagName & tag_name = Moose::SOLUTION_TAG);
+  ///@}
   /**
    * Initialize the variable with coupled default values
    * @param values The default coupled values

--- a/framework/include/kokkos/base/KokkosVariableValue.h
+++ b/framework/include/kokkos/base/KokkosVariableValue.h
@@ -11,7 +11,7 @@
 
 #include "KokkosDatum.h"
 
-#include "MooseVariableBase.h"
+#include "MooseVariableFieldBase.h"
 
 namespace Moose::Kokkos
 {
@@ -134,12 +134,32 @@ public:
    * @param tag The vector tag name
    * @param dof Whether to get DOF values
    */
-  VariableValue(const MooseVariableBase & var,
+  VariableValue(const MooseVariableFieldBase & var,
                 const TagName & tag = Moose::SOLUTION_TAG,
                 bool dof = false)
     : _var(var, tag), _dof(dof)
   {
   }
+  /**
+   * Constructor
+   * @param vars The MOOSE variables
+   * @param tag The vector tag name
+   * @param dof Whether to get DOF values
+   */
+  ///@{
+  VariableValue(const std::vector<const MooseVariableFieldBase *> & vars,
+                const TagName & tag = Moose::SOLUTION_TAG,
+                bool dof = false)
+    : _var(vars, tag), _dof(dof)
+  {
+  }
+  VariableValue(const std::vector<MooseVariableFieldBase *> & vars,
+                const TagName & tag = Moose::SOLUTION_TAG,
+                bool dof = false)
+    : _var(vars, tag), _dof(dof)
+  {
+  }
+  ///@}
 
   /**
    * Get whether the variable was coupled
@@ -150,11 +170,17 @@ public:
   /**
    * Get the current variable value
    * @param datum The Datum object of the current thread
-   * @param qp The local quadrature point index
+   * @param idx The local quadrature point index or DOF index
    * @param comp The variable component
    * @returns The variable value
    */
-  KOKKOS_FUNCTION Real operator()(Datum & datum, unsigned int qp, unsigned int comp = 0) const;
+  ///@{
+  KOKKOS_FUNCTION Real operator()(Datum & datum, unsigned int idx, unsigned int comp = 0) const;
+  KOKKOS_FUNCTION Real operator()(AssemblyDatum & datum, unsigned int idx) const
+  {
+    return this->operator()(datum, idx, datum.comp());
+  }
+  ///@}
 
   /**
    * Get the Kokkos variable
@@ -190,10 +216,27 @@ public:
    * @param var The MOOSE variable
    * @param tag The vector tag name
    */
-  VariableGradient(const MooseVariableBase & var, const TagName & tag = Moose::SOLUTION_TAG)
+  VariableGradient(const MooseVariableFieldBase & var, const TagName & tag = Moose::SOLUTION_TAG)
     : _var(var, tag)
   {
   }
+  /**
+   * Constructor
+   * @param vars The MOOSE variables
+   * @param tag The vector tag name
+   */
+  ///@{
+  VariableGradient(const std::vector<const MooseVariableFieldBase *> & vars,
+                   const TagName & tag = Moose::SOLUTION_TAG)
+    : _var(vars, tag)
+  {
+  }
+  VariableGradient(const std::vector<MooseVariableFieldBase *> vars,
+                   const TagName & tag = Moose::SOLUTION_TAG)
+    : _var(vars, tag)
+  {
+  }
+  ///@}
 
   /**
    * Get whether the variable was coupled
@@ -204,12 +247,17 @@ public:
   /**
    * Get the current variable gradient
    * @param datum The Datum object of the current thread
-   * @param idx The local quadrature point or DOF index
+   * @param qp The local quadrature point index
    * @param comp The variable component
    * @returns The variable gradient
    */
-  KOKKOS_FUNCTION Real3 operator()(Datum & datum, unsigned int idx, unsigned int comp = 0) const;
-
+  ///@{
+  KOKKOS_FUNCTION Real3 operator()(Datum & datum, unsigned int qp, unsigned int comp = 0) const;
+  KOKKOS_FUNCTION Real3 operator()(AssemblyDatum & datum, unsigned int qp) const
+  {
+    return this->operator()(datum, qp, datum.comp());
+  }
+  ///@}
   /**
    * Get the Kokkos variable
    * @returns The Kokkos variable

--- a/framework/include/kokkos/kernels/KokkosTimeDerivative.h
+++ b/framework/include/kokkos/kernels/KokkosTimeDerivative.h
@@ -73,7 +73,7 @@ KokkosTimeDerivative::computeJacobianInternal(const Derived & kernel, AssemblyDa
       unsigned int j = ij / datum.n_jdofs();
 
       accumulateTaggedElementalMatrix(
-          local_ke[ij - ijb], datum.elem().id, i, _lumping ? i : j, datum.jvar());
+          local_ke[ij - ijb], datum.elem().id, i, _lumping ? i : j, datum.jvar(), datum.comp());
     }
   }
 }
@@ -92,5 +92,5 @@ KokkosTimeDerivative::computeQpJacobian(const unsigned int i,
                                         const unsigned int qp,
                                         AssemblyDatum & datum) const
 {
-  return _test(datum, i, qp) * _phi(datum, j, qp) * _du_dot_du;
+  return _test(datum, i, qp) * _phi(datum, j, qp) * _du_dot_du[datum.comp()];
 }

--- a/framework/include/kokkos/kernels/KokkosTimeKernel.h
+++ b/framework/include/kokkos/kernels/KokkosTimeKernel.h
@@ -28,6 +28,11 @@ public:
   TimeKernel(const InputParameters & parameters);
 
   /**
+   * Copy constructor for parallel dispatch
+   */
+  TimeKernel(const TimeKernel & object);
+
+  /**
    * Hook for additional computation for residual after the standard calls
    * @param ib The beginning element-local DOF index
    * @param ie The end element-local DOF index
@@ -56,7 +61,7 @@ protected:
   /**
    * Derivative of u_dot with respect to u
    */
-  const Scalar<const Real> _du_dot_du;
+  Array<Real> _du_dot_du;
 };
 
 template <typename Derived>

--- a/framework/include/kokkos/nodalkernels/KokkosBoundNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosBoundNodalKernel.h
@@ -61,8 +61,9 @@ template <typename Derived>
 KokkosBoundNodalKernel<Derived>::KokkosBoundNodalKernel(const InputParameters & parameters)
   : NodalKernel(parameters), _v_var(coupled("v")), _v(kokkosCoupledNodalValue("v"))
 {
-  if (_var.number() == _v_var)
-    paramError("v", "Coupled variable needs to be different from 'variable'");
+  for (const auto var : variables())
+    if (var->number() == _v_var)
+      paramError("v", "Coupled variable needs to be different from variable");
 }
 
 template <typename Derived>

--- a/framework/include/kokkos/nodalkernels/KokkosTimeDerivativeNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosTimeDerivativeNodalKernel.h
@@ -31,7 +31,7 @@ KokkosTimeDerivativeNodalKernel::computeQpResidual(const unsigned int qp,
 
 KOKKOS_FUNCTION inline Real
 KokkosTimeDerivativeNodalKernel::computeQpJacobian(const unsigned int /* qp */,
-                                                   AssemblyDatum & /* datum */) const
+                                                   AssemblyDatum & datum) const
 {
-  return _du_dot_du;
+  return _du_dot_du[datum.comp()];
 }

--- a/framework/include/kokkos/nodalkernels/KokkosTimeNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosTimeNodalKernel.h
@@ -27,6 +27,11 @@ public:
    */
   TimeNodalKernel(const InputParameters & parameters);
 
+  /**
+   * Copy constructor for parallel dispatch
+   */
+  TimeNodalKernel(const TimeNodalKernel & object);
+
 protected:
   /**
    * Time derivative of the current solution at nodes
@@ -35,7 +40,7 @@ protected:
   /**
    * Derivative of u_dot with respect to u
    */
-  const Scalar<const Real> _du_dot_du;
+  Array<Real> _du_dot_du;
 };
 
 } // namespace Moose::Kokkos

--- a/framework/src/kokkos/base/KokkosResidualObject.K
+++ b/framework/src/kokkos/base/KokkosResidualObject.K
@@ -19,6 +19,10 @@ ResidualObject::validParams()
 {
   auto params = ::ResidualObject::validParams();
 
+  params.makeParamNotRequired<NonlinearVariableName>("variable");
+  params.addParam<std::vector<NonlinearVariableName>>(
+      "variables", "The names of the variables that this residual object operates on");
+
   params.addParam<bool>("use_displaced_mesh",
                         false,
                         "Whether or not this object should use the "
@@ -42,17 +46,41 @@ ResidualObject::ResidualObject(const InputParameters & parameters,
     MeshHolder(*_fe_problem.mesh().getKokkosMesh()),
     AssemblyHolder(_fe_problem.kokkosAssembly()),
     SystemHolder(_fe_problem.getKokkosSystems()),
-    _var(_subproblem.getVariable(_tid,
-                                 getParam<NonlinearVariableName>("variable"),
-                                 Moose::VarKindType::VAR_SOLVER,
-                                 field_type)),
     _t(TransientInterface::_t),
     _t_old(TransientInterface::_t_old),
     _t_step(TransientInterface::_t_step),
     _dt(TransientInterface::_dt),
     _dt_old(TransientInterface::_dt_old)
 {
-  _kokkos_var.init(_var);
+  if (isParamValid("variable") && isParamValid("variables"))
+    mooseError("Cannot specify both 'variable' and 'variables' at the same time.");
+  else if (!isParamValid("variable") && !isParamValid("variables"))
+    mooseError("Either 'variable' or 'variables' should be specified.");
+
+  std::vector<NonlinearVariableName> variables;
+
+  if (isParamValid("variable"))
+    variables.push_back(getParam<NonlinearVariableName>("variable"));
+  else
+    variables = getParam<std::vector<NonlinearVariableName>>("variables");
+
+  for (const auto & variable : variables)
+    _vars.push_back(
+        &_subproblem.getVariable(_tid, variable, Moose::VarKindType::VAR_SOLVER, field_type));
+
+  if (_vars.size() > 1)
+    for (unsigned int i = 1; i < _vars.size(); ++i)
+    {
+      if (_vars[0]->sys().number() != _vars[i]->sys().number())
+        mooseError(
+            "For multi-variable kernels/BCs, all variables should reside in the same system.");
+
+      if (_vars[0]->feType() != _vars[i]->feType())
+        mooseError("For multi-variable kernels/BCs, all variables should have the same FE family "
+                   "and order.");
+    }
+
+  _kokkos_var.init(_vars);
 }
 
 ResidualObject::ResidualObject(const ResidualObject & object)
@@ -60,14 +88,14 @@ ResidualObject::ResidualObject(const ResidualObject & object)
     MeshHolder(object),
     AssemblyHolder(object),
     SystemHolder(object),
-    _var(object._var),
     _kokkos_var(object._kokkos_var),
     _thread(object._thread),
     _t(object._t),
     _t_old(object._t_old),
     _t_step(object._t_step),
     _dt(object._dt),
-    _dt_old(object._dt_old)
+    _dt_old(object._dt_old),
+    _vars(object._vars)
 {
   _vector_tags = object.getVectorTags({});
   _matrix_tags = object.getMatrixTags({});

--- a/framework/src/kokkos/base/KokkosVariable.K
+++ b/framework/src/kokkos/base/KokkosVariable.K
@@ -16,13 +16,13 @@ namespace Moose::Kokkos
 {
 
 void
-Variable::init(const MooseVariableBase & variable, const TagName & tag_name)
+Variable::init(const MooseVariableFieldBase & variable, const TagName & tag_name)
 {
   init(variable, variable.sys().feProblem().getVectorTagID(tag_name));
 }
 
 void
-Variable::init(const MooseVariableBase & variable, const TagID tag)
+Variable::init(const MooseVariableFieldBase & variable, const TagID tag)
 {
   _initialized = true;
   _coupled = true;
@@ -44,9 +44,27 @@ Variable::init(const MooseVariableBase & variable, const TagID tag)
 }
 
 void
-Variable::init(const std::vector<const MooseVariableBase *> & variables,
-               const TagID tag,
-               CoupleableKey)
+Variable::init(const std::vector<MooseVariableFieldBase *> & variables, const TagName & tag_name)
+{
+  init(std::vector<const MooseVariableFieldBase *>(variables.begin(), variables.end()),
+       variables[0]->sys().feProblem().getVectorTagID(tag_name));
+}
+
+void
+Variable::init(const std::vector<const MooseVariableFieldBase *> & variables,
+               const TagName & tag_name)
+{
+  init(variables, variables[0]->sys().feProblem().getVectorTagID(tag_name));
+}
+
+void
+Variable::init(const std::vector<MooseVariableFieldBase *> & variables, const TagID tag)
+{
+  init(std::vector<const MooseVariableFieldBase *>(variables.begin(), variables.end()), tag);
+}
+
+void
+Variable::init(const std::vector<const MooseVariableFieldBase *> & variables, const TagID tag)
 {
   _initialized = true;
   _coupled = true;

--- a/framework/src/kokkos/bcs/KokkosIntegratedBC.K
+++ b/framework/src/kokkos/bcs/KokkosIntegratedBC.K
@@ -25,16 +25,18 @@ IntegratedBC::IntegratedBC(const InputParameters & parameters)
     _grad_test(),
     _phi(),
     _grad_phi(),
-    _u(_var),
-    _grad_u(_var)
+    _u(_kokkos_var),
+    _grad_u(_kokkos_var)
 {
-  addMooseVariableDependency(&_var);
+  addMooseVariableDependency(variables());
 }
 
 void
 IntegratedBC::computeResidual()
 {
-  Policy policy(0, numKokkosBoundarySides());
+  _thread.resize({variables().size(), numKokkosBoundarySides()});
+
+  Policy policy(0, _thread.size());
 
   if (!_residual_dispatcher)
     _residual_dispatcher = DispatcherRegistry::build<ResidualLoop>(this, type());
@@ -47,7 +49,9 @@ IntegratedBC::computeJacobian()
 {
   if (DispatcherRegistry::hasUserMethod<JacobianLoop>(type()))
   {
-    Policy policy(0, numKokkosBoundarySides());
+    _thread.resize({variables().size(), numKokkosBoundarySides()});
+
+    Policy policy(0, _thread.size());
 
     if (!_jacobian_dispatcher)
       _jacobian_dispatcher = DispatcherRegistry::build<JacobianLoop>(this, type());
@@ -59,7 +63,15 @@ IntegratedBC::computeJacobian()
   {
     auto & sys = kokkosSystem(_kokkos_var.sys());
 
-    _thread.resize({sys.getCoupling(_kokkos_var.var()).size(), numKokkosBoundarySides()});
+    if (variables().size() > 1)
+      for (unsigned int i = 1; i < variables().size(); ++i)
+        if (sys.getCoupling(_kokkos_var.var(0)).size() !=
+            sys.getCoupling(_kokkos_var.var(i)).size())
+          mooseError("For multi-variable kernels/BCs, all variables should have the same number of "
+                     "off-diagonal coupling variables.");
+
+    _thread.resize(
+        {variables().size(), sys.getCoupling(_kokkos_var.var()).size(), numKokkosBoundarySides()});
 
     Policy policy(0, _thread.size());
 

--- a/framework/src/kokkos/bcs/KokkosNodalBC.K
+++ b/framework/src/kokkos/bcs/KokkosNodalBC.K
@@ -20,16 +20,17 @@ NodalBC::validParams()
 }
 
 NodalBC::NodalBC(const InputParameters & parameters)
-  : NodalBCBase(parameters, Moose::VarFieldType::VAR_FIELD_STANDARD),
-    _u(_var, Moose::SOLUTION_TAG, true)
+  : NodalBCBase(parameters, Moose::VarFieldType::VAR_FIELD_STANDARD), _u(_kokkos_var, true)
 {
-  addMooseVariableDependency(&_var);
+  addMooseVariableDependency(variables());
 }
 
 void
 NodalBC::computeResidual()
 {
-  Policy policy(0, numKokkosBoundaryNodes());
+  _thread.resize({variables().size(), numKokkosBoundaryNodes()});
+
+  Policy policy(0, _thread.size());
 
   if (!_residual_dispatcher)
     _residual_dispatcher = DispatcherRegistry::build<ResidualLoop>(this, type());
@@ -40,7 +41,9 @@ NodalBC::computeResidual()
 void
 NodalBC::computeJacobian()
 {
-  Policy policy(0, numKokkosBoundaryNodes());
+  _thread.resize({variables().size(), numKokkosBoundaryNodes()});
+
+  Policy policy(0, _thread.size());
 
   if (!_jacobian_dispatcher)
     _jacobian_dispatcher = DispatcherRegistry::build<JacobianLoop>(this, type());
@@ -51,7 +54,15 @@ NodalBC::computeJacobian()
   {
     auto & sys = kokkosSystem(_kokkos_var.sys());
 
-    _thread.resize({sys.getCoupling(_kokkos_var.var()).size(), numKokkosBoundaryNodes()});
+    if (variables().size() > 1)
+      for (unsigned int i = 1; i < variables().size(); ++i)
+        if (sys.getCoupling(_kokkos_var.var(0)).size() !=
+            sys.getCoupling(_kokkos_var.var(i)).size())
+          mooseError("For multi-variable kernels/BCs, all variables should have the same number of "
+                     "off-diagonal coupling variables.");
+
+    _thread.resize(
+        {variables().size(), sys.getCoupling(_kokkos_var.var()).size(), numKokkosBoundaryNodes()});
 
     Policy policy(0, _thread.size());
 

--- a/framework/src/kokkos/interfaces/KokkosCoupleable.K
+++ b/framework/src/kokkos/interfaces/KokkosCoupleable.K
@@ -13,6 +13,8 @@
 #include "SystemBase.h"
 #include "FEProblemBase.h"
 
+using CoupleableKey = Moose::Kokkos::Variable::CoupleableKey;
+
 Moose::Kokkos::Variable
 Coupleable::kokkosCoupledVectorTagVariable(const std::string & var_name,
                                            const std::string & tag_name,
@@ -34,10 +36,10 @@ Coupleable::kokkosCoupledVectorTagVariable(const std::string & var_name,
 
     const_cast<Coupleable *>(this)->addFEVariableCoupleableVectorTag(tag);
 
-    variable.init({var}, tag, {});
+    variable.init(*var, tag);
   }
   else
-    variable.init({_c_parameters.defaultCoupledValue(var_name, comp)}, {});
+    variable.init({_c_parameters.defaultCoupledValue(var_name, comp)}, CoupleableKey{});
 
   return variable;
 }
@@ -52,7 +54,7 @@ Coupleable::kokkosCoupledVectorTagVariables(const std::string & var_name,
 
   if (isCoupled(var_name))
   {
-    std::vector<const MooseVariableBase *> vars;
+    std::vector<const MooseVariableFieldBase *> vars;
 
     for (unsigned int comp = 0; comp < components; ++comp)
     {
@@ -71,7 +73,7 @@ Coupleable::kokkosCoupledVectorTagVariables(const std::string & var_name,
 
     const_cast<Coupleable *>(this)->addFEVariableCoupleableVectorTag(tag);
 
-    variable.init({vars}, tag, {});
+    variable.init(vars, tag);
   }
   else
   {
@@ -80,7 +82,7 @@ Coupleable::kokkosCoupledVectorTagVariables(const std::string & var_name,
     for (unsigned int comp = 0; comp < components; ++comp)
       default_values[comp] = _c_parameters.defaultCoupledValue(var_name, comp);
 
-    variable.init(default_values, {});
+    variable.init(default_values, CoupleableKey{});
   }
 
   return variable;
@@ -91,7 +93,7 @@ Coupleable::kokkosZeroVariable() const
 {
   Moose::Kokkos::Variable variable;
 
-  variable.init({0}, {});
+  variable.init({0}, CoupleableKey{});
 
   return variable;
 }

--- a/framework/src/kokkos/kernels/KokkosCoupledForce.K
+++ b/framework/src/kokkos/kernels/KokkosCoupledForce.K
@@ -31,7 +31,8 @@ KokkosCoupledForce::KokkosCoupledForce(const InputParameters & parameters)
     _v(kokkosCoupledValue("v")),
     _coef(getParam<Real>("coef"))
 {
-  if (_var.number() == _v_var)
-    paramError(
-        "v", "Coupled variable 'v' needs to be different from 'variable' with KokkosCoupledForce.");
+  for (const auto var : variables())
+    if (var->number() == _v_var)
+      paramError(
+          "v", "Coupled variable 'v' needs to be different from variable with KokkosCoupledForce.");
 }

--- a/framework/src/kokkos/kernels/KokkosKernel.K
+++ b/framework/src/kokkos/kernels/KokkosKernel.K
@@ -25,16 +25,18 @@ Kernel::Kernel(const InputParameters & parameters)
     _grad_test(),
     _phi(),
     _grad_phi(),
-    _u(_var),
-    _grad_u(_var)
+    _u(_kokkos_var),
+    _grad_u(_kokkos_var)
 {
-  addMooseVariableDependency(&_var);
+  addMooseVariableDependency(variables());
 }
 
 void
 Kernel::computeResidual()
 {
-  Policy policy(0, numKokkosBlockElements());
+  _thread.resize({variables().size(), numKokkosBlockElements()});
+
+  Policy policy(0, _thread.size());
 
   if (!_residual_dispatcher)
     _residual_dispatcher = DispatcherRegistry::build<ResidualLoop>(this, type());
@@ -47,7 +49,9 @@ Kernel::computeJacobian()
 {
   if (DispatcherRegistry::hasUserMethod<JacobianLoop>(type()))
   {
-    Policy policy(0, numKokkosBlockElements());
+    _thread.resize({variables().size(), numKokkosBlockElements()});
+
+    Policy policy(0, _thread.size());
 
     if (!_jacobian_dispatcher)
       _jacobian_dispatcher = DispatcherRegistry::build<JacobianLoop>(this, type());
@@ -59,7 +63,15 @@ Kernel::computeJacobian()
   {
     auto & sys = kokkosSystem(_kokkos_var.sys());
 
-    _thread.resize({sys.getCoupling(_kokkos_var.var()).size(), numKokkosBlockElements()});
+    if (variables().size() > 1)
+      for (unsigned int i = 1; i < variables().size(); ++i)
+        if (sys.getCoupling(_kokkos_var.var(0)).size() !=
+            sys.getCoupling(_kokkos_var.var(i)).size())
+          mooseError("For multi-variable kernels/BCs, all variables should have the same number of "
+                     "off-diagonal coupling variables.");
+
+    _thread.resize(
+        {variables().size(), sys.getCoupling(_kokkos_var.var()).size(), numKokkosBlockElements()});
 
     Policy policy(0, _thread.size());
 

--- a/framework/src/kokkos/kernels/KokkosMatCoupledForce.K
+++ b/framework/src/kokkos/kernels/KokkosMatCoupledForce.K
@@ -43,10 +43,11 @@ KokkosMatCoupledForce::KokkosMatCoupledForce(const InputParameters & parameters)
   {
     _v_var_to_index[_v_var[j]] = j;
 
-    if (_var.number() == _v_var[j])
-      paramError("v",
-                 "Coupled variable 'v' needs to be different from 'variable', consider using "
-                 "KokkosReaction or something similar");
+    for (const auto var : variables())
+      if (var->number() == _v_var[j])
+        paramError("v",
+                   "Coupled variable 'v' needs to be different from variable, consider using "
+                   "KokkosReaction or something similar");
   }
 
   _v_var_to_index.copyToDevice();

--- a/framework/src/kokkos/kernels/KokkosTimeKernel.K
+++ b/framework/src/kokkos/kernels/KokkosTimeKernel.K
@@ -24,10 +24,20 @@ TimeKernel::validParams()
 }
 
 TimeKernel::TimeKernel(const InputParameters & parameters)
-  : Kernel(parameters),
-    _u_dot(_var, Moose::SOLUTION_DOT_TAG),
-    _du_dot_du(_var.sys().duDotDu(_var.number()))
+  : Kernel(parameters), _u_dot(variables(), Moose::SOLUTION_DOT_TAG), _du_dot_du(variables().size())
 {
+}
+
+TimeKernel::TimeKernel(const TimeKernel & object)
+  : Kernel(object), _u_dot(object._u_dot), _du_dot_du(object._du_dot_du)
+{
+  // TODO: We want to use Array<Scalar<const Real>> for _du_dot_du so that it is automatically
+  // synchronized, but currently there is an NVCC bug preventing it
+
+  for (unsigned int i = 0; i < variables().size(); ++i)
+    _du_dot_du[i] = variables()[i]->sys().duDotDu(variables()[i]->number());
+
+  _du_dot_du.copyToDevice();
 }
 
 } // namespace Moose::Kokkos

--- a/framework/src/kokkos/nodalkernels/KokkosCoupledForceNodalKernel.K
+++ b/framework/src/kokkos/nodalkernels/KokkosCoupledForceNodalKernel.K
@@ -29,8 +29,9 @@ KokkosCoupledForceNodalKernel::KokkosCoupledForceNodalKernel(const InputParamete
     _v(kokkosCoupledNodalValue("v")),
     _coef(getParam<Real>("coef"))
 {
-  if (_var.number() == _v_var)
-    mooseError(
-        "Coupled variable 'v' needs to be different from 'variable' with CoupledForceNodalKernel, "
-        "consider using Reaction or somethig similar");
+  for (const auto var : variables())
+    if (var->number() == _v_var)
+      mooseError(
+          "Coupled variable 'v' needs to be different from variable with CoupledForceNodalKernel, "
+          "consider using Reaction or somethig similar");
 }

--- a/framework/src/kokkos/nodalkernels/KokkosNodalKernel.K
+++ b/framework/src/kokkos/nodalkernels/KokkosNodalKernel.K
@@ -21,16 +21,19 @@ NodalKernel::validParams()
 
 NodalKernel::NodalKernel(const InputParameters & parameters)
   : NodalKernelBase(parameters, Moose::VarFieldType::VAR_FIELD_STANDARD),
-    _u(_var, Moose::SOLUTION_TAG, true),
+    _u(_kokkos_var, true),
     _boundary_restricted(boundaryRestricted())
 {
-  addMooseVariableDependency(&_var);
+  addMooseVariableDependency(variables());
 }
 
 void
 NodalKernel::computeResidual()
 {
-  Policy policy(0, _boundary_restricted ? numKokkosBoundaryNodes() : numKokkosBlockNodes());
+  _thread.resize({variables().size(),
+                  _boundary_restricted ? numKokkosBoundaryNodes() : numKokkosBlockNodes()});
+
+  Policy policy(0, _thread.size());
 
   if (!_residual_dispatcher)
     _residual_dispatcher = DispatcherRegistry::build<ResidualLoop>(this, type());
@@ -43,7 +46,10 @@ NodalKernel::computeJacobian()
 {
   if (DispatcherRegistry::hasUserMethod<JacobianLoop>(type()))
   {
-    Policy policy(0, _boundary_restricted ? numKokkosBoundaryNodes() : numKokkosBlockNodes());
+    _thread.resize({variables().size(),
+                    _boundary_restricted ? numKokkosBoundaryNodes() : numKokkosBlockNodes()});
+
+    Policy policy(0, _thread.size());
 
     if (!_jacobian_dispatcher)
       _jacobian_dispatcher = DispatcherRegistry::build<JacobianLoop>(this, type());
@@ -55,7 +61,15 @@ NodalKernel::computeJacobian()
   {
     auto & sys = kokkosSystem(_kokkos_var.sys());
 
-    _thread.resize({sys.getCoupling(_kokkos_var.var()).size(),
+    if (variables().size() > 1)
+      for (unsigned int i = 1; i < variables().size(); ++i)
+        if (sys.getCoupling(_kokkos_var.var(0)).size() !=
+            sys.getCoupling(_kokkos_var.var(i)).size())
+          mooseError("For multi-variable kernels/BCs, all variables should have the same number of "
+                     "off-diagonal coupling variables.");
+
+    _thread.resize({variables().size(),
+                    sys.getCoupling(_kokkos_var.var()).size(),
                     _boundary_restricted ? numKokkosBoundaryNodes() : numKokkosBlockNodes()});
 
     Policy policy(0, _thread.size());

--- a/framework/src/kokkos/nodalkernels/KokkosTimeNodalKernel.K
+++ b/framework/src/kokkos/nodalkernels/KokkosTimeNodalKernel.K
@@ -25,9 +25,21 @@ TimeNodalKernel::validParams()
 
 TimeNodalKernel::TimeNodalKernel(const InputParameters & parameters)
   : NodalKernel(parameters),
-    _u_dot(_var, Moose::SOLUTION_DOT_TAG, true),
-    _du_dot_du(_var.sys().duDotDu(_var.number()))
+    _u_dot(variables(), Moose::SOLUTION_DOT_TAG, true),
+    _du_dot_du(variables().size())
 {
+}
+
+TimeNodalKernel::TimeNodalKernel(const TimeNodalKernel & object)
+  : NodalKernel(object), _u_dot(object._u_dot), _du_dot_du(object._du_dot_du)
+{
+  // TODO: We want to use Array<Scalar<const Real>> for _du_dot_du so that it is automatically
+  // synchronized, but currently there is an NVCC bug preventing it
+
+  for (unsigned int i = 0; i < variables().size(); ++i)
+    _du_dot_du[i] = variables()[i]->sys().duDotDu(variables()[i]->number());
+
+  _du_dot_du.copyToDevice();
 }
 
 } // namespace Moose::Kokkos

--- a/test/tests/kokkos/kernels/multi_variable/kokkos_multi_variable_kernel_test.i
+++ b/test/tests/kokkos/kernels/multi_variable/kokkos_multi_variable_kernel_test.i
@@ -1,0 +1,92 @@
+[Mesh]
+  [square]
+    type = GeneratedMeshGenerator
+    nx = 2
+    ny = 2
+    dim = 2
+  []
+[]
+
+[Variables]
+  [u]
+    order = FIRST
+    family = LAGRANGE
+  []
+  [v]
+    order = FIRST
+    family = LAGRANGE
+  []
+  [w]
+    order = FIRST
+    family = LAGRANGE
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = KokkosDiffusion
+    variables = 'u v w'
+  []
+  [bf]
+    type = KokkosBodyForce
+    variables = 'u v'
+    postprocessor = ramp
+  []
+[]
+
+[Functions]
+  [ramp]
+    type = ParsedFunction
+    expression = 't'
+  []
+[]
+
+[Postprocessors]
+  [ramp]
+    type = FunctionValuePostprocessor
+    function = ramp
+    execute_on = linear
+  []
+[]
+
+[BCs]
+  [left]
+    type = KokkosDirichletBC
+    variables = 'v w'
+    boundary = 3
+    value = 0
+  []
+
+  [right]
+    type = KokkosDirichletBC
+    variables = 'v w'
+    boundary = 1
+    value = 0
+  []
+
+  [top]
+    type = KokkosDirichletBC
+    variable = 'u'
+    boundary = 2
+    value = 0
+  []
+
+  [bottom]
+    type = KokkosDirichletBC
+    variable = 'u'
+    boundary = 0
+    value = 0
+  []
+[]
+
+[Executioner]
+  type = Transient
+  dt = 1.0
+  end_time = 1.0
+
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  exodus = true
+[]


### PR DESCRIPTION
Refs #30655.

Multivariable kernels are different from vector or array kernels. It works by simply specifying `variables` instead of `variable` to existing kernels. This concept allows consolidating multiple same kernels operating on different standard variables into a single kernel and provides additional parallelism over the variables. This is considered useful for certain applications like neutronics, where the same kernel applies to multiple flux variables representing each energy group. Using array variables for this makes it cumbersome to access each component (group).