### PR TITLE
Mesh partial preparation

### DIFF
--- a/framework/include/meshgenerators/CutMeshByLevelSetGeneratorBase.h
+++ b/framework/include/meshgenerators/CutMeshByLevelSetGeneratorBase.h
@@ -94,11 +94,13 @@ protected:
    * @param new_on_plane_nodes A vector to record the pointers to the newly created nodes on the
    * cutting plane
    * @param new_point The position of the potential new node
+   * @param new_pid The processor id of the new node, if a new node is created
    * @return a pointer to the existing node or the newly created node
    */
   const Node * nonDuplicateNodeCreator(ReplicatedMesh & mesh,
                                        std::vector<const Node *> & new_on_plane_nodes,
-                                       const Point & new_point) const;
+                                       const Point & new_point,
+                                       processor_id_type new_pid) const;
 
   /**
    * Evaluate the level set function at a given point.

--- a/framework/src/meshgenerators/AdvancedExtruderGenerator.C
+++ b/framework/src/meshgenerators/AdvancedExtruderGenerator.C
@@ -1648,9 +1648,29 @@ AdvancedExtruderGenerator::generate()
   if (_has_top_boundary)
     boundary_info.sideset_name(new_boundary_ids.back()) = new_boundary_names.back();
 
-  mesh->unset_is_prepared();
-  // Creating the layered meshes creates a lot of leftover nodes, notably in the boundary_info,
-  // which will crash both paraview and trigger exodiff. Best to be safe.
+  // Our new mesh is still unprepared in most ways.  We don't need to
+  // repartition, since we just extruded our partitioning, but
+  // depending on our ghosting functors we might even have built some
+  // elements that can go remote!
+  mesh->unset_has_synched_id_counts();
+  mesh->unset_has_neighbor_ptrs();
+  mesh->unset_has_cached_elem_data();
+  mesh->unset_has_interior_parent_ptrs();
+  mesh->unset_has_removed_remote_elements();
+  mesh->unset_has_reinit_ghosting_functors();
+  mesh->unset_has_boundary_id_sets();
+  mesh->clear_point_locator();
+
+  // Creating the layered meshes with non-full-order elements creates
+  // a lot of leftover nodes, notably in the boundary_info, which will
+  // crash both paraview and trigger exodiff.
+  // if (extruding_quad_eights)
+  // mesh->unset_has_removed_orphaned_nodes();
+
+  // Somehow just setting the flags above isn't sufficient to handle
+  // the leftover nodes when extruding from a Quad8; this may be a
+  // libMesh bug but for now we'll work around it by forcing a full
+  // re-prepare.
   if (extruding_quad_eights)
     mesh->prepare_for_use();
 

--- a/framework/src/meshgenerators/AnnularMeshGenerator.C
+++ b/framework/src/meshgenerators/AnnularMeshGenerator.C
@@ -323,6 +323,10 @@ AnnularMeshGenerator::generate()
     }
   }
 
-  mesh->prepare_for_use();
+  // We just created this mesh from scratch, so nothing about it is
+  // prepared, but it also isn't marked as prepared, so we can just
+  // let the mesh generator system prepare it later.
+  // mesh->prepare_for_use();
+
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/Boundary2DDelaunayGenerator.C
+++ b/framework/src/meshgenerators/Boundary2DDelaunayGenerator.C
@@ -333,7 +333,7 @@ Boundary2DDelaunayGenerator::General2DDelaunay(
     mesh->get_boundary_info().sideset_name(output_boundary_id[0]) = _output_external_boundary_name;
   }
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
 
   return mesh;
 }

--- a/framework/src/meshgenerators/BoundaryDeletionGenerator.C
+++ b/framework/src/meshgenerators/BoundaryDeletionGenerator.C
@@ -69,8 +69,12 @@ BoundaryDeletionGenerator::generate()
     ids_to_remove = ids;
 
   for (const auto & id : ids_to_remove)
-    mesh->get_boundary_info().remove_id(id);
+    mesh->get_boundary_info().remove_id(id, /* global = */ true);
 
-  mesh->unset_is_prepared();
+  // BoundaryInfo should have updated its caches here, leaving the
+  // mesh just as prepared as it was to begin with, but that's broken
+  // prior to libMesh/libmesh#4419
+  mesh->unset_has_boundary_id_sets();
+
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/BoundaryElementConversionGenerator.C
+++ b/framework/src/meshgenerators/BoundaryElementConversionGenerator.C
@@ -113,7 +113,7 @@ BoundaryElementConversionGenerator::generate()
   if (!mesh.is_replicated())
     mesh.prepare_for_use();
   else
-    mesh.unset_is_prepared();
+    mesh.unset_has_boundary_id_sets();
 
   return std::move(_input);
 }

--- a/framework/src/meshgenerators/BoundaryLayerSubdomainGenerator.C
+++ b/framework/src/meshgenerators/BoundaryLayerSubdomainGenerator.C
@@ -95,6 +95,6 @@ BoundaryLayerSubdomainGenerator::generate()
   // Assign block name
   mesh->subdomain_name(_new_block_id) = _new_block_name;
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_cached_elem_data();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/BoundingBoxNodeSetGenerator.C
+++ b/framework/src/meshgenerators/BoundingBoxNodeSetGenerator.C
@@ -82,6 +82,6 @@ BoundingBoxNodeSetGenerator::generate()
 
   boundary_info.nodeset_name(boundary_ids[0]) = boundary_names[0];
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/BreakBoundaryOnSubdomainGenerator.C
+++ b/framework/src/meshgenerators/BreakBoundaryOnSubdomainGenerator.C
@@ -129,7 +129,7 @@ BreakBoundaryOnSubdomainGenerator::generate()
     }
   }
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
+++ b/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
@@ -481,7 +481,7 @@ BreakMeshByBlockGenerator::generate()
     mesh->remove_orphaned_nodes();
   Partitioner::set_node_processor_ids(*mesh);
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/CartesianMeshGenerator.C
+++ b/framework/src/meshgenerators/CartesianMeshGenerator.C
@@ -441,6 +441,8 @@ CartesianMeshGenerator::generate()
     }
   }
 
-  mesh->prepare_for_use();
+  // The build_foo() calls marked this mesh as prepared, but then we
+  // set subdomain ids without updating caches.
+  mesh->unset_has_cached_elem_data();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/CoarsenBlockGenerator.C
+++ b/framework/src/meshgenerators/CoarsenBlockGenerator.C
@@ -118,16 +118,21 @@ CoarsenBlockGenerator::generate()
                  " times but the max coarsening required is ",
                  max_c);
 
-  // Determine how many times the coarsening will be used
-  if (max_c > 0 && !mesh->is_prepared())
-    // we prepare for use to make sure the neighbors have been found
-    mesh->prepare_for_use();
-
   auto mesh_ptr = recursiveCoarsen(block_ids, mesh, _coarsening, max_c, /*step=*/0);
 
-  // element neighbors are not valid
+  // A lot of our cached data is invalid now.  Copying processor ids
+  // means we can get away without repartitioning yet, though, and in
+  // serial we don't have sync or remote elements to worry about.
   if (max_c > 0)
-    mesh_ptr->unset_is_prepared();
+  {
+    mesh_ptr->unset_has_neighbor_ptrs();
+    mesh_ptr->unset_has_cached_elem_data();
+    mesh_ptr->unset_has_interior_parent_ptrs();
+    mesh_ptr->unset_has_removed_orphaned_nodes();
+    mesh_ptr->unset_has_reinit_ghosting_functors();
+    mesh_ptr->unset_has_boundary_id_sets();
+    mesh_ptr->clear_point_locator();
+  }
 
   // flip elements as we were not careful to build them with a positive volume
   MeshTools::Modification::orient_elements(*mesh_ptr);

--- a/framework/src/meshgenerators/CoarsenBlockGenerator.C
+++ b/framework/src/meshgenerators/CoarsenBlockGenerator.C
@@ -140,7 +140,7 @@ CoarsenBlockGenerator::generate()
   // check that we are not returning a non-conformal mesh
   if (_check_output_mesh_for_nonconformality)
   {
-    mesh_ptr->prepare_for_use();
+    mesh_ptr->complete_preparation();
     unsigned int num_nonconformal_nodes = 0;
     MeshBaseDiagnosticsUtils::checkNonConformalMesh(
         mesh_ptr, _console, 10, TOLERANCE, num_nonconformal_nodes);

--- a/framework/src/meshgenerators/CoarsenBlockGenerator.C
+++ b/framework/src/meshgenerators/CoarsenBlockGenerator.C
@@ -284,7 +284,10 @@ CoarsenBlockGenerator::recursiveCoarsen(const std::vector<subdomain_id_type> & b
 
       // Form a parent, of a low order type as we only have the extreme vertex nodes
       std::unique_ptr<Elem> parent = Elem::build(Elem::first_order_equivalent_type(elem_type));
-      parent->subdomain_id() = common_subdomain_id;
+
+      // Get subdomain id, mapping, p_level, etc.
+      parent->inherit_data_from(*current_elem);
+
       auto parent_ptr = mesh_copy->add_elem(parent.release());
       coarse_elems.insert(parent_ptr);
 

--- a/framework/src/meshgenerators/CoarsenBlockGenerator.C
+++ b/framework/src/meshgenerators/CoarsenBlockGenerator.C
@@ -157,9 +157,9 @@ CoarsenBlockGenerator::recursiveCoarsen(const std::vector<subdomain_id_type> & b
   if (coarse_step == max)
     return dynamic_pointer_cast<MeshBase>(mesh);
 
-  // Elements should know their neighbors
-  if (!mesh->is_prepared())
-    mesh->prepare_for_use();
+  // We need elements to know their neighbors
+  if (!mesh->preparation().has_neighbor_ptrs)
+    mesh->find_neighbors();
 
   // We wont be modifying the starting mesh for simplicity, we will make a copy and return that
   std::unique_ptr<MeshBase> mesh_return;
@@ -429,8 +429,8 @@ CoarsenBlockGenerator::recursiveCoarsen(const std::vector<subdomain_id_type> & b
 
       // Contract to remove the elements that were marked for deletion
       mesh_copy->contract();
-      // Prepare for use to refresh the element neighbors
-      mesh_copy->prepare_for_use();
+      // Refresh the element neighbors
+      mesh_copy->find_neighbors();
     }
 
     // We pick the configuration (eg starting node) for which we managed to coarsen the most

--- a/framework/src/meshgenerators/CoarsenBlockGenerator.C
+++ b/framework/src/meshgenerators/CoarsenBlockGenerator.C
@@ -285,10 +285,12 @@ CoarsenBlockGenerator::recursiveCoarsen(const std::vector<subdomain_id_type> & b
       // Form a parent, of a low order type as we only have the extreme vertex nodes
       std::unique_ptr<Elem> parent = Elem::build(Elem::first_order_equivalent_type(elem_type));
 
-      // Get subdomain id, mapping, p_level, etc.
-      parent->inherit_data_from(*current_elem);
-
       auto parent_ptr = mesh_copy->add_elem(parent.release());
+
+      // Copy processor_id, mapping, etc.  Do this *after* add_elem
+      // for serialized DistributedMesh compatibility.
+      parent_ptr->inherit_data_from(*current_elem);
+
       coarse_elems.insert(parent_ptr);
 
       // Set the nodes to the coarse element

--- a/framework/src/meshgenerators/CombinerGenerator.C
+++ b/framework/src/meshgenerators/CombinerGenerator.C
@@ -180,7 +180,8 @@ CombinerGenerator::generate()
                                    _communicator);
     }
 
-    mesh->unset_is_prepared();
+    // libMesh and MooseMeshUtils should already have marked us
+    // unprepared in the appropriate ways
     return dynamic_pointer_cast<MeshBase>(mesh);
   }
   else // Case 2
@@ -247,7 +248,8 @@ CombinerGenerator::generate()
       }
     }
 
-    final_mesh->unset_is_prepared();
+    // libMesh and MooseMeshUtils should already have marked us
+    // unprepared in the appropriate ways.
     return dynamic_pointer_cast<MeshBase>(final_mesh);
   }
 }

--- a/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
+++ b/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
@@ -346,15 +346,18 @@ const Node *
 CutMeshByLevelSetGeneratorBase::nonDuplicateNodeCreator(
     ReplicatedMesh & mesh,
     std::vector<const Node *> & new_on_plane_nodes,
-    const Point & new_point) const
+    const Point & new_point,
+    processor_id_type new_pid) const
 {
   for (const auto & new_on_plane_node : new_on_plane_nodes)
   {
     if (MooseUtils::absoluteFuzzyEqual((*new_on_plane_node - new_point).norm(), 0.0))
       return new_on_plane_node;
   }
-  new_on_plane_nodes.push_back(mesh.add_point(new_point));
-  return new_on_plane_nodes.back();
+  Node * node = mesh.add_point(new_point);
+  node->processor_id() = new_pid;
+  new_on_plane_nodes.push_back(node);
+  return node;
 }
 
 void
@@ -437,7 +440,8 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
         new_plane_nodes.push_back(nonDuplicateNodeCreator(
             mesh,
             new_on_plane_nodes,
-            pointPairLevelSetInterception(*tet4_node_outside_plane, *tet4_nodes_inside_plane[0])));
+            pointPairLevelSetInterception(*tet4_node_outside_plane, *tet4_nodes_inside_plane[0]),
+            mesh.elem_ptr(elem_id)->processor_id()));
       }
       auto new_elem_tet4 = std::make_unique<Tet4>();
       new_elem_tet4->set_node(0, const_cast<Node *>(tet4_nodes_inside_plane[0]));
@@ -461,7 +465,8 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
           new_plane_nodes.push_back(nonDuplicateNodeCreator(
               mesh,
               new_on_plane_nodes,
-              pointPairLevelSetInterception(*tet4_node_outside_plane, *tet4_node_inside_plane)));
+              pointPairLevelSetInterception(*tet4_node_outside_plane, *tet4_node_inside_plane),
+              mesh.elem_ptr(elem_id)->processor_id()));
         }
       }
       std::vector<const Node *> new_elems_nodes = {tet4_nodes_inside_plane[1],
@@ -498,7 +503,8 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
         new_plane_nodes.push_back(nonDuplicateNodeCreator(
             mesh,
             new_on_plane_nodes,
-            pointPairLevelSetInterception(*tet4_node_inside_plane, *tet4_nodes_outside_plane[0])));
+            pointPairLevelSetInterception(*tet4_node_inside_plane, *tet4_nodes_outside_plane[0]),
+            mesh.elem_ptr(elem_id)->processor_id()));
       }
       std::vector<const Node *> new_elems_nodes = {tet4_nodes_inside_plane[0],
                                                    tet4_nodes_inside_plane[1],
@@ -530,7 +536,8 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
       auto new_plane_node = nonDuplicateNodeCreator(
           mesh,
           new_on_plane_nodes,
-          pointPairLevelSetInterception(*tet4_nodes_inside_plane[0], *tet4_nodes_outside_plane[0]));
+          pointPairLevelSetInterception(*tet4_nodes_inside_plane[0], *tet4_nodes_outside_plane[0]),
+          mesh.elem_ptr(elem_id)->processor_id());
       // A smaller Tet4 is created, this solution is unique
       auto new_elem_tet4 = std::make_unique<Tet4>();
       new_elem_tet4->set_node(0, const_cast<Node *>(new_plane_node));
@@ -552,7 +559,8 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
         new_plane_nodes.push_back(nonDuplicateNodeCreator(
             mesh,
             new_on_plane_nodes,
-            pointPairLevelSetInterception(*tet4_node_outside_plane, *tet4_nodes_inside_plane[0])));
+            pointPairLevelSetInterception(*tet4_node_outside_plane, *tet4_nodes_inside_plane[0]),
+            mesh.elem_ptr(elem_id)->processor_id()));
       }
       auto new_elem_tet4 = std::make_unique<Tet4>();
       new_elem_tet4->set_node(0, const_cast<Node *>(new_plane_nodes[0]));
@@ -574,7 +582,8 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
         new_plane_nodes.push_back(nonDuplicateNodeCreator(
             mesh,
             new_on_plane_nodes,
-            pointPairLevelSetInterception(*tet4_node_inside_plane, *tet4_nodes_outside_plane[0])));
+            pointPairLevelSetInterception(*tet4_node_inside_plane, *tet4_nodes_outside_plane[0]),
+            mesh.elem_ptr(elem_id)->processor_id()));
       }
       std::vector<const Node *> new_elems_nodes = {tet4_nodes_inside_plane[0],
                                                    tet4_nodes_inside_plane[1],

--- a/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
+++ b/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
@@ -173,7 +173,7 @@ CutMeshByLevelSetGeneratorBase::generate()
   std::vector<std::vector<unsigned int>> transition_elems_sides_list;
   if (_generate_transition_layer)
   {
-    if (!mesh.is_prepared())
+    if (!mesh.preparation().has_neighbor_ptrs)
       mesh.find_neighbors();
     // First, we need to identify the retained elements that share the boundary with the crossed
     // elements.

--- a/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
+++ b/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
@@ -285,7 +285,7 @@ CutMeshByLevelSetGeneratorBase::generate()
     mesh.delete_elem(*elem_it);
 
   mesh.contract();
-  mesh.unset_is_prepared();
+  mesh.unset_has_boundary_id_sets();
   return std::move(_input);
 }
 

--- a/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
+++ b/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
@@ -444,7 +444,10 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
       new_elem_tet4->set_node(1, const_cast<Node *>(new_plane_nodes[0]));
       new_elem_tet4->set_node(2, const_cast<Node *>(new_plane_nodes[1]));
       new_elem_tet4->set_node(3, const_cast<Node *>(new_plane_nodes[2]));
-      new_elem_tet4->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id();
+
+      // Copy subdomain id, processor_id, mapping, etc.
+      new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
+
       elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
     }
     else if (tet4_nodes_inside_plane.size() == 2 && tet4_nodes_outside_plane.size() == 2)
@@ -479,7 +482,10 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
         new_elem_tet4->set_node(1, const_cast<Node *>(optimized_node_list[i][1]));
         new_elem_tet4->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
         new_elem_tet4->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
-        new_elem_tet4->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id();
+
+        // Copy subdomain id, processor_id, mapping, etc.
+        new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
+
         elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
       }
     }
@@ -512,7 +518,10 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
         new_elem_tet4->set_node(1, const_cast<Node *>(optimized_node_list[i][1]));
         new_elem_tet4->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
         new_elem_tet4->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
-        new_elem_tet4->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id();
+
+        // Copy subdomain id, processor_id, mapping, etc.
+        new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
+
         elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
       }
     }
@@ -528,7 +537,10 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
       new_elem_tet4->set_node(1, const_cast<Node *>(tet4_nodes_on_plane[0]));
       new_elem_tet4->set_node(2, const_cast<Node *>(tet4_nodes_on_plane[1]));
       new_elem_tet4->set_node(3, const_cast<Node *>(tet4_nodes_inside_plane[0]));
-      new_elem_tet4->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id();
+
+      // Copy subdomain id, processor_id, mapping, etc.
+      new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
+
       elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
     }
     else if (tet4_nodes_inside_plane.size() == 1 && tet4_nodes_outside_plane.size() == 2)
@@ -547,7 +559,10 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
       new_elem_tet4->set_node(1, const_cast<Node *>(new_plane_nodes[1]));
       new_elem_tet4->set_node(2, const_cast<Node *>(tet4_nodes_on_plane[0]));
       new_elem_tet4->set_node(3, const_cast<Node *>(tet4_nodes_inside_plane[0]));
-      new_elem_tet4->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id();
+
+      // Copy subdomain id, processor_id, mapping, etc.
+      new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
+
       elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
     }
     else if (tet4_nodes_inside_plane.size() == 2 && tet4_nodes_outside_plane.size() == 1)
@@ -578,7 +593,10 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
         new_elem_tet4->set_node(1, const_cast<Node *>(optimized_node_list[i][1]));
         new_elem_tet4->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
         new_elem_tet4->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
-        new_elem_tet4->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id();
+
+        // Copy subdomain id, processor_id, mapping, etc.
+        new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
+
         elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
       }
     }

--- a/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
+++ b/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
@@ -449,10 +449,11 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
       new_elem_tet4->set_node(2, const_cast<Node *>(new_plane_nodes[1]));
       new_elem_tet4->set_node(3, const_cast<Node *>(new_plane_nodes[2]));
 
-      // Copy subdomain id, processor_id, mapping, etc.
-      new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
-
       elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
+
+      // Copy processor_id, mapping, etc.  Do this *after* add_elem
+      // for serialized DistributedMesh compatibility.
+      elems_tet4.back()->inherit_data_from(*mesh.elem_ptr(elem_id));
     }
     else if (tet4_nodes_inside_plane.size() == 2 && tet4_nodes_outside_plane.size() == 2)
     {
@@ -488,10 +489,11 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
         new_elem_tet4->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
         new_elem_tet4->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
 
-        // Copy subdomain id, processor_id, mapping, etc.
-        new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
-
         elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
+
+        // Copy processor_id, mapping, etc.  Do this *after* add_elem
+        // for serialized DistributedMesh compatibility.
+        elems_tet4.back()->inherit_data_from(*mesh.elem_ptr(elem_id));
       }
     }
     else if (tet4_nodes_inside_plane.size() == 3 && tet4_nodes_outside_plane.size() == 1)
@@ -525,10 +527,11 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
         new_elem_tet4->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
         new_elem_tet4->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
 
-        // Copy subdomain id, processor_id, mapping, etc.
-        new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
-
         elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
+
+        // Copy processor_id, mapping, etc.  Do this *after* add_elem
+        // for serialized DistributedMesh compatibility.
+        elems_tet4.back()->inherit_data_from(*mesh.elem_ptr(elem_id));
       }
     }
     else if (tet4_nodes_inside_plane.size() == 1 && tet4_nodes_outside_plane.size() == 1)
@@ -545,10 +548,11 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
       new_elem_tet4->set_node(2, const_cast<Node *>(tet4_nodes_on_plane[1]));
       new_elem_tet4->set_node(3, const_cast<Node *>(tet4_nodes_inside_plane[0]));
 
-      // Copy subdomain id, processor_id, mapping, etc.
-      new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
-
       elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
+
+      // Copy processor_id, mapping, etc.  Do this *after* add_elem
+      // for serialized DistributedMesh compatibility.
+      elems_tet4.back()->inherit_data_from(*mesh.elem_ptr(elem_id));
     }
     else if (tet4_nodes_inside_plane.size() == 1 && tet4_nodes_outside_plane.size() == 2)
     {
@@ -568,10 +572,11 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
       new_elem_tet4->set_node(2, const_cast<Node *>(tet4_nodes_on_plane[0]));
       new_elem_tet4->set_node(3, const_cast<Node *>(tet4_nodes_inside_plane[0]));
 
-      // Copy subdomain id, processor_id, mapping, etc.
-      new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
-
       elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
+
+      // Copy processor_id, mapping, etc.  Do this *after* add_elem
+      // for serialized DistributedMesh compatibility.
+      elems_tet4.back()->inherit_data_from(*mesh.elem_ptr(elem_id));
     }
     else if (tet4_nodes_inside_plane.size() == 2 && tet4_nodes_outside_plane.size() == 1)
     {
@@ -603,10 +608,11 @@ CutMeshByLevelSetGeneratorBase::tet4ElemCutter(
         new_elem_tet4->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
         new_elem_tet4->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
 
-        // Copy subdomain id, processor_id, mapping, etc.
-        new_elem_tet4->inherit_data_from(*mesh.elem_ptr(elem_id));
-
         elems_tet4.push_back(mesh.add_elem(std::move(new_elem_tet4)));
+
+        // Copy processor_id, mapping, etc.  Do this *after* add_elem
+        // for serialized DistributedMesh compatibility.
+        elems_tet4.back()->inherit_data_from(*mesh.elem_ptr(elem_id));
       }
     }
     else

--- a/framework/src/meshgenerators/ElementGenerator.C
+++ b/framework/src/meshgenerators/ElementGenerator.C
@@ -142,9 +142,14 @@ ElementGenerator::generate()
     for (const auto i_side : make_range(elem->n_sides()))
       mesh->get_boundary_info().add_side(elem.get(), i_side, i_side);
 
+  // We won't force a repartition for this
+  elem->processor_id() = 0;
+
   mesh->add_elem(std::move(elem));
-  // We just added an element
-  mesh->unset_is_prepared();
+
+  // But some other derived data may need recalculation
+  mesh->clear_point_locator();
+  mesh->unset_has_cached_elem_data();
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/ElementOrderConversionGenerator.C
+++ b/framework/src/meshgenerators/ElementOrderConversionGenerator.C
@@ -58,6 +58,6 @@ ElementOrderConversionGenerator::generate()
       mooseError("Invalid conversion type");
   }
 
-  mesh->unset_is_prepared();
+  // The libMesh functions above should have left the mesh prepared
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/ExamplePatchMeshGenerator.C
+++ b/framework/src/meshgenerators/ExamplePatchMeshGenerator.C
@@ -254,7 +254,10 @@ ExamplePatchMeshGenerator::generate()
     boundary_info.nodeset_name(107) = "top_front_left";
   }
 
-  mesh->prepare_for_use();
+  // We just created this mesh from scratch, so nothing about it is
+  // prepared, but it also isn't marked as prepared, so we can just
+  // let the mesh generator system prepare it later.
+  // mesh->prepare_for_use();
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/ExtraNodesetGenerator.C
+++ b/framework/src/meshgenerators/ExtraNodesetGenerator.C
@@ -181,6 +181,6 @@ ExtraNodesetGenerator::generate()
   for (unsigned int i = 0; i < boundary_ids.size(); ++i)
     boundary_info.nodeset_name(boundary_ids[i]) = boundary_names[i];
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/FillBetweenCurvesGenerator.C
+++ b/framework/src/meshgenerators/FillBetweenCurvesGenerator.C
@@ -196,7 +196,7 @@ FillBetweenCurvesGenerator::generate()
   for (const auto & [bnd_id, bnd_name] : input_bdy_2.get_nodeset_name_map())
     boundary.set_nodeset_name_map()[bnd_id + offset] = bnd_name;
   if (node_list_mesh1.size() + node_list_mesh2.size())
-    mesh->unset_is_prepared();
+    mesh->unset_has_boundary_id_sets();
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/GeneratedMeshGenerator.C
+++ b/framework/src/meshgenerators/GeneratedMeshGenerator.C
@@ -345,6 +345,6 @@ GeneratedMeshGenerator::generate()
     }
   }
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_cached_elem_data();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/MeshCollectionGenerator.C
+++ b/framework/src/meshgenerators/MeshCollectionGenerator.C
@@ -119,6 +119,6 @@ MeshCollectionGenerator::generate()
     }
   }
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/MeshExtruderGenerator.C
+++ b/framework/src/meshgenerators/MeshExtruderGenerator.C
@@ -110,7 +110,7 @@ MeshExtruderGenerator::generate()
   if (isParamValid("top_sideset"))
     changeID(*dest_mesh, getParam<std::vector<BoundaryName>>("top_sideset"), old_top);
 
-  dest_mesh->unset_is_prepared();
+  dest_mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(dest_mesh);
 }
 

--- a/framework/src/meshgenerators/MeshGenerator.C
+++ b/framework/src/meshgenerators/MeshGenerator.C
@@ -335,8 +335,7 @@ MeshGenerator::generateInternal()
 
   if (getParam<bool>("show_info"))
   {
-    if (!mesh->is_prepared())
-      mesh->prepare_for_use();
+    mesh->complete_preparation();
 
     const auto mesh_info = mesh->get_info(/* verbosity = */ 2);
 
@@ -354,8 +353,7 @@ MeshGenerator::generateInternal()
   // output the current mesh block to file
   if (hasOutput())
   {
-    if (!mesh->is_prepared())
-      mesh->prepare_for_use();
+    mesh->complete_preparation();
 
     if (!getParam<bool>("nemesis"))
     {

--- a/framework/src/meshgenerators/MeshRepairGenerator.C
+++ b/framework/src/meshgenerators/MeshRepairGenerator.C
@@ -110,7 +110,6 @@ MeshRepairGenerator::generate()
   if (_split_nonconvex_polygons)
     splitNonConvexPolygons(mesh);
 
-  mesh->unset_is_prepared();
   return mesh;
 }
 
@@ -187,14 +186,17 @@ MeshRepairGenerator::fixOverlappingNodes(std::unique_ptr<MeshBase> & mesh) const
       }
     }
   }
+
+  // We've orphaned the nodes we just disconnected
+  mesh->unset_has_removed_orphaned_nodes();
+
+  // Merging nodes means we may have newly-adjacent neighbors
+  mesh->unset_has_neighbor_ptrs();
+
+  // We've probably invalidated our id counts
+  mesh->unset_has_synched_id_counts();
+
   _console << "Number of overlapping nodes which got merged: " << num_fixed_nodes << std::endl;
-  if (mesh->allow_renumbering())
-    mesh->renumber_nodes_and_elements();
-  else
-  {
-    mesh->remove_orphaned_nodes();
-    mesh->update_parallel_id_counts();
-  }
 }
 
 void
@@ -231,6 +233,8 @@ MeshRepairGenerator::separateSubdomainsByElementType(std::unique_ptr<MeshBase> &
       }
     }
   }
+
+  mesh->unset_has_cached_elem_data();
 }
 
 void

--- a/framework/src/meshgenerators/MeshRepairGenerator.C
+++ b/framework/src/meshgenerators/MeshRepairGenerator.C
@@ -475,6 +475,19 @@ MeshRepairGenerator::splitNonConvexPolygons(std::unique_ptr<MeshBase> & mesh) co
   for (auto & new_elem_ptr : elements_to_add_to_mesh)
     mesh->add_elem(std::move(new_elem_ptr));
 
+  // We may no longer be prepared
+  if (!elems_to_delete.empty())
+  {
+    // Cached data that might need to be recalculated later
+    mesh->unset_has_neighbor_ptrs();
+    mesh->unset_has_reinit_ghosting_functors();
+
+    // Cached data that might need to be recalculated later after we
+    // start supporting distributed meshes here
+    mesh->unset_has_synched_id_counts();
+    mesh->unset_has_removed_remote_elements();
+  }
+
   _console << "Number of non-convex polygons which got split into convex polygons: "
            << num_nonconvex << std::endl;
   if (num_triangulated)

--- a/framework/src/meshgenerators/MeshRepairGenerator.C
+++ b/framework/src/meshgenerators/MeshRepairGenerator.C
@@ -252,6 +252,10 @@ MeshRepairGenerator::splitNonConvexPolygons(std::unique_ptr<MeshBase> & mesh) co
     mooseError("MeshRepairGenerator requires a serial mesh for this operation. "
                "The mesh should not be distributed.");
 
+  // We're not supporting boundary info updates here, but let's scream
+  // if that's a problem.
+  BoundaryInfo & boundary_info = mesh->get_boundary_info();
+
   for (auto elem : mesh->element_ptr_range())
   {
     // We are not splitting non-convex quads. Maybe later.
@@ -457,6 +461,11 @@ MeshRepairGenerator::splitNonConvexPolygons(std::unique_ptr<MeshBase> & mesh) co
       }
       // Element got fixed, can be deleted after (can't while using the range)
       elems_to_delete.push_back(elem);
+
+      for (auto s : make_range(elem->n_sides()))
+        if (boundary_info.n_boundary_ids(elem, s))
+          mooseError("MeshRepairGenerator does not yet support "
+                     "splitting polygons with side boundaries");
     }
   }
   // Delete the original element

--- a/framework/src/meshgenerators/ParsedGenerateNodeset.C
+++ b/framework/src/meshgenerators/ParsedGenerateNodeset.C
@@ -129,7 +129,7 @@ ParsedGenerateNodeset::generate()
   }
   boundary_info.nodeset_name(nodeset_ids[0]) = _nodeset_names[0];
 
-  // TODO: consider if a new nodeset actually impacts preparedness
-  mesh->unset_is_prepared();
+  // The BoundaryInfo will need to get the new id into caches
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/ParsedGenerateSideset.C
+++ b/framework/src/meshgenerators/ParsedGenerateSideset.C
@@ -119,6 +119,6 @@ ParsedGenerateSideset::generate()
   finalize();
   boundary_info.sideset_name(boundary_ids[0]) = _boundary_names[0];
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/ParsedSubdomainGeneratorBase.C
+++ b/framework/src/meshgenerators/ParsedSubdomainGeneratorBase.C
@@ -121,7 +121,7 @@ ParsedSubdomainGeneratorBase::generate()
   // Assign block name, if applicable
   setBlockName(mesh);
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_cached_elem_data();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }
 

--- a/framework/src/meshgenerators/PatternedMeshGenerator.C
+++ b/framework/src/meshgenerators/PatternedMeshGenerator.C
@@ -293,7 +293,10 @@ PatternedMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(
           *_row_meshes[0], stitch_bids[side], input_bids_unique[0][side]);
 
-  _row_meshes[0]->unset_is_prepared();
+  // This should become redundant once libMesh calls it properly from
+  // change_boundary_id()
+  _row_meshes[0]->unset_has_boundary_id_sets();
+
   return dynamic_pointer_cast<MeshBase>(_row_meshes[0]);
 }
 

--- a/framework/src/meshgenerators/PolyLineMeshFollowingNodeSetGenerator.C
+++ b/framework/src/meshgenerators/PolyLineMeshFollowingNodeSetGenerator.C
@@ -213,7 +213,10 @@ done_drawing:
     bi.add_side(mesh.elem_ptr(n_elem - 1), 1, ids[1]);
   }
 
-  mesh.prepare_for_use();
+  // We just created this mesh from scratch, so nothing about it is
+  // prepared, but it also isn't marked as prepared, so we can just
+  // let the mesh generator system prepare it later.
+  // mesh->prepare_for_use();
 
   return uptr_mesh;
 }

--- a/framework/src/meshgenerators/ProjectSideSetOntoLevelSetGenerator.C
+++ b/framework/src/meshgenerators/ProjectSideSetOntoLevelSetGenerator.C
@@ -135,7 +135,16 @@ ProjectSideSetOntoLevelSetGenerator::generate()
   }
 
   new_mesh->subdomain_name(projection_block_id) = getParam<SubdomainName>("subdomain_name");
-  new_mesh->unset_is_prepared();
+
+  // We haven't built up any caches, but we are building in
+  // serial so at least we don't have to worry about id count sync or
+  // remote elements, and we don't have any boundary info or orphaned
+  // nodes or outdated point-locator on this new mesh.
+  new_mesh->unset_has_neighbor_ptrs();
+  new_mesh->unset_has_cached_elem_data();
+  new_mesh->unset_has_interior_parent_ptrs();
+  new_mesh->unset_has_reinit_ghosting_functors();
+
   return dynamic_pointer_cast<MeshBase>(new_mesh);
 }
 

--- a/framework/src/meshgenerators/ProjectSideSetOntoLevelSetGenerator.C
+++ b/framework/src/meshgenerators/ProjectSideSetOntoLevelSetGenerator.C
@@ -128,13 +128,17 @@ ProjectSideSetOntoLevelSetGenerator::generate()
     for (const auto i : make_range(n_nodes))
       new_elem->set_node(i, new_nodes[i]);
 
+    auto new_elem_ptr = new_mesh->add_elem(std::move(new_elem));
+
     // User-selected block name: same for all element types for now
     // But if our side_elem inherited any other special data (like
     // mapping type) from its interior elem, we'll want to copy that.
-    new_elem->inherit_data_from(*side_elem);
-    new_elem->subdomain_id() = projection_block_id;
+    //
+    // Do this *after* add_elem for serialized DistributedMesh
+    // compatibility.
+    new_elem_ptr->inherit_data_from(*side_elem);
 
-    new_mesh->add_elem(std::move(new_elem));
+    new_elem_ptr->subdomain_id() = projection_block_id;
   }
 
   new_mesh->subdomain_name(projection_block_id) = getParam<SubdomainName>("subdomain_name");

--- a/framework/src/meshgenerators/ProjectSideSetOntoLevelSetGenerator.C
+++ b/framework/src/meshgenerators/ProjectSideSetOntoLevelSetGenerator.C
@@ -129,6 +129,9 @@ ProjectSideSetOntoLevelSetGenerator::generate()
       new_elem->set_node(i, new_nodes[i]);
 
     // User-selected block name: same for all element types for now
+    // But if our side_elem inherited any other special data (like
+    // mapping type) from its interior elem, we'll want to copy that.
+    new_elem->inherit_data_from(*side_elem);
     new_elem->subdomain_id() = projection_block_id;
 
     new_mesh->add_elem(std::move(new_elem));

--- a/framework/src/meshgenerators/RefineBlockGenerator.C
+++ b/framework/src/meshgenerators/RefineBlockGenerator.C
@@ -79,21 +79,10 @@ RefineBlockGenerator::generate()
   std::unique_ptr<MeshBase> mesh = std::move(_input);
   int max = *std::max_element(_refinement.begin(), _refinement.end());
 
-  if (max > 0 && !mesh->is_replicated() && !mesh->is_prepared())
-    // refinement requires that (or at least it asserts that) the mesh is either replicated or
-    // prepared
-    mesh->prepare_for_use();
-
   auto mesh_ptr = recursive_refine(block_ids, mesh, _refinement, max);
-
-  if (max > 0 && !mesh_ptr->is_replicated() && !mesh_ptr->is_prepared())
-    // refinement requires that (or at least it asserts that) the mesh is either replicated or
-    // prepared
-    mesh_ptr->prepare_for_use();
 
   // Refine elements that are too big
   bool found_element_to_refine = true;
-  bool refined_on_size = false;
   while (found_element_to_refine)
   {
     found_element_to_refine = false;
@@ -113,12 +102,8 @@ RefineBlockGenerator::generate()
       if (!_enable_neighbor_refinement)
         refinedmesh.face_level_mismatch_limit() = 0;
       refinedmesh.refine_elements();
-      refined_on_size = true;
     }
   }
-
-  if (refined_on_size || max > 0)
-    mesh_ptr->unset_is_prepared();
 
   return mesh_ptr;
 }

--- a/framework/src/meshgenerators/RenameBlockGenerator.C
+++ b/framework/src/meshgenerators/RenameBlockGenerator.C
@@ -294,6 +294,6 @@ RenameBlockGenerator::generate()
   for (const auto & pair : new_names)
     mesh->subdomain_name(pair.first) = pair.second;
 
-  mesh->unset_is_prepared();
+  // change_subdomain_id already set our caches as unprepared
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/RenameBoundaryGenerator.C
+++ b/framework/src/meshgenerators/RenameBoundaryGenerator.C
@@ -234,6 +234,8 @@ RenameBoundaryGenerator::generate()
     boundary_info.nodeset_name(pair.first) = pair.second;
   }
 
-  mesh->unset_is_prepared();
+  // This may become redundant once libMesh updates
+  // change_boundary_id()
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/SideSetsAroundSubdomainGenerator.C
+++ b/framework/src/meshgenerators/SideSetsAroundSubdomainGenerator.C
@@ -186,7 +186,7 @@ SideSetsAroundSubdomainGenerator::generate()
   for (unsigned int i = 0; i < boundary_ids.size(); ++i)
     boundary_info.sideset_name(boundary_ids[i]) = _boundary_names[i];
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }
 

--- a/framework/src/meshgenerators/SideSetsBetweenSubdomainsGenerator.C
+++ b/framework/src/meshgenerators/SideSetsBetweenSubdomainsGenerator.C
@@ -188,6 +188,6 @@ SideSetsBetweenSubdomainsGenerator::generate()
   for (const auto & i : make_range(boundary_ids.size()))
     boundary_info.sideset_name(boundary_ids[i]) = _boundary_names[i];
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/SideSetsFromAllNormalsGenerator.C
+++ b/framework/src/meshgenerators/SideSetsFromAllNormalsGenerator.C
@@ -100,7 +100,8 @@ SideSetsFromAllNormalsGenerator::generate()
 
   finalize();
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
+
   return dynamic_pointer_cast<MeshBase>(mesh);
 }
 

--- a/framework/src/meshgenerators/SideSetsFromBoundingBoxGenerator.C
+++ b/framework/src/meshgenerators/SideSetsFromBoundingBoxGenerator.C
@@ -191,6 +191,6 @@ SideSetsFromBoundingBoxGenerator::generate()
       mooseError("No nodes found within the bounding box");
   }
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/SideSetsFromNormalsGenerator.C
+++ b/framework/src/meshgenerators/SideSetsFromNormalsGenerator.C
@@ -121,6 +121,6 @@ SideSetsFromNormalsGenerator::generate()
     _boundary_to_normal_map[boundary_ids[i]] = _normals[i];
   }
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/SideSetsFromPointsGenerator.C
+++ b/framework/src/meshgenerators/SideSetsFromPointsGenerator.C
@@ -139,6 +139,6 @@ SideSetsFromPointsGenerator::generate()
   for (const auto i : index_range(boundary_ids))
     mesh->get_boundary_info().sideset_name(boundary_ids[i]) = _boundary_names[i];
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/SideSetsGeneratorBase.C
+++ b/framework/src/meshgenerators/SideSetsGeneratorBase.C
@@ -112,9 +112,13 @@ SideSetsGeneratorBase::setup(MeshBase & mesh)
 {
   mooseAssert(_fe_face == nullptr, "FE Face has already been initialized");
 
-  // To know the dimension of the mesh
-  if (!mesh.is_prepared())
-    mesh.prepare_for_use();
+  // To know the dimension, boundaries, and subdomains of the mesh
+  const auto & prep = mesh.preparation();
+  if (!prep.has_cached_elem_data)
+    mesh.cache_elem_data();
+  if (!prep.has_boundary_id_sets)
+    mesh.get_boundary_info().regenerate_id_sets();
+
   const auto dim = mesh.mesh_dimension();
 
   // Setup the FE Object so we can calculate normals
@@ -208,13 +212,12 @@ SideSetsGeneratorBase::setup(MeshBase & mesh)
     _included_neighbor_subdomain_ids = MooseMeshUtils::getSubdomainIDs(mesh, subdomains);
   }
 
-  // We will want to Change the below code when we have more fine-grained control over advertising
-  // what we need and how we satisfy those needs. For now we know we need to have neighbors per
-  // #15823...and we do have an explicit `find_neighbors` call...but we don't have a
-  // `neighbors_found` API and it seems off to do:
-  //
-  // if (!mesh.is_prepared())
-  //   mesh.find_neighbors()
+  // Every one of our subclasses right now needs neighbor pointers,
+  // either via direct neighbor_ptr() calls, or indirectly via
+  // elemSideSatisfiesRequirements() or flood() calls, so we'll just
+  // make sure they're prepped in setup().
+  if (!mesh.preparation().has_neighbor_ptrs)
+    mesh.find_neighbors();
 }
 
 void

--- a/framework/src/meshgenerators/StitchBoundaryMeshGenerator.C
+++ b/framework/src/meshgenerators/StitchBoundaryMeshGenerator.C
@@ -58,6 +58,7 @@ StitchBoundaryMeshGenerator::generate()
                         use_binary_search,
                         getParam<Real>("stitching_hmin_tolerance_factor"));
 
-  mesh->unset_is_prepared();
+  // This may become redundant once stitch_surfaces handles it
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/StitchBoundaryMeshGenerator.C
+++ b/framework/src/meshgenerators/StitchBoundaryMeshGenerator.C
@@ -58,7 +58,9 @@ StitchBoundaryMeshGenerator::generate()
                         use_binary_search,
                         getParam<Real>("stitching_hmin_tolerance_factor"));
 
-  // This may become redundant once stitch_surfaces handles it
-  mesh->unset_has_boundary_id_sets();
+  // stitch_surfaces should be handling mesh preparation
+  // automatically with the above parameters, but until it's doing so
+  // properly let's prefer to be safe rather than sorry.
+  mesh->unset_is_prepared();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/StitchMeshGenerator.C
+++ b/framework/src/meshgenerators/StitchMeshGenerator.C
@@ -198,7 +198,10 @@ StitchMeshGenerator::generate()
       MooseMeshUtils::mergeBoundaryIDsWithSameName(*mesh);
   }
 
-  // This may become redundant once stitch_meshes handles it
-  mesh->unset_has_boundary_id_sets();
+  // stitch_meshes and the other modifiers we're calling should be
+  // handling mesh preparation and/or preparation flagging
+  // automatically, but until they're doing so properly we need to be
+  // safe rather than sorry.
+  mesh->unset_is_prepared();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/StitchMeshGenerator.C
+++ b/framework/src/meshgenerators/StitchMeshGenerator.C
@@ -198,6 +198,7 @@ StitchMeshGenerator::generate()
       MooseMeshUtils::mergeBoundaryIDsWithSameName(*mesh);
   }
 
-  mesh->unset_is_prepared();
+  // This may become redundant once stitch_meshes handles it
+  mesh->unset_has_boundary_id_sets();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
+++ b/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
@@ -118,6 +118,6 @@ SubdomainBoundingBoxGenerator::generate()
       mesh->subdomain_name(_block_id) = getParam<SubdomainName>("block_name");
   }
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_cached_elem_data();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/SubdomainIDGenerator.C
+++ b/framework/src/meshgenerators/SubdomainIDGenerator.C
@@ -41,6 +41,6 @@ SubdomainIDGenerator::generate()
   for (auto & elem : mesh->element_ptr_range())
     elem->subdomain_id() = _subdomain_id;
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_cached_elem_data();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/SubdomainPerElementGenerator.C
+++ b/framework/src/meshgenerators/SubdomainPerElementGenerator.C
@@ -151,6 +151,6 @@ SubdomainPerElementGenerator::generate()
     elem->subdomain_id() = newid;
   }
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_cached_elem_data();
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/TransfiniteMeshGenerator.C
+++ b/framework/src/meshgenerators/TransfiniteMeshGenerator.C
@@ -217,7 +217,11 @@ TransfiniteMeshGenerator::generate()
   boundary_info.sideset_name(3) = "left";
   boundary_info.nodeset_name(3) = "left";
 
-  mesh->prepare_for_use();
+  // We just created this mesh from scratch, so nothing about it is
+  // prepared, but it also isn't marked as prepared, so we can just
+  // let the mesh generator system prepare it later.
+  // mesh->prepare_for_use();
+
   return dynamic_pointer_cast<MeshBase>(mesh);
 }
 

--- a/framework/src/meshgenerators/TransformGenerator.C
+++ b/framework/src/meshgenerators/TransformGenerator.C
@@ -117,7 +117,7 @@ TransformGenerator::generate()
       break;
   }
 
-  mesh->unset_is_prepared();
+  // MeshTools:: operations have already marked us as unprepared
   return dynamic_pointer_cast<MeshBase>(mesh);
 }
 

--- a/framework/src/meshgenerators/XYDelaunayGenerator.C
+++ b/framework/src/meshgenerators/XYDelaunayGenerator.C
@@ -477,9 +477,8 @@ XYDelaunayGenerator::generate()
         libMesh::MeshTools::Modification::change_boundary_id(*result, sentinel_id, user_id);
       result->get_boundary_info().sideset_name(user_id) = user_output_boundary;
     }
-
-    result->unset_is_prepared();
   }
 
+  result->unset_has_boundary_id_sets();
   return result;
 }

--- a/framework/src/meshgenerators/XYZDelaunayGenerator.C
+++ b/framework/src/meshgenerators/XYZDelaunayGenerator.C
@@ -611,7 +611,7 @@ XYZDelaunayGenerator::generate()
   for (auto & hole_ptr : _hole_ptrs)
     hole_ptr->reset();
 
-  mesh->unset_is_prepared();
+  mesh->unset_has_boundary_id_sets();
   return mesh;
 #else
   mooseError("Cannot use XYZDelaunayGenerator without NetGen-enabled libMesh.");

--- a/framework/src/utils/MooseMeshElementConversionUtils.C
+++ b/framework/src/utils/MooseMeshElementConversionUtils.C
@@ -813,6 +813,10 @@ convertHex8Elem(MeshBase & mesh,
   // elements
   const Point elem_cent = mesh.elem_ptr(elem_id)->true_centroid();
   auto new_node = mesh.add_point(elem_cent);
+
+  // Don't force us to repartition later
+  new_node->processor_id() = mesh.elem_ptr(elem_id)->processor_id();
+
   for (const auto & i_side : make_range(mesh.elem_ptr(elem_id)->n_sides()))
   {
     if (std::find(side_indices.begin(), side_indices.end(), i_side) != side_indices.end())
@@ -936,6 +940,10 @@ convertPrism6Elem(MeshBase & mesh,
   // For the PYRAMID5 element, it can further be converted into 2 TET3 elements
   const Point elem_cent = mesh.elem_ptr(elem_id)->true_centroid();
   auto new_node = mesh.add_point(elem_cent);
+
+  // Don't force us to repartition later
+  new_node->processor_id() = mesh.elem_ptr(elem_id)->processor_id();
+
   for (const auto & i_side : make_range(mesh.elem_ptr(elem_id)->n_sides()))
   {
     if (i_side % 4 == 0 ||

--- a/framework/src/utils/MooseMeshElementConversionUtils.C
+++ b/framework/src/utils/MooseMeshElementConversionUtils.C
@@ -71,10 +71,12 @@ hexElemSplitter(MeshBase & mesh,
     new_elem->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
     new_elem->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
 
-    // Copy subdomain id, processor_id, mapping, etc.
-    new_elem->inherit_data_from(*mesh.elem_ptr(elem_id));
-
     elems_Tet4.push_back(mesh.add_elem(std::move(new_elem)));
+
+    // Copy processor_id, mapping, etc.  Do this *after* add_elem for
+    // serialized DistributedMesh compatibility.
+    elems_Tet4.back()->inherit_data_from(*mesh.elem_ptr(elem_id));
+
     converted_elems_ids.push_back(elems_Tet4.back()->id());
 
     for (unsigned int j = 0; j < 4; j++)
@@ -136,10 +138,12 @@ prismElemSplitter(MeshBase & mesh,
     new_elem->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
     new_elem->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
 
-    // Copy subdomain id, processor_id, mapping, etc.
-    new_elem->inherit_data_from(*mesh.elem_ptr(elem_id));
-
     elems_Tet4.push_back(mesh.add_elem(std::move(new_elem)));
+
+    // Copy processor_id, mapping, etc.  Do this *after* add_elem for
+    // serialized DistributedMesh compatibility.
+    elems_Tet4.back()->inherit_data_from(*mesh.elem_ptr(elem_id));
+
     converted_elems_ids.push_back(elems_Tet4.back()->id());
 
     for (unsigned int j = 0; j < 4; j++)
@@ -199,10 +203,12 @@ pyramidElemSplitter(MeshBase & mesh,
     new_elem->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
     new_elem->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
 
-    // Copy subdomain id, processor_id, mapping, etc.
-    new_elem->inherit_data_from(*mesh.elem_ptr(elem_id));
-
     elems_Tet4.push_back(mesh.add_elem(std::move(new_elem)));
+
+    // Copy processor_id, mapping, etc.  Do this *after* add_elem for
+    // serialized DistributedMesh compatibility.
+    elems_Tet4.back()->inherit_data_from(*mesh.elem_ptr(elem_id));
+
     converted_elems_ids.push_back(elems_Tet4.back()->id());
 
     for (unsigned int j = 0; j < 4; j++)
@@ -843,13 +849,16 @@ createUnitPyramid5FromHex8(MeshBase & mesh,
   new_elem->set_node(3, mesh.elem_ptr(elem_id)->side_ptr(side_index)->node_ptr(0));
   new_elem->set_node(4, const_cast<Node *>(new_node));
 
-  // Copy processor_id, mapping, etc.
-  new_elem->inherit_data_from(*mesh.elem_ptr(elem_id));
+  auto new_elem_ptr = mesh.add_elem(std::move(new_elem));
+
+  // Copy processor_id, mapping, etc.  Do this *after* add_elem for
+  // serialized DistributedMesh compatibility.
+  new_elem_ptr->inherit_data_from(*mesh.elem_ptr(elem_id));
 
   // But override subdomain_id to get a new block
-  new_elem->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base * 2;
+  new_elem_ptr->subdomain_id() =
+      mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base * 2;
 
-  auto new_elem_ptr = mesh.add_elem(std::move(new_elem));
   retainEEID(mesh, elem_id, new_elem_ptr);
   for (const auto & bid : side_info)
     mesh.get_boundary_info().add_side(new_elem_ptr, 4, bid);
@@ -888,13 +897,15 @@ createUnitTet4FromHex8(MeshBase & mesh,
                            ->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
   new_elem_0->set_node(3, const_cast<Node *>(new_node));
 
-  // Copy processor_id, mapping, etc.
-  new_elem_0->inherit_data_from(*mesh.elem_ptr(elem_id));
+  auto new_elem_ptr_0 = mesh.add_elem(std::move(new_elem_0));
+
+  // Copy processor_id, mapping, etc.  Do this *after* add_elem for
+  // serialized DistributedMesh compatibility.
+  new_elem_ptr_0->inherit_data_from(*mesh.elem_ptr(elem_id));
 
   // But override subdomain_id to get a new block
-  new_elem_0->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+  new_elem_ptr_0->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
 
-  auto new_elem_ptr_0 = mesh.add_elem(std::move(new_elem_0));
   retainEEID(mesh, elem_id, new_elem_ptr_0);
 
   auto new_elem_1 = std::make_unique<Tet4>();
@@ -912,13 +923,15 @@ createUnitTet4FromHex8(MeshBase & mesh,
                            ->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
   new_elem_1->set_node(3, const_cast<Node *>(new_node));
 
-  // Copy processor_id, mapping, etc.
-  new_elem_1->inherit_data_from(*mesh.elem_ptr(elem_id));
+  auto new_elem_ptr_1 = mesh.add_elem(std::move(new_elem_1));
+
+  // Copy processor_id, mapping, etc.  Do this *after* add_elem for
+  // serialized DistributedMesh compatibility.
+  new_elem_ptr_1->inherit_data_from(*mesh.elem_ptr(elem_id));
 
   // But override subdomain_id to get a new block
-  new_elem_1->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+  new_elem_ptr_1->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
 
-  auto new_elem_ptr_1 = mesh.add_elem(std::move(new_elem_1));
   retainEEID(mesh, elem_id, new_elem_ptr_1);
 
   for (const auto & bid : side_info)
@@ -993,13 +1006,15 @@ createUnitTet4FromPrism6(MeshBase & mesh,
                            ->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
   new_elem_0->set_node(3, const_cast<Node *>(new_node));
 
-  // Copy processor_id, mapping, etc.
-  new_elem_0->inherit_data_from(*mesh.elem_ptr(elem_id));
+  auto new_elem_ptr_0 = mesh.add_elem(std::move(new_elem_0));
+
+  // Copy processor_id, mapping, etc.  Do this *after* add_elem for
+  // serialized DistributedMesh compatibility.
+  new_elem_ptr_0->inherit_data_from(*mesh.elem_ptr(elem_id));
 
   // But override subdomain_id to get a new block
-  new_elem_0->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+  new_elem_ptr_0->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
 
-  auto new_elem_ptr_0 = mesh.add_elem(std::move(new_elem_0));
   retainEEID(mesh, elem_id, new_elem_ptr_0);
 
   Elem * new_elem_ptr_1 = nullptr;
@@ -1020,13 +1035,16 @@ createUnitTet4FromPrism6(MeshBase & mesh,
                              ->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
     new_elem_1->set_node(3, const_cast<Node *>(new_node));
 
-    // Copy processor_id, mapping, etc.
-    new_elem_1->inherit_data_from(*mesh.elem_ptr(elem_id));
+    new_elem_ptr_1 = mesh.add_elem(std::move(new_elem_1));
+
+    // Copy processor_id, mapping, etc.  Do this *after* add_elem for
+    // serialized DistributedMesh compatibility.
+    new_elem_ptr_1->inherit_data_from(*mesh.elem_ptr(elem_id));
 
     // But override subdomain_id to get a new block
-    new_elem_1->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+    new_elem_ptr_1->subdomain_id() =
+        mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
 
-    new_elem_ptr_1 = mesh.add_elem(std::move(new_elem_1));
     retainEEID(mesh, elem_id, new_elem_ptr_1);
   }
 
@@ -1077,13 +1095,15 @@ convertPyramid5Elem(MeshBase & mesh,
       mesh.elem_ptr(elem_id)->side_ptr(4)->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
   new_elem_0->set_node(3, mesh.elem_ptr(elem_id)->node_ptr(4));
 
-  // Copy processor_id, mapping, etc.
-  new_elem_0->inherit_data_from(*mesh.elem_ptr(elem_id));
+  auto new_elem_ptr_0 = mesh.add_elem(std::move(new_elem_0));
+
+  // Copy processor_id, mapping, etc.  Do this *after* add_elem, for
+  // serialized DistributedMesh compatibility.
+  new_elem_ptr_0->inherit_data_from(*mesh.elem_ptr(elem_id));
 
   // But override subdomain_id to get a new block
-  new_elem_0->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+  new_elem_ptr_0->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
 
-  auto new_elem_ptr_0 = mesh.add_elem(std::move(new_elem_0));
   retainEEID(mesh, elem_id, new_elem_ptr_0);
 
   auto new_elem_1 = std::make_unique<Tet4>();
@@ -1098,13 +1118,15 @@ convertPyramid5Elem(MeshBase & mesh,
       mesh.elem_ptr(elem_id)->side_ptr(4)->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
   new_elem_1->set_node(3, mesh.elem_ptr(elem_id)->node_ptr(4));
 
-  // Copy processor_id, mapping, etc.
-  new_elem_1->inherit_data_from(*mesh.elem_ptr(elem_id));
+  auto new_elem_ptr_1 = mesh.add_elem(std::move(new_elem_1));
+
+  // Copy processor_id, mapping, etc.  Do this *after* add_elem, for
+  // serialized DistributedMesh compatibility.
+  new_elem_ptr_1->inherit_data_from(*mesh.elem_ptr(elem_id));
 
   // But override subdomain_id to get a new block
-  new_elem_1->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+  new_elem_ptr_1->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
 
-  auto new_elem_ptr_1 = mesh.add_elem(std::move(new_elem_1));
   retainEEID(mesh, elem_id, new_elem_ptr_1);
 
   for (const auto & bid : elem_side_info[0])

--- a/framework/src/utils/MooseMeshElementConversionUtils.C
+++ b/framework/src/utils/MooseMeshElementConversionUtils.C
@@ -70,7 +70,10 @@ hexElemSplitter(MeshBase & mesh,
     new_elem->set_node(1, const_cast<Node *>(optimized_node_list[i][1]));
     new_elem->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
     new_elem->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
-    new_elem->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id();
+
+    // Copy subdomain id, processor_id, mapping, etc.
+    new_elem->inherit_data_from(*mesh.elem_ptr(elem_id));
+
     elems_Tet4.push_back(mesh.add_elem(std::move(new_elem)));
     converted_elems_ids.push_back(elems_Tet4.back()->id());
 
@@ -132,7 +135,10 @@ prismElemSplitter(MeshBase & mesh,
     new_elem->set_node(1, const_cast<Node *>(optimized_node_list[i][1]));
     new_elem->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
     new_elem->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
-    new_elem->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id();
+
+    // Copy subdomain id, processor_id, mapping, etc.
+    new_elem->inherit_data_from(*mesh.elem_ptr(elem_id));
+
     elems_Tet4.push_back(mesh.add_elem(std::move(new_elem)));
     converted_elems_ids.push_back(elems_Tet4.back()->id());
 
@@ -192,7 +198,10 @@ pyramidElemSplitter(MeshBase & mesh,
     new_elem->set_node(1, const_cast<Node *>(optimized_node_list[i][1]));
     new_elem->set_node(2, const_cast<Node *>(optimized_node_list[i][2]));
     new_elem->set_node(3, const_cast<Node *>(optimized_node_list[i][3]));
-    new_elem->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id();
+
+    // Copy subdomain id, processor_id, mapping, etc.
+    new_elem->inherit_data_from(*mesh.elem_ptr(elem_id));
+
     elems_Tet4.push_back(mesh.add_elem(std::move(new_elem)));
     converted_elems_ids.push_back(elems_Tet4.back()->id());
 
@@ -829,7 +838,13 @@ createUnitPyramid5FromHex8(MeshBase & mesh,
   new_elem->set_node(2, mesh.elem_ptr(elem_id)->side_ptr(side_index)->node_ptr(1));
   new_elem->set_node(3, mesh.elem_ptr(elem_id)->side_ptr(side_index)->node_ptr(0));
   new_elem->set_node(4, const_cast<Node *>(new_node));
+
+  // Copy processor_id, mapping, etc.
+  new_elem->inherit_data_from(*mesh.elem_ptr(elem_id));
+
+  // But override subdomain_id to get a new block
   new_elem->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base * 2;
+
   auto new_elem_ptr = mesh.add_elem(std::move(new_elem));
   retainEEID(mesh, elem_id, new_elem_ptr);
   for (const auto & bid : side_info)
@@ -868,7 +883,13 @@ createUnitTet4FromHex8(MeshBase & mesh,
                            ->side_ptr(side_index)
                            ->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
   new_elem_0->set_node(3, const_cast<Node *>(new_node));
+
+  // Copy processor_id, mapping, etc.
+  new_elem_0->inherit_data_from(*mesh.elem_ptr(elem_id));
+
+  // But override subdomain_id to get a new block
   new_elem_0->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+
   auto new_elem_ptr_0 = mesh.add_elem(std::move(new_elem_0));
   retainEEID(mesh, elem_id, new_elem_ptr_0);
 
@@ -886,7 +907,13 @@ createUnitTet4FromHex8(MeshBase & mesh,
                            ->side_ptr(side_index)
                            ->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
   new_elem_1->set_node(3, const_cast<Node *>(new_node));
+
+  // Copy processor_id, mapping, etc.
+  new_elem_1->inherit_data_from(*mesh.elem_ptr(elem_id));
+
+  // But override subdomain_id to get a new block
   new_elem_1->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+
   auto new_elem_ptr_1 = mesh.add_elem(std::move(new_elem_1));
   retainEEID(mesh, elem_id, new_elem_ptr_1);
 
@@ -957,7 +984,13 @@ createUnitTet4FromPrism6(MeshBase & mesh,
                            ->side_ptr(side_index)
                            ->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
   new_elem_0->set_node(3, const_cast<Node *>(new_node));
+
+  // Copy processor_id, mapping, etc.
+  new_elem_0->inherit_data_from(*mesh.elem_ptr(elem_id));
+
+  // But override subdomain_id to get a new block
   new_elem_0->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+
   auto new_elem_ptr_0 = mesh.add_elem(std::move(new_elem_0));
   retainEEID(mesh, elem_id, new_elem_ptr_0);
 
@@ -978,7 +1011,13 @@ createUnitTet4FromPrism6(MeshBase & mesh,
                              ->side_ptr(side_index)
                              ->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
     new_elem_1->set_node(3, const_cast<Node *>(new_node));
+
+    // Copy processor_id, mapping, etc.
+    new_elem_1->inherit_data_from(*mesh.elem_ptr(elem_id));
+
+    // But override subdomain_id to get a new block
     new_elem_1->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+
     new_elem_ptr_1 = mesh.add_elem(std::move(new_elem_1));
     retainEEID(mesh, elem_id, new_elem_ptr_1);
   }
@@ -1029,7 +1068,13 @@ convertPyramid5Elem(MeshBase & mesh,
       2,
       mesh.elem_ptr(elem_id)->side_ptr(4)->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
   new_elem_0->set_node(3, mesh.elem_ptr(elem_id)->node_ptr(4));
+
+  // Copy processor_id, mapping, etc.
+  new_elem_0->inherit_data_from(*mesh.elem_ptr(elem_id));
+
+  // But override subdomain_id to get a new block
   new_elem_0->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+
   auto new_elem_ptr_0 = mesh.add_elem(std::move(new_elem_0));
   retainEEID(mesh, elem_id, new_elem_ptr_0);
 
@@ -1044,7 +1089,13 @@ convertPyramid5Elem(MeshBase & mesh,
       2,
       mesh.elem_ptr(elem_id)->side_ptr(4)->node_ptr(MathUtils::euclideanMod(0 - lid_index % 2, 4)));
   new_elem_1->set_node(3, mesh.elem_ptr(elem_id)->node_ptr(4));
+
+  // Copy processor_id, mapping, etc.
+  new_elem_1->inherit_data_from(*mesh.elem_ptr(elem_id));
+
+  // But override subdomain_id to get a new block
   new_elem_1->subdomain_id() = mesh.elem_ptr(elem_id)->subdomain_id() + subdomain_id_shift_base;
+
   auto new_elem_ptr_1 = mesh.add_elem(std::move(new_elem_1));
   retainEEID(mesh, elem_id, new_elem_ptr_1);
 

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -59,6 +59,8 @@ mergeBoundaryIDsWithSameName(MeshBase & mesh)
 
   for (const auto & [id1, id2] : same_name_ids)
     mesh.get_boundary_info().renumber_id(id2, id1);
+
+  mesh.unset_has_boundary_id_sets();
 }
 
 void
@@ -102,7 +104,7 @@ changeBoundaryId(MeshBase & mesh,
     boundary_info.remove_id(old_id);
 
   // global information may now be out of sync
-  mesh.unset_is_prepared();
+  mesh.unset_has_boundary_id_sets();
 }
 
 std::vector<boundary_id_type>
@@ -273,7 +275,7 @@ changeSubdomainId(MeshBase & mesh, const subdomain_id_type old_id, const subdoma
       elem->subdomain_id() = new_id;
 
   // global cached information may now be out of sync
-  mesh.unset_is_prepared();
+  mesh.unset_has_cached_elem_data();
 }
 
 Point

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -501,7 +501,8 @@ SubdomainID
 getNextFreeSubdomainID(MeshBase & input_mesh)
 {
   // Call this to get most up to date block id information
-  input_mesh.cache_elem_data();
+  if (!input_mesh.preparation().has_cached_elem_data)
+    input_mesh.cache_elem_data();
 
   std::set<SubdomainID> preexisting_subdomain_ids;
   input_mesh.subdomain_ids(preexisting_subdomain_ids);

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -1408,6 +1408,11 @@ copyIntoMesh(MeshGenerator & mg,
   for (const auto & [edgeset_id, edgeset_name] : other_boundary.get_edgeset_name_map())
     boundary.set_edgeset_name_map().insert(
         std::make_pair<BoundaryID, BoundaryName>(edgeset_id + bid_offset, edgeset_name));
+
+  // libMesh copy_nodes_and_elements should have set us as unprepared
+  // as appropriate for itself, but then we've been editing boundary
+  // ids afterward
+  destination.unset_has_boundary_id_sets();
 }
 
 void

--- a/modules/reactor/src/meshgenerators/AdvancedConcentricCircleGenerator.C
+++ b/modules/reactor/src/meshgenerators/AdvancedConcentricCircleGenerator.C
@@ -252,6 +252,9 @@ AdvancedConcentricCircleGenerator::generate()
                          _quad_elem_type);
   MeshTools::Modification::rotate(*mesh, -_azimuthal_angles[0], 0, 0);
 
+  // stitching will require at least prepared neighbor pointers
+  mesh->find_neighbors();
+
   for (unsigned int i = 1; i < _num_sectors; i++)
   {
     auto mesh_tmp = buildSlice(ring_radii_corr,
@@ -287,8 +290,7 @@ AdvancedConcentricCircleGenerator::generate()
 
     ReplicatedMesh other_mesh(*mesh_tmp);
     MeshTools::Modification::rotate(other_mesh, -_azimuthal_angles[i], 0, 0);
-    mesh->prepare_for_use();
-    other_mesh.prepare_for_use();
+    other_mesh.find_neighbors();
     // As we rotate the mesh in the negative direction (see "-" before _azimuthal_angles[i]),
     // the order of SLICE_END and SLICE_BEGIN should be reversed compared to the similar call in
     // PolygonConcentricCircleMeshGeneratorBase.C
@@ -302,8 +304,6 @@ AdvancedConcentricCircleGenerator::generate()
 
   // An extra step to stich the first and last slices together
   mesh->stitch_surfaces(SLICE_END, SLICE_BEGIN, TOLERANCE, true, false);
-
-  mesh->prepare_for_use();
 
   // Set up customized Block Names and/or IDs
   unsigned int block_it = 0;

--- a/modules/reactor/src/meshgenerators/AdvancedConcentricCircleGenerator.C
+++ b/modules/reactor/src/meshgenerators/AdvancedConcentricCircleGenerator.C
@@ -332,6 +332,8 @@ AdvancedConcentricCircleGenerator::generate()
 
   assignInterfaceBoundaryNames(*mesh);
 
-  mesh->unset_is_prepared();
+  // At this point the mesh should already know in what ways it isn't
+  // prepared, both from its default state and the above MOOSE/libMesh
+  // operations
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
@@ -635,8 +635,7 @@ AssemblyMeshGenerator::generate()
     addDepletionId(*(*_build_mesh), option, DepletionIDGenerationLevel::Assembly, _extrude);
   }
 
-  // Mark mesh as not prepared, as block IDs were re-assigned in this method
-  (*_build_mesh)->unset_is_prepared();
+  // updateElementBlockNameId already marked those caches unprepared
 
   return std::move(*_build_mesh);
 }

--- a/modules/reactor/src/meshgenerators/ConcentricCircleGeneratorBase.C
+++ b/modules/reactor/src/meshgenerators/ConcentricCircleGeneratorBase.C
@@ -254,6 +254,8 @@ ConcentricCircleGeneratorBase::assignBlockIdsNames(ReplicatedMesh & mesh,
       }
   for (unsigned i = 0; i < block_ids_new.size(); ++i)
     mesh.subdomain_name(block_ids_new[i]) = block_names[i];
+
+  mesh.unset_has_cached_elem_data(); // We changed subdomain ids
 }
 
 void

--- a/modules/reactor/src/meshgenerators/ControlDrumMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/ControlDrumMeshGenerator.C
@@ -459,8 +459,7 @@ ControlDrumMeshGenerator::generate()
     addDepletionId(*(*_build_mesh), option, DepletionIDGenerationLevel::Drum, _extrude);
   }
 
-  // Mark mesh as not prepared, as block ID's were re-assigned in this method
-  (*_build_mesh)->unset_is_prepared();
+  // updateElementBlockNameId should already have marked our cache unprepared
 
   return std::move(*_build_mesh);
 }

--- a/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
@@ -884,8 +884,9 @@ CoreMeshGenerator::generate()
     addDepletionId(*(*_build_mesh), option, DepletionIDGenerationLevel::Core, _extrude);
   }
 
-  // Mark mesh as not prepared, as block ID's were re-assigned in this method
-  (*_build_mesh)->unset_is_prepared();
+  // Our cached elem data should have been marked unprepared by our
+  // helper functions, but at the end we also added boundary ids
+  (*_build_mesh)->unset_has_boundary_id_sets();
 
   return std::move(*_build_mesh);
 }

--- a/modules/reactor/src/meshgenerators/FlexiblePatternGenerator.C
+++ b/modules/reactor/src/meshgenerators/FlexiblePatternGenerator.C
@@ -647,7 +647,9 @@ FlexiblePatternGenerator::generate()
     (*_build_mesh)->get_boundary_info().nodeset_name(_external_boundary_id) =
         _external_boundary_name;
   }
-  (*_build_mesh)->find_neighbors();
-  (*_build_mesh)->unset_is_prepared();
+
+  // Our utilities and subgenerators should already have marked the
+  // ways in which we're unprepared now.
+
   return std::move(*_build_mesh);
 }

--- a/modules/reactor/src/meshgenerators/PatternedCartesianMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PatternedCartesianMeshGenerator.C
@@ -1023,7 +1023,7 @@ PatternedCartesianMeshGenerator::generate()
     setMeshProperty("interface_boundary_ids", interface_boundary_ids);
   }
 
-  out_mesh->unset_is_prepared();
+  out_mesh->unset_has_cached_elem_data(); // We changed subdomain ids
   auto mesh = dynamic_pointer_cast<MeshBase>(out_mesh);
   return mesh;
 }

--- a/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
@@ -1021,7 +1021,7 @@ PatternedHexMeshGenerator::generate()
     setMeshProperty("interface_boundary_ids", interface_boundary_ids);
   }
 
-  out_mesh->unset_is_prepared();
+  out_mesh->unset_has_cached_elem_data(); // We changed subdomain ids
   auto mesh = dynamic_pointer_cast<MeshBase>(out_mesh);
   return mesh;
 }

--- a/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
@@ -482,7 +482,18 @@ PeripheralRingMeshGenerator::generate()
         _external_boundary_name;
   }
 
-  _input->unset_is_prepared();
+  // Our new mesh is still unprepared in nearly every way, but we're
+  // building Replicated so id counts are in sync and geometric
+  // ghosting work is irrelevant (we'll still reinit ghosting functors
+  // in case there's something fancy going on with algebraic
+  // ghosting), and we're not extending any NodeElem into edges so
+  // there are no new interior parent pointers to create.
+  _input->unset_has_neighbor_ptrs();
+  _input->unset_has_cached_elem_data();
+  _input->unset_has_reinit_ghosting_functors();
+  _input->unset_has_boundary_id_sets();
+  _input->clear_point_locator();
+
   return dynamic_pointer_cast<MeshBase>(_input);
 }
 

--- a/modules/reactor/src/meshgenerators/PinMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PinMeshGenerator.C
@@ -692,9 +692,7 @@ PinMeshGenerator::generate()
         *(*_build_mesh), elem, rgmb_name_id_map, elem_block_name, next_block_id);
   }
 
-  // Mark mesh as not prepared, as block IDs were re-assigned in this method
-  (*_build_mesh)->unset_is_prepared();
-
+  // updateElementBlockNameId already marked mesh caches unprepared
   return std::move(*_build_mesh);
 }
 

--- a/modules/reactor/src/meshgenerators/PolygonConcentricCircleMeshGeneratorBase.C
+++ b/modules/reactor/src/meshgenerators/PolygonConcentricCircleMeshGeneratorBase.C
@@ -949,7 +949,6 @@ PolygonConcentricCircleMeshGeneratorBase::generate()
   bool flat_side_up = getMeshProperty<bool>("flat_side_up", name());
   if (flat_side_up)
     MeshTools::Modification::rotate(*mesh0, 180.0 / (Real)_num_sides, 0.0, 0.0);
-  mesh0->unset_is_prepared();
 
   if (_has_rings && getParam<bool>("replace_inner_ring_with_delaunay_mesh"))
   {

--- a/modules/reactor/src/meshgenerators/RevolveGenerator.C
+++ b/modules/reactor/src/meshgenerators/RevolveGenerator.C
@@ -1494,9 +1494,19 @@ RevolveGenerator::generate()
     mesh->get_boundary_info().set_nodeset_name_map().insert(input_nodeset_map.begin(),
                                                             input_nodeset_map.end());
 
-  mesh->remove_orphaned_nodes();
-  mesh->renumber_nodes_and_elements();
-  mesh->unset_is_prepared();
+  // Our new mesh is still unprepared in most ways.  We don't need to
+  // repartition, since we just revolved our partitioning, but
+  // depending on our ghosting functors we might even have built some
+  // elements that can go remote!
+  mesh->unset_has_removed_orphaned_nodes();
+  mesh->unset_has_synched_id_counts();
+  mesh->unset_has_neighbor_ptrs();
+  mesh->unset_has_cached_elem_data();
+  mesh->unset_has_interior_parent_ptrs();
+  mesh->unset_has_removed_remote_elements();
+  mesh->unset_has_reinit_ghosting_functors();
+  mesh->unset_has_boundary_id_sets();
+  mesh->clear_point_locator();
 
   return mesh;
 }

--- a/modules/reactor/src/meshgenerators/TriPinHexAssemblyGenerator.C
+++ b/modules/reactor/src/meshgenerators/TriPinHexAssemblyGenerator.C
@@ -319,7 +319,10 @@ TriPinHexAssemblyGenerator::generate()
         _external_boundary_id > 0 ? _external_boundary_id : (boundary_id_type)OUTER_SIDESET_ID) =
         _external_boundary_name;
   }
-  meshes[0]->unset_is_prepared();
+
+  // Everything unprepared by this generation should have been marked
+  // so by helper functions
+
   return dynamic_pointer_cast<MeshBase>(meshes[0]);
 }
 

--- a/modules/reactor/src/meshgenerators/TriPinHexAssemblyGenerator.C
+++ b/modules/reactor/src/meshgenerators/TriPinHexAssemblyGenerator.C
@@ -298,6 +298,13 @@ TriPinHexAssemblyGenerator::generate()
                                OUTER_SIDESET_ID,
                                TOLERANCE,
                                /*clear_stitched_boundary_ids=*/true);
+
+      // We're missing neighbor pointers after the stitching?  This
+      // may be a libMesh bug, but we'll work around it here.  We'll
+      // actually call find_neighbors(), not just mark neighbors
+      // unprepared, because the stitcher wants valid neighbor
+      // pointers.
+      meshes[0]->find_neighbors();
     }
   }
 


### PR DESCRIPTION
Closes #32398, at least until/unless we see opportunities to improve efficiency in future mesh generators.

## Reason
Right now, a MOOSE mesh generator that invalidates any cache (e.g. by adding a boundary id to an element without updating the collective boundary id sets for the mesh) typically marks the entire mesh as unprepared, which forces the regeneration of every cache (e.g. repartitioning, recalculating neighbor links, and other expensive operations). In some cases this may be a significant performance hit.

## Design
As of the last libMesh submodule update, it's now possible to mark a mesh as only being partially unprepared, and then to only do the necessary subset of preparation work later. We should start using those APIs.

## Impact
No API changes, but weakening intermediate preparation levels might trigger any preparation-related bugs in subsequent mesh generators which try to use some cache that isn't ready.

Leaving this marked as draft because I have some additional sweeps to make, but this is passing my private tests and I want to see if CI agrees.