### PR TITLE
Add backtracking to ElementJacobianDamper

### DIFF
--- a/modules/solid_mechanics/doc/content/source/dampers/ElementJacobianDamper.md
+++ b/modules/solid_mechanics/doc/content/source/dampers/ElementJacobianDamper.md
@@ -4,7 +4,9 @@
 
 This damper limits the change in the Jacobians of elements. The damper becomes active if the relative change in Jacobian of any element exceeds the user defined maximum. This damper must be run on the displaced mesh.
 
-Set `use_backtracking = true` to have the damper iteratively cut back a trial nonlinear update when probing it would otherwise produce a degenerate element map.
+Set [!param](/Dampers/ElementJacobianDamper/use_backtracking) to true to have the damper
+iteratively cut back a trial nonlinear update when probing. Without backtracking, a trial update
+that creates a degenerate element map will immediately raise an exception.
 
 !syntax parameters /Dampers/ElementJacobianDamper
 

--- a/modules/solid_mechanics/doc/content/source/dampers/ElementJacobianDamper.md
+++ b/modules/solid_mechanics/doc/content/source/dampers/ElementJacobianDamper.md
@@ -4,6 +4,8 @@
 
 This damper limits the change in the Jacobians of elements. The damper becomes active if the relative change in Jacobian of any element exceeds the user defined maximum. This damper must be run on the displaced mesh.
 
+Set `use_backtracking = true` to have the damper iteratively cut back a trial nonlinear update when probing it would otherwise produce a degenerate element map.
+
 !syntax parameters /Dampers/ElementJacobianDamper
 
 !syntax inputs /Dampers/ElementJacobianDamper

--- a/modules/solid_mechanics/include/dampers/ElementJacobianDamper.h
+++ b/modules/solid_mechanics/include/dampers/ElementJacobianDamper.h
@@ -36,6 +36,15 @@ public:
   virtual Real computeDamping(const NumericVector<Number> & /* solution */,
                               const NumericVector<Number> & update) override;
 
+  /**
+   * Probe a damped update on the displaced mesh and report the maximum relative
+   * change in JxW. Returns false if the trial update produces a degenerate map.
+   */
+  bool probeDamping(const NumericVector<Number> & update,
+                    Real damping,
+                    Real & max_difference,
+                    std::string & error_message);
+
 protected:
   /// Thread ID
   THREAD_ID _tid;
@@ -67,4 +76,13 @@ protected:
 
   /// Maximum allowed relative increment in Jacobian
   const Real _max_jacobian_diff;
+
+  /// Whether to backtrack the trial update when probing would otherwise create a degenerate map
+  const bool _use_backtracking;
+
+  /// Multiplicative cutback applied during backtracking
+  const Real _backtrack_factor;
+
+  /// Maximum number of backtracking attempts
+  const unsigned int _max_backtrack_steps;
 };

--- a/modules/solid_mechanics/src/dampers/ElementJacobianDamper.C
+++ b/modules/solid_mechanics/src/dampers/ElementJacobianDamper.C
@@ -16,9 +16,30 @@
 #include "libmesh/quadrature.h" // _qrule
 
 // C++
-#include <cstring> // for "Jacobian" exception test
+#include <algorithm>
+#include <limits>
 
 registerMooseObject("SolidMechanicsApp", ElementJacobianDamper);
+
+namespace
+{
+bool
+isRecoverableProbeException(const std::string & message)
+{
+  return message.find("Jacobian") != std::string::npos ||
+         message.find("singular") != std::string::npos ||
+         message.find("det != 0") != std::string::npos;
+}
+
+void
+restoreNodes(Elem & elem, const std::vector<Point> & point_copies)
+{
+  mooseAssert(elem.n_nodes() == point_copies.size(), "Node restore cache is the wrong size");
+
+  for (unsigned int i = 0; i < elem.n_nodes(); ++i)
+    elem.node_ref(i) = point_copies[i];
+}
+}
 
 InputParameters
 ElementJacobianDamper::validParams()
@@ -31,6 +52,19 @@ ElementJacobianDamper::validParams()
       "max_increment",
       0.1,
       "The maximum permissible relative increment in the Jacobian per Newton iteration");
+  params.addParam<bool>(
+      "use_backtracking",
+      false,
+      "If true, iteratively cut back the probed Newton update until the displaced mesh remains "
+      "nondegenerate and the Jacobian increment stays within max_increment.");
+  params.addRangeCheckedParam<Real>(
+      "backtrack_factor",
+      0.5,
+      "backtrack_factor > 0 & backtrack_factor < 1",
+      "Multiplicative cutback applied to the trial damping during ElementJacobianDamper "
+      "backtracking.");
+  params.addParam<unsigned int>(
+      "max_backtrack_steps", 12, "Maximum number of ElementJacobianDamper backtracking attempts.");
   params.set<bool>("use_displaced_mesh") = true;
   return params;
 }
@@ -43,7 +77,10 @@ ElementJacobianDamper::ElementJacobianDamper(const InputParameters & parameters)
     _JxW(_assembly.JxW()),
     _fe_problem(*parameters.getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
     _displaced_problem(_fe_problem.getDisplacedProblem()),
-    _max_jacobian_diff(parameters.get<Real>("max_increment"))
+    _max_jacobian_diff(parameters.get<Real>("max_increment")),
+    _use_backtracking(getParam<bool>("use_backtracking")),
+    _backtrack_factor(getParam<Real>("backtrack_factor")),
+    _max_backtrack_steps(getParam<unsigned int>("max_backtrack_steps"))
 {
   if (_displaced_problem == NULL)
     mooseError("ElementJacobianDamper: Must use displaced problem");
@@ -69,85 +106,187 @@ Real
 ElementJacobianDamper::computeDamping(const NumericVector<Number> & /* solution */,
                                       const NumericVector<Number> & update)
 {
-  // Maximum difference in the Jacobian for this Newton iteration
-  Real max_difference = 0.0;
+  auto probe_trial =
+      [&](const Real trial_damping, Real & max_difference, std::string & error_message)
+  {
+    const bool valid_local = probeDamping(update, trial_damping, max_difference, error_message);
+
+    _communicator.max(max_difference);
+
+    int invalid_local = valid_local ? 0 : 1;
+    std::vector<int> invalid_ranks(_communicator.size());
+    _communicator.allgather(invalid_local, invalid_ranks);
+
+    processor_id_type invalid_processor = 0;
+    const auto invalid_it = std::find(invalid_ranks.begin(), invalid_ranks.end(), 1);
+    const bool invalid_global = invalid_it != invalid_ranks.end();
+    if (invalid_global)
+      invalid_processor = std::distance(invalid_ranks.begin(), invalid_it);
+
+    if (invalid_global)
+      _communicator.broadcast(error_message, invalid_processor);
+
+    return !invalid_global;
+  };
+
+  if (!_use_backtracking)
+  {
+    Real max_difference = 0.0;
+    std::string error_message;
+
+    PARALLEL_TRY
+    {
+      if (!probe_trial(/*trial_damping=*/1.0, max_difference, error_message))
+        _fe_problem.setException(error_message);
+    }
+    PARALLEL_CATCH;
+
+    if (max_difference > _max_jacobian_diff)
+      return _max_jacobian_diff / max_difference;
+
+    return 1.0;
+  }
+
+  const Real minimum_trial_damping = std::max(_min_damping, std::numeric_limits<Real>::epsilon());
+  Real damping = 1.0;
+  std::string error_message;
+
+  for (unsigned int step = 0; step <= _max_backtrack_steps; ++step)
+  {
+    Real max_difference = 0.0;
+    bool valid = false;
+
+    PARALLEL_TRY { valid = probe_trial(damping, max_difference, error_message); }
+    PARALLEL_CATCH;
+
+    unsigned int has_exception = _fe_problem.hasException() ? 1 : 0;
+    _communicator.max(has_exception);
+    if (has_exception)
+      return damping;
+
+    if (valid && max_difference <= _max_jacobian_diff)
+      return damping;
+
+    if (damping <= minimum_trial_damping || step == _max_backtrack_steps)
+    {
+      if (!valid)
+        _fe_problem.setException(error_message.empty()
+                                     ? "ElementJacobianDamper could not find a nondegenerate "
+                                       "trial update."
+                                     : error_message);
+      else
+        _fe_problem.setException("ElementJacobianDamper could not reduce the relative Jacobian "
+                                 "increment below max_increment without driving the damping "
+                                 "factor below a usable threshold.");
+      return damping;
+    }
+
+    if (!valid)
+      damping *= _backtrack_factor;
+    else
+      damping =
+          std::min(damping * _backtrack_factor, damping * _max_jacobian_diff / max_difference);
+  }
+
+  return damping;
+}
+
+bool
+ElementJacobianDamper::probeDamping(const NumericVector<Number> & update,
+                                    const Real damping,
+                                    Real & max_difference,
+                                    std::string & error_message)
+{
   MooseArray<Real> JxW_displaced;
 
   // Vector for storing the original node coordinates
   std::vector<Point> point_copies;
 
-  PARALLEL_TRY
+  max_difference = 0.0;
+  error_message.clear();
+
+  try
   {
-    try
+    // Loop over elements in the mesh
+    for (auto & current_elem : _mesh->getMesh().active_local_element_ptr_range())
     {
-      // Loop over elements in the mesh
-      for (auto & current_elem : _mesh->getMesh().active_local_element_ptr_range())
+      point_copies.clear();
+      point_copies.reserve(current_elem->n_nodes());
+
+      // Displace nodes with the trial Newton increment
+      for (unsigned int i = 0; i < current_elem->n_nodes(); ++i)
       {
-        point_copies.clear();
-        point_copies.reserve(current_elem->n_nodes());
+        Node & displaced_node = current_elem->node_ref(i);
 
-        // Displace nodes with current Newton increment
-        for (unsigned int i = 0; i < current_elem->n_nodes(); ++i)
+        point_copies.push_back(displaced_node);
+
+        for (unsigned int j = 0; j < _ndisp; ++j)
         {
-          Node & displaced_node = current_elem->node_ref(i);
-
-          point_copies.push_back(displaced_node);
-
-          for (unsigned int j = 0; j < _ndisp; ++j)
-          {
-            dof_id_type disp_dof_num =
-                displaced_node.dof_number(_sys.number(), _disp_var[j]->number(), 0);
-            displaced_node(j) += update(disp_dof_num);
-          }
+          const dof_id_type disp_dof_num =
+              displaced_node.dof_number(_sys.number(), _disp_var[j]->number(), 0);
+          displaced_node(j) += damping * update(disp_dof_num);
         }
+      }
 
-        // Reinit element to compute Jacobian of displaced element
+      try
+      {
+        // Reinit element to compute Jacobian of the trial displaced element
         _assembly.reinit(current_elem);
         JxW_displaced = _JxW;
-
-        // Un-displace nodes
-        for (unsigned int i = 0; i < current_elem->n_nodes(); ++i)
-        {
-          Node & displaced_node = current_elem->node_ref(i);
-
-          for (unsigned int j = 0; j < _ndisp; ++j)
-            displaced_node(j) = point_copies[i](j);
-        }
-
-        // Reinit element to compute Jacobian before displacement
-        _assembly.reinit(current_elem);
-
-        for (unsigned int qp = 0; qp < _qrule->n_points(); ++qp)
-        {
-          Real diff = std::abs(JxW_displaced[qp] - _JxW[qp]) / _JxW[qp];
-          if (diff > max_difference)
-            max_difference = diff;
-        }
-
-        JxW_displaced.release();
       }
-    }
-    catch (MooseException & e)
-    {
-      _fe_problem.setException(e.what());
-    }
-    catch (std::exception & e)
-    {
-      // Continue if we find a libMesh degenerate map exception, but
-      // just throw for any real error
-      if (!strstr(e.what(), "Jacobian") && !strstr(e.what(), "singular") &&
-          !strstr(e.what(), "det != 0"))
-        throw;
+      catch (const std::exception & e)
+      {
+        restoreNodes(*current_elem, point_copies);
 
-      _fe_problem.setException(e.what());
+        // Degenerate-map failures mean this trial damping is too aggressive
+        if (isRecoverableProbeException(e.what()))
+        {
+          error_message = e.what();
+          return false;
+        }
+
+        throw;
+      }
+
+      restoreNodes(*current_elem, point_copies);
+
+      // Reinit element to compute Jacobian before displacement
+      try
+      {
+        _assembly.reinit(current_elem);
+      }
+      catch (const std::exception & e)
+      {
+        if (isRecoverableProbeException(e.what()))
+        {
+          error_message = e.what();
+          return false;
+        }
+
+        throw;
+      }
+
+      for (unsigned int qp = 0; qp < _qrule->n_points(); ++qp)
+      {
+        const Real denominator = std::max(std::abs(_JxW[qp]), libMesh::TOLERANCE);
+        const Real diff = std::abs(JxW_displaced[qp] - _JxW[qp]) / denominator;
+        if (diff > max_difference)
+          max_difference = diff;
+      }
+
+      JxW_displaced.release();
     }
   }
-  PARALLEL_CATCH;
+  catch (const MooseException & e)
+  {
+    error_message = e.what();
 
-  _communicator.max(max_difference);
+    if (isRecoverableProbeException(error_message))
+      return false;
 
-  if (max_difference > _max_jacobian_diff)
-    return _max_jacobian_diff / max_difference;
+    _fe_problem.setException(error_message);
+    return false;
+  }
 
-  return 1.0;
+  return true;
 }

--- a/modules/solid_mechanics/src/dampers/ElementJacobianDamper.C
+++ b/modules/solid_mechanics/src/dampers/ElementJacobianDamper.C
@@ -108,14 +108,19 @@ ElementJacobianDamper::computeDamping(const NumericVector<Number> & /* solution 
 
     _communicator.max(max_difference);
 
-    unsigned int invalid_local = trial_nondegenerate_local ? 0 : 1;
-    processor_id_type first_invalid_processor = 0;
-    _communicator.maxloc(invalid_local, first_invalid_processor);
+    const unsigned int invalid_local = trial_nondegenerate_local ? 0 : 1;
+    unsigned int invalid = invalid_local;
+    _communicator.max(invalid);
 
-    if (invalid_local)
+    if (invalid)
+    {
+      processor_id_type first_invalid_processor =
+          invalid_local ? _communicator.rank() : std::numeric_limits<processor_id_type>::max();
+      _communicator.min(first_invalid_processor);
       _communicator.broadcast(error_message, first_invalid_processor);
+    }
 
-    return !invalid_local;
+    return !invalid;
   };
 
   if (!_use_backtracking)

--- a/modules/solid_mechanics/src/dampers/ElementJacobianDamper.C
+++ b/modules/solid_mechanics/src/dampers/ElementJacobianDamper.C
@@ -17,26 +17,19 @@
 
 // C++
 #include <algorithm>
+#include <cstring> // for "Jacobian" exception test
 #include <limits>
 
 registerMooseObject("SolidMechanicsApp", ElementJacobianDamper);
 
 namespace
 {
-bool
-isRecoverableProbeException(const std::string & message)
-{
-  return message.find("Jacobian") != std::string::npos ||
-         message.find("singular") != std::string::npos ||
-         message.find("det != 0") != std::string::npos;
-}
-
 void
 restoreNodes(Elem & elem, const std::vector<Point> & point_copies)
 {
   mooseAssert(elem.n_nodes() == point_copies.size(), "Node restore cache is the wrong size");
 
-  for (unsigned int i = 0; i < elem.n_nodes(); ++i)
+  for (const auto i : make_range(elem.n_nodes()))
     elem.node_ref(i) = point_copies[i];
 }
 }
@@ -55,8 +48,9 @@ ElementJacobianDamper::validParams()
   params.addParam<bool>(
       "use_backtracking",
       false,
-      "If true, iteratively cut back the probed Newton update until the displaced mesh remains "
-      "nondegenerate and the Jacobian increment stays within max_increment.");
+      "If true, iteratively cut back the probed Newton update when a full trial update would "
+      "create a degenerate displaced element map. The accepted trial must also satisfy "
+      "max_increment.");
   params.addRangeCheckedParam<Real>(
       "backtrack_factor",
       0.5,
@@ -77,7 +71,7 @@ ElementJacobianDamper::ElementJacobianDamper(const InputParameters & parameters)
     _JxW(_assembly.JxW()),
     _fe_problem(*parameters.getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
     _displaced_problem(_fe_problem.getDisplacedProblem()),
-    _max_jacobian_diff(parameters.get<Real>("max_increment")),
+    _max_jacobian_diff(getParam<Real>("max_increment")),
     _use_backtracking(getParam<bool>("use_backtracking")),
     _backtrack_factor(getParam<Real>("backtrack_factor")),
     _max_backtrack_steps(getParam<unsigned int>("max_backtrack_steps"))
@@ -109,24 +103,19 @@ ElementJacobianDamper::computeDamping(const NumericVector<Number> & /* solution 
   auto probe_trial =
       [&](const Real trial_damping, Real & max_difference, std::string & error_message)
   {
-    const bool valid_local = probeDamping(update, trial_damping, max_difference, error_message);
+    const bool trial_nondegenerate_local =
+        probeDamping(update, trial_damping, max_difference, error_message);
 
     _communicator.max(max_difference);
 
-    int invalid_local = valid_local ? 0 : 1;
-    std::vector<int> invalid_ranks(_communicator.size());
-    _communicator.allgather(invalid_local, invalid_ranks);
+    unsigned int invalid_local = trial_nondegenerate_local ? 0 : 1;
+    processor_id_type first_invalid_processor = 0;
+    _communicator.maxloc(invalid_local, first_invalid_processor);
 
-    processor_id_type invalid_processor = 0;
-    const auto invalid_it = std::find(invalid_ranks.begin(), invalid_ranks.end(), 1);
-    const bool invalid_global = invalid_it != invalid_ranks.end();
-    if (invalid_global)
-      invalid_processor = std::distance(invalid_ranks.begin(), invalid_it);
+    if (invalid_local)
+      _communicator.broadcast(error_message, first_invalid_processor);
 
-    if (invalid_global)
-      _communicator.broadcast(error_message, invalid_processor);
-
-    return !invalid_global;
+    return !invalid_local;
   };
 
   if (!_use_backtracking)
@@ -151,25 +140,21 @@ ElementJacobianDamper::computeDamping(const NumericVector<Number> & /* solution 
   Real damping = 1.0;
   std::string error_message;
 
+  // Try 1 step, then at most max_backtrack_steps extra steps
   for (unsigned int step = 0; step <= _max_backtrack_steps; ++step)
   {
     Real max_difference = 0.0;
-    bool valid = false;
+    bool trial_nondegenerate = false;
 
-    PARALLEL_TRY { valid = probe_trial(damping, max_difference, error_message); }
+    PARALLEL_TRY { trial_nondegenerate = probe_trial(damping, max_difference, error_message); }
     PARALLEL_CATCH;
 
-    unsigned int has_exception = _fe_problem.hasException() ? 1 : 0;
-    _communicator.max(has_exception);
-    if (has_exception)
-      return damping;
-
-    if (valid && max_difference <= _max_jacobian_diff)
+    if (trial_nondegenerate && max_difference <= _max_jacobian_diff)
       return damping;
 
     if (damping <= minimum_trial_damping || step == _max_backtrack_steps)
     {
-      if (!valid)
+      if (!trial_nondegenerate)
         _fe_problem.setException(error_message.empty()
                                      ? "ElementJacobianDamper could not find a nondegenerate "
                                        "trial update."
@@ -178,10 +163,13 @@ ElementJacobianDamper::computeDamping(const NumericVector<Number> & /* solution 
         _fe_problem.setException("ElementJacobianDamper could not reduce the relative Jacobian "
                                  "increment below max_increment without driving the damping "
                                  "factor below a usable threshold.");
+
+      // The exception flag will abort the nonlinear step after the damper returns, so return the
+      // last trial damping only to satisfy the interface.
       return damping;
     }
 
-    if (!valid)
+    if (!trial_nondegenerate)
       damping *= _backtrack_factor;
     else
       damping =
@@ -239,7 +227,8 @@ ElementJacobianDamper::probeDamping(const NumericVector<Number> & update,
         restoreNodes(*current_elem, point_copies);
 
         // Degenerate-map failures mean this trial damping is too aggressive
-        if (isRecoverableProbeException(e.what()))
+        if (strstr(e.what(), "Jacobian") || strstr(e.what(), "singular") ||
+            strstr(e.what(), "det != 0"))
         {
           error_message = e.what();
           return false;
@@ -257,7 +246,8 @@ ElementJacobianDamper::probeDamping(const NumericVector<Number> & update,
       }
       catch (const std::exception & e)
       {
-        if (isRecoverableProbeException(e.what()))
+        if (strstr(e.what(), "Jacobian") || strstr(e.what(), "singular") ||
+            strstr(e.what(), "det != 0"))
         {
           error_message = e.what();
           return false;
@@ -280,11 +270,7 @@ ElementJacobianDamper::probeDamping(const NumericVector<Number> & update,
   catch (const MooseException & e)
   {
     error_message = e.what();
-
-    if (isRecoverableProbeException(error_message))
-      return false;
-
-    _fe_problem.setException(error_message);
+    _fe_problem.setException(e.what());
     return false;
   }
 

--- a/modules/solid_mechanics/test/tests/jacobian_damper/tests
+++ b/modules/solid_mechanics/test/tests/jacobian_damper/tests
@@ -38,4 +38,12 @@
     expect_exit_code = 0
     expect_err = 'negative Jacobian'
   []
+  [backtrack_negative_jacobian]
+    type = RunApp
+    input = 'exception_handling.i'
+    cli_args = 'Dampers/jac/use_backtracking=true'
+    max_parallel = 1
+    expect_out = 'Damping factor:'
+    requirement = "The element Jacobian damper shall optionally backtrack a trial nonlinear update to avoid generating a degenerate element map."
+  []
 []


### PR DESCRIPTION
refs #32806

## Reason

`ElementJacobianDamper` already limits large element Jacobian changes on the displaced mesh, but
its probe path can still encounter a degenerate map when the full trial Newton update inverts an
element. In that case the solve falls back to a timestep cutback instead of trying a smaller
nonlinear update first.

This change adds an opt-in backtracking mode so the damper can reduce the probed update before FE
assembly reaches a `DegenerateMap`.

## Design

- Add optional `use_backtracking`, `backtrack_factor`, and `max_backtrack_steps` parameters to
  `ElementJacobianDamper`.
- Refactor the damper probe into a helper that tests a damped trial update and reports the maximum
  relative `JxW` change.
- Treat degenerate-map exceptions during the probe as a signal that the trial damping is too large,
  then iteratively reduce the trial damping until the probe succeeds and the Jacobian increment is
  below `max_increment`.
- Always restore displaced node coordinates after a failed probe so the damper does not leave the
  displaced mesh in a modified state.
- Add a regression test covering the new backtracking path and update the damper documentation.

## Impact

This is a backward-compatible enhancement to `ElementJacobianDamper`.

- Existing input files are unchanged unless they opt into `use_backtracking = true`.
- The new mode improves robustness for large-displacement solves that would otherwise fail probing a
  nonlinear update due to temporary element inversion.
- No existing APIs are removed or changed incompatibly.

## Testing

- Ran `exception_handling.i` without backtracking to confirm the existing negative-Jacobian path is
  preserved.
- Ran `exception_handling.i` with `Dampers/jac/use_backtracking=true` to confirm the damper now
  reduces the update without emitting the negative-Jacobian error.
- Ran `git diff --check`.