### PR TITLE
Avoid adding all implicit constraint potential geometric entries to Jacobian when using constraints + hash table matrix assembly

### DIFF
--- a/framework/src/geomsearch/NearestNodeLocator.C
+++ b/framework/src/geomsearch/NearestNodeLocator.C
@@ -55,6 +55,9 @@ NearestNodeLocator::NearestNodeLocator(SubProblem & subproblem,
     mooseError("NearestNodeLocator being created for boundaries ", _boundary1, " and ", _boundary2,
   ", but boundary ", _boundary2, " does not exist");
   */
+
+  // Request the nodeToElem map upfront
+  _mesh.nodeToElemMap();
 }
 
 NearestNodeLocator::~NearestNodeLocator() = default;

--- a/framework/src/geomsearch/PenetrationLocator.C
+++ b/framework/src/geomsearch/PenetrationLocator.C
@@ -87,6 +87,9 @@ PenetrationLocator::PenetrationLocator(SubProblem & subproblem,
           "nodal_normal_z variables must exist.  Are you missing the \\[NodalNormals\\] block?");
     }
   }
+
+  // Request the nodeToElem map upfront
+  _mesh.nodeToElemMap();
 }
 
 PenetrationLocator::~PenetrationLocator()

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -633,11 +633,9 @@ MooseMesh::update()
   // Rebuild the boundary conditions
   buildNodeListFromSideList();
 
-  // Update the node to elem map
+  // Clear the node to elem maps
   _node_to_elem_map.clear();
-  _node_to_elem_map_built = false;
   _node_to_active_semilocal_elem_map.clear();
-  _node_to_active_semilocal_elem_map_built = false;
 
   buildNodeList();
   buildBndElemList();
@@ -670,6 +668,20 @@ MooseMesh::update()
 #endif
 
   _finite_volume_info_dirty = true;
+
+  // Rebuild the node to elem maps, in case the object(s) who got references to the maps
+  // actually do need to use them
+  if (_node_to_elem_map_built)
+  {
+    // it won't stay false
+    _node_to_elem_map_built = false;
+    nodeToElemMap();
+  }
+  if (_node_to_active_semilocal_elem_map_built)
+  {
+    _node_to_active_semilocal_elem_map_built = false;
+    nodeToActiveSemilocalElemMap();
+  }
 }
 
 void
@@ -1673,6 +1685,8 @@ MooseMesh::addQuadratureNode(const Elem * elem,
     // Keep track of this new node in two different ways for easy lookup
     _quadrature_nodes[new_id] = qnode;
     _elem_to_side_to_qp_to_quadrature_nodes[elem->id()][side][qp] = qnode;
+    mooseAssert(_node_to_elem_map_built, "Should have been built");
+    mooseAssert(_node_to_active_semilocal_elem_map_built, "Should have been built");
 
     if (elem->active())
     {

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1685,13 +1685,14 @@ MooseMesh::addQuadratureNode(const Elem * elem,
     // Keep track of this new node in two different ways for easy lookup
     _quadrature_nodes[new_id] = qnode;
     _elem_to_side_to_qp_to_quadrature_nodes[elem->id()][side][qp] = qnode;
-    mooseAssert(_node_to_elem_map_built, "Should have been built");
-    mooseAssert(_node_to_active_semilocal_elem_map_built, "Should have been built");
 
     if (elem->active())
     {
-      _node_to_elem_map[new_id].push_back(elem->id());
-      _node_to_active_semilocal_elem_map[new_id].push_back(elem->id());
+      // If they have not been built, no need to start building an incomplete one
+      if (_node_to_elem_map_built)
+        _node_to_elem_map[new_id].push_back(elem->id());
+      if (_node_to_active_semilocal_elem_map_built)
+        _node_to_active_semilocal_elem_map[new_id].push_back(elem->id());
     }
   }
   else

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1738,6 +1738,8 @@ MooseMesh::clearQuadratureNodes()
   _quadrature_nodes.clear();
   _elem_to_side_to_qp_to_quadrature_nodes.clear();
   _extra_bnd_nodes.clear();
+
+  // NOTE: this does not clear them from the nodeToElem and nodeToActiveSemiLocalElem maps
 }
 
 BoundaryID

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -639,8 +639,9 @@ NonlinearSystemBase::addConstraint(const std::string & c_name,
   _constraints.addObject(constraint);
   postAddResidualObject(*constraint);
 
-  if (constraint && constraint->addCouplingEntriesToJacobian())
-    addImplicitGeometricCouplingEntriesToJacobian(true);
+  if (!_fe_problem.useHashTableMatrixAssembly())
+    if (constraint && constraint->addCouplingEntriesToJacobian())
+      addImplicitGeometricCouplingEntriesToJacobian(true);
 }
 
 void


### PR DESCRIPTION
I tried a few other things in that optimization but nothing conclusive enough to include in this PR
(Will come in another PR though, solid 1% gainz I think)

## Reason
When using hash table matrix assembly (HTMA), we are fine with inserting new entries during the Jacobian contribution, and don't need to pre-add a lot of entries (with 0s) that are potentially useful for the constraints

## Design
Avoid setting "add implicit coupling term to Jacobian" to true when using HTMA
Note that this was exceptionally slow for the following three reasons in the case:
- sidesets with constraints were large, so lots of potential DOF coupling added
- constraints were adding a ton of zeros into Jacobian because of that, which is slow with HTMA (insertion is more expensive)
- having a much larger than needed Jacobian made the LU solve very slow

## Impact
Faster assembly
Faster solve