### PR TITLE
Add option to prevent expanding include files in hit format 

### DIFF
--- a/framework/contrib/hit/include/hit/parse.h
+++ b/framework/contrib/hit/include/hit/parse.h
@@ -76,6 +76,7 @@ enum class NodeType
   Section, /// Represents hit sections (i.e. "[pathname]...[../]").
   Comment, /// Represents comments that are not directly part of the actual hit document.
   Field,   /// Represents field-value pairs (i.e. paramname=val).
+  Include, /// Represents !include directives.
   Blank,   /// Represents a blank line
   Other,   /// Represents any other type of node
 };
@@ -89,6 +90,11 @@ enum class TraversalOrder
 };
 
 class Node;
+
+struct ParseOptions
+{
+  bool expand_includes = true;
+};
 
 /**
  * Struct that contains the context for an error message.
@@ -510,6 +516,19 @@ public:
   virtual Node * clone(bool /*absolute_path = false*/) override { return new Blank(); };
 };
 
+/// Include represents a !include directive in the input.
+class Include : public Node
+{
+public:
+  Include(std::shared_ptr<wasp::DefaultHITInterpreter> dhi, wasp::HITNodeView hnv);
+
+  virtual std::string render(int indent = 0,
+                             const std::string & indent_text = default_indent,
+                             int maxlen = 0) const override;
+
+  virtual Node * clone(bool absolute_path = false) override;
+};
+
 /// Section represents a hit section including the section header path and all entries inside
 /// the section (e.g. fields/parameters, subsections, etc.).
 class Section : public Node
@@ -597,7 +616,8 @@ private:
 /// on parse failure and the root is returned instead of this function throwing an Error.
 Node * parse(const std::string & fname,
              const std::string & input,
-             std::vector<ErrorMessage> * syntax_errors = nullptr);
+             std::vector<ErrorMessage> * syntax_errors = nullptr,
+             const ParseOptions & options = ParseOptions{});
 
 /// parses the file checking for errors but does not return any node tree.
 inline void
@@ -685,6 +705,8 @@ public:
   /// The text used to represent a single level of nesting indentation.  It must be comprised of
   /// only whitespace characters.
   std::string indent_string;
+  /// Whether !include directives should be expanded before formatting.
+  bool expand_includes;
 
 private:
   struct Pattern

--- a/framework/contrib/hit/include/hit/parse.h
+++ b/framework/contrib/hit/include/hit/parse.h
@@ -91,6 +91,9 @@ enum class TraversalOrder
 
 class Node;
 
+// structure with options that can be used to control behavior when parsing
+// currently only contains option for formatter to not expand include files
+// this is passed into parse() and buildHITTree() and may be expanded later
 struct ParseOptions
 {
   bool expand_includes = true;
@@ -705,8 +708,6 @@ public:
   /// The text used to represent a single level of nesting indentation.  It must be comprised of
   /// only whitespace characters.
   std::string indent_string;
-  /// Whether !include directives should be expanded before formatting.
-  bool expand_includes;
 
 private:
   struct Pattern
@@ -791,6 +792,7 @@ void buildHITTree(std::shared_ptr<wasp::DefaultHITInterpreter> interpreter,
                   wasp::HITNodeView hnv_parent,
                   Node * hit_parent,
                   std::string & previous_file,
-                  std::size_t & previous_line);
+                  std::size_t & previous_line,
+                  const ParseOptions & options = ParseOptions{});
 
 } // namespace hit

--- a/framework/contrib/hit/src/hit/main.cc
+++ b/framework/contrib/hit/src/hit/main.cc
@@ -437,7 +437,6 @@ format(int argc, char ** argv)
   flags.add("h", "print help");
   flags.add("help", "print help");
   flags.add("i", "modify file(s) inplace");
-  flags.add("no-expand-includes", "preserve !include directives instead of formatting expanded content");
   flags.add("style", "hit style file detailing format to use", "");
 
   auto positional = parseOpts(argc, argv, flags);
@@ -471,8 +470,6 @@ format(int argc, char ** argv)
       return 1;
     }
   }
-
-  fmt.expand_includes = !flags.have("no-expand-includes");
 
   int ret = 0;
   for (int i = 0; i < positional.size(); i++)

--- a/framework/contrib/hit/src/hit/main.cc
+++ b/framework/contrib/hit/src/hit/main.cc
@@ -437,6 +437,7 @@ format(int argc, char ** argv)
   flags.add("h", "print help");
   flags.add("help", "print help");
   flags.add("i", "modify file(s) inplace");
+  flags.add("no-expand-includes", "preserve !include directives instead of formatting expanded content");
   flags.add("style", "hit style file detailing format to use", "");
 
   auto positional = parseOpts(argc, argv, flags);
@@ -470,6 +471,8 @@ format(int argc, char ** argv)
       return 1;
     }
   }
+
+  fmt.expand_includes = !flags.have("no-expand-includes");
 
   int ret = 0;
   for (int i = 0; i < positional.size(); i++)

--- a/framework/contrib/hit/src/hit/parse.cc
+++ b/framework/contrib/hit/src/hit/parse.cc
@@ -375,6 +375,8 @@ Node::type() const
     return NodeType::Section;
   else if (_hnv.type() == wasp::KEYED_VALUE || _hnv.type() == wasp::ARRAY)
     return NodeType::Field;
+  else if (_hnv.type() == wasp::FILE)
+    return NodeType::Include;
   return NodeType::Other;
 }
 
@@ -552,6 +554,26 @@ void
 Comment::setInline(bool is_inline)
 {
   _isinline = is_inline;
+}
+
+Include::Include(std::shared_ptr<wasp::DefaultHITInterpreter> dhi, wasp::HITNodeView hnv)
+  : Node(dhi, hnv)
+{
+}
+
+std::string
+Include::render(int indent, const std::string & indent_text, int /*maxlen*/) const
+{
+  return "\n" + strRepeat(indent_text, indent) + _hnv.data();
+}
+
+Node *
+Include::clone(bool absolute_path)
+{
+  auto n = new Include(_dhi, _hnv);
+  if (absolute_path)
+    n->setOverridePath(fullpath());
+  return n;
 }
 
 Section::Section(const std::string & path) : Node(path) {}
@@ -1024,11 +1046,13 @@ Field::strVal() const
 Node *
 parse(const std::string & fname,
       const std::string & input,
-      std::vector<ErrorMessage> * syntax_errors /* = nullptr */)
+      std::vector<ErrorMessage> * syntax_errors /* = nullptr */,
+      const ParseOptions & options /* = ParseOptions{} */)
 {
   std::stringstream input_errors;
   std::shared_ptr<wasp::DefaultHITInterpreter> interpreter =
       std::make_shared<wasp::DefaultHITInterpreter>(input_errors);
+  interpreter->set_should_load_includes(options.expand_includes);
 
   std::vector<ErrorMessage> errors;
 
@@ -1148,7 +1172,10 @@ matches(const std::string & s, const std::string & regex, bool full = true)
   }
 }
 
-Formatter::Formatter() : canonical_section_markers(true), line_length(100), indent_string("  ") {}
+Formatter::Formatter()
+  : canonical_section_markers(true), line_length(100), indent_string("  "), expand_includes(true)
+{
+}
 
 void
 Formatter::walkPatternConfig(const std::string & prefix, Node * n)
@@ -1170,7 +1197,7 @@ Formatter::walkPatternConfig(const std::string & prefix, Node * n)
 }
 
 Formatter::Formatter(const std::string & fname, const std::string & hit_config)
-  : canonical_section_markers(true), line_length(100), indent_string("  ")
+  : canonical_section_markers(true), line_length(100), indent_string("  "), expand_includes(true)
 {
   std::unique_ptr<hit::Node> root(hit::parse(fname, hit_config));
   if (root->find("format/indent_string"))
@@ -1186,7 +1213,9 @@ Formatter::Formatter(const std::string & fname, const std::string & hit_config)
 std::string
 Formatter::format(const std::string & fname, const std::string & input)
 {
-  std::unique_ptr<hit::Node> root(hit::parse(fname, input));
+  ParseOptions options;
+  options.expand_includes = expand_includes;
+  std::unique_ptr<hit::Node> root(hit::parse(fname, input, nullptr, options));
   format(root.get());
   return root->render(0, indent_string, line_length);
 }
@@ -1389,6 +1418,15 @@ buildHITTree(std::shared_ptr<wasp::DefaultHITInterpreter> interpreter,
         previous_file = hnv_child.node_pool()->stream_name();
         previous_line = hnv_child.last_line();
       }
+    }
+
+    else if (hnv_child.type() == wasp::FILE)
+    {
+      if (hnv_child.node_pool()->stream_name() == previous_file && hnv_child.line() > previous_line + 1)
+        hit_parent->addChild(new Blank());
+      hit_parent->addChild(new Include(interpreter, hnv_child));
+      previous_file = hnv_child.node_pool()->stream_name();
+      previous_line = hnv_child.last_line();
     }
 
     // create and add section node if not found in tree then recurse children

--- a/framework/contrib/hit/src/hit/parse.cc
+++ b/framework/contrib/hit/src/hit/parse.cc
@@ -1052,7 +1052,6 @@ parse(const std::string & fname,
   std::stringstream input_errors;
   std::shared_ptr<wasp::DefaultHITInterpreter> interpreter =
       std::make_shared<wasp::DefaultHITInterpreter>(input_errors);
-  interpreter->set_should_load_includes(options.expand_includes);
 
   std::vector<ErrorMessage> errors;
 
@@ -1080,7 +1079,7 @@ parse(const std::string & fname,
   {
     std::string starting_file = interpreter->root().node_pool()->stream_name();
     std::size_t starting_line = interpreter->root().line();
-    buildHITTree(interpreter, interpreter->root(), root.get(), starting_file, starting_line);
+    buildHITTree(interpreter, interpreter->root(), root.get(), starting_file, starting_line, options);
   }
 
   return root.release();
@@ -1172,10 +1171,7 @@ matches(const std::string & s, const std::string & regex, bool full = true)
   }
 }
 
-Formatter::Formatter()
-  : canonical_section_markers(true), line_length(100), indent_string("  "), expand_includes(true)
-{
-}
+Formatter::Formatter() : canonical_section_markers(true), line_length(100), indent_string("  ") {}
 
 void
 Formatter::walkPatternConfig(const std::string & prefix, Node * n)
@@ -1197,7 +1193,7 @@ Formatter::walkPatternConfig(const std::string & prefix, Node * n)
 }
 
 Formatter::Formatter(const std::string & fname, const std::string & hit_config)
-  : canonical_section_markers(true), line_length(100), indent_string("  "), expand_includes(true)
+  : canonical_section_markers(true), line_length(100), indent_string("  ")
 {
   std::unique_ptr<hit::Node> root(hit::parse(fname, hit_config));
   if (root->find("format/indent_string"))
@@ -1213,8 +1209,9 @@ Formatter::Formatter(const std::string & fname, const std::string & hit_config)
 std::string
 Formatter::format(const std::string & fname, const std::string & input)
 {
+  // formatting should parse the document without included content expanded
   ParseOptions options;
-  options.expand_includes = expand_includes;
+  options.expand_includes = false;
   std::unique_ptr<hit::Node> root(hit::parse(fname, input, nullptr, options));
   format(root.get());
   return root->render(0, indent_string, line_length);
@@ -1340,12 +1337,25 @@ buildHITTree(std::shared_ptr<wasp::DefaultHITInterpreter> interpreter,
              wasp::HITNodeView hnv_parent,
              Node * hit_parent,
              std::string & previous_file,
-             std::size_t & previous_line)
+             std::size_t & previous_line,
+             const ParseOptions & options)
 {
   if (hnv_parent.is_null())
     return;
 
-  for (const auto & hnv_child : hnv_parent)
+  // do range-based traversal in normal conditions to expand included files
+  // do index-based traversal for format to not descend into included files
+  auto walk_children = [](wasp::HITNodeView hnv_parent, bool expand_includes, auto visit)
+  {
+    if (expand_includes)
+      for (const auto & hnv_child : hnv_parent)
+        visit(hnv_child);
+    else
+      for (std::size_t i = 0, count = hnv_parent.child_count(); i < count; i++)
+        visit(hnv_parent.child_at(i));
+  };
+
+  walk_children(hnv_parent, options.expand_includes, [&](const auto & hnv_child)
   {
     // create and add comment node as terminal leaf but do not recurse deeper
     if (hnv_child.type() == wasp::COMMENT)
@@ -1435,7 +1445,7 @@ buildHITTree(std::shared_ptr<wasp::DefaultHITInterpreter> interpreter,
       // recurse using section if found and do not create or add anything new
       if (auto hit_child = hit_parent->find(hnv_child.name());
           hit_child && hit_child->type() == NodeType::Section)
-        buildHITTree(interpreter, hnv_child, hit_child, previous_file, previous_line);
+        buildHITTree(interpreter, hnv_child, hit_child, previous_file, previous_line, options);
 
       // create and add new section node if not found then recurse using node
       else
@@ -1449,12 +1459,12 @@ buildHITTree(std::shared_ptr<wasp::DefaultHITInterpreter> interpreter,
         hit_parent->addChild(hit_child);
         previous_file = hnv_child.node_pool()->stream_name();
         previous_line = hnv_child.line();
-        buildHITTree(interpreter, hnv_child, hit_child, previous_file, previous_line);
+        buildHITTree(interpreter, hnv_child, hit_child, previous_file, previous_line, options);
         previous_file = hnv_child.node_pool()->stream_name();
         previous_line = hnv_child.last_line();
       }
     }
-  }
+  });
 }
 
 } // namespace hit

--- a/framework/contrib/hit/src/hit/parse.cc
+++ b/framework/contrib/hit/src/hit/parse.cc
@@ -1079,7 +1079,8 @@ parse(const std::string & fname,
   {
     std::string starting_file = interpreter->root().node_pool()->stream_name();
     std::size_t starting_line = interpreter->root().line();
-    buildHITTree(interpreter, interpreter->root(), root.get(), starting_file, starting_line, options);
+    buildHITTree(
+        interpreter, interpreter->root(), root.get(), starting_file, starting_line, options);
   }
 
   return root.release();
@@ -1355,116 +1356,120 @@ buildHITTree(std::shared_ptr<wasp::DefaultHITInterpreter> interpreter,
         visit(hnv_parent.child_at(i));
   };
 
-  walk_children(hnv_parent, options.expand_includes, [&](const auto & hnv_child)
-  {
-    // create and add comment node as terminal leaf but do not recurse deeper
-    if (hnv_child.type() == wasp::COMMENT)
-    {
-      // add blank line if needed between previous node line and this node line
-      if (hnv_child.node_pool()->stream_name() == previous_file &&
-          hnv_child.line() > previous_line + 1)
-        hit_parent->addChild(new Blank());
-
-      auto hit_child = new Comment(interpreter, hnv_child);
-      if (hnv_child.node_pool()->stream_name() == previous_file &&
-          hnv_child.line() == previous_line && hit_parent->children().size() > 0)
+  walk_children(
+      hnv_parent,
+      options.expand_includes,
+      [&](const auto & hnv_child)
       {
-        hit_child->setInline(true);
-        hit_parent->children().back()->addChild(hit_child);
-      }
-      else
-      {
-        hit_child->setInline(false);
-        hit_parent->addChild(hit_child);
-      }
-      previous_file = hnv_child.node_pool()->stream_name();
-      previous_line = hnv_child.last_line();
-    }
-
-    // create and add field node depending on conflicts but recurse no deeper
-    else if (hnv_child.type() == wasp::KEYED_VALUE || hnv_child.type() == wasp::ARRAY)
-    {
-      // check if tree has field conflict and overrides need to be considered
-      if (auto found_field = hit_parent->find(hnv_child.name());
-          found_field && found_field->type() == NodeType::Field)
-      {
-        // capture any override settings used for both existing and new field
-        bool override_for_old_node = wasp::is_override(found_field->getNodeView());
-        bool override_for_new_node = wasp::is_override(hnv_child);
-
-        // use overrides of conflicting fields to decide which has precedence
-        if (!override_for_old_node && !override_for_new_node)
+        // create and add comment node as terminal leaf but do not recurse deeper
+        if (hnv_child.type() == wasp::COMMENT)
         {
-          // neither has override so add new next to existing for error later
-          hit_parent->addChild(new Field(interpreter, hnv_child));
+          // add blank line if needed between previous node line and this node line
+          if (hnv_child.node_pool()->stream_name() == previous_file &&
+              hnv_child.line() > previous_line + 1)
+            hit_parent->addChild(new Blank());
+
+          auto hit_child = new Comment(interpreter, hnv_child);
+          if (hnv_child.node_pool()->stream_name() == previous_file &&
+              hnv_child.line() == previous_line && hit_parent->children().size() > 0)
+          {
+            hit_child->setInline(true);
+            hit_parent->children().back()->addChild(hit_child);
+          }
+          else
+          {
+            hit_child->setInline(false);
+            hit_parent->addChild(hit_child);
+          }
           previous_file = hnv_child.node_pool()->stream_name();
           previous_line = hnv_child.last_line();
         }
-        else if (!override_for_old_node && override_for_new_node)
+
+        // create and add field node depending on conflicts but recurse no deeper
+        else if (hnv_child.type() == wasp::KEYED_VALUE || hnv_child.type() == wasp::ARRAY)
         {
-          // only new field has override so remove existing field and replace
-          const auto & hit_siblings = hit_parent->children();
-          for (std::size_t index = 0; index < hit_siblings.size(); index++)
-            if (hit_siblings[index] == found_field)
+          // check if tree has field conflict and overrides need to be considered
+          if (auto found_field = hit_parent->find(hnv_child.name());
+              found_field && found_field->type() == NodeType::Field)
+          {
+            // capture any override settings used for both existing and new field
+            bool override_for_old_node = wasp::is_override(found_field->getNodeView());
+            bool override_for_new_node = wasp::is_override(hnv_child);
+
+            // use overrides of conflicting fields to decide which has precedence
+            if (!override_for_old_node && !override_for_new_node)
             {
-              hit_parent->insertChild(index, new Field(interpreter, hnv_child));
-              delete found_field;
-              break;
+              // neither has override so add new next to existing for error later
+              hit_parent->addChild(new Field(interpreter, hnv_child));
+              previous_file = hnv_child.node_pool()->stream_name();
+              previous_line = hnv_child.last_line();
             }
+            else if (!override_for_old_node && override_for_new_node)
+            {
+              // only new field has override so remove existing field and replace
+              const auto & hit_siblings = hit_parent->children();
+              for (std::size_t index = 0; index < hit_siblings.size(); index++)
+                if (hit_siblings[index] == found_field)
+                {
+                  hit_parent->insertChild(index, new Field(interpreter, hnv_child));
+                  delete found_field;
+                  break;
+                }
+            }
+            else if (override_for_old_node && override_for_new_node)
+              // both fields have override and this is not allowed so throw error
+              throw Error("'" + found_field->fullpath() +
+                              "' specified more than once with override syntax",
+                          found_field);
+          }
+          else
+          {
+            // no conflict so add blank line if necessary then add new field node
+            if (hnv_child.node_pool()->stream_name() == previous_file &&
+                hnv_child.line() > previous_line + 1)
+              hit_parent->addChild(new Blank());
+            hit_parent->addChild(new Field(interpreter, hnv_child));
+            previous_file = hnv_child.node_pool()->stream_name();
+            previous_line = hnv_child.last_line();
+          }
         }
-        else if (override_for_old_node && override_for_new_node)
-          // both fields have override and this is not allowed so throw error
-          throw Error("'" + found_field->fullpath() +
-                          "' specified more than once with override syntax",
-                      found_field);
-      }
-      else
-      {
-        // no conflict so add blank line if necessary then add new field node
-        if (hnv_child.node_pool()->stream_name() == previous_file &&
-            hnv_child.line() > previous_line + 1)
-          hit_parent->addChild(new Blank());
-        hit_parent->addChild(new Field(interpreter, hnv_child));
-        previous_file = hnv_child.node_pool()->stream_name();
-        previous_line = hnv_child.last_line();
-      }
-    }
 
-    else if (hnv_child.type() == wasp::FILE)
-    {
-      if (hnv_child.node_pool()->stream_name() == previous_file && hnv_child.line() > previous_line + 1)
-        hit_parent->addChild(new Blank());
-      hit_parent->addChild(new Include(interpreter, hnv_child));
-      previous_file = hnv_child.node_pool()->stream_name();
-      previous_line = hnv_child.last_line();
-    }
+        else if (hnv_child.type() == wasp::FILE)
+        {
+          if (hnv_child.node_pool()->stream_name() == previous_file &&
+              hnv_child.line() > previous_line + 1)
+            hit_parent->addChild(new Blank());
+          hit_parent->addChild(new Include(interpreter, hnv_child));
+          previous_file = hnv_child.node_pool()->stream_name();
+          previous_line = hnv_child.last_line();
+        }
 
-    // create and add section node if not found in tree then recurse children
-    else if (hnv_child.type() == wasp::OBJECT || hnv_child.type() == wasp::DOCUMENT_ROOT)
-    {
-      // recurse using section if found and do not create or add anything new
-      if (auto hit_child = hit_parent->find(hnv_child.name());
-          hit_child && hit_child->type() == NodeType::Section)
-        buildHITTree(interpreter, hnv_child, hit_child, previous_file, previous_line, options);
+        // create and add section node if not found in tree then recurse children
+        else if (hnv_child.type() == wasp::OBJECT || hnv_child.type() == wasp::DOCUMENT_ROOT)
+        {
+          // recurse using section if found and do not create or add anything new
+          if (auto hit_child = hit_parent->find(hnv_child.name());
+              hit_child && hit_child->type() == NodeType::Section)
+            buildHITTree(interpreter, hnv_child, hit_child, previous_file, previous_line, options);
 
-      // create and add new section node if not found then recurse using node
-      else
-      {
-        // add blank line if needed between previous node line and this node line
-        if (hnv_child.node_pool()->stream_name() == previous_file &&
-            hnv_child.line() > previous_line + 1)
-          hit_parent->addChild(new Blank());
+          // create and add new section node if not found then recurse using node
+          else
+          {
+            // add blank line if needed between previous node line and this node line
+            if (hnv_child.node_pool()->stream_name() == previous_file &&
+                hnv_child.line() > previous_line + 1)
+              hit_parent->addChild(new Blank());
 
-        hit_child = new Section(interpreter, hnv_child);
-        hit_parent->addChild(hit_child);
-        previous_file = hnv_child.node_pool()->stream_name();
-        previous_line = hnv_child.line();
-        buildHITTree(interpreter, hnv_child, hit_child, previous_file, previous_line, options);
-        previous_file = hnv_child.node_pool()->stream_name();
-        previous_line = hnv_child.last_line();
-      }
-    }
-  });
+            hit_child = new Section(interpreter, hnv_child);
+            hit_parent->addChild(hit_child);
+            previous_file = hnv_child.node_pool()->stream_name();
+            previous_line = hnv_child.line();
+            buildHITTree(interpreter, hnv_child, hit_child, previous_file, previous_line, options);
+            previous_file = hnv_child.node_pool()->stream_name();
+            previous_line = hnv_child.last_line();
+          }
+        }
+      });
 }
 
 } // namespace hit

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -1249,3 +1249,48 @@ FILE-A:3.3: 'Block/param_01' specified more than once with override syntax
   // delete extra file which was put on disk to be parsed from base include
   std::remove("file_b.i");
 }
+
+// test formatter on input with includes to make sure they are not expanded
+TEST(HitTests, FormatIncludes)
+{
+  // base input string includes one file within block and one at root level
+  std::string base_input = R"INPUT(
+[Block01] param01a=value01a
+!include include_file_01.i
+param01c=value01c []
+param02a=value02a
+!include include_file_02.i
+param02c=value02c
+)INPUT";
+
+  // write include file 01 to disk that is included within base input block
+  std::ofstream include_file_01("include_file_01.i");
+  include_file_01 << "param01b = value01b";
+  include_file_01.close();
+
+  // write include file 02 to disk that is included from root of base input
+  std::ofstream include_file_02("include_file_02.i");
+  include_file_02 << "param02b = value02b";
+  include_file_02.close();
+
+  // format base input string that has includes then delete files from disk
+  hit::Formatter formatter;
+  std::string formatted_actual = formatter.format("TESTCASE", base_input);
+  std::remove("include_file_01.i");
+  std::remove("include_file_02.i");
+
+  // expected formatted input with include directives not expanded contents
+  std::string formatted_expect = R"INPUT(
+[Block01]
+  param01a = value01a
+  !include include_file_01.i
+  param01c = value01c
+[]
+param02a = value02a
+!include include_file_02.i
+param02c = value02c
+)INPUT";
+
+  // check formatted input is as expected and does not expand include files
+  EXPECT_EQ(formatted_expect, "\n" + formatted_actual + "\n");
+}


### PR DESCRIPTION
closes #32703

This relies on some changes to WASP, which are being reviewed. Marking as draft until those get merged.

This was developed using codex