### PR TITLE
Patch MFEM ParMixedBilinearForm to support trial variables defined on submeshes

### DIFF
--- a/framework/include/mfem/equation_systems/EquationSystem.h
+++ b/framework/include/mfem/equation_systems/EquationSystem.h
@@ -21,6 +21,7 @@
 #include "MFEMMixedBilinearFormKernel.h"
 #include "ScaleIntegrator.h"
 #include "NLScaleIntegrator.h"
+#include "PatchedMixedBilinearForm.h"
 
 namespace Moose::MFEM
 {
@@ -192,7 +193,8 @@ protected:
   NamedFieldsMap<mfem::ParBilinearForm> _blfs;
   NamedFieldsMap<mfem::ParLinearForm> _lfs;
   NamedFieldsMap<mfem::ParNonlinearForm> _nlfs;
-  NamedFieldsMap<NamedFieldsMap<mfem::ParMixedBilinearForm>> _mblfs; // named according to trial var
+  NamedFieldsMap<NamedFieldsMap<Moose::MFEM::ParMixedBilinearForm>>
+      _mblfs; // named according to trial variable
 
   /// Gridfunctions holding essential constraints from Dirichlet BCs
   std::vector<std::unique_ptr<mfem::ParGridFunction>> _var_ess_constraints;

--- a/framework/include/mfem/equation_systems/PatchedMixedBilinearForm.h
+++ b/framework/include/mfem/equation_systems/PatchedMixedBilinearForm.h
@@ -28,6 +28,13 @@ public:
   {
   }
 
+  ParMixedBilinearForm(mfem::ParFiniteElementSpace * tr_fes,
+                       mfem::ParFiniteElementSpace * te_fes,
+                       mfem::ParMixedBilinearForm * mbf)
+    : mfem::ParMixedBilinearForm(tr_fes, te_fes, mbf)
+  {
+  }
+
   // Re-implementation of Assemble to maintain functionality when the trial variable is defined on a
   // submesh of the test variable. Defaults to mfem::ParMixedBilinearForm::Assemble otherwise.
   void Assemble(int skip_zeros = 1);

--- a/framework/include/mfem/equation_systems/PatchedMixedBilinearForm.h
+++ b/framework/include/mfem/equation_systems/PatchedMixedBilinearForm.h
@@ -28,7 +28,11 @@ public:
   {
   }
 
+  // Re-implementation of Assemble to maintain functionality when the trial variable is defined on a
+  // submesh of the test variable. Defaults to mfem::ParMixedBilinearForm::Assemble otherwise.
   void Assemble(int skip_zeros = 1);
+  // Custom implementation of Assemble for use when the trial variable is defined on a submesh of
+  // the test variable
   void SubMeshTolerantAssemble(int skip_zeros);
 };
 } // namespace Moose::MFEM

--- a/framework/include/mfem/equation_systems/PatchedMixedBilinearForm.h
+++ b/framework/include/mfem/equation_systems/PatchedMixedBilinearForm.h
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifdef MOOSE_MFEM_ENABLED
+
+#pragma once
+
+#include "libmesh/ignore_warnings.h"
+#include "mfem/miniapps/common/pfem_extras.hpp"
+#include "libmesh/restore_warnings.h"
+
+namespace Moose::MFEM
+{
+
+/// Patched version of mfem::ParMixedBilinearForm to extend support to cases where MFEM trial variable is defined on a submesh of the MFEM test variable
+class ParMixedBilinearForm : public mfem::ParMixedBilinearForm
+{
+
+public:
+  ParMixedBilinearForm(mfem::ParFiniteElementSpace * tr_fes, mfem::ParFiniteElementSpace * te_fes)
+    : mfem::ParMixedBilinearForm(tr_fes, te_fes)
+  {
+  }
+
+  void Assemble(int skip_zeros = 1);
+  void SubMeshTolerantAssemble(int skip_zeros);
+};
+} // namespace Moose::MFEM
+
+#endif

--- a/framework/include/mfem/equation_systems/TimeDependentEquationSystem.h
+++ b/framework/include/mfem/equation_systems/TimeDependentEquationSystem.h
@@ -39,7 +39,7 @@ protected:
       _td_kernels_map;
   /// Containers to store contributions to weak form of the form (F du/dt, v)
   Moose::MFEM::NamedFieldsMap<mfem::ParBilinearForm> _td_blfs;
-  Moose::MFEM::NamedFieldsMap<Moose::MFEM::NamedFieldsMap<mfem::ParMixedBilinearForm>>
+  Moose::MFEM::NamedFieldsMap<Moose::MFEM::NamedFieldsMap<Moose::MFEM::ParMixedBilinearForm>>
       _td_mblfs; // named according to trial variable
 
   /// Map between variable names and their time derivatives

--- a/framework/src/mfem/equation_systems/EquationSystem.C
+++ b/framework/src/mfem/equation_systems/EquationSystem.C
@@ -541,12 +541,13 @@ EquationSystem::BuildMixedBilinearForms()
   for (const auto i : index_range(_test_var_names))
   {
     auto test_var_name = _test_var_names.at(i);
-    auto test_mblfs = std::make_shared<Moose::MFEM::NamedFieldsMap<mfem::ParMixedBilinearForm>>();
+    auto test_mblfs =
+        std::make_shared<Moose::MFEM::NamedFieldsMap<Moose::MFEM::ParMixedBilinearForm>>();
     for (const auto j : index_range(_coupled_var_names))
     {
       const auto & coupled_var_name = _coupled_var_names.at(j);
-      auto mblf = std::make_shared<mfem::ParMixedBilinearForm>(_coupled_pfespaces.at(j),
-                                                               _test_pfespaces.at(i));
+      auto mblf = std::make_shared<Moose::MFEM::ParMixedBilinearForm>(_coupled_pfespaces.at(j),
+                                                                      _test_pfespaces.at(i));
       // Register MixedBilinearForm if kernels exist for it, and assemble kernels
       if (_kernels_map.Has(test_var_name) &&
           _kernels_map.Get(test_var_name)->Has(coupled_var_name) &&
@@ -554,7 +555,7 @@ EquationSystem::BuildMixedBilinearForms()
       {
         mblf->SetAssemblyLevel(_assembly_level);
         // Apply all mixed kernels with this test/trial pair
-        ApplyDomainBLFIntegrators<mfem::ParMixedBilinearForm>(
+        ApplyDomainBLFIntegrators<Moose::MFEM::ParMixedBilinearForm>(
             coupled_var_name, test_var_name, mblf, _kernels_map);
         // Assemble mixed bilinear forms
         mblf->Assemble();

--- a/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
+++ b/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
@@ -9,8 +9,6 @@
 
 #ifdef MOOSE_MFEM_ENABLED
 
-#pragma once
-
 #include "PatchedMixedBilinearForm.h"
 
 namespace Moose::MFEM

--- a/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
+++ b/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
@@ -1,0 +1,363 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifdef MOOSE_MFEM_ENABLED
+
+#pragma once
+
+#include "PatchedMixedBilinearForm.h"
+
+namespace Moose::MFEM
+{
+
+void
+ParMixedBilinearForm::Assemble(int skip_zeros)
+{
+  if (interior_face_integs.Size())
+  {
+    trial_pfes->ExchangeFaceNbrData();
+    test_pfes->ExchangeFaceNbrData();
+    if (!ext && mat == NULL)
+    {
+      pAllocMat();
+    }
+  }
+
+  if (mfem::ParSubMesh::IsParSubMesh(trial_pfes->GetParMesh()))
+    SubMeshTolerantAssemble(skip_zeros);
+  else
+    MixedBilinearForm::Assemble(skip_zeros);
+
+  if (!ext && interior_face_integs.Size() > 0)
+  {
+    AssembleSharedFaces(skip_zeros);
+  }
+}
+
+void
+ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
+{
+  if (ext)
+  {
+    ext->Assemble();
+    return;
+  }
+
+  mfem::ElementTransformation * eltrans;
+  mfem::DenseMatrix elmat;
+
+  // For usual mfem::MixedBilinearFormAssemble, the iterated FESpace is test_fes
+  mfem::FiniteElementSpace & iterated_fes = *trial_fes;
+  mfem::Mesh * mesh = iterated_fes.GetMesh();
+  const int num_elem = iterated_fes.GetNE();
+  const int num_boundary_elem = iterated_fes.GetNBE();
+
+  if (mat == NULL)
+  {
+    mat = new mfem::SparseMatrix(height, width);
+  }
+
+  if (domain_integs.Size())
+  {
+    for (int k = 0; k < domain_integs.Size(); k++)
+    {
+      if (domain_integs_marker[k] != NULL)
+      {
+        MFEM_VERIFY(domain_integs_marker[k]->Size() ==
+                        (mesh->attributes.Size() ? mesh->attributes.Max() : 0),
+                    "invalid element marker for domain integrator #" << k
+                                                                     << ", counting from zero");
+      }
+    }
+
+    mfem::DofTransformation dom_dof_trans, ran_dof_trans;
+    for (int i = 0; i < num_elem; i++)
+    {
+      const int elem_attr = mesh->GetAttribute(i);
+      trial_fes->GetElementVDofs(i, trial_vdofs, dom_dof_trans);
+      test_fes->GetElementVDofs(i, test_vdofs, ran_dof_trans);
+      eltrans = iterated_fes.GetElementTransformation(i);
+
+      elmat.SetSize(test_vdofs.Size(), trial_vdofs.Size());
+      elmat = 0.0;
+      for (int k = 0; k < domain_integs.Size(); k++)
+      {
+        if (domain_integs_marker[k] == NULL || (*(domain_integs_marker[k]))[elem_attr - 1] == 1)
+        {
+          domain_integs[k]->AssembleElementMatrix2(
+              *trial_fes->GetFE(i), *test_fes->GetFE(i), *eltrans, elemmat);
+          elmat += elemmat;
+        }
+      }
+      TransformDual(ran_dof_trans, dom_dof_trans, elmat);
+      mat->AddSubMatrix(test_vdofs, trial_vdofs, elmat, skip_zeros);
+    }
+  }
+
+  if (boundary_integs.Size())
+  {
+    // Which boundary attributes need to be processed?
+    mfem::Array<int> bdr_attr_marker(mesh->bdr_attributes.Size() ? mesh->bdr_attributes.Max() : 0);
+    bdr_attr_marker = 0;
+    for (int k = 0; k < boundary_integs.Size(); k++)
+    {
+      if (boundary_integs_marker[k] == NULL)
+      {
+        bdr_attr_marker = 1;
+        break;
+      }
+      mfem::Array<int> & bdr_marker = *boundary_integs_marker[k];
+      MFEM_ASSERT(bdr_marker.Size() == bdr_attr_marker.Size(),
+                  "invalid boundary marker for boundary integrator #" << k
+                                                                      << ", counting from zero");
+      for (int i = 0; i < bdr_attr_marker.Size(); i++)
+      {
+        bdr_attr_marker[i] |= bdr_marker[i];
+      }
+    }
+
+    mfem::DofTransformation dom_dof_trans, ran_dof_trans;
+    for (int i = 0; i < num_boundary_elem; i++)
+    {
+      const int bdr_attr = mesh->GetBdrAttribute(i);
+      if (bdr_attr_marker[bdr_attr - 1] == 0)
+      {
+        continue;
+      }
+
+      trial_fes->GetBdrElementVDofs(i, trial_vdofs, dom_dof_trans);
+      test_fes->GetBdrElementVDofs(i, test_vdofs, ran_dof_trans);
+      eltrans = iterated_fes.GetBdrElementTransformation(i);
+
+      elmat.SetSize(test_vdofs.Size(), trial_vdofs.Size());
+      elmat = 0.0;
+      for (int k = 0; k < boundary_integs.Size(); k++)
+      {
+        if (boundary_integs_marker[k] && (*boundary_integs_marker[k])[bdr_attr - 1] == 0)
+        {
+          continue;
+        }
+
+        boundary_integs[k]->AssembleElementMatrix2(
+            *trial_fes->GetBE(i), *test_fes->GetBE(i), *eltrans, elemmat);
+        elmat += elemmat;
+      }
+      TransformDual(ran_dof_trans, dom_dof_trans, elmat);
+      mat->AddSubMatrix(test_vdofs, trial_vdofs, elmat, skip_zeros);
+    }
+  }
+
+  if (interior_face_integs.Size())
+  {
+    mfem::FaceElementTransformations * ftr;
+    mfem::Array<int> trial_vdofs2, test_vdofs2;
+    const mfem::FiniteElement *trial_fe1, *trial_fe2, *test_fe1, *test_fe2;
+
+    int nfaces = mesh->GetNumFaces();
+    for (int i = 0; i < nfaces; i++)
+    {
+      ftr = mesh->GetInteriorFaceTransformations(i);
+      if (ftr != NULL)
+      {
+        trial_fes->GetElementVDofs(ftr->Elem1No, trial_vdofs);
+        test_fes->GetElementVDofs(ftr->Elem1No, test_vdofs);
+        trial_fe1 = trial_fes->GetFE(ftr->Elem1No);
+        test_fe1 = test_fes->GetFE(ftr->Elem1No);
+        if (ftr->Elem2No >= 0)
+        {
+          trial_fes->GetElementVDofs(ftr->Elem2No, trial_vdofs2);
+          test_fes->GetElementVDofs(ftr->Elem2No, test_vdofs2);
+          trial_vdofs.Append(trial_vdofs2);
+          test_vdofs.Append(test_vdofs2);
+          trial_fe2 = trial_fes->GetFE(ftr->Elem2No);
+          test_fe2 = test_fes->GetFE(ftr->Elem2No);
+        }
+        else
+        {
+          // The test_fe2 object is really a dummy and not used on the
+          // boundaries, but we can't dereference a NULL pointer, and we don't
+          // want to actually make a fake element.
+          trial_fe2 = trial_fe1;
+          test_fe2 = test_fe1;
+        }
+        for (int k = 0; k < interior_face_integs.Size(); k++)
+        {
+          interior_face_integs[k]->AssembleFaceMatrix(
+              *trial_fe1, *test_fe1, *trial_fe2, *test_fe2, *ftr, elemmat);
+          mat->AddSubMatrix(test_vdofs, trial_vdofs, elemmat, skip_zeros);
+        }
+      }
+    }
+  }
+
+  if (boundary_face_integs.Size())
+  {
+    mfem::FaceElementTransformations * ftr;
+    mfem::Array<int> tr_vdofs2, te_vdofs2;
+    const mfem::FiniteElement *trial_fe1, *trial_fe2, *test_fe1, *test_fe2;
+
+    // Which boundary attributes need to be processed?
+    mfem::Array<int> bdr_attr_marker(mesh->bdr_attributes.Size() ? mesh->bdr_attributes.Max() : 0);
+    bdr_attr_marker = 0;
+    for (int k = 0; k < boundary_face_integs.Size(); k++)
+    {
+      if (boundary_face_integs_marker[k] == NULL)
+      {
+        bdr_attr_marker = 1;
+        break;
+      }
+      mfem::Array<int> & bdr_marker = *boundary_face_integs_marker[k];
+      MFEM_ASSERT(bdr_marker.Size() == bdr_attr_marker.Size(),
+                  "invalid boundary marker for boundary face integrator #"
+                      << k << ", counting from zero");
+      for (int i = 0; i < bdr_attr_marker.Size(); i++)
+      {
+        bdr_attr_marker[i] |= bdr_marker[i];
+      }
+    }
+
+    for (int i = 0; i < trial_fes->GetNBE(); i++)
+    {
+      const int bdr_attr = mesh->GetBdrAttribute(i);
+      if (bdr_attr_marker[bdr_attr - 1] == 0)
+      {
+        continue;
+      }
+
+      ftr = mesh->GetBdrFaceTransformations(i);
+      if (ftr != NULL)
+      {
+        trial_fes->GetElementVDofs(ftr->Elem1No, trial_vdofs);
+        test_fes->GetElementVDofs(ftr->Elem1No, test_vdofs);
+        trial_fe1 = trial_fes->GetFE(ftr->Elem1No);
+        test_fe1 = test_fes->GetFE(ftr->Elem1No);
+        // The test_fe2 object is really a dummy and not used on the
+        // boundaries, but we can't dereference a NULL pointer, and we don't
+        // want to actually make a fake element.
+        trial_fe2 = trial_fe1;
+        test_fe2 = test_fe1;
+        for (int k = 0; k < boundary_face_integs.Size(); k++)
+        {
+          if (boundary_face_integs_marker[k] &&
+              (*boundary_face_integs_marker[k])[bdr_attr - 1] == 0)
+          {
+            continue;
+          }
+
+          boundary_face_integs[k]->AssembleFaceMatrix(
+              *trial_fe1, *test_fe1, *trial_fe2, *test_fe2, *ftr, elemmat);
+          mat->AddSubMatrix(test_vdofs, trial_vdofs, elemmat, skip_zeros);
+        }
+      }
+    }
+  }
+
+  if (trace_face_integs.Size())
+  {
+    mfem::FaceElementTransformations * ftr;
+    mfem::Array<int> test_vdofs2;
+    const mfem::FiniteElement *trial_face_fe, *test_fe1, *test_fe2;
+
+    int nfaces = mesh->GetNumFaces();
+    for (int i = 0; i < nfaces; i++)
+    {
+      ftr = mesh->GetFaceElementTransformations(i);
+      trial_fes->GetFaceVDofs(i, trial_vdofs);
+      test_fes->GetElementVDofs(ftr->Elem1No, test_vdofs);
+      trial_face_fe = trial_fes->GetFaceElement(i);
+      test_fe1 = test_fes->GetFE(ftr->Elem1No);
+      if (ftr->Elem2No >= 0)
+      {
+        test_fes->GetElementVDofs(ftr->Elem2No, test_vdofs2);
+        test_vdofs.Append(test_vdofs2);
+        test_fe2 = test_fes->GetFE(ftr->Elem2No);
+      }
+      else
+      {
+        // The test_fe2 object is really a dummy and not used on the
+        // boundaries, but we can't dereference a NULL pointer, and we don't
+        // want to actually make a fake element.
+        test_fe2 = test_fe1;
+      }
+      for (int k = 0; k < trace_face_integs.Size(); k++)
+      {
+        trace_face_integs[k]->AssembleFaceMatrix(
+            *trial_face_fe, *test_fe1, *test_fe2, *ftr, elemmat);
+        mat->AddSubMatrix(test_vdofs, trial_vdofs, elemmat, skip_zeros);
+      }
+    }
+  }
+
+  if (boundary_trace_face_integs.Size())
+  {
+    mfem::FaceElementTransformations * ftr;
+    mfem::Array<int> te_vdofs2;
+    const mfem::FiniteElement *trial_face_fe, *test_fe1, *test_fe2;
+
+    // Which boundary attributes need to be processed?
+    mfem::Array<int> bdr_attr_marker(mesh->bdr_attributes.Size() ? mesh->bdr_attributes.Max() : 0);
+    bdr_attr_marker = 0;
+    for (int k = 0; k < boundary_trace_face_integs.Size(); k++)
+    {
+      if (boundary_trace_face_integs_marker[k] == NULL)
+      {
+        bdr_attr_marker = 1;
+        break;
+      }
+      mfem::Array<int> & bdr_marker = *boundary_trace_face_integs_marker[k];
+      MFEM_ASSERT(bdr_marker.Size() == bdr_attr_marker.Size(),
+                  "invalid boundary marker for boundary trace face"
+                  "integrator #"
+                      << k << ", counting from zero");
+      for (int i = 0; i < bdr_attr_marker.Size(); i++)
+      {
+        bdr_attr_marker[i] |= bdr_marker[i];
+      }
+    }
+
+    for (int i = 0; i < trial_fes->GetNBE(); i++)
+    {
+      const int bdr_attr = mesh->GetBdrAttribute(i);
+      if (bdr_attr_marker[bdr_attr - 1] == 0)
+      {
+        continue;
+      }
+
+      ftr = mesh->GetBdrFaceTransformations(i);
+      if (ftr)
+      {
+        const int iface = mesh->GetBdrElementFaceIndex(i);
+        trial_fes->GetFaceVDofs(iface, trial_vdofs);
+        test_fes->GetElementVDofs(ftr->Elem1No, test_vdofs);
+        trial_face_fe = trial_fes->GetFaceElement(iface);
+        test_fe1 = test_fes->GetFE(ftr->Elem1No);
+        // The test_fe2 object is really a dummy and not used on the
+        // boundaries, but we can't dereference a NULL pointer, and we don't
+        // want to actually make a fake element.
+        test_fe2 = test_fe1;
+        for (int k = 0; k < boundary_trace_face_integs.Size(); k++)
+        {
+          if (boundary_trace_face_integs_marker[k] &&
+              (*boundary_trace_face_integs_marker[k])[bdr_attr - 1] == 0)
+          {
+            continue;
+          }
+
+          boundary_trace_face_integs[k]->AssembleFaceMatrix(
+              *trial_face_fe, *test_fe1, *test_fe2, *ftr, elemmat);
+          mat->AddSubMatrix(test_vdofs, trial_vdofs, elemmat, skip_zeros);
+        }
+      }
+    }
+  }
+}
+
+} // namespace Moose::MFEM
+
+#endif

--- a/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
+++ b/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
@@ -29,8 +29,16 @@ ParMixedBilinearForm::Assemble(int skip_zeros)
 
   // TODO: Replace this with new mfem::ParSubMesh::IsParSubMesh implementation
   // that checks whether a mesh is a submesh of a given parent mesh.
-  // Requires MFEM dependency update.
-  if (mfem::ParSubMesh::IsParSubMesh(trial_pfes->GetParMesh()))
+  // Requires MFEM dependency update; introduced in https://github.com/mfem/mfem/pull/5239.
+  auto check_submesh = [](const mfem::ParMesh * sub, const mfem::ParMesh * parent)
+  {
+    while (mfem::ParSubMesh::IsParSubMesh(sub) &&
+           (sub = static_cast<const mfem::ParSubMesh *>(sub)->GetParent()) && sub != parent)
+      ;
+    return sub == parent;
+  };
+
+  if (check_submesh(trial_pfes->GetParMesh(), test_pfes->GetParMesh()))
     SubMeshTolerantAssemble(skip_zeros);
   else
     MixedBilinearForm::Assemble(skip_zeros);
@@ -228,6 +236,7 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
       }
     }
 
+    mfem::DofTransformation dom_dof_trans, ran_dof_trans;
     for (int i = 0; i < trial_fes->GetNBE(); i++)
     {
       const int bdr_attr = mesh->GetBdrAttribute(i);
@@ -240,8 +249,8 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
       if (ftr != NULL)
       {
         const int parent_elem_1 = parent_element_ids[ftr->Elem1No];
-        trial_fes->GetElementVDofs(ftr->Elem1No, trial_vdofs);
-        test_fes->GetElementVDofs(parent_elem_1, test_vdofs);
+        trial_fes->GetElementVDofs(ftr->Elem1No, trial_vdofs, dom_dof_trans);
+        test_fes->GetElementVDofs(parent_elem_1, test_vdofs, ran_dof_trans);
         trial_fe1 = trial_fes->GetFE(ftr->Elem1No);
         test_fe1 = test_fes->GetFE(parent_elem_1);
         // The test_fe2 object is really a dummy and not used on the
@@ -259,6 +268,7 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
 
           boundary_face_integs[k]->AssembleFaceMatrix(
               *trial_fe1, *test_fe1, *trial_fe2, *test_fe2, *ftr, elemmat);
+          TransformDual(ran_dof_trans, dom_dof_trans, elemmat);
           mat->AddSubMatrix(test_vdofs, trial_vdofs, elemmat, skip_zeros);
         }
       }

--- a/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
+++ b/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
@@ -32,8 +32,10 @@ ParMixedBilinearForm::Assemble(int skip_zeros)
   // Requires MFEM dependency update; introduced in https://github.com/mfem/mfem/pull/5239.
   auto check_submesh = [](const mfem::ParMesh * sub, const mfem::ParMesh * parent)
   {
-    while (mfem::ParSubMesh::IsParSubMesh(sub) &&
-           (sub = static_cast<const mfem::ParSubMesh *>(sub)->GetParent()) && sub != parent)
+    if (!mfem::ParSubMesh::IsParSubMesh(sub) ||
+        (mfem::ParSubMesh::IsParSubMesh(sub) && mfem::ParSubMesh::IsParSubMesh(parent)))
+      return false;
+    while ((sub = static_cast<const mfem::ParSubMesh *>(sub)->GetParent()) && sub != parent)
       ;
     return sub == parent;
   };
@@ -65,7 +67,12 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
   mfem::FiniteElementSpace & iterated_fes = *trial_fes;
   mfem::Mesh * mesh = iterated_fes.GetMesh();
   const auto * trial_submesh = static_cast<const mfem::ParSubMesh *>(trial_pfes->GetParMesh());
+  const auto * parent_mesh = trial_submesh->GetParent();
   const auto & parent_element_ids = trial_submesh->GetParentElementIDMap();
+  const auto & parent_face_ids = trial_submesh->GetParentFaceIDMap();
+  const auto & parent_edge_ids = trial_submesh->GetParentEdgeIDMap();
+  const auto & parent_vertex_ids = trial_submesh->GetParentVertexIDMap();
+  const auto & parent_face_to_be = parent_mesh->GetFaceToBdrElMap();
   const int num_elem = iterated_fes.GetNE();
   const int num_boundary_elem = iterated_fes.GetNBE();
 
@@ -137,14 +144,22 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
     mfem::DofTransformation dom_dof_trans, ran_dof_trans;
     for (int i = 0; i < num_boundary_elem; i++)
     {
+      const int iface = mesh->GetBdrElementFaceIndex(i);
+      const int parent_face_id = mesh->Dimension() == 3   ? parent_face_ids[iface]
+                                 : mesh->Dimension() == 2 ? parent_edge_ids[iface]
+                                                          : parent_vertex_ids[iface];
+      const int parent_bdr_elem_id = parent_face_to_be[parent_face_id];
       const int bdr_attr = mesh->GetBdrAttribute(i);
       if (bdr_attr_marker[bdr_attr - 1] == 0)
       {
         continue;
       }
+      MFEM_VERIFY(parent_bdr_elem_id != -1,
+                  "Cannot assemble a mixed boundary integrator from submesh boundary element "
+                      << i << " because it does not correspond to a parent boundary element.");
 
       trial_fes->GetBdrElementVDofs(i, trial_vdofs, dom_dof_trans);
-      test_fes->GetBdrElementVDofs(i, test_vdofs, ran_dof_trans);
+      test_fes->GetBdrElementVDofs(parent_bdr_elem_id, test_vdofs, ran_dof_trans);
       eltrans = iterated_fes.GetBdrElementTransformation(i);
 
       elmat.SetSize(test_vdofs.Size(), trial_vdofs.Size());
@@ -157,7 +172,7 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
         }
 
         boundary_integs[k]->AssembleElementMatrix2(
-            *trial_fes->GetBE(i), *test_fes->GetBE(i), *eltrans, elemmat);
+            *trial_fes->GetBE(i), *test_fes->GetBE(parent_bdr_elem_id), *eltrans, elemmat);
         elmat += elemmat;
       }
       TransformDual(ran_dof_trans, dom_dof_trans, elmat);

--- a/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
+++ b/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
@@ -27,20 +27,8 @@ ParMixedBilinearForm::Assemble(int skip_zeros)
     }
   }
 
-  // TODO: Replace this with new mfem::ParSubMesh::IsParSubMesh implementation
-  // that checks whether a mesh is a submesh of a given parent mesh.
-  // Requires MFEM dependency update; introduced in https://github.com/mfem/mfem/pull/5239.
-  auto check_submesh = [](const mfem::ParMesh * sub, const mfem::ParMesh * parent)
-  {
-    if (!mfem::ParSubMesh::IsParSubMesh(sub) ||
-        (mfem::ParSubMesh::IsParSubMesh(sub) && mfem::ParSubMesh::IsParSubMesh(parent)))
-      return false;
-    while ((sub = static_cast<const mfem::ParSubMesh *>(sub)->GetParent()) && sub != parent)
-      ;
-    return sub == parent;
-  };
-
-  if (check_submesh(trial_pfes->GetParMesh(), test_pfes->GetParMesh()))
+  if ((trial_pfes->GetParMesh() != test_pfes->GetParMesh()) &&
+      mfem::ParSubMesh::IsParSubMesh(trial_pfes->GetParMesh(), test_pfes->GetParMesh()))
     SubMeshTolerantAssemble(skip_zeros);
   else
     MixedBilinearForm::Assemble(skip_zeros);

--- a/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
+++ b/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
@@ -27,6 +27,9 @@ ParMixedBilinearForm::Assemble(int skip_zeros)
     }
   }
 
+  // Call SubMeshTolerantAssemble if trial_pfes is defined on a submesh of the mesh
+  // on which test_pfes is defined, else default to MixedBilinearForm::Assemble
+  // as usual
   if ((trial_pfes->GetParMesh() != test_pfes->GetParMesh()) &&
       mfem::ParSubMesh::IsParSubMesh(trial_pfes->GetParMesh(), test_pfes->GetParMesh()))
     SubMeshTolerantAssemble(skip_zeros);
@@ -55,12 +58,12 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
   mfem::FiniteElementSpace & iterated_fes = *trial_fes;
   mfem::Mesh * mesh = iterated_fes.GetMesh();
   const auto * trial_submesh = static_cast<const mfem::ParSubMesh *>(trial_pfes->GetParMesh());
-  const auto * parent_mesh = trial_submesh->GetParent();
-  const auto & parent_element_ids = trial_submesh->GetParentElementIDMap();
-  const auto & parent_face_ids = trial_submesh->GetParentFaceIDMap();
-  const auto & parent_edge_ids = trial_submesh->GetParentEdgeIDMap();
-  const auto & parent_vertex_ids = trial_submesh->GetParentVertexIDMap();
-  const auto & parent_face_to_be = parent_mesh->GetFaceToBdrElMap();
+  const auto * trial_parent_mesh = trial_submesh->GetParent();
+  const auto & test_element_ids = trial_submesh->GetParentElementIDMap();
+  const auto & test_face_ids = trial_submesh->GetParentFaceIDMap();
+  const auto & test_edge_ids = trial_submesh->GetParentEdgeIDMap();
+  const auto & test_vertex_ids = trial_submesh->GetParentVertexIDMap();
+  const auto & test_face_to_be = trial_parent_mesh->GetFaceToBdrElMap();
   const int num_elem = iterated_fes.GetNE();
   const int num_boundary_elem = iterated_fes.GetNBE();
 
@@ -85,10 +88,10 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
     mfem::DofTransformation dom_dof_trans, ran_dof_trans;
     for (int i = 0; i < num_elem; i++)
     {
-      const int parent_elem_id = parent_element_ids[i];
+      const int test_elem_id = test_element_ids[i];
       const int elem_attr = mesh->GetAttribute(i);
       trial_fes->GetElementVDofs(i, trial_vdofs, dom_dof_trans);
-      test_fes->GetElementVDofs(parent_elem_id, test_vdofs, ran_dof_trans);
+      test_fes->GetElementVDofs(test_elem_id, test_vdofs, ran_dof_trans);
       eltrans = iterated_fes.GetElementTransformation(i);
 
       elmat.SetSize(test_vdofs.Size(), trial_vdofs.Size());
@@ -98,7 +101,7 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
         if (domain_integs_marker[k] == NULL || (*(domain_integs_marker[k]))[elem_attr - 1] == 1)
         {
           domain_integs[k]->AssembleElementMatrix2(
-              *trial_fes->GetFE(i), *test_fes->GetFE(parent_elem_id), *eltrans, elemmat);
+              *trial_fes->GetFE(i), *test_fes->GetFE(test_elem_id), *eltrans, elemmat);
           elmat += elemmat;
         }
       }
@@ -133,21 +136,21 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
     for (int i = 0; i < num_boundary_elem; i++)
     {
       const int iface = mesh->GetBdrElementFaceIndex(i);
-      const int parent_face_id = mesh->Dimension() == 3   ? parent_face_ids[iface]
-                                 : mesh->Dimension() == 2 ? parent_edge_ids[iface]
-                                                          : parent_vertex_ids[iface];
-      const int parent_bdr_elem_id = parent_face_to_be[parent_face_id];
+      const int test_face_id = mesh->Dimension() == 3   ? test_face_ids[iface]
+                               : mesh->Dimension() == 2 ? test_edge_ids[iface]
+                                                        : test_vertex_ids[iface];
+      const int test_bdr_elem_id = test_face_to_be[test_face_id];
       const int bdr_attr = mesh->GetBdrAttribute(i);
       if (bdr_attr_marker[bdr_attr - 1] == 0)
       {
         continue;
       }
-      MFEM_VERIFY(parent_bdr_elem_id != -1,
+      MFEM_VERIFY(test_bdr_elem_id != -1,
                   "Cannot assemble a mixed boundary integrator from submesh boundary element "
                       << i << " because it does not correspond to a parent boundary element.");
 
       trial_fes->GetBdrElementVDofs(i, trial_vdofs, dom_dof_trans);
-      test_fes->GetBdrElementVDofs(parent_bdr_elem_id, test_vdofs, ran_dof_trans);
+      test_fes->GetBdrElementVDofs(test_bdr_elem_id, test_vdofs, ran_dof_trans);
       eltrans = iterated_fes.GetBdrElementTransformation(i);
 
       elmat.SetSize(test_vdofs.Size(), trial_vdofs.Size());
@@ -160,7 +163,7 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
         }
 
         boundary_integs[k]->AssembleElementMatrix2(
-            *trial_fes->GetBE(i), *test_fes->GetBE(parent_bdr_elem_id), *eltrans, elemmat);
+            *trial_fes->GetBE(i), *test_fes->GetBE(test_bdr_elem_id), *eltrans, elemmat);
         elmat += elemmat;
       }
       TransformDual(ran_dof_trans, dom_dof_trans, elmat);
@@ -180,20 +183,20 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
       ftr = mesh->GetInteriorFaceTransformations(i);
       if (ftr != NULL)
       {
-        const int parent_elem_1 = parent_element_ids[ftr->Elem1No];
+        const int test_elem_1 = test_element_ids[ftr->Elem1No];
         trial_fes->GetElementVDofs(ftr->Elem1No, trial_vdofs);
-        test_fes->GetElementVDofs(parent_elem_1, test_vdofs);
+        test_fes->GetElementVDofs(test_elem_1, test_vdofs);
         trial_fe1 = trial_fes->GetFE(ftr->Elem1No);
-        test_fe1 = test_fes->GetFE(parent_elem_1);
+        test_fe1 = test_fes->GetFE(test_elem_1);
         if (ftr->Elem2No >= 0)
         {
-          const int parent_elem_2 = parent_element_ids[ftr->Elem2No];
+          const int test_elem_2 = test_element_ids[ftr->Elem2No];
           trial_fes->GetElementVDofs(ftr->Elem2No, trial_vdofs2);
-          test_fes->GetElementVDofs(parent_elem_2, test_vdofs2);
+          test_fes->GetElementVDofs(test_elem_2, test_vdofs2);
           trial_vdofs.Append(trial_vdofs2);
           test_vdofs.Append(test_vdofs2);
           trial_fe2 = trial_fes->GetFE(ftr->Elem2No);
-          test_fe2 = test_fes->GetFE(parent_elem_2);
+          test_fe2 = test_fes->GetFE(test_elem_2);
         }
         else
         {
@@ -251,11 +254,11 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
       ftr = mesh->GetBdrFaceTransformations(i);
       if (ftr != NULL)
       {
-        const int parent_elem_1 = parent_element_ids[ftr->Elem1No];
+        const int test_elem_1 = test_element_ids[ftr->Elem1No];
         trial_fes->GetElementVDofs(ftr->Elem1No, trial_vdofs, dom_dof_trans);
-        test_fes->GetElementVDofs(parent_elem_1, test_vdofs, ran_dof_trans);
+        test_fes->GetElementVDofs(test_elem_1, test_vdofs, ran_dof_trans);
         trial_fe1 = trial_fes->GetFE(ftr->Elem1No);
-        test_fe1 = test_fes->GetFE(parent_elem_1);
+        test_fe1 = test_fes->GetFE(test_elem_1);
         // The test_fe2 object is really a dummy and not used on the
         // boundaries, but we can't dereference a NULL pointer, and we don't
         // want to actually make a fake element.
@@ -288,17 +291,17 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
     for (int i = 0; i < nfaces; i++)
     {
       ftr = mesh->GetFaceElementTransformations(i);
-      const int parent_elem_1 = parent_element_ids[ftr->Elem1No];
+      const int test_elem_1 = test_element_ids[ftr->Elem1No];
       trial_fes->GetFaceVDofs(i, trial_vdofs);
-      test_fes->GetElementVDofs(parent_elem_1, test_vdofs);
+      test_fes->GetElementVDofs(test_elem_1, test_vdofs);
       trial_face_fe = trial_fes->GetFaceElement(i);
-      test_fe1 = test_fes->GetFE(parent_elem_1);
+      test_fe1 = test_fes->GetFE(test_elem_1);
       if (ftr->Elem2No >= 0)
       {
-        const int parent_elem_2 = parent_element_ids[ftr->Elem2No];
-        test_fes->GetElementVDofs(parent_elem_2, test_vdofs2);
+        const int test_elem_2 = test_element_ids[ftr->Elem2No];
+        test_fes->GetElementVDofs(test_elem_2, test_vdofs2);
         test_vdofs.Append(test_vdofs2);
-        test_fe2 = test_fes->GetFE(parent_elem_2);
+        test_fe2 = test_fes->GetFE(test_elem_2);
       }
       else
       {
@@ -355,11 +358,11 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
       if (ftr)
       {
         const int iface = mesh->GetBdrElementFaceIndex(i);
-        const int parent_elem_1 = parent_element_ids[ftr->Elem1No];
+        const int test_elem_1 = test_element_ids[ftr->Elem1No];
         trial_fes->GetFaceVDofs(iface, trial_vdofs);
-        test_fes->GetElementVDofs(parent_elem_1, test_vdofs);
+        test_fes->GetElementVDofs(test_elem_1, test_vdofs);
         trial_face_fe = trial_fes->GetFaceElement(iface);
-        test_fe1 = test_fes->GetFE(parent_elem_1);
+        test_fe1 = test_fes->GetFE(test_elem_1);
         // The test_fe2 object is really a dummy and not used on the
         // boundaries, but we can't dereference a NULL pointer, and we don't
         // want to actually make a fake element.

--- a/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
+++ b/framework/src/mfem/equation_systems/PatchedMixedBilinearForm.C
@@ -27,6 +27,9 @@ ParMixedBilinearForm::Assemble(int skip_zeros)
     }
   }
 
+  // TODO: Replace this with new mfem::ParSubMesh::IsParSubMesh implementation
+  // that checks whether a mesh is a submesh of a given parent mesh.
+  // Requires MFEM dependency update.
   if (mfem::ParSubMesh::IsParSubMesh(trial_pfes->GetParMesh()))
     SubMeshTolerantAssemble(skip_zeros);
   else
@@ -53,6 +56,8 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
   // For usual mfem::MixedBilinearFormAssemble, the iterated FESpace is test_fes
   mfem::FiniteElementSpace & iterated_fes = *trial_fes;
   mfem::Mesh * mesh = iterated_fes.GetMesh();
+  const auto * trial_submesh = static_cast<const mfem::ParSubMesh *>(trial_pfes->GetParMesh());
+  const auto & parent_element_ids = trial_submesh->GetParentElementIDMap();
   const int num_elem = iterated_fes.GetNE();
   const int num_boundary_elem = iterated_fes.GetNBE();
 
@@ -77,9 +82,10 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
     mfem::DofTransformation dom_dof_trans, ran_dof_trans;
     for (int i = 0; i < num_elem; i++)
     {
+      const int parent_elem_id = parent_element_ids[i];
       const int elem_attr = mesh->GetAttribute(i);
       trial_fes->GetElementVDofs(i, trial_vdofs, dom_dof_trans);
-      test_fes->GetElementVDofs(i, test_vdofs, ran_dof_trans);
+      test_fes->GetElementVDofs(parent_elem_id, test_vdofs, ran_dof_trans);
       eltrans = iterated_fes.GetElementTransformation(i);
 
       elmat.SetSize(test_vdofs.Size(), trial_vdofs.Size());
@@ -89,7 +95,7 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
         if (domain_integs_marker[k] == NULL || (*(domain_integs_marker[k]))[elem_attr - 1] == 1)
         {
           domain_integs[k]->AssembleElementMatrix2(
-              *trial_fes->GetFE(i), *test_fes->GetFE(i), *eltrans, elemmat);
+              *trial_fes->GetFE(i), *test_fes->GetFE(parent_elem_id), *eltrans, elemmat);
           elmat += elemmat;
         }
       }
@@ -163,18 +169,20 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
       ftr = mesh->GetInteriorFaceTransformations(i);
       if (ftr != NULL)
       {
+        const int parent_elem_1 = parent_element_ids[ftr->Elem1No];
         trial_fes->GetElementVDofs(ftr->Elem1No, trial_vdofs);
-        test_fes->GetElementVDofs(ftr->Elem1No, test_vdofs);
+        test_fes->GetElementVDofs(parent_elem_1, test_vdofs);
         trial_fe1 = trial_fes->GetFE(ftr->Elem1No);
-        test_fe1 = test_fes->GetFE(ftr->Elem1No);
+        test_fe1 = test_fes->GetFE(parent_elem_1);
         if (ftr->Elem2No >= 0)
         {
+          const int parent_elem_2 = parent_element_ids[ftr->Elem2No];
           trial_fes->GetElementVDofs(ftr->Elem2No, trial_vdofs2);
-          test_fes->GetElementVDofs(ftr->Elem2No, test_vdofs2);
+          test_fes->GetElementVDofs(parent_elem_2, test_vdofs2);
           trial_vdofs.Append(trial_vdofs2);
           test_vdofs.Append(test_vdofs2);
           trial_fe2 = trial_fes->GetFE(ftr->Elem2No);
-          test_fe2 = test_fes->GetFE(ftr->Elem2No);
+          test_fe2 = test_fes->GetFE(parent_elem_2);
         }
         else
         {
@@ -231,10 +239,11 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
       ftr = mesh->GetBdrFaceTransformations(i);
       if (ftr != NULL)
       {
+        const int parent_elem_1 = parent_element_ids[ftr->Elem1No];
         trial_fes->GetElementVDofs(ftr->Elem1No, trial_vdofs);
-        test_fes->GetElementVDofs(ftr->Elem1No, test_vdofs);
+        test_fes->GetElementVDofs(parent_elem_1, test_vdofs);
         trial_fe1 = trial_fes->GetFE(ftr->Elem1No);
-        test_fe1 = test_fes->GetFE(ftr->Elem1No);
+        test_fe1 = test_fes->GetFE(parent_elem_1);
         // The test_fe2 object is really a dummy and not used on the
         // boundaries, but we can't dereference a NULL pointer, and we don't
         // want to actually make a fake element.
@@ -266,15 +275,17 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
     for (int i = 0; i < nfaces; i++)
     {
       ftr = mesh->GetFaceElementTransformations(i);
+      const int parent_elem_1 = parent_element_ids[ftr->Elem1No];
       trial_fes->GetFaceVDofs(i, trial_vdofs);
-      test_fes->GetElementVDofs(ftr->Elem1No, test_vdofs);
+      test_fes->GetElementVDofs(parent_elem_1, test_vdofs);
       trial_face_fe = trial_fes->GetFaceElement(i);
-      test_fe1 = test_fes->GetFE(ftr->Elem1No);
+      test_fe1 = test_fes->GetFE(parent_elem_1);
       if (ftr->Elem2No >= 0)
       {
-        test_fes->GetElementVDofs(ftr->Elem2No, test_vdofs2);
+        const int parent_elem_2 = parent_element_ids[ftr->Elem2No];
+        test_fes->GetElementVDofs(parent_elem_2, test_vdofs2);
         test_vdofs.Append(test_vdofs2);
-        test_fe2 = test_fes->GetFE(ftr->Elem2No);
+        test_fe2 = test_fes->GetFE(parent_elem_2);
       }
       else
       {
@@ -331,10 +342,11 @@ ParMixedBilinearForm::SubMeshTolerantAssemble(int skip_zeros)
       if (ftr)
       {
         const int iface = mesh->GetBdrElementFaceIndex(i);
+        const int parent_elem_1 = parent_element_ids[ftr->Elem1No];
         trial_fes->GetFaceVDofs(iface, trial_vdofs);
-        test_fes->GetElementVDofs(ftr->Elem1No, test_vdofs);
+        test_fes->GetElementVDofs(parent_elem_1, test_vdofs);
         trial_face_fe = trial_fes->GetFaceElement(iface);
-        test_fe1 = test_fes->GetFE(ftr->Elem1No);
+        test_fe1 = test_fes->GetFE(parent_elem_1);
         // The test_fe2 object is really a dummy and not used on the
         // boundaries, but we can't dereference a NULL pointer, and we don't
         // want to actually make a fake element.

--- a/framework/src/mfem/equation_systems/TimeDependentEquationSystem.C
+++ b/framework/src/mfem/equation_systems/TimeDependentEquationSystem.C
@@ -95,22 +95,23 @@ TimeDependentEquationSystem::BuildMixedBilinearForms()
   for (const auto i : index_range(_test_var_names))
   {
     const auto & test_var_name = _test_var_names.at(i);
-    auto test_mblfs = std::make_shared<Moose::MFEM::NamedFieldsMap<mfem::ParMixedBilinearForm>>();
+    auto test_mblfs =
+        std::make_shared<Moose::MFEM::NamedFieldsMap<Moose::MFEM::ParMixedBilinearForm>>();
     for (const auto j : index_range(_coupled_var_names))
     {
       const auto & coupled_var_name = _coupled_var_names.at(j);
-      auto mblf = std::make_shared<mfem::ParMixedBilinearForm>(_coupled_pfespaces.at(j),
-                                                               _test_pfespaces.at(i));
+      auto mblf = std::make_shared<Moose::MFEM::ParMixedBilinearForm>(_coupled_pfespaces.at(j),
+                                                                      _test_pfespaces.at(i));
       // Register MixedBilinearForm if kernels exist for it, and assemble kernels
       if (test_var_name != coupled_var_name)
       {
         // Apply all mixed kernels with this test/trial pair
-        ApplyBoundaryBLFIntegrators<mfem::ParMixedBilinearForm>(
+        ApplyBoundaryBLFIntegrators<Moose::MFEM::ParMixedBilinearForm>(
             coupled_var_name, test_var_name, mblf, _integrated_bc_map, _dt);
-        ApplyDomainBLFIntegrators<mfem::ParMixedBilinearForm>(
+        ApplyDomainBLFIntegrators<Moose::MFEM::ParMixedBilinearForm>(
             coupled_var_name, test_var_name, mblf, _kernels_map, _dt);
         // Apply dt*du/dt contributions from the operator on the trial variable
-        ApplyDomainBLFIntegrators<mfem::ParMixedBilinearForm>(
+        ApplyDomainBLFIntegrators<Moose::MFEM::ParMixedBilinearForm>(
             coupled_var_name, test_var_name, mblf, _td_kernels_map);
         if (mblf->GetDBFI()->Size() || mblf->GetBBFI()->Size())
         {
@@ -135,17 +136,17 @@ TimeDependentEquationSystem::BuildMixedBilinearForms()
   {
     const auto & test_var_name = _test_var_names.at(i);
     auto test_td_mblfs =
-        std::make_shared<Moose::MFEM::NamedFieldsMap<mfem::ParMixedBilinearForm>>();
+        std::make_shared<Moose::MFEM::NamedFieldsMap<Moose::MFEM::ParMixedBilinearForm>>();
     for (const auto j : index_range(_trial_var_names))
     {
       const auto & trial_var_name = _trial_var_names.at(j);
-      auto td_mblf = std::make_shared<mfem::ParMixedBilinearForm>(_test_pfespaces.at(j),
-                                                                  _test_pfespaces.at(i));
+      auto td_mblf = std::make_shared<Moose::MFEM::ParMixedBilinearForm>(_test_pfespaces.at(j),
+                                                                         _test_pfespaces.at(i));
       // Register MixedBilinearForm if kernels exist for it, and assemble kernels
       if (test_var_name != trial_var_name)
       {
         // Apply all mixed kernels with this test/trial pair
-        ApplyDomainBLFIntegrators<mfem::ParMixedBilinearForm>(
+        ApplyDomainBLFIntegrators<Moose::MFEM::ParMixedBilinearForm>(
             trial_var_name, test_var_name, td_mblf, _td_kernels_map);
         // Assemble mixed bilinear form
         if (td_mblf->GetDBFI()->Size() || td_mblf->GetBBFI()->Size())

--- a/test/tests/mfem/submeshes/gold/OutputData/SubmeshAVMagnetostaticCSV.csv
+++ b/test/tests/mfem/submeshes/gold/OutputData/SubmeshAVMagnetostaticCSV.csv
@@ -1,0 +1,3 @@
+time,MagneticEnergy
+0,0
+1,5692477.3060168

--- a/test/tests/mfem/submeshes/submesh_av_magnetostatic.i
+++ b/test/tests/mfem/submeshes/submesh_av_magnetostatic.i
@@ -6,6 +6,9 @@ high_terminal_bdr = 1
 low_terminal_bdr = 2
 exterior_bdr = '1 2 3'
 
+vacuum_reluctivity = ${fparse (1.0e7)/(4*pi)} # H/m
+wire_conductivity = 1.0e7 # S/m
+
 [Mesh]
   type = MFEMMesh
   file = ../mesh/cylinder-hex-q2.gen
@@ -61,7 +64,7 @@ exterior_bdr = '1 2 3'
 
 
 [AuxKernels]
-  [curl]
+  [curlA]
     type = MFEMCurlAux
     variable = b_field
     source = a_field
@@ -75,7 +78,6 @@ exterior_bdr = '1 2 3'
     variable = a_field
     boundary = ${exterior_bdr}
   []
-
   [top]
     type = MFEMScalarDirichletBC
     variable = electric_potential
@@ -90,18 +92,21 @@ exterior_bdr = '1 2 3'
 []
 
 [Kernels]
-  [curlcurl]
+  [curlA,curlA']
     type = MFEMCurlCurlKernel
     variable = a_field
+    coefficient = ${vacuum_reluctivity}
   []
-  [source]
+  [sigma.gradV,A']
     type = MFEMMixedVectorGradientKernel
     trial_variable = electric_potential
     variable = a_field
-  []  
-  [diff]
+    coefficient = ${wire_conductivity}
+  []
+  [sigma.gradV,gradV']
     type = MFEMDiffusionKernel
     variable = electric_potential
+    coefficient = ${wire_conductivity}
   []
 []
 
@@ -114,16 +119,19 @@ exterior_bdr = '1 2 3'
   device = cpu
 []
 
-[Outputs]
-  [ParaViewDataCollection]
-    type = MFEMParaViewDataCollection
-    file_base = OutputData/Magnetostatic
-    vtk_format = ASCII
+[Postprocessors]
+  [MagneticEnergy]
+    type = MFEMVectorFEInnerProductIntegralPostprocessor
+    coefficient = ${fparse 0.5*vacuum_reluctivity}
+    dual_variable = b_field
+    primal_variable = b_field
+    execution_order_group = 2
   []
-  [SubmeshParaViewDataCollection]
-    type = MFEMParaViewDataCollection
-    file_base = OutputData/MagnetostaticSubmesh
-    vtk_format = ASCII
-    submesh = wire
-  []  
+[]
+
+[Outputs]
+  [ReportedPostprocessors]
+    type = CSV
+    file_base = OutputData/SubmeshAVMagnetostaticCSV
+  []
 []

--- a/test/tests/mfem/submeshes/submesh_av_magnetostatic.i
+++ b/test/tests/mfem/submeshes/submesh_av_magnetostatic.i
@@ -1,6 +1,11 @@
 # Definite Maxwell problem solved with Nedelec elements of the first kind
 # based on MFEM Example 3.
 
+wire_domain = 1
+high_terminal_bdr = 1
+low_terminal_bdr = 2
+exterior_bdr = '1 2 3'
+
 [Mesh]
   type = MFEMMesh
   file = ../mesh/cylinder-hex-q2.gen
@@ -13,7 +18,7 @@
 [SubMeshes]
   [wire]
     type = MFEMDomainSubMesh
-    block = interior
+    block = ${wire_domain}
   []
 []
 
@@ -63,30 +68,24 @@
     execute_on = TIMESTEP_END
   []
 []
-[Functions]
-  [height]
-    type = ParsedFunction
-    expression = 'z'
-  []
-[]
 
 [BCs]
   [tangential_a_bdr]
     type = MFEMVectorTangentialDirichletBC
     variable = a_field
-    boundary = '1 2 3'
+    boundary = ${exterior_bdr}
   []
 
   [top]
     type = MFEMScalarDirichletBC
     variable = electric_potential
-    boundary = 1
+    boundary = ${high_terminal_bdr}
     coefficient = 1.0
   []
   [bottom]
     type = MFEMScalarDirichletBC
     variable = electric_potential
-    boundary = 2
+    boundary = ${low_terminal_bdr}
   []
 []
 

--- a/test/tests/mfem/submeshes/submesh_av_magnetostatic.i
+++ b/test/tests/mfem/submeshes/submesh_av_magnetostatic.i
@@ -1,0 +1,130 @@
+# Definite Maxwell problem solved with Nedelec elements of the first kind
+# based on MFEM Example 3.
+
+[Mesh]
+  type = MFEMMesh
+  file = ../mesh/cylinder-hex-q2.gen
+[]
+
+[Problem]
+  type = MFEMProblem
+[]
+
+[SubMeshes]
+  [wire]
+    type = MFEMDomainSubMesh
+    block = interior
+  []
+[]
+
+[FESpaces]
+  [H1FESpace]
+    type = MFEMScalarFESpace
+    fec_type = H1
+    fec_order = FIRST
+    submesh = wire
+  []
+  [HCurlFESpace]
+    type = MFEMVectorFESpace
+    fec_type = ND
+    fec_order = FIRST
+  []
+  [HDivFESpace]
+    type = MFEMVectorFESpace
+    fec_type = RT
+    fec_order = CONSTANT
+  []
+[]
+
+[Variables]
+  [a_field]
+    type = MFEMVariable
+    fespace = HCurlFESpace
+  []
+  [electric_potential]
+    type = MFEMVariable
+    fespace = H1FESpace
+  []
+[]
+
+[AuxVariables]
+  [b_field]
+    type = MFEMVariable
+    fespace = HDivFESpace
+  []
+[]
+
+
+[AuxKernels]
+  [curl]
+    type = MFEMCurlAux
+    variable = b_field
+    source = a_field
+    execute_on = TIMESTEP_END
+  []
+[]
+[Functions]
+  [height]
+    type = ParsedFunction
+    expression = 'z'
+  []
+[]
+
+[BCs]
+  [tangential_a_bdr]
+    type = MFEMVectorTangentialDirichletBC
+    variable = a_field
+    boundary = '1 2 3'
+  []
+
+  [top]
+    type = MFEMScalarDirichletBC
+    variable = electric_potential
+    boundary = 1
+    coefficient = 1.0
+  []
+  [bottom]
+    type = MFEMScalarDirichletBC
+    variable = electric_potential
+    boundary = 2
+  []
+[]
+
+[Kernels]
+  [curlcurl]
+    type = MFEMCurlCurlKernel
+    variable = a_field
+  []
+  [source]
+    type = MFEMMixedVectorGradientKernel
+    trial_variable = electric_potential
+    variable = a_field
+  []  
+  [diff]
+    type = MFEMDiffusionKernel
+    variable = electric_potential
+  []
+[]
+
+[Solver]
+  type = MFEMMUMPS
+[]
+
+[Executioner]
+  type = MFEMSteady
+  device = cpu
+[]
+
+[Outputs]
+  [ParaViewDataCollection]
+    type = MFEMParaViewDataCollection
+    file_base = OutputData/Magnetostatic
+    vtk_format = ASCII
+  []
+  [SubmeshParaViewDataCollection]
+    type = MFEMParaViewDataCollection
+    file_base = OutputData/MagnetostaticSubmesh
+    vtk_format = ASCII
+    submesh = wire
+  []  
+[]

--- a/test/tests/mfem/submeshes/submesh_av_magnetostatic.i
+++ b/test/tests/mfem/submeshes/submesh_av_magnetostatic.i
@@ -125,7 +125,6 @@ wire_conductivity = 1.0e7 # S/m
     coefficient = ${fparse 0.5*vacuum_reluctivity}
     dual_variable = b_field
     primal_variable = b_field
-    execution_order_group = 2
   []
 []
 

--- a/test/tests/mfem/submeshes/tests
+++ b/test/tests/mfem/submeshes/tests
@@ -46,7 +46,6 @@
     max_parallel = 1
     recover = false
   []
-<<<<<<< HEAD
   [MFEMCoupledCoefficientSource]
     type = XMLDiff
     input = magnetostatic.i
@@ -63,7 +62,6 @@
     max_parallel = 1
     recover = false
   []
-=======
   [MFEMCoupledSubmeshVariableSource]
     type = CSVDiff
     input = submesh_av_magnetostatic.i
@@ -71,9 +69,9 @@
     requirement = 'MOOSE shall have the ability to support source terms arising from the elimination of coupled MFEM variables defined on a submesh.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
+    max_threads = 1 # # MUMPS solver failing on multiple threads
     recover = false
-  []   
->>>>>>> c8522901de (Add magnetostatic test problem using MFEM mixed form integrators with a submesh-restricted trial variable. Refs #32462)
+  []
   [MFEMGeometryCutTransitionSubMesh]
     design = 'syntax/MFEM/ClosedCoilMagnetostatic.md'
     issues = '#31404'

--- a/test/tests/mfem/submeshes/tests
+++ b/test/tests/mfem/submeshes/tests
@@ -46,6 +46,7 @@
     max_parallel = 1
     recover = false
   []
+<<<<<<< HEAD
   [MFEMCoupledCoefficientSource]
     type = XMLDiff
     input = magnetostatic.i
@@ -62,6 +63,17 @@
     max_parallel = 1
     recover = false
   []
+=======
+  [MFEMCoupledSubmeshVariableSource]
+    type = CSVDiff
+    input = submesh_av_magnetostatic.i
+    csvdiff = 'OutputData/SubmeshAVMagnetostaticCSV.csv'    
+    requirement = 'MOOSE shall have the ability to support source terms arising from the elimination of coupled MFEM variables defined on a submesh.'
+    capabilities = 'mfem'
+    compute_devices = 'cpu cuda'
+    recover = false
+  []   
+>>>>>>> c8522901de (Add magnetostatic test problem using MFEM mixed form integrators with a submesh-restricted trial variable. Refs #32462)
   [MFEMGeometryCutTransitionSubMesh]
     design = 'syntax/MFEM/ClosedCoilMagnetostatic.md'
     issues = '#31404'


### PR DESCRIPTION
Closes #32462
