### PR TITLE
Allow 110% cpu per slot by default, fix memory conversion

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1802,9 +1802,7 @@ class TestHarness:
         failgroup = parser.add_argument_group(
             "Failure Criteria", "Control the failure criteria"
         )
-        default_max_cpu_per_slot = (
-            110.0 if "microsoft" in platform.release().lower() else 105.0
-        )  # give more wiggle room in WSL; see #32464
+        default_max_cpu_per_slot = 110.0
         failgroup.add_argument(
             "--max-cpu-per-slot",
             nargs=1,

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -283,12 +283,12 @@ class Scheduler(MooseObject):
                 runner = job.getRunner()
                 slots = job.getSlots()
 
-                max_memory = runner.max_memory
+                max_memory = runner.max_memory  # bytes
                 if max_memory is None or memory > max_memory:
                     runner.setMaxMemory(memory)
 
                     if max_memory_per_slot:
-                        memory_per_slot_mb = memory / slots * 1.0e-6
+                        memory_per_slot_mb = memory / slots * 2**-20
                         if memory_per_slot_mb > max_memory_per_slot:
                             message = (
                                 "JOB KILLED (OVER MEMORY): "

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -63,7 +63,7 @@ def get_process_memory(process: psutil.Process) -> Optional[int]:
             end = start
             while data[end] != 32:
                 end += 1
-            return int(data[start:end]) * 1024
+            return int(data[start:end]) * 1024  # kilobytes -> bytes
 
     # Otherwise, use RSS (will double count shared memory)
     else:
@@ -87,7 +87,7 @@ def get_processes_memory(pids: Iterable[int]) -> dict[int, int]:
     Returns:
     -------
     dict[int, int]:
-        Mapping of pid -> estimated process memory.
+        Mapping of pid -> estimated process memory in bytes.
 
     """
 


### PR DESCRIPTION
- Bumps default allowance for CPU % / slot from 105% to 110% everywhere
- Fixes max memory check to be done MiB instead of MB, which is the standard for memory usage and is also the unit output in the test status

refs #32451