### PR TITLE
Add execution order groups for auxkernels to be able to order array and regular auxkernels as needed

### DIFF
--- a/framework/doc/content/syntax/AuxKernels/index.md
+++ b/framework/doc/content/syntax/AuxKernels/index.md
@@ -90,6 +90,34 @@ execution of a simulation. In this case, the `EXEC_LINEAR` flag should be remove
 `EXEC_INITIAL` flag should be added to perform the auxiliary variable calculation during the initial
 setup phase as well.
 
+### Execution ordering within auxiliary kernels
+
+Scalar auxiliary kernels, that set scalar (global) variables, are always executed first.
+Field auxiliary kernels can be ordered by groups using the `execution_order_group`. Groups execute in
+ascending order, with group `0` being the default group assigned. Negative groups can be used
+to execute before the default group.
+Within a group, auxiliary kernels are executed in the following order:
+
+- nodal auxiliary kernels, which set a single-component field nodal variable
+- nodal vector auxiliary kernels, which set a vector (# of components = dimension of the mesh) field nodal variable
+- nodal array auxiliary kernels, which set an array (# of components can be set as needed) field nodal variable
+- mortar nodal auxiliary kernels, which set a single-component field nodal variable defined in a mortar mesh
+- elemental auxiliary kernels, which set a single-component field elemental variable
+- elemental vector auxiliary kernels, which set a vector (# of components = dimension of the mesh) field elemental variable
+- elemental array auxiliary kernels, which set an array (# of components can be set as needed) field elemental variable
+
+
+The distinction between a nodal and elemental variable is essentially that a nodal variable should have all its degrees of
+freedom both conceptually and practically attached to the node `DofObject` in libMesh.
+
+!alert note
+Setup operations, such as the initial setup and the time step setup, are not currently ordered in execution groups.
+
+!alert note title=When in doubt...
+When you want to check in which order the auxiliary kernels and/or other objects are being executed, the
+[!param](Debug/CommonDebugAction/show_execution_order) parameter may be set to `ALWAYS` to have console output
+of the ordering of execution.
+
 ## Populating lower-dimensional auxiliary variables
 
 Lower-dimensional auxiliary variables may be populated using boundary restricted

--- a/framework/include/loops/BoundaryNodeIntegrityCheckThread.h
+++ b/framework/include/loops/BoundaryNodeIntegrityCheckThread.h
@@ -38,9 +38,6 @@ protected:
   /// The auxiliary system to whom we'll delegate the boundary variable dependency integrity check
   const AuxiliarySystem & _aux_sys;
 
-  /// Nodal auxiliary kernels acting on standard field variables
-  const ExecuteMooseObjectWarehouse<AuxKernel> & _nodal_aux;
-
   /// Nodal auxiliary kernels acting on vector field variables
   const ExecuteMooseObjectWarehouse<VectorAuxKernel> & _nodal_vec_aux;
 

--- a/framework/include/loops/ComputeNodalAuxVarsThread.h
+++ b/framework/include/loops/ComputeNodalAuxVarsThread.h
@@ -11,22 +11,20 @@
 
 // MOOSE includes
 #include "ThreadedNodeLoop.h"
+#include "TheWarehouse.h"
 
 #include "libmesh/node_range.h"
 
 // Forward declarations
 class AuxiliarySystem;
 class FEProblemBase;
-template <typename T>
-class MooseObjectWarehouse;
 
 template <typename AuxKernelType>
 class ComputeNodalAuxVarsThread
   : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>
 {
 public:
-  ComputeNodalAuxVarsThread(FEProblemBase & fe_problem,
-                            const MooseObjectWarehouse<AuxKernelType> & storage);
+  ComputeNodalAuxVarsThread(FEProblemBase & fe_problem, const TheWarehouse::Query & query);
 
   // Splitting Constructor
   ComputeNodalAuxVarsThread(ComputeNodalAuxVarsThread & x, Threads::split split);
@@ -45,8 +43,9 @@ protected:
 
   AuxiliarySystem & _aux_sys;
 
-  /// Storage object containing active AuxKernel objects
-  const MooseObjectWarehouse<AuxKernelType> & _storage;
+  /// Warehouse to retrieve the auxkernels
+  const TheWarehouse::Query _query;
+  TheWarehouse::QueryCache<AttribThread, AttribSubdomains> _query_subdomain;
 
   std::set<SubdomainID> _block_ids;
 

--- a/framework/include/systems/AuxiliarySystem.h
+++ b/framework/include/systems/AuxiliarySystem.h
@@ -158,13 +158,13 @@ public:
 
 protected:
   void computeScalarVars(ExecFlagType type);
-  void computeNodalVars(ExecFlagType type);
-  void computeMortarNodalVars(ExecFlagType type);
-  void computeNodalVecVars(ExecFlagType type);
-  void computeNodalArrayVars(ExecFlagType type);
-  void computeElementalVars(ExecFlagType type);
-  void computeElementalVecVars(ExecFlagType type);
-  void computeElementalArrayVars(ExecFlagType type);
+  void computeNodalVars(ExecFlagType type, int group);
+  void computeMortarNodalVars(ExecFlagType type, int group);
+  void computeNodalVecVars(ExecFlagType type, int group);
+  void computeNodalArrayVars(ExecFlagType type, int group);
+  void computeElementalVars(ExecFlagType type, int group);
+  void computeElementalVecVars(ExecFlagType type, int group);
+  void computeElementalArrayVars(ExecFlagType type, int group);
 
   template <typename AuxKernelType>
   void computeElementalVarsHelper(const MooseObjectWarehouse<AuxKernelType> & warehouse);
@@ -211,6 +211,9 @@ protected:
   ExecuteMooseObjectWarehouse<AuxKernelBase> _kokkos_nodal_aux_storage;
   ExecuteMooseObjectWarehouse<AuxKernelBase> _kokkos_elemental_aux_storage;
 #endif
+
+  /// Execution order groups present within the simulation
+  std::set<int> _execution_order_groups;
 
   friend class ComputeIndicatorThread;
   friend class ComputeMarkerThread;

--- a/framework/include/systems/AuxiliarySystem.h
+++ b/framework/include/systems/AuxiliarySystem.h
@@ -170,7 +170,7 @@ protected:
   void computeElementalVarsHelper(const MooseObjectWarehouse<AuxKernelType> & warehouse);
 
   template <typename AuxKernelType>
-  void computeNodalVarsHelper(const MooseObjectWarehouse<AuxKernelType> & warehouse);
+  void computeNodalVarsHelper(const TheWarehouse::Query & query);
 
   libMesh::System & _sys;
 
@@ -194,7 +194,6 @@ protected:
   ExecuteMooseObjectWarehouse<AuxScalarKernel> _aux_scalar_storage;
 
   // Storage for AuxKernel objects
-  ExecuteMooseObjectWarehouse<AuxKernel> _nodal_aux_storage;
   ExecuteMooseObjectWarehouse<AuxKernel> _mortar_nodal_aux_storage;
   ExecuteMooseObjectWarehouse<AuxKernel> _elemental_aux_storage;
 
@@ -225,12 +224,6 @@ protected:
 
   NumericVector<Number> & solutionInternal() const override { return *_sys.solution; }
 };
-
-inline const ExecuteMooseObjectWarehouse<AuxKernel> &
-AuxiliarySystem::nodalAuxWarehouse() const
-{
-  return _nodal_aux_storage;
-}
 
 inline const ExecuteMooseObjectWarehouse<VectorAuxKernel> &
 AuxiliarySystem::nodalVectorAuxWarehouse() const

--- a/framework/src/auxkernels/AuxKernelBase.C
+++ b/framework/src/auxkernels/AuxKernelBase.C
@@ -34,6 +34,15 @@ AuxKernelBase::validParams()
   exec_enum.addAvailableFlags(EXEC_PRE_DISPLACE);
   exec_enum = {EXEC_LINEAR, EXEC_TIMESTEP_END};
   params.setDocString("execute_on", exec_enum.getDocString());
+  params.addParam<int>(
+      "execution_order_group",
+      0,
+      "Execution order groups are executed in increasing order (e.g., the lowest "
+      "number is executed first). Note that negative group numbers may be used to execute groups "
+      "before the default (0) group. Please refer to the auxkernel documentation "
+      "for ordering of auxkernel execution within a group for example elemental vs nodal or "
+      "between scalar, regular, vector and array auxkernels.");
+  params.addParamNamesToGroup("execute_on execution_order_group", "Execution scheduling");
 
   params.addRequiredParam<AuxVariableName>("variable",
                                            "The name of the variable that this object applies to");

--- a/framework/src/base/Attributes.C
+++ b/framework/src/base/Attributes.C
@@ -15,6 +15,7 @@
 #include "SetupInterface.h"
 #include "MooseVariableInterface.h"
 #include "MooseVariableFE.h"
+#include "AuxKernelBase.h"
 #include "ElementUserObject.h"
 #include "SideUserObject.h"
 #include "InternalSideUserObject.h"
@@ -285,6 +286,9 @@ AttribExecutionOrderGroup::initFrom(const MooseObject * obj)
 {
   const auto * uo = dynamic_cast<const UserObject *>(obj);
   _val = uo ? uo->getParam<int>("execution_order_group") : 0;
+  // Not used for now since auxkernels don't use theWarehouse queries
+  const auto * aux = dynamic_cast<const AuxKernelBase *>(obj);
+  _val = aux ? aux->getParam<int>("execution_order_group") : 0;
 }
 bool
 AttribExecutionOrderGroup::isMatch(const Attribute & other) const

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -2070,6 +2070,7 @@ std::vector<const VariableValue *>
 Coupleable::coupledAllDofValues(const std::string & var_name) const
 {
   auto func = [this, &var_name](unsigned int comp) { return &coupledDofValues(var_name, comp); };
+  checkFuncType(var_name, VarType::Ignore, FuncAge::Curr);
   return coupledVectorHelper<const VariableValue *>(var_name, func);
 }
 

--- a/framework/src/outputs/BlockRestrictionDebugOutput.C
+++ b/framework/src/outputs/BlockRestrictionDebugOutput.C
@@ -199,14 +199,16 @@ BlockRestrictionDebugOutput::printBlockRestrictionMap() const
     {
 
       {
-        const auto & wh = auxSystem.nodalAuxWarehouse();
+        std::vector<AuxKernel *> aux_kernels;
+        _problem_ptr->theWarehouse()
+            .query()
+            .condition<AttribSystem>("AuxKernel")
+            .condition<AttribThread>(0)
+            .condition<AttribSubdomains>(subdomain_id)
+            .queryIntoUnsorted(aux_kernels);
         std::set<std::string> names;
-        if (wh.hasActiveBlockObjects(subdomain_id))
-        {
-          const auto & auxkernels = wh.getActiveBlockObjects(subdomain_id);
-          for (auto & auxkernel : auxkernels)
-            names.insert(auxkernel->name());
-        }
+        for (auto & auxkernel : aux_kernels)
+          names.insert(auxkernel->name());
         objectsFound = printCategoryAndNames("AuxKernels[nodal]", names) || objectsFound;
       }
 

--- a/framework/src/systems/AuxiliarySystem.C
+++ b/framework/src/systems/AuxiliarySystem.C
@@ -438,13 +438,13 @@ AuxiliarySystem::compute(ExecFlagType type)
 
   if (_vars[0].fieldVariables().size() > 0)
   {
-    computeNodalArrayVars(type);
-    computeNodalVecVars(type);
     computeNodalVars(type);
+    computeNodalVecVars(type);
+    computeNodalArrayVars(type);
     computeMortarNodalVars(type);
-    computeElementalArrayVars(type);
-    computeElementalVecVars(type);
     computeElementalVars(type);
+    computeElementalVecVars(type);
+    computeElementalArrayVars(type);
 
 #ifdef MOOSE_KOKKOS_ENABLED
     kokkosCompute(type);

--- a/framework/src/systems/AuxiliarySystem.C
+++ b/framework/src/systems/AuxiliarySystem.C
@@ -44,7 +44,6 @@ AuxiliarySystem::AuxiliarySystem(FEProblemBase & subproblem, const std::string &
     _sys(subproblem.es().add_system<System>(name)),
     _current_solution(_sys.current_local_solution.get()),
     _aux_scalar_storage(_app.getExecuteOnEnum()),
-    _nodal_aux_storage(_app.getExecuteOnEnum()),
     _mortar_nodal_aux_storage(_app.getExecuteOnEnum()),
     _elemental_aux_storage(_app.getExecuteOnEnum()),
     _nodal_vec_aux_storage(_app.getExecuteOnEnum()),
@@ -82,8 +81,15 @@ AuxiliarySystem::initialSetup()
     _aux_scalar_storage.sort(tid);
     _aux_scalar_storage.initialSetup(tid);
 
-    _nodal_aux_storage.sort(tid);
-    _nodal_aux_storage.initialSetup(tid);
+    // Replace this with an "inplace" call to initialSetup when implemented (#32362)
+    std::vector<AuxKernel *> nodal_auxkernels;
+    _fe_problem.theWarehouse()
+        .query()
+        .condition<AttribSystem>("AuxKernel")
+        .condition<AttribThread>(tid)
+        .queryInto(nodal_auxkernels);
+    for (auto & nodal_aux : nodal_auxkernels)
+      nodal_aux->initialSetup();
 
     _mortar_nodal_aux_storage.sort(tid);
     _mortar_nodal_aux_storage.initialSetup(tid);
@@ -121,7 +127,15 @@ AuxiliarySystem::timestepSetup()
   for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _aux_scalar_storage.timestepSetup(tid);
-    _nodal_aux_storage.timestepSetup(tid);
+    std::vector<AuxKernel *> nodal_auxkernels;
+    _fe_problem.theWarehouse()
+        .query()
+        .condition<AttribSystem>("AuxKernel")
+        .condition<AttribThread>(tid)
+        .queryInto(nodal_auxkernels);
+    for (auto & nodal_aux : nodal_auxkernels)
+      nodal_aux->timestepSetup();
+
     _mortar_nodal_aux_storage.timestepSetup(tid);
     _nodal_vec_aux_storage.timestepSetup(tid);
     _nodal_array_aux_storage.timestepSetup(tid);
@@ -144,7 +158,14 @@ AuxiliarySystem::customSetup(const ExecFlagType & exec_type)
   for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _aux_scalar_storage.customSetup(exec_type, tid);
-    _nodal_aux_storage.customSetup(exec_type, tid);
+    std::vector<AuxKernel *> nodal_auxkernels;
+    _fe_problem.theWarehouse()
+        .query()
+        .condition<AttribSystem>("AuxKernel")
+        .condition<AttribThread>(tid)
+        .queryInto(nodal_auxkernels);
+    for (auto & nodal_aux : nodal_auxkernels)
+      nodal_aux->customSetup(exec_type);
     _mortar_nodal_aux_storage.customSetup(exec_type, tid);
     _nodal_vec_aux_storage.customSetup(exec_type, tid);
     _nodal_array_aux_storage.customSetup(exec_type, tid);
@@ -167,7 +188,15 @@ AuxiliarySystem::subdomainSetup()
   for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _aux_scalar_storage.subdomainSetup(tid);
-    _nodal_aux_storage.subdomainSetup(tid);
+    std::vector<AuxKernel *> nodal_auxkernels;
+    _fe_problem.theWarehouse()
+        .query()
+        .condition<AttribSystem>("AuxKernel")
+        .condition<AttribThread>(tid)
+        .queryInto(nodal_auxkernels);
+    for (auto & nodal_aux : nodal_auxkernels)
+      nodal_aux->subdomainSetup();
+
     _mortar_nodal_aux_storage.subdomainSetup(tid);
     _nodal_vec_aux_storage.subdomainSetup(tid);
     _nodal_array_aux_storage.subdomainSetup(tid);
@@ -185,7 +214,14 @@ AuxiliarySystem::jacobianSetup()
   for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _aux_scalar_storage.jacobianSetup(tid);
-    _nodal_aux_storage.jacobianSetup(tid);
+    std::vector<AuxKernel *> nodal_auxkernels;
+    _fe_problem.theWarehouse()
+        .query()
+        .condition<AttribSystem>("AuxKernel")
+        .condition<AttribThread>(tid)
+        .queryInto(nodal_auxkernels);
+    for (auto & nodal_aux : nodal_auxkernels)
+      nodal_aux->jacobianSetup();
     _mortar_nodal_aux_storage.jacobianSetup(tid);
     _nodal_vec_aux_storage.jacobianSetup(tid);
     _nodal_array_aux_storage.jacobianSetup(tid);
@@ -208,7 +244,14 @@ AuxiliarySystem::residualSetup()
   for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _aux_scalar_storage.residualSetup(tid);
-    _nodal_aux_storage.residualSetup(tid);
+    std::vector<AuxKernel *> nodal_auxkernels;
+    _fe_problem.theWarehouse()
+        .query()
+        .condition<AttribSystem>("AuxKernel")
+        .condition<AttribThread>(tid)
+        .queryInto(nodal_auxkernels);
+    for (auto & nodal_aux : nodal_auxkernels)
+      nodal_aux->residualSetup();
     _mortar_nodal_aux_storage.residualSetup(tid);
     _nodal_vec_aux_storage.residualSetup(tid);
     _nodal_array_aux_storage.residualSetup(tid);
@@ -227,7 +270,14 @@ void
 AuxiliarySystem::updateActive(THREAD_ID tid)
 {
   _aux_scalar_storage.updateActive(tid);
-  _nodal_aux_storage.updateActive(tid);
+  std::vector<AuxKernel *> nodal_auxkernels;
+  _fe_problem.theWarehouse()
+      .query()
+      .condition<AttribSystem>("AuxKernel")
+      .condition<AttribThread>(tid)
+      .queryInto(nodal_auxkernels);
+  for (auto & nodal_aux : nodal_auxkernels)
+    nodal_aux->updateActive();
   _mortar_nodal_aux_storage.updateActive(tid);
   _nodal_vec_aux_storage.updateActive(tid);
   _nodal_array_aux_storage.updateActive(tid);
@@ -315,7 +365,7 @@ AuxiliarySystem::addKernel(const std::string & kernel_name,
         if (kernel->isMortar())
           _mortar_nodal_aux_storage.addObject(kernel, tid);
         else
-          _nodal_aux_storage.addObject(kernel, tid);
+          _fe_problem.theWarehouse().add(kernel);
       }
       else
         _elemental_aux_storage.addObject(kernel, tid);
@@ -506,9 +556,14 @@ AuxiliarySystem::getDependObjects(ExecFlagType type)
 
   // Nodal AuxKernels
   {
-    const std::vector<std::shared_ptr<AuxKernel>> & auxs =
-        _nodal_aux_storage[type].getActiveObjects();
-    for (const auto & aux : auxs)
+    std::vector<AuxKernel *> nodal_auxkernels;
+    _fe_problem.theWarehouse()
+        .query()
+        .condition<AttribSystem>("AuxKernel")
+        .condition<AttribExecOns>(type)
+        .condition<AttribThread>(0)
+        .queryInto(nodal_auxkernels);
+    for (const auto & aux : nodal_auxkernels)
     {
       const std::set<UserObjectName> & uo = aux->getDependObjects();
       depend_objects.insert(uo.begin(), uo.end());
@@ -615,8 +670,13 @@ AuxiliarySystem::getDependObjects()
 
   // Nodal AuxKernels
   {
-    const std::vector<std::shared_ptr<AuxKernel>> & auxs = _nodal_aux_storage.getActiveObjects();
-    for (const auto & aux : auxs)
+    std::vector<AuxKernel *> nodal_auxkernels;
+    _fe_problem.theWarehouse()
+        .query()
+        .condition<AttribSystem>("AuxKernel")
+        .condition<AttribThread>(0)
+        .queryInto(nodal_auxkernels);
+    for (const auto & aux : nodal_auxkernels)
     {
       const std::set<UserObjectName> & uo = aux->getDependObjects();
       depend_objects.insert(uo.begin(), uo.end());
@@ -757,8 +817,12 @@ AuxiliarySystem::computeNodalVars(ExecFlagType type, int group)
 {
   TIME_SECTION("computeNodalVars", 3);
 
-  const MooseObjectWarehouse<AuxKernel> & nodal = _nodal_aux_storage[type];
-  computeNodalVarsHelper<AuxKernel>(nodal);
+  TheWarehouse::Query query = _fe_problem.theWarehouse()
+                                  .query()
+                                  .condition<AttribSystem>("AuxKernel")
+                                  .condition<AttribExecOns>(type)
+                                  .condition<AttribExecutionOrderGroup>(group);
+  computeNodalVarsHelper<AuxKernel>(query);
 }
 
 void
@@ -766,15 +830,25 @@ AuxiliarySystem::computeNodalVecVars(ExecFlagType type, int group)
 {
   TIME_SECTION("computeNodalVecVars", 3);
 
-  const MooseObjectWarehouse<VectorAuxKernel> & nodal = _nodal_vec_aux_storage[type];
-  computeNodalVarsHelper<VectorAuxKernel>(nodal);
+  TheWarehouse::Query query = _fe_problem.theWarehouse()
+                                  .query()
+                                  .condition<AttribSystem>("VectorAuxKernel")
+                                  .condition<AttribExecOns>(type)
+                                  .condition<AttribExecutionOrderGroup>(group);
+  computeNodalVarsHelper<VectorAuxKernel>(query);
 }
 
 void
 AuxiliarySystem::computeNodalArrayVars(ExecFlagType type, int group)
 {
-  const MooseObjectWarehouse<ArrayAuxKernel> & nodal = _nodal_array_aux_storage[type];
-  computeNodalVarsHelper<ArrayAuxKernel>(nodal);
+  TIME_SECTION("computeNodalArrayVars", 3);
+
+  TheWarehouse::Query query = _fe_problem.theWarehouse()
+                                  .query()
+                                  .condition<AttribSystem>("ArrayAuxKernel")
+                                  .condition<AttribExecOns>(type)
+                                  .condition<AttribExecutionOrderGroup>(group);
+  computeNodalVarsHelper<ArrayAuxKernel>(query);
 }
 
 void
@@ -961,15 +1035,20 @@ AuxiliarySystem::computeElementalVarsHelper(const MooseObjectWarehouse<AuxKernel
 
 template <typename AuxKernelType>
 void
-AuxiliarySystem::computeNodalVarsHelper(const MooseObjectWarehouse<AuxKernelType> & warehouse)
+AuxiliarySystem::computeNodalVarsHelper(const TheWarehouse::Query & query)
 {
-  if (warehouse.hasActiveBlockObjects())
+  // Get all block restricted aux-kernels
+  std::vector<AuxKernelType *> auxs;
+  query.clone().condition<AttribInterfaces>(Interfaces::BlockRestrictable).queryInto(auxs);
+  // NOTE: we should use this query to pass to the loop instead
+
+  if (auxs.size())
   {
     // Block Nodal AuxKernels
     PARALLEL_TRY
     {
       ConstNodeRange & range = *_mesh.getLocalNodeRange();
-      ComputeNodalAuxVarsThread<AuxKernelType> navt(_fe_problem, warehouse);
+      ComputeNodalAuxVarsThread<AuxKernelType> navt(_fe_problem, query);
       Threads::parallel_reduce(range, navt);
 
       solution().close();
@@ -978,22 +1057,22 @@ AuxiliarySystem::computeNodalVarsHelper(const MooseObjectWarehouse<AuxKernelType
     PARALLEL_CATCH;
   }
 
-  if (warehouse.hasActiveBoundaryObjects())
-  {
-    TIME_SECTION("computeBoundaryObjects", 3);
+  // if (warehouse.hasActiveBoundaryObjects())
+  // {
+  //   TIME_SECTION("computeBoundaryObjects", 3);
 
-    // Boundary Nodal AuxKernels
-    PARALLEL_TRY
-    {
-      ConstBndNodeRange & bnd_nodes = *_mesh.getBoundaryNodeRange();
-      ComputeNodalAuxBcsThread<AuxKernelType> nabt(_fe_problem, warehouse);
-      Threads::parallel_reduce(bnd_nodes, nabt);
+  //   // Boundary Nodal AuxKernels
+  //   PARALLEL_TRY
+  //   {
+  //     ConstBndNodeRange & bnd_nodes = *_mesh.getBoundaryNodeRange();
+  //     ComputeNodalAuxBcsThread<AuxKernelType> nabt(_fe_problem, warehouse);
+  //     Threads::parallel_reduce(bnd_nodes, nabt);
 
-      solution().close();
-      _sys.update();
-    }
-    PARALLEL_CATCH;
-  }
+  //     solution().close();
+  //     _sys.update();
+  //   }
+  //   PARALLEL_CATCH;
+  // }
 }
 
 void
@@ -1032,7 +1111,5 @@ template void
 AuxiliarySystem::computeElementalVarsHelper<AuxKernel>(const MooseObjectWarehouse<AuxKernel> &);
 template void AuxiliarySystem::computeElementalVarsHelper<VectorAuxKernel>(
     const MooseObjectWarehouse<VectorAuxKernel> &);
-template void
-AuxiliarySystem::computeNodalVarsHelper<AuxKernel>(const MooseObjectWarehouse<AuxKernel> &);
-template void AuxiliarySystem::computeNodalVarsHelper<VectorAuxKernel>(
-    const MooseObjectWarehouse<VectorAuxKernel> &);
+template void AuxiliarySystem::computeNodalVarsHelper<AuxKernel>(const TheWarehouse::Query &);
+template void AuxiliarySystem::computeNodalVarsHelper<VectorAuxKernel>(const TheWarehouse::Query &);

--- a/test/tests/auxkernels/array_parsed_aux/array_parsed_aux.i
+++ b/test/tests/auxkernels/array_parsed_aux/array_parsed_aux.i
@@ -73,6 +73,8 @@
     type = ArrayVarReductionAux
     variable = sum
     array_variable = parsed
+    # Needs to be executed after parsed_aux
+    execution_order_group = 2
   []
 []
 

--- a/test/tests/auxkernels/build_array_variable_aux/build_array_variable_aux_from_aux.i
+++ b/test/tests/auxkernels/build_array_variable_aux/build_array_variable_aux_from_aux.i
@@ -1,0 +1,116 @@
+[Mesh]
+  [meshgen]
+    type = GeneratedMeshGenerator
+    nx = 2
+    ny = 2
+    dim = 2
+  []
+[]
+
+[AuxVariables]
+  [a]
+    order = FIRST
+    family = LAGRANGE
+    [AuxKernel]
+      type = FunctionAux
+      function = 't'
+    []
+  []
+  [b]
+    order = FIRST
+    family = LAGRANGE
+    [AuxKernel]
+      type = FunctionAux
+      function = '2 * t'
+    []
+  []
+  [c]
+    order = CONSTANT
+    family = MONOMIAL
+    fv = true
+  []
+  [d]
+    order = CONSTANT
+    family = MONOMIAL
+    fv = true
+  []
+[]
+
+[Problem]
+  kernel_coverage_check = off
+  solve = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 3
+  solve_type = 'NEWTON'
+[]
+
+[AuxVariables]
+  [ab]
+    order = FIRST
+    family = LAGRANGE
+    components = 2
+  []
+  [cd]
+    order = CONSTANT
+    family = MONOMIAL
+    components = 2
+  []
+[]
+
+[AuxKernels]
+  [build_ab]
+    type = BuildArrayVariableAux
+    variable = ab
+    component_variables = 'a b'
+  []
+  [a_compute_d]
+    type = FunctionAux
+    function = '3 * t'
+    variable = 'c'
+  []
+  [build_cd]
+    type = BuildArrayVariableAux
+    variable = cd
+    component_variables = 'c d'
+  []
+  [compute_c]
+    type = FunctionAux
+    function = '4 * t'
+    variable = 'd'
+  []
+[]
+
+[Outputs]
+  csv = true
+[]
+
+# The idea is that the execution should happen in the following order:
+# - auxkernels set a and b
+# - auxkernel set ab from a and b
+# - PPs execute and gather the value from ab
+# same idea for cd, just different places in the input file for defining objects
+[Postprocessors]
+  [max_a_in_ab]
+    type = ElementIntegralArrayVariablePostprocessor
+    variable = 'ab'
+    component = 0
+  []
+  [max_b_in_ab]
+    type = ElementIntegralArrayVariablePostprocessor
+    variable = 'ab'
+    component = 1
+  []
+  [max_c_in_cd]
+    type = ElementIntegralArrayVariablePostprocessor
+    variable = 'cd'
+    component = 0
+  []
+  [max_d_in_cd]
+    type = ElementIntegralArrayVariablePostprocessor
+    variable = 'cd'
+    component = 1
+  []
+[]

--- a/test/tests/auxkernels/build_array_variable_aux/tests
+++ b/test/tests/auxkernels/build_array_variable_aux/tests
@@ -8,6 +8,12 @@
     exodiff = 'build_array_variable_aux_out.e'
     requirement = 'The system shall support the copy the values of standard variables into the component fields of an array variable.'
   []
+  [test_aux]
+    type = 'CSVDiff'
+    input = 'build_array_variable_aux_from_aux.i'
+    csvdiff = 'build_array_variable_aux_from_aux_out.csv'
+    requirement = 'The system shall support the copy the values of auxiliary variables into the component fields of an array variable, and order the execution of the auxkernels such that the array variable is not lagging compared to its component variables.'
+  []
 
   [error]
     requirement = 'The system shall report a reasonable error when copying standard variables into the components of an array variable when'

--- a/test/tests/interfaces/coupleable/coupled_old_vector_nodal.i
+++ b/test/tests/interfaces/coupleable/coupled_old_vector_nodal.i
@@ -68,11 +68,15 @@
     type = VectorVariableMagnitudeAux
     variable = var_mag
     vector_variable = var
+    # Needs to be executed after old
+    execution_order_group = 2
   []
   [old_var_mag]
     type = VectorVariableMagnitudeAux
     variable = old_var_mag
     vector_variable = old_var
+    # Needs to be executed after old
+    execution_order_group = 2
   []
 []
 [Executioner]

--- a/test/tests/vectorpostprocessors/element_value_sampler/mixed_fe_fv_sampler.i
+++ b/test/tests/vectorpostprocessors/element_value_sampler/mixed_fe_fv_sampler.i
@@ -41,6 +41,8 @@
     variable = auxGrad_T_x
     vector_variable = grad_T
     component = 'x'
+    # Needs to execute after the auxkernel setting the gradient
+    execution_order_group = 1
   []
 []
 


### PR DESCRIPTION
refs https://github.com/idaholab/moose/issues/32026

since execution order groups are already implemented in theWarehouse, I moved auxkernels there too. 
This is a rather large task though

If you implement any of the features here:
https://github.com/idaholab/moose/issues/32362
We can make this particular PR more seamless and natural