### PR TITLE
Assorted fixes and improvements

### DIFF
--- a/framework/include/mfem/equation_systems/ComplexEquationSystem.h
+++ b/framework/include/mfem/equation_systems/ComplexEquationSystem.h
@@ -37,6 +37,11 @@ public:
   /// Build bilinear forms (diagonal Jacobian contributions)
   virtual void BuildBilinearForms() override;
 
+  /// Apply essential BC(s) associated with var_name to set true DoFs of trial_gf and update
+  /// markers of all essential boundaries
+  virtual void ApplyComplexEssentialBC(const std::string & var_name,
+                                       mfem::ParComplexGridFunction & trial_gf,
+                                       mfem::Array<int> & global_ess_markers);
   /// Update all essentially constrained true DoF markers and values on boundaries
   virtual void ApplyEssentialBCs() override;
 

--- a/framework/include/mfem/equation_systems/EquationSystem.h
+++ b/framework/include/mfem/equation_systems/EquationSystem.h
@@ -80,9 +80,9 @@ protected:
   bool VectorContainsName(const std::vector<std::string> & the_vector,
                           const std::string & name) const;
 
-  /// Apply essential BC(s) associated with test_var_name to set true DoFs of trial_gf and update
+  /// Apply essential BC(s) associated with var_name to set true DoFs of trial_gf and update
   /// markers of all essential boundaries
-  virtual void ApplyEssentialBC(const std::string & test_var_name,
+  virtual void ApplyEssentialBC(const std::string & var_name,
                                 mfem::ParGridFunction & trial_gf,
                                 mfem::Array<int> & global_ess_markers);
   /// Update all essentially constrained true DoF markers and values on boundaries

--- a/framework/include/mfem/equation_systems/EquationSystem.h
+++ b/framework/include/mfem/equation_systems/EquationSystem.h
@@ -63,10 +63,12 @@ public:
   const std::vector<std::string> & GetTestVarNames() const { return _test_var_names; }
 
 protected:
-  /// Add test variable to EquationSystem.
-  virtual void AddTestVariableNameIfMissing(const std::string & test_var_name);
   /// Add coupled variable to EquationSystem.
   virtual void AddCoupledVariableNameIfMissing(const std::string & coupled_var_name);
+  /// Add eliminated variable to EquationSystem.
+  virtual void AddEliminatedVariableNameIfMissing(const std::string & eliminated_var_name);
+  /// Add test variable to EquationSystem.
+  virtual void AddTestVariableNameIfMissing(const std::string & test_var_name);
   /// Set trial variable names from subset of coupled variables that have an associated test variable.
   virtual void SetTrialVariableNames();
 

--- a/framework/include/mfem/equation_systems/TimeDependentEquationSystem.h
+++ b/framework/include/mfem/equation_systems/TimeDependentEquationSystem.h
@@ -27,8 +27,6 @@ public:
   virtual void AddKernel(std::shared_ptr<MFEMKernel> kernel) override;
 
 protected:
-  /// Set trial variable names from subset of coupled variables that have an associated test variable.
-  virtual void SetTrialVariableNames() override;
   virtual void BuildBilinearForms() override;
   virtual void BuildMixedBilinearForms() override;
   virtual void EliminateCoupledVariables() override;

--- a/framework/src/mfem/equation_systems/ComplexEquationSystem.C
+++ b/framework/src/mfem/equation_systems/ComplexEquationSystem.C
@@ -135,72 +135,55 @@ ComplexEquationSystem::ApplyEssentialBCs()
 void
 ComplexEquationSystem::AddComplexKernel(std::shared_ptr<MFEMComplexKernel> kernel)
 {
-  AddTestVariableNameIfMissing(kernel->getTestVariableName());
-  AddCoupledVariableNameIfMissing(kernel->getTrialVariableName());
-  auto trial_var_name = kernel->getTrialVariableName();
-  auto test_var_name = kernel->getTestVariableName();
-
-  if (auto kernel_ptr = std::dynamic_pointer_cast<MFEMComplexKernel>(kernel))
+  const auto & trial_var_name = kernel->getTrialVariableName();
+  const auto & test_var_name = kernel->getTestVariableName();
+  AddCoupledVariableNameIfMissing(trial_var_name);
+  AddTestVariableNameIfMissing(test_var_name);
+  // Register new complex kernels map if not present for the test variable
+  if (!_cmplx_kernels_map.Has(test_var_name))
   {
-    if (!_cmplx_kernels_map.Has(test_var_name))
-    {
-      auto kernel_field_map =
-          std::make_shared<NamedFieldsMap<std::vector<std::shared_ptr<MFEMComplexKernel>>>>();
-      _cmplx_kernels_map.Register(test_var_name, std::move(kernel_field_map));
-    }
-    // Register new kernels map if not present for the test/trial variable
-    // pair
-    if (!_cmplx_kernels_map.Get(test_var_name)->Has(trial_var_name))
-    {
-      auto kernels = std::make_shared<std::vector<std::shared_ptr<MFEMComplexKernel>>>();
-      _cmplx_kernels_map.Get(test_var_name)->Register(trial_var_name, std::move(kernels));
-    }
-    _cmplx_kernels_map.GetRef(test_var_name).Get(trial_var_name)->push_back(std::move(kernel_ptr));
+    auto kernel_field_map =
+        std::make_shared<NamedFieldsMap<std::vector<std::shared_ptr<MFEMComplexKernel>>>>();
+    _cmplx_kernels_map.Register(test_var_name, std::move(kernel_field_map));
   }
-  else
+  // Register new complex kernels map if not present for the test/trial variable pair
+  if (!_cmplx_kernels_map.Get(test_var_name)->Has(trial_var_name))
   {
-    mooseError("Unknown kernel type. Please use MFEMComplexKernel.");
+    auto kernels = std::make_shared<std::vector<std::shared_ptr<MFEMComplexKernel>>>();
+    _cmplx_kernels_map.Get(test_var_name)->Register(trial_var_name, std::move(kernels));
   }
+  _cmplx_kernels_map.GetRef(test_var_name).Get(trial_var_name)->push_back(std::move(kernel));
 }
 
 void
 ComplexEquationSystem::AddComplexIntegratedBC(std::shared_ptr<MFEMComplexIntegratedBC> bc)
 {
-  AddTestVariableNameIfMissing(bc->getTestVariableName());
-  AddCoupledVariableNameIfMissing(bc->getTrialVariableName());
-  auto trial_var_name = bc->getTrialVariableName();
-  auto test_var_name = bc->getTestVariableName();
-
-  if (auto bc_ptr = std::dynamic_pointer_cast<MFEMComplexIntegratedBC>(bc))
+  const auto & trial_var_name = bc->getTrialVariableName();
+  const auto & test_var_name = bc->getTestVariableName();
+  AddCoupledVariableNameIfMissing(trial_var_name);
+  AddTestVariableNameIfMissing(test_var_name);
+  // Register new complex integrated bc map if not present for the test variable
+  if (!_cmplx_integrated_bc_map.Has(test_var_name))
   {
-    if (!_cmplx_integrated_bc_map.Has(test_var_name))
-    {
-      auto integrated_bc_field_map =
-          std::make_shared<NamedFieldsMap<std::vector<std::shared_ptr<MFEMComplexIntegratedBC>>>>();
-      _cmplx_integrated_bc_map.Register(test_var_name, std::move(integrated_bc_field_map));
-    }
-    // Register new integrated bc map if not present for the test/trial variable
-    // pair
-    if (!_cmplx_integrated_bc_map.Get(test_var_name)->Has(trial_var_name))
-    {
-      auto bcs = std::make_shared<std::vector<std::shared_ptr<MFEMComplexIntegratedBC>>>();
-      _cmplx_integrated_bc_map.Get(test_var_name)->Register(trial_var_name, std::move(bcs));
-    }
-    _cmplx_integrated_bc_map.GetRef(test_var_name)
-        .Get(trial_var_name)
-        ->push_back(std::move(bc_ptr));
+    auto integrated_bc_field_map =
+        std::make_shared<NamedFieldsMap<std::vector<std::shared_ptr<MFEMComplexIntegratedBC>>>>();
+    _cmplx_integrated_bc_map.Register(test_var_name, std::move(integrated_bc_field_map));
   }
-  else
+  // Register new complex integrated bc map if not present for the test/trial variable pair
+  if (!_cmplx_integrated_bc_map.Get(test_var_name)->Has(trial_var_name))
   {
-    mooseError("Unknown integrated BC type. Please use MFEMComplexIntegratedBC.");
+    auto bcs = std::make_shared<std::vector<std::shared_ptr<MFEMComplexIntegratedBC>>>();
+    _cmplx_integrated_bc_map.Get(test_var_name)->Register(trial_var_name, std::move(bcs));
   }
+  _cmplx_integrated_bc_map.GetRef(test_var_name).Get(trial_var_name)->push_back(std::move(bc));
 }
 
 void
 ComplexEquationSystem::AddComplexEssentialBCs(std::shared_ptr<MFEMComplexEssentialBC> bc)
 {
-  AddTestVariableNameIfMissing(bc->getTestVariableName());
-  auto test_var_name = bc->getTestVariableName();
+  const auto & test_var_name = bc->getTestVariableName();
+  AddTestVariableNameIfMissing(test_var_name);
+  // Register new complex essential bc map if not present for the test variable
   if (!_cmplx_essential_bc_map.Has(test_var_name))
   {
     auto bcs = std::make_shared<std::vector<std::shared_ptr<MFEMComplexEssentialBC>>>();

--- a/framework/src/mfem/equation_systems/ComplexEquationSystem.C
+++ b/framework/src/mfem/equation_systems/ComplexEquationSystem.C
@@ -231,8 +231,9 @@ ComplexEquationSystem::FormSystemMatrix(mfem::OperatorHandle & op,
   DeleteAllBlocks();
   _h_blocks.SetSize(_test_var_names.size(), _trial_var_names.size());
   _h_blocks = nullptr;
-  trueRHS.SyncFromBlocks();
+  // Zero out RHS and sync memory
   trueRHS = 0.0;
+  trueRHS.SyncToBlocks();
 
   // Form diagonal blocks.
   for (const auto i : index_range(_test_var_names))
@@ -269,11 +270,7 @@ ComplexEquationSystem::RecoverComplexFEMSolution(
     Moose::MFEM::ComplexGridFunctions & cmplx_gridfunctions)
 {
   for (const auto i : index_range(_trial_var_names))
-  {
-    auto & trial_var_name = _trial_var_names.at(i);
-    trueX.GetBlock(i).SyncAliasMemory(trueX);
-    cmplx_gridfunctions.Get(trial_var_name)->Distribute(&(trueX.GetBlock(i)));
-  }
+    cmplx_gridfunctions.Get(_trial_var_names.at(i))->Distribute(&(trueX.GetBlock(i)));
 }
 
 }

--- a/framework/src/mfem/equation_systems/EquationSystem.C
+++ b/framework/src/mfem/equation_systems/EquationSystem.C
@@ -288,8 +288,9 @@ EquationSystem::FormSystemMatrix(mfem::OperatorHandle & op,
   DeleteAllBlocks();
   _h_blocks.SetSize(_test_var_names.size(), _trial_var_names.size());
   _h_blocks = nullptr;
-  trueRHS.SyncFromBlocks();
+  // Zero out RHS and sync memory
   trueRHS = 0.0;
+  trueRHS.SyncToBlocks();
 
   for (const auto i : index_range(_test_var_names))
   {
@@ -370,11 +371,7 @@ EquationSystem::RecoverFEMSolution(mfem::BlockVector & trueX,
                                    Moose::MFEM::ComplexGridFunctions & /*cmplx_gridfunctions*/)
 {
   for (const auto i : index_range(_trial_var_names))
-  {
-    auto & trial_var_name = _trial_var_names.at(i);
-    trueX.GetBlock(i).SyncAliasMemory(trueX);
-    gridfunctions.Get(trial_var_name)->Distribute(&(trueX.GetBlock(i)));
-  }
+    gridfunctions.Get(_trial_var_names.at(i))->Distribute(&(trueX.GetBlock(i)));
 }
 
 void

--- a/framework/src/mfem/postprocessors/MFEMComplexVectorPeriodAveragedPostprocessor.C
+++ b/framework/src/mfem/postprocessors/MFEMComplexVectorPeriodAveragedPostprocessor.C
@@ -53,23 +53,17 @@ MFEMComplexVectorPeriodAveragedPostprocessor::MFEMComplexVectorPeriodAveragedPos
     _sum_coef(_real_inner_product_coef, _imag_inner_product_coef, 0.5, 0.5),
     _subdomain_integrator(&_scalar_test_fespace)
 {
-
-  _scalar_var.ProjectCoefficient(_scalar_coef);
-
   if (isSubdomainRestricted())
-  {
     _subdomain_integrator.AddDomainIntegrator(new mfem::DomainLFIntegrator(_sum_coef),
                                               getSubdomainMarkers());
-  }
   else
-  {
     _subdomain_integrator.AddDomainIntegrator(new mfem::DomainLFIntegrator(_sum_coef));
-  }
 }
 
 void
 MFEMComplexVectorPeriodAveragedPostprocessor::execute()
 {
+  _scalar_var.ProjectCoefficient(_scalar_coef);
   _subdomain_integrator.Assemble();
   _integral = _subdomain_integrator(_scalar_var);
 }

--- a/framework/src/mfem/problem_operators/ProblemOperatorBase.C
+++ b/framework/src/mfem/problem_operators/ProblemOperatorBase.C
@@ -60,11 +60,6 @@ ProblemOperatorBase::Init(mfem::BlockVector & X)
     _trial_variables[i]->MakeTRef(
         _trial_variables[i]->ParFESpace(), X, _block_true_offsets_trial[i]);
   _trial_true_vector = &X;
-
-  // This might seem silly but after making the tref the memory flags of the grid function and its
-  // true vector are in an empty state other than the aliasing. This operation syncs the flags and
-  // should be a no-op in terms of actual data transfer
-  SetTrialVariablesFromTrueVectors();
 }
 
 void

--- a/framework/src/mfem/problem_operators/ProblemOperatorBase.C
+++ b/framework/src/mfem/problem_operators/ProblemOperatorBase.C
@@ -51,7 +51,7 @@ ProblemOperatorBase::Init(mfem::BlockVector & X)
   X.Update(_block_true_offsets_trial);
   for (const auto i : index_range(_trial_variables))
     X.GetBlock(i) = _trial_variables[i]->GetTrueVector();
-  // Sync the flags from sub-block vectors to global vector
+  // Sync the flags from the global vector with the sub-vectors (copies to global vector location)
   X.SyncFromBlocks();
 
   // After initial assignment of X from the grid function, which may contain initial conditions,
@@ -70,13 +70,10 @@ ProblemOperatorBase::Init(mfem::BlockVector & X)
 void
 ProblemOperatorBase::SetTrialVariablesFromTrueVectors()
 {
-  for (const auto ind : index_range(_trial_variables))
+  mooseAssert(_trial_true_vector, "The true vector should already have been set");
+  for (const auto trial_var : _trial_variables)
   {
-    auto * const trial_var = _trial_variables.at(ind);
-
-    // We must sync the memory flags from the true true vector to the grid function copy of the true
-    // vector
-    mooseAssert(_trial_true_vector, "The true vector should already have been set");
+    // Sync the memory flags from the global true vector to the gridfunction aliases
     trial_var->GetTrueVector().SyncMemory(*_trial_true_vector);
     trial_var->SetFromTrueVector();
   }

--- a/framework/src/mfem/transfers/MFEMSubMeshTransfer.C
+++ b/framework/src/mfem/transfers/MFEMSubMeshTransfer.C
@@ -20,7 +20,7 @@ MFEMSubMeshTransfer::validParams()
   InputParameters params = MFEMGeneralUserObject::validParams();
   params.registerBase("MFEMSubMeshTransfer");
   params.addClassDescription("Class to transfer MFEM variable data to or from a restricted copy of "
-                             "the variable defined on an "
+                             "the variable defined on "
                              " a subspace of an MFEMMesh, represented as an MFEMSubMesh.");
   params.addRequiredParam<VariableName>("from_variable",
                                         "MFEM variable to transfer data from. Can be defined on "

--- a/framework/src/mfem/vectorpostprocessors/MFEMValueSamplerBase.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMValueSamplerBase.C
@@ -150,10 +150,7 @@ MFEMValueSamplerBase::execute()
 void
 MFEMValueSamplerBase::finalize()
 {
-  if (_interp_vals.UseDevice())
-  {
-    _interp_vals.HostReadWrite();
-  }
+  _interp_vals.HostReadWrite();
   _points.HostReadWrite();
 
   const auto mesh_dim = this->getMFEMProblem().mesh().getMFEMParMesh().SpaceDimension();

--- a/modules/doc/content/application_usage/hypre.md
+++ b/modules/doc/content/application_usage/hypre.md
@@ -113,7 +113,7 @@ Here is the full list of Hypre options present in PETSc 3.7.6 (found using `-hel
 
 ```
 HYPRE preconditioner options
-  -pc_hypre_type <boomeramg> (choose one of) pilut parasails boomeramg ams (PCHYPRESetType)
+  -pc_hypre_type <boomeramg> (choose one of) euclid ilu pilut parasails boomeramg ams ads (PCHYPRESetType)
 HYPRE BoomerAMG Options
   -pc_hypre_boomeramg_cycle_type <V> (choose one of) V W (None)
   -pc_hypre_boomeramg_max_levels <25>: Number of levels (of grids) allowed (None)

--- a/test/tests/mfem/transfers/h1_mfem_sub_mfem_sub/parent.i
+++ b/test/tests/mfem/transfers/h1_mfem_sub_mfem_sub/parent.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = MFEMMesh
   file = ../../mesh/square.msh
-  dim = 2
 []
 
 [Problem]

--- a/test/tests/mfem/transfers/h1_mfem_sub_mfem_sub/sub_recv.i
+++ b/test/tests/mfem/transfers/h1_mfem_sub_mfem_sub/sub_recv.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = MFEMMesh
   file = ../../mesh/square.msh
-  dim = 2
 []
 
 [Problem]

--- a/test/tests/mfem/transfers/h1_mfem_sub_mfem_sub/sub_send.i
+++ b/test/tests/mfem/transfers/h1_mfem_sub_mfem_sub/sub_send.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = MFEMMesh
   file = ../../mesh/square.msh
-  dim = 2
 []
 
 [Problem]


### PR DESCRIPTION
## Reason/Design
- Fixes eager coefficient projection by delaying it until postprocessor execution
- Aligns variable/kernel/bc manipulation between time-dependent and complex eq. systems with steady eq. systems
- Fixes compilations against PETSc 3.25
- Fixes minor typo in class description
- Prepares for non-linear initial guesses by prepopulating interior tdofs of solution vector
- Avoids/optimises host/device syncs
