### PR TITLE
Silence duplicate -rpath linker warnings on macOS

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -495,8 +495,8 @@ $(app_LIB): curr_additional_depend_libs := $(ADDITIONAL_DEPEND_LIBS)
 $(app_LIB): curr_additional_libs := $(ADDITIONAL_LIBS)
 $(app_LIB): $(app_HEADER) $(app_plugin_deps) $(depend_libs) $(app_objects) $(ADDITIONAL_DEPEND_LIBS)
 	@echo "Linking Library "$@"..."
-	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(curr_objs) $(LDFLAGS) $(libmesh_LDFLAGS) $(EXTERNAL_FLAGS) $(curr_additional_libs) -rpath $(curr_dir)/lib $(curr_libs)
+	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
+	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(curr_objs) $(LDFLAGS) $(libmesh_LDFLAGS) $(EXTERNAL_FLAGS) $(curr_additional_libs) -rpath $(curr_dir)/lib $(curr_libs) ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $@ $(curr_dir)/lib
 
 ifeq ($(BUILD_TEST_OBJECTS_LIB),no)
@@ -514,8 +514,8 @@ $(app_test_LIB): curr_additional_depend_libs := $(ADDITIONAL_DEPEND_LIBS)
 $(app_test_LIB): curr_additional_libs := $(ADDITIONAL_LIBS)
 $(app_test_LIB): $(app_HEADER) $(app_plugin_deps) $(depend_libs) $(gtest_LIB) $(app_test_objects) $(ADDITIONAL_DEPEND_LIBS)
 	@echo "Linking Test Library "$@"..."
-	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(curr_objs) $(LDFLAGS) $(libmesh_LDFLAGS) $(EXTERNAL_FLAGS) $(curr_additional_libs) -rpath $(curr_dir)/lib $(curr_libs)
+	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
+	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(curr_objs) $(LDFLAGS) $(libmesh_LDFLAGS) $(EXTERNAL_FLAGS) $(curr_additional_libs) -rpath $(curr_dir)/lib $(curr_libs) ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $@ $(curr_dir)/lib
 endif
 

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -553,11 +553,11 @@ prebuild:: | $(moose_config)
 wasp_submodule_status $(moose_revision_header) $(moose_LIB): | prebuild
 moose: wasp_submodule_status $(moose_revision_header) $(moose_LIB) $(MOOSE_KOKKOS_LIB) $(pycapabilities_LIB)
 
-# Check for support for process substitution, and if supported, we delete a known warning on MacOS from
-# the output because it is printed thousands of times
+# Check for support for process substitution, and if supported, we delete known warnings on MacOS from
+# the output because they are printed many times
 CHECK_PROCESS_SUBSTITUTION := $(shell bash -c 'echo hello > >(cat)')
 ifeq ($(CHECK_PROCESS_SUBSTITUTION),hello)
-  SILENCE_SOME_WARNINGS = 1> >(cat >&1) 2> >(grep -v "could not create compact unwind for" >&2)
+  SILENCE_SOME_WARNINGS = 1> >(cat >&1) 2> >(grep -Ev "could not create compact unwind for|duplicate -rpath" >&2)
 endif
 
 # [JWP] With libtool, there is only one link command, it should work whether you are creating


### PR DESCRIPTION
The prior approach (removed from `build.mk`) deduplicated `libmesh_LIBS` and `libmesh_LDFLAGS`, but duplicate `-rpath` entries can also arrive from libtool itself or other link inputs (`LDFLAGS`, `curr_additional_libs`), so removing duplicates from only those two variables did not fully suppress the warning.

Replace it with a source-agnostic approach: wrap linker invocations in `bash -c` to enable process substitution, then extend `SILENCE_SOME_WARNINGS` to also filter duplicate `-rpath` lines from stderr.

Refs #31412