### PR TITLE
Fix even more memory heavy tests

### DIFF
--- a/test/tests/hdgkernels/ldg-diffusion/tests
+++ b/test/tests/hdgkernels/ldg-diffusion/tests
@@ -26,12 +26,14 @@
       input = test.py
       test_case = TestLagrangeTri
       detail = 'simplex elements and'
+      min_slots = 2 # Memory heavy
     []
     [quad]
       type = MMSTest
       input = test.py
       test_case = TestLagrangeQuad
       detail = 'tensor-product elements.'
+      min_slots = 2 # Memory heavy
     []
   []
   [rt_mms]
@@ -41,6 +43,7 @@
       input = test.py
       test_case = TestRTTri
       detail = 'simplex elements and'
+      min_slots = 2 # Memory heavy
     []
     [quad]
       type = MMSTest


### PR DESCRIPTION
## Reason
MMS tests fail too frequently due to over memory error.

## Design
Request more slots.

## Impact
Less random failure.