### PR TITLE
Fix error handling by removing incorrect Py_DECREF

### DIFF
--- a/framework/contrib/hit/src/hit/hit.cpp
+++ b/framework/contrib/hit/src/hit/hit.cpp
@@ -18925,7 +18925,6 @@ __Pyx_CyFunction_get_is_coroutine_value(__pyx_CyFunctionObject *op) {
         PyList_SET_ITEM(fromlist, 0, marker);
 #else
         if (unlikely(PyList_SetItem(fromlist, 0, marker) < 0)) {
-            Py_DECREF(marker);
             Py_DECREF(fromlist);
             return NULL;
         }


### PR DESCRIPTION
https://github.com/idaholab/moose/issues/32870