### PR TITLE
Added option to report nans/infs entering residual

### DIFF
--- a/framework/include/interfaces/TaggingInterface.h
+++ b/framework/include/interfaces/TaggingInterface.h
@@ -421,6 +421,11 @@ private:
                                 const std::set<TagID> & vector_tags,
                                 const std::set<TagID> & absolute_value_vector_tags);
 
+  /**
+   * Checks \c _local_re for NaNs/Infs and throws exception if found
+   */
+  void checkForNans() const;
+
   /// The vector tag ids this Kernel will contribute to
   std::set<TagID> _vector_tags;
 

--- a/framework/include/interfaces/TaggingInterface.h
+++ b/framework/include/interfaces/TaggingInterface.h
@@ -422,7 +422,7 @@ private:
                                 const std::set<TagID> & absolute_value_vector_tags);
 
   /**
-   * Checks \c _local_re for NaNs/Infs and throws exception if found
+   * Checks \c _local_re for NaNs/Infs and throws an exception if found
    */
   void checkForNans() const;
 

--- a/framework/include/interfaces/TaggingInterface.h
+++ b/framework/include/interfaces/TaggingInterface.h
@@ -421,10 +421,12 @@ private:
                                 const std::set<TagID> & vector_tags,
                                 const std::set<TagID> & absolute_value_vector_tags);
 
+#ifndef NDEBUG
   /**
    * Checks \c _local_re for NaNs/Infs and returns an error if found
    */
   void checkForNans() const;
+#endif
 
   /// The vector tag ids this Kernel will contribute to
   std::set<TagID> _vector_tags;

--- a/framework/include/interfaces/TaggingInterface.h
+++ b/framework/include/interfaces/TaggingInterface.h
@@ -422,7 +422,7 @@ private:
                                 const std::set<TagID> & absolute_value_vector_tags);
 
   /**
-   * Checks \c _local_re for NaNs/Infs and throws an exception if found
+   * Checks \c _local_re for NaNs/Infs and returns an error if found
    */
   void checkForNans() const;
 

--- a/framework/include/problems/DisplacedProblem.h
+++ b/framework/include/problems/DisplacedProblem.h
@@ -386,6 +386,8 @@ public:
   virtual bool checkNonlocalCouplingRequirement() const override;
   virtual const libMesh::CouplingMatrix & nonlocalCouplingMatrix(const unsigned i) const override;
 
+  virtual bool checkResidualForNans() const override { return _mproblem.checkResidualForNans(); }
+
 protected:
   FEProblemBase & _mproblem;
   MooseMesh & _mesh;

--- a/framework/include/problems/DisplacedProblem.h
+++ b/framework/include/problems/DisplacedProblem.h
@@ -386,7 +386,9 @@ public:
   virtual bool checkNonlocalCouplingRequirement() const override;
   virtual const libMesh::CouplingMatrix & nonlocalCouplingMatrix(const unsigned i) const override;
 
+#ifndef NDEBUG
   virtual bool checkResidualForNans() const override { return _mproblem.checkResidualForNans(); }
+#endif
 
 protected:
   FEProblemBase & _mproblem;

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -221,6 +221,14 @@ public:
    */
   bool checkingUOAuxState() const { return _checking_uo_aux_state; }
 
+  virtual bool checkResidualForNans() const override { return _check_residual_for_nans; }
+
+  /// Setter for residual NaN/Inf checking
+  void setCheckResidualForNans(bool check_residual_for_nans)
+  {
+    _check_residual_for_nans = check_residual_for_nans;
+  }
+
   /**
    * Whether to trust the user coupling matrix even if we want to do things like be paranoid and
    * create a full coupling matrix. See https://github.com/idaholab/moose/issues/16395 for detailed
@@ -3285,6 +3293,9 @@ protected:
 
   /// Whether or not checking the state of uo/aux evaluation
   const bool _uo_aux_state_check;
+
+  /// Whether to check the residual for NaN or Inf values
+  bool _check_residual_for_nans;
 
   /// Maximum number of quadrature points used in the problem
   unsigned int _max_qps;

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -221,6 +221,7 @@ public:
    */
   bool checkingUOAuxState() const { return _checking_uo_aux_state; }
 
+#ifndef NDEBUG
   virtual bool checkResidualForNans() const override { return _check_residual_for_nans; }
 
   /// Setter for residual NaN/Inf checking
@@ -228,6 +229,7 @@ public:
   {
     _check_residual_for_nans = check_residual_for_nans;
   }
+#endif
 
   /**
    * Whether to trust the user coupling matrix even if we want to do things like be paranoid and
@@ -3294,8 +3296,10 @@ protected:
   /// Whether or not checking the state of uo/aux evaluation
   const bool _uo_aux_state_check;
 
+#ifndef NDEBUG
   /// Whether to check the residual for NaN or Inf values
   bool _check_residual_for_nans;
+#endif
 
   /// Maximum number of quadrature points used in the problem
   unsigned int _max_qps;

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -925,8 +925,10 @@ public:
   /// Setter for debug chain control data output
   void setChainControlDataOutput(bool set_output) { _show_chain_control_data = set_output; }
 
+#ifndef NDEBUG
   /// Whether to check residual for NaN/Inf values
   virtual bool checkResidualForNans() const = 0;
+#endif
 
   /**
    * @return the number of nonlinear systems in the problem

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -925,13 +925,8 @@ public:
   /// Setter for debug chain control data output
   void setChainControlDataOutput(bool set_output) { _show_chain_control_data = set_output; }
 
-  /// Getter for residual NaN/Inf checking
-  bool checkResidualForNans() const { return _check_residual_for_nans; }
-  /// Setter for residual NaN/Inf checking
-  void setCheckResidualForNans(bool check_residual_for_nans)
-  {
-    _check_residual_for_nans = check_residual_for_nans;
-  }
+  /// Whether to check residual for NaN/Inf values
+  virtual bool checkResidualForNans() const = 0;
 
   /**
    * @return the number of nonlinear systems in the problem
@@ -1175,9 +1170,6 @@ private:
 
   /// Whether to output a list of all the chain control data
   bool _show_chain_control_data;
-
-  /// Whether to check the residual for NaN or Inf values
-  bool _check_residual_for_nans;
 
   /// The declared vector tags
   std::vector<VectorTag> _vector_tags;

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -925,6 +925,14 @@ public:
   /// Setter for debug chain control data output
   void setChainControlDataOutput(bool set_output) { _show_chain_control_data = set_output; }
 
+  /// Getter for residual NaN/Inf checking
+  bool checkResidualForNans() const { return _check_residual_for_nans; }
+  /// Setter for residual NaN/Inf checking
+  void setCheckResidualForNans(bool check_residual_for_nans)
+  {
+    _check_residual_for_nans = check_residual_for_nans;
+  }
+
   /**
    * @return the number of nonlinear systems in the problem
    */
@@ -1167,6 +1175,9 @@ private:
 
   /// Whether to output a list of all the chain control data
   bool _show_chain_control_data;
+
+  /// Whether to check the residual for NaN or Inf values
+  bool _check_residual_for_nans;
 
   /// The declared vector tags
   std::vector<VectorTag> _vector_tags;

--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -200,7 +200,8 @@ SetupDebugAction::act()
 #ifdef NDEBUG
     mooseError("The parameter 'error_on_residual_nan' may only be set to 'true' for 'dbg' and "
                "'devel' modes.");
-#endif
+#else
     _problem->setCheckResidualForNans(true);
+#endif
   }
 }

--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -75,6 +75,11 @@ SetupDebugAction::validParams()
       "show_block_restriction",
       BlockRestrictionDebugOutput::getScopes("none"),
       "Print out active objects like variables supplied for each block.");
+  params.addParam<bool>(
+      "error_on_residual_nan",
+      false,
+      "This option applies only to dbg and devel modes. If enabled, residual contributions are "
+      "checked for NaN or Inf values; if found, an error is reported.");
 
   params.addClassDescription("Adds various debugging type output to the simulation system.");
 
@@ -187,5 +192,15 @@ SetupDebugAction::act()
     const std::string type = "ControlOutput";
     auto params = _factory.getValidParams(type);
     _problem->addOutput(type, "_moose_controllable_debug_output", params);
+  }
+
+  // Enable residual NaN/Inf-checking
+  if (getParam<bool>("error_on_residual_nan"))
+  {
+#ifdef NDEBUG
+    mooseError("The parameter 'error_on_residual_nan' may only be set to 'true' for 'dbg' and "
+               "'devel' modes.");
+#endif
+    _problem->setCheckResidualForNans(true);
   }
 }

--- a/framework/src/interfaces/TaggingInterface.C
+++ b/framework/src/interfaces/TaggingInterface.C
@@ -460,6 +460,7 @@ TaggingInterface::assignTaggedLocalMatrix()
     *ke = _local_ke;
 }
 
+#ifndef NDEBUG
 void
 TaggingInterface::checkForNans() const
 {
@@ -480,5 +481,6 @@ TaggingInterface::checkForNans() const
       mooseError(ss.str());
     }
 }
+#endif
 
 TaggingInterface::~TaggingInterface() {}

--- a/framework/src/interfaces/TaggingInterface.C
+++ b/framework/src/interfaces/TaggingInterface.C
@@ -376,6 +376,11 @@ TaggingInterface::prepareMatrixTagLower(Assembly & assembly,
 void
 TaggingInterface::accumulateTaggedLocalResidual()
 {
+#ifndef NDEBUG
+  if (_subproblem.checkResidualForNans())
+    checkForNans();
+#endif
+
   for (auto & re : _re_blocks)
     *re += _local_re;
   for (auto & absre : _absre_blocks)
@@ -386,6 +391,11 @@ TaggingInterface::accumulateTaggedLocalResidual()
 void
 TaggingInterface::assignTaggedLocalResidual()
 {
+#ifndef NDEBUG
+  if (_subproblem.checkResidualForNans())
+    checkForNans();
+#endif
+
   for (auto & re : _re_blocks)
     *re = _local_re;
   for (auto & absre : _absre_blocks)
@@ -448,6 +458,27 @@ TaggingInterface::assignTaggedLocalMatrix()
 {
   for (auto & ke : _ke_blocks)
     *ke = _local_ke;
+}
+
+void
+TaggingInterface::checkForNans() const
+{
+  for (const auto i : index_range(_local_re))
+    if (!std::isfinite(_local_re(i)))
+    {
+      std::stringstream ss;
+      ss << "NaN or Inf detected in '" << _moose_object.name() << "'.\n";
+      ss << "To further troubleshoot this value in this residual object, add the following lines "
+            "before returning the value in the computeQpResidual() (or similar) method in the "
+            "source file for the class of '"
+         << _moose_object.name() << "':\n\n";
+      ss << "  if (!std::isfinite(<return value>))\n";
+      ss << "    mooseError(\"Found NaN or Inf\");\n\n";
+      ss << "Then you can use a breakpoint in a debugger to troubleshoot the origin of the NaN or "
+            "Inf value.";
+
+      mooseError(ss.str());
+    }
 }
 
 TaggingInterface::~TaggingInterface() {}

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -338,7 +338,7 @@ FEProblemBase::validParams()
       "Set to true to allow convergence even though the solution has been marked as 'invalid'");
   params.addParam<bool>("show_invalid_solution_console",
                         true,
-                        "Set to true to show the invalid solution occurance summary in console");
+                        "Set to true to show the invalid solution occurrence summary in console");
   params.addParam<bool>("immediately_print_invalid_solution",
                         false,
                         "Whether or not to report invalid solution warnings at the time the "

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -492,7 +492,9 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _fv_bcs_integrity_check(getParam<bool>("fv_bcs_integrity_check")),
     _material_dependency_check(getParam<bool>("material_dependency_check")),
     _uo_aux_state_check(getParam<bool>("check_uo_aux_state")),
+#ifndef NDEBUG
     _check_residual_for_nans(false),
+#endif
     _max_qps(std::numeric_limits<unsigned int>::max()),
     _max_scalar_order(INVALID_ORDER),
     _has_time_integrator(false),

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -492,6 +492,7 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _fv_bcs_integrity_check(getParam<bool>("fv_bcs_integrity_check")),
     _material_dependency_check(getParam<bool>("material_dependency_check")),
     _uo_aux_state_check(getParam<bool>("check_uo_aux_state")),
+    _check_residual_for_nans(false),
     _max_qps(std::numeric_limits<unsigned int>::max()),
     _max_scalar_order(INVALID_ORDER),
     _has_time_integrator(false),

--- a/framework/src/problems/SubProblem.C
+++ b/framework/src/problems/SubProblem.C
@@ -70,6 +70,7 @@ SubProblem::SubProblem(const InputParameters & parameters)
     _have_ad_objects(false),
     _show_functors(false),
     _show_chain_control_data(false),
+    _check_residual_for_nans(false),
     _typed_vector_tags(2),
     _have_p_refinement(false)
 {

--- a/framework/src/problems/SubProblem.C
+++ b/framework/src/problems/SubProblem.C
@@ -70,7 +70,6 @@ SubProblem::SubProblem(const InputParameters & parameters)
     _have_ad_objects(false),
     _show_functors(false),
     _show_chain_control_data(false),
-    _check_residual_for_nans(false),
     _typed_vector_tags(2),
     _have_p_refinement(false)
 {

--- a/modules/doc/content/application_development/debugging.md
+++ b/modules/doc/content/application_development/debugging.md
@@ -13,7 +13,7 @@ For a good tutorial on debugging [see Example 21](/ex21_debugging.md optional=Tr
 
 ## Debug Executable id=building_dbg
 
-The first step to debugging anything is to build a debug executable.  By default MOOSE-based applications are built in "optimized" (`opt`) mode, which ensures the fastest solves. However, an optimized executable is missing a lot of information that is useful to a debugger and the optimization process itself can cause code to get reordered (or even skipped!) making it difficult to step through a program. Additionally, debug modes contain assert statements that do not appear in the optimized builds, which may immediately catch the underlying issue. The following table summarizes the build options:
+The first step to debugging anything is to build a debug executable.  By default MOOSE-based applications are built in "optimized" (`opt`) mode, which ensures the fastest solves. However, an optimized executable is missing a lot of information that is useful to a debugger and the optimization process itself can cause code to get reordered (or even skipped!) making it difficult to step through a program. Additionally, debugging modes (`devel, `dbg`) contain assert statements that do not appear in the optimized builds, which may immediately catch the underlying issue. The following table summarizes the build options:
 
 | Build | Optimization/Speed | Debugging Info | Profiling Info | Typical Use |
 | :- | :- | :- | :- | :- |

--- a/modules/doc/content/application_development/debugging.md
+++ b/modules/doc/content/application_development/debugging.md
@@ -11,11 +11,18 @@ In particular, if you ever see a "Segfault" or a "Signal 11" that means it's tim
 
 For a good tutorial on debugging [see Example 21](/ex21_debugging.md optional=True)
 
-## Debug Executable
+## Debug Executable id=building_dbg
 
-The first step to debugging anything is to build a debug executable.  By default MOOSE-based applications are built in "optimized" (`opt`) mode.  That ensures the fastest solves.  However, an optimized executable is missing a lot of information that is useful to a debugger and the optimization process itself can cause code to get reordered (or even skipped!) making it difficult to step through a program.
+The first step to debugging anything is to build a debug executable.  By default MOOSE-based applications are built in "optimized" (`opt`) mode, which ensures the fastest solves. However, an optimized executable is missing a lot of information that is useful to a debugger and the optimization process itself can cause code to get reordered (or even skipped!) making it difficult to step through a program. Additionally, debug modes contain assert statements that do not appear in the optimized builds, which may immediately catch the underlying issue. The following table summarizes the build options:
 
-To build an executable suitable for debugging you need to set the `METHOD` environment variable to `dbg`.  You can `export` it in your environment but it's usually simpler to use a UNIX shortcut that allows you to define environment variables at the same time you run a command, like so:
+| Build | Optimization/Speed | Debugging Info | Profiling Info | Typical Use |
+| :- | :- | :- | :- | :- |
+| `opt` | High/High | Low | No | Production runs |
+| `oprof` | High/High | Low | Yes | Profiling |
+| `devel` | Medium/Medium | Medium | No | Daily development |
+| `dbg` | None/Slow | Full | No | Debugging |
+
+The `METHOD` environment variable specifies the build mode. While you could `export` it in your environment, it's usually simpler to use a UNIX shortcut that allows you to define environment variables at the same time you run a command, e.g.,
 
 ```bash
 METHOD=dbg make -j 8
@@ -23,7 +30,9 @@ METHOD=dbg make -j 8
 
 Always remember that the `8` should be modified to reflect the number of processors you want to use for the build (usually the number of cores in your computer).
 
-Once the build is complete you should end up with a "debug executable" that look like: `yourapp-dbg`.  That executable is perfect for loading into a debugger.  However, that executable will run VERY slowly - so make sure that before you begin debugging you come up with a problem that is as small as possible but still shows the problem you're trying to fix.
+The resulting executable is named `<appname>-<build>`, where `<appname>` is the name of your application, and `<build>` is the build (`opt`, `oprof`, `devel`, or `dbg`).
+
+`dbg` builds are ideal for debuggers, but keep in mind that they run very slowly, so you may want to reduce your problem size as much as possible while still preserving the defective behavior.
 
 ## Debuggers
 

--- a/modules/doc/content/application_usage/failed_solves.md
+++ b/modules/doc/content/application_usage/failed_solves.md
@@ -283,19 +283,21 @@ in a scalable manner.
 
 ### Solver reports the presence of a 'not a number' (NaN) id=nan
 
-If the solver is faced with invalid floating point arithmetic, such as dividing by 0 or computing the derivative of a
-L2-norm at 0, it will generate a `NaN` in the solution vector. This is undesirable and will cause the solve to fail.
+If the solver is faced with invalid floating point arithmetic, such as division by zero, a `NaN` or `Inf` will be appear in the nonlinear residual vector, causing the solve to fail.
 MOOSE will report the nonlinear solve as having not converged with:
 
 ```
 Nonlinear solve did not converge due to DIVERGED_FNORM_NAN.
 ```
 
-99% of the time, this arises because a variable is not initialized and the material properties are being evaluated out
-of bounds. Initializing all the variables in the simulation will fix the problem.
+Common sources of NaN or Inf values are:
 
-If not, you must find the source of the `NaN`. In most cases, you will be able to run your simulation again and
-pass the command line argument `--trap-fpe`. In some cases, this will not suffice and you will need to use a debugger.
+- Division by zero
+- Uninitialized variables
+
+To troubleshoot a NaN or Inf value, first compile in `dbg` mode (see [application_development/debugging.md#building_dbg]), which will provide more useful information to debuggers.
+
+For Linux machines, the command line argument `--trap-fpe` (note that this is enabled by default in `dbg` mode) should effectively trap floating point exceptions and provide a means to create a breakpoint in a debugger.
 Detailed instructions on using the debugger with a MOOSE-based application can be found on this [page](application_development/debugging.md).
 Once you have started the debugger, you will need to set a breakpoint on floating point exceptions then generate a backtrace.
 
@@ -318,6 +320,24 @@ avoid the division by 0 by setting a minimum denominator.
 []
 ```
 
+For Mac machines, the above strategy may not be effective. The parameter [!param](/Debug/error_on_residual_nan) can be used in `devel` and `dbg` modes, which throws an error when NaN or Inf values enter the nonlinear residual vector:
+
+```
+[Debug]
+  error_on_residual_nan = true
+[]
+```
+
+This provides the name of the residual object where the bad value enters the residual. If after reviewing the class' `computeQpResidual()` (or similar) method, you are still unable to understand the origin of the NaN or Inf value, you can use a debugger to break at the occurrence: add the following check to the return value `value` for `computeQpResidual()`:
+
+```
+if (!std::isfinite(value))
+  mooseError("NaN or Inf detected");
+```
+
+You can then add a breakpoint on this line and print intermediate values as necessary to determine the source of the NaN or Inf value. See [application_development/debugging.md] for more information.
+
+This approach should catch any NaN or Inf values entering the residual. Please [contact us](help/contact_us.md optional=True) if not, or if you also need to troubleshoot NaN or Inf values entering the Jacobian matrix.
 
 ## Failing nonlinear solve
 

--- a/modules/doc/content/application_usage/failed_solves.md
+++ b/modules/doc/content/application_usage/failed_solves.md
@@ -328,7 +328,7 @@ For Mac machines, the above strategy may not be effective. The parameter [!param
 []
 ```
 
-This provides the name of the residual object where the bad value enters the residual. If after reviewing the class' `computeQpResidual()` (or similar) method, you are still unable to understand the origin of the NaN or Inf value, you can use a debugger to break at the occurrence: add the following check to the return value `value` for `computeQpResidual()`:
+This provides the name of the residual object where the bad value enters the residual. If after reviewing the class's `computeQpResidual()` (or similar) method, you are still unable to understand the origin of the NaN or Inf value, you can use a debugger to break at the occurrence: add the following check to the return value `value` for `computeQpResidual()`:
 
 ```
 if (!std::isfinite(value))

--- a/modules/doc/content/application_usage/failed_solves.md
+++ b/modules/doc/content/application_usage/failed_solves.md
@@ -292,8 +292,8 @@ Nonlinear solve did not converge due to DIVERGED_FNORM_NAN.
 
 Common sources of NaN or Inf values are:
 
-- Division by zero
 - Uninitialized variables
+- Division by zero
 
 To troubleshoot a NaN or Inf value, first compile in `dbg` mode (see [application_development/debugging.md#building_dbg]), which will provide more useful information to debuggers.
 

--- a/test/tests/debug/error_on_residual_nan/error_on_residual_nan.i
+++ b/test/tests/debug/error_on_residual_nan/error_on_residual_nan.i
@@ -1,0 +1,31 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 2
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+  [nan_test]
+    type = NanKernel
+    variable = u
+    timestep_to_nan = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = PJFNK
+[]
+
+[Debug]
+  error_on_residual_nan = true
+[]

--- a/test/tests/debug/error_on_residual_nan/tests
+++ b/test/tests/debug/error_on_residual_nan/tests
@@ -1,0 +1,19 @@
+[Tests]
+  design = 'SetupDebugAction.md'
+  issues = '#32504'
+  [dbg_devel]
+    type = RunException
+    input = 'error_on_residual_nan.i'
+    expect_err = 'NaN or Inf detected in'
+    capabilities = 'method=dbg | method=devel'
+    cli_args = '--no-trap-fpe' # For Linux, this test would fail due to hitting trap
+    requirement = 'The system shall allow the user to specify to report an error when a NaN or Inf value enters the residual.'
+  []
+  [opt_oprof]
+    type = RunException
+    input = 'error_on_residual_nan.i'
+    expect_err = "The parameter 'error_on_residual_nan' may only be set to 'true' for 'dbg' and 'devel' modes."
+    capabilities = 'method=opt | method=oprof'
+    requirement = "The system shall report an error if 'report_on_residual_nan' is enabled in opt mode."
+  []
+[]

--- a/test/tests/debug/error_on_residual_nan/tests
+++ b/test/tests/debug/error_on_residual_nan/tests
@@ -14,6 +14,6 @@
     input = 'error_on_residual_nan.i'
     expect_err = "The parameter 'error_on_residual_nan' may only be set to 'true' for 'dbg' and 'devel' modes."
     capabilities = 'method=opt | method=oprof'
-    requirement = "The system shall report an error if the check for NaNs is selected in the compilation mode with maximum optimization."
+    requirement = "The system shall report an error if the check for NaNs is selected in optimized compilation modes."
   []
 []

--- a/test/tests/debug/error_on_residual_nan/tests
+++ b/test/tests/debug/error_on_residual_nan/tests
@@ -14,6 +14,6 @@
     input = 'error_on_residual_nan.i'
     expect_err = "The parameter 'error_on_residual_nan' may only be set to 'true' for 'dbg' and 'devel' modes."
     capabilities = 'method=opt | method=oprof'
-    requirement = "The system shall report an error if 'report_on_residual_nan' is enabled in opt mode."
+    requirement = "The system shall report an error if the check for NaNs is selected in the compilation mode with maximum optimization."
   []
 []


### PR DESCRIPTION
This is just a draft - I'm just asking for a quick direction check from reviewers. Ignore regression test.

Questions for reviewers:

1. Should the option only be available in !NDEBUG modes? Otherwise we'd get an additional IF statement for every call to `accumulateTaggedLocalResidual()` (to check if the user enabled the nan-checking option), which I'd assume is an unacceptable performance hit.
1. Should the message be an info, a warning, or error? Or should it be an option? {none, warning, error}.
1. Should we be changing the calls to `accumulateTaggedLocalResidual()` as I've done to provide the current element pointer? As you can see, it requires a lot of different objects to modify a line. I'm thinking maybe having "error" as an option might make this unnecessary, as they could break in a debugger at `mooseError` and get that info.
1. What should I call the param? `residual_nan_reporting` if multiple options?

This PR adds a NaN/Inf check to every call to `accumulateTaggedLocalResidual()`. I plan to also modify `assignTaggedLocalResidual()`. Hopefully that should cover any entry of nans into the residual vector.

Closes #32504
