### PR TITLE
Explicitly link torch_cpu and c10 to fix downstream undefined reference

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -138,7 +138,7 @@ ifeq ($(ENABLE_LIBTORCH),true)
 		libmesh_CPPFLAGS += -isystem $(LIBTORCH_DIR)/include/c10
 
     # Dynamically linking with the available pytorch library
-    libmesh_LDFLAGS += -Wl,-rpath,$(LIBTORCH_DIR)/lib -L$(LIBTORCH_DIR)/lib -ltorch
+    libmesh_LDFLAGS += -Wl,-rpath,$(LIBTORCH_DIR)/lib -L$(LIBTORCH_DIR)/lib -ltorch -ltorch_cpu -lc10
 
   else
 		# No libtorch library found


### PR DESCRIPTION
Without `--copy-dt-needed-entries`, transitive `DT_NEEDED` entries from `libtorch.so` are not propagated to downstream apps. Adding `-ltorch_cpu` and `-lc10` explicitly resolves undefined references such as `c10::IValue::reportToTensorTypeError()`.

Refs #32784