### PR TITLE
Resolve indetermination in which element to use for Dirac kernels

### DIFF
--- a/framework/include/dirackernels/DiracKernelBase.h
+++ b/framework/include/dirackernels/DiracKernelBase.h
@@ -103,7 +103,7 @@ protected:
    */
   unsigned currentPointCachedID();
 
-  ///< Current element
+  /// Current element
   const Elem * const & _current_elem;
 
   /// Coordinate system

--- a/framework/include/dirackernels/DiracKernelBase.h
+++ b/framework/include/dirackernels/DiracKernelBase.h
@@ -136,10 +136,8 @@ protected:
   /// drop duplicate points or consider them in residual and Jacobian
   const bool _drop_duplicate_points;
 
-  // @{ Point-not-found behavior
-  CreateMooseEnumClass(PointNotFoundBehavior, ERROR, WARNING, IGNORE);
-  const PointNotFoundBehavior _point_not_found_behavior;
-  // @}
+  /// What to do if the point is not found. See DiracKernelInfo for definition
+  const DiracKernelInfo::PointNotFoundBehavior _point_not_found_behavior;
 
   /// Whether Dirac sources can move during the simulation
   const bool _allow_moving_sources;

--- a/framework/include/dirackernels/DiracKernelInfo.h
+++ b/framework/include/dirackernels/DiracKernelInfo.h
@@ -11,6 +11,7 @@
 
 #include "Moose.h"
 #include "MooseTypes.h"
+#include "MooseEnum.h"
 
 #include <set>
 #include <map>
@@ -75,12 +76,21 @@ public:
    */
   void updatePointLocator(const MooseMesh & mesh);
 
+  // @{ Point-not-found behavior
+  CreateMooseEnumClass(PointNotFoundBehavior, ERROR, WARNING, IGNORE);
+
   /**
    * Used by client DiracKernel classes to determine the Elem in which
    * the Point p resides.  Uses the PointLocator owned by this object.
+   * @param p the point to find the element which contains it
+   * @param mesh the mesh with elements to look at
+   * @param blocks block restriction to find the element in
+   * @param point_not_found_behavior what to do if the point is not found
    */
-  const Elem *
-  findPoint(const Point & p, const MooseMesh & mesh, const std::set<SubdomainID> & blocks);
+  const Elem * findPoint(const Point & p,
+                         const MooseMesh & mesh,
+                         const std::set<SubdomainID> & blocks,
+                         const PointNotFoundBehavior point_not_found_behavior);
 
 protected:
   /**

--- a/framework/include/dirackernels/DiracKernelInfo.h
+++ b/framework/include/dirackernels/DiracKernelInfo.h
@@ -19,6 +19,7 @@
 
 // Forward declarations
 class MooseMesh;
+class MooseBase;
 
 namespace libMesh
 {
@@ -76,7 +77,7 @@ public:
    */
   void updatePointLocator(const MooseMesh & mesh);
 
-  // @{ Point-not-found behavior
+  /// Point-not-found behavior
   CreateMooseEnumClass(PointNotFoundBehavior, ERROR, WARNING, IGNORE);
 
   /**
@@ -86,11 +87,13 @@ public:
    * @param mesh the mesh with elements to look at
    * @param blocks block restriction to find the element in
    * @param point_not_found_behavior what to do if the point is not found
+   * @param consumer the object calling calling this routine
    */
   const Elem * findPoint(const Point & p,
                          const MooseMesh & mesh,
                          const std::set<SubdomainID> & blocks,
-                         const PointNotFoundBehavior point_not_found_behavior);
+                         const PointNotFoundBehavior point_not_found_behavior,
+                         const MooseBase & consumer);
 
 protected:
   /**

--- a/framework/src/dirackernels/DiracKernelBase.C
+++ b/framework/src/dirackernels/DiracKernelBase.C
@@ -149,9 +149,9 @@ DiracKernelBase::addPointWithValidId(Point p, unsigned id, Real value)
       points.push_back(std::make_pair(p, id));
     }
 
-    // Call the other addPoint() method.
-    if (elem)
-      addPoint(elem, p, id, value);
+    // Call the other addPoint() method. (no-op on elem=nullptr)
+    addPoint(elem, p, id, value);
+
     return_elem = elem;
   }
 

--- a/framework/src/dirackernels/DiracKernelBase.C
+++ b/framework/src/dirackernels/DiracKernelBase.C
@@ -39,7 +39,7 @@ DiracKernelBase::validParams()
 
   params.addParam<MooseEnum>(
       "point_not_found_behavior",
-      MooseEnum(getPointNotFoundBehaviorOptions(), "IGNORE"),
+      MooseEnum(DiracKernelInfo::getPointNotFoundBehaviorOptions(), "IGNORE"),
       "By default (IGNORE), it is ignored if an added point cannot be located in the "
       "specified subdomains. If this option is set to ERROR, this situation will result in an "
       "error. If this option is set to WARNING, then a warning will be issued.");
@@ -70,8 +70,8 @@ DiracKernelBase::DiracKernelBase(const InputParameters & parameters)
     _qrule(_assembly.qRule()),
     _JxW(_assembly.JxW()),
     _drop_duplicate_points(parameters.get<bool>("drop_duplicate_points")),
-    _point_not_found_behavior(
-        parameters.get<MooseEnum>("point_not_found_behavior").getEnum<PointNotFoundBehavior>()),
+    _point_not_found_behavior(parameters.get<MooseEnum>("point_not_found_behavior")
+                                  .getEnum<DiracKernelInfo::PointNotFoundBehavior>()),
     _allow_moving_sources(getParam<bool>("allow_moving_sources"))
 {
   // Stateful material properties are not allowed on DiracKernels
@@ -82,24 +82,7 @@ void
 DiracKernelBase::addPoint(const Elem * elem, Point p, unsigned /*id*/, Real value)
 {
   if (!elem || !hasBlocks(elem->subdomain_id()))
-  {
-    std::stringstream msg;
-    msg << "Point " << p << " not found in block(s) " << Moose::stringify(blockIDs(), ", ") << ".";
-    switch (_point_not_found_behavior)
-    {
-      case PointNotFoundBehavior::ERROR:
-        mooseError(msg.str());
-        break;
-      case PointNotFoundBehavior::WARNING:
-        mooseDoOnce(mooseWarning(msg.str()));
-        break;
-      case PointNotFoundBehavior::IGNORE:
-        break;
-      default:
-        mooseError("Internal enum error.");
-    }
     return;
-  }
 
   if (elem->processor_id() != processor_id())
     return;
@@ -123,8 +106,8 @@ DiracKernelBase::addPoint(Point p, unsigned id, Real value)
   // If id == libMesh::invalid_uint (the default), the user is not
   // enabling caching when they add Dirac points.  So all we can do is
   // the PointLocator lookup, and call the other addPoint() method.
-  const Elem * elem = _dirac_kernel_info.findPoint(p, _mesh, blockIDs());
-  addPoint(elem, p, id, value);
+  const Elem * elem = _dirac_kernel_info.findPoint(p, _mesh, blockIDs(), _point_not_found_behavior);
+  addPoint(elem, p, id);
   return elem;
 }
 
@@ -152,7 +135,8 @@ DiracKernelBase::addPointWithValidId(Point p, unsigned id, Real value)
   // safe, because all processors have the same value of we_found_it.
   if (!we_found_it)
   {
-    const Elem * elem = _dirac_kernel_info.findPoint(p, _mesh, blockIDs());
+    const Elem * elem =
+        _dirac_kernel_info.findPoint(p, _mesh, blockIDs(), _point_not_found_behavior);
 
     // Only add the point to the cache on this processor if the Elem is local
     if (elem && (elem->processor_id() == processor_id()))
@@ -165,9 +149,9 @@ DiracKernelBase::addPointWithValidId(Point p, unsigned id, Real value)
       points.push_back(std::make_pair(p, id));
     }
 
-    // Call the other addPoint() method.  This method ignores non-local
-    // and NULL elements automatically.
-    addPoint(elem, p, id, value);
+    // Call the other addPoint() method.
+    if (elem)
+      addPoint(elem, p, id, value);
     return_elem = elem;
   }
 
@@ -299,7 +283,8 @@ DiracKernelBase::addPointWithValidId(Point p, unsigned id, Real value)
   if (we_need_find_point)
   {
     // findPoint() is a parallel-only function
-    const Elem * elem = _dirac_kernel_info.findPoint(p, _mesh, blockIDs());
+    const Elem * elem =
+        _dirac_kernel_info.findPoint(p, _mesh, blockIDs(), _point_not_found_behavior);
 
     updateCaches(cached_elem, elem, p, id);
     addPoint(elem, p, id, value);

--- a/framework/src/dirackernels/DiracKernelBase.C
+++ b/framework/src/dirackernels/DiracKernelBase.C
@@ -106,7 +106,8 @@ DiracKernelBase::addPoint(Point p, unsigned id, Real value)
   // If id == libMesh::invalid_uint (the default), the user is not
   // enabling caching when they add Dirac points.  So all we can do is
   // the PointLocator lookup, and call the other addPoint() method.
-  const Elem * elem = _dirac_kernel_info.findPoint(p, _mesh, blockIDs(), _point_not_found_behavior);
+  const Elem * elem =
+      _dirac_kernel_info.findPoint(p, _mesh, blockIDs(), _point_not_found_behavior, *this);
   addPoint(elem, p, id);
   return elem;
 }
@@ -136,7 +137,7 @@ DiracKernelBase::addPointWithValidId(Point p, unsigned id, Real value)
   if (!we_found_it)
   {
     const Elem * elem =
-        _dirac_kernel_info.findPoint(p, _mesh, blockIDs(), _point_not_found_behavior);
+        _dirac_kernel_info.findPoint(p, _mesh, blockIDs(), _point_not_found_behavior, *this);
 
     // Only add the point to the cache on this processor if the Elem is local
     if (elem && (elem->processor_id() == processor_id()))
@@ -284,7 +285,7 @@ DiracKernelBase::addPointWithValidId(Point p, unsigned id, Real value)
   {
     // findPoint() is a parallel-only function
     const Elem * elem =
-        _dirac_kernel_info.findPoint(p, _mesh, blockIDs(), _point_not_found_behavior);
+        _dirac_kernel_info.findPoint(p, _mesh, blockIDs(), _point_not_found_behavior, *this);
 
     updateCaches(cached_elem, elem, p, id);
     addPoint(elem, p, id, value);

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -147,15 +147,11 @@ DiracKernelInfo::findPoint(const Point & p,
   mesh.comm().min(min_elem_id);
 
   // But we notably need the processor which owns elem_id to return it!
-  bool owns_min_elem_id = false;
-  if (min_elem_id != DofObject::invalid_id && mesh.elemPtr(min_elem_id) &&
-      mesh.elemPtr(min_elem_id)->processor_id() == mesh.processor_id())
-  {
-    elem = mesh.elemPtr(min_elem_id);
-    owns_min_elem_id = true;
-  }
-
-  return owns_min_elem_id ? elem : NULL;
+  if (min_elem_id != DofObject::invalid_id)
+    if (const auto min_elem = mesh.elemPtr(min_elem_id);
+        min_elem && min_elem->processor_id() == mesh.processor_id())
+      return min_elem;
+  return nullptr;
 }
 
 bool

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -9,6 +9,8 @@
 
 #include "DiracKernelInfo.h"
 #include "MooseMesh.h"
+#include "MooseEnum.h"
+#include "DiracKernelBase.h"
 
 // LibMesh
 #include "libmesh/point_locator_base.h"
@@ -112,7 +114,8 @@ DiracKernelInfo::updatePointLocator(const MooseMesh & mesh)
 const Elem *
 DiracKernelInfo::findPoint(const Point & p,
                            const MooseMesh & mesh,
-                           const std::set<SubdomainID> & blocks)
+                           const std::set<SubdomainID> & blocks,
+                           const PointNotFoundBehavior point_not_found_behavior)
 {
   // If the PointLocator has never been created, do so now.  NOTE - WE
   // CAN'T DO THIS if findPoint() is only called on some processors,
@@ -145,6 +148,25 @@ DiracKernelInfo::findPoint(const Point & p,
   // procs will return NULL.
   dof_id_type min_elem_id = elem_id;
   mesh.comm().min(min_elem_id);
+
+  if (min_elem_id == DofObject::invalid_id)
+  {
+    std::stringstream msg;
+    msg << "Point " << p << " not found in block(s) " << Moose::stringify(blocks, ", ") << ".\n";
+    switch (point_not_found_behavior)
+    {
+      case PointNotFoundBehavior::ERROR:
+        ::mooseError(msg.str());
+        break;
+      case PointNotFoundBehavior::WARNING:
+        mooseDoOnce(::mooseWarning(msg.str() + "This message will not be repeated."));
+        break;
+      case PointNotFoundBehavior::IGNORE:
+        break;
+      default:
+        ::mooseError("Internal enum error.");
+    }
+  }
 
   // But we notably need the processor which owns elem_id to return it!
   if (min_elem_id != DofObject::invalid_id)

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -146,7 +146,16 @@ DiracKernelInfo::findPoint(const Point & p,
   dof_id_type min_elem_id = elem_id;
   mesh.comm().min(min_elem_id);
 
-  return min_elem_id == elem_id ? elem : NULL;
+  // But we notably need the processor which owns elem_id to return it!
+  bool owns_min_elem_id = false;
+  if (min_elem_id != DofObject::invalid_id && mesh.elemPtr(min_elem_id) &&
+      mesh.elemPtr(min_elem_id)->processor_id() == mesh.processor_id())
+  {
+    elem = mesh.elemPtr(min_elem_id);
+    owns_min_elem_id = true;
+  }
+
+  return owns_min_elem_id ? elem : NULL;
 }
 
 bool

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -11,6 +11,7 @@
 #include "MooseMesh.h"
 #include "MooseEnum.h"
 #include "DiracKernelBase.h"
+#include "MooseBase.h"
 
 // LibMesh
 #include "libmesh/point_locator_base.h"
@@ -115,7 +116,8 @@ const Elem *
 DiracKernelInfo::findPoint(const Point & p,
                            const MooseMesh & mesh,
                            const std::set<SubdomainID> & blocks,
-                           const PointNotFoundBehavior point_not_found_behavior)
+                           const PointNotFoundBehavior point_not_found_behavior,
+                           const MooseBase & consumer)
 {
   // If the PointLocator has never been created, do so now.  NOTE - WE
   // CAN'T DO THIS if findPoint() is only called on some processors,
@@ -129,7 +131,7 @@ DiracKernelInfo::findPoint(const Point & p,
   // Check that the PointLocator is ready to start locating points.
   // So far I do not have any tests that trip this...
   if (_point_locator->initialized() == false)
-    mooseError("Error, PointLocator is not initialized!");
+    consumer.mooseError("PointLocator is not initialized!");
 
   // Note: The PointLocator object returns NULL when the Point is not
   // found within the Mesh.  This is not considered to be an error as
@@ -156,15 +158,15 @@ DiracKernelInfo::findPoint(const Point & p,
     switch (point_not_found_behavior)
     {
       case PointNotFoundBehavior::ERROR:
-        ::mooseError(msg.str());
+        consumer.mooseError(msg.str());
         break;
       case PointNotFoundBehavior::WARNING:
-        mooseDoOnce(::mooseWarning(msg.str() + "This message will not be repeated."));
+        mooseDoOnce(consumer.mooseWarning(msg.str() + "This message will not be repeated."));
         break;
       case PointNotFoundBehavior::IGNORE:
         break;
       default:
-        ::mooseError("Internal enum error.");
+        consumer.mooseError("Internal enum error.");
     }
   }
 

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -170,7 +170,7 @@ DiracKernelInfo::findPoint(const Point & p,
 
   // But we notably need the processor which owns elem_id to return it!
   if (min_elem_id != DofObject::invalid_id)
-    if (const auto min_elem = mesh.elemPtr(min_elem_id);
+    if (const auto min_elem = mesh.queryElemPtr(min_elem_id);
         min_elem && min_elem->processor_id() == mesh.processor_id())
       return min_elem;
   return nullptr;

--- a/test/tests/dirackernels/point_caching/found_on_other_rank.i
+++ b/test/tests/dirackernels/point_caching/found_on_other_rank.i
@@ -1,0 +1,60 @@
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 5
+    ny = 5
+    nz = 10
+    xmin = -2000
+    xmax = 2000
+    ymin = -2000
+    ymax = 2000
+    zmin = 0
+    zmax = 500
+  []
+[]
+
+[DiracKernels]
+  [bh1]
+    type = ConstantPointSource
+    variable = u
+    value = 10
+    point = '0 0 201.5'
+    point_not_found_behavior='WARNING'
+  []
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = 3
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/dirackernels/point_caching/tests
+++ b/test/tests/dirackernels/point_caching/tests
@@ -1,9 +1,9 @@
 [Tests]
-  issues = '#2364'
   design = 'syntax/DiracKernels/index.md'
 
   [point_caching]
     requirement = "The system shall support source location caching using element ids:"
+    issues = '#2364'
 
     [basic]
       type = 'Exodiff'
@@ -45,5 +45,18 @@
     expect_err = "does not match point"
     requirement = "The DiracKernel system shall report an error if a location does not correspond "
                   "with the supplied element id."
+    issues = '#2364'
+  []
+  [point_found_on_other_rank]
+    type = 'RunApp'
+    input = 'found_on_other_rank.i'
+    # skip the solve, not the setup
+    cli_args = 'Executioner/nl_abs_tol=1e10'
+    requirement = "The DiracKernel system shall not report a warning if the point of application of the kernel is not found on the first rank because it is located in another process' mesh partition."
+    allow_warnings = false
+    # process 0 does not contain the point
+    min_parallel = 2
+    max_parallel = 2
+    issues = '#32551'
   []
 []


### PR DESCRIPTION
Problem number 1
- two elems are candidates for owning the dirac point, as found by the point locator, and the min_elem_id is the one we want to end up (by convention)
- but the process owning min_elem_id element could actually pick the other one. Thus the element is never found by any process owning it

Problem number 2
In all the processes that do not own the element, we return null for the element pointer if it is not found (distributed mesh for example) from the DiracKernelInfo, then DiracKernelBase returns a warning / error / ignore behavior depending on the `point not found behavior`. But the point is actually found in another domain. 

 see discussion #32421
refs idaholab/moose#4455 for another mistake in using the point locator
closes #32551 the main issue here, bad parallel logic

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
