### PR TITLE
Adding getter for use_hash_table_matrix_assembly 

### DIFF
--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -2837,6 +2837,8 @@ public:
 
   void createTagMatrices(CreateTaggedMatrixKey);
 
+  bool useHashTableMatrixAssembly() const { return _use_hash_table_matrix_assembly; }
+
 #ifdef MOOSE_KOKKOS_ENABLED
   /**
    * @returns whether any Kokkos object was added in the problem


### PR DESCRIPTION
and throwing error where it is needed closes #32440

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
