### PR TITLE
SetupQuadratureAction: add per-block custom_types parameter

### DIFF
--- a/framework/doc/content/source/actions/SetupQuadratureAction.md
+++ b/framework/doc/content/source/actions/SetupQuadratureAction.md
@@ -10,7 +10,28 @@ as shown below.
 This action adds the default quadrature rule to the `Problem` then adds custom requested quadratures
 in the specified blocks.
 
+## Per-block quadrature types
+
+In addition to specifying custom quadrature orders per block via `custom_orders`, it is also possible
+to specify a custom quadrature +type+ per block using the `custom_types` parameter. The `custom_types`
+list must have the same number of entries as `custom_blocks`. If `custom_types` is omitted, the global
+`type` is used for all custom blocks, preserving existing behaviour.
+
+The following example specifies both a custom order and a custom quadrature type for two subdomains:
+```text
+[Executioner]
+  [Quadrature]
+    type = GAUSS
+    order = THIRD
+    custom_blocks    = '2 3'
+    custom_orders    = 'THIRD SECOND'
+    custom_types     = 'GAUSS_LOBATTO SIMPSON'
+  []
+[]
+```
+
 More information about quadratures may be found on the
 [Quadrature syntax documentation](syntax/Executioner/Quadrature/index.md).
 
 !syntax parameters /Executioner/Quadrature/SetupQuadratureAction
+```

--- a/framework/doc/content/source/actions/SetupQuadratureAction.md
+++ b/framework/doc/content/source/actions/SetupQuadratureAction.md
@@ -23,7 +23,8 @@ number of entries as [!param](/Executioner/Quadrature/SetupQuadratureAction/cust
 preserving existing behaviour.
 
 The following example specifies both a custom order and a custom quadrature type for two subdomains:
-```text
+
+```moose
 [Executioner]
   [Quadrature]
     type = GAUSS

--- a/framework/doc/content/source/actions/SetupQuadratureAction.md
+++ b/framework/doc/content/source/actions/SetupQuadratureAction.md
@@ -40,4 +40,3 @@ More information about quadratures may be found on the
 [Quadrature syntax documentation](syntax/Executioner/Quadrature/index.md).
 
 !syntax parameters /Executioner/Quadrature/SetupQuadratureAction
-```

--- a/framework/doc/content/source/actions/SetupQuadratureAction.md
+++ b/framework/doc/content/source/actions/SetupQuadratureAction.md
@@ -12,10 +12,15 @@ in the specified blocks.
 
 ## Per-block quadrature types
 
-In addition to specifying custom quadrature orders per block via `custom_orders`, it is also possible
-to specify a custom quadrature +type+ per block using the `custom_types` parameter. The `custom_types`
-list must have the same number of entries as `custom_blocks`. If `custom_types` is omitted, the global
-`type` is used for all custom blocks, preserving existing behaviour.
+In addition to specifying custom quadrature orders per block via
+[!param](/Executioner/Quadrature/SetupQuadratureAction/custom_orders), it is also possible
+to specify a custom quadrature +type+ per block using the
+[!param](/Executioner/Quadrature/SetupQuadratureAction/custom_types) parameter. The
+[!param](/Executioner/Quadrature/SetupQuadratureAction/custom_types) list must have the same
+number of entries as [!param](/Executioner/Quadrature/SetupQuadratureAction/custom_blocks). If
+[!param](/Executioner/Quadrature/SetupQuadratureAction/custom_types) is omitted, the global
+[!param](/Executioner/Quadrature/SetupQuadratureAction/type) is used for all custom blocks,
+preserving existing behaviour.
 
 The following example specifies both a custom order and a custom quadrature type for two subdomains:
 ```text

--- a/framework/include/actions/SetupQuadratureAction.h
+++ b/framework/include/actions/SetupQuadratureAction.h
@@ -50,6 +50,11 @@ public:
         "ELEVENTH TWELFTH THIRTEENTH FOURTEENTH FIFTEENTH SIXTEENTH SEVENTEENTH "
         "EIGHTTEENTH NINTEENTH TWENTIETH");
   }
+  /// A MultiMooseEnum for selecting multiple quadrature types (one per custom block)
+  static MultiMooseEnum getQuadratureTypesMultiEnum()
+  {
+    return MultiMooseEnum("CLOUGH CONICAL GAUSS GRID MONOMIAL SIMPSON TRAP GAUSS_LOBATTO");
+  }
 
 protected:
   libMesh::QuadratureType _type;
@@ -57,5 +62,7 @@ protected:
   Order _element_order;
   Order _side_order;
   const std::vector<std::pair<SubdomainID, MooseEnumItem>> _custom_block_orders;
+  /// Per-block quadrature types, parallel to _custom_block_orders. Falls back to _type if empty.
+  std::vector<libMesh::QuadratureType> _custom_block_types;
   const bool _allow_negative_qweights;
 };

--- a/framework/src/actions/SetupQuadratureAction.C
+++ b/framework/src/actions/SetupQuadratureAction.C
@@ -32,6 +32,11 @@ SetupQuadratureAction::validParams()
       "custom_orders",
       getQuadratureOrdersMultiEnum(),
       "list of quadrature orders for the blocks specified in `custom_blocks`");
+  params.addParam<MultiMooseEnum>(
+      "custom_types",
+      getQuadratureTypesMultiEnum(),
+      "list of quadrature types for the blocks specified in `custom_blocks` "
+      "(must match length of custom_blocks; omit to use global type for all custom blocks)");
   params.addParam<bool>(
       "allow_negative_qweights", true, "Whether or not allow negative quadrature weights");
 
@@ -47,6 +52,18 @@ SetupQuadratureAction::SetupQuadratureAction(const InputParameters & parameters)
     _custom_block_orders(getParam<SubdomainID, MooseEnumItem>("custom_blocks", "custom_orders")),
     _allow_negative_qweights(getParam<bool>("allow_negative_qweights"))
 {
+  for (const auto & t : getParam<MultiMooseEnum>("custom_types"))
+    _custom_block_types.push_back(
+        Moose::stringToEnum<libMesh::QuadratureType>(std::string(t)));
+
+  if (!_custom_block_types.empty() &&
+      _custom_block_types.size() != _custom_block_orders.size())
+    mooseError("'custom_types' must have the same number of entries as 'custom_blocks' "
+               "(got ",
+               _custom_block_types.size(),
+               " types for ",
+               _custom_block_orders.size(),
+               " blocks)");
 }
 
 void
@@ -60,11 +77,15 @@ SetupQuadratureAction::act()
       _type, _order, _element_order, _side_order, Moose::ANY_BLOCK_ID, _allow_negative_qweights);
 
   // add custom block-specific quadrature rules
-  for (const auto & [block, order] : _custom_block_orders)
-    _problem->createQRules(_type,
+  for (const auto i : index_range(_custom_block_orders))
+  {
+    const auto & [block, order] = _custom_block_orders[i];
+    const auto qtype = (i < _custom_block_types.size()) ? _custom_block_types[i] : _type;
+    _problem->createQRules(qtype,
                            _order,
                            Moose::stringToEnum<Order>(order),
                            Moose::stringToEnum<Order>(order),
                            block,
                            _allow_negative_qweights);
+  }
 }

--- a/framework/src/actions/SetupQuadratureAction.C
+++ b/framework/src/actions/SetupQuadratureAction.C
@@ -53,13 +53,11 @@ SetupQuadratureAction::SetupQuadratureAction(const InputParameters & parameters)
     _allow_negative_qweights(getParam<bool>("allow_negative_qweights"))
 {
   for (const auto & t : getParam<MultiMooseEnum>("custom_types"))
-    _custom_block_types.push_back(
-        Moose::stringToEnum<libMesh::QuadratureType>(std::string(t)));
+    _custom_block_types.push_back(Moose::stringToEnum<libMesh::QuadratureType>(std::string(t)));
 
-  if (!_custom_block_types.empty() &&
-      _custom_block_types.size() != _custom_block_orders.size())
-    mooseError("'custom_types' must have the same number of entries as 'custom_blocks' "
-               "(got ",
+  if (!_custom_block_types.empty() && _custom_block_types.size() != _custom_block_orders.size())
+    paramError("custom_types",
+               "Must have the same number of entries as 'custom_blocks' (got ",
                _custom_block_types.size(),
                " types for ",
                _custom_block_orders.size(),

--- a/test/tests/quadrature/type/block-type.i
+++ b/test/tests/quadrature/type/block-type.i
@@ -1,0 +1,59 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 1
+    ny = 2
+    xmin = 0
+    xmax = 1
+    ymin = 0
+    ymax = 2
+  []
+  [bottom]
+    type = SubdomainBoundingBoxGenerator
+    input = gmg
+    block_id = 1
+    bottom_left = '0 0 0'
+    top_right = '1 1 0'
+  []
+  [top]
+    type = SubdomainBoundingBoxGenerator
+    input = bottom
+    block_id = 2
+    bottom_left = '0 1 0'
+    top_right = '1 2 0'
+  []
+[]
+
+[Postprocessors]
+  [block1_qps]
+    type = NumElemQPs
+    block = 1
+  []
+  [block2_qps]
+    type = NumElemQPs
+    block = 2
+  []
+[]
+
+[Problem]
+  type = FEProblem
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+  [Quadrature]
+    type = GAUSS
+    order = THIRD
+    custom_blocks = '1 2'
+    custom_orders = 'THIRD THIRD'
+    custom_types  = 'GAUSS_LOBATTO GAUSS'
+  []
+[]
+
+[Outputs]
+  execute_on = 'timestep_end'
+  exodus = false
+  csv = true
+[]

--- a/test/tests/quadrature/type/gold/block-type_out.csv
+++ b/test/tests/quadrature/type/gold/block-type_out.csv
@@ -1,0 +1,2 @@
+time,block1_qps,block2_qps
+1,9,4

--- a/test/tests/quadrature/type/tests
+++ b/test/tests/quadrature/type/tests
@@ -1,0 +1,15 @@
+[Tests]
+  [per-block-type]
+    type = CSVDiff input = 'block-type.i' csvdiff = 'block-type_out.csv' requirement = "The 
+    system shall support the ability to manually specify the quadrature type "
+                  "used for numerical integration on a per-block basis."
+    issues = '#32522' design = 'Quadrature/index.md'
+  [] [per-block-type-error]
+    type = RunException input = 'block-type.i' cli_args = 
+    "Executioner/Quadrature/custom_types='GAUSS_LOBATTO'" expect_err = "'custom_types' must have 
+    the same number of entries as 'custom_blocks'" requirement = "The system shall report an 
+    error when the number of entries in 'custom_types' "
+                  "does not match the number of entries in 'custom_blocks'."
+    issues = '#32522' design = 'Quadrature/index.md'
+  []
+[]

--- a/test/tests/quadrature/type/tests
+++ b/test/tests/quadrature/type/tests
@@ -1,15 +1,23 @@
 [Tests]
   [per-block-type]
-    type = CSVDiff input = 'block-type.i' csvdiff = 'block-type_out.csv' requirement = "The 
-    system shall support the ability to manually specify the quadrature type "
+    type = CSVDiff
+    input = 'block-type.i'
+    csvdiff = 'block-type_out.csv'
+
+    requirement = "The system shall support the ability to manually specify the quadrature type "
                   "used for numerical integration on a per-block basis."
-    issues = '#32522' design = 'Quadrature/index.md'
-  [] [per-block-type-error]
-    type = RunException input = 'block-type.i' cli_args = 
-    "Executioner/Quadrature/custom_types='GAUSS_LOBATTO'" expect_err = 
-    "Executioner/Quadrature/custom_types: Must have the same number of entries as 'custom_blocks'"
+    issues = '#32522'
+    design = 'Quadrature/index.md'
+  []
+  [per-block-type-error]
+    type = RunException
+    input = 'block-type.i'
+    cli_args = "Executioner/Quadrature/custom_types='GAUSS_LOBATTO'"
+    expect_err = "Executioner/Quadrature/custom_types: Must have the same number of entries as 'custom_blocks'"
+
     requirement = "The system shall report an error when the number of entries in 'custom_types' "
                   "does not match the number of entries in 'custom_blocks'."
-    issues = '#32522' design = 'Quadrature/index.md'
+    issues = '#32522'
+    design = 'Quadrature/index.md'
   []
 []

--- a/test/tests/quadrature/type/tests
+++ b/test/tests/quadrature/type/tests
@@ -6,9 +6,9 @@
     issues = '#32522' design = 'Quadrature/index.md'
   [] [per-block-type-error]
     type = RunException input = 'block-type.i' cli_args = 
-    "Executioner/Quadrature/custom_types='GAUSS_LOBATTO'" expect_err = "'custom_types' must have 
-    the same number of entries as 'custom_blocks'" requirement = "The system shall report an 
-    error when the number of entries in 'custom_types' "
+    "Executioner/Quadrature/custom_types='GAUSS_LOBATTO'" expect_err = 
+    "Executioner/Quadrature/custom_types: Must have the same number of entries as 'custom_blocks'"
+    requirement = "The system shall report an error when the number of entries in 'custom_types' "
                   "does not match the number of entries in 'custom_blocks'."
     issues = '#32522' design = 'Quadrature/index.md'
   []


### PR DESCRIPTION
Adds an optional `custom_types` MultiMooseEnum parameter to 
SetupQuadratureAction that allows users to specify a quadrature type 
per subdomain block, parallel to the existing `custom_blocks`/
`custom_orders` parameters. Essentially, this option allows users to specify quadrature methods on different blocks, e.g. using standard 1st order Gaussian quadrature on block A while using 3rd order Gauss-Lobatto quadrature on block B.

If `custom_types` is omitted, the global `_type` is used for all 
custom blocks, preserving existing behaviour. A mooseError is raised 
if the length of `custom_types` does not match `custom_blocks`.

refs #32522
