### PR TITLE
Speed up memory tracking, add slurm memory tracking, improve resource tracking options

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -859,6 +859,10 @@ class TestHarness:
         else:
             return True
 
+    def shouldOutputMemory(self) -> bool:
+        """Whether or not memory should be output in the Job status."""
+        return self.scheduler.MONITOR_JOB_MEMORY and not self.options.no_memory_tracking
+
     def handleJobStatus(self, job, caveats=None):
         """
         The Scheduler is calling back the TestHarness to inform us of a status change.
@@ -867,7 +871,7 @@ class TestHarness:
         if self.options.show_last_run and job.isSkip():
             return
         elif not job.isSilent():
-            memory = None if self.scheduler.MONITOR_JOB_MEMORY else False
+            memory = None if self.shouldOutputMemory() else False
 
             # Print results and perform any desired post job processing
             if job.isFinished():
@@ -1015,6 +1019,8 @@ class TestHarness:
         if not self.finished_jobs:
             print("No tests ran")
 
+        memory = None if self.shouldOutputMemory() else False
+
         # Longest jobs and longest folders
         if not self.options.dry_run and self.options.longest_jobs:
             longest_jobs = self.getLongestJobs(self.options.longest_jobs)
@@ -1023,16 +1029,12 @@ class TestHarness:
                 for job in longest_jobs:
                     print(
                         util.formatJobResult(
-                            job,
-                            self.options,
-                            caveats=True,
-                            timing=True,
-                            memory=None if self.scheduler.MONITOR_JOB_MEMORY else False,
+                            job, self.options, caveats=True, timing=True, memory=memory
                         )
                     )
 
             # Heaviest jobs by memory
-            if self.scheduler.MONITOR_JOB_MEMORY and (
+            if self.shouldOutputMemory() and (
                 heaviest_jobs := self.getHeaviestJobs(self.options.longest_jobs)
             ):
                 print(
@@ -1045,7 +1047,7 @@ class TestHarness:
                             self.options,
                             caveats=True,
                             timing=True,
-                            memory=self.scheduler.MONITOR_JOB_MEMORY,
+                            memory=True,
                             memory_per_slot=True,
                         )
                     )
@@ -1816,8 +1818,26 @@ class TestHarness:
         failgroup = parser.add_argument_group(
             "Failure Criteria", "Control the failure criteria"
         )
-        default_max_cpu_per_slot = 110.0
         failgroup.add_argument(
+            "--max-fails",
+            nargs=1,
+            type=int,
+            default=50,
+            help="The number of tests allowed to fail before any additional tests will run",
+        )
+        failgroup.add_argument(
+            "--valgrind-max-fails",
+            nargs=1,
+            type=int,
+            default=5,
+            help="The number of valgrind tests allowed to fail before any additional valgrind tests will run",
+        )
+
+        resourcesgroup = parser.add_argument_group(
+            "Resource tracking", "Control tracking of resources"
+        )
+        default_max_cpu_per_slot = 110.0
+        resourcesgroup.add_argument(
             "--max-cpu-per-slot",
             nargs=1,
             type=float,
@@ -1827,25 +1847,21 @@ class TestHarness:
                 f"(default: {default_max_cpu_per_slot})"
             ),
         )
-        failgroup.add_argument(
-            "--max-fails",
-            nargs=1,
-            type=int,
-            default=50,
-            help="The number of tests allowed to fail before any additional tests will run",
-        )
-        failgroup.add_argument(
+        resourcesgroup.add_argument(
             "--max-memory-per-slot",
             nargs=1,
             type=float,
             help="The maximum memory to allow for a job in MB, per slot",
         )
-        failgroup.add_argument(
-            "--valgrind-max-fails",
-            nargs=1,
-            type=int,
-            default=5,
-            help="The number of valgrind tests allowed to fail before any additional valgrind tests will run",
+        resourcesgroup.add_argument(
+            "--no-cpu-tracking",
+            action="store_true",
+            help="Disable all CPU tracking of jobs",
+        )
+        resourcesgroup.add_argument(
+            "--no-memory-tracking",
+            action="store_true",
+            help="Disable all memory tracking of jobs",
         )
 
         hpcgroup = parser.add_argument_group("HPC", "Enable and control HPC execution")
@@ -2114,13 +2130,15 @@ class TestHarness:
                 return config
         return None
 
-    @staticmethod
-    def errorExit(*args):
+    def errorExit(self, *args):
         """
         Helper for printing an error and exiting
         """
-        message = " ".join([f"{v}" for v in args])
-        raise SystemExit(f"ERROR: {message}")
+        prefix = "ERROR:"
+        if self.options.colored:
+            prefix = util.colorText(prefix, "RED")
+        print(prefix, *args)
+        raise SystemExit(1)
 
     def printInfo(self, *args):
         """Print the given message as information."""

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -2135,7 +2135,7 @@ class TestHarness:
         """
         Helper for printing an error and exiting
         """
-        util.errorExit(args, colored=self.options.colored is True)
+        util.errorExit(*args, colored=self.options.colored is True)
 
     def printInfo(self, *args):
         """Print the given message as information."""

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1710,12 +1710,12 @@ class TestHarness:
             "Environment Options", "Control the runtime environment"
         )
         envgroup.add_argument(
-            "--disable-hwloc-topology",
+            "--no-hwloc-topology",
             action="store_true",
             help="Disable pre-caching the hwloc topology for MPI execution",
         )
         envgroup.add_argument(
-            "--disable-openmpi-oversubscribe",
+            "--no-openmpi-oversubscribe",
             action="store_true",
             help="Disable allowing oversubscribe with OpenMPI",
         )
@@ -2057,10 +2057,10 @@ class TestHarness:
 
         if self.app_name is None:
             print_info(
-                "Setting [--disable-hwloc-topology, --minimal-capabilities] because "
+                "Setting [--no-hwloc-topology, --minimal-capabilities] because "
                 "there is not an application",
             )
-            opts.disable_hwloc_topology = True
+            opts.no_hwloc_topology = True
             opts.minimal_capabilities = True
 
         # Set --max-memory-per-slot from MOOSE_MAX_MEMORY_PER_SLOT

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1141,7 +1141,7 @@ class TestHarness:
         elif self.options.hpc == "slurm":
             return "RunSlurm"
         # The default scheduler plugin
-        return "RunParallel"
+        return "RunLocal"
 
     def initializeResults(self):
         """Initializes the results storage

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -2052,10 +2052,8 @@ class TestHarness:
 
         if self.app_name is None:
             print_info(
-                "Setting [--no-hwloc-topology, --minimal-capabilities] because "
-                "there is not an application",
+                "Setting --minimal-capabilities because there is not an application",
             )
-            opts.no_hwloc_topology = True
             opts.minimal_capabilities = True
 
         # Set --max-memory-per-slot from MOOSE_MAX_MEMORY_PER_SLOT

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1835,16 +1835,11 @@ class TestHarness:
         resourcesgroup = parser.add_argument_group(
             "Resource tracking", "Control tracking of resources"
         )
-        default_max_cpu_per_slot = 110.0
         resourcesgroup.add_argument(
             "--max-cpu-per-slot",
             nargs=1,
             type=float,
-            default=default_max_cpu_per_slot,
-            help=(
-                "The maximum percent CPU to allow for a job, per slot "
-                f"(default: {default_max_cpu_per_slot})"
-            ),
+            help=("The maximum percent CPU to allow for a job, per slot"),
         )
         resourcesgroup.add_argument(
             "--max-memory-per-slot",

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -31,8 +31,6 @@ from FactorySystem.Factory import Factory
 from FactorySystem.Parser import Parser
 from FactorySystem.Warehouse import Warehouse
 
-from .mpi_config import get_mpi_config
-
 if TYPE_CHECKING:
     from pycapabilities import Capabilities
 
@@ -451,16 +449,9 @@ class TestHarness:
         # So that testers can see if we have an application
         self.options._app_name = self.app_name
 
-        # Store the mpi configuration we have discovered
-        self.options.mpi_config = get_mpi_config()
-        if self.options.mpi_config.hwloc_topo_file:
-            self.printInfo(
-                "Using hwloc topology in "
-                f'"{self.options.mpi_config.hwloc_topo_file}"'
-            )
-
         # Initialize the scheduler
         self.initialize()
+        self.options.scheduler = self.scheduler.scheduler_options
 
         os.chdir(self._orig_cwd)
 
@@ -568,7 +559,9 @@ class TestHarness:
                     required_capabilities, capabilities
                 )
             except Exception as e:
-                TestHarness.errorExit(f"--only-tests-that-require: {e}")
+                util.errorExit(
+                    f"--only-tests-that-require: {e}", colored=options.colored
+                )
 
         return capabilities, augmented_capabilities, required
 
@@ -1019,8 +1012,6 @@ class TestHarness:
         if not self.finished_jobs:
             print("No tests ran")
 
-        memory = None if self.shouldOutputMemory() else False
-
         # Longest jobs and longest folders
         if not self.options.dry_run and self.options.longest_jobs:
             longest_jobs = self.getLongestJobs(self.options.longest_jobs)
@@ -1029,7 +1020,11 @@ class TestHarness:
                 for job in longest_jobs:
                     print(
                         util.formatJobResult(
-                            job, self.options, caveats=True, timing=True, memory=memory
+                            job,
+                            self.options,
+                            caveats=True,
+                            timing=True,
+                            memory=None if self.shouldOutputMemory() else False,
                         )
                     )
 
@@ -1715,10 +1710,14 @@ class TestHarness:
             "Environment Options", "Control the runtime environment"
         )
         envgroup.add_argument(
-            "--disable-mpi-options",
+            "--disable-hwloc-topology",
             action="store_true",
-            dest="disable_mpi_options",
-            help="Disable automated MPI environment options",
+            help="Disable pre-caching the hwloc topology for MPI execution",
+        )
+        envgroup.add_argument(
+            "--disable-openmpi-oversubscribe",
+            action="store_true",
+            help="Disable allowing oversubscribe with OpenMPI",
         )
 
         screengroup = parser.add_argument_group(
@@ -2058,8 +2057,10 @@ class TestHarness:
 
         if self.app_name is None:
             print_info(
-                "Setting --minimal-capabilities because there is not an application",
+                "Setting [--disable-hwloc-topology, --minimal-capabilities] because "
+                "there is not an application",
             )
+            opts.disable_hwloc_topology = True
             opts.minimal_capabilities = True
 
         # Set --max-memory-per-slot from MOOSE_MAX_MEMORY_PER_SLOT
@@ -2134,11 +2135,7 @@ class TestHarness:
         """
         Helper for printing an error and exiting
         """
-        prefix = "ERROR:"
-        if self.options.colored:
-            prefix = util.colorText(prefix, "RED")
-        print(prefix, *args)
-        raise SystemExit(1)
+        util.errorExit(args, colored=self.options.colored is True)
 
     def printInfo(self, *args):
         """Print the given message as information."""

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -867,6 +867,8 @@ class TestHarness:
         if self.options.show_last_run and job.isSkip():
             return
         elif not job.isSilent():
+            memory = None if self.scheduler.MONITOR_JOB_MEMORY else False
+
             # Print results and perform any desired post job processing
             if job.isFinished():
                 joint_status = job.getJointStatus()
@@ -880,7 +882,10 @@ class TestHarness:
                 # Print status with caveats (if caveats not overridden)
                 caveats = True if caveats is None else caveats
                 print(
-                    util.formatJobResult(job, self.options, caveats=caveats), flush=True
+                    util.formatJobResult(
+                        job, self.options, caveats=caveats, memory=memory
+                    ),
+                    flush=True,
                 )
 
                 # Store job as finished for printing
@@ -899,7 +904,11 @@ class TestHarness:
                 caveats = False if caveats is None else caveats
                 print(
                     util.formatJobResult(
-                        job, self.options, status_message=False, caveats=caveats
+                        job,
+                        self.options,
+                        status_message=False,
+                        caveats=caveats,
+                        memory=memory,
                     ),
                     flush=True,
                 )
@@ -1014,13 +1023,18 @@ class TestHarness:
                 for job in longest_jobs:
                     print(
                         util.formatJobResult(
-                            job, self.options, caveats=True, timing=True
+                            job,
+                            self.options,
+                            caveats=True,
+                            timing=True,
+                            memory=None if self.scheduler.MONITOR_JOB_MEMORY else False,
                         )
                     )
 
             # Heaviest jobs by memory
-            heaviest_jobs = self.getHeaviestJobs(self.options.longest_jobs)
-            if heaviest_jobs:
+            if self.scheduler.MONITOR_JOB_MEMORY and (
+                heaviest_jobs := self.getHeaviestJobs(self.options.longest_jobs)
+            ):
                 print(
                     header(f"{self.options.longest_jobs} Heaviest Jobs (memory/slot)")
                 )
@@ -1031,7 +1045,7 @@ class TestHarness:
                             self.options,
                             caveats=True,
                             timing=True,
-                            memory=True,
+                            memory=self.scheduler.MONITOR_JOB_MEMORY,
                             memory_per_slot=True,
                         )
                     )

--- a/python/TestHarness/mpi_config.py
+++ b/python/TestHarness/mpi_config.py
@@ -15,7 +15,7 @@ from enum import Enum
 from pathlib import Path
 from shutil import which
 from socket import gethostname
-from subprocess import CalledProcessError, check_output, run, PIPE, STDOUT
+from subprocess import PIPE, STDOUT, CalledProcessError, check_output, run
 from traceback import format_exc
 from typing import Optional
 
@@ -28,14 +28,17 @@ class MPIType(Enum):
     MPICH = 2
 
 
-@dataclass
+@dataclass(frozen=True)
 class MPIConfig:
+    """The found MPI configuration."""
+
     mpi_type: MPIType
+    """The MPI type found, if any."""
     hwloc: bool
-    hwloc_topo_file: Optional[str]
+    """Whether or not the found MPI uses hwloc."""
 
 
-def build_hwloc_topo() -> Optional[str]:
+def build_hwloc_topology() -> Optional[str]:
     """
     Build the hwloc topology file, if possible.
 
@@ -43,7 +46,6 @@ def build_hwloc_topo() -> Optional[str]:
     on every single application execution), we can save a
     sizeable amount of time on init.
     """
-
     if (exe := which("lstopo-no-graphics")) is None and (
         exe := which("lstopo")
     ) is None:
@@ -68,7 +70,8 @@ def build_hwloc_topo() -> Optional[str]:
 
 def get_mpi_config() -> MPIConfig:
     """Get the MPI configuration for the implementations that we special case."""
-    config = MPIConfig(mpi_type=MPIType.UNKNOWN, hwloc=False, hwloc_topo_file=None)
+    mpi_type = MPIType.UNKNOWN
+    hwloc = False
 
     mpi_command = os.environ.get("MOOSE_MPI_COMMAND", "mpiexec").split()[0]
     which_mpiexec = which(mpi_command)
@@ -79,14 +82,11 @@ def get_mpi_config() -> MPIConfig:
             pass
         else:
             if "HYDRA" in out:
-                config.mpi_type = MPIType.MPICH
+                mpi_type = MPIType.MPICH
                 if "hwloc" in out:
-                    config.hwloc = True
+                    hwloc = True
             elif "Open MPI" in out:
-                config.mpi_type = MPIType.OPENMPI
-                config.hwloc = True
+                mpi_type = MPIType.OPENMPI
+                hwloc = True
 
-    if config.hwloc:
-        config.hwloc_topo_file = build_hwloc_topo()
-
-    return config
+    return MPIConfig(mpi_type=mpi_type, hwloc=hwloc)

--- a/python/TestHarness/runners/HPCRunner.py
+++ b/python/TestHarness/runners/HPCRunner.py
@@ -7,9 +7,19 @@
 # Licensed under LGPL 2.1, please see LICENSE for details
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
-import re, time, os, subprocess, yaml
+import os
+import re
+import subprocess
+import time
+from typing import TYPE_CHECKING, Optional
+
+import yaml
+from TestHarness.mpi_config import MPIType
 from TestHarness.runners.Runner import Runner
-from TestHarness.mpi_config import MPIConfig, MPIType
+
+if TYPE_CHECKING:
+    from TestHarness.schedulers.RunHPC import HPCJob, RunHPC
+    from TestHarness.schedulers.Scheduler import SchedulerOptions
 
 
 class HPCRunner(Runner):
@@ -17,20 +27,22 @@ class HPCRunner(Runner):
     Base Runner to be used with HPC schedulers (PBS, slurm)
     """
 
-    def __init__(self, job, options, run_hpc):
-        super().__init__(job, options)
+    def __init__(
+        self, job, options, scheduler_options: "SchedulerOptions", run_hpc: "RunHPC"
+    ):
+        super().__init__(job, options, scheduler_options)
 
-        # The RunHPC object
         self.run_hpc = run_hpc
+        """The RunHPC object."""
 
-        # The HPC job, set during spawn()
-        self.hpc_job = None
+        self.hpc_job: Optional["HPCJob"] = None
+        """The HPCJob, set during spawn()."""
 
-        # Interval in seconds for polling for job status
         self.job_status_poll_time = 0.1
+        """The interval in seconds for polling for job status."""
 
-        # Interval in seconds for polling for file completion
         self.file_completion_poll_time = 0.1
+        """The interval in seconds for polling for file completion"""
 
     def spawn(self, timer):
         # The runner_run output, which is the output from what we're
@@ -174,7 +186,10 @@ class HPCRunner(Runner):
         #
         # Where <NULL> is there the null character ends up. Thus, in cases
         # where we have a nonzero exit code and a MPI_ABORT, we'll try to remove these.
-        if self.exit_code != 0 and self.options.mpi_config.mpi_type == MPIType.OPENMPI:
+        if (
+            self.exit_code != 0
+            and self.scheduler_options.mpi_config.mpi_type == MPIType.OPENMPI
+        ):
             output = self.getRunOutput().getOutput(sanitize=False)
             if "MPI_ABORT" in output:
                 output_changed = False

--- a/python/TestHarness/runners/Runner.py
+++ b/python/TestHarness/runners/Runner.py
@@ -71,18 +71,24 @@ class Runner(OutputInterface):
         with self._max_memory_lock:
             return self._max_memory
 
-    def setMaxMemory(self, value: int):
+    def updateMaxMemory(self, value: int) -> bool:
         """
-        Set the max memory in bytes for the process.
+        Update the max memory in bytes for the process, if greater.
 
         Should be used by derived runners to set the memory
         as it is running if available.
 
         Is thread safe so that a running job can update its memory
         usage while being read by the long running job printer.
+
+        Returns whether or not the max memory was updated (if
+        the value was greater than the current max memory).
         """
         with self._max_memory_lock:
-            self._max_memory = value
+            if self._max_memory is None or value > self._max_memory:
+                self._max_memory = value
+                return True
+        return False
 
     @property
     def cpu_percent(self) -> Optional[float]:

--- a/python/TestHarness/runners/Runner.py
+++ b/python/TestHarness/runners/Runner.py
@@ -9,9 +9,12 @@
 
 import os
 from threading import Lock
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from TestHarness import OutputInterface, util
+
+if TYPE_CHECKING:
+    from TestHarness.schedulers.Scheduler import SchedulerOptions
 
 
 class Runner(OutputInterface):
@@ -23,27 +26,34 @@ class Runner(OutputInterface):
     or externally (i.e., PBS, slurm, etc on HPC)
     """
 
-    def __init__(self, job, options):
+    def __init__(self, job, options, scheduler_options: "SchedulerOptions"):
         OutputInterface.__init__(self)
 
-        # The job that this runner is for
         self.job = job
-        # The test harness options
+        """The job that this runner is for."""
         self.options = options
-        # The job's exit code, should be set after wait()
-        self.exit_code = None
-        # The job's estimated max memory in bytes, if any
-        self._max_memory: Optional[int] = None
-        # Thread lock for _max_memory
-        self._max_memory_lock = Lock()
-        # The job's average CPU % usage, if known
-        self._cpu_percent: Optional[float] = None
+        """The TestHarness options."""
+        self.scheduler_options = scheduler_options
 
-        # The output for the actual run of the job. We keep this
-        # separate from self.output in this Runner because HPC
-        # jobs always have a file output, so we want to store
-        # their output separately
+        """The Scheduler options."""
+        self.exit_code = None
+        """The job's exit code, should be set after wait()."""
+        self._max_memory: Optional[int] = None
+        """The job's estimated max memory in bytes, if any."""
+        self._max_memory_lock = Lock()
+        """Thread lock for _max_memory."""
+
+        self._cpu_percent: Optional[float] = None
+        """The job's average CPU % usage, if known."""
+
         self.run_output = OutputInterface()
+        """
+        The output for the actual run of the job.
+
+        We keep this separate from self.output in this Runner because HPC
+        jobs always have a file output, so we want to store their output
+        separately.
+        """
 
     @property
     def pid(self) -> Optional[int]:

--- a/python/TestHarness/runners/SubprocessRunner.py
+++ b/python/TestHarness/runners/SubprocessRunner.py
@@ -112,7 +112,7 @@ class SubprocessRunner(Runner):
 
         # OpenMPI, allow for oversubscription
         if (
-            not self.options.disable_openmpi_oversubscribe
+            not self.options.no_openmpi_oversubscribe
             and self.scheduler_options.mpi_config.mpi_type == MPIType.OPENMPI
         ):
             # Don't clobber state

--- a/python/TestHarness/runners/SubprocessRunner.py
+++ b/python/TestHarness/runners/SubprocessRunner.py
@@ -70,7 +70,7 @@ class SubprocessRunner(Runner):
         # If the tester supports wrapping with a time utility
         # and we're not using shell, wrap the command with
         # a time utility if a timing utility is available
-        if tester.SUPPORTS_TIME and not use_shell:
+        if not self.options.no_cpu_tracking and tester.SUPPORTS_TIME and not use_shell:
             time_command = None
 
             # GNU time; output to file just CPU %

--- a/python/TestHarness/runners/SubprocessRunner.py
+++ b/python/TestHarness/runners/SubprocessRunner.py
@@ -13,44 +13,36 @@ import re
 import shlex
 import subprocess
 import time
-from enum import Enum
 from signal import SIGTERM
 from tempfile import SpooledTemporaryFile
 from threading import Lock
 from typing import Optional
 
-from TestHarness.mpi_config import MPIConfig, MPIType
+from TestHarness.mpi_config import MPIType
 from TestHarness.runners.Runner import Runner
-from TestHarness.util import findBSDTime, findGNUTime
-
-
-class TimeType(Enum):
-    """Type of the time utility found, if any."""
-
-    BSD = 0
-    GNU = 1
-    NONE = 2
+from TestHarness.schedulers.Scheduler import SchedulerOptions, TimeUtilityType
 
 
 class SubprocessRunner(Runner):
     """Runner that spawns a local subprocess."""
 
-    def __init__(self, job, options):
-        Runner.__init__(self, job, options)
+    def __init__(self, job, options, scheduler_options: SchedulerOptions):
+        Runner.__init__(self, job, options, scheduler_options)
 
-        # The output file handler
-        self.outfile = None
-        # The error file handler
-        self.errfile = None
-        # The underlying subprocess
+        self.outfile: Optional[SpooledTemporaryFile] = None
+        """The output file handler."""
+        self.errfile: Optional[SpooledTemporaryFile] = None
+        """The error file handler."""
+
         self.process: Optional[subprocess.Popen] = None
-        # The running process' process ID, if any
+        """The underlying process."""
         self._pid: Optional[int] = None
-        # The lock for self.process
+        """The running process' process ID, if any."""
         self._pid_lock = Lock()
+        """The lock for self._pid."""
 
-        self._time_type: TimeType = TimeType.NONE
-        """The type of time utility used, if any."""
+        self.monitor_time = False
+        """Whether or not we're monitoring the process with a time utility."""
 
     @property
     def pid(self) -> Optional[int]:
@@ -70,25 +62,27 @@ class SubprocessRunner(Runner):
         # If the tester supports wrapping with a time utility
         # and we're not using shell, wrap the command with
         # a time utility if a timing utility is available
-        if not self.options.no_cpu_tracking and tester.SUPPORTS_TIME and not use_shell:
-            time_command = None
+        if (
+            self.scheduler_options.monitor_job_cpu
+            and tester.SUPPORTS_TIME
+            and not use_shell
+        ):
+            time_utility_type = self.scheduler_options.time_utility_type
+            assert time_utility_type != TimeUtilityType.NONE
 
-            # GNU time; output to file just CPU %
-            if gnu_time := findGNUTime():
-                self._time_type = TimeType.GNU
-                time_command = f"{gnu_time} -o {self.timeFilePath()} -f '%P' -q"
-            # BSD time; output to file real, user, sys time
-            if bsd_time := findBSDTime():
-                self._time_type = TimeType.BSD
-                time_command = f"{bsd_time} -o {self.timeFilePath()}"
+            time_utility_path = self.scheduler_options.time_utility_path
+            assert time_utility_path is not None
 
-            # Found a time utility, so wrap the command with
-            # the utility, update the command, and delete any
-            # older time files if they exist
-            if time_command is not None:
-                cmd = f"{time_command} {cmd}"
-                self.deleteTimeFile(graceful=True)
-                tester.setCommandRan(cmd)
+            time_command = f"{time_utility_path} -o {self.timeFilePath()}"
+
+            # GNU time; enable quiet and just output CPU %
+            if self.scheduler_options.time_utility_type == TimeUtilityType.GNU:
+                time_command += " -f '%P' -q"
+
+            cmd = f"{time_command} {cmd}"
+            self.monitor_time = True
+            self.deleteTimeFile(graceful=True)
+            tester.setCommandRan(cmd)
 
         # Split command into list of args to be passed to Popen
         if not use_shell:
@@ -116,21 +110,19 @@ class SubprocessRunner(Runner):
         # Augment the environment if needed
         process_env = tester.augmentEnvironment(self.options)
 
-        # Special MPI environment options, if not disabled
-        if not self.options.disable_mpi_options:
-            mpi_config: MPIConfig = self.options.mpi_config
-            # OpenMPI
-            if mpi_config.mpi_type == MPIType.OPENMPI:
-                # Don't clobber state
-                process_env["OMPI_MCA_orte_tmpdir_base"] = (
-                    self.job.getTempDirectory().name
-                )
-                # Allow oversubscription for hosts that don't have a hostfile
-                process_env["PRTE_MCA_rmaps_default_mapping_policy"] = ":oversubscribe"
-            # hwloc with a prebuilt topology file
-            if mpi_config.hwloc and mpi_config.hwloc_topo_file is not None:
-                process_env["HWLOC_XMLFILE"] = mpi_config.hwloc_topo_file
-                process_env["HWLOC_THISSYSTEM"] = "1"
+        # OpenMPI, allow for oversubscription
+        if (
+            not self.options.disable_openmpi_oversubscribe
+            and self.scheduler_options.mpi_config.mpi_type == MPIType.OPENMPI
+        ):
+            # Don't clobber state
+            process_env["OMPI_MCA_orte_tmpdir_base"] = self.job.getTempDirectory().name
+            # Allow oversubscription for hosts that don't have a hostfile
+            process_env["PRTE_MCA_rmaps_default_mapping_policy"] = ":oversubscribe"
+        # hwloc with a prebuilt topology file
+        if hwloc_topo_file := self.scheduler_options.hwloc_topology_path:
+            process_env["HWLOC_XMLFILE"] = hwloc_topo_file
+            process_env["HWLOC_THISSYSTEM"] = "1"
 
         # Add to environment if requested
         if process_env:
@@ -176,7 +168,7 @@ class SubprocessRunner(Runner):
             if (
                 file == self.errfile
                 and self.exit_code != 0
-                and self.options.mpi_config.mpi_type == MPIType.OPENMPI
+                and self.scheduler_options.mpi_config.mpi_type == MPIType.OPENMPI
                 and len(output) > 2
                 and output[-3:] in ["\n\0\n", "\n\x00\n"]
             ):
@@ -185,12 +177,12 @@ class SubprocessRunner(Runner):
             self.getRunOutput().appendOutput(output)
 
         # Parse the time output if we have one
-        if self._time_type != TimeType.NONE:
+        if self.monitor_time:
             self.parseTimeFile(timer)
 
     def parseTimeFile(self, timer):
         """Parse the time file."""
-        assert self._time_type != TimeType.NONE
+        assert self.monitor_time
 
         # Load the time utility output
         try:
@@ -202,12 +194,14 @@ class SubprocessRunner(Runner):
             self.appendOutput(f"\n\nFailed to find time file {self.timeFilePath()}")
         # Obtain the CPU percentage from the time output
         else:
+            time_type = self.scheduler_options.time_utility_type
+
             # GNU time; should contain just the percentage
-            if self._time_type == TimeType.GNU:
+            if time_type == TimeUtilityType.GNU:
                 if match := re.fullmatch(r"(\d+)%", contents):
                     self.cpu_percent = float(match.group(1))
             # BSD time; need to compute percentage from (user+sys)/real
-            elif self._time_type == TimeType.BSD and (
+            elif time_type == TimeUtilityType.BSD and (
                 match := re.fullmatch(
                     r"(\d+.\d+) real \s+ (\d+.\d+) user \s+ (\d+.\d+) sys", contents
                 )
@@ -236,7 +230,7 @@ class SubprocessRunner(Runner):
 
     def deleteTimeFile(self, graceful: bool):
         """Delete the time file."""
-        assert self._time_type != TimeType.NONE
+        assert self.monitor_time
         try:
             os.remove(self.timeFilePath())
         except FileNotFoundError:
@@ -247,7 +241,7 @@ class SubprocessRunner(Runner):
         super().cleanup()
 
         # Cleanup the time file if it exists
-        if self._time_type != TimeType.NONE:
+        if self.monitor_time:
             self.deleteTimeFile(graceful=True)
 
     def kill(self):

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -425,10 +425,11 @@ class Job(OutputInterface):
             nonlocal runner_spawned
 
             # Fail the job if is used too much CPU
-            if (cpu_percent := runner.cpu_percent) is not None:
+            if (max_cpu_per_slot := self.options.max_cpu_per_slot) is not None and (
+                cpu_percent := runner.cpu_percent
+            ) is not None:
                 slots = self.getSlots()
                 cpu_per_slot = cpu_percent / slots
-                max_cpu_per_slot = self.options.max_cpu_per_slot * slots
                 if cpu_per_slot > max_cpu_per_slot:
                     message = (
                         "\n\nJOB OVER CPU: "

--- a/python/TestHarness/schedulers/RunHPC.py
+++ b/python/TestHarness/schedulers/RunHPC.py
@@ -24,7 +24,7 @@ from enum import Enum
 from multiprocessing.pool import ThreadPool
 from typing import Optional
 
-from RunParallel import RunParallel
+from Scheduler import Scheduler
 
 from TestHarness import util
 
@@ -94,16 +94,10 @@ CallHPCPoolType = Enum("CallHPCPoolType", ["submit", "queue", "status", "kill"])
 """The types for the pools for calling HPC commands."""
 
 
-class RunHPC(RunParallel):
+class RunHPC(Scheduler):
     """
     Base scheduler for jobs that are ran on HPC.
     """
-
-    CAN_SET_HWLOC_TOPOLOGY = False
-    CAN_SET_MAX_MEMORY = False
-    CAN_OPENMPI_OVERSUBSCRIBE = False
-    MONITOR_JOB_CPU = False
-    MONITOR_JOB_MEMORY = False
 
     def __init__(self, harness, params):
         import paramiko
@@ -999,7 +993,7 @@ class RunHPC(RunParallel):
             job.appendOutput(util.outputHeader(f"Job {hpc_job.id} {output}"))
 
     def waitFinish(self):
-        RunParallel.waitFinish(self)
+        super().waitFinish()
 
         # Kill the remaining jobs that are held, which would exist if things
         # fail and jobs that we pre-submitted were skipped due to a failed

--- a/python/TestHarness/schedulers/RunHPC.py
+++ b/python/TestHarness/schedulers/RunHPC.py
@@ -999,7 +999,7 @@ class RunHPC(RunParallel):
             job.appendOutput(util.outputHeader(f"Job {hpc_job.id} {output}"))
 
     def waitFinish(self):
-        super().waitFinish()
+        RunParallel.waitFinish(self)
 
         # Kill the remaining jobs that are held, which would exist if things
         # fail and jobs that we pre-submitted were skipped due to a failed

--- a/python/TestHarness/schedulers/RunHPC.py
+++ b/python/TestHarness/schedulers/RunHPC.py
@@ -99,6 +99,7 @@ class RunHPC(RunParallel):
     Base scheduler for jobs that are ran on HPC.
     """
 
+    MONITOR_JOB_CPU = False
     MONITOR_JOB_MEMORY = False
 
     def __init__(self, harness, params):

--- a/python/TestHarness/schedulers/RunHPC.py
+++ b/python/TestHarness/schedulers/RunHPC.py
@@ -1158,7 +1158,7 @@ class RunHPC(RunParallel):
 
         if submit_env["LOAD_MODULES"]:
             self.harness.printInfo(
-                f'Using modules "{" ".join(submit_env["LOAD_MODULES"])} '
+                f'Using modules "{" ".join(submit_env["LOAD_MODULES"])}" '
                 "for HPC environment"
             )
         if app_exec_prefix:

--- a/python/TestHarness/schedulers/RunHPC.py
+++ b/python/TestHarness/schedulers/RunHPC.py
@@ -99,6 +99,8 @@ class RunHPC(RunParallel):
     Base scheduler for jobs that are ran on HPC.
     """
 
+    CAN_SET_HWLOC_TOPOLOGY = False
+    CAN_OPENMPI_OVERSUBSCRIBE = False
     MONITOR_JOB_CPU = False
     MONITOR_JOB_MEMORY = False
 
@@ -815,7 +817,7 @@ class RunHPC(RunParallel):
     def buildRunner(self, job, options):
         from TestHarness.runners.HPCRunner import HPCRunner
 
-        return HPCRunner(job, options, self)
+        return HPCRunner(job, options, self.scheduler_options, self)
 
     def augmentJobs(self, jobs):
         super().augmentJobs(jobs)

--- a/python/TestHarness/schedulers/RunHPC.py
+++ b/python/TestHarness/schedulers/RunHPC.py
@@ -100,6 +100,7 @@ class RunHPC(RunParallel):
     """
 
     CAN_SET_HWLOC_TOPOLOGY = False
+    CAN_SET_MAX_MEMORY = False
     CAN_OPENMPI_OVERSUBSCRIBE = False
     MONITOR_JOB_CPU = False
     MONITOR_JOB_MEMORY = False
@@ -1168,3 +1169,7 @@ class RunHPC(RunParallel):
             )
 
         return submit_env, app_exec_prefix, app_exec_suffix
+
+    def monitorJobProcesses(self):
+        """Monitor job processes; nothing to do for HPC jobs."""
+        pass

--- a/python/TestHarness/schedulers/RunLocal.py
+++ b/python/TestHarness/schedulers/RunLocal.py
@@ -66,23 +66,30 @@ class RunLocal(Scheduler):
         samples = self._memory_monitor.get_samples()
 
         # Update job memory and kill jobs over memory
-        max_memory_per_slot = self.options.max_memory_per_slot
+        max_memory_per_slot_mb = self.options.max_memory_per_slot
         for pid, job in pid_to_job.items():
-            if (memory := samples.get(pid)) is not None:
+            if (job_memory_bytes := samples.get(pid)) is not None:
                 # If the job is already an error (we killed it), nothing to do:
                 if job.getStatus() == job.error:
                     continue
 
                 # Update max memory, if greater; this is True if it was greater
-                updated = job.getRunner().updateMaxMemory(memory)
+                updated = job.getRunner().updateMaxMemory(job_memory_bytes)
 
                 # Check memory usage if needed
-                if updated and max_memory_per_slot:
-                    memory_per_slot_mb = memory / job.getSlots() * 2**-20
-                    if memory_per_slot_mb > max_memory_per_slot:
-                        message = (
-                            "JOB KILLED (OVER MEMORY): "
-                            f"Memory/slot {memory_per_slot_mb:.2f} "
-                            f"MB > allowed {max_memory_per_slot:.2f} MB"
+                if (
+                    updated
+                    and max_memory_per_slot_mb
+                    and (
+                        job_memory_per_slot_mb := (
+                            job_memory_bytes / job.getSlots() * 2**-20
                         )
-                        job.killProcess(job.error, "KILLED: OVER MEMORY", message)
+                    )
+                    > max_memory_per_slot_mb
+                ):
+                    message = (
+                        "JOB KILLED (OVER MEMORY): "
+                        f"Memory/slot {job_memory_per_slot_mb:.2f} "
+                        f"MB > allowed {max_memory_per_slot_mb:.2f} MB"
+                    )
+                    job.killProcess(job.error, "KILLED: OVER MEMORY", message)

--- a/python/TestHarness/schedulers/RunLocal.py
+++ b/python/TestHarness/schedulers/RunLocal.py
@@ -68,28 +68,33 @@ class RunLocal(Scheduler):
         # Update job memory and kill jobs over memory
         max_memory_per_slot_mb = self.options.max_memory_per_slot
         for pid, job in pid_to_job.items():
-            if (job_memory_bytes := samples.get(pid)) is not None:
-                # If the job is already an error (we killed it), nothing to do:
-                if job.getStatus() == job.error:
-                    continue
+            job_memory_bytes = samples.get(pid)
 
-                # Update max memory, if greater; this is True if it was greater
-                updated = job.getRunner().updateMaxMemory(job_memory_bytes)
+            # Didn't get samples for this Job's process
+            if job_memory_bytes is None:
+                continue
 
-                # Check memory usage if needed
-                if (
-                    updated
-                    and max_memory_per_slot_mb
-                    and (
-                        job_memory_per_slot_mb := (
-                            job_memory_bytes / job.getSlots() * 2**-20
-                        )
+            # If the job is already an error (we may have killed it), nothing to do
+            if job.getStatus() == job.error:
+                continue
+
+            # Update max memory, if greater; this is True if greater
+            updated = job.getRunner().updateMaxMemory(job_memory_bytes)
+
+            # Check memory usage if needed
+            if (
+                updated
+                and max_memory_per_slot_mb
+                and (
+                    job_memory_per_slot_mb := (
+                        job_memory_bytes / job.getSlots() * 2**-20
                     )
-                    > max_memory_per_slot_mb
-                ):
-                    message = (
-                        "JOB KILLED (OVER MEMORY): "
-                        f"Memory/slot {job_memory_per_slot_mb:.2f} "
-                        f"MB > allowed {max_memory_per_slot_mb:.2f} MB"
-                    )
-                    job.killProcess(job.error, "KILLED: OVER MEMORY", message)
+                )
+                > max_memory_per_slot_mb
+            ):
+                message = (
+                    "JOB KILLED (OVER MEMORY): "
+                    f"Memory/slot {job_memory_per_slot_mb:.2f} "
+                    f"MB > allowed {max_memory_per_slot_mb:.2f} MB"
+                )
+                job.killProcess(job.error, "KILLED: OVER MEMORY", message)

--- a/python/TestHarness/schedulers/RunLocal.py
+++ b/python/TestHarness/schedulers/RunLocal.py
@@ -7,32 +7,27 @@
 # Licensed under LGPL 2.1, please see LICENSE for details
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
-import traceback
-import platform
 import os
-from typing import TYPE_CHECKING
+import platform
 from importlib.util import find_spec
-from time import perf_counter
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from TestHarness.schedulers.Scheduler import Scheduler
-from TestHarness import util
 from TestHarness.runners.SubprocessRunner import Runner, SubprocessRunner
+from TestHarness.schedulers.Scheduler import Scheduler
 
-if platform.system() != "Windows" and find_spec("psutil") is not None or TYPE_CHECKING:
+_MONITOR_JOB_MEMORY = platform.system() != "Windows" and find_spec("psutil") is not None
+if _MONITOR_JOB_MEMORY or TYPE_CHECKING:
     from TestHarness.utils.monitor_processes import MemoryMonitor
 
 
-class RunParallel(Scheduler):
-    """
-    RunParallel is a Scheduler plugin responsible for executing a tester
-    command and doing something with its output.
-    """
+class RunLocal(Scheduler):
+    """A scheduler for executing tester commands locally."""
 
-    @staticmethod
-    def validParams():
-        params = Scheduler.validParams()
-        return params
+    CAN_SET_HWLOC_TOPOLOGY = True
+    CAN_SET_MAX_MEMORY = True
+    CAN_OPENMPI_OVERSUBSCRIBE = True
+    MONITOR_JOB_CPU = True
+    MONITOR_JOB_MEMORY = _MONITOR_JOB_MEMORY
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -43,75 +38,9 @@ class RunParallel(Scheduler):
         if self.scheduler_options.monitor_job_memory:
             self._memory_monitor = MemoryMonitor(os.getpid(), interval=0.1)
 
-    def run(self, job):
-        """Run a tester command"""
-        # Build and set the runner that will actually run the commands
-        # This is abstracted away so we can support local runners and PBS/slurm runners
-        job.setRunner(self.buildRunner(job, self.options))
-
-        tester = job.getTester()
-
-        # Do not execute app, and do not processResults
-        if self.options.dry_run:
-            self.setSuccessfulMessage(tester)
-            return
-        # Load results from a previous run
-        elif self.options.show_last_run:
-            job.loadPreviousResults()
-            return
-
-        # Start job timer
-        job.timer.startMain()
-
-        # Anything that throws while running or processing a job should be caught
-        # and the job should fail
-        try:
-            # Launch and wait for the command to finish
-            job.run()
-
-            # Set the successful message
-            if not tester.isSkip() and not job.isFail():
-                self.setSuccessfulMessage(tester)
-        except:
-            trace = traceback.format_exc()
-            job.appendOutput(
-                util.outputHeader("Python exception encountered in Job") + trace
-            )
-            job.setStatus(job.error, "JOB EXCEPTION")
-        finally:
-            # Stop job timer
-            job.timer.stopMain()
-
     def buildRunner(self, job, options) -> Runner:
-        """Builds the runner for a given tester
-
-        This exists as a method so that derived schedulers can change how they
-        run commands (i.e., for PBS and slurm)
-        """
+        """Build a SubprocessRunner."""
         return SubprocessRunner(job, options, self.scheduler_options)
-
-    def setSuccessfulMessage(self, tester):
-        """properly set a finished successful message for tester"""
-        message = ""
-
-        # Handle 'dry run' first, because if true, job.run() never took place
-        if self.options.dry_run:
-            message = "DRY RUN"
-
-        elif tester.specs["check_input"]:
-            message = "SYNTAX PASS"
-
-        elif self.options.scaling and tester.specs["scale_refine"]:
-            message = "SCALED"
-
-        elif (
-            self.options.enable_recover
-            and tester.specs.isValid("skip_checks")
-            and tester.specs["skip_checks"]
-        ):
-            message = "PART1"
-
-        tester.setStatus(tester.success, message)
 
     def waitFinish(self):
         # Start the memory monitor if enabled

--- a/python/TestHarness/schedulers/RunParallel.py
+++ b/python/TestHarness/schedulers/RunParallel.py
@@ -121,6 +121,9 @@ class RunParallel(Scheduler):
 
         super().waitFinish()
 
+        if self._memory_monitor:
+            self._memory_monitor.stop()
+
     def monitorJobProcesses(self):
         """Monitor the running job processes, if enabled."""
         # Process memory monitoring is disabled

--- a/python/TestHarness/schedulers/RunParallel.py
+++ b/python/TestHarness/schedulers/RunParallel.py
@@ -8,10 +8,16 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 import traceback
+import platform
+from typing import TYPE_CHECKING
+from importlib.util import find_spec
 
 from TestHarness.schedulers.Scheduler import Scheduler
 from TestHarness import util
 from TestHarness.runners.SubprocessRunner import Runner, SubprocessRunner
+
+if platform.system() != "Windows" and find_spec("psutil") is not None or TYPE_CHECKING:
+    from TestHarness.utils.monitor_processes import get_processes_memory
 
 
 class RunParallel(Scheduler):
@@ -94,3 +100,37 @@ class RunParallel(Scheduler):
             message = "PART1"
 
         tester.setStatus(tester.success, message)
+
+    def monitorJobProcesses(self):
+        """Monitor the running job processes, if enabled."""
+        # Process memory monitoring is disabled
+        if not self.MONITOR_JOB_MEMORY or self.options.no_memory_tracking:
+            return
+
+        # Get the PIDs of the current running jobs so that they can be sampled
+        pid_to_job = self.getActiveJobPIDMap()
+
+        # Get memory for running jobs
+        processes_memory = get_processes_memory(set(pid_to_job.keys()))
+
+        # Update job memory and kill jobs over memory
+        max_memory_per_slot = self.options.max_memory_per_slot
+        for pid, job in pid_to_job.items():
+            if (memory := processes_memory.get(pid)) is not None:
+                # If the job is already an error (we killed it), nothing to do:
+                if job.getStatus() == job.error:
+                    continue
+
+                # Update max memory, if greater; this is True if it was greater
+                updated = job.getRunner().updateMaxMemory(memory)
+
+                # Check memory usage if needed
+                if updated and max_memory_per_slot:
+                    memory_per_slot_mb = memory / job.getSlots() * 2**-20
+                    if memory_per_slot_mb > max_memory_per_slot:
+                        message = (
+                            "JOB KILLED (OVER MEMORY): "
+                            f"Memory/slot {memory_per_slot_mb:.2f} "
+                            f"MB > allowed {max_memory_per_slot:.2f} MB"
+                        )
+                        job.killProcess(job.error, "KILLED: OVER MEMORY", message)

--- a/python/TestHarness/schedulers/RunParallel.py
+++ b/python/TestHarness/schedulers/RunParallel.py
@@ -116,7 +116,7 @@ class RunParallel(Scheduler):
     def waitFinish(self):
         # Start the memory monitor if enabled
         if self.scheduler_options.monitor_job_memory:
-            self._memory_monitor = MemoryMonitor(os.getpid(), interval=0.1)
+            self._memory_monitor = MemoryMonitor(os.getpid(), interval=0.2)
             self._memory_monitor.start()
 
         super().waitFinish()

--- a/python/TestHarness/schedulers/RunParallel.py
+++ b/python/TestHarness/schedulers/RunParallel.py
@@ -9,15 +9,18 @@
 
 import traceback
 import platform
+import os
 from typing import TYPE_CHECKING
 from importlib.util import find_spec
+from time import perf_counter
+from typing import Optional
 
 from TestHarness.schedulers.Scheduler import Scheduler
 from TestHarness import util
 from TestHarness.runners.SubprocessRunner import Runner, SubprocessRunner
 
 if platform.system() != "Windows" and find_spec("psutil") is not None or TYPE_CHECKING:
-    from TestHarness.utils.monitor_processes import get_processes_memory
+    from TestHarness.utils.monitor_processes import MemoryMonitor
 
 
 class RunParallel(Scheduler):
@@ -30,6 +33,15 @@ class RunParallel(Scheduler):
     def validParams():
         params = Scheduler.validParams()
         return params
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._memory_monitor: Optional[MemoryMonitor] = None
+        """The MemoryMonitor for sampling child process memory, if any."""
+
+        if self.scheduler_options.monitor_job_memory:
+            self._memory_monitor = MemoryMonitor(os.getpid(), interval=0.1)
 
     def run(self, job):
         """Run a tester command"""
@@ -101,22 +113,30 @@ class RunParallel(Scheduler):
 
         tester.setStatus(tester.success, message)
 
+    def waitFinish(self):
+        # Start the memory monitor if enabled
+        if self.scheduler_options.monitor_job_memory:
+            self._memory_monitor = MemoryMonitor(os.getpid(), interval=0.1)
+            self._memory_monitor.start()
+
+        super().waitFinish()
+
     def monitorJobProcesses(self):
         """Monitor the running job processes, if enabled."""
         # Process memory monitoring is disabled
-        if not self.MONITOR_JOB_MEMORY or self.options.no_memory_tracking:
+        if self._memory_monitor is None:
             return
 
         # Get the PIDs of the current running jobs so that they can be sampled
         pid_to_job = self.getActiveJobPIDMap()
 
-        # Get memory for running jobs
-        processes_memory = get_processes_memory(set(pid_to_job.keys()))
+        # Get latest samples from the monitor
+        samples = self._memory_monitor.get_samples()
 
         # Update job memory and kill jobs over memory
         max_memory_per_slot = self.options.max_memory_per_slot
         for pid, job in pid_to_job.items():
-            if (memory := processes_memory.get(pid)) is not None:
+            if (memory := samples.get(pid)) is not None:
                 # If the job is already an error (we killed it), nothing to do:
                 if job.getStatus() == job.error:
                     continue

--- a/python/TestHarness/schedulers/RunParallel.py
+++ b/python/TestHarness/schedulers/RunParallel.py
@@ -70,7 +70,7 @@ class RunParallel(Scheduler):
         This exists as a method so that derived schedulers can change how they
         run commands (i.e., for PBS and slurm)
         """
-        return SubprocessRunner(job, options)
+        return SubprocessRunner(job, options, self.scheduler_options)
 
     def setSuccessfulMessage(self, tester):
         """properly set a finished successful message for tester"""

--- a/python/TestHarness/schedulers/RunParallel.py
+++ b/python/TestHarness/schedulers/RunParallel.py
@@ -25,9 +25,6 @@ class RunParallel(Scheduler):
         params = Scheduler.validParams()
         return params
 
-    def __init__(self, harness, params):
-        Scheduler.__init__(self, harness, params)
-
     def run(self, job):
         """Run a tester command"""
         # Build and set the runner that will actually run the commands

--- a/python/TestHarness/schedulers/RunSlurm.py
+++ b/python/TestHarness/schedulers/RunSlurm.py
@@ -18,6 +18,8 @@ class RunSlurm(RunHPC):
     Scheduler class for the slurm HPC scheduler.
     """
 
+    MONITOR_JOB_MEMORY = True
+
     def __init__(self, harness, params):
         super().__init__(harness, params)
 
@@ -35,8 +37,11 @@ class RunSlurm(RunHPC):
             "--parsable2",
             "--noheader",
             "-o",
-            "jobid,exitcode,state,reason,start,end,maxrss",
+            "jobid,exitcode,state,reason,start,end",
         ]
+        if self.scheduler_options.monitor_job_memory:
+            cmd[-1] += ",maxrss"
+
         exit_code, result, _ = self.callHPC(CallHPCPoolType.status, " ".join(cmd))
         if exit_code != 0:
             return False
@@ -64,7 +69,9 @@ class RunSlurm(RunHPC):
                     "max_rss": 0,
                 }
             # Update max memory, across all sub-jobs in a single job
-            if max_rss := status_split[6]:
+            if self.scheduler_options.monitor_job_memory and (
+                max_rss := status_split[6]
+            ):
                 max_rss_bytes = int(max_rss.split("K")[0]) * 1024
                 statuses[id_num]["max_rss"] = max(
                     statuses[id_num]["max_rss"], max_rss_bytes

--- a/python/TestHarness/schedulers/RunSlurm.py
+++ b/python/TestHarness/schedulers/RunSlurm.py
@@ -35,7 +35,7 @@ class RunSlurm(RunHPC):
             "--parsable2",
             "--noheader",
             "-o",
-            "jobid,exitcode,state,reason,start,end",
+            "jobid,exitcode,state,reason,start,end,maxrss",
         ]
         exit_code, result, _ = self.callHPC(CallHPCPoolType.status, " ".join(cmd))
         if exit_code != 0:
@@ -46,19 +46,29 @@ class RunSlurm(RunHPC):
         for status in result.splitlines():
             # jobid,exitcode,state,reason are split by |
             status_split = status.split("|")
-            # Slurm has sub jobs under each job, and we only care about the top-level job
+            # Slurm has sub jobs under each job, and we only care about
+            # the top level job for most things except max memory
             id = status_split[0]
-            if not id.isdigit():
-                continue
+            id_split = id.split(".")
+            id_num = int(id_split[0])
+            id_suffix = id_split[1] if len(id_split) > 1 else None
             # exitcode is <val>:<val>, where the first value is the
             # exit code of the process, the second is a slurm internal code
-            statuses[id] = {
-                "exitcode": int(status_split[1].split(":")[0]),
-                "state": status_split[2],
-                "reason": status_split[3],
-                "start": status_split[4],
-                "end": status_split[5],
-            }
+            if id_suffix is None:
+                statuses[id_num] = {
+                    "exitcode": int(status_split[1].split(":")[0]),
+                    "state": status_split[2],
+                    "reason": status_split[3],
+                    "start": status_split[4],
+                    "end": status_split[5],
+                    "max_rss": 0,
+                }
+            # Update max memory, across all sub-jobs in a single job
+            if max_rss := status_split[6]:
+                max_rss_bytes = int(max_rss.split("K")[0]) * 1024
+                statuses[id_num]["max_rss"] = max(
+                    statuses[id_num]["max_rss"], max_rss_bytes
+                )
 
         # Update the jobs that we can
         for hpc_job in hpc_jobs:
@@ -69,7 +79,7 @@ class RunSlurm(RunHPC):
                 return None
 
             # Slurm jobs are sometimes not immediately available
-            status = statuses.get(hpc_job.id)
+            status = statuses.get(int(hpc_job.id))
             if status is None:
                 continue
 
@@ -88,13 +98,17 @@ class RunSlurm(RunHPC):
                     "RUNNING",
                     "COMPLETING",
                 ]:
+                    job = hpc_job.job
+
+                    # Update max memory if available
+                    if max_rss := status["max_rss"]:
+                        job.getRunner().updateMaxMemory(max_rss)
+
                     exit_code = int(status["exitcode"])
                     if state == "FAILED" and exit_code == 0:
                         raise Exception(
                             f"Job {hpc_job.id} has unexpected exit code {exit_code} with FAILED state"
                         )
-
-                    job = hpc_job.job
 
                     # Job has timed out; setting a timeout status means that this
                     # state is recoverable

--- a/python/TestHarness/schedulers/RunSlurm.py
+++ b/python/TestHarness/schedulers/RunSlurm.py
@@ -8,7 +8,9 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 import re
+from contextlib import suppress
 from datetime import datetime
+
 from RunHPC import CallHPCPoolType, RunHPC
 
 
@@ -36,6 +38,7 @@ class RunSlurm(RunHPC):
             active_job_ids,
             "--parsable2",
             "--noheader",
+            "--units=K",
             "-o",
             "jobid,exitcode,state,reason,start,end",
         ]
@@ -72,10 +75,11 @@ class RunSlurm(RunHPC):
             if self.scheduler_options.monitor_job_memory and (
                 max_rss := status_split[6]
             ):
-                max_rss_bytes = int(max_rss.split("K")[0]) * 1024
-                statuses[id_num]["max_rss"] = max(
-                    statuses[id_num]["max_rss"], max_rss_bytes
-                )
+                with suppress(ValueError):
+                    max_rss_bytes = int(max_rss.split("K")[0]) * 1024
+                    statuses[id_num]["max_rss"] = max(
+                        statuses[id_num]["max_rss"], max_rss_bytes
+                    )
 
         # Update the jobs that we can
         for hpc_job in hpc_jobs:

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -235,10 +235,10 @@ class Scheduler(MooseObject):
             and mpi_config.hwloc
             and not options.no_hwloc_topology
         ):
-            hwloc_topology_path = build_hwloc_topology()
-            self.harness.printInfo(
-                f"Using cached hwloc topology in '{hwloc_topology_path}'"
-            )
+            if hwloc_topology_path := build_hwloc_topology():
+                self.harness.printInfo(
+                    f"Using cached hwloc topology in '{hwloc_topology_path}'"
+                )
 
         # Can't restrict resources without tracking
         if self.options.max_memory_per_slot and (

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -394,20 +394,19 @@ class Scheduler(MooseObject):
                 if job.getStatus() == job.error:
                     continue
 
-                runner = job.getRunner()
-                max_memory = runner.max_memory  # bytes
-                if max_memory is None or memory > max_memory:
-                    runner.setMaxMemory(memory)
+                # Update max memory, if greater; this is True if it was greater
+                updated = job.getRunner().updateMaxMemory(memory)
 
-                    if max_memory_per_slot:
-                        memory_per_slot_mb = memory / job.getSlots() * 2**-20
-                        if memory_per_slot_mb > max_memory_per_slot:
-                            message = (
-                                "JOB KILLED (OVER MEMORY): "
-                                f"Memory/slot {memory_per_slot_mb:.2f} "
-                                f"MB > allowed {max_memory_per_slot:.2f} MB"
-                            )
-                            job.killProcess(job.error, "KILLED: OVER MEMORY", message)
+                # Check memory usage if needed
+                if updated and max_memory_per_slot:
+                    memory_per_slot_mb = memory / job.getSlots() * 2**-20
+                    if memory_per_slot_mb > max_memory_per_slot:
+                        message = (
+                            "JOB KILLED (OVER MEMORY): "
+                            f"Memory/slot {memory_per_slot_mb:.2f} "
+                            f"MB > allowed {max_memory_per_slot:.2f} MB"
+                        )
+                        job.killProcess(job.error, "KILLED: OVER MEMORY", message)
 
     def waitFinish(self):
         """

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -7,6 +7,7 @@
 # Licensed under LGPL 2.1, please see LICENSE for details
 # https://www.gnu.org/licenses/lgpl-2.1.html
 import os
+import platform
 import sys
 import threading
 import traceback
@@ -28,7 +29,7 @@ Whether or not get_process_memory() is available.
 
 Will be false if psutil is not available."""
 
-if find_spec("psutil") is not None or TYPE_CHECKING:
+if platform.system() != "Windows" and find_spec("psutil") is not None or TYPE_CHECKING:
     from TestHarness.utils.monitor_processes import get_processes_memory
 
     _HAS_GET_PROCESSES_MEMORY = True

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -11,16 +11,24 @@ import platform
 import sys
 import threading
 import traceback
+from dataclasses import dataclass
+from enum import Enum
 from importlib.util import find_spec
 from multiprocessing.pool import ThreadPool
 from time import sleep
 from timeit import default_timer as clock
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import pyhit
 from FactorySystem.MooseObject import MooseObject
 
 from TestHarness.JobDAG import JobDAG
+from TestHarness.mpi_config import (
+    MPIConfig,
+    MPIType,
+    build_hwloc_topology,
+    get_mpi_config,
+)
 from TestHarness.StatusSystem import StatusSystem
 from TestHarness.util import findBSDTime, findGNUTime
 
@@ -38,6 +46,35 @@ if platform.system() != "Windows" and find_spec("psutil") is not None or TYPE_CH
 
 class SchedulerError(Exception):
     pass
+
+
+class TimeUtilityType(Enum):
+    """The type of time utility found, if any."""
+
+    BSD = 0
+    GNU = 1
+    NONE = 2
+
+
+@dataclass(frozen=True)
+class SchedulerOptions:
+    """Options for the Scheduler."""
+
+    hwloc_topology_path: Optional[str]
+    """Path to the pre-built hwloc topology file, if any."""
+
+    mpi_config: MPIConfig
+    """The MPI configuration."""
+
+    monitor_job_cpu: bool
+    """Whether or not to monitor Job CPU usage."""
+    monitor_job_memory: bool
+    """Whether or not to monitor Job memory usage."""
+
+    time_utility_path: Optional[str]
+    """The path to the time utility found, if any."""
+    time_utility_type: TimeUtilityType
+    """The type of time utility found, if any."""
 
 
 class Scheduler(MooseObject):
@@ -74,11 +111,14 @@ class Scheduler(MooseObject):
     # This is what will be checked for when we look for valid schedulers
     IS_SCHEDULER = True
 
+    CAN_SET_HWLOC_TOPOLOGY = True
+    """Whether or not to set hwloc topology if available."""
+    CAN_OPENMPI_OVERSUBSCRIBE = True
+    """Whether or not OpenMPI can be set to oversubscribe."""
+    MONITOR_JOB_CPU = True
+    """Whether or not this Scheduler should monitor Job process CPU usage."""
     MONITOR_JOB_MEMORY = _HAS_GET_PROCESSES_MEMORY
     """Whether or not this Scheduler should monitor Job process memory usage."""
-
-    MONITOR_JOB_CPU = findBSDTime() is not None or findGNUTime() is not None
-    """Whether or not this Scheduler should monitor Job process CPU usage."""
 
     def __init__(self, harness, params):
         MooseObject.__init__(self, harness, params)
@@ -152,13 +192,75 @@ class Scheduler(MooseObject):
         # Whether or not to enforce the timeout of jobs
         self.enforce_timeout = True
 
-        # Can't restrict resources without tracking
-        if self.options.max_memory_per_slot and (
-            not self.MONITOR_JOB_MEMORY or self.options.no_memory_tracking
+        self.scheduler_options: SchedulerOptions = self.buildSchedulerOptions(
+            self.options
+        )
+        """The options for the scheduler."""
+
+    def buildSchedulerOptions(self, options) -> SchedulerOptions:
+        """Build the SchedulerOptions for this scheduler."""
+        # Build MPI configuration
+        mpi_config = get_mpi_config()
+
+        # Whether or not to monitor Job resources, depending on static
+        # Scheduler options and runtime command line options
+        monitor_job_cpu: bool = (
+            self.MONITOR_JOB_CPU is True and not options.no_cpu_tracking
+        )
+        monitor_job_memory: bool = (
+            self.MONITOR_JOB_MEMORY is True and not options.no_memory_tracking
+        )
+
+        # Find the time utility if needed, disabling CPU tracking
+        # if enabled but no time utility available
+        time_utility_type = TimeUtilityType.NONE
+        time_utility_path: Optional[str] = None
+        if monitor_job_memory:
+            if time_utility_path := findGNUTime():
+                time_utility_type = TimeUtilityType.GNU
+            elif time_utility_path := findBSDTime():
+                time_utility_type = TimeUtilityType.BSD
+            if time_utility_type == TimeUtilityType.NONE:
+                monitor_job_cpu = False
+
+        # Build hwloc topology file if set to do so
+        hwloc_topology_path: Optional[str] = None
+        if (
+            self.CAN_SET_HWLOC_TOPOLOGY
+            and mpi_config.hwloc
+            and not options.disable_hwloc_topology
         ):
+            hwloc_topology_path = build_hwloc_topology()
+            self.harness.printInfo(
+                f"Using cached hwloc topology in '{hwloc_topology_path}'"
+            )
+
+        # Can't restrict resources without tracking
+        if self.options.max_memory_per_slot and not monitor_job_memory:
             self.harness.errorExit(
                 "Cannot specify --max-memory-per-slot; memory tracking is not available"
             )
+        # Can't disable hwloc topology
+        if options.disable_hwloc_topology and not self.CAN_SET_HWLOC_TOPOLOGY:
+            self.harness.errorExit(
+                "Cannot --disable-hwloc-topology; scheduler does not "
+                "support setting it"
+            )
+        # Can't disable openmpi oversubscribe
+        if options.disable_openmpi_oversubscribe and not self.CAN_OPENMPI_OVERSUBSCRIBE:
+            self.harness.errorExit(
+                "Cannot --disable-openmpi-oversubscribe; scheduler does not "
+                "support setting it"
+            )
+
+        return SchedulerOptions(
+            hwloc_topology_path=hwloc_topology_path,
+            mpi_config=mpi_config,
+            monitor_job_cpu=monitor_job_cpu,
+            monitor_job_memory=monitor_job_memory,
+            time_utility_path=time_utility_path,
+            time_utility_type=time_utility_type,
+        )
 
     def getErrorState(self):
         """

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -43,6 +43,9 @@ if platform.system() != "Windows" and find_spec("psutil") is not None or TYPE_CH
 
     _HAS_GET_PROCESSES_MEMORY = True
 
+if TYPE_CHECKING:
+    from TestHarness.schedulers.Job import Job
+
 
 class SchedulerError(Exception):
     pass
@@ -113,6 +116,8 @@ class Scheduler(MooseObject):
 
     CAN_SET_HWLOC_TOPOLOGY = True
     """Whether or not to set hwloc topology if available."""
+    CAN_SET_MAX_MEMORY = True
+    """Whether or not Job max memory can be set (Jobs can be killed if over memory)."""
     CAN_OPENMPI_OVERSUBSCRIBE = True
     """Whether or not OpenMPI can be set to oversubscribe."""
     MONITOR_JOB_CPU = True
@@ -236,7 +241,9 @@ class Scheduler(MooseObject):
             )
 
         # Can't restrict resources without tracking
-        if self.options.max_memory_per_slot and not monitor_job_memory:
+        if self.options.max_memory_per_slot and (
+            not monitor_job_memory or not self.CAN_SET_MAX_MEMORY
+        ):
             self.harness.errorExit(
                 "Cannot specify --max-memory-per-slot; memory tracking is not available"
             )
@@ -370,43 +377,18 @@ class Scheduler(MooseObject):
         return True
 
     def monitorJobProcesses(self):
-        """Monitor the running job processes, if enabled."""
-        # Process memory monitoring is disabled
-        if not self.MONITOR_JOB_MEMORY or self.options.no_memory_tracking:
-            return
+        """Monitor the running job processes; called during the poll loop."""
 
-        # Get the PIDs of the current running jobs so that they can be sampled
+        pass
+
+    def getActiveJobPIDMap(self) -> dict[int, "Job"]:
+        """Get the active job PID -> Job map."""
         with self.__active_jobs_lock:
-            pid_to_job = {
+            return {
                 pid: job
                 for job in self.__active_jobs
                 if ((runner := job.getRunner()) and (pid := runner.pid))
             }
-
-        # Get memory for running jobs
-        processes_memory = get_processes_memory(set(pid_to_job.keys()))
-
-        # Update job memory and kill jobs over memory
-        max_memory_per_slot = self.options.max_memory_per_slot
-        for pid, job in pid_to_job.items():
-            if (memory := processes_memory.get(pid)) is not None:
-                # If the job is already an error (we killed it), nothing to do:
-                if job.getStatus() == job.error:
-                    continue
-
-                # Update max memory, if greater; this is True if it was greater
-                updated = job.getRunner().updateMaxMemory(memory)
-
-                # Check memory usage if needed
-                if updated and max_memory_per_slot:
-                    memory_per_slot_mb = memory / job.getSlots() * 2**-20
-                    if memory_per_slot_mb > max_memory_per_slot:
-                        message = (
-                            "JOB KILLED (OVER MEMORY): "
-                            f"Memory/slot {memory_per_slot_mb:.2f} "
-                            f"MB > allowed {max_memory_per_slot:.2f} MB"
-                        )
-                        job.killProcess(job.error, "KILLED: OVER MEMORY", message)
 
     def waitFinish(self):
         """

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -232,6 +232,10 @@ class Scheduler(MooseObject):
                 )
 
         # Can't restrict resources without tracking
+        if self.options.max_cpu_per_slot and not monitor_job_cpu:
+            self.harness.errorExit(
+                "Cannot specify --max-cpu-per-slot; CPU tracking is not available"
+            )
         if self.options.max_memory_per_slot and (
             not monitor_job_memory or not self.CAN_SET_MAX_MEMORY
         ):

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -7,13 +7,11 @@
 # Licensed under LGPL 2.1, please see LICENSE for details
 # https://www.gnu.org/licenses/lgpl-2.1.html
 import os
-import platform
 import sys
 import threading
 import traceback
 from dataclasses import dataclass
 from enum import Enum
-from importlib.util import find_spec
 from multiprocessing.pool import ThreadPool
 from time import sleep
 from timeit import default_timer as clock
@@ -25,12 +23,11 @@ from FactorySystem.MooseObject import MooseObject
 from TestHarness.JobDAG import JobDAG
 from TestHarness.mpi_config import (
     MPIConfig,
-    MPIType,
     build_hwloc_topology,
     get_mpi_config,
 )
 from TestHarness.StatusSystem import StatusSystem
-from TestHarness.util import findBSDTime, findGNUTime
+from TestHarness.util import findBSDTime, findGNUTime, outputHeader
 
 if TYPE_CHECKING:
     from TestHarness.schedulers.Job import Job
@@ -103,17 +100,15 @@ class Scheduler(MooseObject):
     # This is what will be checked for when we look for valid schedulers
     IS_SCHEDULER = True
 
-    CAN_SET_HWLOC_TOPOLOGY = True
+    CAN_SET_HWLOC_TOPOLOGY = False
     """Whether or not to set hwloc topology if available."""
-    CAN_SET_MAX_MEMORY = True
+    CAN_SET_MAX_MEMORY = False
     """Whether or not Job max memory can be set (Jobs can be killed if over memory)."""
-    CAN_OPENMPI_OVERSUBSCRIBE = True
+    CAN_OPENMPI_OVERSUBSCRIBE = False
     """Whether or not OpenMPI can be set to oversubscribe."""
-    MONITOR_JOB_CPU = True
+    MONITOR_JOB_CPU = False
     """Whether or not this Scheduler should monitor Job process CPU usage."""
-    MONITOR_JOB_MEMORY = (
-        platform.system() != "Windows" and find_spec("psutil") is not None
-    )
+    MONITOR_JOB_MEMORY = False
     """Whether or not this Scheduler should monitor Job process memory usage."""
 
     def __init__(self, harness, params):
@@ -324,8 +319,67 @@ class Scheduler(MooseObject):
         )
 
     def run(self, job):
-        """Call derived run method"""
-        return
+        """Run a tester command"""
+
+        # Build and set the runner that will actually run the commands
+        # This is abstracted away so we can support local runners and PBS/slurm runners
+        job.setRunner(self.buildRunner(job, self.options))
+
+        tester = job.getTester()
+
+        # Do not execute app, and do not processResults
+        if self.options.dry_run:
+            self.setSuccessfulMessage(tester)
+            return
+        # Load results from a previous run
+        elif self.options.show_last_run:
+            job.loadPreviousResults()
+            return
+
+        # Start job timer
+        job.timer.startMain()
+
+        # Anything that throws while running or processing a job should be caught
+        # and the job should fail
+        try:
+            # Launch and wait for the command to finish
+            job.run()
+
+            # Set the successful message
+            if not tester.isSkip() and not job.isFail():
+                self.setSuccessfulMessage(tester)
+        except:
+            trace = traceback.format_exc()
+            job.appendOutput(
+                outputHeader("Python exception encountered in Job") + trace
+            )
+            job.setStatus(job.error, "JOB EXCEPTION")
+        finally:
+            # Stop job timer
+            job.timer.stopMain()
+
+    def setSuccessfulMessage(self, tester):
+        """properly set a finished successful message for tester"""
+        message = ""
+
+        # Handle 'dry run' first, because if true, job.run() never took place
+        if self.options.dry_run:
+            message = "DRY RUN"
+
+        elif tester.specs["check_input"]:
+            message = "SYNTAX PASS"
+
+        elif self.options.scaling and tester.specs["scale_refine"]:
+            message = "SCALED"
+
+        elif (
+            self.options.enable_recover
+            and tester.specs.isValid("skip_checks")
+            and tester.specs["skip_checks"]
+        ):
+            message = "PART1"
+
+        tester.setStatus(tester.success, message)
 
     def augmentJobs(self, jobs):
         """

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -270,7 +270,7 @@ class Scheduler(MooseObject):
             }
 
         # Get memory for running jobs
-        processes_memory = get_processes_memory(pid_to_job.keys())
+        processes_memory = get_processes_memory(set(pid_to_job.keys()))
 
         # Update job memory and kill jobs over memory
         max_memory_per_slot = self.options.max_memory_per_slot
@@ -281,14 +281,12 @@ class Scheduler(MooseObject):
                     continue
 
                 runner = job.getRunner()
-                slots = job.getSlots()
-
                 max_memory = runner.max_memory  # bytes
                 if max_memory is None or memory > max_memory:
                     runner.setMaxMemory(memory)
 
                     if max_memory_per_slot:
-                        memory_per_slot_mb = memory / slots * 2**-20
+                        memory_per_slot_mb = memory / job.getSlots() * 2**-20
                         if memory_per_slot_mb > max_memory_per_slot:
                             message = (
                                 "JOB KILLED (OVER MEMORY): "
@@ -309,7 +307,7 @@ class Scheduler(MooseObject):
             while True:
                 if not self.isRunning():
                     break
-                sleep(0.25)
+                sleep(0.1)
                 self.monitorJobProcesses()
 
             error_state = self.getErrorState()

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -220,7 +220,7 @@ class Scheduler(MooseObject):
         # if enabled but no time utility available
         time_utility_type = TimeUtilityType.NONE
         time_utility_path: Optional[str] = None
-        if monitor_job_memory:
+        if monitor_job_cpu:
             if time_utility_path := findGNUTime():
                 time_utility_type = TimeUtilityType.GNU
             elif time_utility_path := findBSDTime():

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -32,17 +32,6 @@ from TestHarness.mpi_config import (
 from TestHarness.StatusSystem import StatusSystem
 from TestHarness.util import findBSDTime, findGNUTime
 
-_HAS_GET_PROCESSES_MEMORY = False
-"""
-Whether or not get_process_memory() is available.
-
-Will be false if psutil is not available."""
-
-if platform.system() != "Windows" and find_spec("psutil") is not None or TYPE_CHECKING:
-    from TestHarness.utils.monitor_processes import get_processes_memory
-
-    _HAS_GET_PROCESSES_MEMORY = True
-
 if TYPE_CHECKING:
     from TestHarness.schedulers.Job import Job
 
@@ -122,7 +111,9 @@ class Scheduler(MooseObject):
     """Whether or not OpenMPI can be set to oversubscribe."""
     MONITOR_JOB_CPU = True
     """Whether or not this Scheduler should monitor Job process CPU usage."""
-    MONITOR_JOB_MEMORY = _HAS_GET_PROCESSES_MEMORY
+    MONITOR_JOB_MEMORY = (
+        platform.system() != "Windows" and find_spec("psutil") is not None
+    )
     """Whether or not this Scheduler should monitor Job process memory usage."""
 
     def __init__(self, harness, params):

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -22,6 +22,7 @@ from FactorySystem.MooseObject import MooseObject
 
 from TestHarness.JobDAG import JobDAG
 from TestHarness.StatusSystem import StatusSystem
+from TestHarness.util import findBSDTime, findGNUTime
 
 _HAS_GET_PROCESSES_MEMORY = False
 """
@@ -75,6 +76,9 @@ class Scheduler(MooseObject):
 
     MONITOR_JOB_MEMORY = _HAS_GET_PROCESSES_MEMORY
     """Whether or not this Scheduler should monitor Job process memory usage."""
+
+    MONITOR_JOB_CPU = findBSDTime() is not None or findGNUTime() is not None
+    """Whether or not this Scheduler should monitor Job process CPU usage."""
 
     def __init__(self, harness, params):
         MooseObject.__init__(self, harness, params)
@@ -147,6 +151,14 @@ class Scheduler(MooseObject):
         self.report_long_jobs = True
         # Whether or not to enforce the timeout of jobs
         self.enforce_timeout = True
+
+        # Can't restrict resources without tracking
+        if self.options.max_memory_per_slot and (
+            not self.MONITOR_JOB_MEMORY or self.options.no_memory_tracking
+        ):
+            self.harness.errorExit(
+                "Cannot specify --max-memory-per-slot; memory tracking is not available"
+            )
 
     def getErrorState(self):
         """
@@ -259,7 +271,7 @@ class Scheduler(MooseObject):
     def monitorJobProcesses(self):
         """Monitor the running job processes, if enabled."""
         # Process memory monitoring is disabled
-        if not self.MONITOR_JOB_MEMORY:
+        if not self.MONITOR_JOB_MEMORY or self.options.no_memory_tracking:
             return
 
         # Get the PIDs of the current running jobs so that they can be sampled

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -228,7 +228,7 @@ class Scheduler(MooseObject):
         if (
             self.CAN_SET_HWLOC_TOPOLOGY
             and mpi_config.hwloc
-            and not options.disable_hwloc_topology
+            and not options.no_hwloc_topology
         ):
             hwloc_topology_path = build_hwloc_topology()
             self.harness.printInfo(
@@ -241,15 +241,14 @@ class Scheduler(MooseObject):
                 "Cannot specify --max-memory-per-slot; memory tracking is not available"
             )
         # Can't disable hwloc topology
-        if options.disable_hwloc_topology and not self.CAN_SET_HWLOC_TOPOLOGY:
+        if options.no_hwloc_topology and not self.CAN_SET_HWLOC_TOPOLOGY:
             self.harness.errorExit(
-                "Cannot --disable-hwloc-topology; scheduler does not "
-                "support setting it"
+                "Cannot --no-hwloc-topology; scheduler does not " "support setting it"
             )
         # Can't disable openmpi oversubscribe
-        if options.disable_openmpi_oversubscribe and not self.CAN_OPENMPI_OVERSUBSCRIBE:
+        if options.no_openmpi_oversubscribe and not self.CAN_OPENMPI_OVERSUBSCRIBE:
             self.harness.errorExit(
-                "Cannot --disable-openmpi-oversubscribe; scheduler does not "
+                "Cannot --no-openmpi-oversubscribe; scheduler does not "
                 "support setting it"
             )
 

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -211,7 +211,7 @@ class Scheduler(MooseObject):
                 time_utility_type = TimeUtilityType.GNU
             elif time_utility_path := findBSDTime():
                 time_utility_type = TimeUtilityType.BSD
-            if time_utility_type == TimeUtilityType.NONE:
+            else:
                 monitor_job_cpu = False
 
         # Build hwloc topology file if set to do so

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -18,7 +18,7 @@ from Tester import Tester
 
 from TestHarness import TestHarness, util
 from TestHarness.capability_util import addAugmentedCapability
-from TestHarness.mpi_config import MPIConfig, MPIType
+from TestHarness.mpi_config import MPIType
 
 
 class RunApp(Tester):
@@ -392,7 +392,7 @@ class RunApp(Tester):
             )
 
             # Need to run mpiexec with containerized openmpi
-            if options.hpc and options.mpi_config.mpi_type == MPIType.OPENMPI:
+            if options.hpc and options.scheduler.mpi_config.mpi_type == MPIType.OPENMPI:
                 cmd = f"mpiexec -n 1 {cmd}"
 
             return cmd

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -516,7 +516,9 @@ class RunApp(Tester):
         if (
             force_mpi
             or ncpus > 1
-            or (options.hpc and options.mpi_config.mpi_type == MPIType.OPENMPI)
+            or (
+                options.hpc and options.scheduler.mpi_config.mpi_type == MPIType.OPENMPI
+            )
         ):
             command = f"{mpi_command} -n {ncpus} {command}"
 

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -657,9 +657,10 @@ class RunApp(Tester):
         derived testers from having a successful status set, before actually running
         the derived processResults method.
 
-        # TODO: because RunParallel is now setting every successful status message,
+        # TODO: because Scheduler is now setting every successful status message,
                 refactor testFileOutput and processResults.
         """
+
         # If we had capability requirements and get an exit 77, it means that the
         # capability doesn't exist in the binary
         if self.specs["capabilities"] and exit_code == 77:

--- a/python/TestHarness/tests/TestHarnessTestCase.py
+++ b/python/TestHarness/tests/TestHarnessTestCase.py
@@ -123,7 +123,11 @@ class TestHarnessTestCase(unittest.TestCase):
             Test spec (dict of str -> params) to run instead.
 
         """
-        argv = ["unused"] + list(args) + ["--term-format", "njCst"]
+        argv = (
+            ["unused"]
+            + list(args)
+            + ["--term-format", "njCst", "--disable-hwloc-topology"]
+        )
         if minimal_capabilities:
             argv += ["--minimal-capabilities"]
 

--- a/python/TestHarness/tests/TestHarnessTestCase.py
+++ b/python/TestHarness/tests/TestHarnessTestCase.py
@@ -124,7 +124,9 @@ class TestHarnessTestCase(unittest.TestCase):
 
         """
         argv = (
-            ["unused"] + list(args) + ["--term-format", "njCst", "--no-hwloc-topology"]
+            ["unused"]
+            + list(args)
+            + ["--term-format", "njCst", "--no-hwloc-topology", "--no-memory-tracking"]
         )
         if minimal_capabilities:
             argv += ["--minimal-capabilities"]

--- a/python/TestHarness/tests/TestHarnessTestCase.py
+++ b/python/TestHarness/tests/TestHarnessTestCase.py
@@ -124,9 +124,7 @@ class TestHarnessTestCase(unittest.TestCase):
 
         """
         argv = (
-            ["unused"]
-            + list(args)
-            + ["--term-format", "njCst", "--disable-hwloc-topology"]
+            ["unused"] + list(args) + ["--term-format", "njCst", "--no-hwloc-topology"]
         )
         if minimal_capabilities:
             argv += ["--minimal-capabilities"]

--- a/python/TestHarness/tests/test_GetExecutable.py
+++ b/python/TestHarness/tests/test_GetExecutable.py
@@ -50,8 +50,8 @@ class TestGetExecutable(TestHarnessTestCase):
             # Cannot test for an absent method when all methods are present
             return
 
-        with self.assertRaisesRegex(SystemExit, "Failed to find MOOSE executable"):
-            self.runTests(f"--{method}")
+        result = self.runTests(f"--{method}", exit_code=1)
+        self.assertIn("Failed to find MOOSE executable", result.output)
 
     def testMethodIsPresent(self):
         """Test for method that exists in test."""

--- a/python/TestHarness/tests/test_OnlyTestsThatRequire.py
+++ b/python/TestHarness/tests/test_OnlyTestsThatRequire.py
@@ -92,14 +92,13 @@ class TestRequireCapability(TestHarnessTestCase):
         )
 
         # Catch exceptions with CLI error
-        with self.assertRaisesRegex(
-            SystemExit,
-            "ERROR: --only-tests-that-require: Capability 'fOO!' has unallowed "
-            "characters",
-        ):
-            self.runTests(
-                "--only-tests-that-require", "fOO!", minimal_capabilities=True
-            )
+        result = self.runTests(
+            "--only-tests-that-require", "fOO!", minimal_capabilities=True, exit_code=1
+        )
+        self.assertIn(
+            "--only-tests-that-require: Capability 'fOO!' has unallowed characters",
+            result.output,
+        )
 
     def testTesterSkip(self):
         """Test the Tester skipping tests with --only-tests-that-require."""

--- a/python/TestHarness/tests/test_Replay.py
+++ b/python/TestHarness/tests/test_Replay.py
@@ -84,13 +84,8 @@ class TestHarnessTester(TestHarnessTestCase):
 
     def testNoResultsFile(self):
         """Verify the TestHarness errors correctly when there is no results file."""
-        with (
-            tempfile.TemporaryDirectory() as output_dir,
-            self.assertRaisesRegex(
-                SystemExit, f"The previous run {output_dir}/non_existent does not exist"
-            ),
-        ):
-            self.runTests(
+        with tempfile.TemporaryDirectory() as output_dir:
+            result = self.runTests(
                 "--show-last-run",
                 "--results-file",
                 "non_existent",
@@ -100,3 +95,6 @@ class TestHarnessTester(TestHarnessTestCase):
                 capture_results=False,
                 exit_code=1,
             )
+        self.assertIn(
+            f"The previous run {output_dir}/non_existent does not exist", result.output
+        )

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -423,26 +423,8 @@ def _findTimeUtility(test_utility: Callable[[str], bool]) -> Optional[str]:
     return None
 
 
-_GNU_TIME_PATH: Optional[str] = None
-"""Global used in findGNUTime() for the path to GNU time."""
-
-_GNU_TIME_PATH_SET: bool = False
-"""Global used in findGNUTime() for if _GNU_TIME_PATH is set."""
-
-_GNU_TIME_LOCK = threading.Lock()
-"""Global thread lock for accessing _GNU_TIME_PATH and _GNU_TIME_PATH_SET."""
-
-
 def findGNUTime() -> Optional[str]:
-    """
-    Find the GNU time utility.
-
-    This is cached so that it only searches for the utility
-    once and then stores the result. The cache is thread safe.
-    """
-    global _GNU_TIME_PATH
-    global _GNU_TIME_PATH_SET
-    global _GNU_TIME_LOCK
+    """Find the GNU time utility, if any."""
 
     # Helper for testing "time" to see if it is GNU time
     def test_gnu_time(path: str) -> bool:
@@ -455,37 +437,11 @@ def findGNUTime() -> Optional[str]:
         else:
             return "(GNU Time)" in out
 
-    # Obtain a lock so that this is thread safe
-    with _GNU_TIME_LOCK:
-        # First time; search for time
-        if not _GNU_TIME_PATH_SET:
-            _GNU_TIME_PATH = _findTimeUtility(test_gnu_time)
-            _GNU_TIME_PATH_SET = True
-
-        # Use value from cache
-        return _GNU_TIME_PATH
-
-
-_BSD_TIME_PATH: Optional[str] = None
-"""Global used in findBSDTime() for the path to BSD time."""
-
-_BSD_TIME_PATH_SET: bool = False
-"""Global used in findBSDTime() for if _BSD_TIME_PATH is set."""
-
-_BSD_TIME_LOCK = threading.Lock()
-"""Global thread lock for accessing _BSD_TIME_PATH and _BSD_TIME_PATH_SET."""
+    return _findTimeUtility(test_gnu_time)
 
 
 def findBSDTime() -> Optional[str]:
-    """
-    Find the BSD time utility.
-
-    This is cached so that it only searches for the utility
-    once and then stores the result. The cache is thread safe.
-    """
-    global _BSD_TIME_PATH
-    global _BSD_TIME_PATH_SET
-    global _BSD_TIME_LOCK
+    """Find the BSD time utility, if any."""
 
     # Helper for testing "time" to see if it is BSD time
     def test_bsd_time(path: str) -> bool:
@@ -500,15 +456,7 @@ def findBSDTime() -> Optional[str]:
             return "illegal option -- -" in process.stderr
         return False
 
-    # Obtain a lock so that this is thread safe
-    with _BSD_TIME_LOCK:
-        # First time; search for time
-        if not _BSD_TIME_PATH_SET:
-            _BSD_TIME_PATH = _findTimeUtility(test_bsd_time)
-            _BSD_TIME_PATH_SET = True
-
-        # Use value from cache
-        return _BSD_TIME_PATH
+    return _findTimeUtility(test_bsd_time)
 
 
 def printPrefixed(prefix: str, *args, color: Optional[str] = None):
@@ -522,3 +470,12 @@ def printPrefixed(prefix: str, *args, color: Optional[str] = None):
 def printInfo(*args, colored: bool):
     """Print the given message as information."""
     printPrefixed("INFO", *args, color="CYAN" if colored else None)
+
+
+def errorExit(*args, colored: bool = True, exit_code: int = 1):
+    """Print an error message with a ERROR prefix and exit."""
+    prefix = "ERROR:"
+    if colored:
+        prefix = colorText(prefix, "RED")
+    print(prefix, *args, flush=True)
+    raise SystemExit(exit_code)

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -147,7 +147,11 @@ def formatResult(
         ):
             if entry.memory is not None or entry.timing == 0:
                 value = int(entry.memory * 2**-20) if entry.memory else 0
-                message = f"[{value:>4}MB]"
+                if value < 10000:
+                    message = f"[{value:>4}MB]"
+                else:
+                    value = int(value / 1024)
+                    message = f"[{value:>4}GB]"
             else:
                 message = "[   ?MB]"
 

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -115,7 +115,7 @@ class MemoryMonitor:
                 pid for pid, p in all_processes.items() if p.info["ppid"] == parent_pid
             )
 
-            # Recrusively check if any of the processes in "children_pids"
+            # Recursively check if any of the processes in "children_pids"
             # are a parent of this process at any level
             def in_children_pids(p: psutil.Process) -> Optional[int]:
                 ppid = p.info["ppid"]

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -11,8 +11,8 @@
 
 import os
 import sys
-from contextlib import suppress
-from typing import TYPE_CHECKING, Iterable, Optional
+from collections import defaultdict
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     import psutil
@@ -49,61 +49,59 @@ def get_process_memory(process: psutil.Process) -> Optional[int]:
     """
     # Prefer PSS if available
     if MEMORY_PSS:
-        data = None
-        with (
-            suppress(FileNotFoundError),
-            suppress(ProcessLookupError),
-            open(f"/proc/{process.pid}/smaps_rollup", "rb") as f,
-        ):
-            data = f.read()
-        if data is not None and (idx := data.find(b"Pss:")) != -1:
-            start = idx + 4
-            while data[start] == 32:
-                start += 1
-            end = start
-            while data[end] != 32:
-                end += 1
-            return int(data[start:end]) * 1024  # kilobytes -> bytes
-
+        try:
+            with open(f"/proc/{process.pid}/smaps_rollup", "rb") as f:
+                for line in f:
+                    if line.startswith(b"Pss:"):
+                        return int(line.split()[1]) * 1024  # b"Pss:   1234 kB"
+        except (FileNotFoundError, ProcessLookupError):
+            pass
     # Otherwise, use RSS (will double count shared memory)
     else:
-        with suppress(psutil.NoSuchProcess):
+        try:
             return process.memory_info().rss
+        except psutil.NoSuchProcess:
+            pass
 
     return None
 
 
-def get_processes_memory(pids: Iterable[int]) -> dict[int, int]:
+def get_processes_memory(pids: set[int]) -> defaultdict[int, int]:
     """
     Get the estimated total memory for each process, including children.
+
+    The children of the parent processes (the ones in "pids") must
+    have their process group IDs set to that of the parent. This
+    enables loading all processes at once, searching by process
+    group ID instead of needing to recurse through the process
+    tree for children for each parent process. This is true
+    in the SubprocessRunner, as we set preexec_fn=os.setsid
+    when spawning the parent subprocess.
 
     If a process is not running, it will not be included.
 
     Arguments:
     ---------
     pids : Iterable[int]
-        The IDs of the processes.
+        The PIDs of the parent processes.
 
     Returns:
     -------
-    dict[int, int]:
-        Mapping of pid -> estimated process memory in bytes.
+    defaultdict[int, int]:
+        Mapping of parent PID -> estimated process memory in bytes.
 
     """
 
-    def recursive_memory(pid: int) -> Optional[int]:
+    result = defaultdict(int)
+
+    for p in psutil.process_iter(["pid"]):
         try:
-            p = psutil.Process(pid)
-        except psutil.NoSuchProcess:
-            return None
+            pgid = os.getpgid(p.info["pid"])
+        except ProcessLookupError:
+            continue
+        if pgid not in pids:
+            continue
+        if (memory := get_process_memory(p)) is not None:
+            result[pgid] += memory
 
-        ps: list[psutil.Process] = [p]
-        with suppress(psutil.NoSuchProcess):
-            ps += p.children(recursive=True)
-
-        if memory := sum([memory for p in ps if (memory := get_process_memory(p))]):
-            return memory
-
-        return None
-
-    return {pid: memory for pid in pids if (memory := recursive_memory(pid))}
+    return result

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -11,18 +11,9 @@
 
 import os
 import sys
+import psutil
 from collections import defaultdict
-from typing import TYPE_CHECKING, Optional
-
-if TYPE_CHECKING:
-    import psutil
-else:
-    from importlib.util import find_spec
-
-    if find_spec("psutil") is not None:
-        import psutil
-    else:
-        raise ModuleNotFoundError("Requires the 'psutil' package")
+from typing import Optional
 
 MEMORY_PSS = sys.platform.startswith("linux") and os.path.exists(
     f"/proc/{os.getpid()}/smaps_rollup"

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -75,10 +75,13 @@ def get_processes_memory(parent_pids: set[int]) -> defaultdict[int, int]:
         Mapping of parent PID -> estimated process memory in bytes.
 
     """
-    # Get the entire flattened process tree
+    # Get the entire flattened process tree, removing process 0 as
+    # it's the exit condition when searching recursively
     all_processes: dict[int, psutil.Process] = {
         p.info["pid"]: p for p in psutil.process_iter(["pid", "ppid"])
     }
+    if 0 in all_processes:
+        del all_processes[0]
 
     # Recrusively check if any of the processes in "parent_pids"
     # are a parent of this process at any level

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -11,9 +11,10 @@
 
 import os
 import sys
-import psutil
 from collections import defaultdict
 from typing import Optional
+
+import psutil
 
 MEMORY_PSS = sys.platform.startswith("linux") and os.path.exists(
     f"/proc/{os.getpid()}/smaps_rollup"
@@ -57,23 +58,15 @@ def get_process_memory(process: psutil.Process) -> Optional[int]:
     return None
 
 
-def get_processes_memory(pids: set[int]) -> defaultdict[int, int]:
+def get_processes_memory(parent_pids: set[int]) -> defaultdict[int, int]:
     """
-    Get the estimated total memory for each process, including children.
-
-    The children of the parent processes (the ones in "pids") must
-    have their process group IDs set to that of the parent. This
-    enables loading all processes at once, searching by process
-    group ID instead of needing to recurse through the process
-    tree for children for each parent process. This is true
-    in the SubprocessRunner, as we set preexec_fn=os.setsid
-    when spawning the parent subprocess.
+    Get the estimated total memory for each parent process, including children.
 
     If a process is not running, it will not be included.
 
     Arguments:
     ---------
-    pids : Iterable[int]
+    parent_pids : set[int]
         The PIDs of the parent processes.
 
     Returns:
@@ -82,17 +75,26 @@ def get_processes_memory(pids: set[int]) -> defaultdict[int, int]:
         Mapping of parent PID -> estimated process memory in bytes.
 
     """
+    # Get the entire flattened process tree
+    all_processes: dict[int, psutil.Process] = {
+        p.info["pid"]: p for p in psutil.process_iter(["pid", "ppid"])
+    }
 
+    # Recrusively check if any of the processes in "parent_pids"
+    # are a parent of this process at any level
+    def in_parent_pids(p: psutil.Process) -> Optional[int]:
+        ppid = p.info["ppid"]
+        # Found a parent
+        if ppid in parent_pids:
+            return p.info["ppid"]
+        # Recursively check
+        return in_parent_pids(pp) if (pp := all_processes.get(ppid)) else None
+
+    # Accumulate memory from relevant processes
     result = defaultdict(int)
-
-    for p in psutil.process_iter(["pid"]):
-        try:
-            pgid = os.getpgid(p.info["pid"])
-        except ProcessLookupError:
-            continue
-        if pgid not in pids:
-            continue
-        if (memory := get_process_memory(p)) is not None:
-            result[pgid] += memory
-
+    for pid, p in all_processes.items():
+        if (ppid := pid if pid in parent_pids else in_parent_pids(p)) is not None and (
+            memory := get_process_memory(p)
+        ) is not None:
+            result[ppid] += memory
     return result

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -68,6 +68,9 @@ class MemoryMonitor:
         self._parent_pid: int = parent_pid
         """PID of the parent process to sample the children of."""
 
+        self._interval: float = interval
+        """How often to sample in seconds."""
+
         self._process: Optional[Process] = None
         """The Multiprocessing process."""
 
@@ -79,9 +82,6 @@ class MemoryMonitor:
 
         self._stop_event = None
         """Event to stop the Multiprocessing process, once started."""
-
-        self._interval: float = interval
-        """How often to sample in seconds."""
 
     def get_samples(self) -> dict[int, int]:
         """

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -86,7 +86,7 @@ def get_processes_memory(parent_pids: set[int]) -> defaultdict[int, int]:
         ppid = p.info["ppid"]
         # Found a parent
         if ppid in parent_pids:
-            return p.info["ppid"]
+            return ppid
         # Recursively check
         return in_parent_pids(pp) if (pp := all_processes.get(ppid)) else None
 

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -12,7 +12,8 @@
 import os
 import sys
 from collections import defaultdict
-from multiprocessing import Event, Manager, Process, get_context
+from multiprocessing import Process, get_context
+from multiprocessing.context import ForkProcess
 from multiprocessing.managers import DictProxy
 from typing import Optional
 
@@ -71,7 +72,7 @@ class MemoryMonitor:
         self._interval: float = interval
         """How often to sample in seconds."""
 
-        self._process: Optional[Process] = None
+        self._process: Optional[ForkProcess] = None
         """The Multiprocessing process."""
 
         self._manager = None

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -12,6 +12,8 @@
 import os
 import sys
 from collections import defaultdict
+from multiprocessing import Event, Manager, Process, get_context
+from multiprocessing.managers import DictProxy
 from typing import Optional
 
 import psutil
@@ -58,46 +60,115 @@ def get_process_memory(process: psutil.Process) -> Optional[int]:
     return None
 
 
-def get_processes_memory(parent_pids: set[int]) -> defaultdict[int, int]:
-    """
-    Get the estimated total memory for each parent process, including children.
+class MemoryMonitor:
+    """Monitor that runs in a separate thread to track children memory usage."""
 
-    If a process is not running, it will not be included.
+    def __init__(self, parent_pid: int, interval: float = 0.1):
+        """Initialize state."""
+        self._parent_pid: int = parent_pid
+        """PID of the parent process to sample the children of."""
 
-    Arguments:
-    ---------
-    parent_pids : set[int]
-        The PIDs of the parent processes.
+        self._process: Optional[Process] = None
+        """The Multiprocessing process."""
 
-    Returns:
-    -------
-    defaultdict[int, int]:
-        Mapping of parent PID -> estimated process memory in bytes.
+        self._manager = None
+        """Manager for sharing data with the Multiprocessing process, once started."""
 
-    """
-    # Get the entire flattened process tree, removing process 0 as
-    # it's the exit condition when searching recursively
-    all_processes: dict[int, psutil.Process] = {
-        p.info["pid"]: p for p in psutil.process_iter(["pid", "ppid"])
-    }
-    if 0 in all_processes:
-        del all_processes[0]
+        self._samples: Optional[DictProxy[int, int]] = None
+        """The shareable samples (child pid -> memory in bytes), once started."""
 
-    # Recrusively check if any of the processes in "parent_pids"
-    # are a parent of this process at any level
-    def in_parent_pids(p: psutil.Process) -> Optional[int]:
-        ppid = p.info["ppid"]
-        # Found a parent
-        if ppid in parent_pids:
-            return ppid
-        # Recursively check
-        return in_parent_pids(pp) if (pp := all_processes.get(ppid)) else None
+        self._stop_event = None
+        """Event to stop the Multiprocessing process, once started."""
 
-    # Accumulate memory from relevant processes
-    result = defaultdict(int)
-    for pid, p in all_processes.items():
-        if (ppid := pid if pid in parent_pids else in_parent_pids(p)) is not None and (
-            memory := get_process_memory(p)
-        ) is not None:
-            result[ppid] += memory
-    return result
+        self._interval: float = interval
+        """How often to sample in seconds."""
+
+    def get_samples(self) -> dict[int, int]:
+        """
+        Get the last samples; child PID to cumulative memory usage in bytes.
+
+        This returns a copy so that the dict can be accessed without
+        locking (required for synchronization with the other thread).
+        Thus, you should get a copy to this once and then use it many
+        times as needed.
+        """
+        assert self._samples is not None
+        return self._samples.copy()
+
+    @staticmethod
+    def _sampler(
+        parent_pid: int, interval: float, stop_event, samples: DictProxy[int, int]
+    ):
+        """Run the sampler process; internal method called by start()."""
+        while not stop_event.is_set():
+            # Get the entire flattened process tree, removing process 0 as
+            # it's the exit condition when searching recursively
+            all_processes: dict[int, psutil.Process] = {
+                p.info["pid"]: p for p in psutil.process_iter(["pid", "ppid"])
+            }
+            if 0 in all_processes:
+                del all_processes[0]
+
+            # Get the processes that are immediate children of the parent
+            children_pids = set(
+                pid for pid, p in all_processes.items() if p.info["ppid"] == parent_pid
+            )
+
+            # Recrusively check if any of the processes in "children_pids"
+            # are a parent of this process at any level
+            def in_children_pids(p: psutil.Process) -> Optional[int]:
+                ppid = p.info["ppid"]
+                # Found a parent
+                if ppid in children_pids:
+                    return ppid
+                # Recursively check
+                return in_children_pids(pp) if (pp := all_processes.get(ppid)) else None
+
+            # Accumulate memory from relevant processes
+            result = defaultdict(int)
+            for pid, p in all_processes.items():
+                if (
+                    ppid := pid if pid in children_pids else in_children_pids(p)
+                ) is not None and (memory := get_process_memory(p)) is not None:
+                    result[ppid] += memory
+
+            # And update the shared state
+            samples.clear()
+            samples.update(result)
+
+            # Wait, but wake early if stop_event is set
+            stop_event.wait(interval)
+
+    def start(self):
+        """Start the sampler process."""
+        assert self._process is None
+
+        ctx = get_context("fork")
+        self._manager = ctx.Manager()
+        self._samples = self._manager.dict()
+        self._stop_event = ctx.Event()
+        self._process = ctx.Process(
+            target=self._sampler,
+            args=(
+                self._parent_pid,
+                self._interval,
+                self._stop_event,
+                self._samples,
+            ),
+            daemon=True,
+        )
+        assert self._process is not None
+        self._process.start()
+
+    def stop(self):
+        """Stop the sampler process."""
+        process = self._process
+        if process is not None:
+            assert self._stop_event is not None
+            self._stop_event.set()
+            process.join(timeout=1)
+            if process.is_alive():
+                process.terminate()
+                process.join()
+            self._process = None
+            self._stop_event = None


### PR DESCRIPTION
- Speeds up memory tracking by reducing recursive searches in the process tree
- Separate memory tracking into a different thread with multiprocessing
- Adds `--disable-cpu-tracking` to disable CPU tracking (stops wrapping test execution in `/usr/bin/time`)
- Adds `--disable-memory-tracking` to disable memory tracking
- Does not output memory if memory tracking is not available or is disabled
- Adds memory tracking to slurm jobs
- Disable `--max-cpu-per-slot` by default
- Prints errors in red (yay!)

Refs #32043, https://github.com/idaholab/moose/pull/32451, closes #32485, closes #32459