### PR TITLE
Add additional parallelism for local DOFs in Kokkos kernels & more use of optimized kernel objects

### DIFF
--- a/framework/doc/content/syntax/KokkosKernels/index.md
+++ b/framework/doc/content/syntax/KokkosKernels/index.md
@@ -113,8 +113,10 @@ See the following source codes of `KokkosCoupledForce` for another example of a 
 ## Optimized Kernel Objects
 
 [Similarly to the original MOOSE](syntax/Kernels/index.md#optimized), Kokkos-MOOSE provides `Moose::Kokkos::KernelValue` and `Moose::Kokkos::KernelGrad` for creating an optimized kernel by factoring out test functions in residual and Jacobian calculations.
-However, instead of `precomputeQpResidual()` and `precomputeQpJacobian()`, you should still define `computeQpResidual()` and `computeQpJacobian()` but with different signatures from those in `Moose::Kokkos::Kernel`.
-The signatures of the hook methods are as follows:
+It is strongly encouraged to leverage these optimized kernel objects whenever possible for best performance.
+However, the usage of optimized kernel objects is slightly different from the original MOOSE.
+Instead of `precomputeQpResidual()` and `precomputeQpJacobian()`, you should still define `computeQpResidual()` and `computeQpJacobian()`, but with different signatures from those in `Moose::Kokkos::Kernel`.
+The signatures of these hook methods are as follows:
 
 - For `Moose::Kokkos::KernelValue`,
 
@@ -126,6 +128,11 @@ template <typename Derived>
 KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int j,
                                        const unsigned int qp,
                                        AssemblyDatum & datum) const;
+template <typename Derived>
+KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int j,
+                                              const unsigned int jvar,
+                                              const unsigned int qp,
+                                              AssemblyDatum & datum) const;
 ```
 
 - For `Moose::Kokkos::KernelGrad`,
@@ -138,6 +145,11 @@ template <typename Derived>
 KOKKOS_FUNCTION Real3 computeQpJacobian(const unsigned int j,
                                         const unsigned int qp,
                                         AssemblyDatum & datum) const;
+template <typename Derived>
+KOKKOS_FUNCTION Real3 computeQpOffDiagJacobian(const unsigned int j,
+                                               const unsigned int jvar,
+                                               const unsigned int qp,
+                                               AssemblyDatum & datum) const;
 ```
 
 See the following source codes of `KokkosConvectionPrecompute` and `KokkosDiffusionPrecompute` for examples of optimized kernels:

--- a/framework/include/kokkos/base/KokkosDatum.h
+++ b/framework/include/kokkos/base/KokkosDatum.h
@@ -184,6 +184,28 @@ public:
    */
   KOKKOS_FUNCTION void reinit() {}
 
+  /**
+   * Set local parallelization option
+   * @param local_thread_id The current local thread ID
+   * @param num_local_threads The number of local threads
+   */
+  KOKKOS_FUNCTION void set_local_parallel(const unsigned int local_thread_id,
+                                          const unsigned int num_local_threads)
+  {
+    _local_thread_id = local_thread_id;
+    _num_local_threads = num_local_threads;
+  }
+  /**
+   * Get the current local thread ID
+   * @returns The current local thread ID
+   */
+  KOKKOS_FUNCTION unsigned int local_thread_id() const { return _local_thread_id; }
+  /**
+   * Get the number of local threads
+   * @returns The number of local threads
+   */
+  KOKKOS_FUNCTION unsigned int num_local_threads() const { return _num_local_threads; }
+
 protected:
   /**
    * Reference of the Kokkos assembly
@@ -247,6 +269,14 @@ private:
   Real3 _xyz;
   Real3 _normal;
   ///@}
+  /**
+   * Thread ID for local parallelization
+   */
+  unsigned int _local_thread_id = 0;
+  /**
+   * Number of threads for local parallelization
+   */
+  unsigned int _num_local_threads = 1;
 };
 
 KOKKOS_FUNCTION inline dof_id_type

--- a/framework/include/kokkos/base/KokkosResidualObject.h
+++ b/framework/include/kokkos/base/KokkosResidualObject.h
@@ -180,11 +180,9 @@ protected:
    * The common loop structure template for computing elemental Jacobian
    * @param datum The AssemblyDatum object of the current thread
    * @param body The quadrature point loop body
-   * @param lumping Whether to lump mass matrix
    */
   template <typename function>
-  KOKKOS_FUNCTION void
-  computeJacobianInternal(AssemblyDatum & datum, function body, const bool lumping = false) const;
+  KOKKOS_FUNCTION void computeJacobianInternal(AssemblyDatum & datum, function body) const;
 
 private:
   /**
@@ -337,9 +335,7 @@ ResidualObject::computeResidualInternal(AssemblyDatum & datum, function body) co
 
 template <typename function>
 KOKKOS_FUNCTION void
-ResidualObject::computeJacobianInternal(AssemblyDatum & datum,
-                                        function body,
-                                        const bool lumping) const
+ResidualObject::computeJacobianInternal(AssemblyDatum & datum, function body) const
 {
   Real local_ke[MAX_CACHED_DOF];
 
@@ -362,8 +358,7 @@ ResidualObject::computeJacobianInternal(AssemblyDatum & datum,
       body(local_ke - ib, ib, ie, j);
 
       for (unsigned int i = ib; i < ie; ++i)
-        accumulateTaggedElementalMatrix(
-            local_ke[i - ib], datum.elem().id, i, lumping ? i : j, datum.jvar());
+        accumulateTaggedElementalMatrix(local_ke[i - ib], datum.elem().id, i, j, datum.jvar());
     }
   }
 }

--- a/framework/include/kokkos/base/KokkosResidualObject.h
+++ b/framework/include/kokkos/base/KokkosResidualObject.h
@@ -180,9 +180,11 @@ protected:
    * The common loop structure template for computing elemental Jacobian
    * @param datum The AssemblyDatum object of the current thread
    * @param body The quadrature point loop body
+   * @param lumping Whether to lump mass matrix
    */
   template <typename function>
-  KOKKOS_FUNCTION void computeJacobianInternal(AssemblyDatum & datum, function body) const;
+  KOKKOS_FUNCTION void
+  computeJacobianInternal(AssemblyDatum & datum, function body, const bool lumping = false) const;
 
 private:
   /**
@@ -304,15 +306,24 @@ ResidualObject::computeResidualInternal(AssemblyDatum & datum, function body) co
 {
   Real local_re[MAX_CACHED_DOF];
 
-  unsigned int num_batches = datum.n_dofs() / MAX_CACHED_DOF;
+  unsigned int stride = MAX_CACHED_DOF * datum.num_local_threads();
+  unsigned int num_batches = datum.n_dofs() / stride;
 
-  if (datum.n_dofs() % MAX_CACHED_DOF)
+  if (datum.n_dofs() % stride)
     ++num_batches;
 
   for (unsigned int batch = 0; batch < num_batches; ++batch)
   {
-    unsigned int ib = batch * MAX_CACHED_DOF;
-    unsigned int ie = ::Kokkos::min(ib + MAX_CACHED_DOF, datum.n_dofs());
+    unsigned int ib = batch * stride;
+    unsigned int ie = ::Kokkos::min(ib + stride, datum.n_dofs());
+
+    const unsigned int n = ie - ib;
+    const unsigned int d = n / datum.num_local_threads();
+    const unsigned int m = n % datum.num_local_threads();
+    const unsigned int t = datum.local_thread_id();
+
+    ib += t * d + (t < m ? t : m);
+    ie = ib + d + (t < m ? 1 : 0);
 
     for (unsigned int i = ib; i < ie; ++i)
       local_re[i - ib] = 0;
@@ -326,31 +337,33 @@ ResidualObject::computeResidualInternal(AssemblyDatum & datum, function body) co
 
 template <typename function>
 KOKKOS_FUNCTION void
-ResidualObject::computeJacobianInternal(AssemblyDatum & datum, function body) const
+ResidualObject::computeJacobianInternal(AssemblyDatum & datum,
+                                        function body,
+                                        const bool lumping) const
 {
   Real local_ke[MAX_CACHED_DOF];
 
-  unsigned int num_batches = datum.n_idofs() * datum.n_jdofs() / MAX_CACHED_DOF;
-
-  if ((datum.n_idofs() * datum.n_jdofs()) % MAX_CACHED_DOF)
-    ++num_batches;
-
-  for (unsigned int batch = 0; batch < num_batches; ++batch)
+  for (unsigned int j = datum.local_thread_id(); j < datum.n_jdofs();
+       j += datum.num_local_threads())
   {
-    unsigned int ijb = batch * MAX_CACHED_DOF;
-    unsigned int ije = ::Kokkos::min(ijb + MAX_CACHED_DOF, datum.n_idofs() * datum.n_jdofs());
+    unsigned int num_batches = datum.n_idofs() / MAX_CACHED_DOF;
 
-    for (unsigned int ij = ijb; ij < ije; ++ij)
-      local_ke[ij - ijb] = 0;
+    if (datum.n_idofs() % MAX_CACHED_DOF)
+      ++num_batches;
 
-    body(local_ke - ijb, ijb, ije);
-
-    for (unsigned int ij = ijb; ij < ije; ++ij)
+    for (unsigned int batch = 0; batch < num_batches; ++batch)
     {
-      unsigned int i = ij % datum.n_jdofs();
-      unsigned int j = ij / datum.n_jdofs();
+      unsigned int ib = batch * MAX_CACHED_DOF;
+      unsigned int ie = ::Kokkos::min(ib + MAX_CACHED_DOF, datum.n_idofs());
 
-      accumulateTaggedElementalMatrix(local_ke[ij - ijb], datum.elem().id, i, j, datum.jvar());
+      for (unsigned int i = ib; i < ie; ++i)
+        local_ke[i - ib] = 0;
+
+      body(local_ke - ib, ib, ie, j);
+
+      for (unsigned int i = ib; i < ie; ++i)
+        accumulateTaggedElementalMatrix(
+            local_ke[i - ib], datum.elem().id, i, lumping ? i : j, datum.jvar());
     }
   }
 }

--- a/framework/include/kokkos/base/KokkosThread.h
+++ b/framework/include/kokkos/base/KokkosThread.h
@@ -47,14 +47,25 @@ public:
    * Get the total thread pool size
    * @returns The total thread pool size
    */
-  thread_id_type size() const { return _size; }
+  KOKKOS_FUNCTION thread_id_type size() const { return _size; }
+  /**
+   * Get the size of each dimension
+   * @param dim The dimension index
+   * @returns The dimension size
+   */
+  KOKKOS_FUNCTION thread_id_type size(const unsigned int dim) const
+  {
+    KOKKOS_ASSERT(dim < _dim);
+
+    return _dims[dim];
+  }
   /**
    * Get the multi-dimensional thread index of a dimension given a one-dimensional thread index
    * @param tid The one-dimensional thread index
    * @param dim for which the multi-dimensional thread index is to be returned
    * @returns The multi-dimensional thread index of the dimension
    */
-  KOKKOS_FUNCTION thread_id_type operator()(thread_id_type tid, unsigned int dim) const
+  KOKKOS_FUNCTION thread_id_type operator()(const thread_id_type tid, const unsigned int dim) const
   {
     KOKKOS_ASSERT(dim < _dim);
 

--- a/framework/include/kokkos/bcs/KokkosCoupledVarNeumannBC.h
+++ b/framework/include/kokkos/bcs/KokkosCoupledVarNeumannBC.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include "KokkosIntegratedBC.h"
+#include "KokkosIntegratedBCValue.h"
 
 /**
  * Implements a Neumann BC where grad(u)=_coupled_var on the boundary.
  * Uses the term produced from integrating the diffusion operator by parts.
  */
-class KokkosCoupledVarNeumannBC : public Moose::Kokkos::IntegratedBC
+class KokkosCoupledVarNeumannBC : public Moose::Kokkos::IntegratedBCValue
 {
 public:
   static InputParameters validParams();
@@ -23,12 +23,9 @@ public:
   KokkosCoupledVarNeumannBC(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int i,
-                                                const unsigned int j,
+  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int j,
                                                 const unsigned int jvar,
                                                 const unsigned int qp,
                                                 AssemblyDatum & datum) const;
@@ -49,23 +46,20 @@ protected:
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosCoupledVarNeumannBC::computeQpResidual(const unsigned int i,
-                                             const unsigned int qp,
-                                             AssemblyDatum & datum) const
+KokkosCoupledVarNeumannBC::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
 {
-  return -_scale_factor(datum, qp) * _coef * _test(datum, i, qp) * _coupled_var(datum, qp);
+  return -_scale_factor(datum, qp) * _coef * _coupled_var(datum, qp);
 }
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosCoupledVarNeumannBC::computeQpOffDiagJacobian(const unsigned int i,
-                                                    const unsigned int j,
+KokkosCoupledVarNeumannBC::computeQpOffDiagJacobian(const unsigned int j,
                                                     const unsigned int jvar,
                                                     const unsigned int qp,
                                                     AssemblyDatum & datum) const
 {
   if (jvar == _coupled_num)
-    return -_scale_factor(datum, qp) * _coef * _test(datum, i, qp) * _phi(datum, j, qp);
+    return -_scale_factor(datum, qp) * _coef * _phi(datum, j, qp);
   else
     return 0;
 }

--- a/framework/include/kokkos/bcs/KokkosDirectionalNeumannBC.h
+++ b/framework/include/kokkos/bcs/KokkosDirectionalNeumannBC.h
@@ -9,14 +9,14 @@
 
 #pragma once
 
-#include "KokkosIntegratedBC.h"
+#include "KokkosIntegratedBCValue.h"
 
 /**
  * Implements a flux boundary condition grad(u).n = V.n, where the
  * vector V is specifed by the user. This differs from NeumannBC,
  * where the user instead specifies the _scalar_ value g = grad(u).n.
  */
-class KokkosDirectionalNeumannBC : public Moose::Kokkos::IntegratedBC
+class KokkosDirectionalNeumannBC : public Moose::Kokkos::IntegratedBCValue
 {
 public:
   static InputParameters validParams();
@@ -24,11 +24,9 @@ public:
   KokkosDirectionalNeumannBC(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
   {
-    return -_test(datum, i, qp) * (_value * datum.normals(qp));
+    return -_value * datum.normals(qp);
   }
 
 protected:

--- a/framework/include/kokkos/bcs/KokkosIntegratedBC.h
+++ b/framework/include/kokkos/bcs/KokkosIntegratedBC.h
@@ -197,10 +197,12 @@ template <typename Derived>
 KOKKOS_FUNCTION void
 IntegratedBC::operator()(ResidualLoop, const ThreadID tid, const Derived & bc) const
 {
-  auto [elem, side] = kokkosBoundaryElementSideID(tid);
+  auto [elem, side] = kokkosBoundaryElementSideID(_thread(tid, 1));
 
   AssemblyDatum datum(
       elem, side, kokkosAssembly(), kokkosSystems(), _kokkos_var, _kokkos_var.var());
+
+  datum.set_local_parallel(_thread(tid, 0), _thread.size(0));
 
   bc.computeResidualInternal(bc, datum);
 }
@@ -209,10 +211,12 @@ template <typename Derived>
 KOKKOS_FUNCTION void
 IntegratedBC::operator()(JacobianLoop, const ThreadID tid, const Derived & bc) const
 {
-  auto [elem, side] = kokkosBoundaryElementSideID(tid);
+  auto [elem, side] = kokkosBoundaryElementSideID(_thread(tid, 1));
 
   AssemblyDatum datum(
       elem, side, kokkosAssembly(), kokkosSystems(), _kokkos_var, _kokkos_var.var());
+
+  datum.set_local_parallel(_thread(tid, 0), _thread.size(0));
 
   bc.computeJacobianInternal(bc, datum);
 }
@@ -221,15 +225,17 @@ template <typename Derived>
 KOKKOS_FUNCTION void
 IntegratedBC::operator()(OffDiagJacobianLoop, const ThreadID tid, const Derived & bc) const
 {
-  auto [elem, side] = kokkosBoundaryElementSideID(_thread(tid, 1));
+  auto [elem, side] = kokkosBoundaryElementSideID(_thread(tid, 2));
 
   auto & sys = kokkosSystem(_kokkos_var.sys());
-  auto jvar = sys.getCoupling(_kokkos_var.var())[_thread(tid, 0)];
+  auto jvar = sys.getCoupling(_kokkos_var.var())[_thread(tid, 1)];
 
   if (!sys.isVariableActive(jvar, kokkosMesh().getElementInfo(elem).subdomain))
     return;
 
   AssemblyDatum datum(elem, side, kokkosAssembly(), kokkosSystems(), _kokkos_var, jvar);
+
+  datum.set_local_parallel(_thread(tid, 0), _thread.size(0));
 
   bc.computeOffDiagJacobianInternal(bc, datum);
 }
@@ -254,16 +260,11 @@ IntegratedBC::computeJacobianInternal(const Derived & bc, AssemblyDatum & datum)
 {
   ResidualObject::computeJacobianInternal(
       datum,
-      [&](Real * local_ke, const unsigned int ijb, const unsigned int ije)
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-          for (unsigned int ij = ijb; ij < ije; ++ij)
-          {
-            unsigned int i = ij % datum.n_jdofs();
-            unsigned int j = ij / datum.n_jdofs();
-
-            local_ke[ij] += datum.JxW(qp) * bc.template computeQpJacobian<Derived>(i, j, qp, datum);
-          }
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += datum.JxW(qp) * bc.template computeQpJacobian<Derived>(i, j, qp, datum);
       });
 }
 
@@ -273,17 +274,12 @@ IntegratedBC::computeOffDiagJacobianInternal(const Derived & bc, AssemblyDatum &
 {
   ResidualObject::computeJacobianInternal(
       datum,
-      [&](Real * local_ke, const unsigned int ijb, const unsigned int ije)
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-          for (unsigned int ij = ijb; ij < ije; ++ij)
-          {
-            unsigned int i = ij % datum.n_jdofs();
-            unsigned int j = ij / datum.n_jdofs();
-
-            local_ke[ij] += datum.JxW(qp) * bc.template computeQpOffDiagJacobian<Derived>(
-                                                i, j, datum.jvar(), qp, datum);
-          }
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += datum.JxW(qp) * bc.template computeQpOffDiagJacobian<Derived>(
+                                               i, j, datum.jvar(), qp, datum);
       });
 }
 

--- a/framework/include/kokkos/bcs/KokkosIntegratedBCBase.h
+++ b/framework/include/kokkos/bcs/KokkosIntegratedBCBase.h
@@ -36,6 +36,12 @@ public:
    * Copy constructor for parallel dispatch
    */
   IntegratedBCBase(const IntegratedBCBase & object);
+
+protected:
+  /**
+   * Number of threads for local DOF parallelization
+   */
+  const unsigned int _num_local_threads;
 };
 
 } // namespace Moose::Kokkos

--- a/framework/include/kokkos/bcs/KokkosIntegratedBCValue.h
+++ b/framework/include/kokkos/bcs/KokkosIntegratedBCValue.h
@@ -1,0 +1,187 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "KokkosIntegratedBC.h"
+
+namespace Moose::Kokkos
+{
+
+/**
+ * The base class for a user to derive their own Kokkos integrated boundary conditions where the
+ * residual is of the form
+ *
+ * $(\dots, \psi_i)$
+ *
+ * i.e. the test function $(\psi_i)$ can be factored out for optimization.
+ *
+ * The user should still define computeQpResidual(), computeQpJacobian(), and
+ * computeQpOffDiagJacobian(), but their signatures are different from the base class. The signature
+ * of computeQpResidual() expected to be defined in the derived class is as follows:
+ *
+ * @tparam Derived The object type
+ * @param qp The local quadrature point index
+ * @param datum The AssemblyDatum object of the current thread
+ * @returns The component of the residual contribution that will be multiplied by the test function
+ *
+ * template <typename Derived>
+ * KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp,
+ *                                        AssemblyDatum & datum) const;
+ *
+ * The signature of computeQpJacobian() and computeQpOffDiagJacobian() can be found in the code
+ * below.
+ */
+class IntegratedBCValue : public IntegratedBC
+{
+public:
+  static InputParameters validParams();
+
+  /**
+   * Constructor
+   */
+  IntegratedBCValue(const InputParameters & parameters);
+
+  /**
+   * Default methods to prevent compile errors even when these methods were not defined in the
+   * derived class
+   */
+  ///@{
+  /**
+   * Compute diagonal Jacobian contribution on a quadrature point
+   * @tparam Derived The object type
+   * @param j The trial function DOF index
+   * @param qp The local quadrature point index
+   * @param datum The AssemblyDatum object of the current thread
+   * @returns The component of the Jacobian contribution that will be multiplied by the test
+   * function
+   */
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int /* j */,
+                                         const unsigned int /* qp */,
+                                         AssemblyDatum & /* datum */) const
+  {
+    ::Kokkos::abort("Default computeQpJacobian() should never be called. Make sure you properly "
+                    "redefined this method in your class without typos.");
+
+    return 0;
+  }
+  /**
+   * Compute off-diagonal Jacobian contribution on a quadrature point
+   * @tparam Derived The object type
+   * @param j The trial function DOF index
+   * @param jvar The variable number for column
+   * @param qp The local quadrature point index
+   * @param datum The AssemblyDatum object of the current thread
+   * @returns The component of the off-diagonal Jacobian contribution that will be multiplied by the
+   * test function
+   */
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int /* j */,
+                                                const unsigned int /* jvar */,
+                                                const unsigned int /* qp */,
+                                                AssemblyDatum & /* datum */) const
+  {
+    ::Kokkos::abort(
+        "Default computeQpOffDiagJacobian() should never be called. Make sure you properly "
+        "redefined this method in your class without typos.");
+
+    return 0;
+  }
+  ///@}
+
+  /**
+   * Functions used to check if users have overriden the hook methods, whose calculations can be
+   * skipped when not overriden
+   * @returns The function pointer of the default hook method
+   */
+  ///@{
+  template <typename Derived>
+  static auto defaultJacobian()
+  {
+    return &IntegratedBCValue::computeQpJacobian<Derived>;
+  }
+  template <typename Derived>
+  static auto defaultOffDiagJacobian()
+  {
+    return &IntegratedBCValue::computeQpOffDiagJacobian<Derived>;
+  }
+  ///@}
+
+  /**
+   * The parallel computation bodies that hide the base class methods to optimize for factoring
+   * out the test function
+   */
+  ///@{
+  template <typename Derived>
+  KOKKOS_FUNCTION void computeResidualInternal(const Derived & bc, AssemblyDatum & datum) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void computeJacobianInternal(const Derived & bc, AssemblyDatum & datum) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void computeOffDiagJacobianInternal(const Derived & bc,
+                                                      AssemblyDatum & datum) const;
+  ///@}
+};
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+IntegratedBCValue::computeResidualInternal(const Derived & bc, AssemblyDatum & datum) const
+{
+  ResidualObject::computeResidualInternal(
+      datum,
+      [&](Real * local_re, const unsigned int ib, const unsigned int ie)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+        {
+          Real value = datum.JxW(qp) * bc.template computeQpResidual<Derived>(qp, datum);
+
+          for (unsigned int i = ib; i < ie; ++i)
+            local_re[i] += value * _test(datum, i, qp);
+        }
+      });
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+IntegratedBCValue::computeJacobianInternal(const Derived & bc, AssemblyDatum & datum) const
+{
+  ResidualObject::computeJacobianInternal(
+      datum,
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+        {
+          Real value = datum.JxW(qp) * bc.template computeQpJacobian<Derived>(j, qp, datum);
+
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += value * _test(datum, i, qp);
+        }
+      });
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+IntegratedBCValue::computeOffDiagJacobianInternal(const Derived & bc, AssemblyDatum & datum) const
+{
+  ResidualObject::computeJacobianInternal(
+      datum,
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+        {
+          Real value = datum.JxW(qp) *
+                       bc.template computeQpOffDiagJacobian<Derived>(j, datum.jvar(), qp, datum);
+
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += value * _test(datum, i, qp);
+        }
+      });
+}
+
+} // namespace Moose::Kokkos

--- a/framework/include/kokkos/bcs/KokkosNeumannBC.h
+++ b/framework/include/kokkos/bcs/KokkosNeumannBC.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "KokkosIntegratedBC.h"
+#include "KokkosIntegratedBCValue.h"
 
-class KokkosNeumannBC : public Moose::Kokkos::IntegratedBC
+class KokkosNeumannBC : public Moose::Kokkos::IntegratedBCValue
 {
 public:
   static InputParameters validParams();
@@ -19,9 +19,7 @@ public:
   KokkosNeumannBC(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int, AssemblyDatum &) const;
 
 private:
   /// Value of grad(u) on the boundary.
@@ -30,9 +28,7 @@ private:
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosNeumannBC::computeQpResidual(const unsigned int i,
-                                   const unsigned int qp,
-                                   AssemblyDatum & datum) const
+KokkosNeumannBC::computeQpResidual(const unsigned int, AssemblyDatum &) const
 {
-  return -_test(datum, i, qp) * _value;
+  return -_value;
 }

--- a/framework/include/kokkos/bcs/KokkosPostprocessorNeumannBC.h
+++ b/framework/include/kokkos/bcs/KokkosPostprocessorNeumannBC.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include "KokkosIntegratedBC.h"
+#include "KokkosIntegratedBCValue.h"
 
 /**
  * Implements a constant Neumann BC where grad(u) is a equal to a postprocessor on the boundary.
  * Uses the term produced from integrating the diffusion operator by parts.
  */
-class KokkosPostprocessorNeumannBC : public Moose::Kokkos::IntegratedBC
+class KokkosPostprocessorNeumannBC : public Moose::Kokkos::IntegratedBCValue
 {
 public:
   /**
@@ -27,9 +27,7 @@ public:
   KokkosPostprocessorNeumannBC(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int, AssemblyDatum &) const;
 
 protected:
   /// Value of grad(u) on the boundary.
@@ -38,9 +36,7 @@ protected:
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosPostprocessorNeumannBC::computeQpResidual(const unsigned int i,
-                                                const unsigned int qp,
-                                                AssemblyDatum & datum) const
+KokkosPostprocessorNeumannBC::computeQpResidual(const unsigned int, AssemblyDatum &) const
 {
-  return -_test(datum, i, qp) * _value;
+  return -_value;
 }

--- a/framework/include/kokkos/bcs/KokkosVacuumBC.h
+++ b/framework/include/kokkos/bcs/KokkosVacuumBC.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "KokkosIntegratedBC.h"
+#include "KokkosIntegratedBCValue.h"
 
 /**
  * Implements a simple Vacuum BC for neutron diffusion on the boundary.
@@ -17,7 +17,7 @@
  * Hence, \f$ D\frac{du}{dn}=-\frac{u}{2} \f$ and \f$ -\frac{u}{2} \f$ is substituted into
  * the Neumann BC term produced from integrating the diffusion operator by parts.
  */
-class KokkosVacuumBC : public Moose::Kokkos::IntegratedBC
+class KokkosVacuumBC : public Moose::Kokkos::IntegratedBCValue
 {
 public:
   static InputParameters validParams();
@@ -25,12 +25,9 @@ public:
   KokkosVacuumBC(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int i,
-                                         const unsigned int j,
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int j,
                                          const unsigned int qp,
                                          AssemblyDatum & datum) const;
 
@@ -41,19 +38,16 @@ private:
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosVacuumBC::computeQpResidual(const unsigned int i,
-                                  const unsigned int qp,
-                                  AssemblyDatum & datum) const
+KokkosVacuumBC::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
 {
-  return _test(datum, i, qp) * _alpha * _u(datum, qp) / 2.;
+  return _alpha * _u(datum, qp) / 2.;
 }
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosVacuumBC::computeQpJacobian(const unsigned int i,
-                                  const unsigned int j,
+KokkosVacuumBC::computeQpJacobian(const unsigned int j,
                                   const unsigned int qp,
                                   AssemblyDatum & datum) const
 {
-  return _test(datum, i, qp) * _alpha * _phi(datum, j, qp) / 2.;
+  return _alpha * _phi(datum, j, qp) / 2.;
 }

--- a/framework/include/kokkos/kernels/KokkosBodyForce.h
+++ b/framework/include/kokkos/kernels/KokkosBodyForce.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "KokkosKernel.h"
+#include "KokkosKernelValue.h"
 
-class KokkosBodyForce : public Moose::Kokkos::Kernel
+class KokkosBodyForce : public Moose::Kokkos::KernelValue
 {
 public:
   static InputParameters validParams();
@@ -19,9 +19,7 @@ public:
   KokkosBodyForce(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int, AssemblyDatum &) const;
 
 protected:
   /// Scale factor
@@ -33,9 +31,7 @@ protected:
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosBodyForce::computeQpResidual(const unsigned int i,
-                                   const unsigned int qp,
-                                   AssemblyDatum & datum) const
+KokkosBodyForce::computeQpResidual(const unsigned int, AssemblyDatum &) const
 {
-  return -_test(datum, i, qp) * _scale * _postprocessor;
+  return -_scale * _postprocessor;
 }

--- a/framework/include/kokkos/kernels/KokkosCoupledForce.h
+++ b/framework/include/kokkos/kernels/KokkosCoupledForce.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include "KokkosKernel.h"
+#include "KokkosKernelValue.h"
 
 /**
  * Implements a source term proportional to the value of a coupled variable. Weak form: $(\\psi_i,
  * -\\sigma v)$.
  */
-class KokkosCoupledForce : public Moose::Kokkos::Kernel
+class KokkosCoupledForce : public Moose::Kokkos::KernelValue
 {
 public:
   static InputParameters validParams();
@@ -23,9 +23,7 @@ public:
   KokkosCoupledForce(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
 
 private:
   /// Coupled variable number
@@ -38,9 +36,7 @@ private:
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosCoupledForce::computeQpResidual(const unsigned int i,
-                                      const unsigned int qp,
-                                      AssemblyDatum & datum) const
+KokkosCoupledForce::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
 {
-  return -_coef * _v(datum, qp) * _test(datum, i, qp);
+  return -_coef * _v(datum, qp);
 }

--- a/framework/include/kokkos/kernels/KokkosCoupledTimeDerivative.h
+++ b/framework/include/kokkos/kernels/KokkosCoupledTimeDerivative.h
@@ -9,12 +9,12 @@
 
 #pragma once
 
-#include "KokkosKernel.h"
+#include "KokkosKernelValue.h"
 
 /**
  * This calculates the time derivative for a coupled variable
  **/
-class KokkosCoupledTimeDerivative : public Moose::Kokkos::Kernel
+class KokkosCoupledTimeDerivative : public Moose::Kokkos::KernelValue
 {
 public:
   static InputParameters validParams();
@@ -22,12 +22,9 @@ public:
   KokkosCoupledTimeDerivative(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int i,
-                                                const unsigned int j,
+  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int j,
                                                 const unsigned int jvar,
                                                 const unsigned int qp,
                                                 AssemblyDatum & datum) const;
@@ -40,23 +37,20 @@ protected:
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosCoupledTimeDerivative::computeQpResidual(const unsigned int i,
-                                               const unsigned int qp,
-                                               AssemblyDatum & datum) const
+KokkosCoupledTimeDerivative::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
 {
-  return _test(datum, i, qp) * _v_dot(datum, qp);
+  return _v_dot(datum, qp);
 }
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosCoupledTimeDerivative::computeQpOffDiagJacobian(const unsigned int i,
-                                                      const unsigned int j,
+KokkosCoupledTimeDerivative::computeQpOffDiagJacobian(const unsigned int j,
                                                       const unsigned int jvar,
                                                       const unsigned int qp,
                                                       AssemblyDatum & datum) const
 {
   if (jvar == _v_var)
-    return _test(datum, i, qp) * _phi(datum, j, qp) * _dv_dot;
+    return _phi(datum, j, qp) * _dv_dot;
   else
     return 0;
 }

--- a/framework/include/kokkos/kernels/KokkosKernel.h
+++ b/framework/include/kokkos/kernels/KokkosKernel.h
@@ -197,7 +197,7 @@ template <typename Derived>
 KOKKOS_FUNCTION void
 Kernel::operator()(ResidualLoop, const ThreadID tid, const Derived & kernel) const
 {
-  auto elem = kokkosBlockElementID(tid);
+  auto elem = kokkosBlockElementID(_thread(tid, 1));
 
   AssemblyDatum datum(elem,
                       libMesh::invalid_uint,
@@ -205,6 +205,8 @@ Kernel::operator()(ResidualLoop, const ThreadID tid, const Derived & kernel) con
                       kokkosSystems(),
                       _kokkos_var,
                       _kokkos_var.var());
+
+  datum.set_local_parallel(_thread(tid, 0), _thread.size(0));
 
   kernel.computeResidualInternal(kernel, datum);
 }
@@ -213,7 +215,7 @@ template <typename Derived>
 KOKKOS_FUNCTION void
 Kernel::operator()(JacobianLoop, const ThreadID tid, const Derived & kernel) const
 {
-  auto elem = kokkosBlockElementID(tid);
+  auto elem = kokkosBlockElementID(_thread(tid, 1));
 
   AssemblyDatum datum(elem,
                       libMesh::invalid_uint,
@@ -222,6 +224,8 @@ Kernel::operator()(JacobianLoop, const ThreadID tid, const Derived & kernel) con
                       _kokkos_var,
                       _kokkos_var.var());
 
+  datum.set_local_parallel(_thread(tid, 0), _thread.size(0));
+
   kernel.computeJacobianInternal(kernel, datum);
 }
 
@@ -229,16 +233,18 @@ template <typename Derived>
 KOKKOS_FUNCTION void
 Kernel::operator()(OffDiagJacobianLoop, const ThreadID tid, const Derived & kernel) const
 {
-  auto elem = kokkosBlockElementID(_thread(tid, 1));
+  auto elem = kokkosBlockElementID(_thread(tid, 2));
 
   auto & sys = kokkosSystem(_kokkos_var.sys());
-  auto jvar = sys.getCoupling(_kokkos_var.var())[_thread(tid, 0)];
+  auto jvar = sys.getCoupling(_kokkos_var.var())[_thread(tid, 1)];
 
   if (!sys.isVariableActive(jvar, kokkosMesh().getElementInfo(elem).subdomain))
     return;
 
   AssemblyDatum datum(
       elem, libMesh::invalid_uint, kokkosAssembly(), kokkosSystems(), _kokkos_var, jvar);
+
+  datum.set_local_parallel(_thread(tid, 0), _thread.size(0));
 
   kernel.computeOffDiagJacobianInternal(kernel, datum);
 }
@@ -263,17 +269,12 @@ Kernel::computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) c
 {
   ResidualObject::computeJacobianInternal(
       datum,
-      [&](Real * local_ke, const unsigned int ijb, const unsigned int ije)
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-          for (unsigned int ij = ijb; ij < ije; ++ij)
-          {
-            unsigned int i = ij % datum.n_jdofs();
-            unsigned int j = ij / datum.n_jdofs();
-
-            local_ke[ij] +=
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] +=
                 datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(i, j, qp, datum);
-          }
       });
 }
 
@@ -283,17 +284,12 @@ Kernel::computeOffDiagJacobianInternal(const Derived & kernel, AssemblyDatum & d
 {
   ResidualObject::computeJacobianInternal(
       datum,
-      [&](Real * local_ke, const unsigned int ijb, const unsigned int ije)
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-          for (unsigned int ij = ijb; ij < ije; ++ij)
-          {
-            unsigned int i = ij % datum.n_jdofs();
-            unsigned int j = ij / datum.n_jdofs();
-
-            local_ke[ij] += datum.JxW(qp) * kernel.template computeQpOffDiagJacobian<Derived>(
-                                                i, j, datum.jvar(), qp, datum);
-          }
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += datum.JxW(qp) * kernel.template computeQpOffDiagJacobian<Derived>(
+                                               i, j, datum.jvar(), qp, datum);
       });
 }
 

--- a/framework/include/kokkos/kernels/KokkosKernelBase.h
+++ b/framework/include/kokkos/kernels/KokkosKernelBase.h
@@ -38,6 +38,12 @@ public:
    * Copy constructor for parallel dispatch
    */
   KernelBase(const KernelBase & object);
+
+protected:
+  /**
+   * Number of threads for local DOF parallelization
+   */
+  const unsigned int _num_local_threads;
 };
 
 } // namespace Moose::Kokkos

--- a/framework/include/kokkos/kernels/KokkosKernelGrad.h
+++ b/framework/include/kokkos/kernels/KokkosKernelGrad.h
@@ -21,9 +21,9 @@ namespace Moose::Kokkos
  *
  * i.e. the gradient of the test function $(\nabla\psi_i)$ can be factored out for optimization.
  *
- * The user should still define computeQpResidual() and computeQpJacobian(), but their signatures
- * are different from the base class. The signature of computeQpResidual() expected to be defined in
- * the derived class is as follows:
+ * The user should still define computeQpResidual(), computeQpJacobian(), and
+ * computeQpOffDiagJacobian(), but their signatures are different from the base class. The signature
+ * of computeQpResidual() expected to be defined in the derived class is as follows:
  *
  * @tparam Derived The object type
  * @param qp The local quadrature point index
@@ -35,8 +35,8 @@ namespace Moose::Kokkos
  * KOKKOS_FUNCTION Real3 computeQpResidual(const unsigned int qp,
  *                                         AssemblyDatum & datum) const;
  *
- * The signature of computeQpJacobian() can be found in the code below. The definition of
- * computeQpOffDiagJacobian() is still the same with the original Kokkos kernel.
+ * The signature of computeQpJacobian() and computeQpOffDiagJacobian() can be found in the code
+ * below.
  */
 class KernelGrad : public Kernel
 {
@@ -72,6 +72,28 @@ public:
 
     return Real3(0);
   }
+  /**
+   * Compute off-diagonal Jacobian contribution on a quadrature point
+   * @tparam Derived The object type
+   * @param j The trial function DOF index
+   * @param jvar The variable number for column
+   * @param qp The local quadrature point index
+   * @param datum The AssemblyDatum object of the current thread
+   * @returns The vector component of the off-diagonal Jacobian contribution that will be multiplied
+   * by the gradient of the test function
+   */
+  template <typename Derived>
+  KOKKOS_FUNCTION Real3 computeQpOffDiagJacobian(const unsigned int /* j */,
+                                                 const unsigned int /* jvar */,
+                                                 const unsigned int /* qp */,
+                                                 AssemblyDatum & /* datum */) const
+  {
+    ::Kokkos::abort(
+        "Default computeQpOffDiagJacobian() should never be called. Make sure you properly "
+        "redefined this method in your class without typos.");
+
+    return Real3(0);
+  }
   ///@}
 
   /**
@@ -85,6 +107,11 @@ public:
   {
     return &KernelGrad::computeQpJacobian<Derived>;
   }
+  template <typename Derived>
+  static auto defaultOffDiagJacobian()
+  {
+    return &KernelGrad::computeQpOffDiagJacobian<Derived>;
+  }
   ///@}
 
   /**
@@ -96,6 +123,9 @@ public:
   KOKKOS_FUNCTION void computeResidualInternal(const Derived & kernel, AssemblyDatum & datum) const;
   template <typename Derived>
   KOKKOS_FUNCTION void computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void computeOffDiagJacobianInternal(const Derived & kernel,
+                                                      AssemblyDatum & datum) const;
   ///@}
 };
 
@@ -128,6 +158,25 @@ KernelGrad::computeJacobianInternal(const Derived & kernel, AssemblyDatum & datu
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
         {
           Real3 value = datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(j, qp, datum);
+
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += value * _grad_test(datum, i, qp);
+        }
+      });
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+KernelGrad::computeOffDiagJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const
+{
+  ResidualObject::computeJacobianInternal(
+      datum,
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+        {
+          Real3 value = datum.JxW(qp) * kernel.template computeQpOffDiagJacobian<Derived>(
+                                            j, datum.jvar(), qp, datum);
 
           for (unsigned int i = ib; i < ie; ++i)
             local_ke[i] += value * _grad_test(datum, i, qp);

--- a/framework/include/kokkos/kernels/KokkosKernelGrad.h
+++ b/framework/include/kokkos/kernels/KokkosKernelGrad.h
@@ -121,29 +121,16 @@ template <typename Derived>
 KOKKOS_FUNCTION void
 KernelGrad::computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const
 {
-  Real3 value;
-
   ResidualObject::computeJacobianInternal(
       datum,
-      [&](Real * local_ke, const unsigned int ijb, const unsigned int ije)
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
         {
-          unsigned int j_old = libMesh::invalid_uint;
+          Real3 value = datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(j, qp, datum);
 
-          for (unsigned int ij = ijb; ij < ije; ++ij)
-          {
-            unsigned int i = ij % datum.n_jdofs();
-            unsigned int j = ij / datum.n_jdofs();
-
-            if (j != j_old)
-            {
-              value = datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(j, qp, datum);
-              j_old = j;
-            }
-
-            local_ke[ij] += value * _grad_test(datum, i, qp);
-          }
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += value * _grad_test(datum, i, qp);
         }
       });
 }

--- a/framework/include/kokkos/kernels/KokkosKernelValue.h
+++ b/framework/include/kokkos/kernels/KokkosKernelValue.h
@@ -21,9 +21,9 @@ namespace Moose::Kokkos
  *
  * i.e. the test function $(\psi_i)$ can be factored out for optimization.
  *
- * The user should still define computeQpResidual() and computeQpJacobian(), but their signatures
- * are different from the base class. The signature of computeQpResidual() expected to be defined in
- * the derived class is as follows:
+ * The user should still define computeQpResidual(), computeQpJacobian(), and
+ * computeQpOffDiagJacobian(), but their signatures are different from the base class. The signature
+ * of computeQpResidual() expected to be defined in the derived class is as follows:
  *
  * @tparam Derived The object type
  * @param qp The local quadrature point index
@@ -34,8 +34,8 @@ namespace Moose::Kokkos
  * KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp,
  *                                        AssemblyDatum & datum) const;
  *
- * The signature of computeQpJacobian() can be found in the code below. The definition of
- * computeQpOffDiagJacobian() is still the same with the original Kokkos kernel.
+ * The signature of computeQpJacobian() and computeQpOffDiagJacobian() can be found in the code
+ * below.
  */
 class KernelValue : public Kernel
 {
@@ -71,6 +71,28 @@ public:
 
     return 0;
   }
+  /**
+   * Compute off-diagonal Jacobian contribution on a quadrature point
+   * @tparam Derived The object type
+   * @param j The trial function DOF index
+   * @param jvar The variable number for column
+   * @param qp The local quadrature point index
+   * @param datum The AssemblyDatum object of the current thread
+   * @returns The component of the off-diagonal Jacobian contribution that will be multiplied by the
+   * test function
+   */
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int /* j */,
+                                                const unsigned int /* jvar */,
+                                                const unsigned int /* qp */,
+                                                AssemblyDatum & /* datum */) const
+  {
+    ::Kokkos::abort(
+        "Default computeQpOffDiagJacobian() should never be called. Make sure you properly "
+        "redefined this method in your class without typos.");
+
+    return 0;
+  }
   ///@}
 
   /**
@@ -84,6 +106,11 @@ public:
   {
     return &KernelValue::computeQpJacobian<Derived>;
   }
+  template <typename Derived>
+  static auto defaultOffDiagJacobian()
+  {
+    return &KernelValue::computeQpOffDiagJacobian<Derived>;
+  }
   ///@}
 
   /**
@@ -95,6 +122,9 @@ public:
   KOKKOS_FUNCTION void computeResidualInternal(const Derived & kernel, AssemblyDatum & datum) const;
   template <typename Derived>
   KOKKOS_FUNCTION void computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void computeOffDiagJacobianInternal(const Derived & kernel,
+                                                      AssemblyDatum & datum) const;
   ///@}
 };
 
@@ -127,6 +157,25 @@ KernelValue::computeJacobianInternal(const Derived & kernel, AssemblyDatum & dat
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
         {
           Real value = datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(j, qp, datum);
+
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += value * _test(datum, i, qp);
+        }
+      });
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+KernelValue::computeOffDiagJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const
+{
+  ResidualObject::computeJacobianInternal(
+      datum,
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+        {
+          Real value = datum.JxW(qp) * kernel.template computeQpOffDiagJacobian<Derived>(
+                                           j, datum.jvar(), qp, datum);
 
           for (unsigned int i = ib; i < ie; ++i)
             local_ke[i] += value * _test(datum, i, qp);

--- a/framework/include/kokkos/kernels/KokkosKernelValue.h
+++ b/framework/include/kokkos/kernels/KokkosKernelValue.h
@@ -120,29 +120,16 @@ template <typename Derived>
 KOKKOS_FUNCTION void
 KernelValue::computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const
 {
-  Real value = 0;
-
   ResidualObject::computeJacobianInternal(
       datum,
-      [&](Real * local_ke, const unsigned int ijb, const unsigned int ije)
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
       {
         for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
         {
-          unsigned int j_old = libMesh::invalid_uint;
+          Real value = datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(j, qp, datum);
 
-          for (unsigned int ij = ijb; ij < ije; ++ij)
-          {
-            unsigned int i = ij % datum.n_jdofs();
-            unsigned int j = ij / datum.n_jdofs();
-
-            if (j != j_old)
-            {
-              value = datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(j, qp, datum);
-              j_old = j;
-            }
-
-            local_ke[ij] += value * _test(datum, i, qp);
-          }
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += value * _test(datum, i, qp);
         }
       });
 }

--- a/framework/include/kokkos/kernels/KokkosMatCoupledForce.h
+++ b/framework/include/kokkos/kernels/KokkosMatCoupledForce.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "KokkosKernel.h"
+#include "KokkosKernelValue.h"
 #include "KokkosMap.h"
 
 /**
@@ -18,7 +18,7 @@
  * m_j is a vector of material properties, and v_j is a vector
  * of variables
  */
-class KokkosMatCoupledForce : public Moose::Kokkos::Kernel
+class KokkosMatCoupledForce : public Moose::Kokkos::KernelValue
 {
 public:
   static InputParameters validParams();
@@ -26,12 +26,9 @@ public:
   KokkosMatCoupledForce(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int i,
-                                                const unsigned int j,
+  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int j,
                                                 const unsigned int jvar,
                                                 const unsigned int qp,
                                                 AssemblyDatum & datum) const;
@@ -48,9 +45,7 @@ private:
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosMatCoupledForce::computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const
+KokkosMatCoupledForce::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
 {
   Real r = 0;
   if (_coupled_props)
@@ -59,13 +54,12 @@ KokkosMatCoupledForce::computeQpResidual(const unsigned int i,
   else
     for (unsigned int j = 0; j < _n_coupled; ++j)
       r += -_coef[j] * _v(datum, qp, j);
-  return r * _test(datum, i, qp);
+  return r;
 }
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosMatCoupledForce::computeQpOffDiagJacobian(const unsigned int i,
-                                                const unsigned int j,
+KokkosMatCoupledForce::computeQpOffDiagJacobian(const unsigned int j,
                                                 const unsigned int jvar,
                                                 const unsigned int qp,
                                                 AssemblyDatum & datum) const
@@ -76,6 +70,6 @@ KokkosMatCoupledForce::computeQpOffDiagJacobian(const unsigned int i,
   unsigned int p = _v_var_to_index[jvar];
 
   if (_coupled_props)
-    return -_coef[p] * _mat_props[p](datum, qp) * _phi(datum, j, qp) * _test(datum, i, qp);
-  return -_coef[p] * _phi(datum, j, qp) * _test(datum, i, qp);
+    return -_coef[p] * _mat_props[p](datum, qp) * _phi(datum, j, qp);
+  return -_coef[p] * _phi(datum, j, qp);
 }

--- a/framework/include/kokkos/kernels/KokkosTimeDerivative.h
+++ b/framework/include/kokkos/kernels/KokkosTimeDerivative.h
@@ -39,16 +39,36 @@ template <typename Derived>
 KOKKOS_FUNCTION void
 KokkosTimeDerivative::computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const
 {
-  ResidualObject::computeJacobianInternal(
-      datum,
-      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
-      {
-        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-          for (unsigned int i = ib; i < ie; ++i)
-            local_ke[i] +=
-                datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(i, j, qp, datum);
-      },
-      _lumping);
+  using Moose::Kokkos::MAX_CACHED_DOF;
+
+  Real local_ke[MAX_CACHED_DOF];
+
+  for (unsigned int j = datum.local_thread_id(); j < datum.n_jdofs();
+       j += datum.num_local_threads())
+  {
+    unsigned int num_batches = datum.n_idofs() / MAX_CACHED_DOF;
+
+    if (datum.n_idofs() % MAX_CACHED_DOF)
+      ++num_batches;
+
+    for (unsigned int batch = 0; batch < num_batches; ++batch)
+    {
+      unsigned int ib = batch * MAX_CACHED_DOF;
+      unsigned int ie = ::Kokkos::min(ib + MAX_CACHED_DOF, datum.n_idofs());
+
+      for (unsigned int i = ib; i < ie; ++i)
+        local_ke[i - ib] = 0;
+
+      for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+        for (unsigned int i = ib; i < ie; ++i)
+          local_ke[i - ib] +=
+              datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(i, j, qp, datum);
+
+      for (unsigned int i = ib; i < ie; ++i)
+        accumulateTaggedElementalMatrix(
+            local_ke[i - ib], datum.elem().id, i, _lumping ? i : j, datum.jvar());
+    }
+  }
 }
 
 template <typename Derived>

--- a/framework/include/kokkos/kernels/KokkosTimeDerivative.h
+++ b/framework/include/kokkos/kernels/KokkosTimeDerivative.h
@@ -39,44 +39,16 @@ template <typename Derived>
 KOKKOS_FUNCTION void
 KokkosTimeDerivative::computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const
 {
-  using Moose::Kokkos::MAX_CACHED_DOF;
-
-  Real local_ke[MAX_CACHED_DOF];
-
-  unsigned int num_batches = datum.n_idofs() * datum.n_jdofs() / MAX_CACHED_DOF;
-
-  if ((datum.n_idofs() * datum.n_jdofs()) % MAX_CACHED_DOF)
-    ++num_batches;
-
-  for (unsigned int batch = 0; batch < num_batches; ++batch)
-  {
-    unsigned int ijb = batch * MAX_CACHED_DOF;
-    unsigned int ije = ::Kokkos::min(ijb + MAX_CACHED_DOF, datum.n_idofs() * datum.n_jdofs());
-
-    for (unsigned int ij = ijb; ij < ije; ++ij)
-      local_ke[ij - ijb] = 0;
-
-    for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
-    {
-      for (unsigned int ij = ijb; ij < ije; ++ij)
+  ResidualObject::computeJacobianInternal(
+      datum,
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
       {
-        unsigned int i = ij % datum.n_jdofs();
-        unsigned int j = ij / datum.n_jdofs();
-
-        local_ke[ij - ijb] +=
-            datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(i, j, qp, datum);
-      }
-    }
-
-    for (unsigned int ij = ijb; ij < ije; ++ij)
-    {
-      unsigned int i = ij % datum.n_jdofs();
-      unsigned int j = ij / datum.n_jdofs();
-
-      accumulateTaggedElementalMatrix(
-          local_ke[ij - ijb], datum.elem().id, i, _lumping ? i : j, datum.jvar());
-    }
-  }
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] +=
+                datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(i, j, qp, datum);
+      },
+      _lumping);
 }
 
 template <typename Derived>

--- a/framework/include/kokkos/kernels/KokkosTimeDerivative.h
+++ b/framework/include/kokkos/kernels/KokkosTimeDerivative.h
@@ -19,21 +19,56 @@ public:
   KokkosTimeDerivative(const InputParameters & parameters);
 
   template <typename Derived>
+  KOKKOS_FUNCTION void computeResidualInternal(const Derived & kernel, AssemblyDatum & datum) const;
+  template <typename Derived>
   KOKKOS_FUNCTION void computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const;
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int j,
                                          const unsigned int qp,
                                          AssemblyDatum & datum) const;
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int i,
-                                         const unsigned int j,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpJacobianDummy(const unsigned int,
+                                              const unsigned int,
+                                              AssemblyDatum &) const
+  {
+    return 0;
+  }
+
+  // The computeQpJacobian() of this class has the same signature with that of KernelValue (without
+  // test function index), but this class itself derives from TimeKernel whose base class is Kernel
+  // (with test function index). Therefore, their function pointers cannot be compared. Instead, we
+  // provide the function pointer of a dummy function to the dispatcher registry to make it think
+  // that non-default computeQpJacobian() was implemented.
+  template <typename Derived>
+  static auto defaultJacobian()
+  {
+    return &KokkosTimeDerivative::computeQpJacobianDummy<Derived>;
+  }
 
 protected:
   const bool _lumping;
 };
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+KokkosTimeDerivative::computeResidualInternal(const Derived & kernel, AssemblyDatum & datum) const
+{
+  ResidualObject::computeResidualInternal(
+      datum,
+      [&](Real * local_re, const unsigned int ib, const unsigned int ie)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+        {
+          Real value = datum.JxW(qp) * kernel.template computeQpResidual<Derived>(qp, datum);
+
+          for (unsigned int i = ib; i < ie; ++i)
+            local_re[i] += value * _test(datum, i, qp);
+        }
+      });
+}
 
 template <typename Derived>
 KOKKOS_FUNCTION void
@@ -60,9 +95,12 @@ KokkosTimeDerivative::computeJacobianInternal(const Derived & kernel, AssemblyDa
         local_ke[i - ib] = 0;
 
       for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+      {
+        Real value = datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(j, qp, datum);
+
         for (unsigned int i = ib; i < ie; ++i)
-          local_ke[i - ib] +=
-              datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(i, j, qp, datum);
+          local_ke[i - ib] += value * _test(datum, i, qp);
+      }
 
       for (unsigned int i = ib; i < ie; ++i)
         accumulateTaggedElementalMatrix(
@@ -73,19 +111,16 @@ KokkosTimeDerivative::computeJacobianInternal(const Derived & kernel, AssemblyDa
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosTimeDerivative::computeQpResidual(const unsigned int i,
-                                        const unsigned int qp,
-                                        AssemblyDatum & datum) const
+KokkosTimeDerivative::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
 {
-  return _test(datum, i, qp) * _u_dot(datum, qp);
+  return _u_dot(datum, qp);
 }
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosTimeDerivative::computeQpJacobian(const unsigned int i,
-                                        const unsigned int j,
+KokkosTimeDerivative::computeQpJacobian(const unsigned int j,
                                         const unsigned int qp,
                                         AssemblyDatum & datum) const
 {
-  return _test(datum, i, qp) * _phi(datum, j, qp) * _du_dot_du;
+  return _phi(datum, j, qp) * _du_dot_du;
 }

--- a/framework/src/kokkos/bcs/KokkosCoupledVarNeumannBC.K
+++ b/framework/src/kokkos/bcs/KokkosCoupledVarNeumannBC.K
@@ -14,7 +14,7 @@ registerKokkosResidualObject("MooseApp", KokkosCoupledVarNeumannBC);
 InputParameters
 KokkosCoupledVarNeumannBC::validParams()
 {
-  InputParameters params = IntegratedBC::validParams();
+  InputParameters params = IntegratedBCValue::validParams();
   params.addRequiredCoupledVar("v", "Coupled variable setting the gradient on the boundary.");
   params.addCoupledVar("scale_factor", 1., "Scale factor to multiply the heat flux with");
   params.addParam<Real>(
@@ -24,8 +24,9 @@ KokkosCoupledVarNeumannBC::validParams()
                              "where $v$ is a variable.");
   return params;
 }
+
 KokkosCoupledVarNeumannBC::KokkosCoupledVarNeumannBC(const InputParameters & parameters)
-  : IntegratedBC(parameters),
+  : IntegratedBCValue(parameters),
     _coupled_var(kokkosCoupledValue("v")),
     _coupled_num(coupled("v")),
     _coef(getParam<Real>("coef")),

--- a/framework/src/kokkos/bcs/KokkosDirectionalNeumannBC.K
+++ b/framework/src/kokkos/bcs/KokkosDirectionalNeumannBC.K
@@ -14,7 +14,7 @@ registerKokkosBoundaryCondition("MooseApp", KokkosDirectionalNeumannBC);
 InputParameters
 KokkosDirectionalNeumannBC::validParams()
 {
-  InputParameters params = IntegratedBC::validParams();
+  InputParameters params = IntegratedBCValue::validParams();
   params.addParam<RealVectorValue>(
       "vector_value", RealVectorValue(), "vector this BC should act in");
   params.addClassDescription("Imposes the integrated boundary condition "
@@ -24,6 +24,6 @@ KokkosDirectionalNeumannBC::validParams()
 }
 
 KokkosDirectionalNeumannBC::KokkosDirectionalNeumannBC(const InputParameters & parameters)
-  : IntegratedBC(parameters), _value(getParam<RealVectorValue>("vector_value"))
+  : IntegratedBCValue(parameters), _value(getParam<RealVectorValue>("vector_value"))
 {
 }

--- a/framework/src/kokkos/bcs/KokkosIntegratedBC.K
+++ b/framework/src/kokkos/bcs/KokkosIntegratedBC.K
@@ -34,7 +34,9 @@ IntegratedBC::IntegratedBC(const InputParameters & parameters)
 void
 IntegratedBC::computeResidual()
 {
-  Policy policy(0, numKokkosBoundarySides());
+  _thread.resize(_num_local_threads, numKokkosBoundarySides());
+
+  Policy policy(0, _thread.size());
 
   if (!_residual_dispatcher)
     _residual_dispatcher = DispatcherRegistry::build<ResidualLoop>(this, type());
@@ -47,7 +49,9 @@ IntegratedBC::computeJacobian()
 {
   if (DispatcherRegistry::hasUserMethod<JacobianLoop>(type()))
   {
-    Policy policy(0, numKokkosBoundarySides());
+    _thread.resize(_num_local_threads, numKokkosBoundarySides());
+
+    Policy policy(0, _thread.size());
 
     if (!_jacobian_dispatcher)
       _jacobian_dispatcher = DispatcherRegistry::build<JacobianLoop>(this, type());
@@ -59,7 +63,8 @@ IntegratedBC::computeJacobian()
   {
     auto & sys = kokkosSystem(_kokkos_var.sys());
 
-    _thread.resize(sys.getCoupling(_kokkos_var.var()).size(), numKokkosBoundarySides());
+    _thread.resize(
+        _num_local_threads, sys.getCoupling(_kokkos_var.var()).size(), numKokkosBoundarySides());
 
     Policy policy(0, _thread.size());
 

--- a/framework/src/kokkos/bcs/KokkosIntegratedBCBase.K
+++ b/framework/src/kokkos/bcs/KokkosIntegratedBCBase.K
@@ -18,6 +18,11 @@ IntegratedBCBase::validParams()
   auto params = BoundaryCondition::validParams();
   params += MaterialPropertyInterface::validParams();
 
+  params.addParam<unsigned int>(
+      "num_local_threads",
+      4,
+      "The number of threads for additional parallelization of local DOFs.");
+
   // Integrated BCs always rely on Boundary MaterialData
   params.set<Moose::MaterialDataType>("_material_data_type") = Moose::BOUNDARY_MATERIAL_DATA;
 
@@ -28,14 +33,16 @@ IntegratedBCBase::IntegratedBCBase(const InputParameters & parameters,
                                    Moose::VarFieldType field_type)
   : BoundaryCondition(parameters, field_type, false),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs())
+    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs()),
+    _num_local_threads(getParam<unsigned int>("num_local_threads"))
 {
 }
 
 IntegratedBCBase::IntegratedBCBase(const IntegratedBCBase & object)
   : BoundaryCondition(object),
     CoupleableMooseVariableDependencyIntermediateInterface(object, {}),
-    MaterialPropertyInterface(object, {})
+    MaterialPropertyInterface(object, {}),
+    _num_local_threads(object._num_local_threads)
 {
 }
 

--- a/framework/src/kokkos/bcs/KokkosIntegratedBCValue.K
+++ b/framework/src/kokkos/bcs/KokkosIntegratedBCValue.K
@@ -1,0 +1,26 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "KokkosIntegratedBCValue.h"
+
+namespace Moose::Kokkos
+{
+
+InputParameters
+IntegratedBCValue::validParams()
+{
+  InputParameters params = IntegratedBC::validParams();
+  return params;
+}
+
+IntegratedBCValue::IntegratedBCValue(const InputParameters & parameters) : IntegratedBC(parameters)
+{
+}
+
+} // namespace Moose::Kokkos

--- a/framework/src/kokkos/bcs/KokkosNeumannBC.K
+++ b/framework/src/kokkos/bcs/KokkosNeumannBC.K
@@ -14,7 +14,7 @@ registerKokkosResidualObject("MooseApp", KokkosNeumannBC);
 InputParameters
 KokkosNeumannBC::validParams()
 {
-  InputParameters params = IntegratedBC::validParams();
+  InputParameters params = IntegratedBCValue::validParams();
   params.addParam<Real>("value",
                         0.0,
                         "For a Laplacian problem, the value of the gradient dotted with the "
@@ -27,6 +27,6 @@ KokkosNeumannBC::validParams()
 }
 
 KokkosNeumannBC::KokkosNeumannBC(const InputParameters & parameters)
-  : IntegratedBC(parameters), _value(getParam<Real>("value"))
+  : IntegratedBCValue(parameters), _value(getParam<Real>("value"))
 {
 }

--- a/framework/src/kokkos/bcs/KokkosPostprocessorNeumannBC.K
+++ b/framework/src/kokkos/bcs/KokkosPostprocessorNeumannBC.K
@@ -14,7 +14,7 @@ registerKokkosResidualObject("MooseApp", KokkosPostprocessorNeumannBC);
 InputParameters
 KokkosPostprocessorNeumannBC::validParams()
 {
-  InputParameters params = IntegratedBC::validParams();
+  InputParameters params = IntegratedBCValue::validParams();
   params.addClassDescription(
       "Neumann boundary condition with value prescribed by a Postprocessor value.");
   params.addParam<PostprocessorName>(
@@ -23,6 +23,6 @@ KokkosPostprocessorNeumannBC::validParams()
 }
 
 KokkosPostprocessorNeumannBC::KokkosPostprocessorNeumannBC(const InputParameters & parameters)
-  : IntegratedBC(parameters), _value(getPostprocessorValue("postprocessor"))
+  : IntegratedBCValue(parameters), _value(getPostprocessorValue("postprocessor"))
 {
 }

--- a/framework/src/kokkos/bcs/KokkosVacuumBC.K
+++ b/framework/src/kokkos/bcs/KokkosVacuumBC.K
@@ -14,13 +14,13 @@ registerKokkosResidualObject("MooseApp", KokkosVacuumBC);
 InputParameters
 KokkosVacuumBC::validParams()
 {
-  InputParameters params = IntegratedBC::validParams();
+  InputParameters params = IntegratedBCValue::validParams();
   params.addClassDescription("Vacuum boundary condition for diffusion.");
   params.addParam<Real>("alpha", 1, "Diffusion coefficient.");
   return params;
 }
 
 KokkosVacuumBC::KokkosVacuumBC(const InputParameters & parameters)
-  : IntegratedBC(parameters), _alpha(getParam<Real>("alpha"))
+  : IntegratedBCValue(parameters), _alpha(getParam<Real>("alpha"))
 {
 }

--- a/framework/src/kokkos/kernels/KokkosBodyForce.K
+++ b/framework/src/kokkos/kernels/KokkosBodyForce.K
@@ -14,7 +14,7 @@ registerKokkosResidualObject("MooseApp", KokkosBodyForce);
 InputParameters
 KokkosBodyForce::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = KernelValue::validParams();
   params.addParam<Real>("value", 1.0, "Coefficient to multiply by the body force term");
   params.addParam<PostprocessorName>(
       "postprocessor", 1, "A postprocessor whose value is multiplied by the body force");
@@ -26,7 +26,7 @@ KokkosBodyForce::validParams()
 }
 
 KokkosBodyForce::KokkosBodyForce(const InputParameters & parameters)
-  : Kernel(parameters),
+  : KernelValue(parameters),
     _scale(getParam<Real>("value")),
     _postprocessor(getPostprocessorValue("postprocessor"))
 {

--- a/framework/src/kokkos/kernels/KokkosCoupledForce.K
+++ b/framework/src/kokkos/kernels/KokkosCoupledForce.K
@@ -14,7 +14,7 @@ registerKokkosResidualObject("MooseApp", KokkosCoupledForce);
 InputParameters
 KokkosCoupledForce::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = KernelValue::validParams();
 
   params.addClassDescription("Implements a source term proportional to the value of a coupled "
                              "variable. Weak form: $(\\psi_i, -\\sigma v)$.");
@@ -26,7 +26,7 @@ KokkosCoupledForce::validParams()
 }
 
 KokkosCoupledForce::KokkosCoupledForce(const InputParameters & parameters)
-  : Kernel(parameters),
+  : KernelValue(parameters),
     _v_var(coupled("v")),
     _v(kokkosCoupledValue("v")),
     _coef(getParam<Real>("coef"))

--- a/framework/src/kokkos/kernels/KokkosCoupledTimeDerivative.K
+++ b/framework/src/kokkos/kernels/KokkosCoupledTimeDerivative.K
@@ -14,7 +14,7 @@ registerKokkosResidualObject("MooseApp", KokkosCoupledTimeDerivative);
 InputParameters
 KokkosCoupledTimeDerivative::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = KernelValue::validParams();
   params.addClassDescription("Time derivative Kernel that acts on a coupled variable. Weak form: "
                              "$(\\psi_i, \\frac{\\partial v_h}{\\partial t})$.");
   params.addRequiredCoupledVar("v", "Coupled variable");
@@ -22,7 +22,7 @@ KokkosCoupledTimeDerivative::validParams()
 }
 
 KokkosCoupledTimeDerivative::KokkosCoupledTimeDerivative(const InputParameters & parameters)
-  : Kernel(parameters),
+  : KernelValue(parameters),
     _v_dot(kokkosCoupledDot("v")),
     _dv_dot(kokkosCoupledDotDu("v")),
     _v_var(coupled("v"))

--- a/framework/src/kokkos/kernels/KokkosKernel.K
+++ b/framework/src/kokkos/kernels/KokkosKernel.K
@@ -34,7 +34,9 @@ Kernel::Kernel(const InputParameters & parameters)
 void
 Kernel::computeResidual()
 {
-  Policy policy(0, numKokkosBlockElements());
+  _thread.resize(_num_local_threads, numKokkosBlockElements());
+
+  Policy policy(0, _thread.size());
 
   if (!_residual_dispatcher)
     _residual_dispatcher = DispatcherRegistry::build<ResidualLoop>(this, type());
@@ -47,7 +49,9 @@ Kernel::computeJacobian()
 {
   if (DispatcherRegistry::hasUserMethod<JacobianLoop>(type()))
   {
-    Policy policy(0, numKokkosBlockElements());
+    _thread.resize(_num_local_threads, numKokkosBlockElements());
+
+    Policy policy(0, _thread.size());
 
     if (!_jacobian_dispatcher)
       _jacobian_dispatcher = DispatcherRegistry::build<JacobianLoop>(this, type());
@@ -59,7 +63,8 @@ Kernel::computeJacobian()
   {
     auto & sys = kokkosSystem(_kokkos_var.sys());
 
-    _thread.resize(sys.getCoupling(_kokkos_var.var()).size(), numKokkosBlockElements());
+    _thread.resize(
+        _num_local_threads, sys.getCoupling(_kokkos_var.var()).size(), numKokkosBlockElements());
 
     Policy policy(0, _thread.size());
 

--- a/framework/src/kokkos/kernels/KokkosKernelBase.K
+++ b/framework/src/kokkos/kernels/KokkosKernelBase.K
@@ -25,6 +25,11 @@ KernelBase::validParams()
   params += BlockRestrictable::validParams();
   params += MaterialPropertyInterface::validParams();
 
+  params.addParam<unsigned int>(
+      "num_local_threads",
+      4,
+      "The number of threads for additional parallelization of local DOFs.");
+
   // Kernels always couple within their element
   params.addRelationshipManager("ElementSideNeighborLayers",
                                 Moose::RelationshipManagerType::COUPLING,
@@ -40,7 +45,8 @@ KernelBase::KernelBase(const InputParameters & parameters, Moose::VarFieldType f
   : ResidualObject(parameters, field_type),
     BlockRestrictable(this),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    MaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS)
+    MaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS),
+    _num_local_threads(getParam<unsigned int>("num_local_threads"))
 {
 }
 
@@ -48,7 +54,8 @@ KernelBase::KernelBase(const KernelBase & object)
   : ResidualObject(object),
     BlockRestrictable(object, {}),
     CoupleableMooseVariableDependencyIntermediateInterface(object, {}),
-    MaterialPropertyInterface(object, {})
+    MaterialPropertyInterface(object, {}),
+    _num_local_threads(object._num_local_threads)
 {
 }
 

--- a/framework/src/kokkos/kernels/KokkosMatCoupledForce.K
+++ b/framework/src/kokkos/kernels/KokkosMatCoupledForce.K
@@ -16,7 +16,7 @@ registerKokkosResidualObject("MooseApp", KokkosMatCoupledForce);
 InputParameters
 KokkosMatCoupledForce::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = KernelValue::validParams();
 
   params.addClassDescription(
       "Implements a forcing term RHS of the form PDE = RHS, where RHS = Sum_j c_j * m_j * v_j. "
@@ -31,7 +31,7 @@ KokkosMatCoupledForce::validParams()
 }
 
 KokkosMatCoupledForce::KokkosMatCoupledForce(const InputParameters & parameters)
-  : Kernel(parameters),
+  : KernelValue(parameters),
     _n_coupled(coupledComponents("v")),
     _coupled_props(isParamValid("material_properties")),
     _v_var(coupledIndices("v")),

--- a/framework/src/kokkos/kernels/KokkosTimeDerivative.K
+++ b/framework/src/kokkos/kernels/KokkosTimeDerivative.K
@@ -14,7 +14,7 @@ registerKokkosResidualObject("MooseApp", KokkosTimeDerivative);
 InputParameters
 KokkosTimeDerivative::validParams()
 {
-  InputParameters params = Moose::Kokkos::TimeKernel::validParams();
+  InputParameters params = TimeKernel::validParams();
   params.addParam<bool>("lumping", false, "True for mass matrix lumping, false otherwise");
   params.addClassDescription("The time derivative operator with the weak form of $(\\psi_i, "
                              "\\frac{\\partial u_h}{\\partial t})$.");
@@ -22,6 +22,6 @@ KokkosTimeDerivative::validParams()
 }
 
 KokkosTimeDerivative::KokkosTimeDerivative(const InputParameters & parameters)
-  : Moose::Kokkos::TimeKernel(parameters), _lumping(getParam<bool>("lumping"))
+  : TimeKernel(parameters), _lumping(getParam<bool>("lumping"))
 {
 }

--- a/modules/heat_transfer/include/kokkos/bcs/KokkosConvectiveHeatFluxBC.h
+++ b/modules/heat_transfer/include/kokkos/bcs/KokkosConvectiveHeatFluxBC.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include "KokkosIntegratedBC.h"
+#include "KokkosIntegratedBCValue.h"
 
 /**
  * Boundary condition for convective heat flux where temperature and heat transfer coefficient are
  * given by material properties.
  */
-class KokkosConvectiveHeatFluxBC : public Moose::Kokkos::IntegratedBC
+class KokkosConvectiveHeatFluxBC : public Moose::Kokkos::IntegratedBCValue
 {
 public:
   static InputParameters validParams();
@@ -23,12 +23,9 @@ public:
   KokkosConvectiveHeatFluxBC(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int i,
-                                         const unsigned int j,
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int j,
                                          const unsigned int qp,
                                          AssemblyDatum & datum) const;
 
@@ -45,20 +42,17 @@ private:
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosConvectiveHeatFluxBC::computeQpResidual(const unsigned int i,
-                                              const unsigned int qp,
-                                              AssemblyDatum & datum) const
+KokkosConvectiveHeatFluxBC::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
 {
-  return -_test(datum, i, qp) * _htc(datum, qp) * (_T_infinity(datum, qp) - _u(datum, qp));
+  return -_htc(datum, qp) * (_T_infinity(datum, qp) - _u(datum, qp));
 }
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosConvectiveHeatFluxBC::computeQpJacobian(const unsigned int i,
-                                              const unsigned int j,
+KokkosConvectiveHeatFluxBC::computeQpJacobian(const unsigned int j,
                                               const unsigned int qp,
                                               AssemblyDatum & datum) const
 {
-  return -_test(datum, i, qp) * _phi(datum, j, qp) *
+  return -_phi(datum, j, qp) *
          (-_htc(datum, qp) + _htc_dT(datum, qp) * (_T_infinity(datum, qp) - _u(datum, qp)));
 }

--- a/modules/heat_transfer/include/kokkos/bcs/KokkosCoupledConvectiveHeatFluxBC.h
+++ b/modules/heat_transfer/include/kokkos/bcs/KokkosCoupledConvectiveHeatFluxBC.h
@@ -9,14 +9,14 @@
 
 #pragma once
 
-#include "KokkosIntegratedBC.h"
+#include "KokkosIntegratedBCValue.h"
 
 /**
  * Boundary condition for convective heat flux where temperature and heat transfer coefficient are
  * given by auxiliary variables.  Typically used in multi-app coupling scenario. It is possible to
  * couple in a vector variable where each entry corresponds to a "phase".
  */
-class KokkosCoupledConvectiveHeatFluxBC : public Moose::Kokkos::IntegratedBC
+class KokkosCoupledConvectiveHeatFluxBC : public Moose::Kokkos::IntegratedBCValue
 {
 public:
   static InputParameters validParams();
@@ -24,12 +24,9 @@ public:
   KokkosCoupledConvectiveHeatFluxBC(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int i,
-                                         const unsigned int j,
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int j,
                                          const unsigned int qp,
                                          AssemblyDatum & datum) const;
 
@@ -48,21 +45,19 @@ private:
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosCoupledConvectiveHeatFluxBC::computeQpResidual(const unsigned int i,
-                                                     const unsigned int qp,
+KokkosCoupledConvectiveHeatFluxBC::computeQpResidual(const unsigned int qp,
                                                      AssemblyDatum & datum) const
 {
   Real q = 0;
   Real u = _u(datum, qp);
   for (unsigned int c = 0; c < _n_components; c++)
     q += _alpha(datum, qp, c) * _htc(datum, qp, c) * (u - _T_infinity(datum, qp, c));
-  return _test(datum, i, qp) * q * _scale_factor(datum, qp);
+  return q * _scale_factor(datum, qp);
 }
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosCoupledConvectiveHeatFluxBC::computeQpJacobian(const unsigned int i,
-                                                     const unsigned int j,
+KokkosCoupledConvectiveHeatFluxBC::computeQpJacobian(const unsigned int j,
                                                      const unsigned int qp,
                                                      AssemblyDatum & datum) const
 {
@@ -70,5 +65,5 @@ KokkosCoupledConvectiveHeatFluxBC::computeQpJacobian(const unsigned int i,
   Real phi = _phi(datum, j, qp);
   for (unsigned int c = 0; c < _n_components; c++)
     dq += _alpha(datum, qp, c) * _htc(datum, qp, c) * phi;
-  return _test(datum, i, qp) * dq * _scale_factor(datum, qp);
+  return dq * _scale_factor(datum, qp);
 }

--- a/modules/heat_transfer/src/kokkos/bcs/KokkosConvectiveHeatFluxBC.K
+++ b/modules/heat_transfer/src/kokkos/bcs/KokkosConvectiveHeatFluxBC.K
@@ -14,7 +14,7 @@ registerKokkosResidualObject("HeatTransferApp", KokkosConvectiveHeatFluxBC);
 InputParameters
 KokkosConvectiveHeatFluxBC::validParams()
 {
-  InputParameters params = IntegratedBC::validParams();
+  InputParameters params = IntegratedBCValue::validParams();
   params.addClassDescription(
       "Convective heat transfer boundary condition with temperature and heat "
       "transfer coefficent given by material properties.");
@@ -31,7 +31,7 @@ KokkosConvectiveHeatFluxBC::validParams()
 }
 
 KokkosConvectiveHeatFluxBC::KokkosConvectiveHeatFluxBC(const InputParameters & parameters)
-  : IntegratedBC(parameters),
+  : IntegratedBCValue(parameters),
     _T_infinity(getKokkosMaterialProperty<Real>("T_infinity")),
     _htc(getKokkosMaterialProperty<Real>("heat_transfer_coefficient")),
     _htc_dT(getKokkosMaterialProperty<Real>("heat_transfer_coefficient_dT"))

--- a/modules/heat_transfer/src/kokkos/bcs/KokkosCoupledConvectiveHeatFluxBC.K
+++ b/modules/heat_transfer/src/kokkos/bcs/KokkosCoupledConvectiveHeatFluxBC.K
@@ -14,7 +14,7 @@ registerKokkosResidualObject("HeatTransferApp", KokkosCoupledConvectiveHeatFluxB
 InputParameters
 KokkosCoupledConvectiveHeatFluxBC::validParams()
 {
-  InputParameters params = IntegratedBC::validParams();
+  InputParameters params = IntegratedBCValue::validParams();
   params.addClassDescription(
       "Convective heat transfer boundary condition with temperature and heat "
       "transfer coefficent given by auxiliary variables.");
@@ -28,7 +28,7 @@ KokkosCoupledConvectiveHeatFluxBC::validParams()
 
 KokkosCoupledConvectiveHeatFluxBC::KokkosCoupledConvectiveHeatFluxBC(
     const InputParameters & parameters)
-  : IntegratedBC(parameters),
+  : IntegratedBCValue(parameters),
     _n_components(coupledComponents("T_infinity")),
     _T_infinity(kokkosCoupledValues("T_infinity")),
     _htc(kokkosCoupledValues("htc")),

--- a/modules/thermal_hydraulics/include/kokkos/bcs/KokkosRadiativeHeatFluxBC.h
+++ b/modules/thermal_hydraulics/include/kokkos/bcs/KokkosRadiativeHeatFluxBC.h
@@ -14,8 +14,7 @@
 /**
  * Radiative heat transfer boundary condition for a plate heat structure
  */
-class KokkosRadiativeHeatFluxBC final
-  : public KokkosRadiativeHeatFluxBCBase<KokkosRadiativeHeatFluxBC>
+class KokkosRadiativeHeatFluxBC : public KokkosRadiativeHeatFluxBCBase
 {
 public:
   static InputParameters validParams();

--- a/modules/thermal_hydraulics/include/kokkos/bcs/KokkosRadiativeHeatFluxBCBase.h
+++ b/modules/thermal_hydraulics/include/kokkos/bcs/KokkosRadiativeHeatFluxBCBase.h
@@ -9,27 +9,22 @@
 
 #pragma once
 
-#include "KokkosIntegratedBC.h"
+#include "KokkosIntegratedBCValue.h"
 
 /**
  * Boundary condition for radiative heat flux where temperature and the
  * temperature of a body in radiative heat transfer are specified.
  */
-template <typename RadiativeHeatFluxBC>
-class KokkosRadiativeHeatFluxBCBase : public Moose::Kokkos::IntegratedBC
+class KokkosRadiativeHeatFluxBCBase : public Moose::Kokkos::IntegratedBCValue
 {
 public:
   static InputParameters validParams();
-
   KokkosRadiativeHeatFluxBCBase(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int i,
-                                         const unsigned int j,
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int j,
                                          const unsigned int qp,
                                          AssemblyDatum & datum) const;
 
@@ -41,54 +36,27 @@ protected:
   const Real _tinf;
 };
 
-template <typename RadiativeHeatFluxBC>
-InputParameters
-KokkosRadiativeHeatFluxBCBase<RadiativeHeatFluxBC>::validParams()
-{
-  InputParameters params = IntegratedBC::validParams();
-  params.addParam<Real>("stefan_boltzmann_constant", 5.670367e-8, "The Stefan-Boltzmann constant.");
-  params.addParam<Real>("Tinfinity", 0, "Temperature of the body in radiative heat transfer.");
-  params.addClassDescription("Boundary condition for radiative heat flux where temperature and the"
-                             "temperature of a body in radiative heat transfer are specified.");
-  return params;
-}
-
-template <typename RadiativeHeatFluxBC>
-KokkosRadiativeHeatFluxBCBase<RadiativeHeatFluxBC>::KokkosRadiativeHeatFluxBCBase(
-    const InputParameters & parameters)
-  : IntegratedBC(parameters),
-    _sigma_stefan_boltzmann(getParam<Real>("stefan_boltzmann_constant")),
-    _tinf(getParam<Real>("Tinfinity"))
-{
-}
-
-template <typename RadiativeHeatFluxBC>
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosRadiativeHeatFluxBCBase<RadiativeHeatFluxBC>::computeQpResidual(const unsigned int i,
-                                                                      const unsigned int qp,
-                                                                      AssemblyDatum & datum) const
+KokkosRadiativeHeatFluxBCBase::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
 {
-  auto bc = static_cast<const RadiativeHeatFluxBC *>(this);
+  auto bc = static_cast<const Derived *>(this);
 
   Real T = _u(datum, qp);
   Real T4 = T * T * T * T;
   Real T4inf = _tinf * _tinf * _tinf * _tinf;
-  return _test(datum, i, qp) * _sigma_stefan_boltzmann * bc->coefficient() * (T4 - T4inf);
+  return _sigma_stefan_boltzmann * bc->coefficient() * (T4 - T4inf);
 }
 
-template <typename RadiativeHeatFluxBC>
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosRadiativeHeatFluxBCBase<RadiativeHeatFluxBC>::computeQpJacobian(const unsigned int i,
-                                                                      const unsigned int j,
-                                                                      const unsigned int qp,
-                                                                      AssemblyDatum & datum) const
+KokkosRadiativeHeatFluxBCBase::computeQpJacobian(const unsigned int j,
+                                                 const unsigned int qp,
+                                                 AssemblyDatum & datum) const
 {
-  auto bc = static_cast<const RadiativeHeatFluxBC *>(this);
+  auto bc = static_cast<const Derived *>(this);
 
   Real T = _u(datum, qp);
   Real T3 = T * T * T;
-  return 4 * _sigma_stefan_boltzmann * _test(datum, i, qp) * bc->coefficient() * T3 *
-         _phi(datum, j, qp);
+  return 4 * _sigma_stefan_boltzmann * bc->coefficient() * T3 * _phi(datum, j, qp);
 }

--- a/modules/thermal_hydraulics/src/kokkos/bcs/KokkosRadiativeHeatFluxBCBase.K
+++ b/modules/thermal_hydraulics/src/kokkos/bcs/KokkosRadiativeHeatFluxBCBase.K
@@ -1,0 +1,28 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "KokkosRadiativeHeatFluxBCBase.h"
+
+InputParameters
+KokkosRadiativeHeatFluxBCBase::validParams()
+{
+  InputParameters params = IntegratedBCValue::validParams();
+  params.addParam<Real>("stefan_boltzmann_constant", 5.670367e-8, "The Stefan-Boltzmann constant.");
+  params.addParam<Real>("Tinfinity", 0, "Temperature of the body in radiative heat transfer.");
+  params.addClassDescription("Boundary condition for radiative heat flux where temperature and the"
+                             "temperature of a body in radiative heat transfer are specified.");
+  return params;
+}
+
+KokkosRadiativeHeatFluxBCBase::KokkosRadiativeHeatFluxBCBase(const InputParameters & parameters)
+  : IntegratedBCValue(parameters),
+    _sigma_stefan_boltzmann(getParam<Real>("stefan_boltzmann_constant")),
+    _tinf(getParam<Real>("Tinfinity"))
+{
+}

--- a/test/include/kokkos/kernels/KokkosXYBodyForce.h
+++ b/test/include/kokkos/kernels/KokkosXYBodyForce.h
@@ -19,17 +19,13 @@ public:
   KokkosXYBodyForce(const InputParameters & parameters);
 
   template <typename Derived>
-  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
-                                         const unsigned int qp,
-                                         AssemblyDatum & datum) const;
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
 };
 
 template <typename Derived>
 KOKKOS_FUNCTION Real
-KokkosXYBodyForce::computeQpResidual(const unsigned int i,
-                                     const unsigned int qp,
-                                     AssemblyDatum & datum) const
+KokkosXYBodyForce::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
 {
   return (datum.q_point(qp)(0) + datum.q_point(qp)(1)) *
-         KokkosBodyForce::computeQpResidual<Derived>(i, qp, datum);
+         KokkosBodyForce::computeQpResidual<Derived>(qp, datum);
 }


### PR DESCRIPTION
## Reason
Local DOF loop in kernels can also be parallelized, but Kokkos kernels have not been leveraging the parallelism, mainly because it is difficult to achieve an optimal parallelization due to varying number of local DOFs in each element. However, it is still better to have a suboptimal parallelization than not having one at all. Even suboptimal parallelization turned out to be very effective in a second-order case.

## Design
Add parallelization to local DOF loops. Users will need to play with the number of threads to find a sweet spot.

## Impact
Improved performance.