### PR TITLE
Add option to skip the assembly of off-diagonal Jacobians from the homogenization constraint

### DIFF
--- a/modules/solid_mechanics/include/kernels/lagrangian/HomogenizedTotalLagrangianStressDivergence.h
+++ b/modules/solid_mechanics/include/kernels/lagrangian/HomogenizedTotalLagrangianStressDivergence.h
@@ -57,6 +57,9 @@ protected:
    */
   virtual Real computeQpOffDiagJacobianScalar(const unsigned int svar_num) override;
 
+protected:
+  bool _use_off_diagonal;
+
 private:
   /// Indices for off-diagonal Jacobian components
   unsigned int _m, _n;

--- a/modules/solid_mechanics/include/kernels/lagrangian/HomogenizedTotalLagrangianStressDivergence.h
+++ b/modules/solid_mechanics/include/kernels/lagrangian/HomogenizedTotalLagrangianStressDivergence.h
@@ -58,7 +58,7 @@ protected:
   virtual Real computeQpOffDiagJacobianScalar(const unsigned int svar_num) override;
 
 protected:
-  bool _use_off_diagonal;
+  const bool _use_off_diagonal;
 
 private:
   /// Indices for off-diagonal Jacobian components

--- a/modules/solid_mechanics/include/kernels/lagrangian/HomogenizedTotalLagrangianStressDivergence.h
+++ b/modules/solid_mechanics/include/kernels/lagrangian/HomogenizedTotalLagrangianStressDivergence.h
@@ -58,6 +58,7 @@ protected:
   virtual Real computeQpOffDiagJacobianScalar(const unsigned int svar_num) override;
 
 protected:
+  /// Whether to use the off diagonal term
   const bool _use_off_diagonal;
 
 private:

--- a/modules/solid_mechanics/include/physics/QuasiStaticSolidMechanicsPhysics.h
+++ b/modules/solid_mechanics/include/physics/QuasiStaticSolidMechanicsPhysics.h
@@ -166,6 +166,8 @@ protected:
   // Other homogenization info
   MultiMooseEnum _constraint_types;
   std::vector<FunctionName> _targets;
+  // Use the off diagonal scalar jacobian for the homogenization system
+  bool _lk_h_off_jac;
 };
 
 template <typename T, typename T2>

--- a/modules/solid_mechanics/include/physics/QuasiStaticSolidMechanicsPhysics.h
+++ b/modules/solid_mechanics/include/physics/QuasiStaticSolidMechanicsPhysics.h
@@ -150,7 +150,7 @@ protected:
   const LKFormulation _lk_formulation;
 
   /// Simplified volumetric locking correction flag for new kernels
-  bool _lk_locking;
+  const bool _lk_locking;
 
   /// Flag indicating if the homogenization system is present for new kernels
   bool _lk_homogenization;
@@ -167,7 +167,7 @@ protected:
   MultiMooseEnum _constraint_types;
   std::vector<FunctionName> _targets;
   // Use the off diagonal scalar jacobian for the homogenization system
-  bool _lk_h_off_jac;
+  const bool _lk_h_off_jac;
 };
 
 template <typename T, typename T2>

--- a/modules/solid_mechanics/include/physics/QuasiStaticSolidMechanicsPhysics.h
+++ b/modules/solid_mechanics/include/physics/QuasiStaticSolidMechanicsPhysics.h
@@ -166,7 +166,7 @@ protected:
   // Other homogenization info
   MultiMooseEnum _constraint_types;
   std::vector<FunctionName> _targets;
-  // Use the off diagonal scalar jacobian for the homogenization system
+  /// Whether to use the off diagonal scalar jacobian for the homogenization system
   const bool _lk_h_off_jac;
 };
 

--- a/modules/solid_mechanics/src/kernels/lagrangian/HomogenizedTotalLagrangianStressDivergence.C
+++ b/modules/solid_mechanics/src/kernels/lagrangian/HomogenizedTotalLagrangianStressDivergence.C
@@ -24,12 +24,15 @@ HomogenizedTotalLagrangianStressDivergence::validParams()
   params.renameCoupledVar(
       "scalar_variable", "macro_var", "Optional scalar field with the macro gradient");
 
+  params.addParam<bool>("off_diagonal_jacobian", true, "Include the off diagonal parts of the constraint Jacobian");
+
   return params;
 }
 
 HomogenizedTotalLagrangianStressDivergence::HomogenizedTotalLagrangianStressDivergence(
     const InputParameters & parameters)
-  : HomogenizationInterface<TotalLagrangianStressDivergence>(parameters)
+  : HomogenizationInterface<TotalLagrangianStressDivergence>(parameters),
+    _use_off_diagonal(getParam<bool>("off_diagonal_jacobian"))
 {
 }
 
@@ -149,6 +152,9 @@ void
 HomogenizedTotalLagrangianStressDivergence::computeScalarOffDiagJacobian(
     const unsigned int jvar_num)
 {
+  if (!_use_off_diagonal)
+    return;
+
   // ONLY assemble the contribution from _alpha component, which is connected with _var
   // The other components are handled by other kernel instances with other _alpha
   if (jvar_num != _var.number())
@@ -187,6 +193,9 @@ void
 HomogenizedTotalLagrangianStressDivergence::computeOffDiagJacobianScalarLocal(
     const unsigned int svar_num)
 {
+  if (!_use_off_diagonal)
+    return;
+
   // Just in case, skip any other scalar variables
   if (svar_num != _kappa_var)
     return;

--- a/modules/solid_mechanics/src/kernels/lagrangian/HomogenizedTotalLagrangianStressDivergence.C
+++ b/modules/solid_mechanics/src/kernels/lagrangian/HomogenizedTotalLagrangianStressDivergence.C
@@ -24,7 +24,8 @@ HomogenizedTotalLagrangianStressDivergence::validParams()
   params.renameCoupledVar(
       "scalar_variable", "macro_var", "Optional scalar field with the macro gradient");
 
-  params.addParam<bool>("off_diagonal_jacobian", true, "Include the off diagonal parts of the constraint Jacobian");
+  params.addParam<bool>(
+      "off_diagonal_jacobian", true, "Include the off diagonal parts of the constraint Jacobian");
 
   return params;
 }

--- a/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
+++ b/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
@@ -114,7 +114,10 @@ QuasiStaticSolidMechanicsPhysics::validParams()
       "column-major order, and there must be 9 entries in total.");
   params.addParam<std::vector<FunctionName>>(
       "targets", {}, "Functions giving the targets to hit for constraint types that are not none.");
-  params.addParam<bool>("homogenized_off_diagonal_jacobian", true, "Whether to include the off diagonal scalar contributions to the homogenized jacobian");
+  params.addParam<bool>(
+      "homogenized_off_diagonal_jacobian",
+      true,
+      "Whether to include the off-diagonal scalar contributions to the homogenized jacobian");
 
   params.addParamNamesToGroup("scaling", "Variables");
   params.addParamNamesToGroup("strain_base_name automatic_eigenstrain_names", "Strain");

--- a/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
+++ b/modules/solid_mechanics/src/physics/QuasiStaticSolidMechanicsPhysics.C
@@ -114,6 +114,7 @@ QuasiStaticSolidMechanicsPhysics::validParams()
       "column-major order, and there must be 9 entries in total.");
   params.addParam<std::vector<FunctionName>>(
       "targets", {}, "Functions giving the targets to hit for constraint types that are not none.");
+  params.addParam<bool>("homogenized_off_diagonal_jacobian", true, "Whether to include the off diagonal scalar contributions to the homogenized jacobian");
 
   params.addParamNamesToGroup("scaling", "Variables");
   params.addParamNamesToGroup("strain_base_name automatic_eigenstrain_names", "Strain");
@@ -152,7 +153,8 @@ QuasiStaticSolidMechanicsPhysics::QuasiStaticSolidMechanicsPhysics(const InputPa
     _lk_locking(getParam<bool>("volumetric_locking_correction")),
     _lk_homogenization(false),
     _constraint_types(getParam<MultiMooseEnum>("constraint_types")),
-    _targets(getParam<std::vector<FunctionName>>("targets"))
+    _targets(getParam<std::vector<FunctionName>>("targets")),
+    _lk_h_off_jac(getParam<bool>("homogenized_off_diagonal_jacobian"))
 {
   // determine if incremental strains are to be used
   if (isParamValid("incremental"))
@@ -1142,6 +1144,8 @@ QuasiStaticSolidMechanicsPhysics::getKernelParameters(std::string type)
         (_lk_large_kinematics && (_lk_formulation == LKFormulation::Updated));
     params.set<bool>("large_kinematics") = _lk_large_kinematics;
     params.set<bool>("stabilize_strain") = _lk_locking;
+    if (_lk_homogenization)
+      params.set<bool>("off_diagonal_jacobian") = _lk_h_off_jac;
   }
   else
     params.set<bool>("use_displaced_mesh") = _use_displaced_mesh;

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/large-tests/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/large-tests/tests
@@ -50,6 +50,20 @@
                   "kinematics"
     capabilities = 'method!=dbg'
   []
+  [3d-strain-no-offdiag]
+    type = CSVDiff
+    input = '3d.i'
+    prereq = '3d-strain'
+    csvdiff = '3d-strain_out.csv'
+    cli_args = "Kernels/sdx/off_diagonal_jacobian=false Kernels/sdy/off_diagonal_jacobian=false "
+               "Kernels/sdz/off_diagonal_jacobian=false Outputs/file_base=3d-strain_out "
+               "constraint_types='strain strain strain strain strain strain strain strain strain' "
+               "targets='strain11 strain21 strain31 strain12 strain22 strain32 strain13 strain23 "
+               "strain33'"
+    requirement = "Homogenization with strain constraints in 3D using large kinematics should work "
+                  "without off-diagonal Jacobians from the constraints"
+    capabilities = 'method!=dbg'
+  []
   [3d-stress]
     type = CSVDiff
     input = '3d.i'

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/large-tests/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/large-tests/tests
@@ -60,8 +60,8 @@
                "constraint_types='strain strain strain strain strain strain strain strain strain' "
                "targets='strain11 strain21 strain31 strain12 strain22 strain32 strain13 strain23 "
                "strain33'"
-    requirement = "Homogenization with strain constraints in 3D using large kinematics should work "
-                  "without off-diagonal Jacobians from the constraints"
+    requirement = "Homogenization with strain constraints in 3D using large kinematics should be able to solve "
+                  "without the off-diagonal contributions to the Jacobian from the constraints"
     capabilities = 'method!=dbg'
   []
   [3d-stress]

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/small-tests/3d.i
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/small-tests/3d.i
@@ -21,8 +21,7 @@
                 1 0 0
                 0 -1 0
                 0 1 0
-            '
-              '    0 0 -1
+                0 0 -1
                 0 0 1'
     fixed_normal = true
     new_boundary = 'left right bottom top back front'

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/small-tests/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/small-tests/tests
@@ -53,6 +53,19 @@
     requirement = "Homogenization with strain constraints hits the targets in 3D"
     capabilities = 'method!=dbg'
   []
+  [3d-strain-no-offdiag]
+    type = CSVDiff
+    input = '3d.i'
+    csvdiff = '3d-strain_out.csv'
+    prereq = '3d-strain'
+    cli_args = "Kernels/sdx/off_diagonal_jacobian=false Kernels/sdy/off_diagonal_jacobian=false "
+               "Kernels/sdz/off_diagonal_jacobian=false Outputs/file_base=3d-strain_out "
+               "constraint_types='strain none none strain strain none strain strain strain' "
+               "targets='strain11 strain12 strain22 strain13 strain23 strain33'"
+    requirement = "Homogenization with strain constraints in 3D should work without off-diagonal "
+                  "Jacobians from the constraints"
+    capabilities = 'method!=dbg'
+  []
   [3d-stress]
     type = CSVDiff
     input = '3d.i'

--- a/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/small-tests/tests
+++ b/modules/solid_mechanics/test/tests/lagrangian/cartesian/total/homogenization/small-tests/tests
@@ -62,8 +62,8 @@
                "Kernels/sdz/off_diagonal_jacobian=false Outputs/file_base=3d-strain_out "
                "constraint_types='strain none none strain strain none strain strain strain' "
                "targets='strain11 strain12 strain22 strain13 strain23 strain33'"
-    requirement = "Homogenization with strain constraints in 3D should work without off-diagonal "
-                  "Jacobians from the constraints"
+    requirement = "Homogenization with strain constraints in 3D should work without the off-diagonal "
+                  "contributions to the Jacobian from the constraints"
     capabilities = 'method!=dbg'
   []
   [3d-stress]


### PR DESCRIPTION
Added options in `HomogenizedTotalLagrangianStressDivergence` and `QuasiStaticSolidMechanicsPhysics` to optionally skip the assembly of scalar off-diagonal Jacobians.

No use of AI.