### PR TITLE
Deduplicate rpath flags in libmesh_LIBS and libmesh_LDFLAGS to suppress MacOS linker warnings

### DIFF
--- a/framework/build.mk
+++ b/framework/build.mk
@@ -53,6 +53,12 @@ libmesh_LIBS     := $(shell METHOD=$(METHOD) $(libmesh_config) --libs)
 libmesh_HOST     := $(shell METHOD=$(METHOD) $(libmesh_config) --host)
 libmesh_LDFLAGS  := $(shell METHOD=$(METHOD) $(libmesh_config) --ldflags)
 
+# Deduplicate rpath flags; libmesh-config --libs embeds rpaths from each bundled
+# dependency (libmesh, timpi, petsc) that share an installation prefix, producing
+# duplicate -rpath entries that macOS ld warns about.
+libmesh_LIBS    := $(shell printf '%s\n' $(libmesh_LIBS) | awk '!seen[$$0]++' | tr '\n' ' ')
+libmesh_LDFLAGS := $(shell printf '%s\n' $(libmesh_LDFLAGS) | awk '!seen[$$0]++' | tr '\n' ' ')
+
 # In the event that we're using something like mpicxx, query it for
 # the underlying compiler (like mpicxx -show); otherwise, fallback to
 # whatever libmesh_CXX is

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -211,6 +211,10 @@ else
 	PYMOD_COMPILEFLAGS := -L$(shell $(pyconfig) --prefix)/lib -Wl,-rpath,$(shell $(pyconfig) --prefix)/lib $(shell $(pyconfig) --includes)
 endif
 
+# Deduplicate rpath flags accumulated from wasp, MFEM, NEML2, etc. to suppress
+# duplicate -rpath linker warnings on macOS when dependencies share an install prefix.
+libmesh_LDFLAGS := $(shell printf '%s\n' $(libmesh_LDFLAGS) | awk '!seen[$$0]++' | tr '\n' ' ')
+
 $(pyhit_srcfiles) $(hit_CLI_srcfiles): | prebuild
 
 pyhit_LIB          := $(HIT_DIR)/hit.$(PYMOD_EXTENSION)


### PR DESCRIPTION
`libmesh-config --libs` embeds `-rpath` entries from each bundled dependency (libmesh, timpi, petsc) that share an installation prefix, producing duplicate `-rpath` flags that Apple `ld` warns about on macOS/Apple Silicon.

Refs #31412