### PR TITLE
Removing usage of 'use_distributed_mesh' property

### DIFF
--- a/framework/include/meshgenerators/PatternedMeshGenerator.h
+++ b/framework/include/meshgenerators/PatternedMeshGenerator.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "MeshGenerator.h"
-#include "libmesh/replicated_mesh.h"
+#include "libmesh/unstructured_mesh.h"
 
 /**
  * Reads one or more 2D mesh files and stitches them together based on
@@ -42,10 +42,10 @@ protected:
   const std::vector<std::vector<unsigned int>> & _pattern;
 
   /// Holds the pointers to the input generated meshes
-  std::vector<std::unique_ptr<ReplicatedMesh>> _meshes;
+  std::vector<std::unique_ptr<MeshBase>> _meshes;
 
   /// Holds a mesh for each row, these will be stitched together in the end
-  std::vector<std::unique_ptr<ReplicatedMesh>> _row_meshes;
+  std::vector<std::unique_ptr<UnstructuredMesh>> _row_meshes;
 
   /**
    * Merges the subdomain name maps between two meshes, throws an error

--- a/framework/include/utils/TriangleManifold.h
+++ b/framework/include/utils/TriangleManifold.h
@@ -125,7 +125,7 @@ private:
   Real _z_cell_size = 1.0;
 
   /// Lookup from packed yz-grid cell index to triangles that could intersect the +x query ray.
-  std::unordered_map<dof_id_type, std::vector<dof_id_type>> _ray_grid;
+  std::unordered_map<std::uint64_t, std::vector<dof_id_type>> _ray_grid;
 
   MeshBase & _mesh;
 

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -324,27 +324,7 @@ SetupMeshAction::act()
         _mesh->setMeshBase(std::move(mesh_base));
       }
       else
-      {
-        const auto & mg_names = _app.getMeshGeneratorNames();
-        std::vector<bool> use_dm;
-        for (const auto & mg_name : mg_names)
-          if (hasMeshProperty<bool>("use_distributed_mesh", mg_name))
-            use_dm.push_back(getMeshProperty<bool>("use_distributed_mesh", mg_name));
-
-        if (!use_dm.empty())
-        {
-          if (std::adjacent_find(use_dm.begin(), use_dm.end(), std::not_equal_to<bool>()) !=
-              use_dm.end())
-            mooseError("You cannot use mesh generators that set different values of the mesh "
-                       "property 'use_distributed_mesh' within the same simulation.");
-
-          const auto ptype = use_dm.front() ? MooseMesh::ParallelType::DISTRIBUTED
-                                            : MooseMesh::ParallelType::REPLICATED;
-          _mesh->setParallelType(ptype);
-        }
-
         _mesh->setMeshBase(_mesh->buildMeshBaseObject());
-      }
     }
   }
 

--- a/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
+++ b/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
@@ -69,8 +69,6 @@ ConcentricCircleMeshGenerator::ConcentricCircleMeshGenerator(const InputParamete
     _smoothing_max_it(getParam<unsigned int>("smoothing_max_it")),
     _portion(getParam<MooseEnum>("portion"))
 {
-  declareMeshProperty("use_distributed_mesh", false);
-
   if (_num_sectors % 2 != 0)
     paramError("num_sectors", "must be an even number.");
 

--- a/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
+++ b/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
@@ -104,7 +104,9 @@ ConcentricCircleMeshGenerator::ConcentricCircleMeshGenerator(const InputParamete
 std::unique_ptr<MeshBase>
 ConcentricCircleMeshGenerator::generate()
 {
-  auto mesh = buildReplicatedMesh(2);
+  auto mesh = dynamic_pointer_cast<UnstructuredMesh>(buildMeshBaseObject(2));
+  if (!mesh) // This should never happen
+    mooseError("ConcentricCircleMeshGenerator is only implemented for unstructured meshes");
   BoundaryInfo & boundary_info = mesh->get_boundary_info();
 
   // Creating real mesh concentric circles

--- a/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
+++ b/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
@@ -133,7 +133,6 @@ DistributedRectilinearMeshGenerator::DistributedRectilinearMeshGenerator(
     _partition_method(getParam<MooseEnum>("partition")),
     _num_side_layers(getParam<unsigned>("num_side_layers"))
 {
-  declareMeshProperty("use_distributed_mesh", true);
 }
 
 template <>

--- a/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
+++ b/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
@@ -133,6 +133,7 @@ DistributedRectilinearMeshGenerator::DistributedRectilinearMeshGenerator(
     _partition_method(getParam<MooseEnum>("partition")),
     _num_side_layers(getParam<unsigned>("num_side_layers"))
 {
+  _mesh->setParallelType(MooseMesh::ParallelType::DISTRIBUTED);
 }
 
 template <>

--- a/framework/src/meshgenerators/ImageMeshGenerator.C
+++ b/framework/src/meshgenerators/ImageMeshGenerator.C
@@ -47,7 +47,6 @@ ImageMeshGenerator::ImageMeshGenerator(const InputParameters & parameters)
     _scale_to_one(getParam<bool>("scale_to_one")),
     _cells_per_pixel(getParam<Real>("cells_per_pixel"))
 {
-  declareMeshProperty("use_distributed_mesh", false);
 }
 
 std::unique_ptr<MeshBase>

--- a/framework/src/meshgenerators/ManifoldSubdomainGenerator.C
+++ b/framework/src/meshgenerators/ManifoldSubdomainGenerator.C
@@ -56,10 +56,6 @@ ManifoldSubdomainGenerator::ManifoldSubdomainGenerator(const InputParameters & p
     _has_restriction(isParamValid("restricted_subdomains")),
     _surface_tolerance(getParam<Real>("surface_tolerance"))
 {
-#if LIBMESH_DOF_ID_BYTES != 8
-  mooseDocumentedError(
-      "moose", 32898, "ManifoldSubdomainGenerator currently only works with 64-bit DoF IDs");
-#endif
 }
 
 std::unique_ptr<MeshBase>

--- a/framework/src/meshgenerators/PatternedMeshGenerator.C
+++ b/framework/src/meshgenerators/PatternedMeshGenerator.C
@@ -11,9 +11,8 @@
 
 #include "CastUniquePointer.h"
 
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/distributed_mesh.h"
 #include "libmesh/boundary_info.h"
+#include "libmesh/mesh_serializer.h"
 #include "libmesh/mesh_modification.h"
 #include "libmesh/mesh_tools.h"
 #include "MooseMeshUtils.h"
@@ -106,16 +105,7 @@ PatternedMeshGenerator::generate()
   _meshes.resize(_input_names.size());
   for (const auto i : index_range(_input_names))
   {
-    std::unique_ptr<ReplicatedMesh> mesh = dynamic_pointer_cast<ReplicatedMesh>(*_mesh_ptrs[i]);
-    if (!mesh)
-      paramError("inputs",
-                 "The input mesh '",
-                 _input_names[i],
-                 "' is not a replicated mesh.\n\n",
-                 type(),
-                 " only works with inputs that are replicated.\n\n",
-                 "Try running without distributed mesh.");
-    _meshes[i] = dynamic_pointer_cast<ReplicatedMesh>(mesh);
+    _meshes[i] = std::move(*_mesh_ptrs[i]);
 
     // List of boundary ids corresponsind to left/right/top/bottom boundary names
     const auto ids = MooseMeshUtils::getBoundaryIDs(*_meshes[i], boundary_names, false);
@@ -182,6 +172,12 @@ PatternedMeshGenerator::generate()
     all_boundary_ids.insert(all_ids.begin(), all_ids.end());
   }
 
+  // Serialize any distributed input meshes for the duration of stitching
+  std::vector<std::unique_ptr<libMesh::MeshSerializer>> serializers;
+  serializers.reserve(_meshes.size());
+  for (auto & m : _meshes)
+    serializers.push_back(std::make_unique<libMesh::MeshSerializer>(*m));
+
   // Check if the user has provided the x, y and z widths.
   // If not (their value is 0 by default), compute them
   auto bbox = MeshTools::create_bounding_box(*_meshes[0]);
@@ -237,14 +233,14 @@ PatternedMeshGenerator::generate()
       if (j == 0)
       {
         auto clone = _meshes[_pattern[i][j]]->clone();
-        _row_meshes[i] = dynamic_pointer_cast<ReplicatedMesh>(clone);
+        _row_meshes[i] = dynamic_pointer_cast<UnstructuredMesh>(clone);
 
         MeshTools::Modification::translate(*_row_meshes[i], deltax, -deltay, 0);
 
         continue;
       }
 
-      ReplicatedMesh & cell_mesh = *_meshes[_pattern[i][j]];
+      MeshBase & cell_mesh = *_meshes[_pattern[i][j]];
 
       // Move the mesh into the right spot.  -i because we are starting at the top
       MeshTools::Modification::translate(cell_mesh, deltax, -deltay, 0);
@@ -293,8 +289,9 @@ PatternedMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(
           *_row_meshes[0], stitch_bids[side], input_bids_unique[0][side]);
 
+  _row_meshes[0]->allow_remote_element_removal(_mesh->allowRemoteElementRemoval());
   _row_meshes[0]->unset_is_prepared();
-  return dynamic_pointer_cast<MeshBase>(_row_meshes[0]);
+  return std::move(_row_meshes[0]);
 }
 
 void

--- a/framework/src/meshgenerators/RinglebMeshGenerator.C
+++ b/framework/src/meshgenerators/RinglebMeshGenerator.C
@@ -58,8 +58,6 @@ RinglebMeshGenerator::RinglebMeshGenerator(const InputParameters & parameters)
     _outer_wall_bid(getParam<boundary_id_type>("outer_wall_bid")),
     _triangles(getParam<bool>("triangles"))
 {
-  declareMeshProperty("use_distributed_mesh", false);
-
   // catch likely user errors
   if (_kmax <= _kmin)
     mooseError("RinglebMesh: kmax must be greater than kmin");

--- a/framework/src/meshgenerators/SpiralAnnularMeshGenerator.C
+++ b/framework/src/meshgenerators/SpiralAnnularMeshGenerator.C
@@ -60,8 +60,6 @@ SpiralAnnularMeshGenerator::SpiralAnnularMeshGenerator(const InputParameters & p
     _exterior_bid(getParam<boundary_id_type>("exterior_bid")),
     _initial_delta_r(2 * libMesh::pi * _inner_radius / _nodes_per_ring)
 {
-  declareMeshProperty("use_distributed_mesh", false);
-
   // catch likely user errors
   if (_outer_radius <= _inner_radius)
     mooseError("SpiralAnnularMesh: outer_radius must be greater than inner_radius");

--- a/modules/reactor/include/meshgenerators/PatternedCartesianMeshGenerator.h
+++ b/modules/reactor/include/meshgenerators/PatternedCartesianMeshGenerator.h
@@ -117,7 +117,7 @@ protected:
    * @param mesh_type whether the peripheral region is for a corner or a side of a patterned mesh
    * @return a mesh of the cartesian pattern mesh with peripheral region added.
    */
-  void addPeripheralMesh(ReplicatedMesh & mesh,
+  void addPeripheralMesh(UnstructuredMesh & mesh,
                          const unsigned int pattern, //_pattern[i][j]
                          const Real pitch,           // pitch_array.front()
                          const std::vector<Real> & extra_dist,
@@ -147,5 +147,5 @@ protected:
    * @param from_meshes meshes to take reporting IDs from
    */
   void addReportingIDs(MeshBase & mesh,
-                       const std::vector<std::unique_ptr<ReplicatedMesh>> & from_meshes) const;
+                       const std::vector<std::unique_ptr<MeshBase>> & from_meshes) const;
 };

--- a/modules/reactor/include/meshgenerators/PatternedHexMeshGenerator.h
+++ b/modules/reactor/include/meshgenerators/PatternedHexMeshGenerator.h
@@ -114,7 +114,7 @@ protected:
    * @param mesh_type whether the peripheral region is for a corner or a side hexagon mesh
    * @return a mesh of the hexagon unit mesh with peripheral region added.
    */
-  void addPeripheralMesh(ReplicatedMesh & mesh,
+  void addPeripheralMesh(UnstructuredMesh & mesh,
                          const unsigned int pattern, //_pattern{i][j]
                          const Real pitch,           // pitch_array.front()
                          const std::vector<Real> & extra_dist,
@@ -146,5 +146,5 @@ protected:
    * @param from_meshes meshes to take reporting IDs from
    */
   void addReportingIDs(MeshBase & mesh,
-                       const std::vector<std::unique_ptr<ReplicatedMesh>> & from_meshes) const;
+                       const std::vector<std::unique_ptr<MeshBase>> & from_meshes) const;
 };

--- a/modules/reactor/include/meshgenerators/PolygonMeshGeneratorBase.h
+++ b/modules/reactor/include/meshgenerators/PolygonMeshGeneratorBase.h
@@ -13,7 +13,6 @@
 #include "MooseEnum.h"
 #include "CastUniquePointer.h"
 #include "MooseMeshUtils.h"
-#include "libmesh/replicated_mesh.h"
 #include "libmesh/mesh_modification.h"
 #include "libmesh/face_quad4.h"
 #include "libmesh/face_quad8.h"
@@ -522,7 +521,7 @@ protected:
    * @param quad_elem_type type of quad element to be created
    * @return a mesh with the peripheral region added to a hexagon input mesh
    */
-  std::unique_ptr<ReplicatedMesh>
+  std::unique_ptr<MeshBase>
   buildSimplePeripheral(const unsigned int num_sectors_per_side,
                         const unsigned int peripheral_invervals,
                         const std::vector<std::pair<Real, Real>> & position_inner,

--- a/modules/reactor/include/utils/ReportingIDGeneratorUtils.h
+++ b/modules/reactor/include/utils/ReportingIDGeneratorUtils.h
@@ -11,8 +11,6 @@
 
 #include "MooseTypes.h"
 #include "libmesh/elem.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/dof_object.h"
 
 namespace ReportingIDGeneratorUtils
 {
@@ -38,7 +36,7 @@ enum class AssignType
  * @return list of reporting IDs for individual mesh elements
  **/
 std::vector<dof_id_type>
-getCellwiseIntegerIDs(const std::vector<std::unique_ptr<libMesh::ReplicatedMesh>> & meshes,
+getCellwiseIntegerIDs(const std::vector<std::unique_ptr<libMesh::MeshBase>> & meshes,
                       const std::vector<std::vector<unsigned int>> & pattern,
                       const bool use_exclude_id,
                       const std::vector<bool> & exclude_ids);
@@ -50,7 +48,7 @@ getCellwiseIntegerIDs(const std::vector<std::unique_ptr<libMesh::ReplicatedMesh>
  * @return list of reporting IDs for individual mesh elements
  **/
 std::vector<dof_id_type>
-getPatternIntegerIDs(const std::vector<std::unique_ptr<libMesh::ReplicatedMesh>> & meshes,
+getPatternIntegerIDs(const std::vector<std::unique_ptr<libMesh::MeshBase>> & meshes,
                      const std::vector<std::vector<unsigned int>> & pattern);
 
 /**
@@ -61,7 +59,7 @@ getPatternIntegerIDs(const std::vector<std::unique_ptr<libMesh::ReplicatedMesh>>
  * @return list of reporting IDs for individual mesh elements
  **/
 std::vector<dof_id_type>
-getManualIntegerIDs(const std::vector<std::unique_ptr<libMesh::ReplicatedMesh>> & meshes,
+getManualIntegerIDs(const std::vector<std::unique_ptr<libMesh::MeshBase>> & meshes,
                     const std::vector<std::vector<unsigned int>> & pattern,
                     const std::vector<std::vector<dof_id_type>> & id_pattern);
 
@@ -72,7 +70,7 @@ getManualIntegerIDs(const std::vector<std::unique_ptr<libMesh::ReplicatedMesh>> 
  * @return list of  block IDs in input meshes
  **/
 std::set<SubdomainID>
-getCellBlockIDs(const std::vector<std::unique_ptr<libMesh::ReplicatedMesh>> & meshes,
+getCellBlockIDs(const std::vector<std::unique_ptr<libMesh::MeshBase>> & meshes,
                 const std::vector<std::vector<unsigned int>> & pattern);
 
 /**
@@ -112,7 +110,7 @@ void assignReportingIDs(MeshBase & mesh,
                         const std::vector<bool> & exclude_ids,
                         const bool has_assembly_boundary,
                         const std::set<subdomain_id_type> background_block_ids,
-                        const std::vector<std::unique_ptr<libMesh::ReplicatedMesh>> & input_meshes,
+                        const std::vector<std::unique_ptr<libMesh::MeshBase>> & input_meshes,
                         const std::vector<std::vector<unsigned int>> & pattern,
                         const std::vector<std::vector<dof_id_type>> & id_pattern);
 }

--- a/modules/reactor/src/meshgenerators/CartesianIDPatternedMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/CartesianIDPatternedMeshGenerator.C
@@ -9,6 +9,8 @@
 
 #include "CartesianIDPatternedMeshGenerator.h"
 #include "ReportingIDGeneratorUtils.h"
+#include "libmesh/mesh_serializer.h"
+#include "libmesh/mesh_tools.h"
 
 registerMooseObject("ReactorApp", CartesianIDPatternedMeshGenerator);
 
@@ -81,20 +83,70 @@ CartesianIDPatternedMeshGenerator::generate()
         "id_name", "An element integer with the name '", _element_id_name, "' already exists");
   }
 
-  // patternedMeshGenerator for Carterisan lattice does not support duct structures
-  const bool has_assembly_duct = false;
-  const std::set<subdomain_id_type> duct_block_ids;
-  // asssign reporting IDs to individual elements
-  ReportingIDGeneratorUtils::assignReportingIDs(*mesh,
-                                                extra_id_index,
-                                                _assign_type,
-                                                _use_exclude_id,
-                                                _exclude_ids,
-                                                has_assembly_duct,
-                                                duct_block_ids,
-                                                _meshes,
-                                                _pattern,
-                                                _id_pattern);
+  // Build a per-tile ID lookup from the utility helpers.  The flat integer_ids vectors
+  // returned by the helpers contain n_elem(tile) identical values per tile in row-major
+  // order; here we only need the representative value for each (row, col) position.
+  const auto bbox = MeshTools::create_bounding_box(*_meshes[0]);
+  const Real min_x = bbox.min()(0);
+  const Real min_y = bbox.min()(1);
+
+  // Populate tile_id[i][j] using the appropriate utility helper.
+  std::vector<std::vector<dof_id_type>> tile_id(_pattern.size());
+  if (_assign_type == ReportingIDGeneratorUtils::AssignType::cell)
+  {
+    const auto integer_ids = ReportingIDGeneratorUtils::getCellwiseIntegerIDs(
+        _meshes, _pattern, _use_exclude_id, _exclude_ids);
+    dof_id_type k = 0;
+    for (MooseIndex(_pattern) i = 0; i < _pattern.size(); ++i)
+    {
+      tile_id[i].resize(_pattern[i].size());
+      for (MooseIndex(_pattern[i]) j = 0; j < _pattern[i].size(); ++j)
+      {
+        tile_id[i][j] = integer_ids[k];
+        k += _meshes[_pattern[i][j]]->n_elem();
+      }
+    }
+  }
+  else if (_assign_type == ReportingIDGeneratorUtils::AssignType::pattern)
+  {
+    const auto integer_ids = ReportingIDGeneratorUtils::getPatternIntegerIDs(_meshes, _pattern);
+    dof_id_type k = 0;
+    for (MooseIndex(_pattern) i = 0; i < _pattern.size(); ++i)
+    {
+      tile_id[i].resize(_pattern[i].size());
+      for (MooseIndex(_pattern[i]) j = 0; j < _pattern[i].size(); ++j)
+      {
+        tile_id[i][j] = integer_ids[k];
+        k += _meshes[_pattern[i][j]]->n_elem();
+      }
+    }
+  }
+  else // manual
+  {
+    const auto integer_ids =
+        ReportingIDGeneratorUtils::getManualIntegerIDs(_meshes, _pattern, _id_pattern);
+    dof_id_type k = 0;
+    for (MooseIndex(_pattern) i = 0; i < _pattern.size(); ++i)
+    {
+      tile_id[i].resize(_pattern[i].size());
+      for (MooseIndex(_pattern[i]) j = 0; j < _pattern[i].size(); ++j)
+      {
+        tile_id[i][j] = integer_ids[k];
+        k += _meshes[_pattern[i][j]]->n_elem();
+      }
+    }
+  }
+
+  // Assign by centroid so the result is correct regardless of element iteration order.
+  // This is necessary in distributed mode where element_ptr_range is not tile-major.
+  libMesh::MeshSerializer mesh_serializer(*mesh);
+  for (auto & elem : mesh->element_ptr_range())
+  {
+    const auto c = elem->vertex_average();
+    const int col = static_cast<int>((c(0) - min_x) / _x_width);
+    const int row = static_cast<int>((min_y + _y_width - c(1)) / _y_width);
+    elem->set_extra_integer(extra_id_index, tile_id[row][col]);
+  }
 
   return mesh;
 }

--- a/modules/reactor/src/meshgenerators/PatternedCartesianMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PatternedCartesianMeshGenerator.C
@@ -11,6 +11,7 @@
 #include "ReportingIDGeneratorUtils.h"
 #include "MooseUtils.h"
 #include "MooseMeshUtils.h"
+#include "libmesh/mesh_serializer.h"
 
 // C++ includes
 #include <cmath> // provides round, not std::round (see http://www.cplusplus.com/reference/cmath/round/)
@@ -380,13 +381,11 @@ PatternedCartesianMeshGenerator::PatternedCartesianMeshGenerator(const InputPara
 std::unique_ptr<MeshBase>
 PatternedCartesianMeshGenerator::generate()
 {
-  std::vector<std::unique_ptr<ReplicatedMesh>> meshes(_input_names.size());
+  std::vector<std::unique_ptr<MeshBase>> meshes(_input_names.size());
   for (const auto i : index_range(_input_names))
   {
     mooseAssert(_mesh_ptrs[i] && (*_mesh_ptrs[i]).get(), "nullptr mesh");
-    meshes[i] = dynamic_pointer_cast<ReplicatedMesh>(std::move(*_mesh_ptrs[i]));
-    if (!meshes[i])
-      paramError("inputs", "Mesh '", _input_names[i], "' is not a replicated mesh but it must be");
+    meshes[i] = std::move(*_mesh_ptrs[i]);
     // throw an error message if the input mesh does not have a flat side up
     if (hasMeshProperty<bool>("flat_side_up", _input_names[i]))
       if (!getMeshProperty<bool>("flat_side_up", _input_names[i]))
@@ -395,6 +394,12 @@ PatternedCartesianMeshGenerator::generate()
                    _input_names[i],
                    "' does not have a flat side facing up, which is not supported.");
   }
+
+  // Serialize any distributed input meshes for the duration of stitching
+  std::vector<std::unique_ptr<libMesh::MeshSerializer>> serializers;
+  serializers.reserve(meshes.size());
+  for (auto & m : meshes)
+    serializers.push_back(std::make_unique<libMesh::MeshSerializer>(*m));
 
   std::vector<Real> pitch_array;
   std::vector<unsigned int> num_sectors_per_side_array;
@@ -613,7 +618,7 @@ PatternedCartesianMeshGenerator::generate()
   std::vector<Real> control_drum_positions_y;
   std::vector<std::vector<Real>> control_drum_azimuthals;
 
-  std::unique_ptr<ReplicatedMesh> out_mesh;
+  std::unique_ptr<UnstructuredMesh> out_mesh;
 
   for (unsigned i = 0; i < _pattern.size(); i++)
   {
@@ -623,7 +628,7 @@ PatternedCartesianMeshGenerator::generate()
     for (unsigned int j = 0; j < _pattern[i].size(); j++)
     {
       const auto pattern = _pattern[i][j];
-      ReplicatedMesh & pattern_mesh = *meshes[pattern];
+      auto & pattern_mesh = *meshes[pattern];
 
       // No pattern boundary, so no need to wrap with a peripheral mesh
       // Use the inputs as they stand and translate accordingly later
@@ -638,7 +643,8 @@ PatternedCartesianMeshGenerator::generate()
 
         if (j == 0 && i == 0)
         {
-          out_mesh = dynamic_pointer_cast<ReplicatedMesh>(pattern_mesh.clone());
+          auto clone_out = pattern_mesh.clone();
+          out_mesh = dynamic_pointer_cast<UnstructuredMesh>(clone_out);
           if (_assign_control_drum_id && _generate_core_metadata)
             out_mesh->add_elem_integer(
                 "control_drum_id",
@@ -713,7 +719,8 @@ PatternedCartesianMeshGenerator::generate()
 
         if (on_periphery)
         {
-          auto tmp_peripheral_mesh = dynamic_pointer_cast<ReplicatedMesh>(pattern_mesh.clone());
+          auto tmp_clone = pattern_mesh.clone();
+          auto tmp_peripheral_mesh = dynamic_pointer_cast<UnstructuredMesh>(tmp_clone);
           addPeripheralMesh(*tmp_peripheral_mesh,
                             pattern,
                             pitch_array.front(),
@@ -1023,14 +1030,14 @@ PatternedCartesianMeshGenerator::generate()
     setMeshProperty("interface_boundary_ids", interface_boundary_ids);
   }
 
+  out_mesh->allow_remote_element_removal(_mesh->allowRemoteElementRemoval());
   out_mesh->unset_is_prepared();
-  auto mesh = dynamic_pointer_cast<MeshBase>(out_mesh);
-  return mesh;
+  return out_mesh;
 }
 
 void
 PatternedCartesianMeshGenerator::addPeripheralMesh(
-    ReplicatedMesh & mesh,
+    UnstructuredMesh & mesh,
     const unsigned int pattern,
     const Real pitch,
     const std::vector<Real> & extra_dist,
@@ -1156,7 +1163,7 @@ PatternedCartesianMeshGenerator::positionSetup(
 
 void
 PatternedCartesianMeshGenerator::addReportingIDs(
-    MeshBase & mesh, const std::vector<std::unique_ptr<ReplicatedMesh>> & from_meshes) const
+    MeshBase & mesh, const std::vector<std::unique_ptr<MeshBase>> & from_meshes) const
 {
   const unsigned int num_reporting_ids = _reporting_id_names.size();
   for (unsigned int i = 0; i < num_reporting_ids; ++i)

--- a/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
@@ -11,6 +11,7 @@
 #include "ReportingIDGeneratorUtils.h"
 #include "MooseUtils.h"
 #include "MooseMeshUtils.h"
+#include "libmesh/mesh_serializer.h"
 
 // C++ includes
 #include <cmath> // provides round, not std::round (see http://www.cplusplus.com/reference/cmath/round/)
@@ -350,15 +351,10 @@ PatternedHexMeshGenerator::PatternedHexMeshGenerator(const InputParameters & par
 std::unique_ptr<MeshBase>
 PatternedHexMeshGenerator::generate()
 {
-  std::vector<std::unique_ptr<ReplicatedMesh>> meshes(_input_names.size());
+  std::vector<std::unique_ptr<MeshBase>> meshes(_input_names.size());
   for (const auto i : index_range(_input_names))
   {
-    meshes[i] = dynamic_pointer_cast<ReplicatedMesh>(std::move(*_mesh_ptrs[i]));
-    if (!meshes[i])
-      paramError("inputs",
-                 "Mesh '",
-                 _input_names[i],
-                 "' is not a replicated mesh. Only replicated meshes are supported");
+    meshes[i] = std::move(*_mesh_ptrs[i]);
 
     // throw an error message if the input mesh has a flat side up
     if (hasMeshProperty<bool>("flat_side_up", _input_names[i]))
@@ -368,6 +364,12 @@ PatternedHexMeshGenerator::generate()
                    _input_names[i],
                    "' has a flat side facing up, which is not supported.");
   }
+
+  // Serialize any distributed input meshes for the duration of stitching
+  std::vector<std::unique_ptr<libMesh::MeshSerializer>> serializers;
+  serializers.reserve(meshes.size());
+  for (auto & m : meshes)
+    serializers.push_back(std::make_unique<libMesh::MeshSerializer>(*m));
 
   std::vector<Real> pitch_array;
   std::vector<unsigned int> num_sectors_per_side_array;
@@ -601,7 +603,7 @@ PatternedHexMeshGenerator::generate()
   std::vector<Real> control_drum_positions_y;
   std::vector<std::vector<Real>> control_drum_azimuthals;
 
-  std::unique_ptr<ReplicatedMesh> out_mesh;
+  std::unique_ptr<UnstructuredMesh> out_mesh;
 
   for (unsigned i = 0; i < _pattern.size(); i++)
   {
@@ -617,7 +619,7 @@ PatternedHexMeshGenerator::generate()
     for (unsigned int j = 0; j < _pattern[i].size(); j++)
     {
       const auto pattern = _pattern[i][j];
-      ReplicatedMesh & pattern_mesh = *meshes[pattern];
+      auto & pattern_mesh = *meshes[pattern];
 
       // No pattern boundary, so no need to wrap with a peripheral mesh
       // Use the inputs as they stand and translate accordingly later
@@ -632,7 +634,8 @@ PatternedHexMeshGenerator::generate()
 
         if (j == 0 && i == 0)
         {
-          out_mesh = dynamic_pointer_cast<ReplicatedMesh>(pattern_mesh.clone());
+          auto clone_out = pattern_mesh.clone();
+          out_mesh = dynamic_pointer_cast<UnstructuredMesh>(clone_out);
           if (_assign_control_drum_id && _generate_core_metadata)
             out_mesh->add_elem_integer(
                 "control_drum_id",
@@ -731,7 +734,8 @@ PatternedHexMeshGenerator::generate()
 
         if (on_periphery)
         {
-          auto tmp_peripheral_mesh = dynamic_pointer_cast<ReplicatedMesh>(pattern_mesh.clone());
+          auto tmp_clone = pattern_mesh.clone();
+          auto tmp_peripheral_mesh = dynamic_pointer_cast<UnstructuredMesh>(tmp_clone);
           addPeripheralMesh(*tmp_peripheral_mesh,
                             pattern,
                             pitch_array.front(),
@@ -1021,14 +1025,14 @@ PatternedHexMeshGenerator::generate()
     setMeshProperty("interface_boundary_ids", interface_boundary_ids);
   }
 
+  out_mesh->allow_remote_element_removal(_mesh->allowRemoteElementRemoval());
   out_mesh->unset_is_prepared();
-  auto mesh = dynamic_pointer_cast<MeshBase>(out_mesh);
-  return mesh;
+  return out_mesh;
 }
 
 void
 PatternedHexMeshGenerator::addPeripheralMesh(
-    ReplicatedMesh & mesh,
+    UnstructuredMesh & mesh,
     const unsigned int pattern,
     const Real pitch,
     const std::vector<Real> & extra_dist,
@@ -1210,7 +1214,7 @@ PatternedHexMeshGenerator::positionSetup(std::vector<std::pair<Real, Real>> & po
 
 void
 PatternedHexMeshGenerator::addReportingIDs(
-    MeshBase & mesh, const std::vector<std::unique_ptr<ReplicatedMesh>> & from_meshes) const
+    MeshBase & mesh, const std::vector<std::unique_ptr<MeshBase>> & from_meshes) const
 {
   const unsigned int num_reporting_ids = _reporting_id_names.size();
   for (unsigned int i = 0; i < num_reporting_ids; ++i)

--- a/modules/reactor/src/meshgenerators/PolygonMeshGeneratorBase.C
+++ b/modules/reactor/src/meshgenerators/PolygonMeshGeneratorBase.C
@@ -1149,7 +1149,7 @@ PolygonMeshGeneratorBase::quadElemDef(ReplicatedMesh & mesh,
   }
 }
 
-std::unique_ptr<ReplicatedMesh>
+std::unique_ptr<MeshBase>
 PolygonMeshGeneratorBase::buildSimplePeripheral(
     const unsigned int num_sectors_per_side,
     const unsigned int peripheral_invervals,

--- a/modules/reactor/src/utils/ReportingIDGeneratorUtils.C
+++ b/modules/reactor/src/utils/ReportingIDGeneratorUtils.C
@@ -13,7 +13,7 @@ using namespace libMesh;
 
 std::vector<dof_id_type>
 ReportingIDGeneratorUtils::getCellwiseIntegerIDs(
-    const std::vector<std::unique_ptr<ReplicatedMesh>> & meshes,
+    const std::vector<std::unique_ptr<MeshBase>> & meshes,
     const std::vector<std::vector<unsigned int>> & pattern,
     const bool use_exclude_id,
     const std::vector<bool> & exclude_ids)
@@ -37,7 +37,7 @@ ReportingIDGeneratorUtils::getCellwiseIntegerIDs(
 
 std::vector<dof_id_type>
 ReportingIDGeneratorUtils::getPatternIntegerIDs(
-    const std::vector<std::unique_ptr<ReplicatedMesh>> & meshes,
+    const std::vector<std::unique_ptr<MeshBase>> & meshes,
     const std::vector<std::vector<unsigned int>> & pattern)
 {
   dof_id_type n = 0;
@@ -54,7 +54,7 @@ ReportingIDGeneratorUtils::getPatternIntegerIDs(
 
 std::vector<dof_id_type>
 ReportingIDGeneratorUtils::getManualIntegerIDs(
-    const std::vector<std::unique_ptr<ReplicatedMesh>> & meshes,
+    const std::vector<std::unique_ptr<MeshBase>> & meshes,
     const std::vector<std::vector<unsigned int>> & pattern,
     const std::vector<std::vector<dof_id_type>> & id_pattern)
 {
@@ -71,9 +71,8 @@ ReportingIDGeneratorUtils::getManualIntegerIDs(
 }
 
 std::set<SubdomainID>
-ReportingIDGeneratorUtils::getCellBlockIDs(
-    const std::vector<std::unique_ptr<ReplicatedMesh>> & meshes,
-    const std::vector<std::vector<unsigned int>> & pattern)
+ReportingIDGeneratorUtils::getCellBlockIDs(const std::vector<std::unique_ptr<MeshBase>> & meshes,
+                                           const std::vector<std::vector<unsigned int>> & pattern)
 {
   std::set<SubdomainID> blks;
   for (MooseIndex(pattern) i = 0; i < pattern.size(); ++i)
@@ -117,7 +116,7 @@ ReportingIDGeneratorUtils::assignReportingIDs(
     const std::vector<bool> & exclude_ids,
     const bool has_assembly_boundary,
     const std::set<subdomain_id_type> background_block_ids,
-    const std::vector<std::unique_ptr<ReplicatedMesh>> & input_meshes,
+    const std::vector<std::unique_ptr<MeshBase>> & input_meshes,
     const std::vector<std::vector<unsigned int>> & pattern,
     const std::vector<std::vector<dof_id_type>> & id_pattern)
 {

--- a/test/tests/meshgenerators/manifold_subdomain/tests
+++ b/test/tests/meshgenerators/manifold_subdomain/tests
@@ -45,7 +45,6 @@
       type = RunApp
       input = cone.i
       cli_args='Mesh/background/nx=10 Mesh/background/ny=10 Mesh/background/nz=10 expected=188'
-      recover = false # See #32882
       capabilities = 'dof_id_bytes=8' # see #32898
       detail = 'the manifold or'
     []
@@ -54,7 +53,6 @@
       input = cone.i
       cli_args = 'Mesh/background/nx=10 Mesh/background/ny=10 Mesh/background/nz=10
                   Mesh/tag/location=OUTSIDE expected="812"'
-      recover = false # See #32882
       capabilities = 'dof_id_bytes=8' # see #32898
       detail = 'the space around the manifold.'
     []

--- a/test/tests/meshgenerators/manifold_subdomain/tests
+++ b/test/tests/meshgenerators/manifold_subdomain/tests
@@ -7,33 +7,28 @@
     [basic_inside]
       type = RunApp
       input = basic.i
-      capabilities = 'dof_id_bytes=8' # see #32898
       detail = 'lie inside a closed STL manifold;'
     []
     [outside]
       type = RunApp
       input = basic.i
-      capabilities = 'dof_id_bytes=8' # see #32898
       cli_args = 'Mesh/apply/location=OUTSIDE expected="8 56"'
       detail = 'lie outside a closed STL manifold.'
     []
     [restricted]
       type = RunApp
       input = restricted.i
-      capabilities = 'dof_id_bytes=8' # see #32898
       detail = 'lie inside a closed STL manifold and already assigned a specified subdomain;'
     []
     [rotated_translated]
       type = RunApp
       input = basic.i
-      capabilities = 'dof_id_bytes=8' # see #32898
       cli_args = 'Mesh/rotate/vector_value="0 0 45" expected="56 8"'
       detail = 'lie inside a closed STL manifold that has been translated and rotated;'
     []
     [scaled]
       type = RunApp
       input = basic.i
-      capabilities = 'dof_id_bytes=8' # see #32898
       cli_args = 'Mesh/scale/vector_value="2 2 2" expected="64"'
       detail = 'lie inside a closed STL manifold that has been scaled.'
     []
@@ -45,7 +40,6 @@
       type = RunApp
       input = cone.i
       cli_args='Mesh/background/nx=10 Mesh/background/ny=10 Mesh/background/nz=10 expected=188'
-      capabilities = 'dof_id_bytes=8' # see #32898
       detail = 'the manifold or'
     []
     [negative]
@@ -53,7 +47,6 @@
       input = cone.i
       cli_args = 'Mesh/background/nx=10 Mesh/background/ny=10 Mesh/background/nz=10
                   Mesh/tag/location=OUTSIDE expected="812"'
-      capabilities = 'dof_id_bytes=8' # see #32898
       detail = 'the space around the manifold.'
     []
   []
@@ -63,7 +56,6 @@
     [invalid_input_dimension]
       type = RunException
       input = invalid_input_dimension.i
-      capabilities = 'dof_id_bytes=8' # see #32898
       expect_err = 'Only 3D meshes are supported.'
       detail = 'manifold subdomain assignment is requested on a non-3D mesh;'
     []
@@ -71,14 +63,12 @@
       type = RunException
       input = invalid_manifold_dimension.i
       expect_err = 'Only 2D meshes are supported.'
-      capabilities = 'dof_id_bytes=8' # see #32898
       detail = 'manifold subdomain assignment is requested using non-2D manifold mesh;'
     []
     [open_surface]
       type = RunException
       input = open_surface.i
       expect_err = 'At least one triangle without three neighbors was found.'
-      capabilities = 'dof_id_bytes=8' # see #32898
       detail = 'the surface is open or non-manifold;'
     []
     [non_tri]
@@ -87,7 +77,6 @@
       cli_args='Mesh/background/nx=5 Mesh/background/ny=5 Mesh/background/nz=5
                 Mesh/inactive="surface" Mesh/tag/manifold=surface_quads'
       expect_err = "At least one non-Tri3 element was found."
-      capabilities = 'dof_id_bytes=8' # see #32898
       detail = 'the manifold has non-TRI elements;'
     []
   []


### PR DESCRIPTION
This property, and it's usage in SetupMeshAction, was causing the mesh to be checkpointed in distributed mode, while being recovered in replicated mode.

This was originally implemented in #16693. The tests added in #32764 revealed the issue.

See civet failure: https://civet.inl.gov/job/3802176/