### PR TITLE
Improve early getter diagnostics for functions and user objects

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -2731,7 +2731,14 @@ FEProblemBase::getFunction(const std::string & name, const THREAD_ID tid)
 
     // Try once more
     if (!hasFunction(name, tid))
+    {
+      mooseAssert(getMooseApp().actionWarehouse().isTaskComplete("add_function"),
+                  "getFunction() was called before Functions have been constructed. The requested "
+                  "Function '" +
+                      name + "' may exist in the input file, but Functions are not available yet.");
+
       mooseError("Unable to find function " + name);
+    }
   }
 
   auto * const ret = dynamic_cast<Function *>(_functions.getActiveObject(name, tid).get());
@@ -4681,7 +4688,14 @@ FEProblemBase::getUserObjectBase(const std::string & name, const THREAD_ID tid /
       .condition<AttribName>(name)
       .queryInto(objs);
   if (objs.empty())
+  {
+    mooseAssert(getMooseApp().actionWarehouse().isTaskComplete("add_user_object"),
+                "A UserObject getter was called before UserObjects have been constructed. The "
+                "requested UserObject '" +
+                    name + "' may exist in the input file, but UserObjects are not available yet.");
+
     mooseError("Unable to find user object with name '" + name + "'");
+  }
   mooseAssert(objs.size() == 1, "Should only find one UO");
   return *(objs[0]);
 }

--- a/test/include/problems/GetterTooEarlyProblem.h
+++ b/test/include/problems/GetterTooEarlyProblem.h
@@ -1,0 +1,21 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+
+#pragma once
+
+#include "FEProblem.h"
+
+class Function;
+class UserObject;
+
+class GetterTooEarlyProblem : public FEProblem
+{
+public:
+  static InputParameters validParams();
+
+  GetterTooEarlyProblem(const InputParameters & params);
+
+protected:
+  const Function * _function;
+  const UserObject * _user_object;
+};

--- a/test/src/problems/GetterTooEarlyProblem.C
+++ b/test/src/problems/GetterTooEarlyProblem.C
@@ -1,0 +1,30 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+
+#include "GetterTooEarlyProblem.h"
+#include "Function.h"
+#include "UserObject.h"
+
+registerMooseObject("MooseTestApp", GetterTooEarlyProblem);
+
+InputParameters
+GetterTooEarlyProblem::validParams()
+{
+  InputParameters params = FEProblem::validParams();
+  params.addRequiredParam<MooseEnum>(
+      "getter", MooseEnum("function user_object"), "The getter to call too early");
+  params.addParam<FunctionName>("function", "Function to request too early");
+  params.addParam<UserObjectName>("user_object", "UserObject to request too early");
+  return params;
+}
+
+GetterTooEarlyProblem::GetterTooEarlyProblem(const InputParameters & params)
+  : FEProblem(params), _function(nullptr), _user_object(nullptr)
+{
+  const auto getter = getParam<MooseEnum>("getter");
+
+  if (getter == "function")
+    _function = &getFunction(getParam<FunctionName>("function"));
+  else if (getter == "user_object")
+    _user_object = &getUserObjectBase(getParam<UserObjectName>("user_object"));
+}

--- a/test/tests/problems/getter_too_early/get_function_too_early.i
+++ b/test/tests/problems/getter_too_early/get_function_too_early.i
@@ -1,0 +1,30 @@
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 1
+    nx = 1
+  []
+[]
+
+[Problem]
+  type = GetterTooEarlyProblem
+  getter = function
+  function = my_func
+  solve = false
+[]
+
+[Functions]
+  [my_func]
+    type = ParsedFunction
+    expression = 'x'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 0
+[]
+
+[Outputs]
+  console = false
+[]

--- a/test/tests/problems/getter_too_early/get_user_object_too_early.i
+++ b/test/tests/problems/getter_too_early/get_user_object_too_early.i
@@ -1,0 +1,29 @@
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 1
+    nx = 1
+  []
+[]
+
+[Problem]
+  type = GetterTooEarlyProblem
+  getter = user_object
+  user_object = test_uo
+  solve = false
+[]
+
+[UserObjects]
+  [test_uo]
+    type = MTUserObject
+  []
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 0
+[]
+
+[Outputs]
+  console = false
+[]

--- a/test/tests/problems/getter_too_early/tests
+++ b/test/tests/problems/getter_too_early/tests
@@ -1,0 +1,21 @@
+[Tests]
+  design = 'source/problems/FEProblemBase.md'
+
+  [get_function_too_early]
+    type = RunException
+    input = get_function_too_early.i
+    capabilities = 'method=dbg'
+    expect_err = 'getFunction\(\) was called before Functions have been constructed'
+    requirement = 'The system shall assert that getFunction() was called too early when a Function is requested before Functions have been constructed.'
+    issues = '#28131'
+  []
+
+  [get_user_object_too_early]
+    type = RunException
+    input = get_user_object_too_early.i
+    capabilities = 'method=dbg'
+    expect_err = "A UserObject getter was called before UserObjects have been constructed"
+    requirement = 'The system shall assert that a UserObject getter was called too early when a UserObject is requested before UserObjects have been constructed.'
+    issues = '#28131'
+  []
+[]


### PR DESCRIPTION
Refs #28131

## Reason
Calling some reference-to-object getters too early can produce confusing missing-object diagnostics. For example, an object may be defined in the input file, but if it is requested before that object family has been constructed, MOOSE can report that the object cannot be found.

This patch improves diagnostics for two central getter paths:

- `FEProblemBase::getFunction(...)`
- `FEProblemBase::getUserObjectBase(...)`

The goal is to distinguish “this object does not exist” from “this getter was called before the relevant object family was constructed.”

## Design
This patch adds readiness checks in non-inlined central `.C` getter paths using the existing `ActionWarehouse::isTaskComplete(...)` mechanism.

If `getFunction()` fails to find a function and the `add_function` task has not completed, MOOSE now reports that `getFunction()` was called before Functions have been constructed. If the task has completed, the existing missing-function diagnostic is preserved.

Similarly, direct/problem-level UserObject lookup through `FEProblemBase::getUserObjectBase(...)` now reports a too early UserObject getter diagnostic when `add_user_object` has not completed. If the task has completed, the existing missing UserObject diagnostic is preserved.

Regression coverage is added with a test `Problem` that intentionally calls these getters during problem construction, before later object construction tasks have run.

This patch intentionally does not modify:

- VPP getter paths
- inline/template header getters
- `UserObjectInterface.C`

I initially tested a similar readiness check in `UserObjectInterface.C`, but existing `interfaces/userobjectinterface` tests showed that approach was too broad. `isTaskComplete("add_user_object")` is still false while MOOSE is actively executing the `add_user_object` task, so that check incorrectly changed normal missing-UserObject diagnostics during UserObject construction. The final UserObject change is therefore limited to the `FEProblemBase::getUserObjectBase(...)` lookup path.

VPP is also left out of this initial patch because it already has some existing “too early” checks in its interface layer and also goes through reporter/vector-value helper paths. @GiudGiud  give me some feedback on the current scope before I try and go over my shoose and wident that patch.

## Impact
This should not change valid input behavior or existing APIs.

The impact is limited to improved error messages for too-early calls to the central Function and direct/problem-level UserObject getter paths. Existing missing-object diagnostics are preserved once the corresponding object family has been constructed.

Tests run:

```bash
METHOD=dbg make -C framework -j 8
METHOD=dbg make -C test -j 8

cd test
METHOD=dbg ./run_tests -j 8 --re='getter_too_early'
METHOD=dbg ./run_tests -j 8 --re='interfaces/userobjectinterface'
METHOD=dbg ./run_tests -j 8 --re='function'
METHOD=dbg ./run_tests -j 8 --re='userobject|user_object'