### PR TITLE
Fix editorial issues, tests in the absence of SLEPc and failing stdlib assertion

### DIFF
--- a/framework/doc/content/source/mfem/actions/AddMFEMComplexBCComponentAction.md
+++ b/framework/doc/content/source/mfem/actions/AddMFEMComplexBCComponentAction.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Action called to add a real or imaginary component of an [MFEMComplexIntegratedBC](source/mfem/bcs/MFEMComplexIntegratedBC.md), each in the form of a separate [MFEMIntegratedBC](source/mfem/bcs/MFEMIntegratedBC.md) user object.
+Action called to add a real or imaginary component of an [MFEMComplexIntegratedBC.md], each in the form of a separate [MFEMIntegratedBC.md] user object.
 
 !syntax parameters /BCs/AddMFEMComplexBCComponentAction
 

--- a/framework/doc/content/source/mfem/actions/AddMFEMComplexKernelComponentAction.md
+++ b/framework/doc/content/source/mfem/actions/AddMFEMComplexKernelComponentAction.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Action called to add a real or imaginary component of an [MFEMComplexKernel](source/mfem/kernels/MFEMComplexKernel.md), each in the form of a separate [MFEMKernel](source/mfem/kernels/MFEMKernel.md) user object.
+Action called to add a real or imaginary component of an [MFEMComplexKernel.md], each in the form of a separate [MFEMKernel.md] user object.
 
 ## Example Input File Syntax
 

--- a/framework/doc/content/source/mfem/actions/AddMFEMFESpaceAction.md
+++ b/framework/doc/content/source/mfem/actions/AddMFEMFESpaceAction.md
@@ -5,8 +5,8 @@
 ## Overview
 
 Action called to add an MFEM finite element space to the problem, parsing content inside an
-[`MFEMFESpace`](source/mfem/fespaces/MFEMFESpace.md) block in the user input. Only has an effect if the
-`Problem` type is set to [`MFEMProblem`](source/mfem/problem/MFEMProblem.md).
+[MFEMFESpace.md] block in the user input. Only has an effect if the
+`Problem` type is set to [MFEMProblem.md].
 
 ## Example Input File Syntax
 

--- a/framework/doc/content/source/mfem/actions/AddMFEMPreconditionerAction.md
+++ b/framework/doc/content/source/mfem/actions/AddMFEMPreconditionerAction.md
@@ -5,8 +5,8 @@
 ## Overview
 
 Action called to add a linear preconditioner to an MFEM problem, parsing content inside a
-[`Preconditioner`](source/mfem/solvers/MFEMSolverBase.md) block in the user input. Only has an effect if
-the `Problem` type is set to [`MFEMProblem`](source/mfem/problem/MFEMProblem.md).
+[`Preconditioner`](MFEMSolverBase.md) block in the user input. Only has an effect if
+the `Problem` type is set to [MFEMProblem.md].
 
 ## Example Input File Syntax
 

--- a/framework/doc/content/source/mfem/actions/AddMFEMSolverAction.md
+++ b/framework/doc/content/source/mfem/actions/AddMFEMSolverAction.md
@@ -5,8 +5,8 @@
 ## Overview
 
 Action called to add a linear solver to an MFEM problem, parsing content inside a
-[`Solver`](source/mfem/solvers/MFEMSolverBase.md) block in the user input. Only has an effect if the
-`Problem` type is set to [`MFEMProblem`](source/mfem/problem/MFEMProblem.md).
+[`Solver`](MFEMSolverBase.md) block in the user input. Only has an effect if the
+`Problem` type is set to [MFEMProblem.md].
 
 ## Example Input File Syntax
 

--- a/framework/doc/content/source/mfem/actions/AddMFEMSubMeshAction.md
+++ b/framework/doc/content/source/mfem/actions/AddMFEMSubMeshAction.md
@@ -6,7 +6,7 @@
 
 Action called to add an MFEM finite element space to the problem, parsing content inside a
 [`SubMeshes`](source/mfem/submeshes/MFEMSubMesh.md) block in the user input. Only has an
-effect if the `Problem` type is set to [`MFEMProblem`](source/mfem/problem/MFEMProblem.md).
+effect if the `Problem` type is set to [MFEMProblem.md].
 
 ## Example Input File Syntax
 

--- a/framework/doc/content/source/mfem/actions/SetMFEMMeshFESpaceAction.md
+++ b/framework/doc/content/source/mfem/actions/SetMFEMMeshFESpaceAction.md
@@ -5,15 +5,14 @@
 ## Summary
 
 Sets the nodal mesh FESpace to use the same FESpace as the
-[`MFEMVariable`](source/mfem/variables/MFEMVariable.md) used to describe node displacements.
+[MFEMVariable.md] used to describe node displacements.
 
 ## Overview
 
 Action called to set the nodal mesh FESpace to use the same FESpace as the variable used to describe
 node displacements in problems involving deformed meshes, parsing content inside the `Mesh` block in
-the user input. Only has an effect if the `Problem` type is set to
-[`MFEMProblem`](source/mfem/problem/MFEMProblem.md), the `Mesh` type is set to [`MFEMMesh`](source/mfem/mesh/MFEMMesh.md)
-and the `displacement` field is set.
+the user input. Only has an effect if the `Problem` type is set to [MFEMProblem.md], the `Mesh` type
+is set to [MFEMMesh.md] and the `displacement` field is set.
 
 ## Example Input File Syntax
 

--- a/framework/doc/content/source/mfem/base/MFEMExecutedObject.md
+++ b/framework/doc/content/source/mfem/base/MFEMExecutedObject.md
@@ -5,13 +5,13 @@
 ## Overview
 
 `MFEMExecutedObject` is the base class for MFEM objects that are scheduled and executed by
-[MFEMProblem](problem/MFEMProblem.md) during a solve. It derives from
-[MFEMObject](base/MFEMObject.md), `SetupInterface`, and `DependencyResolverInterface`.
+[MFEMProblem.md] during a solve. It derives from [MFEMObject.md], [SetupInterface.md], and
+[DependencyResolverInterface.md].
 
 ## Execution ordering
 
 Execution order among `MFEMExecutedObject` instances is determined automatically by
-`DependencyResolverInterface`: the MFEM scheduler builds a dependency graph from the variable,
+[DependencyResolverInterface.md]: the MFEM scheduler builds a dependency graph from the variable,
 postprocessor, and vector postprocessor names that each object declares it consumes or produces,
 then performs a topological sort.
 
@@ -50,11 +50,11 @@ All three have empty default implementations. Derived classes override whichever
 
 The following MFEM object types derive from `MFEMExecutedObject`:
 
-- [MFEMAuxKernel](auxkernels/MFEMAuxKernel.md) — updates real auxiliary variables.
-- [MFEMComplexAuxKernel](auxkernels/MFEMComplexAuxKernel.md) — updates complex auxiliary variables.
-- [MFEMPostprocessor](postprocessors/MFEMPostprocessor.md) — computes a scalar quantity.
-- [MFEMVectorPostprocessor](vectorpostprocessors/MFEMVectorPostprocessor.md) — computes an array of values.
-- [MFEMSubMeshTransfer](transfers/MFEMSubMeshTransfer.md) — transfers variable data between a mesh and a submesh.
+- [MFEMAuxKernel.md] — updates real auxiliary variables.
+- [MFEMComplexAuxKernel.md] — updates complex auxiliary variables.
+- [MFEMPostprocessor.md] — computes a scalar quantity.
+- [MFEMVectorPostprocessor.md] — computes an array of values.
+- [MFEMSubMeshTransfer.md] — transfers variable data between a mesh and a submesh.
 - `MFEMInitialCondition` — sets the initial value on an MFEM variable.
 
 !if-end!

--- a/framework/doc/content/source/mfem/base/MFEMObject.md
+++ b/framework/doc/content/source/mfem/base/MFEMObject.md
@@ -5,7 +5,7 @@
 ## Overview
 
 `MFEMObject` is the common base class for all MFEM objects. It provides every MFEM object with a
-typed reference to the owning [MFEMProblem](problem/MFEMProblem.md) and a set of helpers for
+typed reference to the owning [MFEMProblem.md] and a set of helpers for
 retrieving MFEM coefficients by name.
 
 `MFEMObject` also mixes in `FunctionInterface`, `PostprocessorInterface`,
@@ -18,7 +18,7 @@ The `getMFEMProblem()` method returns a typed reference to the owning `MFEMProbl
 
 ## Coefficient access
 
-MFEM coefficients declared through [MFEMFunctorMaterial](functormaterials/MFEMFunctorMaterial.md)
+MFEM coefficients declared through [MFEMFunctorMaterial.md]
 objects are stored in the `CoefficientManager` owned by `MFEMProblem`. `MFEMObject` exposes two
 families of accessor methods for them:
 
@@ -38,7 +38,7 @@ parameter, so the caller does not need to extract the string itself.
 
 `MFEMObject` is the root of the MFEM object hierarchy. Direct subclasses include:
 
-- [MFEMExecutedObject](base/MFEMExecutedObject.md) — objects that are scheduled and executed by `MFEMProblem` (aux kernels, postprocessors, transfers, initial conditions, etc.).
+- [MFEMExecutedObject.md] — objects that are scheduled and executed by `MFEMProblem` (aux kernels, postprocessors, transfers, initial conditions, etc.).
 - `MFEMSolverBase` — MFEM linear solver and preconditioner objects.
 - `MFEMKernel` / `MFEMComplexKernel` — weak-form contributions to the equation system.
 - `MFEMBoundaryCondition` — boundary conditions applied to the equation system.

--- a/framework/doc/content/source/mfem/bcs/MFEMBoundaryCondition.md
+++ b/framework/doc/content/source/mfem/bcs/MFEMBoundaryCondition.md
@@ -17,13 +17,11 @@ according to the test variable name returned from `getTestVariableName()`.
 `MFEMBoundaryCondition` objects come in two varieties, depending on which child class they inherit
 from:
 
-- Essential boundary conditions, inheriting from [`MFEMEssentialBC`](source/mfem/bcs/MFEMEssentialBC.md),
-  for the application of Dirichlet-like BCs removing degrees of freedom from the problem at the
-  boundary;
+- Essential boundary conditions, inheriting from [MFEMEssentialBC.md], for the application of
+  Dirichlet-like BCs removing degrees of freedom from the problem at the boundary;
 
-- Integrated boundary conditions, inheriting from
-  [`MFEMIntegratedBC`](source/mfem/bcs/MFEMIntegratedBC.md), which apply one or more boundary integrators
-  to the weak form on the specified boundaries.
+- Integrated boundary conditions, inheriting from [MFEMIntegratedBC.md], which apply one or more
+  boundary integrators to the weak form on the specified boundaries.
 
 
 !if-end!

--- a/framework/doc/content/source/mfem/bcs/MFEMComplexIntegratedBC.md
+++ b/framework/doc/content/source/mfem/bcs/MFEMComplexIntegratedBC.md
@@ -10,9 +10,9 @@ Base class for objects applying complex-valued integrated boundary conditions to
 
 `MFEMComplexIntegratedBC` applies boundary integrator(s) to the weak form equation that is labeled
 according to the test variable name returned from `getTestVariableName()`, similar to
-[`MFEMComplexKernel`](source/mfem/kernels/MFEMKernel.md) for domain integrators.
+[MFEMComplexKernel.md] for domain integrators.
 
-Similarly to how [`MFEMComplexKernel`](source/mfem/kernels/MFEMComplexKernel.md) works, `MFEMComplexIntegratedBC`
+Similarly to how [MFEMComplexKernel.md] works, `MFEMComplexIntegratedBC`
 is a container for two `MFEMIntegratedBC` objects, one representing the real part of the integrated BC, and the other
 representing the imaginary part. These two can be set up using the `RealComponent` and `ImagComponent` sub-blocks on the script.
 The two integrators need not be the same, but they do need to be applied to the same variable.

--- a/framework/doc/content/source/mfem/bcs/MFEMIntegratedBC.md
+++ b/framework/doc/content/source/mfem/bcs/MFEMIntegratedBC.md
@@ -13,7 +13,7 @@ boundary integrators to the weak form on the set of user-specified boundaries.
 
 `MFEMIntegratedBC` applies boundary integrator(s) to the weak form equation that is labeled
 according to the test variable name returned from `getTestVariableName()`, similar to
-[`MFEMKernel`](source/mfem/kernels/MFEMKernel.md) for domain integrators.
+[MFEMKernel.md] for domain integrators.
 
 !if-end!
 

--- a/framework/doc/content/source/mfem/equation_systems/EquationSystem.md
+++ b/framework/doc/content/source/mfem/equation_systems/EquationSystem.md
@@ -6,7 +6,7 @@ The EquationSystem is responsible for defining and assembling the weak form of t
 [`mfem::Operator`](https://docs.mfem.org/html/classmfem_1_1Operator.html) used to solve an iteration
 of the FE problem. This operator is passed to an
 [`mfem::NewtonSolver`](https://docs.mfem.org/html/classmfem_1_1NewtonSolver.html) in a
-[ProblemOperator](source/mfem/problem_operators/ProblemOperator.md), which handles the update of the
+[ProblemOperator.md], which handles the update of the
 state of all variables (including any required nonlinear iterations).
 
 !equation

--- a/framework/doc/content/source/mfem/equation_systems/EquationSystem.md
+++ b/framework/doc/content/source/mfem/equation_systems/EquationSystem.md
@@ -32,8 +32,8 @@ form. [`mfem::BilinearFormIntegrators`](https://mfem.org/bilininteg/) add contri
 $A_{ij}(\varphi_i, \phi_j)$ and [`mfem::LinearFormIntegrators`](https://mfem.org/lininteg/) add
 contributions to $b_i(\varphi_i)$ when assembled.
 
-[MFEMKernels](source/mfem/kernels/MFEMKernel.md) can also contribute to domain integrators for 
-non-linear actions. This allows to form the residual $\mathcal{L}(u)$ for non-linear Newton's 
+[MFEMKernels](source/mfem/kernels/MFEMKernel.md) can also contribute to domain integrators for
+non-linear actions. This allows to form the residual $\mathcal{L}(u)$ for non-linear Newton's
 method as shown below
 
 !equation

--- a/framework/doc/content/source/mfem/executioners/MFEMSteady.md
+++ b/framework/doc/content/source/mfem/executioners/MFEMSteady.md
@@ -5,8 +5,7 @@
 ## Overview
 
 `MFEMSteady` is the `Executioner` class used to solve time independent MFEM finite element problems,
-calling the [`MFEMProblemSolve`](MFEMProblemSolve.md) solve object to execute one or more MFEM
-`ProblemOperators`.
+calling the [MFEMProblemSolve.md] solve object to execute one or more MFEM `ProblemOperators`.
 
 As in all `Executioner` classes using the [MFEMProblemSolve.md] solve object, the desired device and assembly
 level to use during problem set-up and solution can be selected.

--- a/framework/doc/content/source/mfem/executioners/MFEMTransient.md
+++ b/framework/doc/content/source/mfem/executioners/MFEMTransient.md
@@ -5,7 +5,7 @@
 ## Overview
 
 `MFEMTransient` is the `Executioner` class used to solve time dependent MFEM finite element
-problems, calling the [`MFEMProblemSolve`](MFEMProblemSolve.md) solve object to execute one or more
+problems, calling the [MFEMProblemSolve.md] solve object to execute one or more
 MFEM `TimeDependentProblemOperators`.
 
 As in all `Executioner` classes using the [MFEMProblemSolve.md] solve object,

--- a/framework/doc/content/source/mfem/fespaces/MFEMGenericFESpace.md
+++ b/framework/doc/content/source/mfem/fespaces/MFEMGenericFESpace.md
@@ -12,9 +12,8 @@ arguments as one would use with raw MFEM. Information on how to
 construct the name of a finite element collection can be [found in the
 MFEM documentation](https://docs.mfem.org/html/classmfem_1_1FiniteElementCollection.html#a15fcfa553d4949eb08f9926ac74d1e80).
 
-Most users will find it easier to use the
-[MFEMScalarFESpace](MFEMScalarFESpace.md) and
-[MFEMVectorFESpace](MFEMVectorFESpace.md) classes instead. These will
+Most users will find it easier to use the [MFEMScalarFESpace.md] and
+[MFEMVectorFESpace.md] classes instead. These will
 select the appropriate finite element collection and vdim based on
 your mesh and a few other parameters. However, not all MFEM finite
 element collections are supported by those classes.

--- a/framework/doc/content/source/mfem/fespaces/MFEMScalarFESpace.md
+++ b/framework/doc/content/source/mfem/fespaces/MFEMScalarFESpace.md
@@ -10,8 +10,7 @@ from the `fec_type` parameter, and the order is controlled using the
 `fec_order` parameter.
 
 If you need a finite element space that can't be constructed using the
-options available in this class, you can use
-[MFEMGenericFESpace](MFEMGenericFESpace.md) instead.
+options available in this class, you can use [MFEMGenericFESpace.md] instead.
 
 ## Example Input File Syntax
 

--- a/framework/doc/content/source/mfem/fespaces/MFEMVectorFESpace.md
+++ b/framework/doc/content/source/mfem/fespaces/MFEMVectorFESpace.md
@@ -27,8 +27,7 @@ Raviart-Thomas finite elements in a 1D reference space but with 2D
 vectors.
 
 If you need a finite element space that can't be constructed using the
-options available in this class, you can use
-[MFEMGenericFESpace](MFEMGenericFESpace.md) instead.
+options available in this class, you can use [MFEMGenericFESpace.md] instead.
 
 ## Example Input File Syntax
 

--- a/framework/doc/content/source/mfem/functions/MFEMParsedFunction.md
+++ b/framework/doc/content/source/mfem/functions/MFEMParsedFunction.md
@@ -9,7 +9,7 @@ to being scalar functions of position and time, can also depend on scalar
 coefficients, including any scalar variables, postprocessors, material
 properties or functions specified by the user.
 
-The input parameters are those of [ParsedFunction](/MooseParsedFunction.md)
+The input parameters are those of [MooseParsedFunction.md]
 and provide the same flexibility. Note that, in the context of MFEM problems,
 a scalar variable is a real-valued scalar field, not (necessarily) a constant
 over the entire domain as elsewhere in MOOSE.

--- a/framework/doc/content/source/mfem/indicators/MFEMIndicator.md
+++ b/framework/doc/content/source/mfem/indicators/MFEMIndicator.md
@@ -15,7 +15,7 @@ Broadly speaking, the `mfem::ErrorEstimator` object looks, after a solve step, a
 and determines which, if any, regions of the mesh need to be refined further. These recommendations are then
 passed on to the `MFEMRefinementMarker`, which marks any elements for refinement and does the actual refinement.
 
-This class serves as an abstract base class, and does no actual implementation. 
+This class serves as an abstract base class, and does no actual implementation.
 
 To keep the naming consistent with similar classes in MOOSE, we refer to this class as an Indicator.
 

--- a/framework/doc/content/source/mfem/kernels/MFEMComplexKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMComplexKernel.md
@@ -9,11 +9,10 @@ Base class for complex MFEM kernels applied to the weak form being solved.
 ## Overview
 
 Complex MFEM kernels are responsible for providing complex-valued domain integrators to add to the weak form of the FE
-problem accumulated in [EquationSystem](source/mfem/equation_systems/EquationSystem.md), along with any
+problem accumulated in [EquationSystem.md], along with any
 required marker arrays to restrict the integrator(s) to subdomains. The `MFEMComplexKernel` is a container
-for two objects of [MFEMKernel](source/mfem/kernels/MFEMKernel.md) type, one representing a real contribution to
-the equation system, and the other representing an imaginary contribution. The real and imaginary kernels need not be the same,
-but they do need to be applied to the same variable, which must be of [MFEMComplexVariable](source/mfem/variables/MFEMComplexVariable.md) type.
+for two objects of [MFEMKernel.md] type, one representing a real contribution to
+the equation system, and the other representing an imaginary contribution. The real and imaginary kernels need not be the same, but they do need to be applied to the same variable, which must be of [MFEMComplexVariable.md] type.
 
 The integrators are applied to the weak form equation that is labeled according to the test variable
 name of the kernel returned from `getTestVariableName()`. In the case of bilinear (or nonlinear)

--- a/framework/doc/content/source/mfem/kernels/MFEMKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMKernel.md
@@ -22,8 +22,8 @@ variable names is the same as the set of trial variable names for a square syste
 
 `MFEMKernel` is a base class. Derived classes should override the `createBFIntegrator`
 and/or the `createLFIntegrator` methods to return a `BilinearFormIntegrator` and/or a
-`LinearFormIntegrator` (respectively) to add to the `EquationSystem`. Derived classes could also 
-override `createNLIntegrator` to solve non-linear problems using 
+`LinearFormIntegrator` (respectively) to add to the `EquationSystem`. Derived classes could also
+override `createNLIntegrator` to solve non-linear problems using
 [EquationSystem](source/mfem/equation_systems/EquationSystem.md).
 
 !if-end!

--- a/framework/doc/content/source/mfem/kernels/MFEMKernel.md
+++ b/framework/doc/content/source/mfem/kernels/MFEMKernel.md
@@ -10,7 +10,7 @@ Base class for MFEM kernels applied to the weak form being solved.
 
 MFEM kernels are responsible for providing domain integrators (inheriting from
 `mfem::BilinearFormIntegrator` or `mfem::LinearFormIntegrator`) to add to the weak form of the FE
-problem accumulated in [EquationSystem](source/mfem/equation_systems/EquationSystem.md), along with any
+problem accumulated in [EquationSystem.md], along with any
 required marker arrays to restrict the integrator(s) to subdomains.
 
 The integrator is applied to the weak form equation that is labeled according to the test variable
@@ -23,8 +23,7 @@ variable names is the same as the set of trial variable names for a square syste
 `MFEMKernel` is a base class. Derived classes should override the `createBFIntegrator`
 and/or the `createLFIntegrator` methods to return a `BilinearFormIntegrator` and/or a
 `LinearFormIntegrator` (respectively) to add to the `EquationSystem`. Derived classes could also
-override `createNLIntegrator` to solve non-linear problems using
-[EquationSystem](source/mfem/equation_systems/EquationSystem.md).
+override `createNLIntegrator` to solve non-linear problems using [EquationSystem.md].
 
 !if-end!
 

--- a/framework/doc/content/source/mfem/problem/MFEMProblem.md
+++ b/framework/doc/content/source/mfem/problem/MFEMProblem.md
@@ -10,7 +10,7 @@
  controlled by the [MFEMProblemSolve.md] object used to solve the problem.
 
 `MFEMProblem` methods are called by `Actions` during parsing of the user's input file, which add
- and/or initialize members of the owned [MFEMProblemData](source/mfem/problem/MFEMProblemData.md) struct.
+ and/or initialize members of the owned [MFEMProblemData.md] struct.
 The order in which these actions are executed respects the dependencies declared in Moose.C.
 
 ## Example Input File Syntax

--- a/framework/doc/content/source/mfem/problem/MFEMProblemData.md
+++ b/framework/doc/content/source/mfem/problem/MFEMProblemData.md
@@ -8,8 +8,7 @@
 
 ## Overview
 
-Data stored in the `MFEMProblemData` struct is built and added to by builder methods in
-[`MFEMProblem`](problem/MFEMProblem.md).
+Data stored in the `MFEMProblemData` struct is built and added to by builder methods in [MFEMProblem.md].
 
 !listing include/mfem/problem/MFEMProblemData.h
 

--- a/framework/doc/content/source/mfem/transfers/MFEMNodalProjector.md
+++ b/framework/doc/content/source/mfem/transfers/MFEMNodalProjector.md
@@ -7,7 +7,7 @@ via projection given a vector of values evaluated at these nodes.
 
 End users should not need to interact with `MFEMNodalProjector` directly. `MFEMNodalProjector` is
 used by MFEM transfers that set values of an MFEMGridFunction, such as
-[MultiAppMFEMShapeEvaluationTransfer](MultiAppMFEMShapeEvaluationTransfer.md).
+[MultiAppMFEMShapeEvaluationTransfer.md].
 
 !if-end!
 

--- a/framework/doc/content/source/mfem/transfers/MFEMSubMeshTransfer.md
+++ b/framework/doc/content/source/mfem/transfers/MFEMSubMeshTransfer.md
@@ -6,7 +6,7 @@
 
 `MFEMSubMeshTransfer` transfers data between [MFEM variables](MFEMVariable.md) sharing a common
 subspace within the same problem, when at least one is defined on an
-[MFEM SubMesh](MFEMSubMesh.md). The finite element space
+[MFEM submesh](MFEMSubMesh.md). The finite element space
 of the MFEM variables must otherwise be of the same type.
 
 !syntax parameters /Transfers/MFEMSubMeshTransfer

--- a/framework/doc/content/source/mfem/transfers/MultiAppMFEMShapeEvaluationTransfer.md
+++ b/framework/doc/content/source/mfem/transfers/MultiAppMFEMShapeEvaluationTransfer.md
@@ -12,15 +12,15 @@ and both belong to an `MFEMProblem` in their respective applications.
 `MultiAppMFEMShapeEvaluationTransfer` executes transfers in three steps:
 
 1. Extraction of a vector of node positions in the `ParFiniteElementSpace` of the destination
-   `mfem::ParGridFunction`, using [`MFEMNodalProjector`](MFEMNodalProjector.md).
+   `mfem::ParGridFunction`, using [MFEMNodalProjector.md].
 2. Interpolation of the source `mfem::ParGridFunction` at this set of node locations, using
    `mfem::FindPointsGSLIB` to perform the required gather/scatter operations to obtain a set of
    points on the local mesh partition, and perform shape function evaluations at these points.
 3. Projection of the evaluated source variable values onto the destination variable nodes, to set
-   the destination variable degrees of freedom, using [`MFEMNodalProjector`](MFEMNodalProjector.md).
+   the destination variable degrees of freedom, using [MFEMNodalProjector.md].
 
 For transfers between identical variables defined on the same mesh, users are recommended to use
-[`MultiAppMFEMCopyTransfer`](MultiAppMFEMCopyTransfer.md) for performance.
+[MultiAppMFEMCopyTransfer.md] for performance.
 
 ## Features Supported
 

--- a/framework/doc/content/source/mfem/transfers/MultiAppMFEMTolibMeshShapeEvaluationTransfer.md
+++ b/framework/doc/content/source/mfem/transfers/MultiAppMFEMTolibMeshShapeEvaluationTransfer.md
@@ -5,15 +5,14 @@
 Allows transfers of [MFEM variables](MFEMVariable.md) from MFEM-based applications to libMesh-based [MooseVariables](MooseVariable.md) via local
 evaluation of shape functions at target nodal projection points. This class supports transfers between different meshes, from scalar MFEM GridFunctions to first and second order LAGRANGE and constant MONOMIAL libMesh variable types.
 
-For transfers in the opposite direction, from libMesh-based applications to MFEM-based applications, please see [MultiApplibMeshToMFEMShapeEvaluationTransfer](MultiApplibMeshToMFEMShapeEvaluationTransfer.md).
+For transfers in the opposite direction, from libMesh-based applications to MFEM-based applications, please see [MultiApplibMeshToMFEMShapeEvaluationTransfer.md].
 
 ## General Description
 
 `MultiAppMFEMTolibMeshShapeEvaluationTransfer` executes transfers in three steps:
 
 1. Extraction of a vector of node positions or element centroids of the destination libMesh solution
-   variable (similar to the method used in
-   [`MultiAppGeneralFieldTransfer`](MultiAppGeneralFieldTransfer.md)).
+   variable (similar to the method used in [MultiAppGeneralFieldTransfer.md]).
 2. Interpolation of the source `mfem::ParGridFunction` at this set of node locations, using
    `mfem::FindPointsGSLIB` to perform the required gather/scatter operations to obtain a set of
    points on the local mesh partition, and perform shape function evaluations at these points.

--- a/framework/doc/content/source/mfem/transfers/MultiApplibMeshToMFEMShapeEvaluationTransfer.md
+++ b/framework/doc/content/source/mfem/transfers/MultiApplibMeshToMFEMShapeEvaluationTransfer.md
@@ -8,20 +8,19 @@ via local evaluation of shape functions at target nodal projection points. This 
 transfers between different meshes, from first and second order LAGRANGE and constant MONOMIAL libMesh
 variable types to scalar MFEM GridFunctions defined on H1 and L2 conforming finite element spaces.
 
-For transfers in the opposite direction, from MFEM-based applications to libMesh-based applications, please see [MultiAppMFEMTolibMeshShapeEvaluationTransfer](MultiAppMFEMTolibMeshShapeEvaluationTransfer.md).
+For transfers in the opposite direction, from MFEM-based applications to libMesh-based applications, please see [MultiAppMFEMTolibMeshShapeEvaluationTransfer.md].
 
 ## General Description
 
 `MultiApplibMeshToMFEMShapeEvaluationTransfer` executes transfers in three steps:
 
 1. Extraction of a vector of node positions in the `ParFiniteElementSpace` of the destination
-   `mfem::ParGridFunction`, using [`MFEMNodalProjector`](MFEMNodalProjector.md).
+   `mfem::ParGridFunction`, using [MFEMNodalProjector.md].
 2. Interpolation of the source libMesh-based `MooseVariable` at this set of node locations. Required
-   gather/scatter operations are performed similarly to those in
-   [`MultiAppGeneralFieldTransfer`](MultiAppGeneralFieldTransfer.md), with interpolation analagous
-   to [`MultiAppGeneralFieldShapeEvaluationTransfer`](MultiAppGeneralFieldShapeEvaluationTransfer.md).
+   gather/scatter operations are performed similarly to those in [MultiAppGeneralFieldTransfer.md],
+   with interpolation analogous to [MultiAppGeneralFieldShapeEvaluationTransfer.md].
 3. Projection of the evaluated source variable values onto the destination variable nodes, to set
-   the destination variable degrees of freedom, using [`MFEMNodalProjector`](MFEMNodalProjector.md).
+   the destination variable degrees of freedom, using [MFEMNodalProjector.md].
 
 ## Features Supported
 

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -326,6 +326,7 @@ CommandLine::setCommandLineParam(std::list<CommandLine::Entry>::iterator entry_i
           const auto & next_entry = *next_entry_it;
           // Merge with the next Entry object and remove said next object
           entry.value = next_entry.name + *next_entry.value_separator + *next_entry.value;
+          entry.value_separator = " ";
           entry.raw_args.insert(
               entry.raw_args.end(), next_entry.raw_args.begin(), next_entry.raw_args.end());
           _entries.erase(next_entry_it);

--- a/framework/src/problems/EigenProblem.C
+++ b/framework/src/problems/EigenProblem.C
@@ -102,7 +102,7 @@ EigenProblem::EigenProblem(const InputParameters & parameters)
 
   es().parameters.set<EigenProblem *>("_eigen_problem") = this;
 #else
-  mooseError("Need to install SLEPc to solve eigenvalue problems, please reconfigure\n");
+  mooseError("Need to install SLEPc to solve eigenvalue problems, please reconfigure libMesh\n");
 #endif /* LIBMESH_HAVE_SLEPC */
 
   // SLEPc older than 3.13.0 can not take initial guess from moose

--- a/test/tests/executioners/eigen_convergence/tests
+++ b/test/tests/executioners/eigen_convergence/tests
@@ -13,6 +13,7 @@
     csvdiff = 'a_out_eigen_0001.csv'
     input = 'a.i'
     absent_out = '12 Nonlinear'
+    capabilities = 'slepc'
     requirement = 'The system shall be able to solve an eigenvalue problem using the L2 norm of Bx and the sign of its first nonzero entry for normalization with a SLEPc eigenvalue solver.'
   []
   [test7]

--- a/test/tests/mfem/submeshes/tests
+++ b/test/tests/mfem/submeshes/tests
@@ -45,13 +45,13 @@
     compute_devices = 'cpu cuda'
     max_parallel = 1
     recover = false
-  []  
+  []
   [MFEMGeometryCutTransitionSubMesh]
     design = 'syntax/MFEM/ClosedCoilMagnetostatic.md'
     issues = '#31404'
     type = CSVDiff
     input = av_magnetostatic.i
-    csvdiff = 'OutputData/AVMagnetostaticClosedCoilCSV.csv'    
+    csvdiff = 'OutputData/AVMagnetostaticClosedCoilCSV.csv'
     requirement = 'MOOSE shall have the ability to strongly enforce global topological constraints in MFEM by defining a transition region for variable discontinuities on one side of a cut plane defined in a solid geometry.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -63,7 +63,7 @@
     issues = '#31404'
     type = CSVDiff
     input = hphi_magnetostatic.i
-    csvdiff = 'OutputData/HPhiMagnetostaticClosedCoilCSV.csv'    
+    csvdiff = 'OutputData/HPhiMagnetostaticClosedCoilCSV.csv'
     requirement = 'MOOSE shall have the ability to strongly enforce global topological constraints in MFEM by defining a transition region for variable discontinuities on one side of a cut plane defined in an exterior vacuum region.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
@@ -74,12 +74,12 @@
     issues = '#31404'
     type = CSVDiff
     input = hphi_magnetodynamic.i
-    csvdiff = 'OutputData/HPhiMagnetodynamicClosedCoilCSV.csv'    
+    csvdiff = 'OutputData/HPhiMagnetodynamicClosedCoilCSV.csv'
     requirement = 'MOOSE shall have the ability to apply boundary conditions on boundaries of embedded volumetric subdomains.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     recover = false
     restep = false
     valgrind = heavy
-  []  
+  []
 []

--- a/test/tests/mfem/transfers/h1_libmesh_parent_mfem_sub/tests
+++ b/test/tests/mfem/transfers/h1_libmesh_parent_mfem_sub/tests
@@ -25,7 +25,7 @@
       cli_args = 'Variables/libmesh_scalar_var/order=SECOND '
                 'AuxVariables/mfem_scalar_var/order=SECOND '
                 'mfem_app0:FESpaces/H1FESpace/fec_order=SECOND '
-                'Outputs/file_base=libmesh_parent_scalar_mfem_sub_quads_order_2 '    
+                'Outputs/file_base=libmesh_parent_scalar_mfem_sub_quads_order_2 '
     []
     [H1Tri]
       type = CSVDiff
@@ -68,7 +68,7 @@
       cli_args = 'Mesh/file=../../mesh/square_quad9.e '
                 'mfem_app0:Mesh/file=../../mesh/square_tri6.e '
                 'Outputs/file_base=libmesh_parent_scalar_mfem_sub_tri_to_quad '
-    []  
+    []
     [H1TriToQuadSecondOrder]
       type = CSVDiff
       input = libmesh_parent_scalar.i
@@ -115,7 +115,7 @@
                 'AuxVariables/mfem_scalar_var/order=SECOND '
                 'mfem_app0:Mesh/file=../../mesh/cube.e '
                 'mfem_app0:FESpaces/H1FESpace/fec_order=SECOND '
-    []    
+    []
     [H1Tet]
       type = CSVDiff
       input = libmesh_parent_scalar.i
@@ -142,10 +142,10 @@
       cli_args = 'Mesh/file=../../mesh/cube_tet10.e '
                 'BCs/sides/boundary=Sides '
                 'Variables/libmesh_scalar_var/order=SECOND '
-                'AuxVariables/mfem_scalar_var/order=SECOND '               
+                'AuxVariables/mfem_scalar_var/order=SECOND '
                 'Outputs/file_base=libmesh_parent_scalar_mfem_sub_tets_order_2 '
                 'mfem_app0:Mesh/file=../../mesh/cube_tet10.e '
-                'mfem_app0:FESpaces/H1FESpace/fec_order=SECOND '               
+                'mfem_app0:FESpaces/H1FESpace/fec_order=SECOND '
     []
     [H1TetToHex]
       type = CSVDiff
@@ -173,10 +173,10 @@
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'BCs/sides/boundary=Sides '
                 'Variables/libmesh_scalar_var/order=SECOND '
-                'AuxVariables/mfem_scalar_var/order=SECOND '               
+                'AuxVariables/mfem_scalar_var/order=SECOND '
                 'Outputs/file_base=libmesh_parent_scalar_mfem_sub_tet_to_hex_order_2 '
                 'mfem_app0:Mesh/file=../../mesh/cube_tet10.e '
-                'mfem_app0:FESpaces/H1FESpace/fec_order=SECOND '               
-    []  
+                'mfem_app0:FESpaces/H1FESpace/fec_order=SECOND '
+    []
   []
 []

--- a/test/tests/mfem/transfers/h1_mfem_parent_libmesh_sub/tests
+++ b/test/tests/mfem/transfers/h1_mfem_parent_libmesh_sub/tests
@@ -25,7 +25,7 @@
       cli_args = 'FESpaces/H1FESpace/fec_order=SECOND '
                 'libmesh_app0:Variables/libmesh_scalar_var/order=SECOND '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_quads_order_2 '
-    []  
+    []
     [H1Tri]
       type = CSVDiff
       input = mfem_parent_scalar.i
@@ -50,7 +50,7 @@
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_tri6.e '
                 'FESpaces/H1FESpace/fec_order=SECOND '
-                'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tris_order_2 '               
+                'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tris_order_2 '
                 'libmesh_app0:Mesh/file=../../mesh/square_tri6.e '
                 'libmesh_app0:Variables/libmesh_scalar_var/order=SECOND '
     []
@@ -78,10 +78,10 @@
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_quad9.e '
                 'FESpaces/H1FESpace/fec_order=SECOND '
-                'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tri_to_quad_order_2 '               
+                'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tri_to_quad_order_2 '
                 'libmesh_app0:Mesh/file=../../mesh/square_tri6.e '
                 'libmesh_app0:Variables/libmesh_scalar_var/order=SECOND '
-    []  
+    []
     [H1Hex]
       type = CSVDiff
       input = mfem_parent_scalar.i
@@ -95,7 +95,7 @@
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_hexes '
                 'libmesh_app0::BCs/sides/boundary=Sides '
                 'libmesh_app0::Mesh/file=../../mesh/cube.e '
-    []  
+    []
     [H1HexSecondOrder]
       type = CSVDiff
       input = mfem_parent_scalar.i
@@ -106,12 +106,12 @@
       recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
-                'FESpaces/H1FESpace/fec_order=SECOND '    
+                'FESpaces/H1FESpace/fec_order=SECOND '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_hexes_order_2 '
                 'libmesh_app0::BCs/sides/boundary=Sides '
                 'libmesh_app0::Mesh/file=../../mesh/cube.e '
-                'libmesh_app0:Variables/libmesh_scalar_var/order=SECOND '               
-    []  
+                'libmesh_app0:Variables/libmesh_scalar_var/order=SECOND '
+    []
     [H1Tet]
       type = CSVDiff
       input = mfem_parent_scalar.i
@@ -136,7 +136,7 @@
       recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube_tet10.e '
-                'FESpaces/H1FESpace/fec_order=SECOND '    
+                'FESpaces/H1FESpace/fec_order=SECOND '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tets_order_2 '
                 'libmesh_app0::BCs/sides/boundary=Sides '
                 'libmesh_app0::Mesh/file=../../mesh/cube_tet10.e '
@@ -166,11 +166,11 @@
       recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
-                'FESpaces/H1FESpace/fec_order=SECOND '    
+                'FESpaces/H1FESpace/fec_order=SECOND '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tet_to_hex_order_2 '
                 'libmesh_app0::BCs/sides/boundary=Sides '
                 'libmesh_app0::Mesh/file=../../mesh/cube_tet10.e '
                 'libmesh_app0:Variables/libmesh_scalar_var/order=SECOND '
     []
-  []      
+  []
 []

--- a/test/tests/mfem/transfers/l2_mfem_parent_libmesh_sub/tests
+++ b/test/tests/mfem/transfers/l2_mfem_parent_libmesh_sub/tests
@@ -52,7 +52,7 @@
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_hexes '
                 'libmesh_app0::Mesh/file=../../mesh/cube.e '
-    []  
+    []
     [L2Tet]
       type = CSVDiff
       input = mfem_parent_scalar.i

--- a/test/tests/mfem/transfers/mfem_parent_mfem_sub/tests
+++ b/test/tests/mfem/transfers/mfem_parent_mfem_sub/tests
@@ -11,7 +11,7 @@
         capabilities = 'mfem'
         compute_devices = 'cpu cuda'
         recover = false
-        cli_args = 'Transfers/active=general_transfer_from_sub '        
+        cli_args = 'Transfers/active=general_transfer_from_sub '
         detail = 'running the inputs, and'
       []
       [verify]
@@ -35,7 +35,7 @@
         capabilities = 'mfem'
         compute_devices = 'cpu cuda'
         recover = false
-        cli_args = 'Transfers/active=general_transfer_from_sub'        
+        cli_args = 'Transfers/active=general_transfer_from_sub'
         detail = 'running the inputs, and '
         max_parallel = 1 # idaholab/moose#32250
       []
@@ -54,7 +54,7 @@
     []
     [VectorTransfer]
       detail = 'for vector variables '
-      [Hex]      
+      [Hex]
         type = CSVDiff
         input = mfem_parent_vector.i
         csvdiff = 'mfem_parent_mfem_sub_vector_h1_hcurl_hdiv_l2_hex.csv'
@@ -64,7 +64,7 @@
         recover = false
         compute_devices = 'cpu cuda'
       []
-      [Tetra]      
+      [Tetra]
         type = CSVDiff
         input = mfem_parent_vector.i
         csvdiff = 'mfem_parent_mfem_sub_vector_h1_hcurl_hdiv_l2_tet.csv'
@@ -77,7 +77,7 @@
                   'mfem_app0:Mesh/file=../../mesh/cube_tet10.e '
                   'Outputs/file_base=mfem_parent_mfem_sub_vector_h1_hcurl_hdiv_l2_tet '
       []
-      [TetToHex]      
+      [TetToHex]
         type = CSVDiff
         input = mfem_parent_vector.i
         csvdiff = 'mfem_parent_mfem_sub_vector_h1_hcurl_hdiv_l2_tet_to_hex.csv'
@@ -89,7 +89,7 @@
         cli_args = 'Mesh/file=../../mesh/cube.e '
                   'mfem_app0:Mesh/file=../../mesh/cube_tet10.e '
                   'Outputs/file_base=mfem_parent_mfem_sub_vector_h1_hcurl_hdiv_l2_tet_to_hex '
-      []      
+      []
     []
     [OutOfMesh]
       detail = 'for scalar variables between meshes of different geometric sizes, '
@@ -104,7 +104,7 @@
         recover = false
         compute_devices = 'cpu cuda'
       []
-    []    
+    []
   []
   [MFEMCopyTransfer]
     design = MultiAppMFEMCopyTransfer.md
@@ -183,7 +183,7 @@
       []
     []
     [ComplexToSubFromParent]
-      detail = 'representing complex variables from a parent application to a sub-application, verified by'      
+      detail = 'representing complex variables from a parent application to a sub-application, verified by'
       [run]
         type = RunApp
         input = sub_complex.i

--- a/test/tests/mfem/transfers/mfem_sub_mfem_sub/tests
+++ b/test/tests/mfem/transfers/mfem_sub_mfem_sub/tests
@@ -1,5 +1,5 @@
 [Tests]
-  [MFEMCopyTransfer]   
+  [MFEMCopyTransfer]
     issues = '#29632'
     design = MultiAppMFEMCopyTransfer.md
     requirement = 'The system shall be able to copy MFEM variable data between sub-applications,'

--- a/test/tests/mfem/transfers/sibling_transfers/tests
+++ b/test/tests/mfem/transfers/sibling_transfers/tests
@@ -22,9 +22,9 @@
       capabilities = 'mfem'
       compute_devices = 'cpu'
       recover = false
-      restep = false      
+      restep = false
       detail = 'between elemental variables,'
-    []    
+    []
     [nodal_elem]
       type = Exodiff
       input = main_between_multiapp.i
@@ -48,7 +48,7 @@
       recover = false
       restep = false
       detail = 'and from nodal variables sent from one sub-app to multiple sub-apps.'
-    []  
+    []
   []
   [libMesh_to_MFEM_sibling_transfers]
     requirement = "The system shall support multiapp sibling transfers from libMesh to MFEM sub-apps via shape function evaluations"
@@ -150,7 +150,7 @@
       type = CSVDiff
       input = mfem_main_between_multiapp.i
       csvdiff = 'OutputData/MFEMtoMFEMSiblingTransfer_mfem_recv0_nodal_sample_0002.csv'
-      cli_args = "MultiApps/mfem_recv/positions_objects='mfem_recv_locs'"     
+      cli_args = "MultiApps/mfem_recv/positions_objects='mfem_recv_locs'"
       capabilities = 'mfem'
       compute_devices = 'cpu'
       recover = false

--- a/test/tests/postprocessors/num_iterations/tests
+++ b/test/tests/postprocessors/num_iterations/tests
@@ -185,6 +185,7 @@
     input = 'eigen_problem.i'
     csvdiff = 'eigen_problem_out.csv'
     max_parallel = 1 # Need results to be very consistent since we count iterations
+    capabilities = 'slepc'
     requirement = 'The system shall report the correct number of nonlinear and linear iterations for a nonlinear eigenvalue problem.'
   []
 []

--- a/test/tests/postprocessors/residual/tests
+++ b/test/tests/postprocessors/residual/tests
@@ -24,6 +24,7 @@
     # value is returned.
     max_parallel = 1
     rel_err = 1
+    capabilities = 'slepc'
     requirement = 'The system shall be able to report the final nonlinear residual for a nonlinear eigenvalue problem.'
   []
 []

--- a/test/tests/problems/eigen_problem/eigensolvers/tests
+++ b/test/tests/problems/eigen_problem/eigensolvers/tests
@@ -198,6 +198,7 @@
     type = 'RunException'
     input = 'dg_krylovschur.i'
     expect_err = 'This object has been marked as contributing to B or Bx but the eigen problem type is not a generalized one'
+    capabilities = 'slepc'
     requirement = "The system shall error if a user requests a standard eigenvalue solve when there are objects marked to contribute to the Bx vector or B matrix."
     cli_args = "Kernels/inactive=''"
   []

--- a/test/tests/problems/eigen_problem/jfnk_mo/tests
+++ b/test/tests/problems/eigen_problem/jfnk_mo/tests
@@ -74,6 +74,7 @@
     issues = '#28993'
     input = ne_coupled_mo.i
     cli_args = "Problem/bx_norm=uint Postprocessors/uint/execute_on='initial nonlinear'"
+    capabilities = 'slepc'
     requirement = 'The system shall error if the user wants the Bx norm provided by a postprocessor but the postprocessor is not executed during residual evaluations.'
     expect_err = "If providing the Bx norm, this postprocessor must execute on linear"
   []

--- a/test/tests/restart/restart_transient_from_eigen/tests
+++ b/test/tests/restart/restart_transient_from_eigen/tests
@@ -6,6 +6,7 @@
     type = 'Exodiff'
     input = 'eigen.i'
     exodiff = 'eigen_out.e'
+    capabilities = 'slepc'
     requirement = 'The system shall support storing the solution of an eigenvalue solve such that it can be restarted later into a non-eigenvalue solve.'
   []
   [transient_from_eigen_solution]


### PR DESCRIPTION
## Design
Removed trailing whitespace, simplified links, fixed a `mooseError()` string, adjusted capabilities and added missing value separator when we lazily collate cmd line entries.

## Reason
Nicer looking markdown, working tests in the absence of SLEPc and working req capabilities tests/functionality.

## Impact
Enable CI in no-slepc build
QOL improvement in documentation development