### PR TITLE
Modify default behavior of wall time checkpoint

### DIFF
--- a/framework/doc/content/source/actions/AutoCheckpointAction.md
+++ b/framework/doc/content/source/actions/AutoCheckpointAction.md
@@ -16,6 +16,10 @@ based checkpoints while disabling wall time based checkpoints.
 []
 ```
 
+!alert note
+Note that manually setting `checkpoint = false` with automatically also change the default value for `wall_time_checkpoint` to false.
+If the latter is set manually in the input to true, wall time checkpoints are still created.
+
 Please refer to the [syntax/Outputs/index.md] for more information.
 
 !syntax parameters /Outputs/AutoCheckpointAction

--- a/framework/doc/content/source/actions/AutoCheckpointAction.md
+++ b/framework/doc/content/source/actions/AutoCheckpointAction.md
@@ -17,7 +17,7 @@ based checkpoints while disabling wall time based checkpoints.
 ```
 
 !alert note
-Note that manually setting `checkpoint = false` with automatically also change the default value for `wall_time_checkpoint` to false.
+Note that manually setting `checkpoint = false` will automatically also change the default value for `wall_time_checkpoint` to false.
 If the latter is set manually in the input to true, wall time checkpoints are still created.
 
 Please refer to the [syntax/Outputs/index.md] for more information.

--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -236,7 +236,7 @@ public:
    * This method executes only the actions in the warehouse that satisfy the task
    * passed in.
    */
-  void executeActionsWithAction(const std::string & name);
+  void executeActionsWithAction(const std::string & task_name);
 
   /**
    * This method sets a Boolean which is used to print information about action dependencies

--- a/framework/include/base/ActionUnitTest.h
+++ b/framework/include/base/ActionUnitTest.h
@@ -1,0 +1,151 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "gtest/gtest.h"
+
+#include "MooseMesh.h"
+#include "FEProblem.h"
+#include "AppFactory.h"
+#include "MooseMain.h"
+
+/**
+ * Base class for building basic unit tests for MOOSE actions
+ *
+ * This class follows the classic actions that are needed in order to build a simulation.
+ * To build a unit test, inherit from this class and build your test using
+ * the following template:
+ *
+ * In your .h file:
+ *
+ * class MyUnitTest : public ActionUnitTest
+ * {
+ * public:
+ *   MyUnitTest() : ActionUnitTest("MyAppUnitApp")
+ *   {
+ *     buildAction();
+ *   }
+ *
+ * protected:
+ *
+ *   void buildActions()
+ *   {
+ *     // Start with the validParams
+ *     InputParameters pars = _action_factory.getValidParams("MyActionThatIAmTesting");
+ *     // Set the parameters you need
+ *     pars.set<bool>("do this thing") = true;
+ *     // Build the action into the action warehouse (just like a meta-action would do)
+ *
+ *   }
+ *
+ *   void runActions()
+ *   {
+ *     // NOTE: if multiple tasks are required, you have to code them here
+ *
+ *     const auto task_name = "name of the task we want to test the action on";
+ *     // Add the task: only needed if the task does not auto-register
+ *     // Check that the task is registered
+ *     mooseAssert(_action_factory.isRegisteredTask(task_name), "Should have registered the task");
+ *     // Run the task
+ *     _app->actionWarehouse().executeActionsWithAction(task_name);
+ *   }
+ *
+ *   // member variable used later in the actual tests
+ *   const MyActionIAmTesting * _action;
+ * };
+ *
+ * In your .C file
+ *
+ * TEST_F(MyActionThatIAmTesting, name of the test)
+ * {
+ *   // Testing individual methods
+ *   EXPECT_EQ("testing", _action->method(par1, par2));
+ *   // Testing if an object has been created by action (if stored in the problem)
+ *   EXPECT_EQ(true, _fe_problem->hasObjectType(name, 0));
+ * }
+ *
+ * NOTE: Testing complex actions that build on other actions may require a deep
+ *       knowledge of the setup phase in MOOSE. Use Debug/show_actions on a regular simulation
+ *       to get more information on the setup
+ */
+class ActionUnitTest : public ::testing::Test
+{
+public:
+  /**
+   * @param app_name The name of client's application
+   */
+  ActionUnitTest(const std::string & app_name)
+    : _app(Moose::createMooseApp(app_name, 0, nullptr)),
+      _factory(_app->getFactory()),
+      _action_factory(_app->getActionFactory())
+  {
+    buildMinimalObjects();
+  }
+
+  void SetUp() override
+  {
+    buildActions();
+    runActions();
+  }
+
+protected:
+  /// Override this to create the action(s) you want to test
+  virtual void buildActions() = 0;
+
+  /// Some base objects we often need to have the action act on them
+  void buildMinimalObjects()
+  {
+    InputParameters mesh_params = _factory.getValidParams("GeneratedMesh");
+    mesh_params.set<MooseEnum>("dim") = "3";
+    mesh_params.set<unsigned int>("nx") = 2;
+    mesh_params.set<unsigned int>("ny") = 2;
+    mesh_params.set<unsigned int>("nz") = 2;
+    _mesh = _factory.createUnique<MooseMesh>("GeneratedMesh", "name1", mesh_params);
+    _mesh->setMeshBase(_mesh->buildMeshBaseObject());
+    _mesh->buildMesh();
+
+    InputParameters problem_params = _factory.getValidParams("FEProblem");
+    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
+    problem_params.set<std::string>(MooseBase::name_param) = "name2";
+    _fe_problem = _factory.create<FEProblem>("FEProblem", "problem", problem_params);
+
+    _fe_problem->createQRules(libMesh::QGAUSS, libMesh::FIRST, libMesh::FIRST, libMesh::FIRST);
+
+    _app->actionWarehouse().problemBase() = _fe_problem;
+  }
+
+  /// Override this to make the actions execute
+  /// NOTE: many tasks will auto-register their task at creation, but for the others,
+  /// do not forget to register them.
+  /// To check if a task is registered, use:
+  /// _action_factory.isRegisteredTask("auto_checkpoint_action")
+  virtual void runActions() = 0;
+
+  /// Convenience routine for adding an object in an Actions test
+  template <typename T>
+  T & addObject(const std::string & type, const std::string & name, InputParameters & params);
+
+  std::unique_ptr<MooseMesh> _mesh;
+  std::shared_ptr<MooseApp> _app;
+  Factory & _factory;
+  ActionFactory & _action_factory;
+  std::shared_ptr<FEProblem> _fe_problem;
+};
+
+template <typename T>
+T &
+ActionUnitTest::addObject(const std::string & type,
+                          const std::string & name,
+                          InputParameters & params)
+{
+  auto objects = _fe_problem->addObject<T>(type, name, params);
+  mooseAssert(objects.size() == 1, "Doesn't work with threading");
+  return *objects[0];
+}

--- a/framework/src/actions/AutoCheckpointAction.C
+++ b/framework/src/actions/AutoCheckpointAction.C
@@ -21,9 +21,11 @@ AutoCheckpointAction::validParams()
       "Action to create shortcut syntax-specified checkpoints and automatic checkpoints.");
 
   params.addParam<bool>("checkpoint", false, "Create checkpoint files using the default options.");
-  params.addParam<bool>("wall_time_checkpoint",
-                        true,
-                        "Enables the output of checkpoints based on elapsed wall time.");
+  params.addParam<bool>(
+      "wall_time_checkpoint",
+      true,
+      "Enables the output of checkpoints based on elapsed wall time. Defaults to true unless "
+      "'checkpoint' is set to false in the input, in which case the default is changed to false.");
 
   return params;
 }
@@ -53,7 +55,11 @@ AutoCheckpointAction::act()
     auto cp_params = _factory.getValidParams("Checkpoint");
 
     cp_params.set<bool>("_built_by_moose") = true;
-    cp_params.set<bool>("wall_time_checkpoint") = getParam<bool>("wall_time_checkpoint");
+    // Don't see a wall time checkpoint unless explictly requested if 'checkpoint=false'
+    cp_params.set<bool>("wall_time_checkpoint") =
+        isParamSetByUser("wall_time_checkpoint")
+            ? getParam<bool>("wall_time_checkpoint")
+            : (isParamSetByUser("checkpoint") ? getParam<bool>("checkpoint") : true);
 
     // We need to keep track of what type of checkpoint we are creating. system created means the
     // default value of 1 for time_step_interval is ignored.

--- a/unit/include/AutoCheckpointTest.h
+++ b/unit/include/AutoCheckpointTest.h
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "gtest_include.h"
+#include "ActionUnitTest.h"
+
+class MooseApp;
+class ActionFactory;
+class Factory;
+class InputParameters;
+
+/**
+ * Unit test for the creation of wall-time checkpoints
+ */
+class AutoCheckpointTest : public ActionUnitTest
+{
+public:
+  AutoCheckpointTest() : ActionUnitTest("MooseUnitApp") {}
+
+protected:
+  void buildActions()
+  {
+    // Add the auto-checkpoint action
+    const auto action_type = "AutoCheckpointAction";
+    InputParameters pars = _action_factory.getValidParams(action_type);
+    pars.set<bool>("checkpoint") = false;
+    auto action = _action_factory.create(action_type, "unit_test_auto_checkpoint", pars);
+    _app->actionWarehouse().addActionBlock(action);
+  }
+  void runActions()
+  {
+    // Add the task: only needed if the task does not auto-register
+    // Check the task
+    mooseAssert(_action_factory.isRegisteredTask("auto_checkpoint_action"),
+                "Should have registered the task");
+    // Run the task
+    _app->actionWarehouse().executeActionsWithAction("auto_checkpoint_action");
+  }
+};

--- a/unit/src/AutoCheckpointTest.C
+++ b/unit/src/AutoCheckpointTest.C
@@ -1,0 +1,30 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest/gtest.h"
+
+#include "AutoCheckpointTest.h"
+#include "MooseApp.h"
+#include "OutputWarehouse.h"
+#include "Checkpoint.h"
+
+TEST_F(AutoCheckpointTest, noWallTimeIfCheckpointSetToFalse)
+{
+  // Check that wall time was not used
+  const auto & output_names = _app->getOutputWarehouse().getOutputNames();
+  // Checkpoint was created
+  EXPECT_EQ(1, output_names.size());
+  // No wall time though
+  const std::string msg = "Wall Time Interval:      Disabled";
+  const auto checkpoint_info = _app->getOutputWarehouse()
+                                   .getOutput<Checkpoint>(*output_names.begin())
+                                   ->checkpointInfo()
+                                   .str();
+  EXPECT_EQ(true, checkpoint_info.find(msg) != std::string::npos);
+}


### PR DESCRIPTION
Users are unhappy about getting those when checkpoint=false

refs #27240

## Reason
Setting checkpoint=false unintuitively still creates checkpoints from the `wall_time_checkpoint` option.

## Design
Modify the autocheckpoint logic from parameters

## Impact
Minor user quality of life enhancement for those running for longer period of wall time and not wanting checkpoint output to fill their HPC disk quota

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
