### PR TITLE
Increase slots for python tests

### DIFF
--- a/test/tests/hdgkernels/ip-advection-diffusion/tests
+++ b/test/tests/hdgkernels/ip-advection-diffusion/tests
@@ -27,36 +27,42 @@
       input = test.py
       test_case = TestMonomialTri
       detail = 'simplex elements with a monomial basis for the interior variable,'
+      min_slots = 2
     []
     [monomial_quad]
       type = MMSTest
       input = test.py
       test_case = TestMonomialQuad
       detail = 'tensor-product elements with a monomial basis for the interior variable,'
+      min_slots = 2
     []
     [lagrange_tri]
       type = MMSTest
       input = test.py
       test_case = TestLagrangeTri
       detail = 'simplex elements with a L2 lagrange basis for the interior variable,'
+      min_slots = 2
     []
     [lagrange_quad]
       type = MMSTest
       input = test.py
       test_case = TestLagrangeQuad
       detail = 'tensor-product elements with a L2 lagrange basis for the interior variable,'
+      min_slots = 2
     []
     [hierarchic_tri]
       type = MMSTest
       input = test.py
       test_case = TestHierarchicTri
       detail = 'simplex elements with a L2 hierarchic basis for the interior variable, and'
+      min_slots = 2
     []
     [hierarchic_quad]
       type = MMSTest
       input = test.py
       test_case = TestHierarchicQuad
       detail = 'tensor-product elements with a L2 hierarchic basis for the interior variable.'
+      min_slots = 2
     []
   []
   [simple_advection]

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -152,6 +152,7 @@
     input = 'test_json.py'
     test_case = "TestFull"
     max_buffer_size = -1
+    min_slots = 2 # memory heavy
     issues = '#7855 #7661 #2881 #10839 #12455'
     design = 'JsonInputFileFormatter.md MooseApp.md'
     requirement = 'The system shall be able to dump input file syntax in JSON format.'
@@ -162,6 +163,7 @@
     input = 'test_json.py'
     test_case = "TestNoTestObjects"
     max_buffer_size = -1
+    min_slots = 2 # memory heavy
     issues = '#7855 #7661 #2881 #10839 #12455'
     design = 'JsonInputFileFormatter.md MooseApp.md'
     requirement = 'The system shall be able to dump input file syntax in JSON format and exclude test object syntax.'
@@ -173,6 +175,7 @@
     input = 'test_json.py'
     test_case = "TestSearch"
     max_buffer_size = -1
+    min_slots = 2 # memory heavy
     issues = '#7855 #7661 #2881 #10839 #12455'
     design = 'JsonInputFileFormatter.md MooseApp.md'
     requirement = 'The system shall be able to dump a subset of JSON formatted syntax.'


### PR DESCRIPTION
## Reason
Python tests seem to have fluctuating memory usage and get killed with `OVER MEMORY` error very frequently.

## Design
Request more slots.

## Impact
Less random failure.