### PR TITLE
Kokkos fix typos, `KokkosHeatConduction` improvement, deprecate `datum.reinit()`

### DIFF
--- a/framework/include/kokkos/auxkernels/KokkosAuxKernel.h
+++ b/framework/include/kokkos/auxkernels/KokkosAuxKernel.h
@@ -255,8 +255,6 @@ AuxKernel::computeElementInternal(const Derived & auxkernel, AssemblyDatum & dat
   {
     const auto value = auxkernel.template computeValue<Derived>(qp, datum);
 
-    datum.reinit();
-
     for (unsigned int i = 0; i < datum.n_dofs(); ++i)
     {
       const auto t = datum.JxW(qp) * _test(datum, i, qp);

--- a/framework/include/kokkos/base/KokkosArray.h
+++ b/framework/include/kokkos/base/KokkosArray.h
@@ -932,7 +932,7 @@ void
 ArrayBase<T, dimension, index_type>::offset(offset_type... d)
 {
   static_assert((std::is_convertible<offset_type, signed_index_type>::value && ...),
-                "All arguments must be convertible to index_type");
+                "All arguments must be convertible to signed_index_type");
   static_assert(sizeof...(d) == dimension, "Number of arguments should match array dimension");
 
   std::vector<signed_index_type> offsets;
@@ -1435,7 +1435,7 @@ Array<T, dimension, index_type, layout>::operator()(indices... i) const
                 "All arguments must be convertible to signed_index_type");
   static_assert(sizeof...(i) == dimension, "Number of arguments should match array dimension");
 
-#ifdef DEBUG
+#ifndef NDEBUG
   {
     signed_index_type idx[dimension] = {static_cast<signed_index_type>(i)...};
 

--- a/framework/include/kokkos/base/KokkosDatum.h
+++ b/framework/include/kokkos/base/KokkosDatum.h
@@ -180,9 +180,9 @@ public:
   KOKKOS_FUNCTION Real3 normals(const unsigned int qp);
 
   /**
-   * Reset the reinit flag
+   * Deprecated, will be removed
    */
-  KOKKOS_FUNCTION void reinit() { _transform_reinit = false; }
+  KOKKOS_FUNCTION void reinit() {}
 
 protected:
   /**
@@ -234,9 +234,10 @@ private:
   KOKKOS_FUNCTION void reinitTransform(const unsigned int qp);
 
   /**
-   * Flag whether the physical transformation data was cached
+   * Cached quadrature point index for checking whether the physical transformation data should be
+   * recomputed
    */
-  bool _transform_reinit = false;
+  unsigned int _cached_qp = libMesh::invalid_uint;
   /**
    * Cached physical transformation data
    */
@@ -317,7 +318,7 @@ Datum::normals(const unsigned int qp)
 KOKKOS_FUNCTION inline void
 Datum::reinitTransform(const unsigned int qp)
 {
-  if (_transform_reinit)
+  if (_cached_qp == qp)
     return;
 
   if (!isSide())
@@ -329,7 +330,7 @@ Datum::reinitTransform(const unsigned int qp)
   else
     _assembly.computePhysicalMap(_elem, _side, qp, &_J, &_JxW, &_xyz, &_normal);
 
-  _transform_reinit = true;
+  _cached_qp = qp;
 }
 
 /**

--- a/framework/include/kokkos/base/KokkosJaggedArray.h
+++ b/framework/include/kokkos/base/KokkosJaggedArray.h
@@ -110,7 +110,7 @@ JaggedArrayInnerData<T, inner, layout>::operator()(indices... i) const
                 "All arguments must be convertible to unsigned int");
   static_assert(sizeof...(i) == inner, "Number of arguments should match array dimension");
 
-#ifdef DEBUG
+#ifndef NDEBUG
   {
     unsigned int idx[inner] = {static_cast<unsigned int>(i)...};
 

--- a/framework/include/kokkos/bcs/KokkosIntegratedBC.h
+++ b/framework/include/kokkos/bcs/KokkosIntegratedBC.h
@@ -32,7 +32,7 @@ namespace Moose::Kokkos
  *                                        const unsigned int qp,
  *                                        AssemblyDatum & datum) const;
  *
- * The signatures of computeQpJacobian() and computeOffDiagQpJacobian() can be found in the code
+ * The signatures of computeQpJacobian() and computeQpOffDiagJacobian() can be found in the code
  * below, and their definition in the derived class is optional. If they are defined in the derived
  * class, they will hide the default definitions in the base class.
  */

--- a/framework/include/kokkos/bcs/KokkosIntegratedBC.h
+++ b/framework/include/kokkos/bcs/KokkosIntegratedBC.h
@@ -243,12 +243,8 @@ IntegratedBC::computeResidualInternal(const Derived & bc, AssemblyDatum & datum)
       [&](Real * local_re, const unsigned int ib, const unsigned int ie)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-        {
-          datum.reinit();
-
           for (unsigned int i = ib; i < ie; ++i)
             local_re[i] += datum.JxW(qp) * bc.template computeQpResidual<Derived>(i, qp, datum);
-        }
       });
 }
 
@@ -261,9 +257,6 @@ IntegratedBC::computeJacobianInternal(const Derived & bc, AssemblyDatum & datum)
       [&](Real * local_ke, const unsigned int ijb, const unsigned int ije)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-        {
-          datum.reinit();
-
           for (unsigned int ij = ijb; ij < ije; ++ij)
           {
             unsigned int i = ij % datum.n_jdofs();
@@ -271,7 +264,6 @@ IntegratedBC::computeJacobianInternal(const Derived & bc, AssemblyDatum & datum)
 
             local_ke[ij] += datum.JxW(qp) * bc.template computeQpJacobian<Derived>(i, j, qp, datum);
           }
-        }
       });
 }
 
@@ -284,9 +276,6 @@ IntegratedBC::computeOffDiagJacobianInternal(const Derived & bc, AssemblyDatum &
       [&](Real * local_ke, const unsigned int ijb, const unsigned int ije)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-        {
-          datum.reinit();
-
           for (unsigned int ij = ijb; ij < ije; ++ij)
           {
             unsigned int i = ij % datum.n_jdofs();
@@ -295,7 +284,6 @@ IntegratedBC::computeOffDiagJacobianInternal(const Derived & bc, AssemblyDatum &
             local_ke[ij] += datum.JxW(qp) * bc.template computeQpOffDiagJacobian<Derived>(
                                                 i, j, datum.jvar(), qp, datum);
           }
-        }
       });
 }
 

--- a/framework/include/kokkos/bcs/KokkosNodalBC.h
+++ b/framework/include/kokkos/bcs/KokkosNodalBC.h
@@ -29,7 +29,7 @@ namespace Moose::Kokkos
  * template <typename Derived>
  * KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
  *
- * The signatures of computeQpJacobian() and computeOffDiagQpJacobian() can be found in the code
+ * The signatures of computeQpJacobian() and computeQpOffDiagJacobian() can be found in the code
  * below, and their definition in the derived class is optional. If they are defined in the derived
  * class, they will hide the default definitions in the base class.
  */

--- a/framework/include/kokkos/kernels/KokkosKernel.h
+++ b/framework/include/kokkos/kernels/KokkosKernel.h
@@ -252,12 +252,8 @@ Kernel::computeResidualInternal(const Derived & kernel, AssemblyDatum & datum) c
       [&](Real * local_re, const unsigned int ib, const unsigned int ie)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-        {
-          datum.reinit();
-
           for (unsigned int i = ib; i < ie; ++i)
             local_re[i] += datum.JxW(qp) * kernel.template computeQpResidual<Derived>(i, qp, datum);
-        }
       });
 }
 
@@ -270,9 +266,6 @@ Kernel::computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) c
       [&](Real * local_ke, const unsigned int ijb, const unsigned int ije)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-        {
-          datum.reinit();
-
           for (unsigned int ij = ijb; ij < ije; ++ij)
           {
             unsigned int i = ij % datum.n_jdofs();
@@ -281,7 +274,6 @@ Kernel::computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) c
             local_ke[ij] +=
                 datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(i, j, qp, datum);
           }
-        }
       });
 }
 
@@ -294,9 +286,6 @@ Kernel::computeOffDiagJacobianInternal(const Derived & kernel, AssemblyDatum & d
       [&](Real * local_ke, const unsigned int ijb, const unsigned int ije)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-        {
-          datum.reinit();
-
           for (unsigned int ij = ijb; ij < ije; ++ij)
           {
             unsigned int i = ij % datum.n_jdofs();
@@ -305,7 +294,6 @@ Kernel::computeOffDiagJacobianInternal(const Derived & kernel, AssemblyDatum & d
             local_ke[ij] += datum.JxW(qp) * kernel.template computeQpOffDiagJacobian<Derived>(
                                                 i, j, datum.jvar(), qp, datum);
           }
-        }
       });
 }
 

--- a/framework/include/kokkos/kernels/KokkosKernel.h
+++ b/framework/include/kokkos/kernels/KokkosKernel.h
@@ -32,7 +32,7 @@ namespace Moose::Kokkos
  *                                        const unsigned int qp,
  *                                        AssemblyDatum & datum) const;
  *
- * The signatures of computeQpJacobian() and computeOffDiagQpJacobian() can be found in the code
+ * The signatures of computeQpJacobian() and computeQpOffDiagJacobian() can be found in the code
  * below, and their definition in the derived class is optional. If they are defined in the derived
  * class, they will hide the default definitions in the base class.
  */

--- a/framework/include/kokkos/kernels/KokkosKernelGrad.h
+++ b/framework/include/kokkos/kernels/KokkosKernelGrad.h
@@ -109,8 +109,6 @@ KernelGrad::computeResidualInternal(const Derived & kernel, AssemblyDatum & datu
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
         {
-          datum.reinit();
-
           Real3 value = datum.JxW(qp) * kernel.template computeQpResidual<Derived>(qp, datum);
 
           for (unsigned int i = ib; i < ie; ++i)
@@ -131,8 +129,6 @@ KernelGrad::computeJacobianInternal(const Derived & kernel, AssemblyDatum & datu
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
         {
-          datum.reinit();
-
           unsigned int j_old = libMesh::invalid_uint;
 
           for (unsigned int ij = ijb; ij < ije; ++ij)

--- a/framework/include/kokkos/kernels/KokkosKernelValue.h
+++ b/framework/include/kokkos/kernels/KokkosKernelValue.h
@@ -108,8 +108,6 @@ KernelValue::computeResidualInternal(const Derived & kernel, AssemblyDatum & dat
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
         {
-          datum.reinit();
-
           Real value = datum.JxW(qp) * kernel.template computeQpResidual<Derived>(qp, datum);
 
           for (unsigned int i = ib; i < ie; ++i)
@@ -130,8 +128,6 @@ KernelValue::computeJacobianInternal(const Derived & kernel, AssemblyDatum & dat
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
         {
-          datum.reinit();
-
           unsigned int j_old = libMesh::invalid_uint;
 
           for (unsigned int ij = ijb; ij < ije; ++ij)

--- a/framework/include/kokkos/kernels/KokkosTimeDerivative.h
+++ b/framework/include/kokkos/kernels/KokkosTimeDerivative.h
@@ -58,8 +58,6 @@ KokkosTimeDerivative::computeJacobianInternal(const Derived & kernel, AssemblyDa
 
     for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
     {
-      datum.reinit();
-
       for (unsigned int ij = ijb; ij < ije; ++ij)
       {
         unsigned int i = ij % datum.n_jdofs();

--- a/framework/include/kokkos/kernels/KokkosTimeKernel.h
+++ b/framework/include/kokkos/kernels/KokkosTimeKernel.h
@@ -68,12 +68,8 @@ TimeKernel::computeResidualInternal(const Derived & kernel, AssemblyDatum & datu
       [&](Real * local_re, const unsigned int ib, const unsigned int ie)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-        {
-          datum.reinit();
-
           for (unsigned int i = ib; i < ie; ++i)
             local_re[i] += datum.JxW(qp) * kernel.template computeQpResidual<Derived>(i, qp, datum);
-        }
 
         kernel.computeResidualAdditional(ib, ie, datum, local_re);
       });

--- a/framework/include/kokkos/materials/KokkosMaterial.h
+++ b/framework/include/kokkos/materials/KokkosMaterial.h
@@ -183,10 +183,7 @@ Material::operator()(ElementInit, const ThreadID tid, const Derived & material) 
   const unsigned int num_qps = _constant_option == PropertyConstantOption::NONE ? datum.n_qps() : 1;
 
   for (unsigned int qp = 0; qp < num_qps; ++qp)
-  {
-    datum.reinit();
     material.template initQpStatefulProperties<Derived>(qp, datum);
-  }
 }
 
 template <typename Derived>
@@ -200,10 +197,7 @@ Material::operator()(SideInit, const ThreadID tid, const Derived & material) con
   const unsigned int num_qps = _constant_option == PropertyConstantOption::NONE ? datum.n_qps() : 1;
 
   for (unsigned int qp = 0; qp < num_qps; ++qp)
-  {
-    datum.reinit();
     material.template initQpStatefulProperties<Derived>(qp, datum);
-  }
 }
 
 template <typename Derived>
@@ -217,10 +211,7 @@ Material::operator()(NeighborInit, const ThreadID tid, const Derived & material)
   const unsigned int num_qps = _constant_option == PropertyConstantOption::NONE ? datum.n_qps() : 1;
 
   for (unsigned int qp = 0; qp < num_qps; ++qp)
-  {
-    datum.reinit();
     material.template initQpStatefulProperties<Derived>(qp, datum);
-  }
 }
 
 template <typename Derived>
@@ -236,10 +227,7 @@ Material::operator()(ElementCompute, const ThreadID tid, const Derived & materia
   const unsigned int num_qps = _constant_option == PropertyConstantOption::NONE ? datum.n_qps() : 1;
 
   for (unsigned int qp = 0; qp < num_qps; ++qp)
-  {
-    datum.reinit();
     material.template computeQpProperties<Derived>(qp, datum);
-  }
 }
 
 template <typename Derived>
@@ -253,10 +241,7 @@ Material::operator()(SideCompute, const ThreadID tid, const Derived & material) 
   const unsigned int num_qps = _constant_option == PropertyConstantOption::NONE ? datum.n_qps() : 1;
 
   for (unsigned int qp = 0; qp < num_qps; ++qp)
-  {
-    datum.reinit();
     material.template computeQpProperties<Derived>(qp, datum);
-  }
 }
 
 template <typename Derived>
@@ -270,10 +255,7 @@ Material::operator()(NeighborCompute, const ThreadID tid, const Derived & materi
   const unsigned int num_qps = _constant_option == PropertyConstantOption::NONE ? datum.n_qps() : 1;
 
   for (unsigned int qp = 0; qp < num_qps; ++qp)
-  {
-    datum.reinit();
     material.template computeQpProperties<Derived>(qp, datum);
-  }
 }
 
 } // namespace Moose::Kokkos

--- a/framework/include/kokkos/nodalkernels/KokkosNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosNodalKernel.h
@@ -29,7 +29,7 @@ namespace Moose::Kokkos
  * template <typename Derived>
  * KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
  *
- * The signatures of computeQpJacobian() and computeOffDiagQpJacobian() can be found in the code
+ * The signatures of computeQpJacobian() and computeQpOffDiagJacobian() can be found in the code
  * below, and their definition in the derived class is optional. If they are defined in the derived
  * class, they will hide the default definitions in the base class.
  */

--- a/framework/include/kokkos/postprocessors/KokkosIntegralPostprocessor.h
+++ b/framework/include/kokkos/postprocessors/KokkosIntegralPostprocessor.h
@@ -44,8 +44,6 @@ KokkosIntegralPostprocessor<Base>::reduce(Datum & datum, Real * result) const
 
   for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
   {
-    datum.reinit();
-
     sum += datum.JxW(qp) * static_cast<const Derived *>(this)->computeQpIntegral(qp, datum);
     vol += datum.JxW(qp);
   }

--- a/framework/include/kokkos/reporters/KokkosElementVariableStatistics.h
+++ b/framework/include/kokkos/reporters/KokkosElementVariableStatistics.h
@@ -33,8 +33,6 @@ KokkosElementVariableStatistics::computeValue(Datum & datum) const
 
   for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
   {
-    datum.reinit();
-
     val += _v(datum, qp) * datum.JxW(qp);
     vol += datum.JxW(qp);
   }

--- a/framework/include/kokkos/vectorpostprocessors/KokkosExtraIDIntegralVectorPostprocessor.h
+++ b/framework/include/kokkos/vectorpostprocessors/KokkosExtraIDIntegralVectorPostprocessor.h
@@ -110,8 +110,6 @@ KokkosExtraIDIntegralVectorPostprocessor::reduce(Datum & datum, Real * result) c
 
   for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
   {
-    datum.reinit();
-
     const auto JxW = datum.JxW(qp);
 
     unsigned int i = 0;
@@ -146,8 +144,6 @@ KokkosExtraIDIntegralVectorPostprocessor::execute(Datum & datum) const
 
   for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
   {
-    datum.reinit();
-
     const auto JxW = datum.JxW(qp);
 
     unsigned int i = 0;

--- a/framework/src/kokkos/systems/KokkosSystem.K
+++ b/framework/src/kokkos/systems/KokkosSystem.K
@@ -305,8 +305,7 @@ System::getNodalBCDofs(const NodalBCBase * nbc, Array<bool> & dofs)
   for (auto node : nbc->getContiguousNodes())
     dofs[_local_node_dof_index[var][node]] = true;
 
-  // Let remote processes know about ghost DOFs associated with nodal BCs not to compute
-  // residual on them
+  // Let remote processes know about ghost DOFs associated with nodal BCs not to contribute on them
 
   auto num_procs = _comm.size();
 

--- a/modules/heat_transfer/include/kokkos/kernels/KokkosHeatConduction.h
+++ b/modules/heat_transfer/include/kokkos/kernels/KokkosHeatConduction.h
@@ -9,9 +9,11 @@
 
 #pragma once
 
-#include "KokkosDiffusion.h"
+#include "KokkosKernelGrad.h"
 
-class KokkosHeatConduction : public KokkosDiffusion
+using Real3 = Moose::Kokkos::Real3;
+
+class KokkosHeatConduction : public Moose::Kokkos::KernelGrad
 {
 public:
   static InputParameters validParams();
@@ -19,14 +21,11 @@ public:
   KokkosHeatConduction(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real3 computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int i,
-                                         const unsigned int j,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real3 computeQpJacobian(const unsigned int j,
+                                          const unsigned int qp,
+                                          AssemblyDatum & datum) const;
 
 private:
   Moose::Kokkos::MaterialProperty<Real> _diffusion_coefficient;
@@ -34,26 +33,20 @@ private:
 };
 
 template <typename Derived>
-KOKKOS_FUNCTION Real
-KokkosHeatConduction::computeQpResidual(const unsigned int i,
-                                        const unsigned int qp,
-                                        AssemblyDatum & datum) const
+KOKKOS_FUNCTION Real3
+KokkosHeatConduction::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
 {
-  return _diffusion_coefficient(datum, qp) *
-         KokkosDiffusion::computeQpResidual<Derived>(i, qp, datum);
+  return _diffusion_coefficient(datum, qp) * _grad_u(datum, qp);
 }
 
 template <typename Derived>
-KOKKOS_FUNCTION Real
-KokkosHeatConduction::computeQpJacobian(const unsigned int i,
-                                        const unsigned int j,
+KOKKOS_FUNCTION Real3
+KokkosHeatConduction::computeQpJacobian(const unsigned int j,
                                         const unsigned int qp,
                                         AssemblyDatum & datum) const
 {
-  Real jac = _diffusion_coefficient(datum, qp) *
-             KokkosDiffusion::computeQpJacobian<Derived>(i, j, qp, datum);
+  Real3 jac = _diffusion_coefficient(datum, qp) * _grad_phi(datum, j, qp);
   if (_diffusion_coefficient_dT)
-    jac += _diffusion_coefficient_dT(datum, qp) * _phi(datum, j, qp) *
-           KokkosDiffusion::computeQpResidual<Derived>(i, qp, datum);
+    jac += _diffusion_coefficient_dT(datum, qp) * _phi(datum, j, qp) * _grad_u(datum, qp);
   return jac;
 }

--- a/modules/heat_transfer/include/kokkos/kernels/KokkosHeatConduction.h
+++ b/modules/heat_transfer/include/kokkos/kernels/KokkosHeatConduction.h
@@ -11,10 +11,13 @@
 
 #include "KokkosKernelGrad.h"
 
-using Real3 = Moose::Kokkos::Real3;
-
+/**
+ * Kokkos kernel for a heat conduction term with an isotropic conductivity
+ */
 class KokkosHeatConduction : public Moose::Kokkos::KernelGrad
 {
+  using Real3 = Moose::Kokkos::Real3;
+
 public:
   static InputParameters validParams();
 
@@ -33,14 +36,14 @@ private:
 };
 
 template <typename Derived>
-KOKKOS_FUNCTION Real3
+KOKKOS_FUNCTION Moose::Kokkos::Real3
 KokkosHeatConduction::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
 {
   return _diffusion_coefficient(datum, qp) * _grad_u(datum, qp);
 }
 
 template <typename Derived>
-KOKKOS_FUNCTION Real3
+KOKKOS_FUNCTION Moose::Kokkos::Real3
 KokkosHeatConduction::computeQpJacobian(const unsigned int j,
                                         const unsigned int qp,
                                         AssemblyDatum & datum) const

--- a/modules/heat_transfer/src/kokkos/kernels/KokkosHeatConduction.K
+++ b/modules/heat_transfer/src/kokkos/kernels/KokkosHeatConduction.K
@@ -14,7 +14,7 @@ registerKokkosResidualObject("HeatTransferApp", KokkosHeatConduction);
 InputParameters
 KokkosHeatConduction::validParams()
 {
-  InputParameters params = KokkosDiffusion::validParams();
+  InputParameters params = KernelGrad::validParams();
   params.addClassDescription("Diffusive heat conduction term $-\\nabla\\cdot(k\\nabla T)$ of the "
                              "thermal energy conservation equation");
   params.addParam<MaterialPropertyName>("diffusion_coefficient",
@@ -29,7 +29,7 @@ KokkosHeatConduction::validParams()
 }
 
 KokkosHeatConduction::KokkosHeatConduction(const InputParameters & parameters)
-  : KokkosDiffusion(parameters)
+  : KernelGrad(parameters)
 {
   _diffusion_coefficient = getKokkosMaterialProperty<Real>("diffusion_coefficient");
 

--- a/test/include/kokkos/vectorpostprocessors/KokkosBlockSolutionOutput.h
+++ b/test/include/kokkos/vectorpostprocessors/KokkosBlockSolutionOutput.h
@@ -43,10 +43,7 @@ KokkosBlockSolutionOutput::execute(Datum & datum) const
   Real sum = 0;
 
   for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-  {
-    datum.reinit();
     sum += datum.JxW(qp) * _var(datum, qp);
-  }
 
   _solution[datum.elemID()] = sum;
 }

--- a/test/include/kokkos/vectorpostprocessors/KokkosBoundarySolutionOutput.h
+++ b/test/include/kokkos/vectorpostprocessors/KokkosBoundarySolutionOutput.h
@@ -43,10 +43,7 @@ KokkosBoundarySolutionOutput::execute(Datum & datum) const
   Real sum = 0;
 
   for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-  {
-    datum.reinit();
     sum += datum.JxW(qp) * _var(datum, qp);
-  }
 
   _solution(datum.side(), datum.elemID()) = sum;
 }


### PR DESCRIPTION
Refs #30655.

`KokkosHeatConduction` Jacobian assembly is 2x faster.