### PR TITLE
Make April 2026 news public

### DIFF
--- a/framework/doc/content/syntax/KokkosKernels/index.md
+++ b/framework/doc/content/syntax/KokkosKernels/index.md
@@ -110,7 +110,7 @@ See the following source codes of `KokkosCoupledForce` for another example of a 
 !alert note
 [Every GPU function needs to be inlineable](syntax/Kokkos/index.md#kokkos_execution_space) and thus should be defined in headers.
 
-## Optimized Kernel Objects
+## Optimized Kernel Objects id=kokkos_kernel_optimized
 
 [Similarly to the original MOOSE](syntax/Kernels/index.md#optimized), Kokkos-MOOSE provides `Moose::Kokkos::KernelValue` and `Moose::Kokkos::KernelGrad` for creating an optimized kernel by factoring out test functions in residual and Jacobian calculations.
 It is strongly encouraged to leverage these optimized kernel objects whenever possible for best performance.

--- a/modules/doc/content/getting_started/installation/clone_moose.md
+++ b/modules/doc/content/getting_started/installation/clone_moose.md
@@ -21,5 +21,5 @@ The `master` branch of `idaholab/moose` is the stable branch that will only be u
 passing. This protects you from the day-to-day changes in the MOOSE repository. MOOSE-based applications
 should typically use this branch.
 
-For the development of MOOSE (contributing changes to MOOSE), you should use the
+For the development of MOOSE (that is, contributing changes to MOOSE), you should use the
 `devel` branch of `idaholab/moose` as the base for a change.

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -35,6 +35,17 @@ The [MOOSE User Short Workshop slides](user_short_workshop/index.md alternative=
 have been made available. This workshop is approximately 4 hours in length and focuses
 on the fundamentals of using a MOOSE application.
 
+### View Factor Improvements
+
+The following improvements have been made to view factors:
+
+- Added [!param](/UserObjects/SpecifiedViewFactor/normalization_method) parameter
+  to allow choosing between the default (Lagrange multiplier) view factor normalization
+  method and an inverse row sum method.
+- Added [SpecifiedViewFactor.md] for user-specified view factors (deprecates [ConstantViewFactorSurfaceRadiation.md])
+- Allowed [ViewFactorVectorPostprocessor.md] to work with [ViewFactorBase.md] objects
+  directly.
+
 ## MOOSE Bug Fixes
 
 ## MOOSE Modules Changes

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -100,7 +100,7 @@ on the fundamentals of using a MOOSE application.
 
 ### 1D spline in 3D space meshing capabilities
 
-The [SplineMeshGenerator.md] was added to MOOSE to create meshes of edge elements following a 1D spline.
+The [BSplineCurveGenerator.md] was added to MOOSE to create meshes of edge elements following a 1D spline.
 The B-Spline accepts starting and ending locations and directions, to be able to connect 1D meshes with a smooth
 connection.
 

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -173,7 +173,7 @@ unlike the use of [SIMPLE.md] with conjugate heat transfer which has been studie
 
 ### Thermal hydraulics module
 
-The [HSCoupled2D3D.md] now supports the application of a symmetry factor when the 3D domain mesh only covers an angular sector of the
+The [HSCoupler2D3D.md] now supports the application of a symmetry factor when the 3D domain mesh only covers an angular sector of the
 true 3D structure geometry.
 
 ## libMesh-level Changes

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -2,6 +2,24 @@
 
 ## MOOSE Improvements
 
+### Removal of MFEMGeneralUserObject
+
+MFEM systems are no longer built on top of a general user object. MFEM systems
+are now instead queried like first-class systems through `theWarehouse`.
+Additionally, "execute" objects, like MFEM auxiliary kernels, postprocessors,
+vectorpostprocessors, and sub-mesh transfers sub-class from `MFEMExecutedObject`
+which inherits from `DependencyResolverInterface`. `MFEMExecutedObjects` are
+consequently automatically dependency sorted before execution such that an
+auxiliary kernel may depend on a postprocessor which depends on a different
+auxiliary kernel which depends on a different postprocessor, which is a
+dependency chain which has never been supported previously in MOOSE. This
+dependency chain is made possible by the fact that each execute object performs
+its own element loops (if required). This is also being done within the ongoing
+libMesh/Kokkos development such that we may see arbitrary dependency resolution
+with the libMesh finite element backend in oncoming months when using
+MOOSE-Kokkos objects. This arbitrary dependency resolution removes the need for
+parameters such as `execution_order_group` within user objects.
+
 ## MOOSE Bug Fixes
 
 ## MOOSE Modules Changes

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -4,11 +4,11 @@
 
 ### MFEM Backend improvements
 
-- Removal of MFEMGeneralUserObject means MFEM systems are no longer built on
+- Removal of `MFEMGeneralUserObject` means MFEM systems are no longer built on
   top of a general user object. MFEM systems are now instead queried like
   first-class systems through `TheWarehouse`. Additionally, "execute" objects,
   like MFEM auxiliary kernels, postprocessors, vectorpostprocessors, and
-  sub-mesh transfers sub-class from `MFEMExecutedObject`, which inherits from
+  sub-mesh transfers, sub-class from `MFEMExecutedObject`, which inherits from
   `DependencyResolverInterface`. `MFEMExecutedObject`s are consequently
   automatically dependency sorted before execution, such that an auxiliary
   kernel may depend on a postprocessor which itself depends on a different

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -20,6 +20,21 @@ with the libMesh finite element backend in oncoming months when using
 MOOSE-Kokkos objects. This arbitrary dependency resolution removes the need for
 parameters such as `execution_order_group` within user objects.
 
+### Added NaN/Inf Debug Option
+
+In some architectures (notably MacOS), floating point exceptions, like those produced by NaNs or Infs,
+do not get thrown, even in `devel` and `dbg` compile modes. A new option for `devel`
+and `dbg` modes, `Debug/error_on_residual_nan=true`, can now be used for these
+situations, which will throw an error upon any NaN or Inf value entering the
+nonlinear residual and provide the name of the residual object so that users
+can troubleshoot the source of the bad value.
+
+### Added MOOSE User Short Workshop Slides
+
+The [MOOSE User Short Workshop slides](user_short_workshop/index.md alternative=missing_config.md)
+have been made available. This workshop is approximately 4 hours in length and focuses
+on the fundamentals of using a MOOSE application.
+
 ## MOOSE Bug Fixes
 
 ## MOOSE Modules Changes

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -1,10 +1,5 @@
 # MOOSE Newsletter (April 2026)
 
-!alert! construction title=In Progress
-This MOOSE Newsletter edition is in progress. Please check back in May 2026
-for a complete description of all MOOSE changes.
-!alert-end!
-
 ## MOOSE Improvements
 
 ## MOOSE Bug Fixes

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -42,7 +42,7 @@ Consequently, the shim methods (e.g., `computeQpResidualShim`) that were origina
 Other improvements include:
 
 - Material properties can now have different `constant_on` options on different subdomains. For example, a material property can be defined with `constant_on = ELEMENT` on subdomain A and `constant_on = SUBDOMAIN` on subdomain B. However, boundary-restricted material properties should still have the same option across the domain.
-- Dimension limit of `Array` (up to 5 dimensions) and `JaggedArray` (up to 3 inner and outer dimensions) was removed by leveraging variadic templates. They can now have arbitrary dimensions.
+- Dimension limit of `Array` (up to 5 dimensions), `JaggedArray` (up to 3 inner and outer dimensions), and `MaterialProperty` (up to 4 dimensions) was removed by leveraging variadic templates. They can now have arbitrary dimensions.
 - The `datum.reinit()` function was removed. Calling it for each quadrature point in a quadrature loop is no longer required.
 - Basic parsed function support was added, and [KokkosParsedFunction.md], [KokkosParsedMaterial.md], and [KokkosParsedAux.md] are now available. However, using other functions in a parsed function is currently not supported for GPUs due to the limitation of virtual dispatches on GPUs. Parsed objects can facilitate the rapid prototyping of simulations using simple function definitions directly in the input file. Known applications of these parsed objects include field postprocessing, direct input of an analytical shape (for example, a cosine axial power profile) and simple linear models for material properties.
 - The Kokkos version of `VectorPostprocessors` and `Reporters` are now available.

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -44,7 +44,7 @@ Other improvements include:
 - Material properties can now have different `constant_on` options on different subdomains. For example, a material property can be defined with `constant_on = ELEMENT` on subdomain A and `constant_on = SUBDOMAIN` on subdomain B. However, boundary-restricted material properties should still have the same option across the domain.
 - Dimension limit of `Array` (up to 5 dimensions) and `JaggedArray` (up to 3 inner and outer dimensions) was removed by leveraging variadic templates. They can now have arbitrary dimensions.
 - The `datum.reinit()` function was removed. Calling it for each quadrature point in a quadrature loop is no longer required.
-- Basic parsed function support was added, and [KokkosParsedFunction.md], [KokkosParsedMaterial.md], and [KokkosParsedAux.md] are now available. However, using other functions in a parsed function is currently not supported for GPUs due to the limitation of virtual dispatches on GPUs.
+- Basic parsed function support was added, and [KokkosParsedFunction.md], [KokkosParsedMaterial.md], and [KokkosParsedAux.md] are now available. However, using other functions in a parsed function is currently not supported for GPUs due to the limitation of virtual dispatches on GPUs. Parsed objects can facilitate the rapid prototyping of simulations using simple function definitions directly in the input file. Known applications of these parsed objects include field postprocessing, direct input of an analytical shape (for example a cosine axial power profile) and simple linear models for material properties.
 - The Kokkos version of `VectorPostprocessors` and `Reporters` are now available.
 - Different registration paths for user objects and reducers were unified, and all the `UserObjects` and their derivatives (`Postprocessors`, `VectorPostprocessors` and `Reporters`) are now registered with `registerKokkosUserObject`. Making an object to be a reducer is achieved by defining reducer hook methods instead of user object hook method. See [this page](syntax/KokkosUserObjects/index.md#reducers) for details.
 - Incompatibility of `UserObjectInterface` with Kokkos-MOOSE user objects was fixed.
@@ -65,18 +65,6 @@ can troubleshoot the source of the bad value.
 The [MOOSE User Short Workshop slides](user_short_workshop/index.md alternative=missing_config.md)
 have been made available. This workshop is approximately 4 hours in length and focuses
 on the fundamentals of using a MOOSE application.
-
-### Parsed expression support in Kokkos-MOOSE
-
-[KokkosParsedAux.md], [KokkosParsedFunction.md] and [KokkosParsedMaterial.md] were added to MOOSE
-to facilitate the rapid prototyping of simulations using simple function definitions directly in the input file.
-Known applications of these parsed objects include field postprocessing, direct input of an analytical shape
-(for example a cosine axial power profile) and simple linear models for material properties.
-
-### Kokkos-MOOSE material changes
-
-Kokkos materials in MOOSE now support mixing `constant_on` selections. A material property that is constant
-over a subdomain or over each element is computed as little as needed, saving computation time.
 
 ### 1D spline in 3D space meshing capabilities
 

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -2,23 +2,55 @@
 
 ## MOOSE Improvements
 
-### Removal of MFEMGeneralUserObject
+### MFEM Backend improvements
 
-MFEM systems are no longer built on top of a general user object. MFEM systems
-are now instead queried like first-class systems through `TheWarehouse`.
-Additionally, "execute" objects, like MFEM auxiliary kernels, postprocessors,
-vectorpostprocessors, and sub-mesh transfers sub-class from `MFEMExecutedObject`,
-which inherits from `DependencyResolverInterface`. `MFEMExecutedObjects` are
-consequently automatically dependency sorted before execution, such that an
-auxiliary kernel may depend on a postprocessor which itself depends on a different
-auxiliary kernel which depends on a different postprocessor. This is a
-dependency chain which has never been supported previously in MOOSE. This
-dependency chain is made possible by the fact that each execute object performs
-its own element loops (if required). This is also being done within the ongoing
-libMesh/Kokkos development, such that we may see arbitrary dependency resolution
-with the libMesh finite element backend in oncoming months when using
-MOOSE-Kokkos objects. This arbitrary dependency resolution removes the need for
-parameters such as `execution_order_group` within user objects.
+- Removal of MFEMGeneralUserObject means MFEM systems are no longer built on
+  top of a general user object. MFEM systems are now instead queried like
+  first-class systems through `TheWarehouse`. Additionally, "execute" objects,
+  like MFEM auxiliary kernels, postprocessors, vectorpostprocessors, and
+  sub-mesh transfers sub-class from `MFEMExecutedObject`, which inherits from
+  `DependencyResolverInterface`. `MFEMExecutedObject`s are consequently
+  automatically dependency sorted before execution, such that an auxiliary
+  kernel may depend on a postprocessor which itself depends on a different
+  auxiliary kernel which depends on a different postprocessor. This is a
+  dependency chain which has never been supported previously in MOOSE. This
+  dependency chain is made possible by the fact that each execute object
+  performs its own element loops (if required). This is also being done within
+  the ongoing libMesh/Kokkos development, such that we may see arbitrary
+  dependency resolution with the libMesh finite element backend in oncoming
+  months when using MOOSE-Kokkos objects. This arbitrary dependency resolution
+  removes the need for parameters such as `execution_order_group` within user
+  objects.
+  ([idaholab/moose#32701](https://github.com/idaholab/moose/pull/32701))
+- Solves using SuperLU_DIST now respect the user's compute device request,
+  whereas before they would invariantly use the GPU if SuperLU_DIST had been
+  compiled with support for GPUs.
+  ([idaholab/moose#32702](https://github.com/idaholab/moose/pull/32702))
+- Non-linear support for both steady and transient problems is now a reality.
+  `MFEMKernel` and `MFEMIntegratedBC` have both been extended to add a new
+  member function, `createNLIntegrator()`, which developers can use to bind
+  their custom-built domain or boundary `mfem::NonlinearFormIntegrator`s,
+  respectively.
+  ([idaholab/moose#32256](https://github.com/idaholab/moose/pull/32256))
+- The user can now request shape evaluation transfers for an arbitrary
+  number of variables across libMesh- and MFEM-backed `MultiApp`s. Source and
+  target variables can be defined on different meshes, and if the transfer is
+  between two MFEM-backed `MultiApp`s, there is also support for vector and
+  complex variables. For a full list of supported features, check the docs for
+  the new `MultiApp{MFEM,MFEMTolibMesh,libMeshToMFEM}ShapeEvaluationTransfer`
+  family of classes.
+  ([idaholab/moose#32315](https://github.com/idaholab/moose/pull/32315))
+- Corrected an issue in the formulation of the transient mixed heat conduction
+  problem and in its mesh's nodeset numbering.
+  ([idaholab/moose#32494](https://github.com/idaholab/moose/pull/32494))
+- Dropped the `--copy-dt-needed-entries` linker flag, for better compatibility
+  with the LLVM linker (LLD) used, e.g., by the ROCm toolchain.
+  ([idaholab/moose#32769](https://github.com/idaholab/moose/pull/32769))
+- Fixed a number of instances where the main mesh was being retrieved instead
+  of the (sub)mesh pertaining to the variable being acted upon, and improved
+  the performance of time-dependent problems by updating the equation system
+  and variable solution vectors more judiciously.
+  ([idaholab/moose#32543](https://github.com/idaholab/moose/pull/32543))
 
 ### Kokkos Backend Improvements
 

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -35,7 +35,66 @@ The [MOOSE User Short Workshop slides](user_short_workshop/index.md alternative=
 have been made available. This workshop is approximately 4 hours in length and focuses
 on the fundamentals of using a MOOSE application.
 
-### View Factor Improvements
+### Parsed expression support in Kokkos-MOOSE
+
+[KokkosParsedAux.md], [KokkosParsedFunction.md] and [KokkosParsedMaterial.md] were added to MOOSE
+to facilitate the rapid prototyping of simulations using simple function definitions directly in the input file.
+Known applications of these parsed objects include field postprocessing, direct input of an analytical shape
+(for example a cosine axial power profile) and simple linear models for material properties.
+
+### Kokkos-MOOSE material changes
+
+Kokkos materials in MOOSE now support mixing `constant_on` selections. A material property that is constant
+over a subdomain or over each element is computed as little as needed, saving computation time.
+
+### 1D spline in 3D space meshing capabilities
+
+The [SplineMeshGenerator.md] was added to MOOSE to create meshes of edge elements following a 1D spline.
+The B-Spline accepts starting and ending locations and directions, to be able to connect 1D meshes with a smooth
+connection.
+
+### Reporter point sources
+
+The point sources treatment in [ReporterPointSource.md] was improved to better handle points in very close
+proximity. The tolerance parameter can be used to decide whether to merge close sources or keep them separate.
+
+### Tensor material properties from other properties
+
+The [RankTwoTensorFromComponentProperties.md] was added to form tensor material properties from other
+material properties. This facilitates the creation of fully anisotropic diffusion coefficients.
+
+### Eigenvalue solve object
+
+The [Eigenvalue.md] executioner was modified to rely on an eigen-problem solve object. This lets application
+developers create new executioners that leverage the solve objects to solve eigenvalue problems as part of
+workflows that include additional solution steps.
+
+### Renumbering elements based on subdomains
+
+The [RenumberBySubdomainGenerator.md] was added to renumber (change their ID) elements and their nodes in the
+mesh based on the subdomain appartenance of the elements. This enables element and node-based loops in MOOSE
+to change subdomains, and reinit on the new subdomain, as little as possible. This is an optimization that
+has been observed to reduce computational costs up to 10% in a specific case.
+
+### Linear finite volume boundary conditions
+
+Linear finite volume boundary conditions can now be controlled using the [Controls system](syntax/Controls/index.md).
+
+Linear finite volume boundary conditions now include sidedness detection to be able to easily evaluate
+functors and variables on either side of the boundary. For example in conjugate heat transfer problems,
+the fluid and solid domain may lie on different sides of the boundary, and thus the fluid and solid temperatures
+should be evaluated on the appropriate side.
+
+## MOOSE Bug Fixes
+
+- Nodal dampers now correctly handle block restriction mismatches between the variable and the damper.
+- Constraints no longer seek to add potential sparsity pattern entries when hash table matrix assembly is enabled. This
+  removes an unnecessary and slow operation.
+
+
+## MOOSE Modules Changes
+
+### Heat Transfer module
 
 The following improvements have been made to view factors:
 
@@ -46,9 +105,26 @@ The following improvements have been made to view factors:
 - Allowed [ViewFactorVectorPostprocessor.md] to work with [ViewFactorBase.md] objects
   directly.
 
-## MOOSE Bug Fixes
+The [KokkosHeatConductionTimeDerivative.md] was added to be able to solve transient heat conduction problems
+with Kokkos-MOOSE.
 
-## MOOSE Modules Changes
+### Reactor module
+
+The [ControlDrumMaterial.md] was added to define material properties for the various drum segments (absorber, clad, background, etc),
+be able to evaluate at runtime in which segment a quadrature point lies, and return the appropriate property.
+
+Deletion methods were added to the Constructive Solid Geometry support, to prepare for the merging of various
+cells and universities when creating assemblies from multiple cells.
+
+### Navier Stokes module
+
+[PIMPLE.md] can now be used with the conjugate heat transfer capabilities. This combination has not been validated
+unlike the use of [SIMPLE.md] with conjugate heat transfer which has been studied in `OpenPronghorn`.
+
+### Thermal hydraulics module
+
+The [HSCoupled2D3D.md] now supports the application of a symmetry factor when the 3D domain mesh only covers an angular sector of the
+true 3D structure geometry.
 
 ## libMesh-level Changes
 

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -5,13 +5,13 @@
 ### Removal of MFEMGeneralUserObject
 
 MFEM systems are no longer built on top of a general user object. MFEM systems
-are now instead queried like first-class systems through `theWarehouse`.
+are now instead queried like first-class systems through `TheWarehouse`.
 Additionally, "execute" objects, like MFEM auxiliary kernels, postprocessors,
-vectorpostprocessors, and sub-mesh transfers sub-class from `MFEMExecutedObject`
+vectorpostprocessors, and sub-mesh transfers sub-class from `MFEMExecutedObject`,
 which inherits from `DependencyResolverInterface`. `MFEMExecutedObjects` are
-consequently automatically dependency sorted before execution such that an
-auxiliary kernel may depend on a postprocessor which depends on a different
-auxiliary kernel which depends on a different postprocessor, which is a
+consequently automatically dependency sorted before execution, such that an
+auxiliary kernel may depend on a postprocessor which itself depends on a different
+auxiliary kernel which depends on a different postprocessor. This is a
 dependency chain which has never been supported previously in MOOSE. This
 dependency chain is made possible by the fact that each execute object performs
 its own element loops (if required). This is also being done within the ongoing

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -20,6 +20,37 @@ with the libMesh finite element backend in oncoming months when using
 MOOSE-Kokkos objects. This arbitrary dependency resolution removes the need for
 parameters such as `execution_order_group` within user objects.
 
+### Kokkos Backend Improvements
+
+A big design change that affects all Kokkos-MOOSE objects was made: every hook method of objects is now defined as a template function with respect to the derived object type. For example:
+
+```cpp
+template <typename Derived>
+KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
+                                       const unsigned int qp,
+                                       AssemblyDatum & datum) const;
+```
+
+This is to ease the static polymorphism implementation for users. Even though the hook method is defined in a base class, users can safely cast `this` pointer to their derived type and call derived class methods using the template argument, like:
+
+```cpp
+static_cast<const Derived *>(this)->foo();
+```
+
+Consequently, the shim methods (e.g., `computeQpResidualShim`) that were originally intended to serve this purpose were removed.
+
+Other improvements include:
+
+- Material properties can now have different `constant_on` options on different subdomains. For example, a material property can be defined with `constant_on = ELEMENT` on subdomain A and `constant_on = SUBDOMAIN` on subdomain B. However, boundary-restricted material properties should still have the same option across the domain.
+- Dimension limit of `Array` (up to 5 dimensions) and `JaggedArray` (up to 3 inner and outer dimensions) was removed by leveraging variadic templates. They can now have arbitrary dimensions.
+- The `datum.reinit()` function was removed. Calling it for each quadrature point in a quadrature loop is no longer required.
+- Basic parsed function support was added, and [KokkosParsedFunction.md], [KokkosParsedMaterial.md], and [KokkosParsedAux.md] are now available. However, using other functions in a parsed function is currently not supported for GPUs due to the limitation of virtual dispatches on GPUs.
+- The Kokkos version of `VectorPostprocessors` and `Reporters` are now available.
+- Different registration paths for user objects and reducers were unified, and all the `UserObjects` and their derivatives (`Postprocessors`, `VectorPostprocessors` and `Reporters`) are now registered with `registerKokkosUserObject`. Making an object to be a reducer is achieved by defining reducer hook methods instead of user object hook method. See [this page](syntax/KokkosUserObjects/index.md#reducers) for details.
+- Incompatibility of `UserObjectInterface` with Kokkos-MOOSE user objects was fixed.
+- `Kernels` and `IntegratedBCs` can exploit additional parallelism over local degrees of freedom (DOFs) by setting the `num_local_threads` parameter, which can improve performance. The optimal number of threads is problem-dependent but is generally recommended to be a divisor of the number of DOFs per element.
+- `IntegratedBCValue` is now provided for optimizing integrated boundary conditions where the residual is of the form $(\dots, \psi_i)$, i.e. the test function can be factored out. This is the equivalent of [KernelValue](syntax/KokkosKernels/index.md#kokkos_kernel_optimized) for integrated boundary conditions and has the same interface.
+
 ### Added NaN/Inf Debug Option
 
 In some architectures (notably MacOS), floating point exceptions, like those produced by NaNs or Infs,

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -136,6 +136,18 @@ functors and variables on either side of the boundary. For example in conjugate 
 the fluid and solid domain may lie on different sides of the boundary, and thus the fluid and solid temperatures
 should be evaluated on the appropriate side.
 
+### Transfers improvements
+
+The [MultiAppGeneralFieldFunctorTransfer.md] was added to be able to transfer evaluations of any [functor](syntax/Functors/index.md)
+onto a target mesh. This transfer includes both interpolation and extrapolation features, to be able to provide transferred values
+even when the target mesh extends beyond the source mesh. The extrapolation behavior for this new transfer is selected using the
+[!param](/Transfers/MultiAppGeneralFieldFunctorTransfer/extrapolation_behavior) parameter.
+
+Additionally, all [MultiAppGeneralFieldTransfer.md]-derived classes can now specify the
+[!param](/Transfers/MultiAppGeneralFieldFunctorTransfer/post_transfer_extrapolation) parameter to activate an additional extrapolation step
+performed at the end of the transfer after all values have been transfered. The extrapolation values are computed on the target mesh from the
+previously transferred valid values nearest to an extrapolation point.
+
 ## MOOSE Bug Fixes
 
 - Nodal dampers now correctly handle block restriction mismatches between the variable and the damper.

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -20,6 +20,9 @@
 
 ## PETSc-level Changes
 
+PETSc has been updated from version `3.24.5` to `3.24.6`. A summary comparison of the changes within
+this update can be found on the [PETSc GitLab](https://gitlab.com/petsc/petsc/-/compare/v3.24.5...v3.24.6?from_project_id=13882401).
+
 ## Conda Package Updates
 
 ### `moose-build 2026.04.21 [mpich,openmpi]`

--- a/modules/doc/content/newsletter/2026/2026_04.md
+++ b/modules/doc/content/newsletter/2026/2026_04.md
@@ -15,7 +15,7 @@ auxiliary kernel which depends on a different postprocessor. This is a
 dependency chain which has never been supported previously in MOOSE. This
 dependency chain is made possible by the fact that each execute object performs
 its own element loops (if required). This is also being done within the ongoing
-libMesh/Kokkos development such that we may see arbitrary dependency resolution
+libMesh/Kokkos development, such that we may see arbitrary dependency resolution
 with the libMesh finite element backend in oncoming months when using
 MOOSE-Kokkos objects. This arbitrary dependency resolution removes the need for
 parameters such as `execution_order_group` within user objects.
@@ -44,9 +44,9 @@ Other improvements include:
 - Material properties can now have different `constant_on` options on different subdomains. For example, a material property can be defined with `constant_on = ELEMENT` on subdomain A and `constant_on = SUBDOMAIN` on subdomain B. However, boundary-restricted material properties should still have the same option across the domain.
 - Dimension limit of `Array` (up to 5 dimensions) and `JaggedArray` (up to 3 inner and outer dimensions) was removed by leveraging variadic templates. They can now have arbitrary dimensions.
 - The `datum.reinit()` function was removed. Calling it for each quadrature point in a quadrature loop is no longer required.
-- Basic parsed function support was added, and [KokkosParsedFunction.md], [KokkosParsedMaterial.md], and [KokkosParsedAux.md] are now available. However, using other functions in a parsed function is currently not supported for GPUs due to the limitation of virtual dispatches on GPUs. Parsed objects can facilitate the rapid prototyping of simulations using simple function definitions directly in the input file. Known applications of these parsed objects include field postprocessing, direct input of an analytical shape (for example a cosine axial power profile) and simple linear models for material properties.
+- Basic parsed function support was added, and [KokkosParsedFunction.md], [KokkosParsedMaterial.md], and [KokkosParsedAux.md] are now available. However, using other functions in a parsed function is currently not supported for GPUs due to the limitation of virtual dispatches on GPUs. Parsed objects can facilitate the rapid prototyping of simulations using simple function definitions directly in the input file. Known applications of these parsed objects include field postprocessing, direct input of an analytical shape (for example, a cosine axial power profile) and simple linear models for material properties.
 - The Kokkos version of `VectorPostprocessors` and `Reporters` are now available.
-- Different registration paths for user objects and reducers were unified, and all the `UserObjects` and their derivatives (`Postprocessors`, `VectorPostprocessors` and `Reporters`) are now registered with `registerKokkosUserObject`. Making an object to be a reducer is achieved by defining reducer hook methods instead of user object hook method. See [this page](syntax/KokkosUserObjects/index.md#reducers) for details.
+- Different registration paths for user objects and reducers were unified, and all the `UserObjects` and their derivatives (`Postprocessors`, `VectorPostprocessors` and `Reporters`) are now registered with `registerKokkosUserObject`. Making an object to be a reducer is achieved by defining reducer hook methods instead of user object hook methods. See [this page](syntax/KokkosUserObjects/index.md#reducers) for details.
 - Incompatibility of `UserObjectInterface` with Kokkos-MOOSE user objects was fixed.
 - `Kernels` and `IntegratedBCs` can exploit additional parallelism over local degrees of freedom (DOFs) by setting the `num_local_threads` parameter, which can improve performance. The optimal number of threads is problem-dependent but is generally recommended to be a divisor of the number of DOFs per element.
 - `IntegratedBCValue` is now provided for optimizing integrated boundary conditions where the residual is of the form $(\dots, \psi_i)$, i.e. the test function can be factored out. This is the equivalent of [KernelValue](syntax/KokkosKernels/index.md#kokkos_kernel_optimized) for integrated boundary conditions and has the same interface.
@@ -109,7 +109,6 @@ should be evaluated on the appropriate side.
 - Nodal dampers now correctly handle block restriction mismatches between the variable and the damper.
 - Constraints no longer seek to add potential sparsity pattern entries when hash table matrix assembly is enabled. This
   removes an unnecessary and slow operation.
-
 
 ## MOOSE Modules Changes
 

--- a/modules/doc/content/newsletter/2026/2026_05.md
+++ b/modules/doc/content/newsletter/2026/2026_05.md
@@ -1,0 +1,20 @@
+# MOOSE Newsletter (May 2026)
+
+!alert! construction title=In Progress
+This MOOSE Newsletter edition is in progress. Please check back in June 2026
+for a complete description of all MOOSE changes.
+!alert-end!
+
+## MOOSE Improvements
+
+## MOOSE Bug Fixes
+
+## MOOSE Modules Changes
+
+## libMesh-level Changes
+
+## PETSc-level Changes
+
+## Conda Package Updates
+
+## Apptainer Package Updates

--- a/modules/doc/content/newsletter/index.md
+++ b/modules/doc/content/newsletter/index.md
@@ -6,6 +6,7 @@ monthly to the [MOOSE discussion forum](contact_us.md) as well as provided below
 
 ## 2026
 
+- [April, 2026](2026_04.md)
 - [March, 2026](2026_03.md)
 - [February, 2026](2026_02.md)
 - [January, 2026](2026_01.md)


### PR DESCRIPTION
Add template for May 2026 news

Refs #11446

@idaholab/moose-ccb  - per usual, please add your missing content from this month, as well as facilitate adding those of your review-ees and collaborators. Thanks!

@loganharbour - I added two of my suggestions from the most-recent package update PR in 23f3f52, pertaining to markdown documentation. I could add [the third](https://github.com/idaholab/moose/pull/32572#discussion_r3120409406) here too, but didn't necessarily want it to complicate CI testing off the bat, since the third change was in the `scripts/get_mac_sdk.sh` file.