### PR TITLE
Gather all the nodal dofs of multiple nodes with array variables

### DIFF
--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -1476,8 +1476,18 @@ MooseVariableData<OutputType>::reinitNodes(const std::vector<dof_id_type> & node
     {
       if (nd->n_dofs(_sys.number(), _var_num) > 0)
       {
-        dof_id_type dof = nd->dof_number(_sys.number(), _var_num, 0);
-        _dof_indices.push_back(dof);
+        if constexpr (std::is_same<RealEigenVector, OutputType>::value)
+        {
+          static thread_local std::vector<dof_id_type> dof_indices;
+          _dof_map.array_dof_indices(nd, dof_indices, _var_num);
+          for (const auto dof : dof_indices)
+            _dof_indices.push_back(dof);
+        }
+        else
+        {
+          dof_id_type dof = nd->dof_number(_sys.number(), _var_num, 0);
+          _dof_indices.push_back(dof);
+        }
       }
     }
   }

--- a/test/tests/constraints/nodal_constraint/array_variables/MWE_array_aux.i
+++ b/test/tests/constraints/nodal_constraint/array_variables/MWE_array_aux.i
@@ -1,0 +1,141 @@
+# Minimal Working Example to reproduce an array variable + nodal constraint issue
+# This test case creates:
+# 1. A scalar nonlinear variable (T_solid)
+# 2. An array auxiliary variable (Nus) with 2 components
+# 3. Nodal constraints that couple T_solid
+#
+# Expected behavior: Should run without error
+# Actual behavior: Crashes with DOF indices error during constraint evaluation
+# The bug was that the array variable dofs were not all gathered at each node
+
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 1
+    nx = 10
+    xmin = 0
+    xmax = 1.0
+  []
+
+  [add_bdy]
+    type = ExtraNodesetGenerator
+    input = gen
+    coord = '0.5 0 0'
+    new_boundary = 'fluid_solid'
+  []
+[]
+
+[Functions]
+  [htc_func]
+    type = ConstantFunction
+    value = 1000
+  []
+  [re_func]
+    type = ConstantFunction
+    value = 5000
+  []
+[]
+
+[Variables]
+  # Solid temperature
+  [T_solid]
+    order = FIRST
+    family = LAGRANGE
+    initial_condition = 500
+  []
+[]
+
+[AuxVariables]
+  # Regular scalar auxiliary variable
+  [htc]
+    order = FIRST
+    family = LAGRANGE
+    initial_condition = 1000
+  []
+
+  # ARRAY AUXILIARY VARIABLE - This is what causes the issue
+  # Component 0: Heat transfer coefficient
+  # Component 1: Reynolds number
+  [Nus]
+    order = FIRST
+    family = LAGRANGE
+    components = 2
+    initial_condition = '1000 5000'
+  []
+[]
+
+[AuxKernels]
+  # Compute array variable using functions
+  [compute_Nus]
+    type = FunctionArrayAux
+    variable = Nus
+    functions = 'htc_func re_func'
+    execute_on = 'INITIAL TIMESTEP_BEGIN'
+  []
+
+  # Extract HTC (component 0) from array variable
+  [extract_htc]
+    type = ArrayVariableComponent
+    variable = htc
+    array_variable = Nus
+    component = 0
+    execute_on = 'INITIAL TIMESTEP_BEGIN'
+  []
+[]
+
+[Kernels]
+  # Simple diffusion for solid
+  [heat_solid]
+    type = Diffusion
+    variable = T_solid
+  []
+[]
+
+[Constraints]
+  # These nodal constraints copy T_solid to Tw at interface nodes
+  # The crash occurs when MOOSE tries to reinitialize neighbor nodes
+  # and encounters the Nus array auxiliary variable
+
+  [copy_Tw_node5]
+    type = LinearNodalConstraint
+    variable = T_solid
+    primary = '2'
+    secondary_node_set = '2'
+    penalty = 1e6
+    weights = 1
+  []
+[]
+
+[BCs]
+  [left_bc]
+    type = DirichletBC
+    variable = T_solid
+    boundary = 'left'
+    value = 600
+  []
+
+  [right_bc]
+    type = DirichletBC
+    variable = T_solid
+    boundary = 'right'
+    value = 400
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
+  nl_abs_tol = 1e-8
+[]
+
+[Problem]
+  kernel_coverage_check = false
+[]
+
+[Outputs]
+  exodus = true
+  print_linear_residuals = false
+[]
+

--- a/test/tests/constraints/nodal_constraint/array_variables/tests
+++ b/test/tests/constraints/nodal_constraint/array_variables/tests
@@ -1,0 +1,11 @@
+[Tests]
+  issues = '#32700'
+  design = 'ArrayMooseVariable.md'
+  [run_with_nodal_constraints]
+    type = RunApp
+    input = 'MWE_array_aux.i'
+    requirement = 'The system shall be able to use nodal constraints in the presence of array variables.'
+    # see #29005
+    mesh_mode = 'replicated'
+  []
+[]

--- a/unit/src/MooseVariableDataReinitNodesTest.C
+++ b/unit/src/MooseVariableDataReinitNodesTest.C
@@ -1,0 +1,88 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest/gtest.h"
+
+#include "MooseObjectUnitTest.h"
+#include "MooseVariableFE.h"
+#include "MooseMesh.h"
+
+/**
+ * Fixture: mesh + FEProblem with a scalar and a 2-component array aux variable.
+ * DOFs are numbered and the semilocal node list is populated so reinitNodes works.
+ */
+class MooseVariableDataReinitNodesTest : public MooseObjectUnitTest
+{
+public:
+  MooseVariableDataReinitNodesTest() : MooseObjectUnitTest("MooseUnitApp")
+  {
+    {
+      InputParameters params = _factory.getValidParams("MooseVariable");
+      params.set<MooseEnum>("order") = "FIRST";
+      params.set<MooseEnum>("family") = "LAGRANGE";
+      _fe_problem->addAuxVariable("MooseVariable", "scalar_var", params);
+    }
+    {
+      InputParameters params = _factory.getValidParams("ArrayMooseVariable");
+      params.set<MooseEnum>("order") = "FIRST";
+      params.set<MooseEnum>("family") = "LAGRANGE";
+      params.set<unsigned int>("components") = 2;
+      _fe_problem->addAuxVariable("ArrayMooseVariable", "array_var", params);
+    }
+
+    _fe_problem->es().init();
+    // MooseVariableData checks isSemiLocal so we have to populate this range
+    std::set<dof_id_type> no_ghosts;
+    _mesh->updateActiveSemiLocalNodeRange(no_ghosts);
+
+    for (const auto & node : _mesh->getMesh().local_node_ptr_range())
+      _node_ids.push_back(node->id());
+  }
+
+protected:
+  std::vector<dof_id_type> _node_ids;
+};
+
+TEST_F(MooseVariableDataReinitNodesTest, scalarVariableDofsMatchLibmesh)
+{
+  auto & var = _fe_problem->getStandardVariable(0, "scalar_var");
+  var.reinitNodes(_node_ids);
+
+  const auto sys_num = var.sys().number();
+  const auto var_num = var.number();
+
+  std::vector<dof_id_type> expected;
+  for (const auto node_id : _node_ids)
+  {
+    const auto & nd = _mesh->getMesh().node_ref(node_id);
+    expected.push_back(nd.dof_number(sys_num, var_num, 0));
+  }
+
+  EXPECT_EQ(var.dofIndices(), expected);
+}
+
+TEST_F(MooseVariableDataReinitNodesTest, arrayVariableDofsMatchLibmesh)
+{
+  auto & var = _fe_problem->getArrayVariable(0, "array_var");
+  var.reinitNodes(_node_ids);
+
+  const auto & dof_map = var.dofMap();
+  const auto var_num = var.number();
+
+  std::vector<dof_id_type> expected;
+  std::vector<dof_id_type> node_component_dofs;
+  for (const auto node_id : _node_ids)
+  {
+    const auto & nd = _mesh->getMesh().node_ref(node_id);
+    dof_map.array_dof_indices(&nd, node_component_dofs, var_num);
+    expected.insert(expected.end(), node_component_dofs.begin(), node_component_dofs.end());
+  }
+
+  EXPECT_EQ(var.dofIndices(), expected);
+}


### PR DESCRIPTION
## Reason
When using a nodal constraint, we reinit systems on multiple nodes.
For each variable, we first check if it has dofs (reinit) then compute the values
The first part was not right for array variables and causing a seg fault

## Design
On reinitNodes, make sure to gather more than just 1 dof per node for array variables 

## Impact
Let MOOSE run problems with nodal constraints and array variables
Note that the nodal constraint does not have to be acting on the array variable to hit the problem

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
