### PR TITLE
Add autotools to moose-build

### DIFF
--- a/conda/build/meta.yaml
+++ b/conda/build/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2026.04.21" %}
+{% set version = "2026.04.27" %}
 
 package:
   name: moose-build
@@ -57,6 +57,8 @@ requirements:
     - hdf5 {{ hdf5 }}
     - hdf5 {{ hdf5 }} mpi_{{ mpi }}_*
     # Build tools
+    - autoconf
+    - automake
     - bison
     - cmake
     - make

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -1,8 +1,4 @@
-# Making a Change to this package?
-# REMEMBER TO UPDATE the .yaml files for the following packages:
-#   moose/conda_build_config.yaml
-# As well as any directions pertaining to modifying those files.
-{% set version = "2026.04.21" %}
+{% set version = "2026.04.27" %}
 
 package:
   name: moose-dev
@@ -19,14 +15,14 @@ build:
   run_exports:
     # things that depend on this moose-dev must use the
     # exact moose-* packages that this was built with
-    - moose-build 2026.04.21 {{ mpi }}
+    - moose-build 2026.04.27 {{ mpi }}
     - moose-libmesh 2026.04.13_0185b8b {{ mpi }}_0
     - moose-wasp 2025.09.19_02960f1 build_6
     - moose-tools 2026.04.21
 
 requirements:
   run:
-    - moose-build 2026.04.21 {{ mpi }}
+    - moose-build 2026.04.27 {{ mpi }}
     - moose-libmesh 2026.04.13_0185b8b {{ mpi }}_0
     - moose-wasp 2025.09.19_02960f1 build_6
     - moose-tools 2026.04.21


### PR DESCRIPTION
Follow-on to #32572 that we need to be able to use moose-build successfully for libmesh CI