### PR TITLE
Remove app failure workaround code in linear viscoelasticy model

### DIFF
--- a/modules/solid_mechanics/src/materials/LinearViscoelasticityBase.C
+++ b/modules/solid_mechanics/src/materials/LinearViscoelasticityBase.C
@@ -186,12 +186,6 @@ LinearViscoelasticityBase::recomputeQpApparentProperties(unsigned int qp)
   // 1. we get the viscoelastic properties and their inverse if needed
   computeQpViscoelasticProperties();
 
-  // This is a temporary fix to allow downstream app tests to pass. Delete these three lines
-  // once the apps are updated.
-  if (_longterm_elasticity_tensor &&
-      MooseUtils::absoluteFuzzyEqual((*_longterm_elasticity_tensor)[_qp].L2norm(), 0.0))
-    (*_longterm_elasticity_tensor)[_qp] = _first_elasticity_tensor[_qp];
-
   if (_need_viscoelastic_properties_inverse)
     computeQpViscoelasticPropertiesInv();
 


### PR DESCRIPTION
ref #32508

I added the lines deleted here in a prior commit to avoid breaking the tests in blackbear. The blackbear change has been merged, so these operations are not necessary anymore.