### PR TITLE
Make MFEM materials both block and boundary restrictable

### DIFF
--- a/framework/doc/content/source/mfem/functormaterials/MFEMFunctorMaterial.md
+++ b/framework/doc/content/source/mfem/functormaterials/MFEMFunctorMaterial.md
@@ -8,9 +8,9 @@ Base class for declaration of material properties to add to MFEM problems.
 
 ## Overview
 
-`MFEMFunctorMaterial` is the base class for materials defined for MFEM problems. They may be defined on one
-or more subdomains (blocks); if no subdomains are provided, the material will be applied on all
-subdomains in the mesh.
+`MFEMFunctorMaterial` is the base class for materials defined for MFEM problems. They may be defined on either
+(a) one or more subdomains (blocks) or (b) one or more boundaries; if no subdomains or boundaries are provided,
+the material will be applied on all subdomains and boundaries of the main mesh.
 
 `MFEMFunctorMaterial` is intended to allow the specification of `mfem::Coefficient`,
 `mfem::VectorCoefficient`, and `mfem::MatrixCoefficient` objects to add to the MFEM problem in a

--- a/framework/include/mfem/functormaterials/MFEMFunctorMaterial.h
+++ b/framework/include/mfem/functormaterials/MFEMFunctorMaterial.h
@@ -13,9 +13,12 @@
 
 #include "MFEMGeneralUserObject.h"
 #include "MFEMBlockRestrictable.h"
+#include "MFEMBoundaryRestrictable.h"
 #include "CoefficientManager.h"
 
-class MFEMFunctorMaterial : public MFEMGeneralUserObject, public MFEMBlockRestrictable
+class MFEMFunctorMaterial : public MFEMGeneralUserObject,
+                            public MFEMBlockRestrictable,
+                            public MFEMBoundaryRestrictable
 {
 public:
   static InputParameters validParams();

--- a/framework/include/mfem/interfaces/MFEMBlockRestrictable.h
+++ b/framework/include/mfem/interfaces/MFEMBlockRestrictable.h
@@ -27,8 +27,8 @@ public:
 
   MFEMBlockRestrictable(const InputParameters & parameters, const mfem::ParMesh & mfem_mesh);
 
-  mfem::Array<int> subdomainsToAttributes(const std::vector<SubdomainName> & subdomain_names);
-  std::vector<std::string> subdomainsToStrings(const std::vector<SubdomainName> & subdomain_names);
+  mfem::Array<int> subdomainsToAttributes();
+  std::vector<std::string> subdomainsToStrings();
 
   /// Returns a bool indicating if the object is restricted to a subset of subdomains.
   bool isSubdomainRestricted() { return _subdomain_names.size(); }

--- a/framework/include/mfem/interfaces/MFEMBoundaryRestrictable.h
+++ b/framework/include/mfem/interfaces/MFEMBoundaryRestrictable.h
@@ -27,8 +27,8 @@ public:
 
   MFEMBoundaryRestrictable(const InputParameters & parameters, const mfem::ParMesh & mfem_mesh);
 
-  mfem::Array<int> boundariesToAttributes(const std::vector<BoundaryName> & boundary_names);
-  std::vector<std::string> boundariesToStrings(const std::vector<BoundaryName> & boundary_names);
+  mfem::Array<int> boundariesToAttributes();
+  std::vector<std::string> boundariesToStrings();
 
   /// Returns a bool indicating if the object is restricted to a subset of boundaries
   bool isBoundaryRestricted() const
@@ -36,9 +36,9 @@ public:
     return !(_boundary_attributes.Size() == 1 && _boundary_attributes[0] == -1);
   }
 
-  const mfem::ParMesh & getMesh() { return _mfem_mesh; }
   const mfem::Array<int> & getBoundaryAttributes() { return _boundary_attributes; }
   mfem::Array<int> & getBoundaryMarkers() { return _boundary_markers; }
+  const mfem::ParMesh & getMesh() { return _mfem_mesh; }
 
 protected:
   /// Stores the names of the boundaries.

--- a/framework/include/mfem/interfaces/MFEMBoundaryRestrictable.h
+++ b/framework/include/mfem/interfaces/MFEMBoundaryRestrictable.h
@@ -28,6 +28,7 @@ public:
   MFEMBoundaryRestrictable(const InputParameters & parameters, const mfem::ParMesh & mfem_mesh);
 
   mfem::Array<int> boundariesToAttributes(const std::vector<BoundaryName> & boundary_names);
+  std::vector<std::string> boundariesToStrings(const std::vector<BoundaryName> & boundary_names);
 
   /// Returns a bool indicating if the object is restricted to a subset of boundaries
   bool isBoundaryRestricted() const

--- a/framework/src/mfem/functormaterials/MFEMFunctorMaterial.C
+++ b/framework/src/mfem/functormaterials/MFEMFunctorMaterial.C
@@ -17,6 +17,7 @@ MFEMFunctorMaterial::validParams()
 {
   InputParameters params = MFEMGeneralUserObject::validParams();
   params += MFEMBlockRestrictable::validParams();
+  params += MFEMBoundaryRestrictable::validParams();
 
   params.addClassDescription(
       "Base class for declaration of material properties to add to MFEM problems.");
@@ -35,8 +36,11 @@ MFEMFunctorMaterial::pointFromMFEMVector(const mfem::Vector & vec)
 MFEMFunctorMaterial::MFEMFunctorMaterial(const InputParameters & parameters)
   : MFEMGeneralUserObject(parameters),
     MFEMBlockRestrictable(parameters, getMFEMProblem().mesh().getMFEMParMesh()),
+    MFEMBoundaryRestrictable(parameters, getMFEMProblem().mesh().getMFEMParMesh()),
     _properties(getMFEMProblem().getCoefficients())
 {
+  if (isSubdomainRestricted() && isBoundaryRestricted())
+    paramError("boundary", "Cannot specify both block and boundary parameters");
 }
 
 MFEMFunctorMaterial::~MFEMFunctorMaterial() {}

--- a/framework/src/mfem/functormaterials/MFEMGenericFunctorMaterial.C
+++ b/framework/src/mfem/functormaterials/MFEMGenericFunctorMaterial.C
@@ -38,8 +38,11 @@ MFEMGenericFunctorMaterial::MFEMGenericFunctorMaterial(const InputParameters & p
     paramError("prop_names", "Must match the size of prop_values");
 
   for (const auto i : index_range(_prop_names))
-    _properties.declareScalarProperty(
-        _prop_names[i], subdomainsToStrings(_subdomain_names), _prop_values[i]);
+    _properties.declareScalarProperty(_prop_names[i],
+                                      isBoundaryRestricted()
+                                          ? boundariesToStrings(_boundary_names)
+                                          : subdomainsToStrings(_subdomain_names),
+                                      _prop_values[i]);
 }
 
 MFEMGenericFunctorMaterial::~MFEMGenericFunctorMaterial() {}

--- a/framework/src/mfem/functormaterials/MFEMGenericFunctorMaterial.C
+++ b/framework/src/mfem/functormaterials/MFEMGenericFunctorMaterial.C
@@ -39,9 +39,8 @@ MFEMGenericFunctorMaterial::MFEMGenericFunctorMaterial(const InputParameters & p
 
   for (const auto i : index_range(_prop_names))
     _properties.declareScalarProperty(_prop_names[i],
-                                      isBoundaryRestricted()
-                                          ? boundariesToStrings(_boundary_names)
-                                          : subdomainsToStrings(_subdomain_names),
+                                      isBoundaryRestricted() ? boundariesToStrings()
+                                                             : subdomainsToStrings(),
                                       _prop_values[i]);
 }
 

--- a/framework/src/mfem/functormaterials/MFEMGenericFunctorVectorMaterial.C
+++ b/framework/src/mfem/functormaterials/MFEMGenericFunctorVectorMaterial.C
@@ -84,9 +84,8 @@ MFEMGenericFunctorVectorMaterial::MFEMGenericFunctorVectorMaterial(
 
   for (const auto i : index_range(_prop_names))
     _properties.declareVectorProperty(_prop_names[i],
-                                      isBoundaryRestricted()
-                                          ? boundariesToStrings(_boundary_names)
-                                          : subdomainsToStrings(_subdomain_names),
+                                      isBoundaryRestricted() ? boundariesToStrings()
+                                                             : subdomainsToStrings(),
                                       _prop_values[i]);
 }
 

--- a/framework/src/mfem/functormaterials/MFEMGenericFunctorVectorMaterial.C
+++ b/framework/src/mfem/functormaterials/MFEMGenericFunctorVectorMaterial.C
@@ -83,8 +83,11 @@ MFEMGenericFunctorVectorMaterial::MFEMGenericFunctorVectorMaterial(
     paramError("prop_names", "Must match the size of prop_values");
 
   for (const auto i : index_range(_prop_names))
-    _properties.declareVectorProperty(
-        _prop_names[i], subdomainsToStrings(_subdomain_names), _prop_values[i]);
+    _properties.declareVectorProperty(_prop_names[i],
+                                      isBoundaryRestricted()
+                                          ? boundariesToStrings(_boundary_names)
+                                          : subdomainsToStrings(_subdomain_names),
+                                      _prop_values[i]);
 }
 
 MFEMGenericFunctorVectorMaterial::~MFEMGenericFunctorVectorMaterial() {}

--- a/framework/src/mfem/interfaces/MFEMBlockRestrictable.C
+++ b/framework/src/mfem/interfaces/MFEMBlockRestrictable.C
@@ -30,21 +30,20 @@ MFEMBlockRestrictable::MFEMBlockRestrictable(const InputParameters & parameters,
                                              const mfem::ParMesh & mfem_mesh)
   : _mfem_mesh(mfem_mesh),
     _subdomain_names(parameters.get<std::vector<SubdomainName>>("block")),
-    _subdomain_attributes(_subdomain_names.size())
+    _subdomain_attributes(subdomainsToAttributes())
 {
-  _subdomain_attributes = subdomainsToAttributes(_subdomain_names);
   if (!_subdomain_attributes.IsEmpty())
     mfem::common::AttrToMarker(
         _mfem_mesh.attributes.Max(), _subdomain_attributes, _subdomain_markers);
 }
 
 mfem::Array<int>
-MFEMBlockRestrictable::subdomainsToAttributes(const std::vector<SubdomainName> & subdomain_names)
+MFEMBlockRestrictable::subdomainsToAttributes()
 {
   mfem::Array<int> attributes;
   auto & mesh = getMesh();
 
-  for (const SubdomainName & subdomain_name : subdomain_names)
+  for (const SubdomainName & subdomain_name : _subdomain_names)
   {
     try
     {
@@ -64,9 +63,9 @@ MFEMBlockRestrictable::subdomainsToAttributes(const std::vector<SubdomainName> &
 }
 
 std::vector<std::string>
-MFEMBlockRestrictable::subdomainsToStrings(const std::vector<SubdomainName> & names)
+MFEMBlockRestrictable::subdomainsToStrings()
 {
-  auto attrs = subdomainsToAttributes(names);
+  const auto & attrs = _subdomain_attributes;
   std::vector<std::string> strs(attrs.Size());
   std::transform(attrs.begin(), attrs.end(), strs.begin(), [](int n) { return std::to_string(n); });
   return strs;

--- a/framework/src/mfem/interfaces/MFEMBlockRestrictable.C
+++ b/framework/src/mfem/interfaces/MFEMBlockRestrictable.C
@@ -64,13 +64,12 @@ MFEMBlockRestrictable::subdomainsToAttributes(const std::vector<SubdomainName> &
 }
 
 std::vector<std::string>
-MFEMBlockRestrictable::subdomainsToStrings(const std::vector<SubdomainName> & subdomain_names)
+MFEMBlockRestrictable::subdomainsToStrings(const std::vector<SubdomainName> & names)
 {
-  auto attributes = subdomainsToAttributes(subdomain_names);
-  std::vector<std::string> subdomain_attr_strings(subdomain_names.size());
-  for (const auto i : index_range(subdomain_names))
-    subdomain_attr_strings[i] = std::to_string(attributes[i]);
-  return subdomain_attr_strings;
+  auto attrs = subdomainsToAttributes(names);
+  std::vector<std::string> strs(attrs.Size());
+  std::transform(attrs.begin(), attrs.end(), strs.begin(), [](int n) { return std::to_string(n); });
+  return strs;
 }
 
 #endif

--- a/framework/src/mfem/interfaces/MFEMBoundaryRestrictable.C
+++ b/framework/src/mfem/interfaces/MFEMBoundaryRestrictable.C
@@ -65,4 +65,13 @@ MFEMBoundaryRestrictable::boundariesToAttributes(const std::vector<BoundaryName>
   return attributes;
 }
 
+std::vector<std::string>
+MFEMBoundaryRestrictable::boundariesToStrings(const std::vector<BoundaryName> & boundary_names)
+{
+  auto attrs = boundariesToAttributes(boundary_names);
+  std::vector<std::string> strs(attrs.Size());
+  std::transform(attrs.begin(), attrs.end(), strs.begin(), [](int n) { return std::to_string(n); });
+  return strs;
+}
+
 #endif

--- a/framework/src/mfem/interfaces/MFEMBoundaryRestrictable.C
+++ b/framework/src/mfem/interfaces/MFEMBoundaryRestrictable.C
@@ -28,22 +28,21 @@ MFEMBoundaryRestrictable::MFEMBoundaryRestrictable(const InputParameters & param
                                                    const mfem::ParMesh & mfem_mesh)
   : _mfem_mesh(mfem_mesh),
     _boundary_names(parameters.get<std::vector<BoundaryName>>("boundary")),
-    _boundary_attributes(_boundary_names.size())
+    _boundary_attributes(boundariesToAttributes())
 {
-  _boundary_attributes = boundariesToAttributes(_boundary_names);
   if (!_boundary_attributes.IsEmpty())
     mfem::common::AttrToMarker(
         _mfem_mesh.bdr_attributes.Max(), _boundary_attributes, _boundary_markers);
 }
 
 mfem::Array<int>
-MFEMBoundaryRestrictable::boundariesToAttributes(const std::vector<BoundaryName> & boundary_names)
+MFEMBoundaryRestrictable::boundariesToAttributes()
 {
-  mfem::Array<int> attributes(boundary_names.size());
+  mfem::Array<int> attributes(_boundary_names.size());
   auto & mesh = getMesh();
   std::transform(
-      boundary_names.begin(),
-      boundary_names.end(),
+      _boundary_names.begin(),
+      _boundary_names.end(),
       attributes.begin(),
       [&mesh](const BoundaryName & boundary) -> int
       {
@@ -66,9 +65,9 @@ MFEMBoundaryRestrictable::boundariesToAttributes(const std::vector<BoundaryName>
 }
 
 std::vector<std::string>
-MFEMBoundaryRestrictable::boundariesToStrings(const std::vector<BoundaryName> & boundary_names)
+MFEMBoundaryRestrictable::boundariesToStrings()
 {
-  auto attrs = boundariesToAttributes(boundary_names);
+  const auto & attrs = _boundary_attributes;
   std::vector<std::string> strs(attrs.Size());
   std::transform(attrs.begin(), attrs.end(), strs.begin(), [](int n) { return std::to_string(n); });
   return strs;

--- a/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
@@ -61,6 +61,10 @@ MFEMCutTransitionSubMesh::buildSubMesh()
       getMesh(), getMesh().attribute_sets.GetAttributeSet(_transition_subdomain)));
   _submesh->attribute_sets.attr_sets = getMesh().attribute_sets.attr_sets;
   _submesh->bdr_attribute_sets.attr_sets = getMesh().bdr_attribute_sets.attr_sets;
+  // Create boundary attribute set labelling the exterior of the newly created
+  // transition region, excluding the cut
+  _submesh->bdr_attribute_sets.SetAttributeSet(
+      _transition_subdomain_boundary, mfem::Array<int>({getMesh().bdr_attributes.Max() + 1}));
 }
 
 void
@@ -228,7 +232,6 @@ MFEMCutTransitionSubMesh::setAttributes(mfem::ParMesh & parent_mesh,
       MPI_IN_PLACE, new_attrs, old_max_attr, MPI_INT, MPI_MAX, getMFEMProblem().getComm());
 
   mfem::AttributeSets & attr_sets = parent_mesh.attribute_sets;
-  mfem::AttributeSets & bdr_attr_sets = parent_mesh.bdr_attribute_sets;
   // Create attribute set labelling the newly created transition region on one side of the cut
   attr_sets.CreateAttributeSet(_transition_subdomain);
   // Create attribute set labelling the entire closed geometry
@@ -251,11 +254,6 @@ MFEMCutTransitionSubMesh::setAttributes(mfem::ParMesh & parent_mesh,
       }
     }
   }
-
-  // Create boundary attribute set labelling the exterior of the newly created
-  // transition region, excluding the cut
-  bdr_attr_sets.SetAttributeSet(_transition_subdomain_boundary,
-                                mfem::Array<int>({parent_mesh.bdr_attributes.Max() + 1}));
 
   parent_mesh.SetAttributes();
 }


### PR DESCRIPTION
## Bug fixes
- When converting subdomain names to attribute ids, we no longer assume their number matches, i.e. one name might correspond to more than one id, for instance after creating a cut transition submesh;
- When creating a cut transition submesh, we no longer add a boundary attribute set to the parent mesh corresponding to the exterior boundary of the newly created submesh - indeed, that boundary, as a labelled entity as such, does not exist and is not created in the parent mesh, only in the submesh.

## Feature additions
- Material coefficients (i.e. functors) are now boundary restrictable too (in addition to being subdomain/block restrictable). This is to allow boundary integrators (for example) to use (arbitrarily convoluted) coefficients defined on the boundary itself: up until now we could only (soundly) use literal constants or globally defined coefficients.