### PR TITLE
Run black format due to black update; update wasp and moose-dev due to format

### DIFF
--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2026.02.16" %}
+{% set version = "2026.02.17" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -2,7 +2,7 @@ mpi:
   - mpich
 
 moose_dev:
-  - moose-dev 2026.02.16
+  - moose-dev 2026.02.17
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -33,14 +33,14 @@ source:
       - message.patch
 
 build:
-  number: 3
-  string: build_3
+  number: 4
+  string: build_4
 
 outputs:
   - name: moose-wasp-base
     build:
-      number: 3
-      string: build_3
+      number: 4
+      string: build_4
       script: ${RECIPE_DIR}/build_wasp.sh
       script_env:
         - MOOSE_JOBS
@@ -62,7 +62,7 @@ outputs:
 
   - name: moose-pyhit
     build:
-      number: 3
+      number: 4
       script: ${RECIPE_DIR}/build_pyhit.sh
       script_env:
         - MOOSE_JOBS

--- a/conda/wasp/test_pyhit.py
+++ b/conda/wasp/test_pyhit.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Test pyhit"""
+
 import sys
 
 if __name__ == "__main__":

--- a/framework/scripts/LikelyOptimzer.py
+++ b/framework/scripts/LikelyOptimzer.py
@@ -218,7 +218,7 @@ if __name__ == "__main__":
     # parser.add_option("-t", "--num-threads", action="store", dest="threads", default=4, help="Number of threads to run gcov in parallel [default=4]")
 
     # parser args and exit if they don't have reasonable values
-    (options, args) = parser.parse_args(sys.argv[1:])
+    options, args = parser.parse_args(sys.argv[1:])
     check_args(parser, options, args)
 
     dir = args[0] if len(args) == 1 else "."

--- a/framework/scripts/fixup_headers.py
+++ b/framework/scripts/fixup_headers.py
@@ -179,5 +179,5 @@ if __name__ == "__main__":
     parser.add_option("--cxx-only", action="store_true", dest="cxx_only", default=False)
     parser.add_option("-f", "--force", action="store_true", dest="force", default=False)
 
-    (global_options, args) = parser.parse_args()
+    global_options, args = parser.parse_args()
     fixupHeader()

--- a/framework/scripts/write_appresource_file.py
+++ b/framework/scripts/write_appresource_file.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """helper script to write a meta resource file containing useful build time attributes"""
+
 import os
 import sys
 import re

--- a/modules/combined/examples/geochem-porous_flow/geotes_weber_tensleep/create_input_files.py
+++ b/modules/combined/examples/geochem-porous_flow/geotes_weber_tensleep/create_input_files.py
@@ -197,7 +197,6 @@ def write_mesh(f, res):
 import os
 import sys
 
-
 sys.stdout.write(
     "Outputting injection borehole specification to " + injection_bh_filename + "\n"
 )

--- a/modules/doc/content/newsletter/2026/2026_02.md
+++ b/modules/doc/content/newsletter/2026/2026_02.md
@@ -141,6 +141,14 @@ In the future, many more test specification parameters will be transitioned to u
 
 - Updated dependencies per above
 
+### `moose-wasp 2025.09.19_02960f1_4`
+
+- Rebuild due to new black format in `conda/wasp/test_pyhit.py`
+
+### `moose-dev 2026.02.17`
+
+- Rebuild due to `moose-wasp 2025.09.19_02960f1_4` bump
+
 ## Apptainer Package Updates
 
 ### `moose-dev:2026.02.05`
@@ -176,3 +184,7 @@ In the future, many more test specification parameters will be transitioned to u
 - Update go for gperftools build to 2.16.0
 - Update miniforge to 26.1.0-0
 - Update pytorch to 2.10.0
+
+### `moose-dev:2026.02.17`
+
+- Rebuild due to `moose-wasp 2025.09.19_02960f1_4` bump

--- a/modules/electromagnetics/doc/content/media_scripts/dipole_radiation_pattern.py
+++ b/modules/electromagnetics/doc/content/media_scripts/dipole_radiation_pattern.py
@@ -1,7 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-
 theta = np.arange(0, 2 * np.pi, 0.01 * np.pi)
 # Radiation intensity (directional component) for electrically small wire dipole antenna from Pozar (p. 644)
 # This is approximately the same directionally as that in the half-wave case in Silver (p. 98-99)

--- a/modules/geochemistry/test/tests/kinetics/bio_arsenate.py
+++ b/modules/geochemistry/test/tests/kinetics/bio_arsenate.py
@@ -15,7 +15,6 @@ import sys
 import math
 import matplotlib.pyplot as plt
 
-
 f = open(os.path.join("gold", "bio_arsenate1_shortdt_out.csv"), "r")
 data = [list(map(float, line.strip().split(","))) for line in f.readlines()[2:]]
 f.close()

--- a/modules/geochemistry/test/tests/kinetics/bio_sulfate.py
+++ b/modules/geochemistry/test/tests/kinetics/bio_sulfate.py
@@ -15,7 +15,6 @@ import sys
 import math
 import matplotlib.pyplot as plt
 
-
 f = open(os.path.join("gold", "bio_sulfate_1_21_out.csv"), "r")
 data = [list(map(float, line.strip().split(","))) for line in f.readlines()[2:]]
 f.close()

--- a/modules/porous_flow/doc/content/modules/porous_flow/tests/buckley_leverett/buckley_leverett.py
+++ b/modules/porous_flow/doc/content/modules/porous_flow/tests/buckley_leverett/buckley_leverett.py
@@ -11,7 +11,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-
 sat_data = np.genfromtxt(
     "../../../../../../test/tests/buckley_leverett/gold/bl01_sat_0001.csv",
     delimiter=",",

--- a/modules/porous_flow/doc/content/modules/porous_flow/tests/fluidstate/fluidstate.py
+++ b/modules/porous_flow/doc/content/modules/porous_flow/tests/fluidstate/fluidstate.py
@@ -11,7 +11,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-
 #
 # The similarity solution (r^2/t) is applicable even when dissolution is included
 #

--- a/modules/porous_flow/doc/content/modules/porous_flow/tests/gravity/gravity.py
+++ b/modules/porous_flow/doc/content/modules/porous_flow/tests/gravity/gravity.py
@@ -67,7 +67,7 @@ def grav02():
 
 
 water1 = grav01()
-(gas, water) = grav02()
+gas, water = grav02()
 
 xpoints = np.arange(-1.02, 0.05, 0.01)
 moosex = [-0.1 * i for i in range(11)]

--- a/modules/porous_flow/doc/content/modules/porous_flow/tests/heat_advection/heat_advection.py
+++ b/modules/porous_flow/doc/content/modules/porous_flow/tests/heat_advection/heat_advection.py
@@ -14,7 +14,6 @@ import numpy as np
 from scipy.special import expi
 import matplotlib.pyplot as plt
 
-
 a01 = np.genfromtxt(
     "../../../../../../test/tests/heat_advection/gold/heat_advection_1d_csv_T_0010.csv",
     delimiter=",",

--- a/modules/porous_flow/examples/coal_mining/mesh/create_model.py
+++ b/modules/porous_flow/examples/coal_mining/mesh/create_model.py
@@ -14,13 +14,10 @@ import subprocess
 import math
 from optparse import OptionParser, OptionValueError
 
-
 # parse command line
-p = OptionParser(
-    usage="""usage: %prog [options] <plan_mesh_vtp> <output_basename>
+p = OptionParser(usage="""usage: %prog [options] <plan_mesh_vtp> <output_basename>
 Creates an exodus and vtk mesh called output_basename.e and output_basename.vtu
-"""
-)
+""")
 p.add_option("-v", action="store_true", dest="verbose", help="Verbose output")
 p.add_option(
     "--seam_thickness",
@@ -46,11 +43,11 @@ p.add_option(
     dest="base_elevation",
     help="Elevation of the base of the model.  Default=%default",
 )
-(opts, args) = p.parse_args()
+opts, args = p.parse_args()
 if len(args) != 2:
     p.print_help()
     sys.exit(1)
-(plan_mesh_vtp, output_base_name) = args
+plan_mesh_vtp, output_base_name = args
 
 if opts.verbose:
     sys.stdout.write("Determining the vertical mesh\n")

--- a/modules/porous_flow/examples/multiapp_fracture_flow/fracture_diffusion/plot_results.py
+++ b/modules/porous_flow/examples/multiapp_fracture_flow/fracture_diffusion/plot_results.py
@@ -13,7 +13,6 @@ import sys
 import numpy as np
 import matplotlib.pyplot as plt
 
-
 l2errors = {}
 
 # benchmark results (no MultiApp)

--- a/modules/porous_flow/examples/thm_example/paper_solns.py
+++ b/modules/porous_flow/examples/thm_example/paper_solns.py
@@ -30,7 +30,6 @@ import scipy.interpolate
 import matplotlib.pyplot as plt
 import scipy.special
 
-
 ##############################
 #                            #
 # Main controlling parameter #

--- a/modules/porous_flow/test/tests/hysteresis/hys.py
+++ b/modules/porous_flow/test/tests/hysteresis/hys.py
@@ -1237,21 +1237,21 @@ hys = Hys(
 )
 
 #### Testing of calculating order and the turning points
-(order, S_ldel) = hys.order_and_turning_points([1.0])
+order, S_ldel = hys.order_and_turning_points([1.0])
 assert order == 0 and len(S_ldel) == 0
-(order, S_ldel) = hys.order_and_turning_points([0.9, 0.8, 0.7, 0.6, 0.5])
+order, S_ldel = hys.order_and_turning_points([0.9, 0.8, 0.7, 0.6, 0.5])
 assert order == 0 and len(S_ldel) == 0
-(order, S_ldel) = hys.order_and_turning_points([0.6, 0.7])
+order, S_ldel = hys.order_and_turning_points([0.6, 0.7])
 assert order == 1 and len(S_ldel) == 1 and S_ldel[0] == 0.5
-(order, S_ldel) = hys.order_and_turning_points([0.7, 0.8, 0.9])
+order, S_ldel = hys.order_and_turning_points([0.7, 0.8, 0.9])
 assert order == 1 and len(S_ldel) == 1 and S_ldel[0] == 0.5
-(order, S_ldel) = hys.order_and_turning_points([0.8, 0.7, 0.6])
+order, S_ldel = hys.order_and_turning_points([0.8, 0.7, 0.6])
 assert order == 2 and len(S_ldel) == 2 and S_ldel[0] == 0.5 and S_ldel[1] == 0.9
-(order, S_ldel) = hys.order_and_turning_points([0.5])
+order, S_ldel = hys.order_and_turning_points([0.5])
 assert order == 0 and len(S_ldel) == 0
-(order, S_ldel) = hys.order_and_turning_points([0.4])
+order, S_ldel = hys.order_and_turning_points([0.4])
 assert order == 0 and len(S_ldel) == 0
-(order, S_ldel) = hys.order_and_turning_points([0.9, 0.6, 0.8, 0.7])
+order, S_ldel = hys.order_and_turning_points([0.9, 0.6, 0.8, 0.7])
 assert (
     order == 4
     and len(S_ldel) == 4
@@ -1260,7 +1260,7 @@ assert (
     and S_ldel[2] == 0.6
     and S_ldel[3] == 0.8
 )
-(order, S_ldel) = hys.order_and_turning_points([0.85])
+order, S_ldel = hys.order_and_turning_points([0.85])
 assert (
     order == 3
     and len(S_ldel) == 3
@@ -1268,7 +1268,7 @@ assert (
     and S_ldel[1] == 0.9
     and S_ldel[2] == 0.6
 )
-(order, S_ldel) = hys.order_and_turning_points([0.2])
+order, S_ldel = hys.order_and_turning_points([0.2])
 assert order == 0 and len(S_ldel) == 0
 
 eps = 1e-8

--- a/modules/solid_mechanics/doc/tests/create_vtr.py
+++ b/modules/solid_mechanics/doc/tests/create_vtr.py
@@ -13,11 +13,9 @@ import sys
 from optparse import OptionParser, OptionValueError
 import vtk
 
-p = OptionParser(
-    usage="""usage: %prog [options] <out_vtr>
+p = OptionParser(usage="""usage: %prog [options] <out_vtr>
 Creates an undecorated rectilinear grid (.vtr file)
-"""
-)
+""")
 p.add_option(
     "-x",
     "--xgrid",
@@ -52,14 +50,14 @@ p.add_option(
     dest="ascii",
     help="ASCII, instead of binary, .vtr output",
 )
-(opts, args) = p.parse_args()
+opts, args = p.parse_args()
 
 # get the output filename
 if len(args) != 1:
     p.print_help()
     print("Incorrect number of agruments")
     sys.exit(1)
-(out_vtr) = args[0]
+out_vtr = args[0]
 
 if not out_vtr.endswith(".vtr"):
     p.print_help()
@@ -72,7 +70,7 @@ if opts.verbose:
 xArray = vtk.vtkDoubleArray()
 min_max_num = opts.xgrid.split(":")
 if len(min_max_num) == 3:
-    (x0, x1, nx) = (float(min_max_num[0]), float(min_max_num[1]), int(min_max_num[2]))
+    x0, x1, nx = (float(min_max_num[0]), float(min_max_num[1]), int(min_max_num[2]))
     x_coords = [x0 + i * (x1 - x0) / float(nx - 1) for i in range(nx)]
 else:
     try:
@@ -87,7 +85,7 @@ for x in x_coords:
 yArray = vtk.vtkDoubleArray()
 min_max_num = opts.ygrid.split(":")
 if len(min_max_num) == 3:
-    (y0, y1, ny) = (float(min_max_num[0]), float(min_max_num[1]), int(min_max_num[2]))
+    y0, y1, ny = (float(min_max_num[0]), float(min_max_num[1]), int(min_max_num[2]))
     y_coords = [y0 + i * (y1 - y0) / float(ny - 1) for i in range(ny)]
 else:
     try:
@@ -102,7 +100,7 @@ for y in y_coords:
 zArray = vtk.vtkDoubleArray()
 min_max_num = opts.zgrid.split(":")
 if len(min_max_num) == 3:
-    (z0, z1, nz) = (float(min_max_num[0]), float(min_max_num[1]), int(min_max_num[2]))
+    z0, z1, nz = (float(min_max_num[0]), float(min_max_num[1]), int(min_max_num[2]))
     z_coords = [z0 + i * (z1 - z0) / float(nz - 1) for i in range(nz)]
 else:
     try:

--- a/modules/solid_mechanics/doc/tests/yf.py
+++ b/modules/solid_mechanics/doc/tests/yf.py
@@ -71,12 +71,10 @@ def yield_function(x, y, z):
 
 
 # parse command line
-p = OptionParser(
-    usage="""usage: %prog [options] <vtk_file>
+p = OptionParser(usage="""usage: %prog [options] <vtk_file>
 Inserts yield function values into <vtk_file>.
 Only 3D input is accepted: this program assumes that the individual yield functions are functions of x, y, z.
-"""
-)
+""")
 p.add_option("-v", action="store_true", dest="verbose", help="Verbose")
 p.add_option(
     "--name",
@@ -132,7 +130,7 @@ p.add_option(
     dest="twoD_example_alternative",
     help="Yield function will contain contributions from an alternative example 2D yield function",
 )
-(opts, args) = p.parse_args()
+opts, args = p.parse_args()
 
 # get the com filename
 if len(args) != 1:
@@ -167,7 +165,7 @@ yf = vtk.vtkDoubleArray()
 yf.SetName(opts.name)
 yf.SetNumberOfValues(indata.GetNumberOfPoints())
 for ptid in range(indata.GetNumberOfPoints()):
-    (x, y, z) = indata.GetPoint(ptid)
+    x, y, z = indata.GetPoint(ptid)
     yf.SetValue(ptid, yield_function(x, y, z))
 indata.GetPointData().AddArray(yf)
 

--- a/modules/solid_mechanics/doc/theory/capped_weak_plane.py
+++ b/modules/solid_mechanics/doc/theory/capped_weak_plane.py
@@ -151,11 +151,11 @@ p.add_option(
 p.add_option(
     "-l", action="store_true", dest="labels", help="Include labels on the contours"
 )
-(opts, args) = p.parse_args()
+opts, args = p.parse_args()
 if len(args) != 4:
     p.print_help()
     sys.exit(1)
-(coh, tanphi, tensile, compressive) = map(float, args)
+coh, tanphi, tensile, compressive = map(float, args)
 tip_s = opts.tip_smoother if opts.tip_smoother >= 0 else 0.1 * coh
 s_tol = opts.smoothing_tol if opts.smoothing_tol >= 0 else 0.1 * coh
 

--- a/modules/solid_mechanics/examples/coal_mining/mesh/create_model.py
+++ b/modules/solid_mechanics/examples/coal_mining/mesh/create_model.py
@@ -14,13 +14,10 @@ import subprocess
 import math
 from optparse import OptionParser, OptionValueError
 
-
 # parse command line
-p = OptionParser(
-    usage="""usage: %prog [options] <plan_mesh_vtp> <output_basename>
+p = OptionParser(usage="""usage: %prog [options] <plan_mesh_vtp> <output_basename>
 Creates an exodus and vtk mesh called output_basename.e and output_basename.vtu
-"""
-)
+""")
 p.add_option("-v", action="store_true", dest="verbose", help="Verbose output")
 p.add_option(
     "--seam_thickness",
@@ -46,11 +43,11 @@ p.add_option(
     dest="base_elevation",
     help="Elevation of the base of the model.  Default=%default",
 )
-(opts, args) = p.parse_args()
+opts, args = p.parse_args()
 if len(args) != 2:
     p.print_help()
     sys.exit(1)
-(plan_mesh_vtp, output_base_name) = args
+plan_mesh_vtp, output_base_name = args
 
 if opts.verbose:
     sys.stdout.write("Determining the vertical mesh\n")

--- a/python/GridVTKData/griddeddata_from_vtk.py
+++ b/python/GridVTKData/griddeddata_from_vtk.py
@@ -44,7 +44,7 @@ p.add_option("-v", action="store_true", dest="verbose", help="Verbose")
 
 
 # extract commandline arguments
-(opts, args) = p.parse_args()
+opts, args = p.parse_args()
 if len(args) < 2:
     sys.stderr.write("Number of arguments incorrect\n")
     sys.exit(1)

--- a/python/GridVTKData/griddeddata_to_vtk.py
+++ b/python/GridVTKData/griddeddata_to_vtk.py
@@ -15,8 +15,7 @@ import math
 import vtk
 
 # parse command line
-p = OptionParser(
-    usage="""usage: %prog [options] <gridfile> <vtrfile_base>
+p = OptionParser(usage="""usage: %prog [options] <gridfile> <vtrfile_base>
 Converts the griddata file (suitable for PiecewiseMultilinear functions) into vtr format.
 
 Eg
@@ -28,17 +27,16 @@ So in the above example,
   mygrid0.vtr mygrid1.vtr would be produced if there were two TIMEs in mygrid.txt
   etc
 
-"""
-)
+""")
 p.add_option("-v", action="store_true", dest="verbose", help="Verbose")
 
 
 # extract commandline arguments
-(opts, args) = p.parse_args()
+opts, args = p.parse_args()
 if len(args) != 2:
     sys.stderr.write("Number of arguments incorrect\n")
     sys.exit(1)
-(grid_file, vtr_base) = args
+grid_file, vtr_base = args
 
 
 # extract the data from the grid file

--- a/python/MooseDocs/base/Extension.py
+++ b/python/MooseDocs/base/Extension.py
@@ -10,6 +10,7 @@
 An Extension is comprised of Component objects, the objects are used for tokenizeing markdown
 and converting tokens to rendered HTML.
 """
+
 from types import ModuleType
 
 from ..common import mixins

--- a/python/MooseDocs/base/Translator.py
+++ b/python/MooseDocs/base/Translator.py
@@ -12,6 +12,7 @@ Module that defines Translator objects for converted AST from Reader to Rendered
 Renderer objects. The Translator objects exist as a place to import extensions and bridge
 between the reading and rendering content.
 """
+
 import os
 import uuid
 import logging

--- a/python/MooseDocs/base/__init__.py
+++ b/python/MooseDocs/base/__init__.py
@@ -11,6 +11,7 @@
 The base module defines the primary base classes for creating MooseDocs objects for
 converting Markdown into HTML or LaTeX.
 """
+
 from .lexers import Lexer, RecursiveLexer, Grammar
 from .readers import Reader, MarkdownReader
 from .renderers import Renderer, HTMLRenderer, MaterializeRenderer, LatexRenderer

--- a/python/MooseDocs/base/executioners.py
+++ b/python/MooseDocs/base/executioners.py
@@ -7,6 +7,7 @@
 # Licensed under LGPL 2.1, please see LICENSE for details
 # https://www.gnu.org/licenses/lgpl-2.1.html
 """Module for defining Executioner objects, which are helpers for tokenization and rendering."""
+
 import sys
 import os
 import copy

--- a/python/MooseDocs/base/lexers.py
+++ b/python/MooseDocs/base/lexers.py
@@ -10,6 +10,7 @@
 """
 Module for defining the default Lexer objects that plugin to base.Reader objects.
 """
+
 import collections
 import logging
 import traceback

--- a/python/MooseDocs/base/readers.py
+++ b/python/MooseDocs/base/readers.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Defines Reader objects that convert raw text into an AST."""
+
 import os
 import logging
 

--- a/python/MooseDocs/base/renderers.py
+++ b/python/MooseDocs/base/renderers.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Defines Renderer objects that convert AST (from Reader) into an output format."""
+
 import os
 import re
 import logging

--- a/python/MooseDocs/commands/__init__.py
+++ b/python/MooseDocs/commands/__init__.py
@@ -8,4 +8,5 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """MooseDocs command-line commands."""
+
 from .build import command_line_options, main

--- a/python/MooseDocs/commands/build.py
+++ b/python/MooseDocs/commands/build.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Defines the MooseDocs build command."""
+
 import os
 import sys
 import time

--- a/python/MooseDocs/commands/check.py
+++ b/python/MooseDocs/commands/check.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Developer tools for MooseDocs."""
+
 import argparse
 import os
 import re

--- a/python/MooseDocs/commands/generate.py
+++ b/python/MooseDocs/commands/generate.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Developer tools for MooseDocs."""
+
 import argparse
 import os
 import re

--- a/python/MooseDocs/commands/syntax.py
+++ b/python/MooseDocs/commands/syntax.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Developer tools for MooseDocs."""
+
 import argparse
 import os
 import re

--- a/python/MooseDocs/common/__init__.py
+++ b/python/MooseDocs/common/__init__.py
@@ -10,6 +10,7 @@
 """
 Module for objects and functions that are commonly used throughout the MooseDocs system.
 """
+
 from .storage import Storage
 from .parse_settings import match_settings, parse_settings, get_settings_as_dict
 from .box import box

--- a/python/MooseDocs/common/build_class_database.py
+++ b/python/MooseDocs/common/build_class_database.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Tools for extracting C++ class information."""
+
 import os
 import re
 import logging

--- a/python/MooseDocs/common/exceptions.py
+++ b/python/MooseDocs/common/exceptions.py
@@ -10,6 +10,7 @@
 """
 The MooseDocs systems raises the following exceptions.
 """
+
 import logging
 
 LOG = logging.getLogger(__name__)

--- a/python/MooseDocs/common/load_config.py
+++ b/python/MooseDocs/common/load_config.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Tool for loading MooseDocs config hit file."""
+
 import types
 import importlib
 import logging

--- a/python/MooseDocs/common/log.py
+++ b/python/MooseDocs/common/log.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Helper for defining custom MooseDocs logging."""
+
 import logging
 import traceback
 import multiprocessing

--- a/python/MooseDocs/common/mixins.py
+++ b/python/MooseDocs/common/mixins.py
@@ -10,6 +10,7 @@
 """
 Contains base classes intended to be used internal to this module.
 """
+
 import uuid
 import copy
 import MooseDocs

--- a/python/MooseDocs/common/parse_settings.py
+++ b/python/MooseDocs/common/parse_settings.py
@@ -10,6 +10,7 @@
 """
 Tools for parsing key value pairs from a raw string (e.g., 'key=value foo=bar')
 """
+
 import re
 import copy
 

--- a/python/MooseDocs/common/read.py
+++ b/python/MooseDocs/common/read.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Utilities for reading files."""
+
 import sys
 import codecs
 import os

--- a/python/MooseDocs/extensions/command.py
+++ b/python/MooseDocs/extensions/command.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Extension for adding commands to Markdown syntax."""
+
 import re
 
 from .. import common

--- a/python/MooseDocs/extensions/core.py
+++ b/python/MooseDocs/extensions/core.py
@@ -10,6 +10,7 @@
 """
 Defines the "core" extension for translating MooseDocs markdown to HTML and LaTeX.
 """
+
 import re
 import uuid
 import logging

--- a/python/MooseDocs/main.py
+++ b/python/MooseDocs/main.py
@@ -11,6 +11,7 @@ Main program for running MooseDocs. The moosedocs.py script that exists within t
 documentation directory for applications call this in similar fashion to
 MOOSE run_tests.
 """
+
 import argparse
 import logging
 

--- a/python/MooseDocs/test/base/test_components.py
+++ b/python/MooseDocs/test/base/test_components.py
@@ -11,6 +11,7 @@
 """
 Tests for Component objects.
 """
+
 import unittest
 import mock
 

--- a/python/MooseDocs/test/base/test_lexers.py
+++ b/python/MooseDocs/test/base/test_lexers.py
@@ -11,6 +11,7 @@
 """
 Tests for Lexer and related objects.
 """
+
 import re
 import unittest
 

--- a/python/MooseDocs/test/base/test_readers.py
+++ b/python/MooseDocs/test/base/test_readers.py
@@ -9,6 +9,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Test for the Reader objects."""
+
 import unittest
 import re
 import logging

--- a/python/MooseDocs/test/base/test_translator.py
+++ b/python/MooseDocs/test/base/test_translator.py
@@ -11,6 +11,7 @@
 """
 Tests for Component objects.
 """
+
 import unittest
 import os
 

--- a/python/MooseDocs/test/common/test_storage.py
+++ b/python/MooseDocs/test/common/test_storage.py
@@ -9,6 +9,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Testing for common.Storage class."""
+
 ####################################################################################################
 #                                    DO NOT MODIFY THIS HEADER                                     #
 #                   MOOSE - Multiphysics Object Oriented Simulation Environment                    #

--- a/python/MooseDocs/test/extensions/test_listing.py
+++ b/python/MooseDocs/test/extensions/test_listing.py
@@ -965,8 +965,7 @@ class TestMooseParsedInput(AppSyntaxTestCase):
 []
 !listing-end!
 """
-        cls.parsed_text_re = re.compile(
-            r"""\[Kernels\<\<\<(.*?)\>\>\>\]
+        cls.parsed_text_re = re.compile(r"""\[Kernels\<\<\<(.*?)\>\>\>\]
   \[diff\]
     type = Diffusion\<\<\<(.*?)\>\>\>
     variable\<\<\<(.*?)\>\>\> = u
@@ -978,8 +977,7 @@ class TestMooseParsedInput(AppSyntaxTestCase):
 \[\]
 
 \[UnknownSyntax\]
-\[\]"""
-        )
+\[\]""")
         return super().setUpClass()
 
     def setupContent(self):

--- a/python/MooseDocs/tree/__init__.py
+++ b/python/MooseDocs/tree/__init__.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Module for defining tree structures for various MooseDocs operations."""
+
 from . import base
 from . import html
 from . import tokens

--- a/python/TestHarness/testers/CSVValidationTester.py
+++ b/python/TestHarness/testers/CSVValidationTester.py
@@ -26,16 +26,16 @@ def diff_files(gold_file, out_file, err_type="relative"):
     found_column = {}
 
     csv = CSVTools()
-    (table1, table2) = csv.convertToTable([open(gold_file, "r"), open(out_file, "r")])
+    table1, table2 = csv.convertToTable([open(gold_file, "r"), open(out_file, "r")])
 
     # Make sure header names are the same (also makes sure # cols is the same)
     # This way it reports what column is missing, not just # cols is different
     keys1 = table1.keys()
     keys2 = table2.keys()
-    (large, small) = (keys1, keys2)
+    large, small = (keys1, keys2)
 
     if len(keys1) < len(keys2):
-        (large, small) = (keys2, keys1)
+        large, small = (keys2, keys1)
         for key in large:
             if key not in small:
                 csv.addError(gold_file, "Header '" + key + "' is missing")
@@ -148,7 +148,7 @@ class CSVValidationTester(FileTester):
                     self.getTestDir(), self.specs["gold_dir"], file
                 )
                 out_file = os.path.join(self.getTestDir(), file)
-                (mean, std) = diff_files(gold_file, out_file, self.specs["err_type"])
+                mean, std = diff_files(gold_file, out_file, self.specs["err_type"])
 
                 computed = ""
                 if mean > self.specs["mean_limit"]:

--- a/python/TestHarness/testers/MMSTest.py
+++ b/python/TestHarness/testers/MMSTest.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Implement MMSTest for testing with the method of manufactured solutions."""
+
 from PythonUnitTest import PythonUnitTest
 
 

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -269,7 +269,7 @@ def getSharedOption(libmesh_dir):
     with open(libtool, "r") as f:
         for line in f:
             try:
-                (key, value) = line.rstrip().split("=", 2)
+                key, value = line.rstrip().split("=", 2)
             except Exception:
                 continue
 
@@ -352,7 +352,7 @@ def deleteFilesAndFolders(test_dir, paths, delete_folders=True):
         for file in paths:
             path = os.path.dirname(file)
             while path != "":
-                (path, tail) = os.path.split(path)
+                path, tail = os.path.split(path)
                 try:
                     os.rmdir(os.path.join(test_dir, path, tail))
                 except:

--- a/python/jacobiandebug/analyzejacobian.py
+++ b/python/jacobiandebug/analyzejacobian.py
@@ -22,7 +22,6 @@ from optparse import OptionParser
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from TestHarness import util
 
-
 # These kernels have guaranteed correct Jacobians
 whitelisted_kernels = ["Diffusion", "TimeDerivative"]
 
@@ -396,7 +395,7 @@ if __name__ == "__main__":
         help="Append the following list of arguments to the command line (Encapsulate the command in quotes)",
     )
 
-    (options, args) = parser.parse_args()
+    options, args = parser.parse_args()
 
     for arg in args:
         if arg[-2:] == ".i":

--- a/python/moosepytest/runtestharness.py
+++ b/python/moosepytest/runtestharness.py
@@ -19,7 +19,6 @@ from io import StringIO
 
 from TestHarness import TestHarness
 
-
 MOOSE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 

--- a/python/mooseutils/csvdiff.py
+++ b/python/mooseutils/csvdiff.py
@@ -312,13 +312,13 @@ class CSVDiffer(CSVTools):
         # the order of the tests is most general to most specific, so if a general
         # one fails then the more specific ones will probably not only fail, but
         # crash the program because it's looking in a column that doesn't exist
-        (table1, table2) = self.convertToTable(self.files)
+        table1, table2 = self.convertToTable(self.files)
 
         # Make sure header names are the same (also makes sure # cols is the same)
         # This way it reports what column is missing, not just # cols is different
         keys1 = table1.keys()
         keys2 = table2.keys()
-        (large, small) = (keys1, keys2)
+        large, small = (keys1, keys2)
 
         # check if custom tolerances used, column name exists in one of
         # the CSV files
@@ -329,7 +329,7 @@ class CSVDiffer(CSVTools):
                 if key not in small or key not in large:
                     self.addError(self.files[0], "Header '" + key + "' is missing")
         elif len(keys1) < len(keys2):
-            (large, small) = (keys2, keys1)
+            large, small = (keys2, keys1)
             for key in large:
                 if key not in small and key not in self.ignore:
                     self.addError(self.files[0], "Header '" + key + "' is missing")

--- a/python/mooseutils/mooseutils.py
+++ b/python/mooseutils/mooseutils.py
@@ -245,12 +245,12 @@ def check_configuration(packages, message=True):
     missing = []
     re_operators = re.compile(r"([=<>]+)")
     for package in packages:
-        (_package, _operator, _version) = package, None, None
+        _package, _operator, _version = package, None, None
         # parse version operator
         if re_operators.findall(_package):
             try:
                 _op = re_operators.findall(_package)[0]
-                (_package, _operator, _version) = re.findall(
+                _package, _operator, _version = re.findall(
                     rf"([.\w_-]+)([{_op}]+)(.*)", _package
                 )[0]
             # Try and capture possible regex issues

--- a/python/peacock/Input/ParamsTable.py
+++ b/python/peacock/Input/ParamsTable.py
@@ -305,7 +305,7 @@ class ParamsTable(QtWidgets.QTableWidget, MooseWidget):
             return self._paramValue(row)
 
     def _openFileDialog(self, param, text, use_extension):
-        (file_name, filter_name) = QtWidgets.QFileDialog.getOpenFileName(
+        file_name, filter_name = QtWidgets.QFileDialog.getOpenFileName(
             self, text, os.getcwd(), "File (*)"
         )
         if not file_name:

--- a/python/peacock/tests/postprocessor_tab/gold/TestPostprocessorPluginManager_test_script.py
+++ b/python/peacock/tests/postprocessor_tab/gold/TestPostprocessorPluginManager_test_script.py
@@ -10,6 +10,7 @@
 """
 python TestPostprocessorPluginManager_test_script.py
 """
+
 import matplotlib.pyplot as plt
 import mooseutils
 

--- a/python/pycapabilities/tests/test_capabilities.py
+++ b/python/pycapabilities/tests/test_capabilities.py
@@ -9,6 +9,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Test capabilities module."""
+
 import unittest
 
 import pycapabilities

--- a/python/pyhit/pyhit.py
+++ b/python/pyhit/pyhit.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Wrapper for hit parser."""
+
 import os
 import moosetree
 import hit

--- a/scripts/apptainer_generator.py
+++ b/scripts/apptainer_generator.py
@@ -2,6 +2,7 @@
 """
 Manipulate Apptainer/Harbor containers based on version/hashes of MOOSE repository
 """
+
 import os
 import sys
 import argparse

--- a/scripts/are_queued_jobs_finished.py
+++ b/scripts/are_queued_jobs_finished.py
@@ -3,6 +3,7 @@
 Check if all jobs provided in PBS job file has finished.
   exit(0) if all jobs are finished, exit(1) if not.
 """
+
 # This file is part of the MOOSE framework
 # https://mooseframework.inl.gov
 #

--- a/scripts/memory_logger.py
+++ b/scripts/memory_logger.py
@@ -210,7 +210,7 @@ class Server:
         self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.server_socket.bind((socket.gethostname(), 0))
         self.server_socket.listen(5)
-        (self.host, self.port) = self.server_socket.getsockname()
+        self.host, self.port = self.server_socket.getsockname()
 
         # We will store all connections (sockets objects) made to the server in a list
         self.client_connections.append(self.server_socket)
@@ -1105,7 +1105,7 @@ class ReadLog:
         CYAN = "\033[36m"
         YELLOW = "\033[33m"
         last_memory = 0.0
-        (terminal_width, terminal_height) = self.getTerminalSize()
+        terminal_width, terminal_height = self.getTerminalSize()
         for timestamp in self.memory_list:
             to = GetTime(float(timestamp[0]))
             total_memory = int(timestamp[1])
@@ -1598,8 +1598,7 @@ def parseArguments(args=None):
 
 
 def lldbImportError():
-    print(
-        """
+    print("""
   Unable to import lldb
 
     The Python lldb API is now supplied by Xcode but not
@@ -1616,8 +1615,7 @@ def lldbImportError():
     It may also be necessary to unload the miniconda module.
     If you receive a fatal Python error about PyThreadState
     try using your system's version of Python instead.
-  """
-    )
+  """)
 
 
 if __name__ == "__main__":

--- a/scripts/separate_unittests.py
+++ b/scripts/separate_unittests.py
@@ -12,6 +12,7 @@
 With only a filename given, this script runs each unittest in a file in a separate process.
 If the test name is given as well, it will only run that test.
 """
+
 import sys, os
 import unittest
 from importlib import import_module

--- a/scripts/sqa_stats.py
+++ b/scripts/sqa_stats.py
@@ -11,6 +11,7 @@
 """
 Report statistics regarding the SQA documentation in MOOSE.
 """
+
 import mooseutils
 
 if __name__ == "__main__":

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1677,3 +1677,32 @@ f73302f346e05b294a71e1c1725aa917f2891183: # 32342
   wasp:
     full_version: 2025.09.19_02960f1_3
     hash: 44637c2
+
+a67141a7d1d7eaae0132956bdcf7b1d82b58d067: # 32364
+  libmesh:
+    full_version: 2026.02.13_6232e98_0
+    hash: '1881419'
+  libmesh-vtk:
+    full_version: 9.6.0_0
+    hash: 7e4f471
+  moose-dev:
+    full_version: 2026.02.17
+    hash: '6599578'
+  mpi:
+    full_version: 2026.02.16
+    hash: 572cf81
+  petsc:
+    full_version: 3.24.4_0
+    hash: d5b5601
+  pprof:
+    full_version: 2026.01.11_71be6bf
+    hash: 2e7209c
+  seacas:
+    full_version: 2025.10.14_1
+    hash: '9685477'
+  tools:
+    full_version: 2026.02.16
+    hash: 8f1ccc2
+  wasp:
+    full_version: 2025.09.19_02960f1_4
+    hash: ac33097

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -75,7 +75,7 @@ packages:
   # dependers: moose-dev
   wasp:
     version: 2025.09.19_02960f1
-    build_number: 3
+    build_number: 4
     conda: conda/wasp
     templates:
       conda/wasp/meta.yaml.template: conda/wasp/meta.yaml
@@ -92,7 +92,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2026.02.16
+    version: 2026.02.17
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml

--- a/test/tests/mesh/patterned_mesh/pattern_mesh.py
+++ b/test/tests/mesh/patterned_mesh/pattern_mesh.py
@@ -11,6 +11,7 @@
 Creates images for TiledMesh documentation.
 python pattern_mesh.py
 """
+
 import vtk
 import chigger
 

--- a/test/tests/mesh/stitched_mesh/stitched_mesh.py
+++ b/test/tests/mesh/stitched_mesh/stitched_mesh.py
@@ -10,6 +10,7 @@
 """
 Creates images for StitchedMesh documentation.
 """
+
 import vtk
 import chigger
 

--- a/test/tests/mesh/tiled_mesh/tiled_mesh.py
+++ b/test/tests/mesh/tiled_mesh/tiled_mesh.py
@@ -11,6 +11,7 @@
 Creates images for TiledMesh documentation.
 python tiled_mesh.py
 """
+
 import vtk
 import chigger
 

--- a/test/tests/time_integrators/scalar/run.py
+++ b/test/tests/time_integrators/scalar/run.py
@@ -70,7 +70,7 @@ def run_moose(dt, time_integrator):
         # communicate() waits for the process to terminate, so there's no
         # need to wait() for it.  It also sets the returncode attribute on
         # child.
-        (stdoutdata, stderrdata) = child.communicate()
+        stdoutdata, stderrdata = child.communicate()
         if child.returncode != 0:
             print("Running MOOSE failed: program output is below:")
             print(stdoutdata)

--- a/test/tests/time_integrators/scalar/run_stiff.py
+++ b/test/tests/time_integrators/scalar/run_stiff.py
@@ -65,7 +65,7 @@ def run_moose(y2_exponent, dt, time_integrator, lam):
         # communicate() waits for the process to terminate, so there's no
         # need to wait() for it.  It also sets the returncode attribute on
         # child.
-        (stdoutdata, stderrdata) = child.communicate()
+        stdoutdata, stderrdata = child.communicate()
 
         if child.returncode != 0:
             print("Running MOOSE failed: program output is below:")


### PR DESCRIPTION
Black format bump in 26.1.0 in https://github.com/idaholab/moose/pull/32342 caused black format to stop failing.

## Conda packages

### `moose-wasp 2025.09.19_02960f1_4`

- Rebuild due to new black format in `conda/wasp/test_pyhit.py`

### `moose-dev 2026.02.17`

- Rebuild due to `moose-wasp 2025.09.19_02960f1_4` bump

## Apptainer containers

### `moose-dev:2026.02.17`

- Rebuild due to `moose-wasp 2025.09.19_02960f1_4` bump