### PR TITLE
Code refactoring and bug fixing in MFEM-related classes

### DIFF
--- a/framework/doc/content/source/mfem/auxkernels/MFEMAuxKernel.md
+++ b/framework/doc/content/source/mfem/auxkernels/MFEMAuxKernel.md
@@ -15,7 +15,7 @@ An `MFEMAuxKernel` is derived from `MFEMGeneralUserObject`, and thus the order o
 can be controlled similar to other MOOSE UserObjects using the `execution_order_group` input
 parameter.
 
-`MFEMAuxKernel` is a purely virtual base class. Derived classes should override the `execute`
+`MFEMAuxKernel` is a base class. Derived classes should override the `execute`
  method to update the `_result_var` during execution.
 
 !if-end!

--- a/framework/doc/content/source/mfem/auxkernels/MFEMComplexAuxKernel.md
+++ b/framework/doc/content/source/mfem/auxkernels/MFEMComplexAuxKernel.md
@@ -15,7 +15,7 @@ An `MFEMComplexAuxKernel` is derived from `MFEMGeneralUserObject`, and thus the 
 can be controlled similar to other MOOSE UserObjects using the `execution_order_group` input
 parameter.
 
-`MFEMComplexAuxKernel` is a purely virtual base class. Derived classes should override the `execute`
+`MFEMComplexAuxKernel` is a base class. Derived classes should override the `execute`
  method to update the `_result_var` during execution.
 
 !if-end!

--- a/framework/doc/content/source/mfem/auxkernels/MFEMComplexDivAux.md
+++ b/framework/doc/content/source/mfem/auxkernels/MFEMComplexDivAux.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-AuxKernel for calculating the divegence of a complex $H(\mathrm{div})$ conforming source variable defined
+AuxKernel for calculating the divergence of a complex $H(\mathrm{div})$ conforming source variable defined
 on a 3D Raviart-Thomas finite element space and storing it in a complex scalar elemental result variable
 defined on an $L^2$ FE space.
 

--- a/framework/doc/content/source/mfem/auxkernels/MFEMDivAux.md
+++ b/framework/doc/content/source/mfem/auxkernels/MFEMDivAux.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-AuxKernel for calculating the divegence of an $H(\mathrm{div})$ conforming source variable defined
+AuxKernel for calculating the divergence of an $H(\mathrm{div})$ conforming source variable defined
 on a 3D Raviart-Thomas finite element space and storing it in a scalar elemental result variable
 defined on an $L^2$ FE space.
 

--- a/framework/doc/content/source/mfem/kernels/MFEMKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMKernel.md
@@ -20,7 +20,7 @@ forms, the trial variable that the integrator acts on is the variable returned f
 equations (labeled by test variable) with the trial variable solved using them, the set of test
 variable names is the same as the set of trial variable names for a square system.
 
-`MFEMKernel` is a purely virtual base class. Derived classes should override the `createBFIntegrator`
+`MFEMKernel` is a base class. Derived classes should override the `createBFIntegrator`
 and/or the `createLFIntegrator` methods to return a `BilinearFormIntegrator` and/or a
 `LinearFormIntegrator` (respectively) to add to the `EquationSystem`. Derived classes could also 
 override `createNLIntegrator` to solve non-linear problems using 

--- a/framework/include/mfem/bcs/MFEMBoundaryCondition.h
+++ b/framework/include/mfem/bcs/MFEMBoundaryCondition.h
@@ -24,11 +24,11 @@ public:
   MFEMBoundaryCondition(const InputParameters & parameters);
   virtual ~MFEMBoundaryCondition() = default;
 
-  /// Get name of the test variable labelling the weak form this kernel is added to
+  /// Get name of the test variable labelling the weak form this bc is added to
   const VariableName & getTestVariableName() const { return _test_var_name; }
 
 protected:
-  /// Name of (the test variable associated with) the weak form that the kernel is applied to.
+  /// Name of (the test variable associated with) the weak form that the bc is applied to.
   const VariableName & _test_var_name;
 };
 

--- a/framework/include/mfem/bcs/MFEMBoundaryIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMBoundaryIntegratedBC.h
@@ -23,9 +23,6 @@ public:
   /// Create MFEM integrator to apply to the RHS of the weak form. Ownership managed by the caller.
   virtual mfem::LinearFormIntegrator * createLFIntegrator();
 
-  /// Create MFEM integrator to apply to the LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator();
-
 protected:
   mfem::Coefficient & _coef;
 };

--- a/framework/include/mfem/bcs/MFEMBoundaryNormalIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMBoundaryNormalIntegratedBC.h
@@ -23,9 +23,6 @@ public:
   /// Create MFEM integrator to apply to the RHS of the weak form. Ownership managed by the caller.
   virtual mfem::LinearFormIntegrator * createLFIntegrator() override;
 
-  /// Create MFEM integrator to apply to the LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() override;
-
 protected:
   mfem::VectorCoefficient & _vec_coef;
 };

--- a/framework/include/mfem/bcs/MFEMComplexEssentialBC.h
+++ b/framework/include/mfem/bcs/MFEMComplexEssentialBC.h
@@ -21,7 +21,7 @@ public:
   MFEMComplexEssentialBC(const InputParameters & parameters);
   virtual ~MFEMComplexEssentialBC() = default;
 
-  /// Get name of the trial variable (gridfunction) the kernel acts on.
+  /// Get name of the trial variable (gridfunction) the bc acts on.
   /// Defaults to the name of the test variable labelling the weak form.
   virtual const std::string & getTrialVariableName() const { return _test_var_name; }
 

--- a/framework/include/mfem/bcs/MFEMComplexIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMComplexIntegratedBC.h
@@ -41,7 +41,7 @@ public:
   virtual void setRealBC(std::shared_ptr<MFEMIntegratedBC> bc) { _real_bc = bc; }
   virtual void setImagBC(std::shared_ptr<MFEMIntegratedBC> bc) { _imag_bc = bc; }
 
-  /// Get name of the trial variable (gridfunction) the kernel acts on.
+  /// Get name of the trial variable (gridfunction) the bc acts on.
   /// Defaults to the name of the test variable labelling the weak form.
   virtual const std::string & getTrialVariableName() const { return _test_var_name; }
 

--- a/framework/include/mfem/bcs/MFEMEssentialBC.h
+++ b/framework/include/mfem/bcs/MFEMEssentialBC.h
@@ -21,7 +21,7 @@ public:
   MFEMEssentialBC(const InputParameters & parameters);
   virtual ~MFEMEssentialBC() = default;
 
-  /// Get name of the trial variable (gridfunction) the kernel acts on.
+  /// Get name of the trial variable (gridfunction) the bc acts on.
   /// Defaults to the name of the test variable labelling the weak form.
   virtual const std::string & getTrialVariableName() const { return _test_var_name; }
 

--- a/framework/include/mfem/bcs/MFEMIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMIntegratedBC.h
@@ -30,7 +30,7 @@ public:
   /// Create MFEM integrator to apply to the LHS of the weak form. Ownership managed by the caller.
   virtual mfem::BilinearFormIntegrator * createBFIntegrator() { return nullptr; };
 
-  /// Get name of the trial variable (gridfunction) the kernel acts on.
+  /// Get name of the trial variable (gridfunction) the bc acts on.
   /// Defaults to the name of the test variable labelling the weak form.
   virtual const std::string & getTrialVariableName() const { return _test_var_name; }
 };

--- a/framework/include/mfem/bcs/MFEMVectorBoundaryIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorBoundaryIntegratedBC.h
@@ -23,9 +23,6 @@ public:
   /// Create MFEM integrator to apply to the RHS of the weak form. Ownership managed by the caller.
   virtual mfem::LinearFormIntegrator * createLFIntegrator() override;
 
-  /// Create MFEM integrator to apply to the LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() override;
-
 protected:
   mfem::VectorCoefficient & _vec_coef;
 };

--- a/framework/include/mfem/bcs/MFEMVectorFEBoundaryFluxIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorFEBoundaryFluxIntegratedBC.h
@@ -23,9 +23,6 @@ public:
   /// Create MFEM integrator to apply to the RHS of the weak form. Ownership managed by the caller.
   virtual mfem::LinearFormIntegrator * createLFIntegrator();
 
-  /// Create MFEM integrator to apply to the LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator();
-
 protected:
   mfem::Coefficient & _coef;
 };

--- a/framework/include/mfem/bcs/MFEMVectorFEBoundaryTangentIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorFEBoundaryTangentIntegratedBC.h
@@ -23,9 +23,6 @@ public:
   /// Create MFEM integrator to apply to the RHS of the weak form. Ownership managed by the caller.
   virtual mfem::LinearFormIntegrator * createLFIntegrator();
 
-  /// Create MFEM integrator to apply to the LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator();
-
 protected:
   mfem::VectorCoefficient & _vec_coef;
 };

--- a/framework/include/mfem/bcs/MFEMVectorFEMassIntegratedBC.h
+++ b/framework/include/mfem/bcs/MFEMVectorFEMassIntegratedBC.h
@@ -20,9 +20,6 @@ public:
 
   MFEMVectorFEMassIntegratedBC(const InputParameters & parameters);
 
-  /// Create MFEM integrator to apply to the RHS of the weak form. Ownership managed by the caller.
-  virtual mfem::LinearFormIntegrator * createLFIntegrator();
-
   /// Create MFEM integrator to apply to the LHS of the weak form. Ownership managed by the caller.
   virtual mfem::BilinearFormIntegrator * createBFIntegrator();
 

--- a/framework/include/mfem/containers/MFEMContainers.h
+++ b/framework/include/mfem/containers/MFEMContainers.h
@@ -123,45 +123,26 @@ protected:
   }
 
   /// Check that the field pointer is valid and the field has not already been registered.
-  void CheckFieldIsRegistrable(const std::string & field_name, T * field) const
+  void CheckFieldIsRegistrable([[maybe_unused]] const std::string & field_name,
+                               [[maybe_unused]] T * field) const
   {
-    if (!field)
-    {
-      MFEM_ABORT("Cannot register NULL field with name '" << field_name << "'.");
-    }
-
-    CheckForDoubleRegistration(field_name, field);
-  }
-
-  /// Check for double-registration of a field. A double-registered field may
-  /// result in undefined behavior.
-  void CheckForDoubleRegistration(const std::string & field_name, T * field) const
-  {
-    if (Has(field_name) && Get(field_name) == field)
-    {
-      MFEM_ABORT("The field '" << field_name << "' is already registered.");
-    }
+    mooseAssert(field, "Cannot register NULL field with name '" + field_name + "'.");
+    mooseAssert(!Has(field_name) || Get(field_name) != field,
+                "The field '" + field_name + "' is already registered.");
   }
 
   /// Check that a field exists in the map.
   void CheckFieldIsRegistered(const std::string & field_name) const
   {
     if (!Has(field_name))
-    {
-      MFEM_ABORT("The field '" << field_name << "' has not been registered.");
-    }
+      mooseError("The field '" + field_name + "' has not been registered.");
   }
 
   /// Ensure that a returned shared pointer is valid.
   inline std::shared_ptr<T> EnsureFieldPointerIsNonNull(const_iterator & iterator) const
   {
     auto owned_ptr = iterator->second;
-
-    if (!owned_ptr)
-    {
-      MFEM_ABORT("The field '" << iterator->first << "' is NULL.");
-    }
-
+    mooseAssert(owned_ptr, "The field '" + iterator->first + "' is NULL.");
     return owned_ptr;
   }
 
@@ -170,12 +151,7 @@ protected:
   inline TDerived * EnsurePointerCastIsNonNull(T * ptr) const
   {
     auto derived_ptr = dynamic_cast<TDerived *>(ptr);
-
-    if (!derived_ptr)
-    {
-      MFEM_ABORT("The dynamic cast performed on the field pointer failed.");
-    }
-
+    mooseAssert(derived_ptr, "The dynamic cast performed on the field pointer failed.");
     return derived_ptr;
   }
 

--- a/framework/include/mfem/equation_systems/EquationSystem.h
+++ b/framework/include/mfem/equation_systems/EquationSystem.h
@@ -74,7 +74,12 @@ protected:
   /// Deletes the HypreParMatrix associated with any pointer stored in _h_blocks,
   /// and then proceeds to delete all dynamically allocated memory for _h_blocks
   /// itself, resetting all dimensions to zero.
-  void DeleteAllBlocks();
+  void DeleteHBlocks();
+
+  /// Deletes the HypreParMatrix associated with any pointer stored in _jacobian_blocks,
+  /// and then proceeds to delete all dynamically allocated memory for _jacobian_blocks
+  /// itself, resetting all dimensions to zero.
+  void DeleteJacobianBlocks();
 
   bool VectorContainsName(const std::vector<std::string> & the_vector,
                           const std::string & name) const;

--- a/framework/include/mfem/fespaces/MFEMFESpace.h
+++ b/framework/include/mfem/fespaces/MFEMFESpace.h
@@ -63,6 +63,10 @@ protected:
   /// in this finite element space.
   virtual int getVDim() const = 0;
 
+  /// Mesh FESpace is defined with respect to. May differ from main problem mesh if
+  /// FESpace is defined on an MFEMSubMesh.
+  mfem::ParMesh & _pmesh;
+
 private:
   /// Constructs the fec from the fec name.
   void buildFEC() const;
@@ -73,10 +77,6 @@ private:
   void buildFESpace() const;
   /// Stores the constructed fespace.
   mutable std::shared_ptr<mfem::ParFiniteElementSpace> _fespace{nullptr};
-
-  /// Mesh FESpace is defined with respect to. May differ from main problem mesh if
-  /// FESpace is defined on an MFEMSubMesh.
-  mfem::ParMesh & _pmesh;
 };
 
 #endif

--- a/framework/include/mfem/kernels/MFEMKernel.h
+++ b/framework/include/mfem/kernels/MFEMKernel.h
@@ -27,8 +27,10 @@ public:
 
   virtual ~MFEMKernel() = default;
 
-  /// Create a new MFEM integrator to apply to the weak form. Ownership managed by the caller.
+  /// Create MFEM integrator to apply to the RHS of the weak form. Ownership managed by the caller.
   virtual mfem::LinearFormIntegrator * createLFIntegrator() { return nullptr; }
+
+  /// Create MFEM integrator to apply to the LHS of the weak form. Ownership managed by the caller.
   virtual mfem::BilinearFormIntegrator * createBFIntegrator() { return nullptr; }
   virtual mfem::NonlinearFormIntegrator * createNLIntegrator() { return nullptr; }
 

--- a/framework/include/mfem/postprocessors/MFEMComplexVectorPeriodAveragedPostprocessor.h
+++ b/framework/include/mfem/postprocessors/MFEMComplexVectorPeriodAveragedPostprocessor.h
@@ -41,18 +41,16 @@ private:
   mfem::real_t _integral;
 
   /// Input variables
-  mfem::ParComplexGridFunction & _primal_var;
-  mfem::ParComplexGridFunction & _dual_var;
   mfem::L2_FECollection _l2_fec;
   mfem::ParFiniteElementSpace _scalar_test_fespace;
   mfem::ParGridFunction _scalar_var;
   mfem::Coefficient & _scalar_coef;
 
   /// Coefficients extracted from real and imaginary parts of complex variables
-  mfem::VectorGridFunctionCoefficient _primal_var_real_coef;
-  mfem::VectorGridFunctionCoefficient _primal_var_imag_coef;
-  mfem::VectorGridFunctionCoefficient _dual_var_real_coef;
-  mfem::VectorGridFunctionCoefficient _dual_var_imag_coef;
+  mfem::VectorCoefficient & _primal_var_real_coef;
+  mfem::VectorCoefficient & _primal_var_imag_coef;
+  mfem::VectorCoefficient & _dual_var_real_coef;
+  mfem::VectorCoefficient & _dual_var_imag_coef;
 
   // Inner products and their weighted sum
   mfem::InnerProductCoefficient _real_inner_product_coef;

--- a/framework/include/mfem/postprocessors/MFEMVectorFEInnerProductIntegralPostprocessor.h
+++ b/framework/include/mfem/postprocessors/MFEMVectorFEInnerProductIntegralPostprocessor.h
@@ -39,9 +39,6 @@ public:
 private:
   mfem::real_t _integral;
   mfem::ParGridFunction & _primal_var;
-  mfem::ParGridFunction & _dual_var;
-  mfem::Coefficient & _scalar_coef;
-  mfem::VectorGridFunctionCoefficient _dual_var_coef;
   mfem::ScalarVectorProductCoefficient _scaled_dual_var_coef;
   mfem::ParLinearForm _subdomain_integrator;
 };

--- a/framework/include/mfem/problem/MFEMProblem.h
+++ b/framework/include/mfem/problem/MFEMProblem.h
@@ -15,6 +15,7 @@
 #include "MFEMProblemData.h"
 #include "MFEMMesh.h"
 #include "MFEMRefinementMarker.h"
+#include "MFEMComplexVariable.h"
 
 class MFEMProblem : public ExternalProblem
 {
@@ -307,7 +308,18 @@ public:
   /**
    * @returns a shared pointer to an MFEM parallel grid function
    */
-  std::shared_ptr<mfem::ParGridFunction> getGridFunction(const std::string & name);
+  std::shared_ptr<mfem::ParGridFunction> getGridFunction(const std::string & name)
+  {
+    return _problem_data.gridfunctions.GetShared(name);
+  }
+
+  /**
+   * @returns a shared pointer to an MFEM parallel complex grid function
+   */
+  std::shared_ptr<mfem::ParComplexGridFunction> getComplexGridFunction(const std::string & name)
+  {
+    return _problem_data.cmplx_gridfunctions.GetShared(name);
+  }
 
   enum class NumericType
   {

--- a/framework/include/mfem/problem_operators/ComplexEquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/ComplexEquationSystemProblemOperator.h
@@ -33,12 +33,8 @@ public:
 
   [[nodiscard]] Moose::MFEM::ComplexEquationSystem * GetEquationSystem() const override
   {
-    if (!_equation_system)
-    {
-      mooseError(
-          "No ComplexEquationSystem has been added to ComplexEquationSystemProblemOperator.");
-    }
-
+    mooseAssert(_equation_system,
+                "No ComplexEquationSystem in ComplexEquationSystemProblemOperator.");
     return _equation_system.get();
   }
 

--- a/framework/include/mfem/problem_operators/EquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/EquationSystemProblemOperator.h
@@ -31,11 +31,7 @@ public:
 
   [[nodiscard]] Moose::MFEM::EquationSystem * GetEquationSystem() const override
   {
-    if (!_equation_system)
-    {
-      MFEM_ABORT("No equation system has been added to ProblemOperator.");
-    }
-
+    mooseAssert(_equation_system, "No EquationSystem in EquationSystemProblemOperator.");
     return _equation_system.get();
   }
 

--- a/framework/include/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.h
@@ -37,11 +37,8 @@ public:
 
   [[nodiscard]] Moose::MFEM::TimeDependentEquationSystem * GetEquationSystem() const override
   {
-    if (!_equation_system)
-    {
-      MFEM_ABORT("No equation system has been added.");
-    }
-
+    mooseAssert(_equation_system,
+                "No TimeDependentEquationSystem in TimeDependentEquationSystemProblemOperator.");
     return _equation_system.get();
   }
 

--- a/framework/include/mfem/solvers/MFEMCGSolver.h
+++ b/framework/include/mfem/solvers/MFEMCGSolver.h
@@ -27,7 +27,7 @@ public:
   void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) override;
 
 protected:
-  void constructSolver(const InputParameters & parameters) override;
+  void constructSolver() override;
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMGMRESSolver.h
+++ b/framework/include/mfem/solvers/MFEMGMRESSolver.h
@@ -27,7 +27,7 @@ public:
   void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) override;
 
 protected:
-  void constructSolver(const InputParameters & parameters) override;
+  void constructSolver() override;
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMHypreADS.h
+++ b/framework/include/mfem/solvers/MFEMHypreADS.h
@@ -28,7 +28,7 @@ public:
   void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) override;
 
 protected:
-  void constructSolver(const InputParameters & parameters) override;
+  void constructSolver() override;
 
 private:
   const MFEMFESpace & _mfem_fespace;

--- a/framework/include/mfem/solvers/MFEMHypreAMS.h
+++ b/framework/include/mfem/solvers/MFEMHypreAMS.h
@@ -28,7 +28,7 @@ public:
   void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) override;
 
 protected:
-  void constructSolver(const InputParameters & parameters) override;
+  void constructSolver() override;
 
 private:
   const MFEMFESpace & _mfem_fespace;

--- a/framework/include/mfem/solvers/MFEMHypreBoomerAMG.h
+++ b/framework/include/mfem/solvers/MFEMHypreBoomerAMG.h
@@ -27,7 +27,7 @@ public:
   void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) override;
 
 protected:
-  void constructSolver(const InputParameters & parameters) override;
+  void constructSolver() override;
 
 private:
   std::shared_ptr<mfem::ParFiniteElementSpace> _mfem_fespace{nullptr};

--- a/framework/include/mfem/solvers/MFEMHypreFGMRES.h
+++ b/framework/include/mfem/solvers/MFEMHypreFGMRES.h
@@ -27,7 +27,7 @@ public:
   void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) override;
 
 protected:
-  void constructSolver(const InputParameters & parameters) override;
+  void constructSolver() override;
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMHypreGMRES.h
+++ b/framework/include/mfem/solvers/MFEMHypreGMRES.h
@@ -28,7 +28,7 @@ public:
   void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) override;
 
 protected:
-  void constructSolver(const InputParameters & parameters) override;
+  void constructSolver() override;
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMHyprePCG.h
+++ b/framework/include/mfem/solvers/MFEMHyprePCG.h
@@ -27,7 +27,7 @@ public:
   void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) override;
 
 protected:
-  void constructSolver(const InputParameters & parameters) override;
+  void constructSolver() override;
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMMUMPS.h
+++ b/framework/include/mfem/solvers/MFEMMUMPS.h
@@ -24,7 +24,7 @@ public:
   MFEMMUMPS(const InputParameters & parameters);
 
 protected:
-  void constructSolver(const InputParameters & parameters) override;
+  void constructSolver() override;
 
   /// Updates the solver with the bilinear form in case LOR solve is required
   void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) override;

--- a/framework/include/mfem/solvers/MFEMOperatorJacobiSmoother.h
+++ b/framework/include/mfem/solvers/MFEMOperatorJacobiSmoother.h
@@ -27,7 +27,7 @@ public:
   void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) override;
 
 protected:
-  void constructSolver(const InputParameters & parameters) override;
+  void constructSolver() override;
 };
 
 #endif

--- a/framework/include/mfem/solvers/MFEMSolverBase.h
+++ b/framework/include/mfem/solvers/MFEMSolverBase.h
@@ -39,7 +39,7 @@ public:
   bool isLOR() const { return _lor || (_preconditioner && _preconditioner->isLOR()); }
 
   /// Override in derived classes to construct and set the solver options.
-  virtual void constructSolver(const InputParameters & parameters) = 0;
+  virtual void constructSolver() = 0;
 
 protected:
   /// Checks for the correct configuration of quadrature bases for LOR spectral equivalence

--- a/framework/include/mfem/solvers/MFEMSuperLU.h
+++ b/framework/include/mfem/solvers/MFEMSuperLU.h
@@ -48,7 +48,7 @@ public:
   MFEMSuperLU(const InputParameters & parameters);
 
 protected:
-  void constructSolver(const InputParameters & parameters) override;
+  void constructSolver() override;
 
   /// Updates the solver with the bilinear form in case LOR solve is required
   void updateSolver(mfem::ParBilinearForm & a, mfem::Array<int> & tdofs) override;

--- a/framework/include/mfem/vectorpostprocessors/MFEMLineValueSampler.h
+++ b/framework/include/mfem/vectorpostprocessors/MFEMLineValueSampler.h
@@ -13,8 +13,6 @@
 
 #include "MFEMValueSamplerBase.h"
 
-#include "mfem.hpp"
-
 /*
  * MFEM Postprocessor which samples values at a set of points evenly
  * distributed along a line.

--- a/framework/include/mfem/vectorpostprocessors/MFEMPointValueSampler.h
+++ b/framework/include/mfem/vectorpostprocessors/MFEMPointValueSampler.h
@@ -13,8 +13,6 @@
 
 #include "MFEMValueSamplerBase.h"
 
-#include "mfem.hpp"
-
 /*
  * MFEM Postprocessor which samples values at points.
  */

--- a/framework/include/mfem/vectorpostprocessors/MFEMValueSamplerBase.h
+++ b/framework/include/mfem/vectorpostprocessors/MFEMValueSamplerBase.h
@@ -13,10 +13,6 @@
 
 #include "MFEMVectorPostprocessor.h"
 
-#include "MooseTypes.h"
-#include "libmesh/point.h"
-#include "mfem.hpp"
-
 /*
  * MFEM Postprocessor which samples values at points.
  *

--- a/framework/include/mfem/vectorpostprocessors/MFEMValueSamplerBase.h
+++ b/framework/include/mfem/vectorpostprocessors/MFEMValueSamplerBase.h
@@ -34,13 +34,14 @@ public:
   virtual void finalize() override;
 
 private:
+  const VariableName & _var_name;
+  const mfem::GridFunction & _var;
+  mfem::ParMesh & _mesh;
+
   mfem::FindPointsGSLIB _finder;
   mfem::Ordering::Type _points_ordering;
   mfem::Vector _points;
   mfem::Vector _interp_vals;
-
-  const VariableName & _var_name;
-  const mfem::GridFunction & _var;
 
   // VectorPostprocessor declared values - the values written to these are output
   std::vector<std::reference_wrapper<VectorPostprocessorValue>> _declared_points;

--- a/framework/src/mfem/auxkernels/MFEMAuxKernel.C
+++ b/framework/src/mfem/auxkernels/MFEMAuxKernel.C
@@ -27,7 +27,7 @@ MFEMAuxKernel::validParams()
 MFEMAuxKernel::MFEMAuxKernel(const InputParameters & parameters)
   : MFEMGeneralUserObject(parameters),
     _result_var_name(getParam<AuxVariableName>("variable")),
-    _result_var(*getMFEMProblem().getProblemData().gridfunctions.Get(_result_var_name))
+    _result_var(*getMFEMProblem().getGridFunction(_result_var_name))
 {
 }
 

--- a/framework/src/mfem/auxkernels/MFEMComplexAuxKernel.C
+++ b/framework/src/mfem/auxkernels/MFEMComplexAuxKernel.C
@@ -27,7 +27,7 @@ MFEMComplexAuxKernel::validParams()
 MFEMComplexAuxKernel::MFEMComplexAuxKernel(const InputParameters & parameters)
   : MFEMGeneralUserObject(parameters),
     _result_var_name(getParam<AuxVariableName>("variable")),
-    _result_var(*getMFEMProblem().getProblemData().cmplx_gridfunctions.Get(_result_var_name))
+    _result_var(*getMFEMProblem().getComplexGridFunction(_result_var_name))
 {
 }
 

--- a/framework/src/mfem/auxkernels/MFEMComplexCurlAux.C
+++ b/framework/src/mfem/auxkernels/MFEMComplexCurlAux.C
@@ -33,7 +33,7 @@ MFEMComplexCurlAux::validParams()
 MFEMComplexCurlAux::MFEMComplexCurlAux(const InputParameters & parameters)
   : MFEMComplexAuxKernel(parameters),
     _source_var_name(getParam<VariableName>("source")),
-    _source_var(*getMFEMProblem().getProblemData().cmplx_gridfunctions.Get(_source_var_name)),
+    _source_var(*getMFEMProblem().getComplexGridFunction(_source_var_name)),
     _scale_factor(getParam<mfem::real_t>("scale_factor_real"),
                   getParam<mfem::real_t>("scale_factor_imag")),
     _curl(_source_var.ParFESpace(), _result_var.ParFESpace())

--- a/framework/src/mfem/auxkernels/MFEMComplexDivAux.C
+++ b/framework/src/mfem/auxkernels/MFEMComplexDivAux.C
@@ -34,7 +34,7 @@ MFEMComplexDivAux::validParams()
 MFEMComplexDivAux::MFEMComplexDivAux(const InputParameters & parameters)
   : MFEMComplexAuxKernel(parameters),
     _source_var_name(getParam<VariableName>("source")),
-    _source_var(*getMFEMProblem().getProblemData().cmplx_gridfunctions.Get(_source_var_name)),
+    _source_var(*getMFEMProblem().getComplexGridFunction(_source_var_name)),
     _scale_factor(getParam<mfem::real_t>("scale_factor_real"),
                   getParam<mfem::real_t>("scale_factor_imag")),
     _div(_source_var.ParFESpace(), _result_var.ParFESpace())

--- a/framework/src/mfem/auxkernels/MFEMComplexGradAux.C
+++ b/framework/src/mfem/auxkernels/MFEMComplexGradAux.C
@@ -33,7 +33,7 @@ MFEMComplexGradAux::validParams()
 MFEMComplexGradAux::MFEMComplexGradAux(const InputParameters & parameters)
   : MFEMComplexAuxKernel(parameters),
     _source_var_name(getParam<VariableName>("source")),
-    _source_var(*getMFEMProblem().getProblemData().cmplx_gridfunctions.Get(_source_var_name)),
+    _source_var(*getMFEMProblem().getComplexGridFunction(_source_var_name)),
     _scale_factor(getParam<mfem::real_t>("scale_factor_real"),
                   getParam<mfem::real_t>("scale_factor_imag")),
     _grad(_source_var.ParFESpace(), _result_var.ParFESpace())

--- a/framework/src/mfem/auxkernels/MFEMComplexSumAux.C
+++ b/framework/src/mfem/auxkernels/MFEMComplexSumAux.C
@@ -56,7 +56,7 @@ MFEMComplexSumAux::MFEMComplexSumAux(const InputParameters & parameters)
   for (const auto & var_name : _var_names)
   {
     const mfem::ParComplexGridFunction * gf =
-        getMFEMProblem().getProblemData().cmplx_gridfunctions.Get(var_name);
+        getMFEMProblem().getComplexGridFunction(var_name).get();
     if (gf->ParFESpace() == _result_var.ParFESpace())
       _summed_vars.push_back(gf);
     else

--- a/framework/src/mfem/auxkernels/MFEMCurlAux.C
+++ b/framework/src/mfem/auxkernels/MFEMCurlAux.C
@@ -30,7 +30,7 @@ MFEMCurlAux::validParams()
 MFEMCurlAux::MFEMCurlAux(const InputParameters & parameters)
   : MFEMAuxKernel(parameters),
     _source_var_name(getParam<VariableName>("source")),
-    _source_var(*getMFEMProblem().getProblemData().gridfunctions.Get(_source_var_name)),
+    _source_var(*getMFEMProblem().getGridFunction(_source_var_name)),
     _scale_factor(getParam<mfem::real_t>("scale_factor")),
     _curl(_source_var.ParFESpace(), _result_var.ParFESpace())
 {

--- a/framework/src/mfem/auxkernels/MFEMDivAux.C
+++ b/framework/src/mfem/auxkernels/MFEMDivAux.C
@@ -30,7 +30,7 @@ MFEMDivAux::validParams()
 MFEMDivAux::MFEMDivAux(const InputParameters & parameters)
   : MFEMAuxKernel(parameters),
     _source_var_name(getParam<VariableName>("source")),
-    _source_var(*getMFEMProblem().getProblemData().gridfunctions.Get(_source_var_name)),
+    _source_var(*getMFEMProblem().getGridFunction(_source_var_name)),
     _scale_factor(getParam<mfem::real_t>("scale_factor")),
     _div(_source_var.ParFESpace(), _result_var.ParFESpace())
 {

--- a/framework/src/mfem/auxkernels/MFEMGradAux.C
+++ b/framework/src/mfem/auxkernels/MFEMGradAux.C
@@ -30,7 +30,7 @@ MFEMGradAux::validParams()
 MFEMGradAux::MFEMGradAux(const InputParameters & parameters)
   : MFEMAuxKernel(parameters),
     _source_var_name(getParam<VariableName>("source")),
-    _source_var(*getMFEMProblem().getProblemData().gridfunctions.Get(_source_var_name)),
+    _source_var(*getMFEMProblem().getGridFunction(_source_var_name)),
     _scale_factor(getParam<mfem::real_t>("scale_factor")),
     _grad(_source_var.ParFESpace(), _result_var.ParFESpace())
 {

--- a/framework/src/mfem/auxkernels/MFEMSumAux.C
+++ b/framework/src/mfem/auxkernels/MFEMSumAux.C
@@ -41,8 +41,7 @@ MFEMSumAux::MFEMSumAux(const InputParameters & parameters)
                "scale factors.");
   for (const auto & var_name : _var_names)
   {
-    const mfem::ParGridFunction * gf =
-        getMFEMProblem().getProblemData().gridfunctions.Get(var_name);
+    const mfem::ParGridFunction * gf = getMFEMProblem().getGridFunction(var_name).get();
     if (gf->ParFESpace() == _result_var.ParFESpace())
       _summed_vars.push_back(gf);
     else

--- a/framework/src/mfem/bcs/MFEMBoundaryCondition.C
+++ b/framework/src/mfem/bcs/MFEMBoundaryCondition.C
@@ -30,18 +30,7 @@ MFEMBoundaryCondition::validParams()
 MFEMBoundaryCondition::MFEMBoundaryCondition(const InputParameters & parameters)
   : MFEMGeneralUserObject(parameters),
     MFEMBoundaryRestrictable(
-        parameters,
-        getMFEMProblem().getProblemData().gridfunctions.Has(getParam<VariableName>("variable"))
-            ? *getMFEMProblem()
-                   .getProblemData()
-                   .gridfunctions.GetRef(getParam<VariableName>("variable"))
-                   .ParFESpace()
-                   ->GetParMesh()
-            : *getMFEMProblem()
-                   .getProblemData()
-                   .cmplx_gridfunctions.GetRef(getParam<VariableName>("variable"))
-                   .ParFESpace()
-                   ->GetParMesh()),
+        parameters, getMFEMProblem().getMFEMVariableMesh(getParam<VariableName>("variable"))),
     _test_var_name(getParam<VariableName>("variable"))
 {
 }

--- a/framework/src/mfem/bcs/MFEMBoundaryIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMBoundaryIntegratedBC.C
@@ -38,11 +38,4 @@ MFEMBoundaryIntegratedBC::createLFIntegrator()
   return new mfem::BoundaryLFIntegrator(_coef);
 }
 
-// Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
-mfem::BilinearFormIntegrator *
-MFEMBoundaryIntegratedBC::createBFIntegrator()
-{
-  return nullptr;
-}
-
 #endif

--- a/framework/src/mfem/bcs/MFEMBoundaryNormalIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMBoundaryNormalIntegratedBC.C
@@ -40,11 +40,4 @@ MFEMBoundaryNormalIntegratedBC::createLFIntegrator()
   return new mfem::BoundaryNormalLFIntegrator(_vec_coef);
 }
 
-// Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
-mfem::BilinearFormIntegrator *
-MFEMBoundaryNormalIntegratedBC::createBFIntegrator()
-{
-  return nullptr;
-}
-
 #endif

--- a/framework/src/mfem/bcs/MFEMVectorBoundaryIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorBoundaryIntegratedBC.C
@@ -37,11 +37,4 @@ MFEMVectorBoundaryIntegratedBC::createLFIntegrator()
   return new mfem::VectorBoundaryLFIntegrator(_vec_coef);
 }
 
-// Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
-mfem::BilinearFormIntegrator *
-MFEMVectorBoundaryIntegratedBC::createBFIntegrator()
-{
-  return nullptr;
-}
-
 #endif

--- a/framework/src/mfem/bcs/MFEMVectorFEBoundaryFluxIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorFEBoundaryFluxIntegratedBC.C
@@ -37,11 +37,4 @@ MFEMVectorFEBoundaryFluxIntegratedBC::createLFIntegrator()
   return new mfem::VectorFEBoundaryFluxLFIntegrator(_coef);
 }
 
-// Create MFEM integrator to apply to the LHS of the weak form. Ownership managed by the caller.
-mfem::BilinearFormIntegrator *
-MFEMVectorFEBoundaryFluxIntegratedBC::createBFIntegrator()
-{
-  return nullptr;
-}
-
 #endif

--- a/framework/src/mfem/bcs/MFEMVectorFEBoundaryTangentIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorFEBoundaryTangentIntegratedBC.C
@@ -37,11 +37,4 @@ MFEMVectorFEBoundaryTangentIntegratedBC::createLFIntegrator()
   return new mfem::VectorFEBoundaryTangentLFIntegrator(_vec_coef);
 }
 
-// Create MFEM integrator to apply to the LHS of the weak form. Ownership managed by the caller.
-mfem::BilinearFormIntegrator *
-MFEMVectorFEBoundaryTangentIntegratedBC::createBFIntegrator()
-{
-  return nullptr;
-}
-
 #endif

--- a/framework/src/mfem/bcs/MFEMVectorFEMassIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorFEMassIntegratedBC.C
@@ -29,13 +29,6 @@ MFEMVectorFEMassIntegratedBC::MFEMVectorFEMassIntegratedBC(const InputParameters
 {
 }
 
-// Create MFEM integrator to apply to the RHS of the weak form. Ownership managed by the caller.
-mfem::LinearFormIntegrator *
-MFEMVectorFEMassIntegratedBC::createLFIntegrator()
-{
-  return nullptr;
-}
-
 // Create MFEM integrator to apply to the LHS of the weak form. Ownership managed by the caller.
 mfem::BilinearFormIntegrator *
 MFEMVectorFEMassIntegratedBC::createBFIntegrator()

--- a/framework/src/mfem/equation_systems/ComplexEquationSystem.C
+++ b/framework/src/mfem/equation_systems/ComplexEquationSystem.C
@@ -241,7 +241,7 @@ ComplexEquationSystem::FormSystemMatrix(mfem::OperatorHandle & op,
 {
 
   // Allocate block operator
-  DeleteAllBlocks();
+  DeleteHBlocks();
   _h_blocks.SetSize(_test_var_names.size(), _trial_var_names.size());
   _h_blocks = nullptr;
   // Zero out RHS and sync memory

--- a/framework/src/mfem/equation_systems/EquationSystem.C
+++ b/framework/src/mfem/equation_systems/EquationSystem.C
@@ -15,19 +15,32 @@
 namespace Moose::MFEM
 {
 
-EquationSystem::~EquationSystem() { DeleteAllBlocks(); }
+EquationSystem::~EquationSystem()
+{
+  DeleteHBlocks();
+  DeleteJacobianBlocks();
+}
 
 void
-EquationSystem::DeleteAllBlocks()
+EquationSystem::DeleteHBlocks()
 {
   for (const auto i : make_range(_h_blocks.NumRows()))
     for (const auto j : make_range(_h_blocks.NumCols()))
+    {
+      if (_jacobian_blocks.NumRows() && _jacobian_blocks(i, j) == _h_blocks(i, j))
+        _jacobian_blocks(i, j) = nullptr;
       delete _h_blocks(i, j);
+    }
   _h_blocks.DeleteAll();
+}
 
+void
+EquationSystem::DeleteJacobianBlocks()
+{
   for (const auto i : make_range(_jacobian_blocks.NumRows()))
     for (const auto j : make_range(_jacobian_blocks.NumCols()))
-      delete _jacobian_blocks(i, j);
+      if (!_h_blocks.NumRows() || _jacobian_blocks(i, j) != _h_blocks(i, j))
+        delete _jacobian_blocks(i, j);
   _jacobian_blocks.DeleteAll();
 }
 
@@ -303,7 +316,7 @@ EquationSystem::FormSystemMatrix(mfem::OperatorHandle & op,
                                  mfem::BlockVector & trueRHS)
 {
   // Allocate block operator
-  DeleteAllBlocks();
+  DeleteHBlocks();
   _h_blocks.SetSize(_test_var_names.size(), _trial_var_names.size());
   _h_blocks = nullptr;
   // Zero out RHS and sync memory
@@ -407,10 +420,11 @@ EquationSystem::Mult(const mfem::Vector & sol, mfem::Vector & residual) const
 void
 EquationSystem::FormJacobianMatrix(const mfem::Vector & u)
 {
-  const mfem::BlockVector update_vector(const_cast<mfem::Vector &>(u), _block_true_offsets);
+  DeleteJacobianBlocks();
   _jacobian_blocks.SetSize(_test_var_names.size(), _trial_var_names.size());
   _jacobian_blocks = nullptr;
 
+  const mfem::BlockVector update_vector(const_cast<mfem::Vector &>(u), _block_true_offsets);
   for (const auto i : index_range(_test_var_names))
   {
     auto test_var_name = _test_var_names.at(i);
@@ -419,12 +433,13 @@ EquationSystem::FormJacobianMatrix(const mfem::Vector & u)
       auto nlf = _nlfs.Get(test_var_name);
       mfem::HypreParMatrix * nlf_jac =
           dynamic_cast<mfem::HypreParMatrix *>(&nlf->GetGradient(update_vector.GetBlock(i)));
-      if (!nlf_jac)
-        mooseError("Jacobian contribution of nonlinear form associated with ",
-                   test_var_name,
-                   " is not castable into a HypreParMatrix");
+      mooseAssert(nlf_jac,
+                  "Jacobian contribution of nonlinear form associated with " + test_var_name +
+                      " is not castable into a HypreParMatrix");
       _jacobian_blocks(i, i) = mfem::ParAdd(_h_blocks(i, i), nlf_jac);
     }
+    else
+      _jacobian_blocks(i, i) = _h_blocks(i, i);
     for (const auto j : index_range(_trial_var_names))
       if (i != j) // nlf->GetGradient only contributes to on-diagonal blocks
         _jacobian_blocks(i, j) = _h_blocks(i, j);

--- a/framework/src/mfem/executioners/MFEMProblemSolve.C
+++ b/framework/src/mfem/executioners/MFEMProblemSolve.C
@@ -92,7 +92,7 @@ MFEMProblemSolve::solve()
       _mfem_problem.getProblemData().eqn_system->BuildEquationSystem();
 
       // Remove me: reconstruct the solver due to possible mfem/hypre bug
-      _mfem_problem.getProblemData().jacobian_solver->constructSolver(emptyInputParameters());
+      _mfem_problem.getProblemData().jacobian_solver->constructSolver();
 
       // Reset gridfunctions
       for (const auto & problem_operator : _problem_operators)

--- a/framework/src/mfem/fespaces/MFEMSimplifiedFESpace.C
+++ b/framework/src/mfem/fespaces/MFEMSimplifiedFESpace.C
@@ -33,7 +33,7 @@ MFEMSimplifiedFESpace::MFEMSimplifiedFESpace(const InputParameters & parameters)
 int
 MFEMSimplifiedFESpace::getProblemDim() const
 {
-  return getMFEMProblem().mesh().getMFEMParMesh().Dimension();
+  return _pmesh.Dimension();
 }
 
 #endif

--- a/framework/src/mfem/ics/MFEMScalarBoundaryIC.C
+++ b/framework/src/mfem/ics/MFEMScalarBoundaryIC.C
@@ -27,12 +27,8 @@ MFEMScalarBoundaryIC::validParams()
 
 MFEMScalarBoundaryIC::MFEMScalarBoundaryIC(const InputParameters & params)
   : MFEMInitialCondition(params),
-    MFEMBoundaryRestrictable(params,
-                             *getMFEMProblem()
-                                  .getProblemData()
-                                  .gridfunctions.GetRef(getParam<VariableName>("variable"))
-                                  .ParFESpace()
-                                  ->GetParMesh())
+    MFEMBoundaryRestrictable(
+        params, getMFEMProblem().getMFEMVariableMesh(getParam<VariableName>("variable")))
 {
 }
 

--- a/framework/src/mfem/indicators/MFEMIndicator.C
+++ b/framework/src/mfem/indicators/MFEMIndicator.C
@@ -27,7 +27,7 @@ MFEMIndicator::MFEMIndicator(const InputParameters & params)
   : MFEMGeneralUserObject(params),
     _var_name(getParam<VariableName>("variable")),
     _kernel_name(getParam<std::string>("kernel")),
-    _fespace(*getMFEMProblem().getProblemData().gridfunctions.Get(_var_name)->ParFESpace())
+    _fespace(*getMFEMProblem().getGridFunction(_var_name)->ParFESpace())
 {
 }
 

--- a/framework/src/mfem/indicators/MFEML2ZienkiewiczZhuIndicator.C
+++ b/framework/src/mfem/indicators/MFEML2ZienkiewiczZhuIndicator.C
@@ -62,9 +62,9 @@ MFEML2ZienkiewiczZhuIndicator::createEstimator()
   // Check it correctly casts into ElasticityIntegrator
   is_supported |= (dynamic_cast<mfem::ElasticityIntegrator *>(_integ.get()) != nullptr);
 
-  mooseAssert(is_supported,
-              "MFEML2ZienkiewiczZhuIndicator only supports MFEMDiffusionKernel, MFEMCurlCurlKernel "
-              "and MFEMLinearElasticityKernel");
+  if (!is_supported)
+    mooseError("MFEML2ZienkiewiczZhuIndicator only supports MFEMDiffusionKernel, "
+               "MFEMCurlCurlKernel and MFEMLinearElasticityKernel");
 
   int order = getFESpace().GetMaxElementOrder();
   int dim = getParMesh().Dimension();

--- a/framework/src/mfem/indicators/MFEML2ZienkiewiczZhuIndicator.C
+++ b/framework/src/mfem/indicators/MFEML2ZienkiewiczZhuIndicator.C
@@ -86,7 +86,7 @@ MFEML2ZienkiewiczZhuIndicator::createEstimator()
   }
 
   // fetch the grid function we need
-  auto gridfunction = getMFEMProblem().getProblemData().gridfunctions.GetShared(_var_name);
+  auto gridfunction = getMFEMProblem().getGridFunction(_var_name);
 
   // finally, initialise the estimator
   _error_estimator = std::make_shared<mfem::L2ZienkiewiczZhuEstimator>(

--- a/framework/src/mfem/kernels/MFEMComplexKernel.C
+++ b/framework/src/mfem/kernels/MFEMComplexKernel.C
@@ -31,7 +31,8 @@ MFEMComplexKernel::validParams()
 
 MFEMComplexKernel::MFEMComplexKernel(const InputParameters & parameters)
   : MFEMGeneralUserObject(parameters),
-    MFEMBlockRestrictable(parameters, getMFEMProblem().mesh().getMFEMParMesh()),
+    MFEMBlockRestrictable(parameters,
+                          getMFEMProblem().getMFEMVariableMesh(getParam<VariableName>("variable"))),
     _test_var_name(getParam<VariableName>("variable"))
 {
 }

--- a/framework/src/mfem/kernels/MFEMNLDiffusionKernel.C
+++ b/framework/src/mfem/kernels/MFEMNLDiffusionKernel.C
@@ -37,7 +37,7 @@ MFEMNLDiffusionKernel::MFEMNLDiffusionKernel(const InputParameters & parameters)
   : MFEMKernel(parameters),
     _k_coef(getScalarCoefficient("k_coefficient")),
     _dk_du_coef(getScalarCoefficient("dk_du_coefficient")),
-    _trial_var(getMFEMProblem().getProblemData().gridfunctions.GetRef(getTrialVariableName()))
+    _trial_var(*getMFEMProblem().getGridFunction(getTrialVariableName()))
 {
 }
 

--- a/framework/src/mfem/outputs/MFEMDataCollection.C
+++ b/framework/src/mfem/outputs/MFEMDataCollection.C
@@ -68,7 +68,7 @@ MFEMDataCollection::output()
   dc.SetCycle(getFileNumber());
   dc.SetTime(time());
   dc.Save();
-  _file_num++;
+  ++_file_num;
 }
 
 #endif

--- a/framework/src/mfem/postprocessors/MFEMComplexVectorPeriodAveragedPostprocessor.C
+++ b/framework/src/mfem/postprocessors/MFEMComplexVectorPeriodAveragedPostprocessor.C
@@ -34,20 +34,25 @@ MFEMComplexVectorPeriodAveragedPostprocessor::validParams()
 MFEMComplexVectorPeriodAveragedPostprocessor::MFEMComplexVectorPeriodAveragedPostprocessor(
     const InputParameters & parameters)
   : MFEMPostprocessor(parameters),
-    MFEMBlockRestrictable(parameters, getMFEMProblem().mesh().getMFEMParMesh()),
-    _primal_var(getMFEMProblem().getProblemData().cmplx_gridfunctions.GetRef(
-        getParam<VariableName>("primal_variable"))),
-    _dual_var(getMFEMProblem().getProblemData().cmplx_gridfunctions.GetRef(
-        getParam<VariableName>("dual_variable"))),
-    _l2_fec(_primal_var.ParFESpace()->GetMaxElementOrder(),
-            getMFEMProblem().mesh().getMFEMParMesh().Dimension()),
-    _scalar_test_fespace(&getMFEMProblem().mesh().getMFEMParMesh(), &_l2_fec),
+    MFEMBlockRestrictable(
+        parameters,
+        getMFEMProblem().getMFEMVariableMesh(getParam<VariableName>("primal_variable"))),
+    _l2_fec(getMFEMProblem()
+                .getComplexGridFunction(getParam<VariableName>("primal_variable"))
+                ->ParFESpace()
+                ->GetMaxElementOrder(),
+            getMesh().Dimension()),
+    _scalar_test_fespace(const_cast<mfem::ParMesh *>(&getMesh()), &_l2_fec),
     _scalar_var(&_scalar_test_fespace),
     _scalar_coef(getScalarCoefficient("coefficient")),
-    _primal_var_real_coef(&_primal_var.real()),
-    _primal_var_imag_coef(&_primal_var.imag()),
-    _dual_var_real_coef(&_dual_var.real()),
-    _dual_var_imag_coef(&_dual_var.imag()),
+    _primal_var_real_coef(
+        getVectorCoefficientByName(getParam<VariableName>("primal_variable") + "_real")),
+    _primal_var_imag_coef(
+        getVectorCoefficientByName(getParam<VariableName>("primal_variable") + "_imag")),
+    _dual_var_real_coef(
+        getVectorCoefficientByName(getParam<VariableName>("dual_variable") + "_real")),
+    _dual_var_imag_coef(
+        getVectorCoefficientByName(getParam<VariableName>("dual_variable") + "_imag")),
     _real_inner_product_coef(_primal_var_real_coef, _dual_var_real_coef),
     _imag_inner_product_coef(_primal_var_imag_coef, _dual_var_imag_coef),
     _sum_coef(_real_inner_product_coef, _imag_inner_product_coef, 0.5, 0.5),

--- a/framework/src/mfem/postprocessors/MFEML2Error.C
+++ b/framework/src/mfem/postprocessors/MFEML2Error.C
@@ -31,7 +31,7 @@ MFEML2Error::validParams()
 MFEML2Error::MFEML2Error(const InputParameters & parameters)
   : MFEMPostprocessor(parameters),
     _coeff(getScalarCoefficient("function")),
-    _var(getMFEMProblem().getProblemData().gridfunctions.GetRef(getParam<VariableName>("variable")))
+    _var(*getMFEMProblem().getGridFunction(getParam<VariableName>("variable")))
 {
 }
 

--- a/framework/src/mfem/postprocessors/MFEMVectorFEInnerProductIntegralPostprocessor.C
+++ b/framework/src/mfem/postprocessors/MFEMVectorFEInnerProductIntegralPostprocessor.C
@@ -33,26 +33,20 @@ MFEMVectorFEInnerProductIntegralPostprocessor::validParams()
 MFEMVectorFEInnerProductIntegralPostprocessor::MFEMVectorFEInnerProductIntegralPostprocessor(
     const InputParameters & parameters)
   : MFEMPostprocessor(parameters),
-    MFEMBlockRestrictable(parameters, getMFEMProblem().mesh().getMFEMParMesh()),
-    _primal_var(getMFEMProblem().getProblemData().gridfunctions.GetRef(
-        getParam<VariableName>("primal_variable"))),
-    _dual_var(getMFEMProblem().getProblemData().gridfunctions.GetRef(
-        getParam<VariableName>("dual_variable"))),
-    _scalar_coef(getScalarCoefficient("coefficient")),
-    _dual_var_coef(&_dual_var),
-    _scaled_dual_var_coef(_scalar_coef, _dual_var_coef),
+    MFEMBlockRestrictable(
+        parameters,
+        getMFEMProblem().getMFEMVariableMesh(getParam<VariableName>("primal_variable"))),
+    _primal_var(*getMFEMProblem().getGridFunction(getParam<VariableName>("primal_variable"))),
+    _scaled_dual_var_coef(getScalarCoefficient("coefficient"),
+                          getVectorCoefficientByName(getParam<VariableName>("dual_variable"))),
     _subdomain_integrator(_primal_var.ParFESpace())
 {
   if (isSubdomainRestricted())
-  {
     _subdomain_integrator.AddDomainIntegrator(
         new mfem::VectorFEDomainLFIntegrator(_scaled_dual_var_coef), getSubdomainMarkers());
-  }
   else
-  {
     _subdomain_integrator.AddDomainIntegrator(
         new mfem::VectorFEDomainLFIntegrator(_scaled_dual_var_coef));
-  }
 }
 
 void

--- a/framework/src/mfem/postprocessors/MFEMVectorL2Error.C
+++ b/framework/src/mfem/postprocessors/MFEMVectorL2Error.C
@@ -31,7 +31,7 @@ MFEMVectorL2Error::validParams()
 MFEMVectorL2Error::MFEMVectorL2Error(const InputParameters & parameters)
   : MFEMPostprocessor(parameters),
     _vec_coeff(getVectorCoefficient("function")),
-    _var(getMFEMProblem().getProblemData().gridfunctions.GetRef(getParam<VariableName>("variable")))
+    _var(*getMFEMProblem().getGridFunction(getParam<VariableName>("variable")))
 {
 }
 

--- a/framework/src/mfem/problem/MFEMProblem.C
+++ b/framework/src/mfem/problem/MFEMProblem.C
@@ -12,7 +12,6 @@
 #include "MFEMProblem.h"
 #include "MFEMInitialCondition.h"
 #include "MFEMVariable.h"
-#include "MFEMComplexVariable.h"
 #include "MFEMIndicator.h"
 #include "MFEMSubMesh.h"
 #include "MFEMFunctorMaterial.h"
@@ -674,12 +673,6 @@ MFEMProblem::addTransfer(const std::string & transfer_name,
     FEProblemBase::addUserObject(transfer_name, name, parameters);
   else
     FEProblemBase::addTransfer(transfer_name, name, parameters);
-}
-
-std::shared_ptr<mfem::ParGridFunction>
-MFEMProblem::getGridFunction(const std::string & name)
-{
-  return getUserObject<MFEMVariable>(name).getGridFunction();
 }
 
 void

--- a/framework/src/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.C
@@ -25,7 +25,6 @@ void
 TimeDependentEquationSystemProblemOperator::Init(mfem::BlockVector & X)
 {
   TimeDependentProblemOperator::Init(X);
-  GetEquationSystem()->BuildEquationSystem();
   // Set timestepper
   auto & ode_solver = _problem_data.ode_solver;
   ode_solver = std::make_unique<mfem::BackwardEulerSolver>();
@@ -37,36 +36,24 @@ TimeDependentEquationSystemProblemOperator::Init(mfem::BlockVector & X)
 void
 TimeDependentEquationSystemProblemOperator::Solve()
 {
-  // Initialise time derivative
-  for (const auto i : index_range(_trial_var_names))
-  {
-    auto & trial_var_name = _trial_var_names.at(i);
-    auto & time_derivative_name =
-        _problem_data.time_derivative_map.getTimeDerivativeName(trial_var_name);
-    auto * trial_var = _problem_data.gridfunctions.Get(trial_var_name);
-    auto * trial_var_time_derivative = _problem_data.gridfunctions.Get(time_derivative_name);
+  auto & dt = _problem.dt();
+  auto & gfs = _problem_data.gridfunctions;
+  auto & tdm = _problem_data.time_derivative_map;
 
-    *trial_var_time_derivative = *trial_var;
-  }
+  // Initialise time derivative
+  for (const auto & trial_var_name : _trial_var_names)
+    gfs.GetRef(tdm.getTimeDerivativeName(trial_var_name)) = gfs.GetRef(trial_var_name);
+
   // Advance time step of the MFEM problem. Time is also updated here, and
   // _problem_operator->SetTime is called inside the ode_solver->Step method to
   // update the time used by time dependent (function) coefficients.
-  _problem_data.ode_solver->Step(*_trial_true_vector, _problem.time(), _problem.dt());
+  _problem_data.ode_solver->Step(*_trial_true_vector, _problem.time(), dt);
   // Synchonise time dependent GridFunctions with updated DoF data.
   SetTrialVariablesFromTrueVectors();
 
   // Set time derivatives
-  for (const auto i : index_range(_trial_var_names))
-  {
-    auto & trial_var_name = _trial_var_names.at(i);
-    auto & time_derivative_name =
-        _problem_data.time_derivative_map.getTimeDerivativeName(trial_var_name);
-    auto * trial_var = _problem_data.gridfunctions.Get(trial_var_name);
-    auto * trial_var_time_derivative = _problem_data.gridfunctions.Get(time_derivative_name);
-
-    *trial_var_time_derivative -= *trial_var;
-    *trial_var_time_derivative /= -_problem.dt();
-  }
+  for (const auto & trial_var_name : _trial_var_names)
+    (gfs.GetRef(tdm.getTimeDerivativeName(trial_var_name)) -= gfs.GetRef(trial_var_name)) /= -dt;
 }
 
 void
@@ -75,7 +62,6 @@ TimeDependentEquationSystemProblemOperator::ImplicitSolve(const mfem::real_t dt,
                                                           mfem::Vector & X_new)
 {
   X_new = X_old;
-  SetTrialVariablesFromTrueVectors();
 
   if ((GetEquationSystem()->_non_linear))
     for (const auto i : index_range(_trial_variables))
@@ -93,7 +79,6 @@ TimeDependentEquationSystemProblemOperator::ImplicitSolve(const mfem::real_t dt,
   _problem_data.nonlinear_solver->SetPreconditioner(_problem_data.jacobian_solver->getSolver());
   _problem_data.nonlinear_solver->SetOperator(*GetEquationSystem());
   _problem_data.nonlinear_solver->Mult(_true_rhs, X_new);
-  SetTrialVariablesFromTrueVectors();
 }
 
 void

--- a/framework/src/mfem/solvers/MFEMCGSolver.C
+++ b/framework/src/mfem/solvers/MFEMCGSolver.C
@@ -32,11 +32,11 @@ MFEMCGSolver::validParams()
 
 MFEMCGSolver::MFEMCGSolver(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
-  constructSolver(parameters);
+  constructSolver();
 }
 
 void
-MFEMCGSolver::constructSolver(const InputParameters &)
+MFEMCGSolver::constructSolver()
 {
   auto solver = std::make_unique<mfem::CGSolver>(getMFEMProblem().getComm());
   solver->SetRelTol(getParam<mfem::real_t>("l_tol"));

--- a/framework/src/mfem/solvers/MFEMGMRESSolver.C
+++ b/framework/src/mfem/solvers/MFEMGMRESSolver.C
@@ -32,11 +32,11 @@ MFEMGMRESSolver::validParams()
 
 MFEMGMRESSolver::MFEMGMRESSolver(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
-  constructSolver(parameters);
+  constructSolver();
 }
 
 void
-MFEMGMRESSolver::constructSolver(const InputParameters &)
+MFEMGMRESSolver::constructSolver()
 {
   auto solver = std::make_unique<mfem::GMRESSolver>(getMFEMProblem().getComm());
   solver->SetRelTol(getParam<mfem::real_t>("l_tol"));

--- a/framework/src/mfem/solvers/MFEMHypreADS.C
+++ b/framework/src/mfem/solvers/MFEMHypreADS.C
@@ -28,11 +28,11 @@ MFEMHypreADS::validParams()
 MFEMHypreADS::MFEMHypreADS(const InputParameters & parameters)
   : MFEMSolverBase(parameters), _mfem_fespace(getUserObject<MFEMFESpace>("fespace"))
 {
-  constructSolver(parameters);
+  constructSolver();
 }
 
 void
-MFEMHypreADS::constructSolver(const InputParameters &)
+MFEMHypreADS::constructSolver()
 {
   auto solver = std::make_unique<mfem::HypreADS>(_mfem_fespace.getFESpace().get());
   solver->SetPrintLevel(getParam<int>("print_level"));

--- a/framework/src/mfem/solvers/MFEMHypreAMS.C
+++ b/framework/src/mfem/solvers/MFEMHypreAMS.C
@@ -32,11 +32,11 @@ MFEMHypreAMS::validParams()
 MFEMHypreAMS::MFEMHypreAMS(const InputParameters & parameters)
   : MFEMSolverBase(parameters), _mfem_fespace(getUserObject<MFEMFESpace>("fespace"))
 {
-  constructSolver(parameters);
+  constructSolver();
 }
 
 void
-MFEMHypreAMS::constructSolver(const InputParameters &)
+MFEMHypreAMS::constructSolver()
 {
   auto solver = std::make_unique<mfem::HypreAMS>(_mfem_fespace.getFESpace().get());
   if (getParam<bool>("singular"))

--- a/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
+++ b/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
@@ -37,11 +37,11 @@ MFEMHypreBoomerAMG::MFEMHypreBoomerAMG(const InputParameters & parameters)
     _mfem_fespace(isParamSetByUser("fespace") ? getUserObject<MFEMFESpace>("fespace").getFESpace()
                                               : nullptr)
 {
-  constructSolver(parameters);
+  constructSolver();
 }
 
 void
-MFEMHypreBoomerAMG::constructSolver(const InputParameters &)
+MFEMHypreBoomerAMG::constructSolver()
 {
   auto solver = std::make_unique<mfem::HypreBoomerAMG>();
 

--- a/framework/src/mfem/solvers/MFEMHypreFGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreFGMRES.C
@@ -31,11 +31,11 @@ MFEMHypreFGMRES::validParams()
 
 MFEMHypreFGMRES::MFEMHypreFGMRES(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
-  constructSolver(parameters);
+  constructSolver();
 }
 
 void
-MFEMHypreFGMRES::constructSolver(const InputParameters &)
+MFEMHypreFGMRES::constructSolver()
 {
   auto solver = std::make_unique<mfem::HypreFGMRES>(getMFEMProblem().getComm());
   solver->SetTol(getParam<mfem::real_t>("l_tol"));

--- a/framework/src/mfem/solvers/MFEMHypreGMRES.C
+++ b/framework/src/mfem/solvers/MFEMHypreGMRES.C
@@ -33,11 +33,11 @@ MFEMHypreGMRES::validParams()
 
 MFEMHypreGMRES::MFEMHypreGMRES(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
-  constructSolver(parameters);
+  constructSolver();
 }
 
 void
-MFEMHypreGMRES::constructSolver(const InputParameters &)
+MFEMHypreGMRES::constructSolver()
 {
   auto solver = std::make_unique<mfem::patched::HypreGMRES>(getMFEMProblem().getComm());
   solver->SetTol(getParam<mfem::real_t>("l_tol"));

--- a/framework/src/mfem/solvers/MFEMHyprePCG.C
+++ b/framework/src/mfem/solvers/MFEMHyprePCG.C
@@ -32,11 +32,11 @@ MFEMHyprePCG::validParams()
 
 MFEMHyprePCG::MFEMHyprePCG(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
-  constructSolver(parameters);
+  constructSolver();
 }
 
 void
-MFEMHyprePCG::constructSolver(const InputParameters &)
+MFEMHyprePCG::constructSolver()
 {
   auto solver = std::make_unique<mfem::patched::HyprePCG>(getMFEMProblem().getComm());
   solver->SetTol(getParam<mfem::real_t>("l_tol"));

--- a/framework/src/mfem/solvers/MFEMMUMPS.C
+++ b/framework/src/mfem/solvers/MFEMMUMPS.C
@@ -27,11 +27,11 @@ MFEMMUMPS::validParams()
 
 MFEMMUMPS::MFEMMUMPS(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
-  constructSolver(parameters);
+  constructSolver();
 }
 
 void
-MFEMMUMPS::constructSolver(const InputParameters &)
+MFEMMUMPS::constructSolver()
 {
   auto solver = std::make_unique<mfem::MUMPSSolver>(getMFEMProblem().getComm());
   solver->SetPrintLevel(getParam<int>("print_level"));

--- a/framework/src/mfem/solvers/MFEMOperatorJacobiSmoother.C
+++ b/framework/src/mfem/solvers/MFEMOperatorJacobiSmoother.C
@@ -26,11 +26,11 @@ MFEMOperatorJacobiSmoother::validParams()
 MFEMOperatorJacobiSmoother::MFEMOperatorJacobiSmoother(const InputParameters & parameters)
   : MFEMSolverBase(parameters)
 {
-  constructSolver(parameters);
+  constructSolver();
 }
 
 void
-MFEMOperatorJacobiSmoother::constructSolver(const InputParameters &)
+MFEMOperatorJacobiSmoother::constructSolver()
 {
   _solver = std::make_unique<mfem::OperatorJacobiSmoother>();
 }

--- a/framework/src/mfem/solvers/MFEMSuperLU.C
+++ b/framework/src/mfem/solvers/MFEMSuperLU.C
@@ -26,11 +26,11 @@ MFEMSuperLU::validParams()
 
 MFEMSuperLU::MFEMSuperLU(const InputParameters & parameters) : MFEMSolverBase(parameters)
 {
-  constructSolver(parameters);
+  constructSolver();
 }
 
 void
-MFEMSuperLU::constructSolver(const InputParameters &)
+MFEMSuperLU::constructSolver()
 {
   _solver = std::make_unique<Moose::MFEM::SuperLUSolver>(getMFEMProblem().getComm());
 }

--- a/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
@@ -167,8 +167,8 @@ MFEMCutTransitionSubMesh::labelMesh(mfem::ParMesh & parent_mesh)
 mfem::Vector
 MFEMCutTransitionSubMesh::findFaceNormal(const mfem::ParMesh & mesh, const int & face)
 {
-  mooseAssert(mesh.SpaceDimension() == 3,
-              "MFEMCutTransitionSubMesh only works in 3-dimensional meshes!");
+  if (mesh.SpaceDimension() != 3)
+    mooseError("MFEMCutTransitionSubMesh only works in 3-dimensional meshes!");
   mfem::Vector normal;
   mfem::Array<int> face_verts;
   std::vector<mfem::Vector> v;

--- a/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
@@ -44,8 +44,7 @@ MFEMCutTransitionSubMesh::MFEMCutTransitionSubMesh(const InputParameters & param
     MFEMBlockRestrictable(parameters, getMFEMProblem().mesh().getMFEMParMesh()),
     _cut_boundary(getParam<BoundaryName>("cut_boundary")),
     _cut_submesh(std::make_shared<mfem::ParSubMesh>(mfem::ParSubMesh::CreateFromBoundary(
-        getMFEMProblem().mesh().getMFEMParMesh(),
-        getMesh().bdr_attribute_sets.GetAttributeSet(_cut_boundary)))),
+        getMesh(), getMesh().bdr_attribute_sets.GetAttributeSet(_cut_boundary)))),
     _transition_subdomain_boundary(getParam<BoundaryName>("transition_subdomain_boundary")),
     _transition_subdomain(getParam<SubdomainName>("transition_subdomain")),
     _closed_subdomain(getParam<SubdomainName>("closed_subdomain")),
@@ -56,7 +55,7 @@ MFEMCutTransitionSubMesh::MFEMCutTransitionSubMesh(const InputParameters & param
 void
 MFEMCutTransitionSubMesh::buildSubMesh()
 {
-  labelMesh(getMFEMProblem().mesh().getMFEMParMesh());
+  labelMesh(const_cast<mfem::ParMesh &>(getMesh()));
   _submesh = std::make_shared<mfem::ParSubMesh>(mfem::ParSubMesh::CreateFromDomain(
       getMesh(), getMesh().attribute_sets.GetAttributeSet(_transition_subdomain)));
   _submesh->attribute_sets.attr_sets = getMesh().attribute_sets.attr_sets;

--- a/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
@@ -114,25 +114,22 @@ MFEMCutTransitionSubMesh::labelMesh(mfem::ParMesh & parent_mesh)
 
   // share cut verts coords or global ids across all procs
   int n_cut_vertices = global_cut_vert_ids.size();
-  std::vector<int> cut_vert_sizes(mpi_comm_size, 0);
+  std::vector<int> cut_vert_sizes(mpi_comm_size);
   MPI_Allgather(
-      &n_cut_vertices, 1, MPI_INT, &cut_vert_sizes[0], 1, MPI_INT, getMFEMProblem().getComm());
+      &n_cut_vertices, 1, MPI_INT, cut_vert_sizes.data(), 1, MPI_INT, getMFEMProblem().getComm());
   // Make an offset array and total the sizes.
-  std::vector<int> n_vert_offset(mpi_comm_size, 0);
-  for (int i = 1; i < mpi_comm_size; i++)
-    n_vert_offset[i] = n_vert_offset[i - 1] + cut_vert_sizes[i - 1];
-  int global_n_cut_vertices = 0;
-  for (int i = 0; i < mpi_comm_size; i++)
-    global_n_cut_vertices += cut_vert_sizes[i];
+  std::vector<int> n_vert_offset(mpi_comm_size);
+  std::exclusive_scan(cut_vert_sizes.begin(), cut_vert_sizes.end(), n_vert_offset.begin(), 0);
+  int global_n_cut_vertices = std::accumulate(cut_vert_sizes.begin(), cut_vert_sizes.end(), 0);
 
   // Gather the queries to all ranks.
-  std::vector<HYPRE_BigInt> all_cut_verts(global_n_cut_vertices, 0);
-  MPI_Allgatherv(&global_cut_vert_ids[0],
+  std::vector<HYPRE_BigInt> all_cut_verts(global_n_cut_vertices);
+  MPI_Allgatherv(global_cut_vert_ids.data(),
                  n_cut_vertices,
                  HYPRE_MPI_BIG_INT,
-                 &all_cut_verts[0],
-                 &cut_vert_sizes[0],
-                 &n_vert_offset[0],
+                 all_cut_verts.data(),
+                 cut_vert_sizes.data(),
+                 n_vert_offset.data(),
                  HYPRE_MPI_BIG_INT,
                  getMFEMProblem().getComm());
 

--- a/framework/src/mfem/transfers/MFEMSubMeshTransfer.C
+++ b/framework/src/mfem/transfers/MFEMSubMeshTransfer.C
@@ -34,9 +34,9 @@ MFEMSubMeshTransfer::validParams()
 MFEMSubMeshTransfer::MFEMSubMeshTransfer(const InputParameters & parameters)
   : MFEMGeneralUserObject(parameters),
     _source_var_name(getParam<VariableName>("from_variable")),
-    _source_var(*getMFEMProblem().getProblemData().gridfunctions.Get(_source_var_name)),
+    _source_var(*getMFEMProblem().getGridFunction(_source_var_name)),
     _result_var_name(getParam<VariableName>("to_variable")),
-    _result_var(*getMFEMProblem().getProblemData().gridfunctions.Get(_result_var_name))
+    _result_var(*getMFEMProblem().getGridFunction(_result_var_name))
 {
 }
 

--- a/framework/src/mfem/transfers/MultiAppMFEMCopyTransfer.C
+++ b/framework/src/mfem/transfers/MultiAppMFEMCopyTransfer.C
@@ -70,9 +70,9 @@ MultiAppMFEMCopyTransfer::transfer(MFEMProblem & to_problem, MFEMProblem & from_
   auto getGF = [&](MFEMProblem & problem, const std::string & name) -> mfem::Vector &
   {
     if (problem.getProblemData().gridfunctions.Has(name))
-      return *problem.getProblemData().gridfunctions.Get(name);
+      return *problem.getGridFunction(name);
     if (problem.getProblemData().cmplx_gridfunctions.Has(name))
-      return *problem.getProblemData().cmplx_gridfunctions.Get(name);
+      return *problem.getComplexGridFunction(name);
     mooseError("No real or complex variable named '", name, "' found.");
   };
 

--- a/framework/src/mfem/transfers/MultiAppMFEMCopyTransfer.C
+++ b/framework/src/mfem/transfers/MultiAppMFEMCopyTransfer.C
@@ -119,14 +119,11 @@ MultiAppMFEMCopyTransfer::execute()
     int transfers_done = 0;
     for (unsigned int i = 0; i < getFromMultiApp()->numGlobalApps(); i++)
     {
-      if (getFromMultiApp()->hasLocalApp(i))
+      if (getFromMultiApp()->hasLocalApp(i) && getToMultiApp()->hasLocalApp(i))
       {
-        if (getToMultiApp()->hasLocalApp(i))
-        {
-          transfer(static_cast<MFEMProblem &>(getToMultiApp()->appProblemBase(i)),
-                   static_cast<MFEMProblem &>(getFromMultiApp()->appProblemBase(i)));
-          transfers_done++;
-        }
+        transfer(static_cast<MFEMProblem &>(getToMultiApp()->appProblemBase(i)),
+                 static_cast<MFEMProblem &>(getFromMultiApp()->appProblemBase(i)));
+        ++transfers_done;
       }
     }
     if (!transfers_done)

--- a/framework/src/mfem/vectorpostprocessors/MFEMValueSamplerBase.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMValueSamplerBase.C
@@ -90,24 +90,21 @@ MFEMValueSamplerBase::validParams()
 MFEMValueSamplerBase::MFEMValueSamplerBase(const InputParameters & parameters,
                                            const std::vector<Point> & points)
   : MFEMVectorPostprocessor(parameters),
+    _var_name(getParam<VariableName>("variable")),
+    _var(*getMFEMProblem().getGridFunction(_var_name)),
+    _mesh(const_cast<mfem::ParMesh &>(getMFEMProblem().getMFEMVariableMesh(_var_name))),
     _finder(this->comm().get()),
     _points_ordering(getParam<MooseEnum>("point_ordering") == "NODES" ? mfem::Ordering::byNODES
                                                                       : mfem::Ordering::byVDIM),
-    _points(pointsToMFEMVector(
-        points, this->getMFEMProblem().mesh().getMFEMParMesh().SpaceDimension(), _points_ordering)),
-    _interp_vals(points.size()),
-    _var_name(getParam<VariableName>("variable")),
-    _var(getMFEMProblem().getProblemData().gridfunctions.GetRef(_var_name))
+    _points(pointsToMFEMVector(points, _mesh.SpaceDimension(), _points_ordering)),
+    _interp_vals(points.size())
 {
-  if (this->getMFEMProblem().mesh().shouldDisplace())
-  {
+  if (getMFEMProblem().mesh().shouldDisplace())
     mooseError("MFEMValueSamplerBase does not yet support problems with displacement.");
-  }
 
   // set up points vector
-  auto & mesh = this->getMFEMProblem().mesh().getMFEMParMesh();
-  mesh.EnsureNodes();
-  _finder.Setup(mesh);
+  _mesh.EnsureNodes();
+  _finder.Setup(_mesh);
   _finder.FindPoints(_points, _points_ordering);
 
   // check all points were found
@@ -121,7 +118,7 @@ MFEMValueSamplerBase::MFEMValueSamplerBase(const InputParameters & parameters,
   }
 
   // declare points vectors for outputting
-  const auto mesh_dim = this->getMFEMProblem().mesh().getMFEMParMesh().SpaceDimension();
+  const auto mesh_dim = _mesh.SpaceDimension();
   for (int i = 0; i < mesh_dim; i++)
   {
     std::reference_wrapper<VectorPostprocessorValue> declared_dim =
@@ -153,7 +150,7 @@ MFEMValueSamplerBase::finalize()
   _interp_vals.HostReadWrite();
   _points.HostReadWrite();
 
-  const auto mesh_dim = this->getMFEMProblem().mesh().getMFEMParMesh().SpaceDimension();
+  const auto mesh_dim = _mesh.SpaceDimension();
   MFEMVectorToPostprocessorPoints(_points, _declared_points, mesh_dim, _points_ordering);
   const auto val_dims = _var.VectorDim();
   const auto num_points = _declared_points[0].get().size();

--- a/framework/src/utils/BSpline.C
+++ b/framework/src/utils/BSpline.C
@@ -11,6 +11,7 @@
 #include "libMeshReducedNamespace.h"
 #include "MooseError.h"
 #include "SplineUtils.h"
+#include "Conversion.h"
 
 using namespace libMesh;
 


### PR DESCRIPTION
## Reason
The real reason is this is just a collection of trivial changes I don't want crowding other PRs.

## Design
Besides minor refactoring, notable semantics changing tweaks include:
- the removal of a call to `BuildEquationSystem()` in the initialisation of time-dependent problem operators;
- the removal of a call to `SetTrialVariablesFromTrueVectors()`;
- an std assertion fix in `&global_cut_vert_ids[0]` when `global_cut_vert_ids` is empty;
- a memory leak fix in `FormJacobianMatrix()`;
- a fix for non-unity builds (that CIVET fails to detect because it needs a dbg build);
- fixes for objects retrieving the parent/main mesh instead of the mesh for the variable they act on.

## Impact
Shorter, simpler code. Slightly better performance for transient problems, e.g. `time (./moose_test-dbg -i tests/mfem/ics/transient_scalar_ic.i > /dev/null)` is ~11% faster on my machine, but that drops to ~2% in optimised mode and I assume problems with more timesteps will see a smaller impact as well.
