### PR TITLE
Avoid bool->PetscBool conversions

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -335,9 +335,8 @@ addPetscOptionsFromCommandline(FEProblemBase * const problem)
   // Some vector/matrix-type options may have been consumed before the PETSc database rebuild.
   // Replay only the command-line-controlled applications so input-file options handled through
   // setSinglePetscOption() do not pay the cost twice.
-  bool have_vec_type = false;
+  bool have_vec_type = petscOptionsHasName(command_line_options, "-vec_type");
   bool have_mat_type = false;
-  have_vec_type = petscOptionsHasName(command_line_options, "-vec_type");
 
   for (const auto sys_index : make_range(problem->numSolverSystems()))
   {

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -335,7 +335,7 @@ addPetscOptionsFromCommandline(FEProblemBase * const problem)
   // Some vector/matrix-type options may have been consumed before the PETSc database rebuild.
   // Replay only the command-line-controlled applications so input-file options handled through
   // setSinglePetscOption() do not pay the cost twice.
-  PetscBool have_vec_type = PETSC_FALSE;
+  bool have_vec_type = false;
   bool have_mat_type = false;
   have_vec_type = petscOptionsHasName(command_line_options, "-vec_type");
 

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -335,7 +335,7 @@ addPetscOptionsFromCommandline(FEProblemBase * const problem)
   // Some vector/matrix-type options may have been consumed before the PETSc database rebuild.
   // Replay only the command-line-controlled applications so input-file options handled through
   // setSinglePetscOption() do not pay the cost twice.
-  bool have_vec_type = petscOptionsHasName(command_line_options, "-vec_type");
+  const bool have_vec_type = petscOptionsHasName(command_line_options, "-vec_type");
   bool have_mat_type = false;
 
   for (const auto sys_index : make_range(problem->numSolverSystems()))


### PR DESCRIPTION
My combination of gcc and PETSc don't seem to want to allow this conversion, only the other way around.

This fixes #32790 for me