### PR TITLE
Order sibling transfer execution in between multiapps

### DIFF
--- a/framework/doc/content/syntax/MultiApps/index.md
+++ b/framework/doc/content/syntax/MultiApps/index.md
@@ -36,12 +36,20 @@ Sub-apps are created when a MultiApp is added by MOOSE.
 A `MultiApp` can be executed at any point during the main solve by setting the
 [!param](/MultiApps/TransientMultiApp/execute_on) parameter.
 MultiApps at the same point are executed sequentially.
-Before the execution, data on the main app are transferred to sub-apps of all the MultiApps and data on sub-apps are transferred back after the execution.
-The execution order of all MultiApps at the same point is not determined.
-The order is also irrelevant because no data transfers directly among MultiApps.
-To enforce the ordering of execution, users can use multi-level MultiApps or set the MultiApps executed at different points.
-If a `MultiApp` is set to be executed on timestep_begin or timestep_end, the formed loosely-coupled systems of fully-coupled
-equations can be solved with [Fixed Point iterations](syntax/Executioner/index.md).
+Before the execution, data on the main app are transferred to sub-apps of all the `MultiApps` and
+data on sub-apps are transferred back after the execution.
+The execution order of all `MultiApps` within the same `execute_on` schedule is not determined
+unless the [!param](/MultiApps/TransientMultiApp/execution_order_group)
+parameter is passed to order the transfers.
+The order is only relevant for data transfers between applications, notably when data transfers are intermingled with `MultiApps` execution,
+see [Transfers execution](Transfers/index.md#execution).
+To enforce the ordering of execution, users can also use multi-level `MultiApps` or set the `MultiApps`
+to be executed at different points with the [!param](/MultiApps/TransientMultiApp/execute_on) parameter.
+
+If a `MultiApp` is set to be executed on `timestep_begin` or `timestep_end`, the coupled systems of
+equations can be solved with [Fixed Point iterations](syntax/Executioner/index.md), which we refer to
+as tight coupling. Tight coupling should converge to the same results as full coupling with the proper
+considerations on time integration and data transfers.
 
 !listing multiapps/transient_multiapp/dt_from_parent.i block=MultiApps
 
@@ -111,7 +119,7 @@ not automatically transfer the mesh modifications performed by [Adaptivity](synt
 on either the main or sub-app, though it does transfer initial mesh modification work such as uniform
 refinement.
 
-When using the same mesh between two applications, the [MultiAppCopyTransfer.md] may be
+When using the same mesh between two applications, with no modification, the [MultiAppCopyTransfer.md] may be
 utilized for more efficient transfers of field variables.
 
 ## Parallel Execution
@@ -148,7 +156,7 @@ When restarting or recovering, the main app restores the restart data of all sub
 (a data structure holding all the current state including solution vectors, stateful material properties,
 post-processors, restartable quantities declared in objects and etc. of the sub-apps), which are used by
 sub-apps to restart/recover the calculations in their initial setups.
-The same backups are also used by multiapps for saving/restoring the current state during fixed point iterations.
+The same backups are also used by `MultiApps` for saving/restoring the current state during fixed point iterations.
 
 A sub-app may choose to use a restart file instead of the main backup file by setting [!param](/Problem/FEProblem/force_restart) to true.
 

--- a/framework/doc/content/syntax/Transfers/index.md
+++ b/framework/doc/content/syntax/Transfers/index.md
@@ -56,6 +56,33 @@ calculations that utilize the scalar variable, regardless of how this scalar is 
 approach allows the sub-application input file to run in union of independent from the parent without
 modification, which is useful for development and testing.
 
+## Execution ordering of transfers
+
+The execution of transfers is, like most objects, first governed by setting the
+[!param](/Transfers/MultiAppCopyTransfer/execute_on) parameter.
+A special `SAME_AS_MULTIAPP` `execute_on` is available, and generally the default,
+which copies the `execute_on` of the [!param](/Transfers/MultiAppCopyTransfer/to_multi_app) if specified,
+else the [!param](/Transfers/MultiAppCopyTransfer/from_multi_app).
+
+Within a given `execute_on` schedule, the following rules are applied:
+
+- transfers from the parent to the child app(s) are executed before the execution of all the `MultiApps`.
+  If no `MultiApps` are executed on that `execute_on`, the `Transfers` on that `execute_on` are executed anyway.
+- transfers from the child app(s) to the parent are executed after the execution of all the `MultiApps`.
+
+For transfers executing between sibling `Multiapps`, e.g. from one `MultiApps` (with potentially multiple child apps)
+to another `MultiApps`, there are two possibilities:
+
+- if the transfer is executed on the same `execute_on` as the [!param](/Transfers/MultiAppCopyTransfer/from_multi_app),
+  then by default, it will be executed right AFTER that application, on the same [!param](/MultiApps/TransientMultiApp/execution_order_group),
+  so that another application can be run with updated data on a later [!param](/MultiApps/TransientMultiApp/execution_order_group)
+  on the same `execute_on` schedule. This can be reversed by setting [!param](/Transfers/MultiAppCopyTransfer/execute_after_from_multiapp)
+  to false.
+- if the transfer is NOT executed on the same `execute_on` as the [!param](/Transfers/MultiAppCopyTransfer/from_multi_app),
+  then the transfer is executed BEFORE all `MultiApps` on that `execute_on`, following the execution of transfers from
+  the parent to the child app(s).
+
+
 ## Coordinate transformations id=coord-transform
 
 Different applications may use different setups. For example a neutronics

--- a/framework/doc/content/syntax/Transfers/index.md
+++ b/framework/doc/content/syntax/Transfers/index.md
@@ -70,8 +70,8 @@ Within a given `execute_on` schedule, the following rules are applied:
   If no `MultiApps` are executed on that `execute_on`, the `Transfers` on that `execute_on` are executed anyway.
 - transfers from the child app(s) to the parent are executed after the execution of all the `MultiApps`.
 
-For transfers executing between sibling `Multiapps`, e.g. from one `MultiApps` (with potentially multiple child apps)
-to another `MultiApps`, there are two possibilities:
+For transfers executing between sibling `MultiApps`, e.g. from one `MultiApp` (with potentially multiple child apps)
+to another `MultiApp`, there are two possibilities:
 
 - if the transfer is executed on the same `execute_on` as the [!param](/Transfers/MultiAppCopyTransfer/from_multi_app),
   then by default, it will be executed right AFTER that application, on the same [!param](/MultiApps/TransientMultiApp/execution_order_group),

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1623,8 +1623,15 @@ public:
    * Execute MultiAppTransfers associated with execution flag and direction.
    * @param type The execution flag to execute.
    * @param direction The direction (to or from) to transfer.
+   * @param source_app The source application to execute transfers from. Defaults to all sources
+   * @param skip_transfers_with_source_app_executing_on_type whether to skip all the transfers for
+   * which the source application is also executing on the same 'execute_on' type. If the source app
+   *        is inactive, the transfer will execute if this is true
    */
-  void execMultiAppTransfers(ExecFlagType type, Transfer::DIRECTION direction);
+  void execMultiAppTransfers(ExecFlagType type,
+                             Transfer::DIRECTION direction,
+                             const MultiAppName & source_app = "",
+                             bool skip_transfers_with_source_app_executing_on_type = false);
 
   /**
    * Execute the MultiApps associated with the ExecFlagType

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1686,14 +1686,6 @@ public:
                            InputParameters & parameters);
 
   /**
-   * Execute the Transfers associated with the ExecFlagType
-   *
-   * Note: This does _not_ execute MultiApp Transfers!
-   * Those are executed automatically when MultiApps are executed.
-   */
-  void execTransfers(ExecFlagType type);
-
-  /**
    * Computes the residual of a nonlinear system using whatever is sitting in the current
    * solution vector then returns the L2 norm.
    */

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1725,14 +1725,6 @@ public:
                            InputParameters & parameters);
 
   /**
-   * Execute the Transfers associated with the ExecFlagType
-   *
-   * Note: This does _not_ execute MultiApp Transfers!
-   * Those are executed automatically when MultiApps are executed.
-   */
-  void execTransfers(ExecFlagType type);
-
-  /**
    * Computes the residual of a nonlinear system using whatever is sitting in the current
    * solution vector then returns the L2 norm.
    */

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1662,8 +1662,15 @@ public:
    * Execute MultiAppTransfers associated with execution flag and direction.
    * @param type The execution flag to execute.
    * @param direction The direction (to or from) to transfer.
+   * @param source_app The source application to execute transfers from. Defaults to all sources
+   * @param skip_transfers_with_source_app_executing_on_type whether to skip all the transfers for
+   * which the source application is also executing on the same 'execute_on' type. If the source app
+   *        is inactive, the transfer will execute if this is true
    */
-  void execMultiAppTransfers(ExecFlagType type, Transfer::DIRECTION direction);
+  void execMultiAppTransfers(ExecFlagType type,
+                             Transfer::DIRECTION direction,
+                             const MultiAppName & source_app = "",
+                             bool skip_transfers_with_source_app_executing_on_type = false);
 
   /**
    * Execute the MultiApps associated with the ExecFlagType

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -3278,6 +3278,9 @@ protected:
   /// Transfers executed just before MultiApps to transfer data between them
   ExecuteMooseObjectWarehouse<Transfer> _between_multi_app_transfers;
 
+  /// Whether to execute siblings transfers after multiapps execute
+  const bool _execute_siblings_transfer_after_source_multiapp_execution;
+
   /// A map of objects that consume random numbers
   std::map<std::string, std::unique_ptr<RandomData>> _random_data_objects;
 

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1663,14 +1663,10 @@ public:
    * @param type The execution flag to execute.
    * @param direction The direction (to or from) to transfer.
    * @param source_app The source application to execute transfers from. Defaults to all sources
-   * @param skip_transfers_with_source_app_executing_on_type whether to skip all the transfers for
-   * which the source application is also executing on the same 'execute_on' type. If the source app
-   *        is inactive, the transfer will execute if this is true
    */
   void execMultiAppTransfers(ExecFlagType type,
                              Transfer::DIRECTION direction,
-                             const MultiAppName & source_app = "",
-                             bool skip_transfers_with_source_app_executing_on_type = false);
+                             const MultiAppName & source_app = "");
 
   /**
    * Execute the MultiApps associated with the ExecFlagType
@@ -3277,9 +3273,6 @@ protected:
 
   /// Transfers executed just before MultiApps to transfer data between them
   ExecuteMooseObjectWarehouse<Transfer> _between_multi_app_transfers;
-
-  /// Whether to execute siblings transfers after multiapps execute
-  const bool _execute_siblings_transfer_after_source_multiapp_execution;
 
   /// A map of objects that consume random numbers
   std::map<std::string, std::unique_ptr<RandomData>> _random_data_objects;

--- a/framework/include/transfers/Transfer.h
+++ b/framework/include/transfers/Transfer.h
@@ -92,6 +92,9 @@ public:
     _direction = direction;
   }
 
+  /// Whether the transfer should be executed after its source application
+  bool executeAfterSourceApp() const { return _exec_after_source_app_exec; }
+
 protected:
   SubProblem & _subproblem;
   FEProblemBase & _fe_problem;
@@ -108,6 +111,11 @@ protected:
 
   /// The directions this Transfer is to be executed on
   MultiMooseEnum _directions;
+
+  /// Whether a transfer executing on BETWEEN_MULTIAPPS and on the same execute_on flag
+  /// should execute before or after that application
+  /// For FROM and TO_MULTIAPP this is is true and we refuse setting it to false
+  const bool _exec_after_source_app_exec;
 
 public:
   const static libMesh::Number OutOfMeshValue;

--- a/framework/include/transfers/Transfer.h
+++ b/framework/include/transfers/Transfer.h
@@ -93,7 +93,7 @@ public:
   }
 
   /// Whether the transfer should be executed after its source application
-  bool executeAfterSourceApp() const { return _exec_after_source_app_exec; }
+  bool executeAfterSiblingSourceApp() const { return _exec_after_source_app_exec; }
 
 protected:
   SubProblem & _subproblem;

--- a/framework/src/executioners/FixedPointSolve.C
+++ b/framework/src/executioners/FixedPointSolve.C
@@ -369,7 +369,6 @@ FixedPointSolve::solve()
   {
     // Fixed point iteration loop ends right above
     _problem.execute(EXEC_MULTIAPP_FIXED_POINT_END);
-    _problem.execTransfers(EXEC_MULTIAPP_FIXED_POINT_END);
     if (!_problem.execMultiApps(EXEC_MULTIAPP_FIXED_POINT_END, autoAdvance()))
     {
       _fixed_point_status = MooseFixedPointConvergenceReason::DIVERGED_FAILED_MULTIAPP;
@@ -419,12 +418,10 @@ FixedPointSolve::solveStep(const std::set<dof_id_type> & transformed_dofs)
   _app.solutionInvalidity().resetTimeStepOccurences();
 
   _executioner.preSolve();
-  _problem.execTransfers(EXEC_TIMESTEP_BEGIN);
 
   if (_fixed_point_it == 0)
   {
     _problem.execute(EXEC_MULTIAPP_FIXED_POINT_BEGIN);
-    _problem.execTransfers(EXEC_MULTIAPP_FIXED_POINT_BEGIN);
     if (!_problem.execMultiApps(EXEC_MULTIAPP_FIXED_POINT_BEGIN, autoAdvance()))
     {
       _fixed_point_status = MooseFixedPointConvergenceReason::DIVERGED_FAILED_MULTIAPP;
@@ -518,7 +515,6 @@ FixedPointSolve::solveStep(const std::set<dof_id_type> & transformed_dofs)
     _problem.onTimestepEnd();
     _problem.execute(EXEC_TIMESTEP_END);
 
-    _problem.execTransfers(EXEC_TIMESTEP_END);
     if (!_problem.execMultiApps(EXEC_TIMESTEP_END, auto_advance))
       _fixed_point_status = MooseFixedPointConvergenceReason::DIVERGED_FAILED_MULTIAPP;
 

--- a/framework/src/mfem/executioners/MFEMProblemSolve.C
+++ b/framework/src/mfem/executioners/MFEMProblemSolve.C
@@ -66,10 +66,8 @@ MFEMProblemSolve::solve()
 
   // Solve step begins
   _executioner.preSolve();
-  _mfem_problem.execTransfers(EXEC_TIMESTEP_BEGIN);
 
   _mfem_problem.execute(EXEC_MULTIAPP_FIXED_POINT_BEGIN);
-  _mfem_problem.execTransfers(EXEC_MULTIAPP_FIXED_POINT_BEGIN);
   _mfem_problem.execMultiApps(EXEC_MULTIAPP_FIXED_POINT_BEGIN, true);
   _mfem_problem.outputStep(EXEC_MULTIAPP_FIXED_POINT_BEGIN);
 
@@ -105,7 +103,6 @@ MFEMProblemSolve::solve()
   // Execute user objects, transfers, and multiapps at timestep end
   _mfem_problem.onTimestepEnd();
   _mfem_problem.execute(EXEC_TIMESTEP_END);
-  _mfem_problem.execTransfers(EXEC_TIMESTEP_END);
   _mfem_problem.execMultiApps(EXEC_TIMESTEP_END, true);
   _executioner.postSolve();
   // Solve step ends
@@ -114,7 +111,6 @@ MFEMProblemSolve::solve()
   {
     // Fixed point iteration loop ends right above
     _mfem_problem.execute(EXEC_MULTIAPP_FIXED_POINT_END);
-    _mfem_problem.execTransfers(EXEC_MULTIAPP_FIXED_POINT_END);
     _mfem_problem.execMultiApps(EXEC_MULTIAPP_FIXED_POINT_END, true);
     _mfem_problem.outputStep(EXEC_MULTIAPP_FIXED_POINT_END);
   }

--- a/framework/src/mfem/executioners/MFEMSteady.C
+++ b/framework/src/mfem/executioners/MFEMSteady.C
@@ -117,7 +117,6 @@ MFEMSteady::execute()
   // first step in any steady state solve is always 1 (preserving backwards compatibility)
   _time_step = 1;
   _mfem_problem.timestepSetup();
-  _mfem_problem.execTransfers(EXEC_TIMESTEP_BEGIN);
   if (!_mfem_problem.execMultiApps(EXEC_TIMESTEP_BEGIN, true))
   {
     _last_solve_converged = false;
@@ -133,7 +132,6 @@ MFEMSteady::execute()
   // need to keep _time in sync with _time_step to get correct output
   _time = _time_step;
   _mfem_problem.execute(EXEC_TIMESTEP_END);
-  _mfem_problem.execTransfers(EXEC_TIMESTEP_END);
   _mfem_problem.execMultiApps(EXEC_TIMESTEP_END, true);
   _mfem_problem.outputStep(EXEC_TIMESTEP_END);
   _time = _system_time;

--- a/framework/src/mfem/executioners/MFEMTransient.C
+++ b/framework/src/mfem/executioners/MFEMTransient.C
@@ -92,7 +92,6 @@ MFEMTransient::takeStep(Real input_dt)
   _time -= _dt;
 
   _problem.onTimestepBegin();
-  _problem.execTransfers(EXEC_TIMESTEP_BEGIN);
   if (!_problem.execMultiApps(EXEC_TIMESTEP_BEGIN, true))
   {
     _last_solve_converged = false;
@@ -115,7 +114,6 @@ MFEMTransient::takeStep(Real input_dt)
   }
 
   _problem.execute(EXEC_TIMESTEP_END);
-  _problem.execTransfers(EXEC_TIMESTEP_END);
   _problem.execMultiApps(EXEC_TIMESTEP_END, true);
 
   if (lastSolveConverged())

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -246,6 +246,11 @@ MultiApp::validParams()
   params.addParam<bool>(
       "clone_parent_mesh", false, "True to clone parent app mesh and use it for this MultiApp.");
 
+  params.addParam<unsigned int>("execution_order_group",
+                                0,
+                                "Execution order group. If Problem/num_concurrent_multiapps>1, "
+                                "multiple multiapps may be executed synchronously.");
+
   params.addPrivateParam<bool>("use_positions", true);
   params.declareControllable("enable");
   params.declareControllable("cli_args", {EXEC_PRE_MULTIAPP_SETUP});

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -125,6 +125,7 @@
 #include "Checkpoint.h"
 #include "MortarInterfaceWarehouse.h"
 #include "AutomaticMortarGeneration.h"
+#include "DependencyResolver.h"
 
 #include "libmesh/exodusII_io.h"
 #include "libmesh/quadrature.h"
@@ -5901,24 +5902,51 @@ FEProblemBase::getMultiAppTransferWarehouse(Transfer::DIRECTION direction) const
 }
 
 bool
-FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
+FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
 {
   // Active MultiApps
   const std::vector<MooseSharedPointer<MultiApp>> & multi_apps =
-      _multi_apps[type].getActiveObjects();
+      _multi_apps[exec_on].getActiveObjects();
 
   // Do anything that needs to be done to Apps before transfers
   for (const auto & multi_app : multi_apps)
     multi_app->preTransfer(_dt, _time);
 
   // Execute Transfers _to_ MultiApps
-  execMultiAppTransfers(type, MultiAppTransfer::TO_MULTIAPP);
+  execMultiAppTransfers(exec_on, MultiAppTransfer::TO_MULTIAPP);
 
   // Execute Transfers _beween_ MultiApps for the multiapps that don't execute on this flag
   // NOTE: these is usually no need to execute a transfer unless the multiapp providing its
   // data also executed. But we need to obey what the user requested for the execution schedule,
   // hence the two executions
-  execMultiAppTransfers(type, MultiAppTransfer::BETWEEN_MULTIAPP, "", true);
+  execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, "", true);
+
+  // Order the multiapps
+  DependencyResolver<MooseSharedPointer<MultiApp>> resolver;
+
+  // Add all the apps executing on 'exec_on' to the resolution
+  for (const auto & multi_app : multi_apps)
+    resolver.addItem(multi_app);
+  // Add all the dependencies found from active transfers executing on 'exec_on'
+  for (const auto & sibling_transfer : _between_multi_app_transfers[exec_on].getActiveObjects())
+  {
+    auto multiapp_transfer = dynamic_cast<MultiAppTransfer *>(sibling_transfer.get());
+    resolver.addEdge(multiapp_transfer->getFromMultiApp(), multiapp_transfer->getToMultiApp());
+  }
+
+  std::vector<std::vector<MooseSharedPointer<MultiApp>>> ordered_multi_apps;
+  if (multi_apps.size())
+    try
+    {
+      ordered_multi_apps = resolver.getSortedValuesSets();
+    }
+    catch (CyclicDependencyException<std::string> & e)
+    {
+      mooseError("Cyclic dependencies detected in multiapps and siblings transfers: ",
+                 MooseUtils::join(e.getCyclicDependencies(), " <- "),
+                 "\nPlease execute one of the transfers between multiapps on a different "
+                 "'execute_on' to break the cycle.");
+    }
 
   // Execute MultiApps
   if (multi_apps.size())
@@ -5926,20 +5954,23 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
     TIME_SECTION("execMultiApps", 1, "Executing MultiApps", false);
 
     if (_verbose_multiapps)
-      _console << COLOR_CYAN << "\nExecuting MultiApps on " << Moose::stringify(type)
+      _console << COLOR_CYAN << "\nExecuting MultiApps on " << Moose::stringify(exec_on)
                << COLOR_DEFAULT << std::endl;
 
     bool success = true;
 
-    for (const auto & multi_app : multi_apps)
+    for (const auto & multi_app_group : ordered_multi_apps)
     {
-      success = multi_app->solveStep(_dt, _time, auto_advance);
-      // no need to finish executing the subapps if one fails
-      if (!success)
-        break;
+      for (const auto & multi_app : multi_app_group)
+      {
+        success = multi_app->solveStep(_dt, _time, auto_advance);
+        // no need to finish executing the subapps if one fails
+        if (!success)
+          break;
 
-      // Execute Transfers _between_ Multiapps after each app executes
-      execMultiAppTransfers(type, MultiAppTransfer::BETWEEN_MULTIAPP, multi_app->name());
+        // Execute Transfers _between_ Multiapps after each app executes
+        execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, multi_app->name());
+      }
     }
 
     MooseUtils::parallelBarrierNotify(_communicator, _parallel_barrier_messaging);
@@ -5950,12 +5981,13 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
       return false;
 
     if (_verbose_multiapps)
-      _console << COLOR_CYAN << "Finished Executing MultiApps on " << Moose::stringify(type) << "\n"
+      _console << COLOR_CYAN << "Finished Executing MultiApps on " << Moose::stringify(exec_on)
+               << "\n"
                << COLOR_DEFAULT << std::endl;
   }
 
   // Execute Transfers _from_ MultiApps
-  execMultiAppTransfers(type, MultiAppTransfer::FROM_MULTIAPP);
+  execMultiAppTransfers(exec_on, MultiAppTransfer::FROM_MULTIAPP);
 
   // If we made it here then everything passed
   return true;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5766,17 +5766,43 @@ FEProblemBase::getMultiApp(const std::string & multi_app_name) const
 }
 
 void
-FEProblemBase::execMultiAppTransfers(ExecFlagType type, Transfer::DIRECTION direction)
+FEProblemBase::execMultiAppTransfers(ExecFlagType type,
+                                     Transfer::DIRECTION direction,
+                                     const MultiAppName & source_app,
+                                     bool skip_transfers_with_source_app_executing_on_type)
 {
+  // Keep track of whether a transfer is actually executed to avoid extraneous console output
+  bool is_executing_a_transfer = false;
   bool to_multiapp = direction == MultiAppTransfer::TO_MULTIAPP;
   bool from_multiapp = direction == MultiAppTransfer::FROM_MULTIAPP;
+
+  // Build console output
   std::string string_direction;
+  std::string additional_source_info = "";
   if (to_multiapp)
     string_direction = " To ";
   else if (from_multiapp)
     string_direction = " From ";
   else
     string_direction = " Between ";
+  if (!source_app.empty())
+    additional_source_info = " from app. '" + source_app + "'";
+
+  // This lambda only checks the source app, since the exec_type selection is done in the warehouse
+  auto executeThisTransfer =
+      [&source_app, &type, &skip_transfers_with_source_app_executing_on_type](auto & transfer)
+  {
+    mooseAssert(transfer->getExecuteOnEnum().contains(type), "Should execute on this schedule");
+    if (!transfer->hasFromMultiApp())
+      return true;
+    if (skip_transfers_with_source_app_executing_on_type &&
+        (transfer->getFromMultiApp()->getExecuteOnEnum().contains(type) ||
+         !transfer->getFromMultiApp()->enabled()))
+      return false;
+    if (source_app.empty() || transfer->getFromName() == source_app)
+      return true;
+    return false;
+  };
 
   const MooseObjectWarehouse<Transfer> & wh = to_multiapp     ? _to_multi_app_transfers[type]
                                               : from_multiapp ? _from_multi_app_transfers[type]
@@ -5791,7 +5817,7 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type, Transfer::DIRECTION dire
     if (_verbose_multiapps)
     {
       _console << COLOR_CYAN << "\nTransfers on " << Moose::stringify(type) << string_direction
-               << "MultiApps" << COLOR_DEFAULT << ":" << std::endl;
+               << "MultiApps" << additional_source_info << COLOR_DEFAULT << ":" << std::endl;
 
       VariadicTable<std::string, std::string, std::string, std::string> table(
           {"Name", "Type", "From", "To"});
@@ -5801,6 +5827,11 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type, Transfer::DIRECTION dire
       {
         auto multiapp_transfer = dynamic_cast<MultiAppTransfer *>(transfer.get());
 
+        // Don't add transfer to table if it won't execute
+        if (!executeThisTransfer(multiapp_transfer))
+          continue;
+
+        is_executing_a_transfer = true;
         table.addRow(multiapp_transfer->name(),
                      multiapp_transfer->type(),
                      multiapp_transfer->getFromName(),
@@ -5808,28 +5839,32 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type, Transfer::DIRECTION dire
       }
 
       // Print it
-      table.print(_console);
+      if (is_executing_a_transfer)
+        table.print(_console);
     }
 
     for (const auto & transfer : transfers)
     {
+      auto multiapp_transfer = dynamic_cast<MultiAppTransfer *>(transfer.get());
+      if (!executeThisTransfer(multiapp_transfer))
+        continue;
+
       transfer->setCurrentDirection(direction);
       transfer->execute();
     }
 
     MooseUtils::parallelBarrierNotify(_communicator, _parallel_barrier_messaging);
 
-    if (_verbose_multiapps)
+    if (_verbose_multiapps && is_executing_a_transfer)
       _console << COLOR_CYAN << "Transfers on " << Moose::stringify(type) << " Are Finished\n"
                << COLOR_DEFAULT << std::endl;
   }
-  else if (_multi_apps[type].getActiveObjects().size())
-  {
-    if (_verbose_multiapps)
-      _console << COLOR_CYAN << "\nNo Transfers on " << Moose::stringify(type) << string_direction
-               << "MultiApps\n"
-               << COLOR_DEFAULT << std::endl;
-  }
+
+  if (_multi_apps[type].getActiveObjects().size() && !is_executing_a_transfer && _verbose_multiapps)
+    _console << COLOR_CYAN << "\nNo "
+             << (skip_transfers_with_source_app_executing_on_type ? "early " : "")
+             << "Transfers on " << Moose::stringify(type) << string_direction << "MultiApps\n"
+             << COLOR_DEFAULT << std::endl;
 }
 
 std::vector<std::shared_ptr<Transfer>>
@@ -5879,8 +5914,11 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
   // Execute Transfers _to_ MultiApps
   execMultiAppTransfers(type, MultiAppTransfer::TO_MULTIAPP);
 
-  // Execute Transfers _between_ Multiapps
-  execMultiAppTransfers(type, MultiAppTransfer::BETWEEN_MULTIAPP);
+  // Execute Transfers _beween_ MultiApps for the multiapps that don't execute on this flag
+  // NOTE: these is usually no need to execute a transfer unless the multiapp providing its
+  // data also executed. But we need to obey what the user requested for the execution schedule,
+  // hence the two executions
+  execMultiAppTransfers(type, MultiAppTransfer::BETWEEN_MULTIAPP, "", true);
 
   // Execute MultiApps
   if (multi_apps.size())
@@ -5899,6 +5937,9 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
       // no need to finish executing the subapps if one fails
       if (!success)
         break;
+
+      // Execute Transfers _between_ Multiapps after each app executes
+      execMultiAppTransfers(type, MultiAppTransfer::BETWEEN_MULTIAPP, multi_app->name());
     }
 
     MooseUtils::parallelBarrierNotify(_communicator, _parallel_barrier_messaging);

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1473,8 +1473,6 @@ FEProblemBase::initialSetup()
 
   if (!_app.isRecovering())
   {
-    execTransfers(EXEC_INITIAL);
-
     bool converged = execMultiApps(EXEC_INITIAL);
     if (!converged)
       mooseError("failed to converge initial MultiApp");
@@ -6109,20 +6107,6 @@ FEProblemBase::computeMultiAppsDT(ExecFlagType type)
 }
 
 void
-FEProblemBase::execTransfers(ExecFlagType type)
-{
-  if (_transfers[type].hasActiveObjects())
-  {
-    TIME_SECTION("execTransfers", 3, "Executing Transfers");
-
-    const auto & transfers = _transfers[type].getActiveObjects();
-
-    for (const auto & transfer : transfers)
-      transfer->execute();
-  }
-}
-
-void
 FEProblemBase::addTransfer(const std::string & transfer_name,
                            const std::string & name,
                            InputParameters & parameters)
@@ -7521,8 +7505,6 @@ FEProblemBase::computeResidualAndJacobian(const NumericVector<Number> & soln,
         _displaced_problem->setCurrentlyComputingResidualAndJacobian(true);
       }
 
-      execTransfers(EXEC_LINEAR);
-
       execMultiApps(EXEC_LINEAR);
 
       for (unsigned int tid = 0; tid < n_threads; tid++)
@@ -7760,8 +7742,6 @@ FEProblemBase::computeResidualTags(const std::set<TagID> & tags)
       for (const auto & it : _random_data_objects)
         it.second->updateSeeds(EXEC_LINEAR);
 
-      execTransfers(EXEC_LINEAR);
-
       execMultiApps(EXEC_LINEAR);
 
       for (unsigned int tid = 0; tid < n_threads; tid++)
@@ -7915,7 +7895,6 @@ FEProblemBase::computeJacobianTags(const std::set<TagID> & tags)
         if (_displaced_problem)
           _displaced_problem->setCurrentlyComputingJacobian(true);
 
-        execTransfers(EXEC_NONLINEAR);
         execMultiApps(EXEC_NONLINEAR);
 
         for (unsigned int tid = 0; tid < n_threads; tid++)
@@ -8117,7 +8096,6 @@ FEProblemBase::computeLinearSystemTags(const NumericVector<Number> & soln,
   for (const auto & it : _random_data_objects)
     it.second->updateSeeds(EXEC_NONLINEAR);
 
-  execTransfers(EXEC_NONLINEAR);
   execMultiApps(EXEC_NONLINEAR);
 
   computeUserObjects(EXEC_NONLINEAR, Moose::PRE_AUX);

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6068,22 +6068,18 @@ FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
 
     bool success = true;
 
-    for (const auto & multi_app_group : ordered_multi_apps)
+    for (const auto & multi_app : multi_app_group)
     {
-      for (const auto & multi_app : multi_app_group)
-      {
-        success = multi_app->solveStep(_dt, _time, auto_advance);
-        // no need to finish executing the subapps if one fails
-        if (!success)
-          break;
+      success = multi_app->solveStep(_dt, _time, auto_advance);
+      // no need to finish executing the subapps if one fails
+      if (!success)
+        break;
 
-        // Execute Transfers _between_ Multiapps after each app executes
-        execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, multi_app->name());
-      }
+      // Execute Transfers _between_ Multiapps after each app executes
+      execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, multi_app->name());
     }
 
     MooseUtils::parallelBarrierNotify(_communicator, _parallel_barrier_messaging);
-
     _communicator.min(success);
 
     if (!success)

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6047,12 +6047,14 @@ FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
     {
       ordered_multi_apps = resolver.getSortedValuesSets();
     }
-    catch (CyclicDependencyException<std::string> & e)
+    catch (CyclicDependencyException<MooseSharedPointer<MultiApp>> & e)
     {
-      mooseError("Cyclic dependencies detected in multiapps and siblings transfers: ",
-                 MooseUtils::join(e.getCyclicDependencies(), " <- "),
-                 "\nPlease execute one of the transfers between multiapps on a different "
-                 "'execute_on' to break the cycle.");
+      mooseWarning("Cyclic dependencies detected in multiapps and siblings transfers"
+                   "\nPlease execute one of the transfers between multiapps on a different "
+                   "'execute_on' to break the cycle.");
+      ordered_multi_apps.resize(multi_apps.size());
+      for (const auto i : index_range(multi_apps))
+        ordered_multi_apps[i] = {multi_apps[i]};
     }
 
   // Execute MultiApps

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1497,8 +1497,6 @@ FEProblemBase::initialSetup()
 
   if (!_app.isRecovering())
   {
-    execTransfers(EXEC_INITIAL);
-
     bool converged = execMultiApps(EXEC_INITIAL);
     if (!converged)
       mooseError("failed to converge initial MultiApp");
@@ -6218,20 +6216,6 @@ FEProblemBase::computeMultiAppsDT(ExecFlagType type)
 }
 
 void
-FEProblemBase::execTransfers(ExecFlagType type)
-{
-  if (_transfers[type].hasActiveObjects())
-  {
-    TIME_SECTION("execTransfers", 3, "Executing Transfers");
-
-    const auto & transfers = _transfers[type].getActiveObjects();
-
-    for (const auto & transfer : transfers)
-      transfer->execute();
-  }
-}
-
-void
 FEProblemBase::addTransfer(const std::string & transfer_name,
                            const std::string & name,
                            InputParameters & parameters)
@@ -7630,8 +7614,6 @@ FEProblemBase::computeResidualAndJacobian(const NumericVector<Number> & soln,
         _displaced_problem->setCurrentlyComputingResidualAndJacobian(true);
       }
 
-      execTransfers(EXEC_LINEAR);
-
       execMultiApps(EXEC_LINEAR);
 
       for (unsigned int tid = 0; tid < n_threads; tid++)
@@ -7869,8 +7851,6 @@ FEProblemBase::computeResidualTags(const std::set<TagID> & tags)
       for (const auto & it : _random_data_objects)
         it.second->updateSeeds(EXEC_LINEAR);
 
-      execTransfers(EXEC_LINEAR);
-
       execMultiApps(EXEC_LINEAR);
 
       for (unsigned int tid = 0; tid < n_threads; tid++)
@@ -8024,7 +8004,6 @@ FEProblemBase::computeJacobianTags(const std::set<TagID> & tags)
         if (_displaced_problem)
           _displaced_problem->setCurrentlyComputingJacobian(true);
 
-        execTransfers(EXEC_NONLINEAR);
         execMultiApps(EXEC_NONLINEAR);
 
         for (unsigned int tid = 0; tid < n_threads; tid++)
@@ -8226,7 +8205,6 @@ FEProblemBase::computeLinearSystemTags(const NumericVector<Number> & soln,
   for (const auto & it : _random_data_objects)
     it.second->updateSeeds(EXEC_NONLINEAR);
 
-  execTransfers(EXEC_NONLINEAR);
   execMultiApps(EXEC_NONLINEAR);
 
   computeUserObjects(EXEC_NONLINEAR, Moose::PRE_AUX);

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5875,17 +5875,43 @@ FEProblemBase::getMultiApp(const std::string & multi_app_name) const
 }
 
 void
-FEProblemBase::execMultiAppTransfers(ExecFlagType type, Transfer::DIRECTION direction)
+FEProblemBase::execMultiAppTransfers(ExecFlagType type,
+                                     Transfer::DIRECTION direction,
+                                     const MultiAppName & source_app,
+                                     bool skip_transfers_with_source_app_executing_on_type)
 {
+  // Keep track of whether a transfer is actually executed to avoid extraneous console output
+  bool is_executing_a_transfer = false;
   bool to_multiapp = direction == MultiAppTransfer::TO_MULTIAPP;
   bool from_multiapp = direction == MultiAppTransfer::FROM_MULTIAPP;
+
+  // Build console output
   std::string string_direction;
+  std::string additional_source_info = "";
   if (to_multiapp)
     string_direction = " To ";
   else if (from_multiapp)
     string_direction = " From ";
   else
     string_direction = " Between ";
+  if (!source_app.empty())
+    additional_source_info = " from app. '" + source_app + "'";
+
+  // This lambda only checks the source app, since the exec_type selection is done in the warehouse
+  auto executeThisTransfer =
+      [&source_app, &type, &skip_transfers_with_source_app_executing_on_type](auto & transfer)
+  {
+    mooseAssert(transfer->getExecuteOnEnum().contains(type), "Should execute on this schedule");
+    if (!transfer->hasFromMultiApp())
+      return true;
+    if (skip_transfers_with_source_app_executing_on_type &&
+        (transfer->getFromMultiApp()->getExecuteOnEnum().contains(type) ||
+         !transfer->getFromMultiApp()->enabled()))
+      return false;
+    if (source_app.empty() || transfer->getFromName() == source_app)
+      return true;
+    return false;
+  };
 
   const MooseObjectWarehouse<Transfer> & wh = to_multiapp     ? _to_multi_app_transfers[type]
                                               : from_multiapp ? _from_multi_app_transfers[type]
@@ -5900,7 +5926,7 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type, Transfer::DIRECTION dire
     if (_verbose_multiapps)
     {
       _console << COLOR_CYAN << "\nTransfers on " << Moose::stringify(type) << string_direction
-               << "MultiApps" << COLOR_DEFAULT << ":" << std::endl;
+               << "MultiApps" << additional_source_info << COLOR_DEFAULT << ":" << std::endl;
 
       VariadicTable<std::string, std::string, std::string, std::string> table(
           {"Name", "Type", "From", "To"});
@@ -5910,6 +5936,11 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type, Transfer::DIRECTION dire
       {
         auto multiapp_transfer = dynamic_cast<MultiAppTransfer *>(transfer.get());
 
+        // Don't add transfer to table if it won't execute
+        if (!executeThisTransfer(multiapp_transfer))
+          continue;
+
+        is_executing_a_transfer = true;
         table.addRow(multiapp_transfer->name(),
                      multiapp_transfer->type(),
                      multiapp_transfer->getFromName(),
@@ -5917,28 +5948,32 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type, Transfer::DIRECTION dire
       }
 
       // Print it
-      table.print(_console);
+      if (is_executing_a_transfer)
+        table.print(_console);
     }
 
     for (const auto & transfer : transfers)
     {
+      auto multiapp_transfer = dynamic_cast<MultiAppTransfer *>(transfer.get());
+      if (!executeThisTransfer(multiapp_transfer))
+        continue;
+
       transfer->setCurrentDirection(direction);
       transfer->execute();
     }
 
     MooseUtils::parallelBarrierNotify(_communicator, _parallel_barrier_messaging);
 
-    if (_verbose_multiapps)
+    if (_verbose_multiapps && is_executing_a_transfer)
       _console << COLOR_CYAN << "Transfers on " << Moose::stringify(type) << " Are Finished\n"
                << COLOR_DEFAULT << std::endl;
   }
-  else if (_multi_apps[type].getActiveObjects().size())
-  {
-    if (_verbose_multiapps)
-      _console << COLOR_CYAN << "\nNo Transfers on " << Moose::stringify(type) << string_direction
-               << "MultiApps\n"
-               << COLOR_DEFAULT << std::endl;
-  }
+
+  if (_multi_apps[type].getActiveObjects().size() && !is_executing_a_transfer && _verbose_multiapps)
+    _console << COLOR_CYAN << "\nNo "
+             << (skip_transfers_with_source_app_executing_on_type ? "early " : "")
+             << "Transfers on " << Moose::stringify(type) << string_direction << "MultiApps\n"
+             << COLOR_DEFAULT << std::endl;
 }
 
 std::vector<std::shared_ptr<Transfer>>
@@ -5988,8 +6023,11 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
   // Execute Transfers _to_ MultiApps
   execMultiAppTransfers(type, MultiAppTransfer::TO_MULTIAPP);
 
-  // Execute Transfers _between_ Multiapps
-  execMultiAppTransfers(type, MultiAppTransfer::BETWEEN_MULTIAPP);
+  // Execute Transfers _beween_ MultiApps for the multiapps that don't execute on this flag
+  // NOTE: these is usually no need to execute a transfer unless the multiapp providing its
+  // data also executed. But we need to obey what the user requested for the execution schedule,
+  // hence the two executions
+  execMultiAppTransfers(type, MultiAppTransfer::BETWEEN_MULTIAPP, "", true);
 
   // Execute MultiApps
   if (multi_apps.size())
@@ -6008,6 +6046,9 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
       // no need to finish executing the subapps if one fails
       if (!success)
         break;
+
+      // Execute Transfers _between_ Multiapps after each app executes
+      execMultiAppTransfers(type, MultiAppTransfer::BETWEEN_MULTIAPP, multi_app->name());
     }
 
     MooseUtils::parallelBarrierNotify(_communicator, _parallel_barrier_messaging);

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -125,6 +125,7 @@
 #include "Checkpoint.h"
 #include "MortarInterfaceWarehouse.h"
 #include "AutomaticMortarGeneration.h"
+#include "DependencyResolver.h"
 
 #include "libmesh/exodusII_io.h"
 #include "libmesh/quadrature.h"
@@ -6010,24 +6011,51 @@ FEProblemBase::getMultiAppTransferWarehouse(Transfer::DIRECTION direction) const
 }
 
 bool
-FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
+FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
 {
   // Active MultiApps
   const std::vector<MooseSharedPointer<MultiApp>> & multi_apps =
-      _multi_apps[type].getActiveObjects();
+      _multi_apps[exec_on].getActiveObjects();
 
   // Do anything that needs to be done to Apps before transfers
   for (const auto & multi_app : multi_apps)
     multi_app->preTransfer(_dt, _time);
 
   // Execute Transfers _to_ MultiApps
-  execMultiAppTransfers(type, MultiAppTransfer::TO_MULTIAPP);
+  execMultiAppTransfers(exec_on, MultiAppTransfer::TO_MULTIAPP);
 
   // Execute Transfers _beween_ MultiApps for the multiapps that don't execute on this flag
   // NOTE: these is usually no need to execute a transfer unless the multiapp providing its
   // data also executed. But we need to obey what the user requested for the execution schedule,
   // hence the two executions
-  execMultiAppTransfers(type, MultiAppTransfer::BETWEEN_MULTIAPP, "", true);
+  execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, "", true);
+
+  // Order the multiapps
+  DependencyResolver<MooseSharedPointer<MultiApp>> resolver;
+
+  // Add all the apps executing on 'exec_on' to the resolution
+  for (const auto & multi_app : multi_apps)
+    resolver.addItem(multi_app);
+  // Add all the dependencies found from active transfers executing on 'exec_on'
+  for (const auto & sibling_transfer : _between_multi_app_transfers[exec_on].getActiveObjects())
+  {
+    auto multiapp_transfer = dynamic_cast<MultiAppTransfer *>(sibling_transfer.get());
+    resolver.addEdge(multiapp_transfer->getFromMultiApp(), multiapp_transfer->getToMultiApp());
+  }
+
+  std::vector<std::vector<MooseSharedPointer<MultiApp>>> ordered_multi_apps;
+  if (multi_apps.size())
+    try
+    {
+      ordered_multi_apps = resolver.getSortedValuesSets();
+    }
+    catch (CyclicDependencyException<std::string> & e)
+    {
+      mooseError("Cyclic dependencies detected in multiapps and siblings transfers: ",
+                 MooseUtils::join(e.getCyclicDependencies(), " <- "),
+                 "\nPlease execute one of the transfers between multiapps on a different "
+                 "'execute_on' to break the cycle.");
+    }
 
   // Execute MultiApps
   if (multi_apps.size())
@@ -6035,20 +6063,23 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
     TIME_SECTION("execMultiApps", 1, "Executing MultiApps", false);
 
     if (_verbose_multiapps)
-      _console << COLOR_CYAN << "\nExecuting MultiApps on " << Moose::stringify(type)
+      _console << COLOR_CYAN << "\nExecuting MultiApps on " << Moose::stringify(exec_on)
                << COLOR_DEFAULT << std::endl;
 
     bool success = true;
 
-    for (const auto & multi_app : multi_apps)
+    for (const auto & multi_app_group : ordered_multi_apps)
     {
-      success = multi_app->solveStep(_dt, _time, auto_advance);
-      // no need to finish executing the subapps if one fails
-      if (!success)
-        break;
+      for (const auto & multi_app : multi_app_group)
+      {
+        success = multi_app->solveStep(_dt, _time, auto_advance);
+        // no need to finish executing the subapps if one fails
+        if (!success)
+          break;
 
-      // Execute Transfers _between_ Multiapps after each app executes
-      execMultiAppTransfers(type, MultiAppTransfer::BETWEEN_MULTIAPP, multi_app->name());
+        // Execute Transfers _between_ Multiapps after each app executes
+        execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, multi_app->name());
+      }
     }
 
     MooseUtils::parallelBarrierNotify(_communicator, _parallel_barrier_messaging);
@@ -6059,12 +6090,13 @@ FEProblemBase::execMultiApps(ExecFlagType type, bool auto_advance)
       return false;
 
     if (_verbose_multiapps)
-      _console << COLOR_CYAN << "Finished Executing MultiApps on " << Moose::stringify(type) << "\n"
+      _console << COLOR_CYAN << "Finished Executing MultiApps on " << Moose::stringify(exec_on)
+               << "\n"
                << COLOR_DEFAULT << std::endl;
   }
 
   // Execute Transfers _from_ MultiApps
-  execMultiAppTransfers(type, MultiAppTransfer::FROM_MULTIAPP);
+  execMultiAppTransfers(exec_on, MultiAppTransfer::FROM_MULTIAPP);
 
   // If we made it here then everything passed
   return true;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -276,10 +276,6 @@ FEProblemBase::validParams()
                         "barrier notifications when executing "
                         "or transferring to/from Multiapps "
                         "(default: false)");
-  params.addParam<bool>("execute_siblings_transfer_after_source_multiapp_execution",
-                        false,
-                        "Whether to execute the siblings transfer staggered with the multiapp "
-                        "execution, after the 'from_multiapp' of the transfer executes");
 
   MooseEnum verbosity("false true extra", "false");
   params.addParam<MooseEnum>("verbose_setup",
@@ -468,8 +464,6 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _to_multi_app_transfers(_app.getExecuteOnEnum(), /*threaded=*/false),
     _from_multi_app_transfers(_app.getExecuteOnEnum(), /*threaded=*/false),
     _between_multi_app_transfers(_app.getExecuteOnEnum(), /*threaded=*/false),
-    _execute_siblings_transfer_after_source_multiapp_execution(
-        getParam<bool>("execute_siblings_transfer_after_source_multiapp_execution")),
 #ifdef LIBMESH_ENABLE_AMR
     _adaptivity(*this),
     _cycles_completed(0),
@@ -5882,8 +5876,7 @@ FEProblemBase::getMultiApp(const std::string & multi_app_name) const
 void
 FEProblemBase::execMultiAppTransfers(ExecFlagType type,
                                      Transfer::DIRECTION direction,
-                                     const MultiAppName & source_app,
-                                     bool skip_transfers_with_source_app_executing_on_type)
+                                     const MultiAppName & source_app)
 {
   // Keep track of whether a transfer is actually executed to avoid extraneous console output
   bool is_executing_a_transfer = false;
@@ -5903,17 +5896,25 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type,
     additional_source_info = " from app. '" + source_app + "'";
 
   // This lambda only checks the source app, since the exec_type selection is done in the warehouse
-  auto executeThisTransfer =
-      [&source_app, &type, &skip_transfers_with_source_app_executing_on_type](auto & transfer)
+  auto executeThisTransfer = [this, &direction, &source_app, &type](auto & transfer)
   {
     mooseAssert(transfer->getExecuteOnEnum().contains(type), "Should execute on this schedule");
-    if (!transfer->hasFromMultiApp())
+    // no restriction / ordering groups on transfers from parent to child at this time
+    if (direction != MultiAppTransfer::BETWEEN_MULTIAPP)
       return true;
-    if (skip_transfers_with_source_app_executing_on_type &&
-        (transfer->getFromMultiApp()->getExecuteOnEnum().contains(type) ||
-         !transfer->getFromMultiApp()->enabled()))
-      return false;
-    if (source_app.empty() || transfer->getFromName() == source_app)
+    // on sibling transfers, we can delay until the app has been executed if the transfer is set
+    // that way.
+    if (transfer->getFromName() == source_app && transfer->executeAfterSourceApp())
+    {
+      libmesh_ignore(this);
+      mooseAssert(
+          this->getMultiApp(transfer->parameters().template get<MultiAppName>("from_multi_app"))
+              ->getExecuteOnEnum()
+              .contains(type),
+          "from_multiapp should also execute on this schedule");
+    }
+    if ((source_app.empty() && !transfer->executeAfterSourceApp()) ||
+        (transfer->getFromName() == source_app && transfer->executeAfterSourceApp()))
       return true;
     return false;
   };
@@ -5930,9 +5931,6 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type,
 
     if (_verbose_multiapps)
     {
-      _console << COLOR_CYAN << "\nTransfers on " << Moose::stringify(type) << string_direction
-               << "MultiApps" << additional_source_info << COLOR_DEFAULT << ":" << std::endl;
-
       VariadicTable<std::string, std::string, std::string, std::string> table(
           {"Name", "Type", "From", "To"});
 
@@ -5954,7 +5952,12 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type,
 
       // Print it
       if (is_executing_a_transfer)
+      {
+        _console << COLOR_CYAN << "\nTransfers on " << Moose::stringify(type) << string_direction
+                 << "MultiApps" << additional_source_info << COLOR_DEFAULT << ":" << std::endl;
+
         table.print(_console);
+      }
     }
 
     for (const auto & transfer : transfers)
@@ -5975,9 +5978,8 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type,
   }
 
   if (_multi_apps[type].getActiveObjects().size() && !is_executing_a_transfer && _verbose_multiapps)
-    _console << COLOR_CYAN << "\nNo "
-             << (skip_transfers_with_source_app_executing_on_type ? "early " : "")
-             << "Transfers on " << Moose::stringify(type) << string_direction << "MultiApps\n"
+    _console << COLOR_CYAN << "\nNo Transfers on " << Moose::stringify(type) << string_direction
+             << "MultiApps\n"
              << COLOR_DEFAULT << std::endl;
 }
 
@@ -6032,10 +6034,7 @@ FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
   // NOTE: these is usually no need to execute a transfer unless the multiapp providing its
   // data also executed. But we need to obey what the user requested for the execution schedule,
   // hence the two executions
-  if (_execute_siblings_transfer_after_source_multiapp_execution)
-    execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, "", true);
-  else
-    execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP);
+  execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP);
 
   // Order the multiapps based on their execution group
   // Build the ordered multiapp groups

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5904,7 +5904,7 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type,
       return true;
     // on sibling transfers, we can delay until the app has been executed if the transfer is set
     // that way.
-    if (transfer->getFromName() == source_app && transfer->executeAfterSourceApp())
+    if (transfer->getFromName() == source_app && transfer->executeAfterSiblingSourceApp())
     {
       libmesh_ignore(this);
       mooseAssert(
@@ -5913,8 +5913,13 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type,
               .contains(type),
           "from_multiapp should also execute on this schedule");
     }
-    if ((source_app.empty() && !transfer->executeAfterSourceApp()) ||
-        (transfer->getFromName() == source_app && transfer->executeAfterSourceApp()))
+    // Execute if:
+    // - transfer is set execute before from_multiapp, and we are calling this before source apps
+    // - from_multiapp app is not executing on this execute_on
+    // - from_multiapp just executed (set to source app)
+    if ((source_app.empty() && (!transfer->executeAfterSiblingSourceApp() ||
+                                !transfer->getFromMultiApp()->getExecuteOnEnum().contains(type))) ||
+        (transfer->getFromName() == source_app && transfer->executeAfterSiblingSourceApp()))
       return true;
     return false;
   };

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5893,7 +5893,7 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type,
   else
     string_direction = " Between ";
   if (!source_app.empty())
-    additional_source_info = " from app. '" + source_app + "'";
+    additional_source_info = " from app '" + source_app + "'";
 
   // This lambda only checks the source app, since the exec_type selection is done in the warehouse
   auto executeThisTransfer = [this, &direction, &source_app, &type](auto & transfer)
@@ -5907,11 +5907,8 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type,
     if (transfer->getFromName() == source_app && transfer->executeAfterSiblingSourceApp())
     {
       libmesh_ignore(this);
-      mooseAssert(
-          this->getMultiApp(transfer->parameters().template get<MultiAppName>("from_multi_app"))
-              ->getExecuteOnEnum()
-              .contains(type),
-          "from_multiapp should also execute on this schedule");
+      mooseAssert(this->getMultiApp(transfer->getFromName())->getExecuteOnEnum().contains(type),
+                  "from_multiapp should also execute on this schedule");
     }
     // Execute if:
     // - transfer is set execute before from_multiapp, and we are calling this before source apps
@@ -5967,7 +5964,7 @@ FEProblemBase::execMultiAppTransfers(ExecFlagType type,
 
     for (const auto & transfer : transfers)
     {
-      auto multiapp_transfer = dynamic_cast<MultiAppTransfer *>(transfer.get());
+      auto multiapp_transfer = libMesh::cast_ptr<MultiAppTransfer *>(transfer.get());
       if (!executeThisTransfer(multiapp_transfer))
         continue;
 
@@ -6036,7 +6033,7 @@ FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
   execMultiAppTransfers(exec_on, MultiAppTransfer::TO_MULTIAPP);
 
   // Execute Transfers _beween_ MultiApps for the multiapps that don't execute on this flag
-  // NOTE: these is usually no need to execute a transfer unless the multiapp providing its
+  // NOTE: there is usually no need to execute a transfer unless the multiapp providing its
   // data also executed. But we need to obey what the user requested for the execution schedule,
   // hence the two executions
   execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP);
@@ -6074,7 +6071,7 @@ FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
           break;
       }
 
-      // Execute Transfers _between_ Multiapps after each app executes
+      // Execute Transfers _between_ MultiApps after each app executes
       for (const auto & multi_app : multi_app_group)
         execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, multi_app->name());
     }

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6037,32 +6037,13 @@ FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
   else
     execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP);
 
-  // Order the multiapps
-  DependencyResolver<MooseSharedPointer<MultiApp>> resolver;
+  // Order the multiapps based on their execution group
+  // Build the ordered multiapp groups
+  std::map<unsigned int, std::vector<MooseSharedPointer<MultiApp>>> ordered_multi_apps;
 
-  // Add all the apps executing on 'exec_on' to the resolution
   for (const auto & multi_app : multi_apps)
-    resolver.addItem(multi_app);
-  // Add all the dependencies found from active transfers executing on 'exec_on'
-  for (const auto & sibling_transfer : _between_multi_app_transfers[exec_on].getActiveObjects())
-  {
-    auto multiapp_transfer = dynamic_cast<MultiAppTransfer *>(sibling_transfer.get());
-    resolver.addEdge(multiapp_transfer->getFromMultiApp(), multiapp_transfer->getToMultiApp());
-  }
-
-  std::vector<std::vector<MooseSharedPointer<MultiApp>>> ordered_multi_apps;
-  if (_execute_siblings_transfer_after_source_multiapp_execution && multi_apps.size())
-    try
-    {
-      ordered_multi_apps = resolver.getSortedValuesSets();
-    }
-    catch (CyclicDependencyException<MooseSharedPointer<MultiApp>> & e)
-    {
-      mooseInfo("Cyclic dependencies detected in multiapps and siblings transfers"
-                "\nPlease execute one of the transfers between multiapps on a different "
-                "'execute_on' to break the cycle.");
-      ordered_multi_apps.resize(0);
-    }
+    ordered_multi_apps[multi_app->getParam<unsigned int>("execution_order_group")].push_back(
+        multi_app);
 
   // Execute MultiApps
   if (multi_apps.size())

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -276,6 +276,10 @@ FEProblemBase::validParams()
                         "barrier notifications when executing "
                         "or transferring to/from Multiapps "
                         "(default: false)");
+  params.addParam<bool>("execute_siblings_transfer_after_source_multiapp_execution",
+                        false,
+                        "Whether to execute the siblings transfer staggered with the multiapp "
+                        "execution, after the 'from_multiapp' of the transfer executes");
 
   MooseEnum verbosity("false true extra", "false");
   params.addParam<MooseEnum>("verbose_setup",
@@ -464,6 +468,8 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _to_multi_app_transfers(_app.getExecuteOnEnum(), /*threaded=*/false),
     _from_multi_app_transfers(_app.getExecuteOnEnum(), /*threaded=*/false),
     _between_multi_app_transfers(_app.getExecuteOnEnum(), /*threaded=*/false),
+    _execute_siblings_transfer_after_source_multiapp_execution(
+        getParam<bool>("execute_siblings_transfer_after_source_multiapp_execution")),
 #ifdef LIBMESH_ENABLE_AMR
     _adaptivity(*this),
     _cycles_completed(0),
@@ -6026,7 +6032,10 @@ FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
   // NOTE: these is usually no need to execute a transfer unless the multiapp providing its
   // data also executed. But we need to obey what the user requested for the execution schedule,
   // hence the two executions
-  execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, "", true);
+  if (_execute_siblings_transfer_after_source_multiapp_execution)
+    execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, "", true);
+  else
+    execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP);
 
   // Order the multiapps
   DependencyResolver<MooseSharedPointer<MultiApp>> resolver;
@@ -6042,19 +6051,17 @@ FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
   }
 
   std::vector<std::vector<MooseSharedPointer<MultiApp>>> ordered_multi_apps;
-  if (multi_apps.size())
+  if (_execute_siblings_transfer_after_source_multiapp_execution && multi_apps.size())
     try
     {
       ordered_multi_apps = resolver.getSortedValuesSets();
     }
     catch (CyclicDependencyException<MooseSharedPointer<MultiApp>> & e)
     {
-      mooseWarning("Cyclic dependencies detected in multiapps and siblings transfers"
-                   "\nPlease execute one of the transfers between multiapps on a different "
-                   "'execute_on' to break the cycle.");
-      ordered_multi_apps.resize(multi_apps.size());
-      for (const auto i : index_range(multi_apps))
-        ordered_multi_apps[i] = {multi_apps[i]};
+      mooseInfo("Cyclic dependencies detected in multiapps and siblings transfers"
+                "\nPlease execute one of the transfers between multiapps on a different "
+                "'execute_on' to break the cycle.");
+      ordered_multi_apps.resize(0);
     }
 
   // Execute MultiApps
@@ -6068,15 +6075,23 @@ FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
 
     bool success = true;
 
-    for (const auto & multi_app : multi_app_group)
+    for (const auto & [group, multi_app_group] : ordered_multi_apps)
     {
-      success = multi_app->solveStep(_dt, _time, auto_advance);
-      // no need to finish executing the subapps if one fails
-      if (!success)
-        break;
+      if (_verbose_multiapps && ordered_multi_apps.size() > 1)
+        _console << COLOR_CYAN << "\nExecuting MultiApps from group " << group << COLOR_DEFAULT
+                 << std::endl;
+
+      for (const auto & multi_app : multi_app_group)
+      {
+        success = multi_app->solveStep(_dt, _time, auto_advance);
+        // no need to finish executing the subapps if one fails
+        if (!success)
+          break;
+      }
 
       // Execute Transfers _between_ Multiapps after each app executes
-      execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, multi_app->name());
+      for (const auto & multi_app : multi_app_group)
+        execMultiAppTransfers(exec_on, MultiAppTransfer::BETWEEN_MULTIAPP, multi_app->name());
     }
 
     MooseUtils::parallelBarrierNotify(_communicator, _parallel_barrier_messaging);
@@ -6091,7 +6106,7 @@ FEProblemBase::execMultiApps(ExecFlagType exec_on, bool auto_advance)
                << COLOR_DEFAULT << std::endl;
   }
 
-  // Execute Transfers _from_ MultiApps
+  // Execute Transfers _from_ MultiApps (to the parent app)
   execMultiAppTransfers(exec_on, MultiAppTransfer::FROM_MULTIAPP);
 
   // If we made it here then everything passed

--- a/framework/src/transfers/MultiAppPostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorTransfer.C
@@ -108,7 +108,7 @@ MultiAppPostprocessorTransfer::execute()
                           !getToMultiApp()->hasLocalApp(i),
                       "Source and target app parallel distribution must be the same");
 
-        // Case 1: a single source app, multiple (or single) target apps
+        // Case 1: a single source app, possibly multiple target apps
         // All target apps must be local
         if (getFromMultiApp()->numGlobalApps() == 1)
           for (const auto j : make_range(getToMultiApp()->numGlobalApps()))

--- a/framework/src/transfers/MultiAppPostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorTransfer.C
@@ -108,7 +108,7 @@ MultiAppPostprocessorTransfer::execute()
                           !getToMultiApp()->hasLocalApp(i),
                       "Source and target app parallel distribution must be the same");
 
-        // Case 1: a single source app, multiple target apps
+        // Case 1: a single source app, multiple (or single) target apps
         // All target apps must be local
         if (getFromMultiApp()->numGlobalApps() == 1)
           for (const auto j : make_range(getToMultiApp()->numGlobalApps()))
@@ -215,7 +215,9 @@ MultiAppPostprocessorTransfer::checkSiblingsTransferSupported() const
   // Check that we are in one of the supported configurations
   // Case 2: same number of source and target apps
   // The allocation of the child apps on the processors must be the same
-  if (getFromMultiApp()->numGlobalApps() == getToMultiApp()->numGlobalApps())
+  // Note: case 1 is supported because we do a reduction on the postprocessor value
+  if (getFromMultiApp()->numGlobalApps() == getToMultiApp()->numGlobalApps() &&
+      getFromMultiApp()->numGlobalApps() != 1)
   {
     for (const auto i : make_range(getToMultiApp()->numGlobalApps()))
       if (getFromMultiApp()->hasLocalApp(i) + getToMultiApp()->hasLocalApp(i) == 1)

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -157,15 +157,17 @@ MultiAppTransfer::MultiAppTransfer(const InputParameters & parameters)
 
   // Check the parameter for sibling transfers being nested within multiapp execution loop
   const auto & exec_on = getExecuteOnEnum();
-  if (isParamValid("execute_after_from_multiapp") && _from_multi_app &&
+  if (getParam<bool>("check_multiapp_execute_on") && isParamValid("execute_after_from_multiapp") &&
+      _from_multi_app &&
       ((_from_multi_app->getExecuteOnEnum() != exec_on) &&
        !(exec_on.size() == 1 && int(exec_on.get(0)) == EXEC_SAME_AS_MULTIAPP)))
-    paramWarning("execute_after_from_multiapp",
-                 "This parameter is only obeyed when the from_multi_app and the transfer are "
-                 "executing on the same execute_on flag.\nfrom_multi_app execution schedule: ",
-                 Moose::stringify(_from_multi_app->getExecuteOnEnum()),
-                 "\nTransfer execution schedule: ",
-                 Moose::stringify(exec_on));
+    paramError("execute_after_from_multiapp",
+               "This parameter is only obeyed when the from_multi_app and the transfer are "
+               "executing on the same execute_on flag.\nfrom_multi_app execution schedule: ",
+               Moose::stringify(_from_multi_app->getExecuteOnEnum()),
+               "\nTransfer execution schedule: ",
+               Moose::stringify(exec_on),
+               "\nYou can disable this error by setting 'check_multiapp_execute_on' to false.");
   // This parameter is only obeyed for BETWEEN_MULTIAPP
   if (!(_directions.size() == 1 && _directions.get(0) == BETWEEN_MULTIAPP) &&
       isParamValid("execute_after_from_multiapp"))
@@ -173,13 +175,13 @@ MultiAppTransfer::MultiAppTransfer(const InputParameters & parameters)
                "This parameter is only intended for modifying the execution schedule of "
                "siblings transfers, e.g. transfers from a from_multi_app to a to_multi_app");
   // The default isn't enough to achieve staggering unless users staggered the multiapps.
-  // This is effectively a warning by default for siblings transfers BUT:
-  // - the order of execution is actually important here. you don't want to make things explicit by
-  // accident
+  // This is effectively a warning by default for sibling transfers BUT:
+  // - the order of execution is actually important here. You don't want to make things explicit
+  // (in terms of time integration) by lagging a term on accident
   // - we would need dependency resolution between multiapps to set the order group to get
-  // staggering
-  //   by default.
-  if (_directions.contains("between_multiapp") && _exec_after_source_app_exec &&
+  // staggering by default.
+  if (getParam<bool>("check_multiapp_execute_on") && _directions.contains("between_multiapp") &&
+      _exec_after_source_app_exec &&
       _from_multi_app->getParam<unsigned int>("execution_order_group") >=
           _to_multi_app->getParam<unsigned int>("execution_order_group") &&
       // no need to check ordering groups if executing apps on different schedules
@@ -194,7 +196,8 @@ MultiAppTransfer::MultiAppTransfer(const InputParameters & parameters)
                  "'to_multi_app', but after both.\nfrom_multi_app execution order group: ",
                  Moose::stringify(_from_multi_app->getParam<unsigned int>("execution_order_group")),
                  "\nto_multi_app execution order group: ",
-                 Moose::stringify(_to_multi_app->getParam<unsigned int>("execution_order_group")));
+                 Moose::stringify(_to_multi_app->getParam<unsigned int>("execution_order_group")),
+                 "\nYou can disable this warning by setting 'check_multiapp_execute_on' to false.");
 
   // Handle deprecated parameters
   if (parameters.isParamSetByUser("direction"))

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -155,6 +155,24 @@ MultiAppTransfer::MultiAppTransfer(const InputParameters & parameters)
     _current_direction = _directions[0];
   }
 
+  // Check the parameter for sibling transfers being nested within multiapp execution loop
+  const auto & exec_on = getExecuteOnEnum();
+  if (isParamValid("execute_after_from_multiapp") && _from_multi_app &&
+      ((_from_multi_app->getExecuteOnEnum() != exec_on) &&
+       !(exec_on.size() == 1 && int(exec_on.get(0)) == EXEC_SAME_AS_MULTIAPP)))
+    paramWarning("execute_after_from_multiapp",
+                 "This parameter is only obeyed when the from_multi_app and the transfer are "
+                 "executing on the same execute_on flag.\nfrom_multi_app execution schedule: ",
+                 Moose::stringify(_from_multi_app->getExecuteOnEnum()),
+                 "\nTransfer execution schedule: ",
+                 Moose::stringify(exec_on));
+  // This parameter is only obeyed for BETWEEN_MULTIAPP
+  if (!(_directions.size() == 1 && _directions.get(0) == BETWEEN_MULTIAPP) &&
+      isParamValid("execute_after_from_multiapp"))
+    paramError("execute_after_from_multiapp",
+               "This parameter is only intended for modifying the execution schedule of "
+               "BETWEEN_MULTIAPPS transfers");
+
   // Handle deprecated parameters
   if (parameters.isParamSetByUser("direction"))
   {

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -171,7 +171,7 @@ MultiAppTransfer::MultiAppTransfer(const InputParameters & parameters)
       isParamValid("execute_after_from_multiapp"))
     paramError("execute_after_from_multiapp",
                "This parameter is only intended for modifying the execution schedule of "
-               "BETWEEN_MULTIAPPS transfers");
+               "siblings transfers, e.g. transfers from a from_multi_app to a to_multi_app");
   // The default isn't enough to achieve staggering unless users staggered the multiapps.
   // This is effectively a warning by default for siblings transfers BUT:
   // - the order of execution is actually important here. you don't want to make things explicit by

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -182,7 +182,11 @@ MultiAppTransfer::MultiAppTransfer(const InputParameters & parameters)
   if (_directions.contains("between_multiapp") && _exec_after_source_app_exec &&
       _from_multi_app->getParam<unsigned int>("execution_order_group") >=
           _to_multi_app->getParam<unsigned int>("execution_order_group") &&
-      _from_multi_app->getExecuteOnEnum() == _to_multi_app->getExecuteOnEnum())
+      // no need to check ordering groups if executing apps on different schedules
+      _from_multi_app->getExecuteOnEnum() == _to_multi_app->getExecuteOnEnum() &&
+      // no need to check ordering groups if transfer is executed on a different schedule
+      ((_from_multi_app->getExecuteOnEnum() == exec_on) ||
+       (exec_on.size() == 1 && int(exec_on.get(0)) == EXEC_SAME_AS_MULTIAPP)))
     paramWarning("execute_after_from_multiapp",
                  "Transfer is set to execute after the 'from_multi_app' but the 'to_multi_app' is "
                  "executing before or in the same 'execution_order_group' as the 'from_multi_app'. "

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -172,6 +172,25 @@ MultiAppTransfer::MultiAppTransfer(const InputParameters & parameters)
     paramError("execute_after_from_multiapp",
                "This parameter is only intended for modifying the execution schedule of "
                "BETWEEN_MULTIAPPS transfers");
+  // The default isn't enough to achieve staggering unless users staggered the multiapps.
+  // This is effectively a warning by default for siblings transfers BUT:
+  // - the order of execution is actually important here. you don't want to make things explicit by
+  // accident
+  // - we would need dependency resolution between multiapps to set the order group to get
+  // staggering
+  //   by default.
+  if (_directions.contains("between_multiapp") && _exec_after_source_app_exec &&
+      _from_multi_app->getParam<unsigned int>("execution_order_group") >=
+          _to_multi_app->getParam<unsigned int>("execution_order_group") &&
+      _from_multi_app->getExecuteOnEnum() == _to_multi_app->getExecuteOnEnum())
+    paramWarning("execute_after_from_multiapp",
+                 "Transfer is set to execute after the 'from_multi_app' but the 'to_multi_app' is "
+                 "executing before or in the same 'execution_order_group' as the 'from_multi_app'. "
+                 "Thus the transfer is not actually executing in between the 'from_' and "
+                 "'to_multi_app', but after both.\nfrom_multi_app execution order group: ",
+                 Moose::stringify(_from_multi_app->getParam<unsigned int>("execution_order_group")),
+                 "\nto_multi_app execution order group: ",
+                 Moose::stringify(_to_multi_app->getParam<unsigned int>("execution_order_group")));
 
   // Handle deprecated parameters
   if (parameters.isParamSetByUser("direction"))

--- a/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
@@ -54,6 +54,10 @@ MultiAppVariableValueSamplePostprocessorTransfer::validParams()
       "supplied array variable in 'source_variable'. For instance, if there are 9 sub-applications "
       "and 3 components in the variable, sub-apps 0-2 will go to component 0, 3-5 will go to 1, "
       "and 6-8 will go to 2.");
+
+  // Sibling transfers not supported
+  params.suppressParameter<bool>("execute_after_from_multiapp");
+
   return params;
 }
 

--- a/framework/src/transfers/Transfer.C
+++ b/framework/src/transfers/Transfer.C
@@ -46,11 +46,18 @@ Transfer::validParams()
       "Whether this Transfer will be 'to' or 'from' a MultiApp, or "
       "bidirectional, by providing both FROM_MULTIAPP and TO_MULTIAPP.",
       "Specifying direction+multiapp is deprecated. Specify the to_multi_app and from_multi_app");
-  params.registerBase("Transfer");
+
+  // No default to avoid displaying it in the documentation
+  params.addParam<bool>(
+      "execute_after_from_multiapp",
+      "Whether to execute the transfer after the from_multiapp has executed when both share and "
+      "execute_on flag. Note that this setting is only used to move the execution of "
+      "BETWEEN_MULTIAPP (siblings) transfers, FROM_ and TO_MULTIAPP transfers are always executed "
+      "after the from_multiapp and before the to_multiapp respectively.");
 
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
   params.addParamNamesToGroup("_called_legacy_params", "Advanced");
-
+  params.registerBase("Transfer");
   params.declareControllable("enable");
   return params;
 }
@@ -67,7 +74,10 @@ Transfer::Transfer(const InputParameters & parameters)
     _direction(possibleDirections()),
     _current_direction(possibleDirections()),
     _directions(isParamValid("direction") ? getParam<MultiMooseEnum>("direction")
-                                          : possibleDirections())
+                                          : possibleDirections()),
+    _exec_after_source_app_exec(isParamValid("execute_after_from_multiapp")
+                                    ? getParam<bool>("execute_after_from_multiapp")
+                                    : true)
 {
   if (parameters.isParamSetByUser("direction") && _directions.size() == 0)
     paramError("direction", "At least one direction is required");

--- a/framework/src/transfers/Transfer.C
+++ b/framework/src/transfers/Transfer.C
@@ -50,7 +50,7 @@ Transfer::validParams()
   // No default to avoid displaying it in the documentation
   params.addParam<bool>(
       "execute_after_from_multiapp",
-      "Whether to execute the transfer after the from_multiapp has executed when both share and "
+      "Whether to execute the transfer after the from_multiapp has executed when both share an "
       "execute_on flag. Note that this setting is only used to move the execution of "
       "BETWEEN_MULTIAPP (siblings) transfers, FROM_ and TO_MULTIAPP transfers are always executed "
       "after the from_multiapp and before the to_multiapp respectively.");

--- a/modules/functional_expansion_tools/src/transfers/MultiAppFXTransfer.C
+++ b/modules/functional_expansion_tools/src/transfers/MultiAppFXTransfer.C
@@ -33,6 +33,9 @@ MultiAppFXTransfer::validParams()
       "multi_app_object_name",
       "Name of the MutableCoefficientsInterface-derived object in the MultiApp.");
 
+  // Sibling transfers not supported
+  params.suppressParameter<bool>("execute_after_from_multiapp");
+
   return params;
 }
 

--- a/modules/level_set/src/transfers/LevelSetMeshRefinementTransfer.C
+++ b/modules/level_set/src/transfers/LevelSetMeshRefinementTransfer.C
@@ -32,6 +32,8 @@ LevelSetMeshRefinementTransfer::validParams()
   exec = {LevelSet::EXEC_COMPUTE_MARKERS, LevelSet::EXEC_ADAPT_MESH};
   params.set<bool>("check_multiapp_execute_on") = false;
   params.suppressParameter<ExecFlagEnum>("execute_on");
+  // Sibling transfers not supported
+  params.suppressParameter<bool>("execute_after_from_multiapp");
 
   return params;
 }

--- a/test/tests/mfem/transfers/sibling_transfers/main_between_multiapp.i
+++ b/test/tests/mfem/transfers/sibling_transfers/main_between_multiapp.i
@@ -24,6 +24,11 @@
   []
 []
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   # Nodal to nodal variables
   [mfem_to_libmesh_nodal_nodal]

--- a/test/tests/transfers/general_field/functor/nearest_location/between_siblings/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/functor/nearest_location/between_siblings/main_between_multiapp.i
@@ -29,6 +29,11 @@
 extrapolation_behavior_node = 'nearest-node'
 extrapolation_behavior_elem = 'nearest-elem'
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   # Nodal to nodal variables
   [app1_to_2_nodal_nodal]

--- a/test/tests/transfers/general_field/functor/nearest_location/between_siblings/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/functor/nearest_location/between_siblings/main_between_multiapp.i
@@ -30,7 +30,8 @@ extrapolation_behavior_node = 'nearest-node'
 extrapolation_behavior_elem = 'nearest-elem'
 
 [GlobalParams]
-  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  # the test relies on the child apps output, but the multiapps cannot both execute after transfers
+  # alternatively we could execute the transfers on an earlier execute_on as the MultiApps
   execute_after_from_multiapp = false
 []
 

--- a/test/tests/transfers/general_field/functor/siblings/main_between_multiapp_functor.i
+++ b/test/tests/transfers/general_field/functor/siblings/main_between_multiapp_functor.i
@@ -45,6 +45,11 @@
   num_steps = 1
 []
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   # Nodal to nodal variables
   [app1_to_2_nodal_nodal]

--- a/test/tests/transfers/general_field/functor/siblings/main_between_multiapp_functor.i
+++ b/test/tests/transfers/general_field/functor/siblings/main_between_multiapp_functor.i
@@ -46,7 +46,8 @@
 []
 
 [GlobalParams]
-  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  # the test relies on the child apps output, but the multiapps cannot both execute after transfers
+  # alternatively we could execute the transfers on an earlier execute_on as the MultiApps
   execute_after_from_multiapp = false
 []
 

--- a/test/tests/transfers/general_field/nearest_node/between_siblings/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/nearest_node/between_siblings/main_between_multiapp.i
@@ -26,6 +26,11 @@
   input_files = sub_between_diffusion2.i
 []
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   # Nodal to nodal variables
   [app1_to_2_nodal_nodal]

--- a/test/tests/transfers/general_field/nearest_node/between_siblings/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/nearest_node/between_siblings/main_between_multiapp.i
@@ -27,7 +27,8 @@
 []
 
 [GlobalParams]
-  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  # the test relies on the child apps output, but the multiapps cannot both execute after transfers
+  # alternatively we could execute the transfers on an earlier execute_on as the MultiApps
   execute_after_from_multiapp = false
 []
 

--- a/test/tests/transfers/general_field/nearest_node/nearest_app/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/nearest_node/nearest_app/main_between_multiapp.i
@@ -53,7 +53,8 @@
 bbox_factor_tr = 1.0001
 
 [GlobalParams]
-  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  # the test relies on the child apps output, but the multiapps cannot both execute after transfers
+  # alternatively we could execute the transfers on an earlier execute_on as the MultiApps
   execute_after_from_multiapp = false
 []
 

--- a/test/tests/transfers/general_field/nearest_node/nearest_app/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/nearest_node/nearest_app/main_between_multiapp.i
@@ -52,6 +52,10 @@
 # slight inflation to avoid floating point issues on borders
 bbox_factor_tr = 1.0001
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
 
 [Transfers]
   # Nodal to nodal variables

--- a/test/tests/transfers/general_field/nearest_node/nearest_position/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/nearest_node/nearest_position/main_between_multiapp.i
@@ -45,7 +45,8 @@
 []
 
 [GlobalParams]
-  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  # the test relies on the child apps output, but the multiapps cannot both execute after transfers
+  # alternatively we could execute the transfers on an earlier execute_on as the MultiApps
   execute_after_from_multiapp = false
 []
 

--- a/test/tests/transfers/general_field/nearest_node/nearest_position/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/nearest_node/nearest_position/main_between_multiapp.i
@@ -44,6 +44,11 @@
   output_in_position = true
 []
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   # Nodal to nodal variables
   [app1_to_2_nodal_nodal]

--- a/test/tests/transfers/general_field/shape_evaluation/between_siblings/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/shape_evaluation/between_siblings/main_between_multiapp.i
@@ -33,7 +33,8 @@
 []
 
 [GlobalParams]
-  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  # the test relies on the child apps output, but the multiapps cannot both execute after transfers
+  # alternatively we could execute the transfers on an earlier execute_on as the MultiApps
   execute_after_from_multiapp = false
 []
 

--- a/test/tests/transfers/general_field/shape_evaluation/between_siblings/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/shape_evaluation/between_siblings/main_between_multiapp.i
@@ -32,6 +32,11 @@
   []
 []
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   # Nodal to nodal variables
   [app1_to_2_nodal_nodal]

--- a/test/tests/transfers/general_field/user_object/between_siblings/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/user_object/between_siblings/main_between_multiapp.i
@@ -31,7 +31,8 @@
 []
 
 [GlobalParams]
-  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  # the test relies on the child apps output, but the multiapps cannot both execute after transfers
+  # alternatively we could execute the transfers on an earlier execute_on as the MultiApps
   execute_after_from_multiapp = false
 []
 

--- a/test/tests/transfers/general_field/user_object/between_siblings/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/user_object/between_siblings/main_between_multiapp.i
@@ -30,6 +30,11 @@
   []
 []
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   # Nodal to nodal variables
   [app1_to_2_nodal_nodal]

--- a/test/tests/transfers/general_field/user_object/nearest_position/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/user_object/nearest_position/main_between_multiapp.i
@@ -49,7 +49,8 @@
 []
 
 [GlobalParams]
-  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  # the test relies on the child apps output, but the multiapps cannot both execute after transfers
+  # alternatively we could execute the transfers on an earlier execute_on as the MultiApps
   execute_after_from_multiapp = false
 []
 

--- a/test/tests/transfers/general_field/user_object/nearest_position/main_between_multiapp.i
+++ b/test/tests/transfers/general_field/user_object/nearest_position/main_between_multiapp.i
@@ -48,6 +48,11 @@
   []
 []
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   # Nodal to nodal variables
   [app1_to_2_nodal_nodal]

--- a/test/tests/transfers/multiapp_copy_transfer/between_multiapps/main.i
+++ b/test/tests/transfers/multiapp_copy_transfer/between_multiapps/main.i
@@ -23,6 +23,9 @@
   to_multi_app = sub2
   source_variable = x1
   variable = x2
+  # Get around the ordering check
+  execute_on = 'INITIAL'
+  check_multiapp_execute_on = false
 []
 
 [Executioner]

--- a/test/tests/transfers/multiapp_postprocessor_to_scalar/between_multiapp/main.i
+++ b/test/tests/transfers/multiapp_postprocessor_to_scalar/between_multiapp/main.i
@@ -66,6 +66,11 @@
   []
 []
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   [pp_transfer_1]
     type = MultiAppPostprocessorToAuxScalarTransfer

--- a/test/tests/transfers/multiapp_postprocessor_transfer/between_multiapp/main.i
+++ b/test/tests/transfers/multiapp_postprocessor_transfer/between_multiapp/main.i
@@ -66,6 +66,11 @@
   []
 []
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   [pp_transfer_1]
     type = MultiAppPostprocessorTransfer

--- a/test/tests/transfers/multiapp_reporter_transfer/between_multiapp/main.i
+++ b/test/tests/transfers/multiapp_reporter_transfer/between_multiapp/main.i
@@ -66,6 +66,11 @@
   []
 []
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   [pp_transfer_1]
     type = MultiAppReporterTransfer

--- a/test/tests/transfers/multiapp_scalar_to_auxscalar_transfer/between_multiapp/main.i
+++ b/test/tests/transfers/multiapp_scalar_to_auxscalar_transfer/between_multiapp/main.i
@@ -66,6 +66,11 @@
   []
 []
 
+[GlobalParams]
+  # the test relies on the child apps output, but the multiapps cannot both execute before transfers
+  execute_after_from_multiapp = false
+[]
+
 [Transfers]
   [pp_transfer_1]
     type = MultiAppScalarToAuxScalarTransfer

--- a/test/tests/transfers/sibling_staggering/gold/main_between_multiapp_out_ma10.csv
+++ b/test/tests/transfers/sibling_staggering/gold/main_between_multiapp_out_ma10.csv
@@ -1,0 +1,2 @@
+time,time_app1,time_in_app2
+1,1,0

--- a/test/tests/transfers/sibling_staggering/gold/main_between_multiapp_out_ma20.csv
+++ b/test/tests/transfers/sibling_staggering/gold/main_between_multiapp_out_ma20.csv
@@ -1,0 +1,2 @@
+time,time_app2,time_in_app1
+1,1,1

--- a/test/tests/transfers/sibling_staggering/main_between_multiapp.i
+++ b/test/tests/transfers/sibling_staggering/main_between_multiapp.i
@@ -1,0 +1,74 @@
+# Check that the transfers and app executions occur in the expected order
+# App1 execution then transfers from app1 to app2, then app2 execution
+
+[Problem]
+  solve = false
+  verbose_multiapps = true
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+[]
+
+# This application use at most 3 processes
+[MultiApps]
+  [ma1]
+    type = TransientMultiApp
+    input_files = sub_between_diffusion1.i
+    max_procs_per_app = 3
+    output_in_position = true
+  []
+[]
+
+# This application will use as many processes as the main app
+[MultiApps]
+  [ma2]
+    type = TransientMultiApp
+    input_files = sub_between_diffusion2.i
+    output_in_position = true
+  []
+[]
+
+[Transfers]
+  [pp_1_to_2]
+    type = MultiAppPostprocessorTransfer
+    from_multi_app = ma1
+    to_multi_app = ma2
+    from_postprocessor = 'time_app1'
+    to_postprocessor = 'time_in_app1'
+  []
+  [pp_2_to_1]
+    type = MultiAppPostprocessorTransfer
+    from_multi_app = ma2
+    to_multi_app = ma1
+    from_postprocessor = 'time_app2'
+    to_postprocessor = 'time_in_app2'
+    # Break the dependency cycle
+    execute_on = 'TIMESTEP_END'
+  []
+[]
+
+# To create multiple subapps for the 1 to N and N to M tests
+# The subapps should not overlap for shape evaluation transfers
+# or at least, the block restriction of the source variables between
+# applications should not overlap
+[Positions]
+  [app1_locs]
+    type = InputPositions
+    positions = '0 0 0
+                 0 1.01 0'
+  []
+  # Keep in mind app2's mesh is offset
+  [app2_locs]
+    type = InputPositions
+    positions = '-0.7 -0.45 0
+                 0.7 0.3 0
+                 -0.5 0.5 0'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]

--- a/test/tests/transfers/sibling_staggering/main_between_multiapp.i
+++ b/test/tests/transfers/sibling_staggering/main_between_multiapp.i
@@ -4,8 +4,6 @@
 [Problem]
   solve = false
   verbose_multiapps = true
-
-  execute_siblings_transfer_after_source_multiapp_execution = true
 []
 
 [Mesh]

--- a/test/tests/transfers/sibling_staggering/main_between_multiapp.i
+++ b/test/tests/transfers/sibling_staggering/main_between_multiapp.i
@@ -11,7 +11,7 @@
   dim = 2
 []
 
-# This application use at most 3 processes
+# This application uses at most 3 processes
 [MultiApps]
   [ma1]
     type = TransientMultiApp
@@ -19,10 +19,8 @@
     max_procs_per_app = 3
     output_in_position = true
   []
-[]
 
-# This application will use as many processes as the main app
-[MultiApps]
+  # This application will use as many processes as the main app
   [ma2]
     type = TransientMultiApp
     input_files = sub_between_diffusion2.i

--- a/test/tests/transfers/sibling_staggering/main_between_multiapp.i
+++ b/test/tests/transfers/sibling_staggering/main_between_multiapp.i
@@ -4,6 +4,8 @@
 [Problem]
   solve = false
   verbose_multiapps = true
+
+  execute_siblings_transfer_after_source_multiapp_execution = true
 []
 
 [Mesh]
@@ -27,6 +29,7 @@
     type = TransientMultiApp
     input_files = sub_between_diffusion2.i
     output_in_position = true
+    execution_order_group = 1
   []
 []
 
@@ -44,8 +47,6 @@
     to_multi_app = ma1
     from_postprocessor = 'time_app2'
     to_postprocessor = 'time_in_app2'
-    # Break the dependency cycle
-    execute_on = 'TIMESTEP_END'
   []
 []
 

--- a/test/tests/transfers/sibling_staggering/sub_between_diffusion1.i
+++ b/test/tests/transfers/sibling_staggering/sub_between_diffusion1.i
@@ -1,0 +1,31 @@
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 5
+    ny = 5
+  []
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Outputs]
+  csv = true
+  execute_on = 'TIMESTEP_END'
+[]
+
+[Postprocessors]
+  [time_app1]
+    type = TimePostprocessor
+  []
+  [time_in_app2]
+    type = Receiver
+  []
+[]

--- a/test/tests/transfers/sibling_staggering/sub_between_diffusion2.i
+++ b/test/tests/transfers/sibling_staggering/sub_between_diffusion2.i
@@ -1,0 +1,36 @@
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 3
+    ny = 3
+    # partial overlap but also, no equidistant points
+    xmin = 0.1111
+    ymin = 0.3333
+    xmax = 1.211111
+    ymax = 1.222222
+  []
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Outputs]
+  csv = true
+  execute_on = 'TIMESTEP_END'
+[]
+
+[Postprocessors]
+  [time_in_app1]
+    type = Receiver
+  []
+  [time_app2]
+    type = TimePostprocessor
+  []
+[]

--- a/test/tests/transfers/sibling_staggering/tests
+++ b/test/tests/transfers/sibling_staggering/tests
@@ -1,0 +1,13 @@
+[Tests]
+  issues = '#31573'
+  design = 'MultiAppTransfer.md'
+
+  [staggered]
+    type = CSVDiff
+    input = 'main_between_multiapp.i'
+    csvdiff = 'main_between_multiapp_out_ma10.csv main_between_multiapp_out_ma20.csv'
+    requirement = "The system shall be able to stagger the execution of multiapps and transfers between these multiapps in a way that reduces the lag in the the transfered quantities."
+    # Transfers execute_on don't match the MultiApps
+    allow_warnings = true
+  []
+[]

--- a/test/tests/transfers/sibling_staggering/tests
+++ b/test/tests/transfers/sibling_staggering/tests
@@ -1,0 +1,11 @@
+[Tests]
+  issues = '#31573'
+  design = 'MultiAppTransfer.md'
+
+  [staggered]
+    type = CSVDiff
+    input = 'main_between_multiapp.i'
+    csvdiff = 'main_between_multiapp_out_ma10.csv main_between_multiapp_out_ma20.csv'
+    requirement = "The system shall be able to stagger the execution of multiapps and transfers between these multiapps in a way that reduces the lag in the the transfered quantities."
+  []
+[]

--- a/test/tests/transfers/sibling_staggering/tests
+++ b/test/tests/transfers/sibling_staggering/tests
@@ -1,6 +1,6 @@
 [Tests]
   issues = '#31573'
-  design = 'MultiAppTransfer.md'
+  design = 'Transfers/index.md'
 
   [staggered]
     type = CSVDiff

--- a/test/tests/transfers/sibling_staggering/tests
+++ b/test/tests/transfers/sibling_staggering/tests
@@ -10,4 +10,41 @@
     # Transfers execute_on don't match the MultiApps
     allow_warnings = true
   []
+
+  [warnings]
+    requirement = 'The system shall report a warning if'
+    [different_execute_on]
+      type = RunApp
+      input = 'main_between_multiapp.i'
+      cli_args = "Transfers/pp_1_to_2/execute_after_from_multiapp=false
+                  Transfers/pp_1_to_2/execute_on=INITIAL"
+      expect_out = 'This parameter is only obeyed when the from_multi_app and the transfer are executing on the same execute_on flag.'
+      detail = 'a sibling transfer is set to execute before its source application but it does not share the same execution schedule as that source application,'
+      allow_warnings = true
+    []
+    [execution_order_groups]
+      type = RunException
+      input = 'main_between_multiapp.i'
+      # there are transfers both ways, so they will all trigger the check
+      cli_args = "MultiApps/ma2/execution_order_group=0"
+      expect_err = "Transfer is set to execute after the 'from_multi_app' but the 'to_multi_app' is executing before or in the same 'execution_order_group' as the 'from_multi_app'. Thus the transfer is not actually executing in between the 'from_' and 'to_multi_app', but after both"
+      detail = 'a sibling transfer is set to execute after its source application but the target application is executing on the same schedule and with an earlier execution order group, thus preventing sending updated data from the source to the target application.'
+    []
+  []
+  [errors]
+    requirement = 'The system shall report an error if'
+    [different_execute_on]
+      type = RunException
+      input = 'main_between_multiapp.i'
+      # create a non-sibling transfer
+      cli_args = "Transfers/active=pp_1_to_2b
+                  Transfers/pp_1_to_2b/type=MultiAppPostprocessorTransfer
+                  Transfers/pp_1_to_2b/from_multi_app=ma1
+                  Transfers/pp_1_to_2b/from_postprocessor='time_app1'
+                  Transfers/pp_1_to_2b/to_postprocessor='dummy'
+                  Transfers/pp_1_to_2b/execute_after_from_multiapp=false"
+      expect_err = 'This parameter is only intended for modifying the execution schedule of BETWEEN_MULTIAPPS transfers'
+      detail = 'a transfer is set to execute after its source application but this option is not currently implemented for child to parent and parent to child transfer.'
+    []
+  []
 []

--- a/test/tests/transfers/sibling_staggering/tests
+++ b/test/tests/transfers/sibling_staggering/tests
@@ -43,7 +43,7 @@
                   Transfers/pp_1_to_2b/from_postprocessor='time_app1'
                   Transfers/pp_1_to_2b/to_postprocessor='dummy'
                   Transfers/pp_1_to_2b/execute_after_from_multiapp=false"
-      expect_err = 'This parameter is only intended for modifying the execution schedule of BETWEEN_MULTIAPPS transfers'
+      expect_err = 'This parameter is only intended for modifying the execution schedule of siblings transfers, e.g. transfers from a from_multi_app to a to_multi_app'
       detail = 'a transfer is set to execute after its source application but this option is not currently implemented for child to parent and parent to child transfer.'
     []
   []

--- a/test/tests/transfers/sibling_staggering/tests
+++ b/test/tests/transfers/sibling_staggering/tests
@@ -13,15 +13,6 @@
 
   [warnings]
     requirement = 'The system shall report a warning if'
-    [different_execute_on]
-      type = RunApp
-      input = 'main_between_multiapp.i'
-      cli_args = "Transfers/pp_1_to_2/execute_after_from_multiapp=false
-                  Transfers/pp_1_to_2/execute_on=INITIAL"
-      expect_out = 'This parameter is only obeyed when the from_multi_app and the transfer are executing on the same execute_on flag.'
-      detail = 'a sibling transfer is set to execute before its source application but it does not share the same execution schedule as that source application,'
-      allow_warnings = true
-    []
     [execution_order_groups]
       type = RunException
       input = 'main_between_multiapp.i'
@@ -34,6 +25,15 @@
   [errors]
     requirement = 'The system shall report an error if'
     [different_execute_on]
+      type = RunException
+      input = 'main_between_multiapp.i'
+      cli_args = "Transfers/pp_1_to_2/execute_after_from_multiapp=false
+                  Transfers/pp_1_to_2/execute_on=INITIAL"
+      allow_warnings = true
+      expect_err = 'This parameter is only obeyed when the from_multi_app and the transfer are executing on the same execute_on flag.'
+      detail = 'a sibling transfer is set to execute before its source application but it does not share the same execution schedule as that source application,'
+    []
+    [non-sibling_param_does_not_apply]
       type = RunException
       input = 'main_between_multiapp.i'
       # create a non-sibling transfer


### PR DESCRIPTION
This addresses the first part of our M2 on concurrent execution of apps, which is to stagger transfers so we get the best out of non-concurrent execution.

Also will improve our SFR coupling.
closes https://github.com/idaholab/moose/issues/31573