### PR TITLE
Offload SuperLU_DIST solves only if using GPUs and consolidate eq sys updates between solves

### DIFF
--- a/framework/doc/content/syntax/MFEM/MixedHeatTransfer.md
+++ b/framework/doc/content/syntax/MFEM/MixedHeatTransfer.md
@@ -28,7 +28,7 @@ the mixed weak form of the transient heat equation
 \left(\rho c_p \frac{\partial T}{\partial t}, T'\right)_\Omega + \left(\vec \nabla \cdot \vec h, T'\right)_\Omega
 = 0 \,\,\, \forall T' \in V_T \\
 \left(k^{-1} \vec h, \vec h'\right)_\Omega - (T, \vec \nabla \cdot \vec h')_\Omega
-= (T , \vec h' \cdot \hat n)_{\partial \Omega} \,\,\, \forall \vec h' \in V_h
+= -(T , \vec h' \cdot \hat n)_{\partial \Omega} \,\,\, \forall \vec h' \in V_h
 \end{split}
 \end{equation}
 

--- a/framework/include/materials/ParsedMaterialBase.h
+++ b/framework/include/materials/ParsedMaterialBase.h
@@ -20,12 +20,10 @@ class ParsedMaterialBase
 public:
   static InputParameters validParams();
 
-  ParsedMaterialBase(const InputParameters & parameters, const MooseObject * obj);
+  ParsedMaterialBase(const InputParameters & parameters);
+  virtual ~ParsedMaterialBase() = default;
 
 protected:
-  /// Pointer to the MooseObject (to call paramError)
-  const MooseObject * const _derived_object;
-
   /// Parameter that the function comes from
   const std::string _function_param;
 

--- a/framework/include/mfem/equation_systems/EquationSystem.h
+++ b/framework/include/mfem/equation_systems/EquationSystem.h
@@ -46,8 +46,11 @@ public:
   virtual void Init(GridFunctions & gridfunctions,
                     ComplexGridFunctions & cmplx_gridfunctions,
                     mfem::AssemblyLevel assembly_level);
-  /// Build linear system, with essential boundary conditions accounted for
-  virtual void FormLinearSystem(mfem::BlockVector & trueX, mfem::BlockVector & trueRHS);
+  /**
+   * Assemble the linear part of the operator, assemble the right-hand side, apply essential and
+   * eliminated-variable constraints, and populate the true-DoF vectors used by the solve.
+   */
+  void FormSystem(mfem::BlockVector & trueX, mfem::BlockVector & trueRHS);
   /// Compute residual y = Mu
   void Mult(const mfem::Vector & u, mfem::Vector & residual) const override;
   /// Get Jacobian at the provided vector of true DoFs of trial variables

--- a/framework/include/mfem/problem_operators/ComplexEquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/ComplexEquationSystemProblemOperator.h
@@ -27,11 +27,11 @@ public:
   {
   }
 
-  void SetGridFunctions() override;
-  void Init(mfem::BlockVector & X) override;
+  virtual void SetGridFunctions() override;
+  virtual void Init(mfem::BlockVector & X) override;
   virtual void Solve() override;
 
-  [[nodiscard]] Moose::MFEM::ComplexEquationSystem * GetEquationSystem() const override
+  [[nodiscard]] virtual Moose::MFEM::ComplexEquationSystem * GetEquationSystem() const override
   {
     mooseAssert(_equation_system,
                 "No ComplexEquationSystem in ComplexEquationSystemProblemOperator.");

--- a/framework/include/mfem/problem_operators/ComplexEquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/ComplexEquationSystemProblemOperator.h
@@ -28,7 +28,6 @@ public:
   }
 
   virtual void SetGridFunctions() override;
-  virtual void Init(mfem::BlockVector & X) override;
   virtual void Solve() override;
 
   [[nodiscard]] virtual Moose::MFEM::ComplexEquationSystem * GetEquationSystem() const override

--- a/framework/include/mfem/problem_operators/EquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/EquationSystemProblemOperator.h
@@ -25,11 +25,11 @@ public:
   {
   }
 
-  void SetGridFunctions() override;
-  void Init(mfem::BlockVector & X) override;
+  virtual void SetGridFunctions() override;
+  virtual void Init(mfem::BlockVector & X) override;
   virtual void Solve() override;
 
-  [[nodiscard]] Moose::MFEM::EquationSystem * GetEquationSystem() const override
+  [[nodiscard]] virtual Moose::MFEM::EquationSystem * GetEquationSystem() const override
   {
     mooseAssert(_equation_system, "No EquationSystem in EquationSystemProblemOperator.");
     return _equation_system.get();

--- a/framework/include/mfem/problem_operators/EquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/EquationSystemProblemOperator.h
@@ -26,7 +26,6 @@ public:
   }
 
   virtual void SetGridFunctions() override;
-  virtual void Init(mfem::BlockVector & X) override;
   virtual void Solve() override;
 
   [[nodiscard]] virtual Moose::MFEM::EquationSystem * GetEquationSystem() const override
@@ -34,6 +33,10 @@ public:
     mooseAssert(_equation_system, "No EquationSystem in EquationSystemProblemOperator.");
     return _equation_system.get();
   }
+
+protected:
+  /// Add kernels/bcs and assemble the linear part of the equation system
+  void BuildEquationSystemOperator();
 
 private:
   std::shared_ptr<Moose::MFEM::EquationSystem> _equation_system{nullptr};

--- a/framework/include/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.h
@@ -30,12 +30,13 @@ public:
   {
   }
 
-  void SetGridFunctions() override;
-  void Init(mfem::BlockVector & X) override;
-  void ImplicitSolve(const mfem::real_t dt, const mfem::Vector & X, mfem::Vector & dX_dt) override;
-  void Solve() override;
+  virtual void SetGridFunctions() override;
+  virtual void Init(mfem::BlockVector & X) override;
+  virtual void ImplicitSolve(const mfem::real_t, const mfem::Vector &, mfem::Vector &) override;
+  virtual void Solve() override;
 
-  [[nodiscard]] Moose::MFEM::TimeDependentEquationSystem * GetEquationSystem() const override
+  [[nodiscard]] virtual Moose::MFEM::TimeDependentEquationSystem *
+  GetEquationSystem() const override
   {
     mooseAssert(_equation_system,
                 "No TimeDependentEquationSystem in TimeDependentEquationSystemProblemOperator.");

--- a/framework/include/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.h
+++ b/framework/include/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.h
@@ -44,6 +44,7 @@ public:
   }
 
 protected:
+  /// Add kernels/bcs and assemble the linear part of the equation system
   void BuildEquationSystemOperator(mfem::real_t dt);
 
 private:

--- a/framework/include/mfem/problem_operators/TimeDependentProblemOperator.h
+++ b/framework/include/mfem/problem_operators/TimeDependentProblemOperator.h
@@ -23,9 +23,9 @@ class TimeDependentProblemOperator : public mfem::TimeDependentOperator, public 
 public:
   TimeDependentProblemOperator(MFEMProblem & problem) : ProblemOperatorBase(problem) {}
 
-  void SetGridFunctions() override;
-  void Solve() override {}
-  void ImplicitSolve(const mfem::real_t, const mfem::Vector &, mfem::Vector &) override {}
+  virtual void SetGridFunctions() override;
+  virtual void Solve() override {}
+  virtual void ImplicitSolve(const mfem::real_t, const mfem::Vector &, mfem::Vector &) override {}
 };
 
 } // namespace Moose::MFEM

--- a/framework/include/mfem/solvers/MFEMSuperLU.h
+++ b/framework/include/mfem/solvers/MFEMSuperLU.h
@@ -30,6 +30,7 @@ public:
     _s_superlu->SetOperator(*_a_superlu.get());
   }
   void Mult(const mfem::Vector & x, mfem::Vector & y) const override { _s_superlu->Mult(x, y); }
+  void SetDeviceOffload(bool offload) { _s_superlu->SetDeviceOffload(offload); }
 
 private:
   std::unique_ptr<mfem::SuperLURowLocMatrix> _a_superlu{nullptr};

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -13,6 +13,7 @@
 #include "MooseUtils.h"
 #include "MooseError.h"
 #include "MooseTypes.h"
+#include "MooseEnum.h"
 #include "MultiMooseEnum.h"
 #include "ExecFlagEnum.h"
 #include "Conversion.h"

--- a/framework/src/materials/DerivativeParsedMaterial.C
+++ b/framework/src/materials/DerivativeParsedMaterial.C
@@ -25,7 +25,7 @@ DerivativeParsedMaterialTempl<is_ad>::validParams()
 template <bool is_ad>
 DerivativeParsedMaterialTempl<is_ad>::DerivativeParsedMaterialTempl(
     const InputParameters & parameters)
-  : ParsedMaterialBase(parameters, this),
+  : ParsedMaterialBase(parameters),
     DerivativeParsedMaterialHelperTempl<is_ad>(
         parameters, VariableNameMappingMode::USE_MOOSE_NAMES, _function_param)
 {

--- a/framework/src/materials/ParsedMaterial.C
+++ b/framework/src/materials/ParsedMaterial.C
@@ -24,7 +24,7 @@ ParsedMaterialTempl<is_ad>::validParams()
 
 template <bool is_ad>
 ParsedMaterialTempl<is_ad>::ParsedMaterialTempl(const InputParameters & parameters)
-  : ParsedMaterialBase(parameters, this),
+  : ParsedMaterialBase(parameters),
     ParsedMaterialHelper<is_ad>(
         parameters, VariableNameMappingMode::USE_MOOSE_NAMES, _function_param)
 {

--- a/framework/src/materials/ParsedMaterialBase.C
+++ b/framework/src/materials/ParsedMaterialBase.C
@@ -73,9 +73,8 @@ ParsedMaterialBase::validParams()
   return params;
 }
 
-ParsedMaterialBase::ParsedMaterialBase(const InputParameters & parameters, const MooseObject * obj)
-  : _derived_object(obj),
-    _function_param(parameters.isParamValid("function") ? "function" : "expression"),
+ParsedMaterialBase::ParsedMaterialBase(const InputParameters & parameters)
+  : _function_param(parameters.isParamValid("function") ? "function" : "expression"),
     _function(parameters.get<std::string>(_function_param))
 {
   // get constant vectors
@@ -100,8 +99,8 @@ ParsedMaterialBase::validateVectorNames(const std::set<std::string> & reserved_n
   // helper method to raise an paramError
   auto raiseErr = [this](std::string param_name, std::string msg)
   {
-    if (_derived_object != nullptr)
-      _derived_object->paramError(param_name, msg);
+    if (auto derived_object = dynamic_cast<MooseObject *>(this))
+      derived_object->paramError(param_name, msg);
     else
       mooseException(msg);
   };

--- a/framework/src/mfem/equation_systems/ComplexEquationSystem.C
+++ b/framework/src/mfem/equation_systems/ComplexEquationSystem.C
@@ -135,8 +135,8 @@ ComplexEquationSystem::ApplyEssentialBCs()
     // Make sure we update the size, if this mesh has changed recently for instance
     trial_gf.Update();
 
-    // For now, we zero out the gridfunction before populating it with the essential dofs
-    trial_gf = std::complex<mfem::real_t>(0, 0);
+    // Assign initial condition as initial guess for non-linear problems
+    static_cast<mfem::Vector &>(trial_gf) = _complex_gfuncs->GetRef(trial_var_name);
 
     mfem::Array<int> global_ess_markers(trial_gf.ParFESpace()->GetParMesh()->bdr_attributes.Max());
     global_ess_markers = 0;

--- a/framework/src/mfem/equation_systems/ComplexEquationSystem.C
+++ b/framework/src/mfem/equation_systems/ComplexEquationSystem.C
@@ -135,7 +135,7 @@ ComplexEquationSystem::ApplyEssentialBCs()
     // Make sure we update the size, if this mesh has changed recently for instance
     trial_gf.Update();
 
-    // Assign initial condition as initial guess for non-linear problems
+    // Initial guess for non-linear problems (initial condition or the previous time step solution)
     static_cast<mfem::Vector &>(trial_gf) = _complex_gfuncs->GetRef(trial_var_name);
 
     mfem::Array<int> global_ess_markers(trial_gf.ParFESpace()->GetParMesh()->bdr_attributes.Max());

--- a/framework/src/mfem/equation_systems/EquationSystem.C
+++ b/framework/src/mfem/equation_systems/EquationSystem.C
@@ -235,8 +235,8 @@ EquationSystem::ApplyEssentialBCs()
     // Make sure we update the size, if this mesh has changed recently for instance
     trial_gf.Update();
 
-    // For now, we zero out the gridfunction before populating it with the essential dofs
-    trial_gf = 0;
+    // Assign initial condition as initial guess for non-linear problems
+    trial_gf = _gfuncs->GetRef(trial_var_name);
 
     mfem::Array<int> global_ess_markers(trial_gf.ParFESpace()->GetParMesh()->bdr_attributes.Max());
     global_ess_markers = 0;

--- a/framework/src/mfem/equation_systems/EquationSystem.C
+++ b/framework/src/mfem/equation_systems/EquationSystem.C
@@ -375,7 +375,7 @@ EquationSystem::FormSystemMatrix(mfem::OperatorHandle & op,
 }
 
 void
-EquationSystem::FormLinearSystem(mfem::BlockVector & trueX, mfem::BlockVector & trueRHS)
+EquationSystem::FormSystem(mfem::BlockVector & trueX, mfem::BlockVector & trueRHS)
 {
   height = trueX.Size();
   width = trueRHS.Size();

--- a/framework/src/mfem/equation_systems/EquationSystem.C
+++ b/framework/src/mfem/equation_systems/EquationSystem.C
@@ -235,7 +235,7 @@ EquationSystem::ApplyEssentialBCs()
     // Make sure we update the size, if this mesh has changed recently for instance
     trial_gf.Update();
 
-    // Assign initial condition as initial guess for non-linear problems
+    // Initial guess for non-linear problems (initial condition or the previous time step solution)
     trial_gf = _gfuncs->GetRef(trial_var_name);
 
     mfem::Array<int> global_ess_markers(trial_gf.ParFESpace()->GetParMesh()->bdr_attributes.Max());

--- a/framework/src/mfem/executioners/MFEMProblemSolve.C
+++ b/framework/src/mfem/executioners/MFEMProblemSolve.C
@@ -88,9 +88,6 @@ MFEMProblemSolve::solve()
     // Short-circuit evaluation guarantees we only do one of p- or h-refinement between solves
     while (_mfem_problem.pRefine() || _mfem_problem.hRefine())
     {
-      // Fix me: rebuild equation system (should probably be called per operator)
-      _mfem_problem.getProblemData().eqn_system->BuildEquationSystem();
-
       // Remove me: reconstruct the solver due to possible mfem/hypre bug
       _mfem_problem.getProblemData().jacobian_solver->constructSolver();
 

--- a/framework/src/mfem/problem_operators/ComplexEquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/ComplexEquationSystemProblemOperator.C
@@ -50,17 +50,9 @@ ComplexEquationSystemProblemOperator::SetGridFunctions()
 }
 
 void
-ComplexEquationSystemProblemOperator::Init(mfem::BlockVector & X)
-{
-  X.Update(_block_true_offsets_trial);
-  X = 0.0;
-  GetEquationSystem()->BuildEquationSystem();
-}
-
-void
 ComplexEquationSystemProblemOperator::Solve()
 {
-  GetEquationSystem()->FormLinearSystem(_true_x, _true_rhs);
+  BuildEquationSystemOperator();
 
   if (_problem_data.jacobian_solver->isLOR())
     mooseError("LOR solve is not supported for complex equation systems.");

--- a/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
@@ -22,20 +22,9 @@ EquationSystemProblemOperator::SetGridFunctions()
 }
 
 void
-EquationSystemProblemOperator::Init(mfem::BlockVector & X)
-{
-  ProblemOperator::Init(X);
-  GetEquationSystem()->BuildEquationSystem();
-  // Assign initial condition as initial guess for non-linear problems
-  if ((GetEquationSystem()->_non_linear))
-    for (const auto i : index_range(_trial_variables))
-      *(GetEquationSystem()->_var_ess_constraints.at(i)) = *_trial_variables[i];
-}
-
-void
 EquationSystemProblemOperator::Solve()
 {
-  GetEquationSystem()->FormLinearSystem(_true_x, _true_rhs);
+  BuildEquationSystemOperator();
 
   if (_problem_data.jacobian_solver->isLOR() && GetEquationSystem()->GetTestVarNames().size() > 1)
     mooseError("LOR solve is only supported for single-variable systems");
@@ -47,6 +36,13 @@ EquationSystemProblemOperator::Solve()
   _problem_data.nonlinear_solver->SetOperator(*GetEquationSystem());
   _problem_data.nonlinear_solver->Mult(_true_rhs, _true_x);
   GetEquationSystem()->SetTrialVariablesFromTrueVectors(_true_x);
+}
+
+void
+EquationSystemProblemOperator::BuildEquationSystemOperator()
+{
+  GetEquationSystem()->BuildEquationSystem();
+  GetEquationSystem()->FormLinearSystem(_true_x, _true_rhs);
 }
 
 } // namespace Moose::MFEM

--- a/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
@@ -35,6 +35,7 @@ EquationSystemProblemOperator::Solve()
   _problem_data.nonlinear_solver->SetPreconditioner(_problem_data.jacobian_solver->getSolver());
   _problem_data.nonlinear_solver->SetOperator(*GetEquationSystem());
   _problem_data.nonlinear_solver->Mult(_true_rhs, _true_x);
+
   GetEquationSystem()->SetTrialVariablesFromTrueVectors(_true_x);
 }
 

--- a/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/EquationSystemProblemOperator.C
@@ -42,7 +42,7 @@ void
 EquationSystemProblemOperator::BuildEquationSystemOperator()
 {
   GetEquationSystem()->BuildEquationSystem();
-  GetEquationSystem()->FormLinearSystem(_true_x, _true_rhs);
+  GetEquationSystem()->FormSystem(_true_x, _true_rhs);
 }
 
 } // namespace Moose::MFEM

--- a/framework/src/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.C
@@ -63,10 +63,6 @@ TimeDependentEquationSystemProblemOperator::ImplicitSolve(const mfem::real_t dt,
 {
   X_new = X_old;
 
-  if ((GetEquationSystem()->_non_linear))
-    for (const auto i : index_range(_trial_variables))
-      *(GetEquationSystem()->_var_ess_constraints.at(i)) = *_trial_variables[i];
-
   _problem_data.coefficients.setTime(GetTime());
   BuildEquationSystemOperator(dt);
 

--- a/framework/src/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.C
@@ -58,11 +58,9 @@ TimeDependentEquationSystemProblemOperator::Solve()
 
 void
 TimeDependentEquationSystemProblemOperator::ImplicitSolve(const mfem::real_t dt,
-                                                          const mfem::Vector & X_old,
+                                                          const mfem::Vector &,
                                                           mfem::Vector & X_new)
 {
-  X_new = X_old;
-
   _problem_data.coefficients.setTime(GetTime());
   BuildEquationSystemOperator(dt);
 
@@ -74,7 +72,9 @@ TimeDependentEquationSystemProblemOperator::ImplicitSolve(const mfem::real_t dt,
 
   _problem_data.nonlinear_solver->SetPreconditioner(_problem_data.jacobian_solver->getSolver());
   _problem_data.nonlinear_solver->SetOperator(*GetEquationSystem());
-  _problem_data.nonlinear_solver->Mult(_true_rhs, X_new);
+  _problem_data.nonlinear_solver->Mult(_true_rhs, _true_x);
+
+  X_new = _true_x;
 }
 
 void

--- a/framework/src/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.C
+++ b/framework/src/mfem/problem_operators/TimeDependentEquationSystemProblemOperator.C
@@ -82,7 +82,7 @@ TimeDependentEquationSystemProblemOperator::BuildEquationSystemOperator(mfem::re
 {
   GetEquationSystem()->SetTimeStep(dt);
   GetEquationSystem()->BuildEquationSystem();
-  GetEquationSystem()->FormLinearSystem(_true_x, _true_rhs);
+  GetEquationSystem()->FormSystem(_true_x, _true_rhs);
 }
 
 } // namespace Moose::MFEM

--- a/framework/src/mfem/solvers/MFEMSuperLU.C
+++ b/framework/src/mfem/solvers/MFEMSuperLU.C
@@ -32,7 +32,9 @@ MFEMSuperLU::MFEMSuperLU(const InputParameters & parameters) : MFEMSolverBase(pa
 void
 MFEMSuperLU::constructSolver()
 {
-  _solver = std::make_unique<Moose::MFEM::SuperLUSolver>(getMFEMProblem().getComm());
+  auto solver = std::make_unique<Moose::MFEM::SuperLUSolver>(getMFEMProblem().getComm());
+  solver->SetDeviceOffload(mfem::Device::IsAvailable());
+  _solver = std::move(solver);
 }
 
 void

--- a/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
+++ b/framework/src/mfem/submeshes/MFEMCutTransitionSubMesh.C
@@ -133,14 +133,12 @@ MFEMCutTransitionSubMesh::labelMesh(mfem::ParMesh & parent_mesh)
                  getMFEMProblem().getComm());
 
   // Detect shared vertices and add corresponding elements
-  for (int g = 1, sv = 0; g < parent_mesh.GetNGroups(); g++)
-  {
-    for (int gv = 0; gv < parent_mesh.GroupNVertices(g); gv++, sv++)
+  for (const auto g : make_range(1, parent_mesh.GetNGroups()))
+    for (const auto gv : make_range(parent_mesh.GroupNVertices(g)))
     {
       // all elements touching this shared vertex should be updated
       int cut_vert = parent_mesh.GroupVertex(g, gv);
       for (std::size_t i = 0; i < all_cut_verts.size(); i += 1)
-      {
         if (gi[cut_vert] == all_cut_verts[i]) // check if shared vertex is on the cut plane
         {
           int ne = vert_to_elem->RowSize(cut_vert); // number of elements touching cut vertex
@@ -154,9 +152,7 @@ MFEMCutTransitionSubMesh::labelMesh(mfem::ParMesh & parent_mesh)
               transition_els.Append(el_adj_to_cut);
           }
         }
-      }
     }
-  }
 
   transition_els.Sort();
   transition_els.Unique();

--- a/test/tests/mfem/kernels/mixed_heattransfer.i
+++ b/test/tests/mfem/kernels/mixed_heattransfer.i
@@ -73,7 +73,7 @@
     boundary = 4
   []
   [gamma_h_topbottom]
-    type = MFEMVectorDirichletBC
+    type = MFEMVectorNormalDirichletBC
     variable = time_integrated_heat_flux
     vector_coefficient = '0.0 0.0'
     boundary = '1 3'


### PR DESCRIPTION
## Reason
Currently, SuperLU_DIST will invariably use the GPU if it's been compiled with GPU support, irrespectively of the user-selected device. Equation system updates are currently (inconsistently) scattered between init, solve and refinement loops.

## Design
SuperLU_DIST is now told to use the same device selected by the user to run their MOOSE app. Equation system updates now all happen at the beginning of each problem operator's solve on all cases. Initial conditions are injected at the time we define essential BCs.

## Impact
No surprises when selecting cpu as the compute device. Consistent/simpler eq system updates.
