### PR TITLE
Suppress a threading false positive in valgrind testing

### DIFF
--- a/python/TestHarness/suppressions/errors.supp
+++ b/python/TestHarness/suppressions/errors.supp
@@ -183,6 +183,20 @@
    ...
 }
 {
+   kokkos_openmp_tls_init_false_positive
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   ...
+   fun:allocate_dtv
+   ...
+   fun:_dl_allocate_tls
+   fun:pthread_create*
+   ...
+   fun:GOMP_parallel
+   ...
+}
+{
    Boost_math
    Memcheck:Leak
    ...


### PR DESCRIPTION
occurring post the fix for #32058

@BozoVazic this should be enough to remedy the issue