### PR TITLE
Make it explicit what vector tags we need to additionally handle

### DIFF
--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -980,11 +980,20 @@ DisplacedProblem::addCachedResidualDirectly(NumericVector<Number> & residual, co
         Assembly::GlobalDataKey{},
         getVectorTag(_displaced_solver_systems[currentNlSysNum()]->nonTimeVectorTag()));
 
+  std::vector<VectorTag> extra_residual_vector_tags;
+  extra_residual_vector_tags.reserve(currentResidualVectorTags().size());
+  const auto time_tag = _displaced_solver_systems[currentNlSysNum()]->timeVectorTag();
+  const auto non_time_tag = _displaced_solver_systems[currentNlSysNum()]->nonTimeVectorTag();
+  for (const auto & vector_tag : currentResidualVectorTags())
+    if (vector_tag._id != time_tag && vector_tag._id != non_time_tag)
+      extra_residual_vector_tags.push_back(vector_tag);
+
   // Flush extra vector tag caches (e.g. from extra_vector_tags on NodalConstraints)
-  // to their respective system vectors. Without this, NodalConstraint contributions
-  // to extra vector tags are silently discarded by the blanket clearCachedResiduals.
+  // to their respective system vectors after the standard TIME/NONTIME caches above.
+  // Without this, NodalConstraint contributions to extra vector tags are silently
+  // discarded by the blanket clearCachedResiduals.
   _assembly[tid][currentNlSysNum()]->addCachedResiduals(Assembly::GlobalDataKey{},
-                                                        currentResidualVectorTags());
+                                                        extra_residual_vector_tags);
 
   // We do this because by adding the cached residual directly, we cannot ensure that all of the
   // cached residuals are emptied after only the two add calls above

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1992,11 +1992,20 @@ FEProblemBase::addCachedResidualDirectly(NumericVector<Number> & residual, const
     _assembly[tid][_current_nl_sys->number()]->addCachedResidualDirectly(
         residual, Assembly::GlobalDataKey{}, getVectorTag(_current_nl_sys->nonTimeVectorTag()));
 
+  std::vector<VectorTag> extra_residual_vector_tags;
+  extra_residual_vector_tags.reserve(currentResidualVectorTags().size());
+  const auto time_tag = _current_nl_sys->timeVectorTag();
+  const auto non_time_tag = _current_nl_sys->nonTimeVectorTag();
+  for (const auto & vector_tag : currentResidualVectorTags())
+    if (vector_tag._id != time_tag && vector_tag._id != non_time_tag)
+      extra_residual_vector_tags.push_back(vector_tag);
+
   // Flush extra vector tag caches (e.g. from extra_vector_tags on NodalConstraints)
-  // to their respective system vectors. Without this, NodalConstraint contributions
-  // to extra vector tags are silently discarded by the blanket clearCachedResiduals.
+  // to their respective system vectors after the standard TIME/NONTIME caches above.
+  // Without this, NodalConstraint contributions to extra vector tags are silently
+  // discarded by the blanket clearCachedResiduals.
   _assembly[tid][_current_nl_sys->number()]->addCachedResiduals(Assembly::GlobalDataKey{},
-                                                                currentResidualVectorTags());
+                                                                extra_residual_vector_tags);
 
   // We do this because by adding the cached residual directly, we cannot ensure that all of the
   // cached residuals are emptied after only the two add calls above


### PR DESCRIPTION
This is a follow-on to #32489. We already insert the contributions from the time and non-time residual tags into `residual`, so we only need to add cached residuals corresponding to all the other residual vector tags subsequently (the cached data in `Assembly` corresponding to the time and non-time vector tags are cleared at the end of the respective calls to `Assembly::addCachedResidualsDirectly` so it's important to note that there was not a correctness issue in PR #32489)