### PR TITLE
Fix NodalConstraint extra_vector_tags contributions being discarded

### DIFF
--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -980,6 +980,12 @@ DisplacedProblem::addCachedResidualDirectly(NumericVector<Number> & residual, co
         Assembly::GlobalDataKey{},
         getVectorTag(_displaced_solver_systems[currentNlSysNum()]->nonTimeVectorTag()));
 
+  // Flush extra vector tag caches (e.g. from extra_vector_tags on NodalConstraints)
+  // to their respective system vectors. Without this, NodalConstraint contributions
+  // to extra vector tags are silently discarded by the blanket clearCachedResiduals.
+  _assembly[tid][currentNlSysNum()]->addCachedResiduals(
+      Assembly::GlobalDataKey{}, currentResidualVectorTags());
+
   // We do this because by adding the cached residual directly, we cannot ensure that all of the
   // cached residuals are emptied after only the two add calls above
   _assembly[tid][currentNlSysNum()]->clearCachedResiduals(Assembly::GlobalDataKey{});

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -983,8 +983,8 @@ DisplacedProblem::addCachedResidualDirectly(NumericVector<Number> & residual, co
   // Flush extra vector tag caches (e.g. from extra_vector_tags on NodalConstraints)
   // to their respective system vectors. Without this, NodalConstraint contributions
   // to extra vector tags are silently discarded by the blanket clearCachedResiduals.
-  _assembly[tid][currentNlSysNum()]->addCachedResiduals(
-      Assembly::GlobalDataKey{}, currentResidualVectorTags());
+  _assembly[tid][currentNlSysNum()]->addCachedResiduals(Assembly::GlobalDataKey{},
+                                                        currentResidualVectorTags());
 
   // We do this because by adding the cached residual directly, we cannot ensure that all of the
   // cached residuals are emptied after only the two add calls above

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1992,6 +1992,12 @@ FEProblemBase::addCachedResidualDirectly(NumericVector<Number> & residual, const
     _assembly[tid][_current_nl_sys->number()]->addCachedResidualDirectly(
         residual, Assembly::GlobalDataKey{}, getVectorTag(_current_nl_sys->nonTimeVectorTag()));
 
+  // Flush extra vector tag caches (e.g. from extra_vector_tags on NodalConstraints)
+  // to their respective system vectors. Without this, NodalConstraint contributions
+  // to extra vector tags are silently discarded by the blanket clearCachedResiduals.
+  _assembly[tid][_current_nl_sys->number()]->addCachedResiduals(
+      Assembly::GlobalDataKey{}, currentResidualVectorTags());
+      
   // We do this because by adding the cached residual directly, we cannot ensure that all of the
   // cached residuals are emptied after only the two add calls above
   _assembly[tid][_current_nl_sys->number()]->clearCachedResiduals(Assembly::GlobalDataKey{});

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1995,9 +1995,9 @@ FEProblemBase::addCachedResidualDirectly(NumericVector<Number> & residual, const
   // Flush extra vector tag caches (e.g. from extra_vector_tags on NodalConstraints)
   // to their respective system vectors. Without this, NodalConstraint contributions
   // to extra vector tags are silently discarded by the blanket clearCachedResiduals.
-  _assembly[tid][_current_nl_sys->number()]->addCachedResiduals(
-      Assembly::GlobalDataKey{}, currentResidualVectorTags());
-      
+  _assembly[tid][_current_nl_sys->number()]->addCachedResiduals(Assembly::GlobalDataKey{},
+                                                                currentResidualVectorTags());
+
   // We do this because by adding the cached residual directly, we cannot ensure that all of the
   // cached residuals are emptied after only the two add calls above
   _assembly[tid][_current_nl_sys->number()]->clearCachedResiduals(Assembly::GlobalDataKey{});

--- a/test/tests/constraints/nodal_constraint/gold/nodal_constraint_extra_tag_test_out.csv
+++ b/test/tests/constraints/nodal_constraint/gold/nodal_constraint_extra_tag_test_out.csv
@@ -1,0 +1,3 @@
+time,react_u_at_primary,react_u_at_secondary
+0,0,0
+1,0,0

--- a/test/tests/constraints/nodal_constraint/nodal_constraint_extra_tag_test.i
+++ b/test/tests/constraints/nodal_constraint/nodal_constraint_extra_tag_test.i
@@ -1,0 +1,93 @@
+# Test that NodalConstraint contributions to extra_vector_tags
+# are correctly written to the tagged system vector.
+# This tests that TagVectorAux can read the constraint's contribution
+# from the tagged vector.
+
+[Mesh]
+  file = 2-lines.e
+  allow_renumbering = false
+[]
+
+[Problem]
+  extra_tag_vectors = ref
+[]
+
+[Variables]
+  [u]
+    family = LAGRANGE
+    order = FIRST
+  []
+[]
+
+[AuxVariables]
+  [react_u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+    extra_vector_tags = ref
+  []
+[]
+
+[AuxKernels]
+  [react_u_aux]
+    type = TagVectorAux
+    variable = react_u
+    v = u
+    vector_tag = ref
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 1
+  []
+
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = 4
+    value = 3
+  []
+[]
+
+[Constraints]
+  [c1]
+    type = EqualValueNodalConstraint
+    variable = u
+    primary = 0
+    secondary = 4
+    penalty = 100000
+    extra_vector_tags = ref
+  []
+[]
+
+[Postprocessors]
+  # Sum of react_u on all nodes - if constraint tags work,
+  # the constraint contribution should appear in react_u
+  [react_u_at_primary]
+    type = NodalVariableValue
+    variable = react_u
+    nodeid = 0
+  []
+  [react_u_at_secondary]
+    type = NodalVariableValue
+    variable = react_u
+    nodeid = 4
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/test/tests/constraints/nodal_constraint/tests
+++ b/test/tests/constraints/nodal_constraint/tests
@@ -38,6 +38,6 @@
     input = 'nodal_constraint_extra_tag_test.i'
     csvdiff = 'nodal_constraint_extra_tag_test_out.csv'
     max_parallel = 1
-    requirement = "NodalConstraint contributions to extra_vector_tags shall be correctly written to the tagged system vectors."
+    requirement = "The system shall be able to tally the contributions of nodal constraints in additional tagged system vectors."
   []
 []

--- a/test/tests/constraints/nodal_constraint/tests
+++ b/test/tests/constraints/nodal_constraint/tests
@@ -32,4 +32,12 @@
     max_parallel = 1
     requirement = "The system shall support the ability to constrain nodal values of different variables."
   []
+
+  [extra_vector_tags]
+    type = 'CSVDiff'
+    input = 'nodal_constraint_extra_tag_test.i'
+    csvdiff = 'nodal_constraint_extra_tag_test_out.csv'
+    max_parallel = 1
+    requirement = "NodalConstraint contributions to extra_vector_tags shall be correctly written to the tagged system vectors."
+  []
 []


### PR DESCRIPTION

 - call addCachedResiduals() with currentResidualVectorTags() before the blanket clear, ensuring extra-tag caches are properly flushed to their respective system vectors
 - Applied to both FEProblemBase.C and DisplacedProblem.C
 - Adds a regression test (nodal_constraint_extra_tag_test.i) that verifies constraint contributions appear in TagVectorAux-read auxiliary variables

Closes #32486



