### PR TITLE
Add link to MFEM getting started docs from installation instructions

### DIFF
--- a/framework/doc/content/syntax/Kokkos/index.md
+++ b/framework/doc/content/syntax/Kokkos/index.md
@@ -32,7 +32,7 @@ It supports multi-dimensional indexing.
 The dimension can either be specified through the second template argument with the default being one-dimension or using type aliases: for instance, a three-dimensional array of type `double` can be declared either by `Array<double, 3>` or `Array3D<double>`.
 The entries of an array can be accessed with either `operator()` with multi-dimensional indices or `operator[]` with a flattened, dimensionless index, where the flattening follows a layout in which the innermost dimension varies the fastest.
 They automatically return either CPU or GPU data depending on where they are being accessed.
-The index type template argument is set to 8-byte integer by default to accomodate large arrays.
+The index type template argument is set to 8-byte integer by default to accommodate large arrays.
 However, 8-byte integer computation is significantly more expensive than 4-byte integer computation.
 If your array size is small enough, consider using 4-byte indices to optimize index calculations.
 If having the outermost dimension run the fastest is desired for multi-dimensional arrays, the fourth layout template argument can be optionally set to `Moose::Kokkos::LayoutType::RIGHT` (default is `LEFT`).
@@ -78,7 +78,7 @@ for (auto & datum : data)
 !alert note
 The GPU memory is always uninitialized upon allocation.
 
-Because the memory spaces are separate between CPU and GPU, there is no automatic synchronzation of data.
+Because the memory spaces are separate between CPU and GPU, there is no automatic synchronization of data.
 Therefore, data should be explicitly copied between them when one side is updated.
 Arrays provide three APIs for this purpose: `copyToHost()`, `copyToDevice()`, and `copyToDeviceNested()`.
 `copyToHost()` and `copyToDevice()` copies data from GPU to CPU and CPU to GPU, respectively, as their names imply.
@@ -425,7 +425,7 @@ It can be used to protect the Kokkos-related codes in non-Kokkos source files.
 Also, the build system defines another preprocessor `MOOSE_KOKKOS_SCOPE` that is only defined for the Kokkos source files.
 It is useful for protecting Kokkos codes in header files that can be included in both Kokkos and non-Kokkos source files.
 However, it is important to note that `MOOSE_KOKKOS_SCOPE` should not be used to protect member variables or virtual member functions in a class, as it can make CPU and GPU compiler see inconsistent class definitions having different sizes and cause memory misalignment.
-It is primarly used to protect inlined GPU functions with the `KOKKOS_FUNCTION` specifier in header files or non-virtual CPU functions that are not allowed to be called in non-Kokkos source files.
+It is primarily used to protect inlined GPU functions with the `KOKKOS_FUNCTION` specifier in header files or non-virtual CPU functions that are not allowed to be called in non-Kokkos source files.
 
 ## Kokkos-MOOSE Objects
 

--- a/modules/doc/content/getting_started/installation/install_libtorch.md
+++ b/modules/doc/content/getting_started/installation/install_libtorch.md
@@ -172,7 +172,7 @@ This can be a problem when using the moose conda environment with new versions o
 
 When encountering GLIBC-related compatibility issues on Linux machines the user has two options:
 
-1. [Rebuilding Petsc and libMesh manually](gcc_install_moose.md) using compatible compilers (most newer systems
+1. [Rebuilding PETSc and libMesh manually](gcc_install_moose.md) using compatible compilers (most newer systems
    like Ubuntu come with compatible compilers).
 
 2. Building libtorch from source. The user can find instructions on how to install libtorch
@@ -186,13 +186,13 @@ using suitable system compilers. At the time these instruction are written, only
 acceleration is tested.
 The following packages need to be also installed to enable this feature:
 
-- [A sutiable Nvidia driver](https://www.nvidia.com/en-us/drivers/)
-- [Cuda toolkit](https://developer.nvidia.com/cuda-toolkit) - only strictly required if
+- [A suitable Nvidia driver](https://www.nvidia.com/en-us/drivers/)
+- [CUDA toolkit](https://developer.nvidia.com/cuda-toolkit) - only strictly required if
    building libtorch from source.
 
 The supported versions can be determined using the [compatibility matrix](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix).
 Once the dependencies of MOOSE are installed, we can use the setup script to fetch
-the correct libtorch package from the official ditribution:
+the correct libtorch package from the official distribution:
 
 ```
 ./scripts/setup_libtorch.sh --version=2.1 --libtorch-distribution=cuda
@@ -206,5 +206,5 @@ The configuration and build parts of the process are the same as discussed befor
 
 On non-INL HPC systems, one can follow the manual installation process discussed above.
 On INL machines, containers are provided with readily compiled dependencies, including libtorch.
-For more information on containers, see the [instuctions](inl_hpc_install_moose.md).
+For more information on containers, see the [instructions](inl_hpc_install_moose.md).
 In this case, the `moose-dev` module already contains `libtorch`.

--- a/modules/doc/content/getting_started/installation/install_mfem.md
+++ b/modules/doc/content/getting_started/installation/install_mfem.md
@@ -71,3 +71,5 @@ make -j $MOOSE_JOBS
 cd ../test
 make -j $MOOSE_JOBS
 ```
+
+Use [this page](syntax/MFEM/index.md) as your starting point for learning how to use the MFEM capability in MOOSE.


### PR DESCRIPTION
## Design
Added a link at the bottom of MFEM's installation instructions to the getting started guide, similar to how we link to the NEML2 or Kokkos getting stated guides. Also took the chance to fix a handful of typos.

## Reason/Impact
More accessible/reachable documentation.