### PR TITLE
Fix virtual destructor advice

### DIFF
--- a/framework/doc/content/sqa/framework_scs.md
+++ b/framework/doc/content/sqa/framework_scs.md
@@ -492,7 +492,7 @@ class MyClass:
     - Include dependent header files in the *.C file whenever possible (i.e. the header uses only references or pointers in it's various declarations) and use forward declarations in the header file as needed.
     - One exception is when doing so would require end users to include multiple files to complete definitions of child objects (Errors typically show up as "incomplete class" or something similar during compilation).
 - Avoid using a global variable when possible.
-- Every destructor must be virtual.
+- Every class with virtual methods must have a virtual destructor
 - All function definitions should be in *.C files.
     - The only exceptions are for inline functions for speed and templates.
 - Thou shalt not commit accidental insertion in a std::map by using brackets in a right-hand side operator unless proof is provided that it can't fail.


### PR DESCRIPTION
Refs #32131

No, we're not going to add a vtable and an extra thunk to small objects that wouldn't otherwise require the former.

## Reason
If taken literally, the existing advice would make small classes use significantly more memory and CPU, unnecessarily.

## Design
Restrict the existing advice to the cases recommended by Effective C++.  If we want the same level of safety without adding any runtime cost, we could demand that classes with non-virtual destructors also be declared `final`, but there are cases where we use inheritance for code sharing without expecting to use the subclasses via base class handles and we'd still need some kind of exception for those.

## Impact
Hopefully this will make our guidelines more useful to AIs, as well as to the rest of us pedants.