### PR TITLE
Avoid unnecessary nodalArea queries

### DIFF
--- a/modules/contact/src/constraints/MechanicalContactConstraint.C
+++ b/modules/contact/src/constraints/MechanicalContactConstraint.C
@@ -775,7 +775,7 @@ MechanicalContactConstraint::computeContactForce(const Node & node,
       !newly_captured && _tension_release >= 0.0 &&
       (_contact_linesearch ? true : pinfo->_locked_this_step < 2))
   {
-    // If we don't have a non-default _tension_release, we don't need
+    // If _tension_release is zero (the default), we don't need
     // to query a nodalArea because we only care about the sign of
     // contact pressure.
     if (!_tension_release)

--- a/modules/contact/src/constraints/MechanicalContactConstraint.C
+++ b/modules/contact/src/constraints/MechanicalContactConstraint.C
@@ -775,11 +775,25 @@ MechanicalContactConstraint::computeContactForce(const Node & node,
       !newly_captured && _tension_release >= 0.0 &&
       (_contact_linesearch ? true : pinfo->_locked_this_step < 2))
   {
-    const Real contact_pressure = -(pinfo->_normal * pinfo->_contact_force) / nodalArea(node);
-    if (-contact_pressure >= _tension_release)
+    // If we don't have a non-default _tension_release, we don't need
+    // to query a nodalArea because we only care about the sign of
+    // contact pressure.
+    if (!_tension_release)
     {
-      pinfo->release();
-      pinfo->_contact_force.zero();
+      if (pinfo->_normal * pinfo->_contact_force >= 0)
+      {
+        pinfo->release();
+        pinfo->_contact_force.zero();
+      }
+    }
+    else
+    {
+      const Real contact_pressure = -(pinfo->_normal * pinfo->_contact_force) / nodalArea(node);
+      if (-contact_pressure >= _tension_release)
+      {
+        pinfo->release();
+        pinfo->_contact_force.zero();
+      }
     }
   }
 }


### PR DESCRIPTION
Refs #18768 - for me this first cropped up because it triggers a bug in the interaction between contact `NodalArea` and non-conforming Flex IGA meshes.

## Reason
In the default mechanical contact settings, with 0 `tension_release`, we don't need to query nodalArea or divide by it, but we do so anyway.  This triggers a bug (being worked on in another branch, but this is a sufficient workaround for most users) with NodalArea on disconnected (e.g. Flex IGA) meshes, and it wastes a few CPU cycles for most users.

## Design
Handle the positive `tension_release` and the 0 `tension_release` cases separately, with simplified evaluation for the latter.

## Impact
No API changes, just a little bit faster and more robust.