### PR TITLE
Fixed iteration post-processors for Eigenvalue executioner

### DIFF
--- a/framework/doc/content/source/postprocessors/NumNonlinearIterations.md
+++ b/framework/doc/content/source/postprocessors/NumNonlinearIterations.md
@@ -7,6 +7,8 @@
 `NumNonlinearIterations` reports the number of nonlinear iterations in the just-completed
 solve.
 
+For situations where the same nonlinear system is solved multiple times per time step, e.g., when a fixed point iteration is performed when using MultiApps, if [!param](/Postprocessors/NumNonlinearIterations/accumulate_over_step) is set to `true`, then the total number of nonlinear iterations per step is returned, rather than just the most recent solve of that system in that time step.
+
 ## Example Input Syntax
 
 !listing test/tests/postprocessors/cumulative_value_postprocessor/cumulative_value_postprocessor.i block=Postprocessors

--- a/framework/include/systems/NonlinearEigenSystem.h
+++ b/framework/include/systems/NonlinearEigenSystem.h
@@ -82,6 +82,9 @@ public:
    */
   unsigned int getNumConvergedEigenvalues() const { return _eigen_sys.get_n_converged(); };
 
+  virtual unsigned int nNonlinearIterations() const override;
+  virtual unsigned int nLinearIterations() const override;
+
   virtual libMesh::NonlinearSolver<Number> * nonlinearSolver() override;
 
   /**

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -557,12 +557,12 @@ public:
   /**
    * Return the number of non-linear iterations
    */
-  unsigned int nNonlinearIterations() const { return _n_iters; }
+  virtual unsigned int nNonlinearIterations() const { return _n_iters; }
 
   /**
    * Return the number of linear iterations
    */
-  unsigned int nLinearIterations() const { return _n_linear_iters; }
+  virtual unsigned int nLinearIterations() const { return _n_linear_iters; }
 
   /**
    * Return the total number of residual evaluations done so far in this calculation

--- a/framework/src/postprocessors/NumNonlinearIterations.C
+++ b/framework/src/postprocessors/NumNonlinearIterations.C
@@ -19,10 +19,10 @@ InputParameters
 NumNonlinearIterations::validParams()
 {
   InputParameters params = GeneralPostprocessor::validParams();
-  params.addParam<bool>(
-      "accumulate_over_step",
-      false,
-      "When set to true, accumulates to count the total over all Picard iterations for each step");
+  params.addParam<bool>("accumulate_over_step",
+                        false,
+                        "When set to true, accumulates to count the total over all fixed point "
+                        "iterations for each step");
   params.addClassDescription("Outputs the number of nonlinear iterations");
 
   // Not supported

--- a/framework/src/systems/NonlinearEigenSystem.C
+++ b/framework/src/systems/NonlinearEigenSystem.C
@@ -276,6 +276,20 @@ NonlinearEigenSystem::solve()
     ti->postSolve();
   }
 
+  // store iterations
+  if (_eigen_problem.isNonlinearEigenvalueSolver(number()))
+  {
+    auto snes = getSNES();
+
+    PetscInt nl_its;
+    LibmeshPetscCallA(_eigen_problem.comm().get(), SNESGetIterationNumber(snes, &nl_its));
+    _n_iters = nl_its;
+
+    PetscInt l_its;
+    LibmeshPetscCallA(_eigen_problem.comm().get(), SNESGetLinearSolveIterations(snes, &l_its));
+    _n_linear_iters = l_its;
+  }
+
   // store eigenvalues
   unsigned int n_converged_eigenvalues = getNumConvergedEigenvalues();
 
@@ -294,6 +308,28 @@ NonlinearEigenSystem::solve()
 
   if (_eigen_problem.isNonlinearEigenvalueSolver(number()) && _num_constrained_dofs)
     solution().restore_subvector(std::move(subvec), _eigen_sys.local_non_condensed_dofs_vector);
+}
+
+unsigned int
+NonlinearEigenSystem::nNonlinearIterations() const
+{
+  if (!_time_integrators.empty())
+    mooseError("Not implemented for time integrators.");
+  if (!_eigen_problem.isNonlinearEigenvalueSolver(number()))
+    mooseError("Only implemented for nonlinear eigenvalue solvers.");
+
+  return _n_iters;
+}
+
+unsigned int
+NonlinearEigenSystem::nLinearIterations() const
+{
+  if (!_time_integrators.empty())
+    mooseError("Not implemented for time integrators.");
+  if (!_eigen_problem.isNonlinearEigenvalueSolver(number()))
+    mooseError("Only implemented for nonlinear eigenvalue solvers.");
+
+  return _n_linear_iters;
 }
 
 void

--- a/test/tests/postprocessors/num_iterations/eigen_problem.i
+++ b/test/tests/postprocessors/num_iterations/eigen_problem.i
@@ -1,0 +1,73 @@
+# Test problem modified from ../../problems/eigen_problem/eigensolvers/ne.i:
+#
+# The minimum eigenvalue of this problem is 2*(PI/a)^2;
+# Its inverse is 0.5*(a/PI)^2 = 5.0660591821169. Here a is equal to 10.
+
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    xmin = 0
+    xmax = 10
+    ymin = 0
+    ymax = 10
+    elem_type = QUAD4
+    nx = 8
+    ny = 8
+  []
+[]
+
+
+
+[Variables]
+  [u]
+    order = FIRST
+    family = LAGRANGE
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+  [rhs]
+    type = Reaction
+    variable = u
+    rate = -1.0
+    extra_vector_tags = 'eigen'
+  []
+[]
+
+[BCs]
+  [homogeneous]
+    type = DirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    value = 0
+  []
+  [eigen]
+    type = EigenDirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+  []
+[]
+
+[Postprocessors]
+  [num_nonlin]
+    type = NumNonlinearIterations
+  []
+  [num_lin]
+    type = NumLinearIterations
+  []
+[]
+
+[Executioner]
+  type = Eigenvalue
+  solve_type = PJFNK
+[]
+
+[Outputs]
+  csv = true
+  execute_on = 'FINAL'
+[]

--- a/test/tests/postprocessors/num_iterations/gold/eigen_problem_out.csv
+++ b/test/tests/postprocessors/num_iterations/gold/eigen_problem_out.csv
@@ -1,0 +1,2 @@
+time,num_lin,num_nonlin
+2,12,4

--- a/test/tests/postprocessors/num_iterations/tests
+++ b/test/tests/postprocessors/num_iterations/tests
@@ -1,8 +1,8 @@
 [Tests]
-  design = 'TimeIntegrator/index.md'
-  issues = '#11444'
+  design = 'NumNonlinearIterations.md NumLinearIterations.md'
+  issues = '#11444 #32505'
 
-  [methods]
+  [time_integrators]
     requirement = "The system shall support time integration schemes that compute a consistent "
                   "number of nonlinear and linear iterations for"
 
@@ -179,5 +179,12 @@
 
       detail = 'and Ralston methods.'
     []
+  []
+  [eigen_problem]
+    type = CSVDiff
+    input = 'eigen_problem.i'
+    csvdiff = 'eigen_problem_out.csv'
+    max_parallel = 1 # Need results to be very consistent since we count iterations
+    requirement = 'The system shall report the correct number of nonlinear and linear iterations for a nonlinear eigenvalue problem.'
   []
 []


### PR DESCRIPTION
This PR:
- improves doc for `NumNonlinearIterations`
- Makes `NumNonlinearIterations` and `NumLinearIterations` work for `Eigenvalue` executioner with nonlinear solve types. For other types, throw error if someone tries to get those iteration counts.

Closes #32505
