### PR TITLE
Add missing call to pimple solve initial setup for PIMPLE + CHT

### DIFF
--- a/modules/navier_stokes/src/executioners/PIMPLE.C
+++ b/modules/navier_stokes/src/executioners/PIMPLE.C
@@ -37,6 +37,7 @@ PIMPLE::PIMPLE(const InputParameters & parameters) : TransientBase(parameters), 
 void
 PIMPLE::init()
 {
+  _pimple_solve.initialSetup();
   TransientBase::init();
   _pimple_solve.linkRhieChowUserObject();
   _pimple_solve.setupPressurePin();


### PR DESCRIPTION
see idaholab/moose#32571

## Reason
CHT can be setup with PIMPLE considering all the parameters are there, but it fails because of missing functors because of this missing call

## Design
Add pimple_solve->initialSetup() to the PIMPLE initial setup

## Impact
Let users try out PIMPLE + CHT
