### PR TITLE
Update libmesh, neml2; add nvtx push/pop to `PerfGuard`; fix mfem build script

### DIFF
--- a/apptainer/libmesh.def
+++ b/apptainer/libmesh.def
@@ -109,8 +109,13 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     cd ${ROOT_BUILD_DIR}
     mkdir -p ${LIBMESH_DIR}/logs
     METHODS="{{ METHODS or "opt dbg oprof devel" }}"
+    IFS=' ' read -r -a LIBMESH_ARR_OPTIONS <<< "{{ LIBMESH_OPTIONS }}"
+    if [ -n "$CUDA_DIR" ]; then
+        LIBMESH_ARR_OPTIONS+=("--with-nvtx=${CUDA_DIR}" "--enable-perflog")
+    fi
+
     LIBMESH_SRC_DIR=${LIBMESH_SRC_DIR} LIBMESH_DIR=${LIBMESH_DIR} MOOSE_JOBS=${MOOSE_JOBS} METHODS=${METHODS} ./scripts/{{ LIBMESH_BUILD_SCRIPT }} \
-        {{ LIBMESH_OPTIONS }} --skip-submodule-update 2>&1 | tee ${LIBMESH_DIR}/logs/build.log
+        "${LIBMESH_ARR_OPTIONS[@]}" --skip-submodule-update 2>&1 | tee ${LIBMESH_DIR}/logs/build.log
     cp ${LIBMESH_SRC_DIR}/build/config.log ${LIBMESH_DIR}/logs/
 
     # Fix possibly bad permissions

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2026.02.13_6232e98" %}
+{% set version = "2026.02.18_f8a1758" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -3,8 +3,8 @@ mpi:
   - openmpi
 
 moose_libmesh:
-  - moose-libmesh 2026.02.13_6232e98 mpich_0
-  - moose-libmesh 2026.02.13_6232e98 openmpi_0
+  - moose-libmesh 2026.02.18_f8a1758 mpich_0
+  - moose-libmesh 2026.02.18_f8a1758 openmpi_0
 
 moose_wasp:
   - moose-wasp 2025.09.19_02960f1

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2026.02.17" %}
+{% set version = "2026.02.20" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -2,7 +2,7 @@ mpi:
   - mpich
 
 moose_dev:
-  - moose-dev 2026.02.17
+  - moose-dev 2026.02.20
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/framework/include/actions/SetupQuadratureAction.h
+++ b/framework/include/actions/SetupQuadratureAction.h
@@ -10,6 +10,8 @@
 #pragma once
 
 #include "Action.h"
+#include "MooseEnum.h"
+
 // libMesh
 #include "libmesh/enum_order.h"
 #include "libmesh/enum_quadrature_type.h"

--- a/framework/include/interfaces/PerfGraphInterface.h
+++ b/framework/include/interfaces/PerfGraphInterface.h
@@ -48,6 +48,7 @@
 #define TIME_SECTION(...)                                                                          \
   GET_MACRO(__VA_ARGS__, TIME_SECTION4, TIME_SECTION3, TIME_SECTION2, TIME_SECTION1, )(__VA_ARGS__)
 
+class MooseApp;
 class InputParameters;
 class MooseObject;
 

--- a/framework/include/utils/PerfGuard.h
+++ b/framework/include/utils/PerfGuard.h
@@ -10,7 +10,8 @@
 #pragma once
 
 #include "MooseTypes.h"
-#include "PerfGraph.h"
+
+class PerfGraph;
 
 /**
  * Scope guard for starting and stopping timing for a node
@@ -30,14 +31,14 @@ public:
    * @param graph The graph to add time into
    * @param id The unique id of the section
    */
-  PerfGuard(PerfGraph & graph, const PerfID id) : _graph(graph) { _graph.push(id); }
+  PerfGuard(PerfGraph & graph, const PerfID id);
 
   /**
    * Stop timing
    */
-  ~PerfGuard() { _graph.pop(); }
+  ~PerfGuard();
 
 protected:
-  ///The graph we're working on
+  /// The graph we're working on
   PerfGraph & _graph;
 };

--- a/framework/src/base/Capabilities.C
+++ b/framework/src/base/Capabilities.C
@@ -446,6 +446,15 @@ Capabilities::registerMooseCapabilities()
   }
 
   {
+    const auto doc = "libMesh performance logging";
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+    have("libmesh_perflog", doc);
+#else
+    libmesh_missing("libmesh_perflog", doc, "--enable-perflog");
+#endif
+  }
+
+  {
     const auto doc = "Boost C++ library";
 #ifdef LIBMESH_HAVE_EXTERNAL_BOOST
     have("boost", doc);

--- a/framework/src/base/Capabilities.C
+++ b/framework/src/base/Capabilities.C
@@ -437,6 +437,15 @@ Capabilities::registerMooseCapabilities()
   }
 
   {
+    const auto doc = "NVIDIA Tools Extension Library API";
+#ifdef LIBMESH_HAVE_NVTX_API
+    have("nvtx_api", doc);
+#else
+    libmesh_missing("nvtx_api", doc, "--with-nvtx");
+#endif
+  }
+
+  {
     const auto doc = "Boost C++ library";
 #ifdef LIBMESH_HAVE_EXTERNAL_BOOST
     have("boost", doc);

--- a/framework/src/utils/PerfGuard.C
+++ b/framework/src/utils/PerfGuard.C
@@ -1,0 +1,24 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "PerfGuard.h"
+#include "PerfGraph.h"
+#include "nvtx3/nvtx3.hpp"
+
+PerfGuard::PerfGuard(PerfGraph & graph, const PerfID id) : _graph(graph)
+{
+  _graph.push(id);
+  nvtxRangePushA(moose::internal::getPerfGraphRegistry().sectionInfo(id)._name.c_str());
+}
+
+PerfGuard::~PerfGuard()
+{
+  _graph.pop();
+  nvtxRangePop();
+}

--- a/framework/src/utils/PerfGuard.C
+++ b/framework/src/utils/PerfGuard.C
@@ -9,16 +9,22 @@
 
 #include "PerfGuard.h"
 #include "PerfGraph.h"
+#ifdef LIBMESH_HAVE_NVTX_API
 #include "nvtx3/nvtx3.hpp"
+#endif
 
 PerfGuard::PerfGuard(PerfGraph & graph, const PerfID id) : _graph(graph)
 {
   _graph.push(id);
+#ifdef LIBMESH_HAVE_NVTX_API
   nvtxRangePushA(moose::internal::getPerfGraphRegistry().sectionInfo(id)._name.c_str());
+#endif
 }
 
 PerfGuard::~PerfGuard()
 {
   _graph.pop();
+#ifdef LIBMESH_HAVE_NVTX_API
   nvtxRangePop();
+#endif
 }

--- a/modules/doc/content/newsletter/2026/2026_02.md
+++ b/modules/doc/content/newsletter/2026/2026_02.md
@@ -86,6 +86,11 @@ In the future, many more test specification parameters will be transitioned to u
   - Infinite-element builder code is now compatible with more general unstructured distributed meshes.
   - `InfQuad::is_child_on_side()` is no longer completely broken.
 
+### `2026.02.18_f8a1758_0` Update
+
+- Bug fix for `PetscVector(Vec)` constructor for parallel non-`VECMPI` vectors.  This fixes a regression in the use of other parallel-capable (e.g. `-vec_type kokkos`) implementations with our `SNES` solver interfaces on multiple ranks.
+- Bug fix for `FEMContext` initialization of data for non-local (outside any `Elem`) data.
+
 ## PETSc-level Changes
 
 ## Conda Package Updates
@@ -149,6 +154,14 @@ In the future, many more test specification parameters will be transitioned to u
 
 - Rebuild due to `moose-wasp 2025.09.19_02960f1_4` bump
 
+### `moose-libmesh 2026.02.13_6232e98_0`
+
+- Update libmesh [`6232e98...f8a1758`](github.com/libMesh/libmesh/compare/6232e98388e305fdf30f2a4905f83c4f71c577c6...f8a17588c82a850969afc7d740f3da286da01463)
+
+### `moose-dev 2026.02.20`
+
+- Bump due to dependency updates
+
 ## Apptainer Package Updates
 
 ### `moose-dev:2026.02.05`
@@ -188,3 +201,12 @@ In the future, many more test specification parameters will be transitioned to u
 ### `moose-dev:2026.02.17`
 
 - Rebuild due to `moose-wasp 2025.09.19_02960f1_4` bump
+
+### `moose-libmesh:2026.02.18_f8a1758_0`
+
+- Update libmesh [`6232e98...f8a1758`](github.com/libMesh/libmesh/compare/6232e98388e305fdf30f2a4905f83c4f71c577c6...f8a17588c82a850969afc7d740f3da286da01463)
+- Set `--with-nvtx` and `--enable-perflog` when building with cuda (see #32039)
+
+### `moose-dev:2026.02.20`
+
+- Bump due to dependency updates

--- a/modules/solid_mechanics/test/tests/neml2/crystal_plasticity/approx_kinematics_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/crystal_plasticity/approx_kinematics_neml2.i
@@ -13,13 +13,6 @@
   []
 []
 
-[Solvers]
-  [newton]
-    type = NewtonWithLineSearch
-    max_linesearch_iterations = 5
-  []
-[]
-
 [Data]
   [crystal_geometry]
     type = CubicCrystal
@@ -102,7 +95,6 @@
     type = WR2ImplicitExponentialTimeIntegration
     variable = 'state/orientation'
   []
-
   [implicit_rate]
     type = ComposedModel
     models = "spatial_velocity_gradient split_to_deformation_rate split_to_vorticity euler_rodrigues elasticity orientation_rate resolved_shear
@@ -110,9 +102,30 @@
               sum_slip_rates slip_rule slip_strength voce_hardening
               integrate_slip_hardening integrate_elastic_strain integrate_orientation"
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'implicit_rate'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = NewtonWithLineSearch
+    max_linesearch_iterations = 5
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [model_without_stress]
     type = ImplicitUpdate
-    implicit_model = 'implicit_rate'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
   [full_stress]

--- a/modules/solid_mechanics/test/tests/neml2/crystal_plasticity/exact_kinematics_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/crystal_plasticity/exact_kinematics_neml2.i
@@ -13,13 +13,6 @@
   []
 []
 
-[Solvers]
-  [newton]
-    type = NewtonWithLineSearch
-    max_linesearch_iterations = 5
-  []
-[]
-
 [Data]
   [crystal_geometry]
     type = CubicCrystal
@@ -124,9 +117,30 @@
               plastic_velgrad plastic_defgrad_rate
               integrate_slip_hardening integrate_plastic_defgrad"
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'implicit_rate'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = NewtonWithLineSearch
+    max_linesearch_iterations = 5
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [model_without_stress]
     type = ImplicitUpdate
-    implicit_model = 'implicit_rate'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
   # Convert PK2 stress to a full second order tensor

--- a/modules/solid_mechanics/test/tests/neml2/laromance/models/laromance_matl_radial_return.i
+++ b/modules/solid_mechanics/test/tests/neml2/laromance/models/laromance_matl_radial_return.i
@@ -1,12 +1,5 @@
 # UNITS are MPa
-[Solvers]
-  [newton]
-    type = Newton
-    abs_tol = 1e-8
-    rel_tol = 1e-6
-    # verbose = true
-  []
-[]
+
 [Models]
   #####################################################################################
   # Compute the invariant plastic flow direction since we are doing J2 radial return
@@ -97,9 +90,31 @@
     models = "plastic_update stress_update vonmises rom_ep
               integrate_ep"
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'rate'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    abs_tol = 1e-8
+    rel_tol = 1e-6
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [radial_return]
     type = ImplicitUpdate
-    implicit_model = 'rate'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
   #####################################################################################

--- a/modules/solid_mechanics/test/tests/neml2/plasticity/isoharden_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/plasticity/isoharden_neml2.i
@@ -1,9 +1,3 @@
-[Solvers]
-  [newton]
-    type = Newton
-  []
-[]
-
 [Models]
   [isoharden]
     type = VoceIsotropicHardening
@@ -70,9 +64,29 @@
               yield normality eprate Eprate
               consistency integrate_ep integrate_Ep"
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'surface'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [return_map]
     type = ImplicitUpdate
-    implicit_model = 'surface'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
   [model]

--- a/modules/solid_mechanics/test/tests/neml2/plasticity/isokinharden_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/plasticity/isokinharden_neml2.i
@@ -1,9 +1,3 @@
-[Solvers]
-  [newton]
-    type = Newton
-  []
-[]
-
 [Models]
   [isoharden]
     type = VoceIsotropicHardening
@@ -87,9 +81,29 @@
               yield normality eprate Kprate Eprate
               consistency integrate_ep integrate_Kp integrate_Ep"
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'surface'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [return_map]
     type = ImplicitUpdate
-    implicit_model = 'surface'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
   [model]

--- a/modules/solid_mechanics/test/tests/neml2/plasticity/kinharden_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/plasticity/kinharden_neml2.i
@@ -1,9 +1,3 @@
-[Solvers]
-  [newton]
-    type = Newton
-  []
-[]
-
 [Models]
   [kinharden]
     type = LinearKinematicHardening
@@ -74,9 +68,29 @@
               yield normality Kprate Eprate
               consistency integrate_Kp integrate_Ep"
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'surface'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [return_map]
     type = ImplicitUpdate
-    implicit_model = 'surface'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
   [model]

--- a/modules/solid_mechanics/test/tests/neml2/plasticity/perfect_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/plasticity/perfect_neml2.i
@@ -1,9 +1,3 @@
-[Solvers]
-  [newton]
-    type = Newton
-  []
-[]
-
 [Models]
   [elastic_strain]
     type = SR2LinearCombination
@@ -57,9 +51,29 @@
               yield normality Eprate
               consistency integrate_Ep"
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'surface'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [return_map]
     type = ImplicitUpdate
-    implicit_model = 'surface'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
   [model]

--- a/modules/solid_mechanics/test/tests/neml2/solve_failure/neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/solve_failure/neml2.i
@@ -1,9 +1,3 @@
-[Solvers]
-  [newton]
-    type = Newton
-  []
-[]
-
 [Models]
   [isoharden]
     type = LinearIsotropicHardening
@@ -90,9 +84,29 @@
               Erate Eerate elasticity
               consistency integrate_ep integrate_X integrate_S'
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'surface'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [model]
     type = ImplicitUpdate
-    implicit_model = 'surface'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
 []

--- a/modules/solid_mechanics/test/tests/neml2/viscoplasticity/chaboche_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/viscoplasticity/chaboche_neml2.i
@@ -1,9 +1,3 @@
-[Solvers]
-  [newton]
-    type = Newton
-  []
-[]
-
 [Models]
   [isoharden]
     type = VoceIsotropicHardening
@@ -109,9 +103,29 @@
     type = ComposedModel
     models = 'isoharden kinharden mandel_stress overstress vonmises yield normality flow_rate eprate Eprate X1rate X2rate Erate Eerate elasticity integrate_stress integrate_ep integrate_X1 integrate_X2'
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'implicit_rate'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [model]
     type = ImplicitUpdate
-    implicit_model = 'implicit_rate'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
 []

--- a/modules/solid_mechanics/test/tests/neml2/viscoplasticity/isoharden_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/viscoplasticity/isoharden_neml2.i
@@ -73,9 +73,29 @@
     type = ComposedModel
     models = 'mandel_stress vonmises isoharden yield normality flow_rate Eprate eprate Erate Eerate elasticity integrate_stress integrate_ep'
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'implicit_rate'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [model]
     type = ImplicitUpdate
-    implicit_model = 'implicit_rate'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
 []

--- a/modules/solid_mechanics/test/tests/neml2/viscoplasticity/isokinharden_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/viscoplasticity/isokinharden_neml2.i
@@ -1,9 +1,3 @@
-[Solvers]
-  [newton]
-    type = Newton
-  []
-[]
-
 [Models]
   [isoharden]
     type = LinearIsotropicHardening
@@ -90,9 +84,29 @@
     type = ComposedModel
     models = 'isoharden kinharden mandel_stress overstress vonmises yield normality flow_rate eprate Eprate Kprate Erate Eerate elasticity integrate_stress integrate_ep integrate_Kp'
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'implicit_rate'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [model]
     type = ImplicitUpdate
-    implicit_model = 'implicit_rate'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
 []

--- a/modules/solid_mechanics/test/tests/neml2/viscoplasticity/kinharden_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/viscoplasticity/kinharden_neml2.i
@@ -1,9 +1,3 @@
-[Solvers]
-  [newton]
-    type = Newton
-  []
-[]
-
 [Models]
   [kinharden]
     type = LinearKinematicHardening
@@ -78,9 +72,29 @@
     type = ComposedModel
     models = 'kinharden mandel_stress overstress vonmises yield normality flow_rate Eprate Kprate Erate Eerate elasticity integrate_stress integrate_Kp'
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'implicit_rate'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [model]
     type = ImplicitUpdate
-    implicit_model = 'implicit_rate'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
 []

--- a/modules/solid_mechanics/test/tests/neml2/viscoplasticity/perfect_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/viscoplasticity/perfect_neml2.i
@@ -1,9 +1,3 @@
-[Solvers]
-  [newton]
-    type = Newton
-  []
-[]
-
 [Models]
   [mandel_stress]
     type = IsotropicMandelStress
@@ -61,9 +55,29 @@
     type = ComposedModel
     models = 'mandel_stress vonmises yield normality flow_rate Eprate Erate Eerate elasticity integrate_stress'
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'implicit_rate'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [model]
     type = ImplicitUpdate
-    implicit_model = 'implicit_rate'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
 []

--- a/modules/solid_mechanics/test/tests/neml2/viscoplasticity/radial_return_neml2.i
+++ b/modules/solid_mechanics/test/tests/neml2/viscoplasticity/radial_return_neml2.i
@@ -1,9 +1,3 @@
-[Solvers]
-  [newton]
-    type = Newton
-  []
-[]
-
 [Models]
   ###############################################################################
   # Use the trial state to precalculate invariant flow directions
@@ -112,11 +106,31 @@
   []
   [implicit_rate]
     type = ComposedModel
-    models = "surface flow_rate integrate_gamma"
+    models = 'surface flow_rate integrate_gamma'
   []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'implicit_rate'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
   [return_map]
     type = ImplicitUpdate
-    implicit_model = 'implicit_rate'
+    equation_system = 'eq_sys'
     solver = 'newton'
   []
   [model0]

--- a/python/MooseDocs/base/renderers.py
+++ b/python/MooseDocs/base/renderers.py
@@ -365,7 +365,6 @@ class HTMLRenderer(Renderer):
                     kwargs["src"] = rel(kwargs["src"])
                 html.Tag(js_node, "script", type="text/javascript", **kwargs)
 
-
         self._addTitle(head, root, page)
 
     def _addTitle(self, head, root, page):
@@ -379,13 +378,14 @@ class HTMLRenderer(Renderer):
         """
 
         # Locate h1 heading and, if it is found, extract the rendered text
-        if 'title' in [child.name for child in head]:
+        if "title" in [child.name for child in head]:
             return
         h = find_heading(page)
         if h is not None:
-            html.Tag(head, 'title', string=h.text())
+            html.Tag(head, "title", string=h.text())
         else:
-            html.Tag(head, 'title', string=str(page.name))
+            html.Tag(head, "title", string=str(page.name))
+
 
 class MaterializeRenderer(HTMLRenderer):
     """

--- a/python/MooseDocs/common/find_heading.py
+++ b/python/MooseDocs/common/find_heading.py
@@ -1,12 +1,13 @@
-#* This file is part of the MOOSE framework
-#* https://mooseframework.inl.gov
-#*
-#* All rights reserved, see COPYRIGHT for full restrictions
-#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-#*
-#* Licensed under LGPL 2.1, please see LICENSE for details
-#* https://www.gnu.org/licenses/lgpl-2.1.html
+# * This file is part of the MOOSE framework
+# * https://mooseframework.inl.gov
+# *
+# * All rights reserved, see COPYRIGHT for full restrictions
+# * https://github.com/idaholab/moose/blob/master/COPYRIGHT
+# *
+# * Licensed under LGPL 2.1, please see LICENSE for details
+# * https://www.gnu.org/licenses/lgpl-2.1.html
+
 
 def find_heading(page, id_=None):
     """Helper for returning a copy of the heading tokens."""
-    return page.get('title') if id_ is None else page.get('headings', dict()).get(id_)
+    return page.get("title") if id_ is None else page.get("headings", dict()).get(id_)

--- a/python/MooseDocs/extensions/media.py
+++ b/python/MooseDocs/extensions/media.py
@@ -346,15 +346,15 @@ class RenderImage(components.RenderComponent):
 
     def createMaterialize(self, parent, token, page):
         tag = self.createHTML(parent, token, page)
-        if not token['href']:
-            tag.addClass('materialboxed moose-image')
+        if not token["href"]:
+            tag.addClass("materialboxed moose-image")
             # Add these to make materialboxed work better with
             # accessibility tools. Not ideal to force these onto a
             # <picture> element rather than use something clickable
             # like <a>, but Materialize doesn't seem to want to work
             # correctly with anything else.
-            tag['role'] = 'button'
-            tag['tabindex'] = '0'
+            tag["role"] = "button"
+            tag["tabindex"] = "0"
         return tag
 
     def createLatex(self, parent, token, page):

--- a/scripts/configure_neml2.sh
+++ b/scripts/configure_neml2.sh
@@ -39,9 +39,6 @@ function configure_neml2()
   cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DNEML2_TESTS=OFF \
-    -DNEML2_RUNNER=OFF \
-    -DNEML2_PYBIND=OFF \
-    -DNEML2_DOC=OFF \
     -DNEML2_WORK_DISPATCHER=ON \
     -DNEML2_JSON=OFF \
     -DNEML2_CONTRIB_PREFIX="$2/contrib" \

--- a/scripts/configure_neml2.sh
+++ b/scripts/configure_neml2.sh
@@ -47,7 +47,6 @@ function configure_neml2()
     -DNEML2_CONTRIB_PREFIX="$2/contrib" \
     -Dtorch_ROOT="$(get_variable LIBTORCH_DIR)" \
     -Dwasp_ROOT="$(get_variable WASP_DIR)" \
-    -Dtimpi_ROOT="$(get_variable TIMPI_DIR)" \
     -G "Unix Makefiles" \
     -B "$2" \
     -S "$1" \

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1706,3 +1706,32 @@ a67141a7d1d7eaae0132956bdcf7b1d82b58d067: # 32364
   wasp:
     full_version: 2025.09.19_02960f1_4
     hash: ac33097
+
+53c9cf672618cc2e5c84f816905c07c84f8fbc76: # 32379
+  libmesh:
+    full_version: 2026.02.18_f8a1758_0
+    hash: 47aa7d2
+  libmesh-vtk:
+    full_version: 9.6.0_0
+    hash: 7e4f471
+  moose-dev:
+    full_version: 2026.02.20
+    hash: d2ceaf6
+  mpi:
+    full_version: 2026.02.16
+    hash: 572cf81
+  petsc:
+    full_version: 3.24.4_0
+    hash: d5b5601
+  pprof:
+    full_version: 2026.01.11_71be6bf
+    hash: 2e7209c
+  seacas:
+    full_version: 2025.10.14_1
+    hash: '9685477'
+  tools:
+    full_version: 2026.02.16
+    hash: 8f1ccc2
+  wasp:
+    full_version: 2025.09.19_02960f1_4
+    hash: ac33097

--- a/scripts/update_and_rebuild_mfem.sh
+++ b/scripts/update_and_rebuild_mfem.sh
@@ -97,8 +97,23 @@ SUPPORTED_METHODS="oprof devel dbg opt"
 : ${METHODS:=${METHOD:-$SUPPORTED_METHODS}}
 
 # Map from the supported libMesh-like methods to CMake's build types
-typeset -A METHOD_TO_CMAKE_BUILD_TYPE_MAP
-METHOD_TO_CMAKE_BUILD_TYPE_MAP=([oprof]=PROFILE [devel]=RELWITHDEBINFO [dbg]=DEBUG [opt]=RELEASE)
+build_type_pairs=(
+  "oprof=PROFILE"
+  "devel=RELWITHDEBINFO"
+  "dbg=DEBUG"
+  "opt=RELEASE"
+)
+
+get_build_type() {
+  local key="$1"
+  local pair
+  for pair in "${build_type_pairs[@]}"; do
+    case "$pair" in
+      "$key="*) echo "${pair#*=}"; return 0 ;;
+    esac
+  done
+  return 1
+}
 
 # The order here, i.e. in METHODS, _is_ important: the libraries for the last
 # of the requested methods will be available for external use (see below)
@@ -107,7 +122,8 @@ do
   [[ $SUPPORTED_METHODS =~ $METHOD ]] ||
   { echo "Error: Build method $METHOD is not recognised, choose from $SUPPORTED_METHODS."; exit 1; }
 
-  CMAKE_BUILD_TYPE=${METHOD_TO_CMAKE_BUILD_TYPE_MAP[$METHOD]}
+
+  CMAKE_BUILD_TYPE="$(get_build_type "$METHOD")"
 
   # If we're not going fast, remove the build directory and reconfigure
   if [ -z "$go_fast" ]; then

--- a/scripts/update_and_rebuild_neml2.sh
+++ b/scripts/update_and_rebuild_neml2.sh
@@ -32,8 +32,6 @@ if [[ "$#" -eq 1 ]] && [[ "$1" == "--help" ]]; then
   echo
   echo "Influential environment variables:"
   echo "  MOOSE_DIR       The path to the MOOSE directory. Default to the parent directory of this script."
-  echo "  LIBMESH_SRC_DIR The path to the libMesh source directory. Default to <MOOSE_DIR>/libmesh."
-  echo "  LIBMESH_DIR     The path to the libMesh directory. Default to <LIBMESH_SRC_DIR>/installed."
   echo "  WASP_SRC_DIR    The path to the WASP source directory. Default to <MOOSE_DIR>/framework/contrib/wasp."
   echo "  WASP_DIR        The path to the WASP directory. Default to <WASP_SRC_DIR>/install."
   echo "  LIBTORCH_DIR    The path to the libtorch directory. Default to <MOOSE_DIR>/framework/contrib/libtorch."

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -55,7 +55,7 @@ packages:
       - scripts/apple-silicon-hdf5-autogen.patch
   # dependers: moose-dev
   libmesh:
-    version: 2026.02.13_6232e98
+    version: 2026.02.18_f8a1758
     build_number: 0
     conda: conda/libmesh
     templates:
@@ -92,7 +92,7 @@ packages:
       - python/pyhit/pyhit.py
   # dependers: none
   moose-dev:
-    version: 2026.02.17
+    version: 2026.02.20
     conda: conda/moose-dev
     templates:
       conda/moose-dev/conda_build_config.yaml.template: conda/moose-dev/conda_build_config.yaml


### PR DESCRIPTION
Closes #32039, closes #32369, closes #32330

## libMesh update https://github.com/libMesh/libmesh/compare/6232e98388e305fdf30f2a4905f83c4f71c577c6...f8a17588c82a850969afc7d740f3da286da01463

- Bug fix for `PetscVector(Vec)` constructor for parallel non-`VECMPI` vectors.  This fixes a regression in the use of other parallel-capable (e.g. `-vec_type kokkos`) implementations with our `SNES` solver interfaces on multiple ranks.
- Bug fix for `FEMContext` initialization of data for non-local (outside any `Elem`) data.

## Conda packages

### `moose-libmesh 2026.02.18_f8a1758_0`

- Update libmesh https://github.com/libMesh/libmesh/compare/6232e98388e305fdf30f2a4905f83c4f71c577c6...f8a17588c82a850969afc7d740f3da286da01463

### `moose-dev 2026.02.20`

- Bump due to dependency updates

## Apptainer containers

### `moose-libmesh:2026.02.18_f8a1758_0`

- Update libmesh https://github.com/libMesh/libmesh/compare/6232e98388e305fdf30f2a4905f83c4f71c577c6...f8a17588c82a850969afc7d740f3da286da01463
- Set `--with-nvtx` and `--enable-perflog` when building with cuda (see #32039)

### `moose-dev:2026.02.20`

- Bump due to dependency updates
