### PR TITLE
Workaround ICE with gcc 15 and 16

### DIFF
--- a/modules/phase_field/include/utils/ExpressionBuilder.h
+++ b/modules/phase_field/include/utils/ExpressionBuilder.h
@@ -363,7 +363,8 @@ public:
     // the default constructor assigns a temporary id node to root we use the address of the
     // current EBTerm object as the ID. This could be problematic if we create and destroy terms,
     // but then we should not expect the substitution to do sane things anyways.
-    EBTerm() : _root(new EBTempIDNode(reinterpret_cast<unsigned long long>(this))){};
+    __attribute__((noinline)) EBTerm()
+      : _root(new EBTempIDNode(reinterpret_cast<unsigned long long>(this))) {};
 
     EBTerm(const EBTerm & term) : _root(term.cloneRoot()){};
     ~EBTerm() { delete _root; };


### PR DESCRIPTION
## Reason
When compiling in `opt` mode, gcc 15 and 16 both crash with an internal compiler error (seg fault) on a number of class constructors in the phase field module, e.g.:
```
/redacted/moose/modules/phase_field/src/materials/VanDerWaalsFreeEnergy.C:46:1: internal compiler error: Segmentation fault
   46 | }
      | ^
0x23fb47f internal_error(char const*, ...)
	../../gcc-16.1.0/gcc/diagnostic-global-context.cc:787
0x10ffdbf crash_signal
	../../gcc-16.1.0/gcc/toplev.cc:325
0x14fa9a8 print_reg(rtx_def*, int, _IO_FILE*)
	../../gcc-16.1.0/gcc/config/i386/i386.cc:14034
0x14fdd8d ix86_print_operand_address_as
	../../gcc-16.1.0/gcc/config/i386/i386.cc:15134
0xccf313 output_address(machine_mode, rtx_def*)
	../../gcc-16.1.0/gcc/final.cc:3679
0xccf215 output_operand(rtx_def*, int)
	../../gcc-16.1.0/gcc/final.cc:3663
0xccff91 output_asm_insn(char const*, rtx_def**)
	../../gcc-16.1.0/gcc/final.cc:3552
0xcd15c3 final_scan_insn_1
	../../gcc-16.1.0/gcc/final.cc:2856
0xcd19bb final_scan_insn(rtx_insn*, _IO_FILE*, int, int, int*)
	../../gcc-16.1.0/gcc/final.cc:2902
0xcd1c67 final_1
	../../gcc-16.1.0/gcc/final.cc:1984
0xcd24df rest_of_handle_final
	../../gcc-16.1.0/gcc/final.cc:4272
0xcd24df execute
	../../gcc-16.1.0/gcc/final.cc:4350
```

## Design
After some digging, trying different things and, I must admit, exchanging some ideas with ChatGPT, I found that explicitly preventing inlining of `EBTerm`'s default constructor works around the issue. Should probably still build a minimal reproducer and file a bug report though.

## Impact
Ubuntu 25.10 and later use gcc 15 by default, so this can effectively prevent people from compiling the module unless they downgrade gcc. @ngrilli ran into this when trying to compile TMAP8 during yesterday's training session at CFMS.

Also, I've noticed some classes  in the `test` directory are registered to the wrong app, `registerMooseObject("PhaseFieldTestApp", ...)`, which has flown under the radar thus far because we actually don't run the tests using these classes... Is this worth fixing, or should we just remove any unused code?
