### PR TITLE
Fix element damper evaluation on undefined variables (#32058)

### DIFF
--- a/framework/include/dampers/ElementDamper.h
+++ b/framework/include/dampers/ElementDamper.h
@@ -43,6 +43,11 @@ public:
   Real computeDamping();
 
   /**
+   * Check whether this damper's variable has DOFs/components on the given element
+   */
+  bool variableDefinedOnElement(const Elem * elem) const;
+
+  /**
    * Get the variable this damper is acting on
    */
   MooseVariable * getVariable() { return &_var; }

--- a/framework/src/dampers/ElementDamper.C
+++ b/framework/src/dampers/ElementDamper.C
@@ -46,6 +46,9 @@ ElementDamper::ElementDamper(const InputParameters & parameters)
     _u(_var.sln()),
     _grad_u(_var.gradSln())
 {
+  mooseAssert(_var.count() == 1,
+              "ElementDamper only supports scalar variables. Variable '" + _var.name() +
+                  "' has multiple components.");
 }
 
 Real
@@ -62,4 +65,10 @@ ElementDamper::computeDamping()
   }
 
   return damping;
+}
+
+bool
+ElementDamper::variableDefinedOnElement(const Elem * elem) const
+{
+  return _var.hasBlocks(elem->subdomain_id());
 }

--- a/framework/src/loops/ComputeElemDampingThread.C
+++ b/framework/src/loops/ComputeElemDampingThread.C
@@ -45,19 +45,21 @@ ComputeElemDampingThread::onElement(const Elem * elem)
 
   std::set<MooseVariable *> damped_vars;
 
-  const std::vector<std::shared_ptr<ElementDamper>> & edampers =
-      _nl.getElementDamperWarehouse().getActiveObjects(_tid);
+  const auto & edampers = _element_dampers.getActiveObjects(_tid);
   for (const auto & damper : edampers)
-    damped_vars.insert(damper->getVariable());
+    if (damper->variableDefinedOnElement(elem))
+      damped_vars.insert(damper->getVariable());
 
-  _nl.reinitIncrementAtQpsForDampers(_tid, damped_vars);
+  if (!damped_vars.empty())
+    _nl.reinitIncrementAtQpsForDampers(_tid, damped_vars);
 
-  const std::vector<std::shared_ptr<ElementDamper>> & objects =
-      _element_dampers.getActiveObjects(_tid);
-  for (const auto & obj : objects)
+  for (const auto & damper : edampers)
   {
-    Real cur_damping = obj->computeDamping();
-    obj->checkMinDamping(cur_damping);
+    if (!damper->variableDefinedOnElement(elem))
+      continue;
+
+    Real cur_damping = damper->computeDamping();
+    damper->checkMinDamping(cur_damping);
     if (cur_damping < _damping)
       _damping = cur_damping;
   }

--- a/test/tests/dampers/bounding_value_element_damper/bounding_value_element_block_restricted_test.i
+++ b/test/tests/dampers/bounding_value_element_damper/bounding_value_element_block_restricted_test.i
@@ -1,0 +1,84 @@
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 10
+    ny = 1
+    xmin = 0.0
+    xmax = 1.0
+    ymin = 0.0
+    ymax = 1.0
+  []
+  [left_block]
+    type = SubdomainBoundingBoxGenerator
+    input = gen
+    block_id = 1
+    bottom_left = '0.0 0.0 0.0'
+    top_right = '0.1 1.0 0.0'
+  []
+  [right_block]
+    type = SubdomainBoundingBoxGenerator
+    input = left_block
+    block_id = 2
+    bottom_left = '0.1 0.0 0.0'
+    top_right = '1.0 1.0 0.0'
+  []
+[]
+
+[Variables]
+  [theta_m]
+    family = MONOMIAL
+    order = CONSTANT
+    block = 1
+    initial_condition = 0.0
+  []
+  [dummy]
+    family = MONOMIAL
+    order = CONSTANT
+    block = 2
+    initial_condition = 0.0
+  []
+[]
+
+[Kernels]
+  [theta_td]
+    type = TimeDerivative
+    variable = theta_m
+    block = 1
+  []
+  [theta_src]
+    type = BodyForce
+    variable = theta_m
+    value = 1.0
+    block = 1
+  []
+  [dummy_td]
+    type = TimeDerivative
+    variable = dummy
+    block = 2
+  []
+[]
+
+[Dampers]
+  [limit_theta]
+    type = BoundingValueElementDamper
+    variable = theta_m
+    min_value = -0.1
+    max_value = 0.25
+    min_damping = 1e-8
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  dt = 1.0
+  num_steps = 1
+  nl_rel_tol = 1e-12
+  nl_abs_tol = 1e-12
+  l_tol = 1e-14
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/dampers/bounding_value_element_damper/tests
+++ b/test/tests/dampers/bounding_value_element_damper/tests
@@ -1,7 +1,7 @@
 [Tests]
-  issues = '#7856'
   design = 'source/dampers/BoundingValueElementDamper.md'
   [./bounding_value_max]
+    issues = '#7856'
     type = 'RunException'
     input = 'bounding_value_max_test.i'
     expect_out = 'Damping factor: 0.2388'
@@ -9,11 +9,19 @@
     requirement = "The system shall include the ability to reduce the change in nonlinear residual based on a maximum value on elements."
   [../]
   [./bounding_value_min]
+    issues = '#7856'
     type = 'RunException'
     input = 'bounding_value_max_test.i'
     cli_args = "Kernels/source/function='-t'"
     expect_out = 'Damping factor: 0.2388'
     expect_err = 'Solve failed and timestep already at or below dtmin, cannot continue!'
     requirement = "The system shall include the ability to reduce the change in nonlinear residual based on a minimum value on elements."
+  [../]
+  [./bounding_value_block_restricted]
+    issues = '#32058'
+    type = 'RunApp'
+    input = 'bounding_value_element_block_restricted_test.i'
+    cli_args = '--n-threads=2'
+    requirement = "The system shall not evaluate an elemental bounding-value damper on elements where a block-restricted variable to damp is undefined."
   [../]
 []


### PR DESCRIPTION
closes #32058

## Reason
Element dampers could still be evaluated on elements where a block-restricted variable to damp is undefined. In that case, element damper data such as solution/increment arrays can be empty, which leads to a MooseArray out-of-bounds access during damping evaluation.

## Design
This mirrors the nodal damper fix.

The change adds an element-level guard in `ElementDamper` to determine whether the damper variable is defined on the current element. `ComputeElemDampingThread` then:
- only collects variables for dampers whose variable is defined on the current element,
- only reinitializes increment data for those variables, and
- skips `computeDamping()` for dampers whose variable is undefined there.

A scalar-variable `mooseAssert` was also added in `ElementDamper`, analogous to the nodal-side guard.

A regression test was added for the block-restricted elemental bounding-value damper case, and the existing element damper test issue tags were updated so the legacy tests keep `#7856` while the new regression test is associated with `#32058`.

## Impact
This does not change the user-facing API. It fixes incorrect element damper evaluation for block-restricted variables and adds regression coverage for that case.

Validation was performed in both execution modes:
- threaded execution reproduced the failure pre-patch and passed post-fix
- pure MPI execution reproduced the failure pre-patch and passed post-fix
