### PR TITLE
Cache hwloc topology for openmpi, various hwloc cache cleanup

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -453,6 +453,11 @@ class TestHarness:
 
         # Store the mpi configuration we have discovered
         self.options.mpi_config = get_mpi_config()
+        if self.options.mpi_config.hwloc_topo_file:
+            self.printInfo(
+                "Using hwloc topology in "
+                f'"{self.options.mpi_config.hwloc_topo_file}" for MPICH'
+            )
 
         # Initialize the scheduler
         self.initialize()

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -456,7 +456,7 @@ class TestHarness:
         if self.options.mpi_config.hwloc_topo_file:
             self.printInfo(
                 "Using hwloc topology in "
-                f'"{self.options.mpi_config.hwloc_topo_file}" for MPICH'
+                f'"{self.options.mpi_config.hwloc_topo_file}"'
             )
 
         # Initialize the scheduler

--- a/python/TestHarness/mpi_config.py
+++ b/python/TestHarness/mpi_config.py
@@ -15,7 +15,7 @@ from enum import Enum
 from pathlib import Path
 from shutil import which
 from socket import gethostname
-from subprocess import CalledProcessError, check_output, run
+from subprocess import CalledProcessError, check_output, run, PIPE, STDOUT
 from traceback import format_exc
 from typing import Optional
 
@@ -52,15 +52,18 @@ def build_hwloc_topo() -> Optional[str]:
     try:
         store_dir = os.path.join(Path.home(), ".local", "share", "moose", "testharness")
         os.makedirs(store_dir, exist_ok=True)
-        store_file = os.path.join(store_dir, f"hwloc_topo_{gethostname()}.xml")
-        cmd = [exe, "--of", "xml", "-f", store_file]
-        run(cmd, check=True)
-        return store_file
     except Exception:
-        print("WARNING: Failed to build hwloc topology file")
-        print(format_exc())
+        print(f"WARNING: Failed to setup .local directory:\n{format_exc()}\n")
+        return None
 
-    return None
+    store_file = os.path.join(store_dir, f"hwloc_topo_{gethostname()}.xml")
+    cmd = [exe, "--of", "xml", "-f", store_file]
+    process = run(cmd, stderr=STDOUT, stdout=PIPE, check=False, text=True)
+    if process.returncode != 0:
+        print(f"WARNING: Failed to build hwloc topology file:\n{process.stdout}\n")
+        return None
+
+    return store_file
 
 
 def get_mpi_config() -> MPIConfig:

--- a/python/TestHarness/mpi_config.py
+++ b/python/TestHarness/mpi_config.py
@@ -84,6 +84,7 @@ def get_mpi_config() -> MPIConfig:
                     config.hwloc = True
             elif "Open MPI" in out:
                 config.mpi_type = MPIType.OPENMPI
+                config.hwloc = True
 
     if config.hwloc:
         config.hwloc_topo_file = build_hwloc_topo()

--- a/python/TestHarness/runners/SubprocessRunner.py
+++ b/python/TestHarness/runners/SubprocessRunner.py
@@ -127,11 +127,10 @@ class SubprocessRunner(Runner):
                 )
                 # Allow oversubscription for hosts that don't have a hostfile
                 process_env["PRTE_MCA_rmaps_default_mapping_policy"] = ":oversubscribe"
-            # MPICH with hwloc with a prebuilt topology file
-            elif mpi_config.mpi_type == MPIType.MPICH:
-                if mpi_config.hwloc and mpi_config.hwloc_topo_file is not None:
-                    process_env["HWLOC_XMLFILE"] = mpi_config.hwloc_topo_file
-                    process_env["HWLOC_THISSYSTEM"] = "1"
+            # hwloc with a prebuilt topology file
+            if mpi_config.hwloc and mpi_config.hwloc_topo_file is not None:
+                process_env["HWLOC_XMLFILE"] = mpi_config.hwloc_topo_file
+                process_env["HWLOC_THISSYSTEM"] = "1"
 
         # Add to environment if requested
         if process_env:

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -759,8 +759,8 @@ class Job(OutputInterface):
 
         if env_ran:
             header += [
-                "Environment variable(s): "
-                + " ".join([f'{k}="{v}"' for k, v in env_ran.items()])
+                "Environment variable(s):",
+                *[f'  {k}="{v}"' for k, v in sorted(env_ran.items())],
             ]
         output = "\n".join(header) + "\n"
 


### PR DESCRIPTION
In general, this decreases local Testharness runtime using openmpi significantly. It should speed up all of the "apptainer openmpi ..." recipes, in which we test the apps after the build.

refs https://github.com/idaholab/moose/issues/32252

### Summary of changes

- Adds info when using a cached hwloc topology (meant most for me)
- Better print errors when topology build fails
- Also used cached topology for openmpi
- Print TestHarness job environment variables with one on each line, in alphabetical order

### Example

Framework tests (moose-dev-openmi) on rod with topology caching:

```
Ran 5106 tests in 237.4 seconds. Average test time 0.4 seconds, maximum test time 14.3 seconds.
```

Framework tests on rod (moose-dev-openmpi) without topology caching:

```
Ran 5106 tests in 363.0 seconds. Average test time 1.2 seconds, maximum test time 13.1 seconds.
```