### PR TITLE
Moved THM tutorial tests to 'examples' spec

### DIFF
--- a/modules/thermal_hydraulics/tutorials/single_phase_flow/examples
+++ b/modules/thermal_hydraulics/tutorials/single_phase_flow/examples
@@ -1,6 +1,4 @@
 [Tests]
-  design = 'thm_tutorial.md'
-  issues = '#25570'
   [tutorial]
     requirement = "The system shall be able to complete the thermal hydraulics tutorial's "
     [01]
@@ -9,7 +7,6 @@
       csvdiff = '01_flow_channel_out.csv'
       cli_args = 'Outputs/csv=true Executioner/num_steps=10'
       valgrind = none # disabling due to timeouts; tested elsewhere
-      detail = 'first step,'
     []
     [02]
       type = CSVDiff
@@ -17,7 +14,6 @@
       csvdiff = '02_core_out.csv'
       cli_args = 'Outputs/csv=true Executioner/num_steps=10'
       valgrind = none # disabling due to timeouts; tested elsewhere
-      detail = 'second step,'
     []
     [03]
       type = CSVDiff
@@ -25,7 +21,6 @@
       csvdiff = '03_upper_loop_out.csv'
       cli_args = 'Outputs/csv=true Executioner/num_steps=10'
       valgrind = none # disabling due to timeouts; tested elsewhere
-      detail = 'third step,'
     []
     [04]
       type = CSVDiff
@@ -34,7 +29,6 @@
       cli_args = 'Outputs/csv=true Executioner/num_steps=10'
       recover = false
       valgrind = none # disabling due to timeouts; tested elsewhere
-      detail = 'fourth step,'
       # PR #26848. Clang 16 Apple Si is not compatible.
       capabilities = 'machine=x86_64'
       rel_err = 4e-5
@@ -48,7 +42,6 @@
       recover = false
       valgrind = none # disabling due to timeouts; tested elsewhere
       max_parallel = 1
-      detail = 'fifth step,'
       capabilities = 'method!=dbg'
     []
     [06]
@@ -61,7 +54,6 @@
       recover = false
       valgrind = none # disabling due to timeouts; tested elsewhere
       max_parallel = 1
-      detail = 'and sixth step.'
     []
   []
 []


### PR DESCRIPTION
The THM tutorial tests are relatively fragile with respect to roundoff changes, and they should not be necessary to run within the standard regression suite, so they are moved to a separate test specs `examples`, as in the `stochastic_tools` module, which runs on a specific CIVET recipe.

Refs #32439
