### PR TITLE
Mesh generator robustness

### DIFF
--- a/framework/doc/content/syntax/Mesh/index.md
+++ b/framework/doc/content/syntax/Mesh/index.md
@@ -33,12 +33,12 @@ through dependencies so that complex meshes may be built up from a series of sim
 
 ### Mesh Generator development
 
-Mesh generator developers should call `mesh->unset_is_prepared()` at the end of
-the `generate` routine unless they are confident that their mesh is indeed
-prepared. Examples of actions that render the mesh unprepared are
+Mesh generator developers should set the preparation state of their
+mesh at the end of the `generate` routine.  A previously prepared
+input mesh may have been rendered unprepared by actions such as:
 
 - Translating, rotating, or scaling the mesh. This will conceptually change the
-  mesh bounding box, invalidate the point locator, and potentially change the
+  mesh bounding box, invalidate a point locator, and potentially change the
   spatial dimension of the mesh (e.g. rotating a line from the x-axis into the
   xy plane, etc.)
 - Adding elements. These elements will need their neighbor links set in order
@@ -48,10 +48,69 @@ prepared. Examples of actions that render the mesh unprepared are
 - Changing boundary IDs. This invalidates global data (e.g. data aggregated
   across all processes) in the `libMesh::BoundaryInfo` object
 
-When in doubt, the mesh is likely not prepared. Calling `unset_is_prepared` is a
-defensive action that at worst will incur an unnecessary `prepare_for_use`,
-which may slow down the simulation setup, and at best may save follow-on mesh
-generators or simulation execution from undesirable behavior.
+When in doubt, the mesh is likely not prepared. Calling
+`mesh.unset_is_prepared()` to let the mesh object know that
+preparation needs to be done is a defensive action that at worst will
+incur an unnecessary `prepare_for_use`, which may slow down the
+simulation setup, and at best may save follow-on mesh generators or
+simulation execution from incorrect behavior.  Follow-on mesh
+generators can test `mesh.is_prepared()` to see if the cached or
+derived data they need is ready yet.
+
+For more efficient simulation setup, mesh generator developers can
+carefully mark a mesh as unprepared in only specific ways, or can test
+`mesh.preparation()` data members to verify that the specific
+preparation that they need is ready.  `Preparation` data currently
+includes the `bool` values:
+
+- `has_synched_id_counts` - when adding or removing elements or nodes
+  in an unsynchronized way on a distributed mesh, counts like
+  `n_elem()` or `next_unique_id()` can be outdated.  Flagged by
+  `mesh.unset_has_synched_id_counts()`; corrected by
+  `mesh.update_parallel_id_counts()`.
+- `has_neighbor_ptrs` - when adding or removing mesh elements,
+  `Elem::neighbor_ptr()` links are not generated immediately.
+  Flagged by `mesh.unset_has_neighbor_ptrs()`; corrected by
+  `mesh.find_neighbors()`.
+- `has_cached_elem_data` - when modifying the mesh, cached data like
+  `get_mesh_subdomains()`, `elem_dimensions()`, etc. is not
+  immediately updated.  Flagged by
+  `mesh.unset_has_cached_elem_data()`; corrected by
+  `mesh.cache_elem_data()`.
+- `has_boundary_id_sets` - when adding, removing, or modifying
+  individual entries in the `BoundaryInfo`, the cached summaries of
+  that boundary data are not immediately updated.  Flagged by
+  `mesh.unset_has_boundary_id_sets()`; corrected by
+  `mesh.get_boundary_info().regenerate_id_sets()`.
+- `has_reinit_ghosting_functors` - when modifying the mesh, custom
+  `GhostingFunctor` subclasses (including `RelationshipManager`
+  objects in MOOSE) may require the opportunity to cache data about
+  the modifications.  Flagged by
+  `unset_has_reinit_ghosting_functors()`; corrected by
+  `mesh.reinit_ghosting_functors()`;
+- `is_partitioned` - whether mesh elements and nodes all already
+  have been assigned a `processor_id()`, in an adequately
+  load-balanced way.  Flagged by `mesh.unset_is_partitioned()`;
+  corrected by `mesh.partition()`.
+- `has_interior_parent_ptrs` - when manually creating lower-dimensional
+  elements to add to a higher-dimensional mesh, their
+  `interior_parent()` links are absent until added.  Flagged by
+  `mesh.unset_has_interior_parent_ptrs()`; corrected manually or by
+  `mesh.detect_interior_parents()`.
+- `has_removed_remote_elements` - after partitioning or reducing the
+  ghosting required in a distributed mesh, elements and nodes not
+  required by the ghosting are not immediately removed.  Flagged by
+  `mesh.unset_has_removed_remote_elements()`; corrected by
+  `mesh.delete_remote_elements()`.
+- `has_removed_orphaned_nodes` - after deleting elements, nodes only
+  used by deleted elements should be removed.  Flagged by
+  `mesh.unset_has_removed_orphaned_nodes()`; corrected by
+  `mesh.remove_orphaned_nodes()`.
+- Because clearing a point locator is as efficient as flagging it
+  outdated, and because point locators are generated on the fly,
+  a call to `mesh.clear_point_locator()` is sufficient to flag a mesh
+  geometry change that would have left a cached locator invalid.
+
 
 ### DAG and final mesh selection id=final
 

--- a/framework/doc/content/syntax/Mesh/index.md
+++ b/framework/doc/content/syntax/Mesh/index.md
@@ -109,7 +109,9 @@ includes the `bool` values:
 - Because clearing a point locator is as efficient as flagging it
   outdated, and because point locators are generated on the fly,
   a call to `mesh.clear_point_locator()` is sufficient to flag a mesh
-  geometry change that would have left a cached locator invalid.
+  change that would have left a cached locator invalid.  Any change to
+  mesh geometry (node positions) or contents (adding or removing
+  elements) invalidates a cached locator.
 
 
 ### DAG and final mesh selection id=final

--- a/framework/src/base/MeshGeneratorSystem.C
+++ b/framework/src/base/MeshGeneratorSystem.C
@@ -431,10 +431,11 @@ MeshGeneratorSystem::executeMeshGenerators()
       // Assert that the mesh is either marked as not prepared or if it is marked as prepared,
       // that it's *actually* prepared
       if (!MeshTools::valid_is_prepared(*current_mesh))
-        generator->mooseError("The generated mesh is marked as prepared but is not actually "
+        generator->mooseError("The generated mesh is marked as prepared but is not fully "
                               "prepared. Please edit the '",
                               generator->type(),
-                              "' class to call 'unset_is_prepared()'");
+                              "' class to call 'unset_is_prepared()', or more fine-grained "
+                              "alternatives as appropriate.");
 #endif
 
       // Now we need to possibly give this mesh to downstream generators

--- a/framework/src/base/MeshGeneratorSystem.C
+++ b/framework/src/base/MeshGeneratorSystem.C
@@ -429,13 +429,18 @@ MeshGeneratorSystem::executeMeshGenerators()
 
 #ifdef DEBUG
       // Assert that the mesh is either marked as not prepared or if it is marked as prepared,
-      // that it's *actually* prepared
+      // that it's *actually* prepared.
+      //
+      // In newer version of libMesh, this also asserts that a mesh
+      // marked as partially prepared is indeed prepared in (at least)
+      // the aspects which are so marked.
       if (!MeshTools::valid_is_prepared(*current_mesh))
-        generator->mooseError("The generated mesh is marked as prepared but is not fully "
-                              "prepared. Please edit the '",
-                              generator->type(),
-                              "' class to call 'unset_is_prepared()', or more fine-grained "
-                              "alternatives as appropriate.");
+        generator->mooseError(
+            "The generated mesh is marked as (at least partially) prepared but is not "
+            "prepared in the marked sense(s). Please edit the '",
+            generator->type(),
+            "' class to call 'unset_is_prepared()', or more fine-grained "
+            "alternatives as appropriate.");
 #endif
 
       // Now we need to possibly give this mesh to downstream generators

--- a/framework/src/mesh/AnnularMesh.C
+++ b/framework/src/mesh/AnnularMesh.C
@@ -292,5 +292,8 @@ AnnularMesh::buildMesh()
     }
   }
 
+  // We just created this mesh from scratch, and we're not in the mesh
+  // generator system that will handle flagged preparation
+  // requirements later, so we need a full prepare_for_use() here.
   mesh.prepare_for_use();
 }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2923,6 +2923,9 @@ MooseMesh::changeBoundaryId(MeshBase & mesh,
   // from showing up when printing information, etc.
   if (delete_prev)
     boundary_info.remove_id(old_id);
+
+  // The cached boundary id sets will need re-preparation
+  mesh.unset_has_boundary_id_sets();
 }
 
 const RealVectorValue &

--- a/framework/src/mesh/RinglebMesh.C
+++ b/framework/src/mesh/RinglebMesh.C
@@ -210,7 +210,9 @@ RinglebMesh::buildMesh()
     }
   }
 
-  /// Find neighbors, etc.
+  // We just created this mesh from scratch, and we're not in the mesh
+  // generator system that will handle flagged preparation
+  // requirements later, so we need a full prepare_for_use() here.
   mesh.prepare_for_use();
 
   /// Create the triangular elements if required by the user

--- a/framework/src/meshgenerators/AdvancedExtruderGenerator.C
+++ b/framework/src/meshgenerators/AdvancedExtruderGenerator.C
@@ -319,6 +319,8 @@ AdvancedExtruderGenerator::generate()
   }
 
   // retrieve subdomain/sideset/nodeset name maps
+  if (!_input->preparation().has_cached_elem_data)
+    _input->cache_elem_data();
   const auto & input_subdomain_map = _input->get_subdomain_name_map();
   const auto & input_sideset_map = _input->get_boundary_info().get_sideset_name_map();
   const auto & input_nodeset_map = _input->get_boundary_info().get_nodeset_name_map();

--- a/framework/src/meshgenerators/BlockDeletionGenerator.C
+++ b/framework/src/meshgenerators/BlockDeletionGenerator.C
@@ -50,6 +50,10 @@ BlockDeletionGenerator::BlockDeletionGenerator(const InputParameters & parameter
 std::unique_ptr<MeshBase>
 BlockDeletionGenerator::generate()
 {
+  // We're querying subdomain id caches from our input mesh
+  if (!_input->preparation().has_cached_elem_data)
+    _input->cache_elem_data();
+
   if (isParamValid("block"))
     // Get the list of block ids from the block names
     _block_ids =

--- a/framework/src/meshgenerators/BoundaryDeletionGenerator.C
+++ b/framework/src/meshgenerators/BoundaryDeletionGenerator.C
@@ -43,6 +43,10 @@ BoundaryDeletionGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
+  // We need prepared boundary id sets here
+  if (!mesh->preparation().has_boundary_id_sets)
+    mesh->get_boundary_info().regenerate_id_sets();
+
   // Gather the boundary ids of interest from the names
   std::set<boundary_id_type> ids;
   for (const auto & name : _boundary_names)

--- a/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
+++ b/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
@@ -155,6 +155,10 @@ BreakMeshByBlockGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
+  // Make sure subdomain caches are up to date
+  if (!mesh->preparation().has_cached_elem_data)
+    mesh->cache_elem_data();
+
   // Max node id is used later to generate new unique node IDs
   auto max_node_id = mesh->max_node_id();
   // If the mesh is prepared, max_node_id is already the same on all processors so do not need to

--- a/framework/src/meshgenerators/CoarsenBlockGenerator.C
+++ b/framework/src/meshgenerators/CoarsenBlockGenerator.C
@@ -75,6 +75,8 @@ CoarsenBlockGenerator::generate()
   const std::set<SubdomainID> block_ids_set(block_ids.begin(), block_ids.end());
 
   // Check that the block ids/names exist in the mesh
+  if (!_input->preparation().has_cached_elem_data)
+    _input->cache_elem_data();
   std::set<SubdomainID> mesh_blocks;
   _input->subdomain_ids(mesh_blocks);
 

--- a/framework/src/meshgenerators/CombinerGenerator.C
+++ b/framework/src/meshgenerators/CombinerGenerator.C
@@ -160,6 +160,11 @@ CombinerGenerator::generate()
       if (!other_mesh)
         paramError("inputs", _input_names[i], " is not a valid unstructured mesh");
 
+      // We'll be using cached subdomain sets in copyIntoMesh, so our
+      // const inputs need caches ready.
+      if (!other_mesh->preparation().has_cached_elem_data)
+        other_mesh->cache_elem_data();
+
       // Move It
       if (_positions.size())
       {
@@ -181,6 +186,10 @@ CombinerGenerator::generate()
   else // Case 2
   {
     auto input_mesh = dynamic_pointer_cast<UnstructuredMesh>(*_meshes[0]);
+
+    // We'll be using cached subdomain sets in copyIntoMesh
+    if (!input_mesh->preparation().has_cached_elem_data)
+      input_mesh->cache_elem_data();
 
     if (!input_mesh)
       paramError("inputs", _input_names[0], " is not a valid unstructured mesh");

--- a/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
+++ b/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
@@ -80,6 +80,10 @@ CutMeshByLevelSetGeneratorBase::CutMeshByLevelSetGeneratorBase(const InputParame
 std::unique_ptr<MeshBase>
 CutMeshByLevelSetGeneratorBase::generate()
 {
+  // We're querying elem dim caches from our input mesh
+  if (!_input->preparation().has_cached_elem_data)
+    _input->cache_elem_data();
+
   auto replicated_mesh_ptr = dynamic_cast<ReplicatedMesh *>(_input.get());
   if (!replicated_mesh_ptr)
     paramError("input", "Input is not a replicated mesh, which is required");

--- a/framework/src/meshgenerators/ElementDeletionGeneratorBase.C
+++ b/framework/src/meshgenerators/ElementDeletionGeneratorBase.C
@@ -42,7 +42,10 @@ ElementDeletionGeneratorBase::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
-  // Make sure that the mesh is prepared
+  // Make sure that the mesh is prepared.  We'll just do a full
+  // prepare_for_use() here, since we expect to be able to use
+  // neighbor pointers, multiple caches, *and* on distributed meshes a
+  // load-balanced partitioning.
   if (!mesh->is_prepared())
     mesh->prepare_for_use();
 

--- a/framework/src/meshgenerators/ElementsToTetrahedronsConverter.C
+++ b/framework/src/meshgenerators/ElementsToTetrahedronsConverter.C
@@ -48,6 +48,10 @@ ElementsToTetrahedronsConverter::ElementsToTetrahedronsConverter(const InputPara
 std::unique_ptr<MeshBase>
 ElementsToTetrahedronsConverter::generate()
 {
+  // We're querying elem dim caches from our input mesh
+  if (!_input->preparation().has_cached_elem_data)
+    _input->cache_elem_data();
+
   auto replicated_mesh_ptr = dynamic_cast<ReplicatedMesh *>(_input.get());
   if (!replicated_mesh_ptr)
     paramError("input", "Input is not a replicated mesh, which is required");

--- a/framework/src/meshgenerators/FillBetweenSidesetsGenerator.C
+++ b/framework/src/meshgenerators/FillBetweenSidesetsGenerator.C
@@ -106,6 +106,12 @@ FillBetweenSidesetsGenerator::FillBetweenSidesetsGenerator(const InputParameters
 std::unique_ptr<MeshBase>
 FillBetweenSidesetsGenerator::generate()
 {
+  // We're querying subdomain id caches from our input meshes
+  if (!_input_1->preparation().has_cached_elem_data)
+    _input_1->cache_elem_data();
+  if (!_input_2->preparation().has_cached_elem_data)
+    _input_2->cache_elem_data();
+
   auto input_mesh_1 = std::move(_input_1);
   auto input_mesh_2 = std::move(_input_2);
 

--- a/framework/src/meshgenerators/GeneratedMeshGenerator.C
+++ b/framework/src/meshgenerators/GeneratedMeshGenerator.C
@@ -249,6 +249,10 @@ GeneratedMeshGenerator::generate()
         _boundary_name_prefix + old_nodeset_name;
   }
 
+  // FIXME: change_boundary_id() was *supposed* to leave the mesh in
+  // a fully prepared state, but there's a libMesh bug to fix first.
+  mesh->unset_has_boundary_id_sets();
+
   // Apply the bias if any exists
   if (_bias_x != 1.0 || _bias_y != 1.0 || _bias_z != 1.0)
   {

--- a/framework/src/meshgenerators/MeshRepairGenerator.C
+++ b/framework/src/meshgenerators/MeshRepairGenerator.C
@@ -67,6 +67,10 @@ std::unique_ptr<MeshBase>
 MeshRepairGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
+
+  // We're trying to repair a potentially broken mesh; we'll just
+  // start with a full prepare rather than trying to be efficient and
+  // risking missing something.
   mesh->prepare_for_use();
 
   // Blanket ban on distributed. This can be relaxed for some operations if needed

--- a/framework/src/meshgenerators/NodeSetsGeneratorBase.C
+++ b/framework/src/meshgenerators/NodeSetsGeneratorBase.C
@@ -81,6 +81,10 @@ NodeSetsGeneratorBase::NodeSetsGeneratorBase(const InputParameters & parameters)
 void
 NodeSetsGeneratorBase::setup(MeshBase & mesh)
 {
+  // We'll need cached subdomain_ids later
+  if (!mesh.preparation().has_cached_elem_data)
+    mesh.cache_elem_data();
+
   // Parameter checks and filling vector of ids (used instead of names for efficiency)
   if (_check_included_nodesets)
   {

--- a/framework/src/meshgenerators/ParsedExtraElementIDGenerator.C
+++ b/framework/src/meshgenerators/ParsedExtraElementIDGenerator.C
@@ -80,6 +80,10 @@ ParsedExtraElementIDGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
+  // Make sure subdomain caches are up to date
+  if (!mesh->preparation().has_cached_elem_data)
+    mesh->cache_elem_data();
+
   // the extra element ids would not have existed at construction so we only do this now
   for (const auto & eeid_name : _eeid_names)
     _eeid_indices.push_back(mesh->get_elem_integer_index(eeid_name));

--- a/framework/src/meshgenerators/ParsedSubdomainGeneratorBase.C
+++ b/framework/src/meshgenerators/ParsedSubdomainGeneratorBase.C
@@ -74,6 +74,10 @@ ParsedSubdomainGeneratorBase::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
+  // Make sure subdomain caches are up to date
+  if (!mesh->preparation().has_cached_elem_data)
+    mesh->cache_elem_data();
+
   // the extra element ids would not have existed at construction so we only do this now
   for (const auto & eeid_name : _eeid_names)
     _eeid_indices.push_back(mesh->get_elem_integer_index(eeid_name));

--- a/framework/src/meshgenerators/PolyLineMeshFollowingNodeSetGenerator.C
+++ b/framework/src/meshgenerators/PolyLineMeshFollowingNodeSetGenerator.C
@@ -98,6 +98,10 @@ PolyLineMeshFollowingNodeSetGenerator::generate()
   if (!base_mesh->is_serial())
     paramError("input", "Input mesh must not be distributed");
 
+  // We may rely on boundary info caches later
+  if (!base_mesh->preparation().has_boundary_id_sets)
+    base_mesh->get_boundary_info().regenerate_id_sets();
+
   // Get nodeset ID in input mesh
   const auto nodeset_id =
       MooseMeshUtils::getBoundaryID(getParam<BoundaryName>("nodeset"), *base_mesh);

--- a/framework/src/meshgenerators/RefineBlockGenerator.C
+++ b/framework/src/meshgenerators/RefineBlockGenerator.C
@@ -61,6 +61,8 @@ RefineBlockGenerator::generate()
       MooseMeshUtils::getSubdomainIDs(*_input, getParam<std::vector<SubdomainName>>("block"));
 
   // Check that the block ids/names exist in the mesh
+  if (!_input->preparation().has_cached_elem_data)
+    _input->cache_elem_data();
   std::set<SubdomainID> mesh_blocks;
   _input->subdomain_ids(mesh_blocks);
 

--- a/framework/src/meshgenerators/RenameBlockGenerator.C
+++ b/framework/src/meshgenerators/RenameBlockGenerator.C
@@ -146,6 +146,8 @@ RenameBlockGenerator::generate()
   const MeshBase & const_mesh = *mesh;
 
   // Get the subdomains in the mesh (this is global)
+  if (!mesh->preparation().has_cached_elem_data)
+    mesh->cache_elem_data();
   std::set<subdomain_id_type> block_ids;
   mesh->subdomain_ids(block_ids);
 

--- a/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
+++ b/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
@@ -62,6 +62,10 @@ SubdomainBoundingBoxGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
+  // We'll need cached subdomain_ids later
+  if (!mesh->preparation().has_cached_elem_data)
+    mesh->cache_elem_data();
+
   std::set<SubdomainID> restricted_ids;
   if (_has_restriction)
   {

--- a/framework/src/meshgenerators/TransformGenerator.C
+++ b/framework/src/meshgenerators/TransformGenerator.C
@@ -112,8 +112,12 @@ TransformGenerator::rotateExtrinsic(MeshBase & mesh,
   const auto R = RealTensorValue::extrinsic_rotation_matrix(
       alpha, beta, gamma); // this line is the only difference from rotate...
 
-  if (beta)
-    mesh.set_spatial_dimension(3);
+  // Let's not try to guess what this did to our spatial dimension (it
+  // could have reduced it, depending on the input mesh!), let's just
+  // mark that it needs to be recomputed.
+  // if (beta)
+  //  mesh.set_spatial_dimension(3);
+  mesh.unset_has_cached_elem_data();
 
   for (auto & node : mesh.node_ptr_range())
   {
@@ -132,7 +136,10 @@ TransformGenerator::rotateWithMatrix(MeshBase & mesh,
                                      const GenericRealTensorValue<false> & rotation_matrix)
 {
 #if LIBMESH_DIM == 3
-  mesh.set_spatial_dimension(3);
+  // Let's not try to guess what this did to our spatial dimension,
+  // let's just mark that it needs to be recomputed.
+  // mesh.set_spatial_dimension(3);
+  mesh.unset_has_cached_elem_data();
 
   for (auto & node : mesh.node_ptr_range())
   {

--- a/framework/src/meshgenerators/TransformGenerator.C
+++ b/framework/src/meshgenerators/TransformGenerator.C
@@ -134,8 +134,6 @@ TransformGenerator::rotateExtrinsic(MeshBase & mesh,
   // Let's not try to guess what this did to our spatial dimension (it
   // could have reduced it, depending on the input mesh!), let's just
   // mark that it needs to be recomputed.
-  // if (beta)
-  //  mesh.set_spatial_dimension(3);
   mesh.unset_has_cached_elem_data();
 
   for (auto & node : mesh.node_ptr_range())
@@ -157,7 +155,6 @@ TransformGenerator::rotateWithMatrix(MeshBase & mesh,
 #if LIBMESH_DIM == 3
   // Let's not try to guess what this did to our spatial dimension,
   // let's just mark that it needs to be recomputed.
-  // mesh.set_spatial_dimension(3);
   mesh.unset_has_cached_elem_data();
 
   for (auto & node : mesh.node_ptr_range())

--- a/framework/src/meshgenerators/TransformGenerator.C
+++ b/framework/src/meshgenerators/TransformGenerator.C
@@ -77,18 +77,37 @@ TransformGenerator::generate()
   else
     vector_value = getParam<RealVectorValue>("vector_value");
 
+  // Any non-identity transform is going to invalidate any existing
+  // point locator
+  mesh->clear_point_locator();
+
   switch (_transform)
   {
     case 1:
     case 2:
     case 3:
       MeshTools::Modification::translate(*mesh, vector_value(0), vector_value(1), vector_value(2));
+      // libMesh translate() fails to properly mark the spatial
+      // dimension as unprepared in cases where we've displaced a 1D
+      // mesh in y or z or a 2D mesh in z.  Until that's fixed we work
+      // around the bug.
+      mesh->unset_has_cached_elem_data();
       break;
     case 4:
       MeshTools::Modification::rotate(*mesh, vector_value(0), vector_value(1), vector_value(2));
+      // libMesh rotate() tries to set the spatial dimension properly,
+      // and probably does for all realistic use cases, but there are
+      // at least hypothetical cases where it could be wrong.
+      //
+      // Until that's fixed we work around it.
+      mesh->unset_has_cached_elem_data();
       break;
     case 5:
       MeshTools::Modification::scale(*mesh, vector_value(0), vector_value(1), vector_value(2));
+      // Is anybody using scale() to just squash a manifold's spatial
+      // dimension down to its mesh dimension?  Let's be safe until
+      // libMesh is handling that case.
+      mesh->unset_has_cached_elem_data();
       break;
     case 6:
       TransformGenerator::rotateWithMatrix(*mesh, rotation_matrix);

--- a/framework/src/meshgenerators/UniqueExtraIDMeshGenerator.C
+++ b/framework/src/meshgenerators/UniqueExtraIDMeshGenerator.C
@@ -53,6 +53,10 @@ UniqueExtraIDMeshGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
+  // Make sure subdomain caches are up to date
+  if (!mesh->preparation().has_cached_elem_data)
+    mesh->cache_elem_data();
+
   std::set<SubdomainID> restricted_ids;
   if (_has_restriction)
   {

--- a/framework/src/meshgenerators/XYDelaunayGenerator.C
+++ b/framework/src/meshgenerators/XYDelaunayGenerator.C
@@ -214,6 +214,10 @@ XYDelaunayGenerator::generate()
   {
     const auto & subdomain_names = getParam<std::vector<SubdomainName>>("input_subdomain_names");
 
+    // Make sure subdomain info caches are up to date
+    if (!mesh->preparation().has_cached_elem_data)
+      mesh->cache_elem_data();
+
     const auto subdomain_ids = MooseMeshUtils::getSubdomainIDs(*mesh, subdomain_names);
 
     // Check that the requested subdomains exist in the mesh

--- a/framework/src/meshgenerators/XYMeshLineCutter.C
+++ b/framework/src/meshgenerators/XYMeshLineCutter.C
@@ -103,6 +103,10 @@ XYMeshLineCutter::XYMeshLineCutter(const InputParameters & parameters)
 std::unique_ptr<MeshBase>
 XYMeshLineCutter::generate()
 {
+  // We're querying elem dim caches from our input mesh
+  if (!_input->preparation().has_cached_elem_data)
+    _input->cache_elem_data();
+
   auto replicated_mesh_ptr = dynamic_cast<ReplicatedMesh *>(_input.get());
   if (!replicated_mesh_ptr)
     paramError("input", "Input is not a replicated mesh, which is required");

--- a/framework/src/utils/MooseMeshElementConversionUtils.C
+++ b/framework/src/utils/MooseMeshElementConversionUtils.C
@@ -1239,6 +1239,11 @@ assignConvertedElementsSubdomainNameSuffix(
     const SubdomainName & tet_suffix,
     const SubdomainName & pyramid_suffix)
 {
+  // If we have an unprepared mesh, we at least need its element
+  // caches prepared for subdomain_ids
+  if (!mesh.preparation().has_cached_elem_data)
+    mesh.cache_elem_data();
+
   for (const auto & subdomain_id : original_subdomain_ids)
   {
     if (MooseMeshUtils::hasSubdomainID(mesh, subdomain_id + sid_shift_base))

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -501,6 +501,9 @@ getNextFreeSubdomainID(MeshBase & input_mesh)
 BoundaryID
 getNextFreeBoundaryID(MeshBase & input_mesh)
 {
+  if (!input_mesh.preparation().has_boundary_id_sets)
+    input_mesh.get_boundary_info().regenerate_id_sets();
+
   auto boundary_ids = input_mesh.get_boundary_info().get_boundary_ids();
   if (boundary_ids.empty())
     return 0;

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -1252,8 +1252,17 @@ copyIntoMesh(MeshGenerator & mg,
     // Note: if performance becomes an issue, this is overkill for just getting the max node id
     std::set<subdomain_id_type> source_ids;
     std::set<subdomain_id_type> dest_ids;
+
+    // We need source subdomain ids already cached; libMesh will
+    // scream otherwise
     source.subdomain_ids(source_ids, true);
+
+    // Our destination is non-const, so we can fix any missing caches
+    if (!destination.preparation().has_cached_elem_data)
+      destination.cache_elem_data();
+
     destination.subdomain_ids(dest_ids, true);
+
     mooseAssert(source_ids.size(), "Should have a subdomain");
     mooseAssert(dest_ids.size(), "Should have a subdomain");
     unsigned int max_dest_bid = *dest_ids.rbegin();

--- a/modules/reactor/src/meshgenerators/AzimuthalBlockSplitGenerator.C
+++ b/modules/reactor/src/meshgenerators/AzimuthalBlockSplitGenerator.C
@@ -78,6 +78,10 @@ AzimuthalBlockSplitGenerator::generate()
 
   ReplicatedMesh & mesh = *replicated_mesh_ptr;
 
+  // We'll be querying the mesh for subdomain ids
+  if (!mesh.preparation().has_cached_elem_data)
+    mesh.cache_elem_data();
+
   // Check the order of the input mesh's elements
   // Meanwhile, record the vertex average of each element for future comparison
   unsigned short order = 0;

--- a/modules/reactor/src/meshgenerators/AzimuthalBlockSplitGenerator.C
+++ b/modules/reactor/src/meshgenerators/AzimuthalBlockSplitGenerator.C
@@ -424,8 +424,12 @@ AzimuthalBlockSplitGenerator::generate()
 
   MeshTools::Modification::rotate(mesh, -90.0, 0.0, 0.0);
 
-  // Workaround - this flagging should be done by libMesh rotate()
+  // Workaround - the point locator clear should be done in rotate()
   mesh.clear_point_locator();
+
+  // The rotate() could unset this (because spatial_dimension() can be
+  // changed) but let's unset to be sure our subdomain changes get
+  // recached.
   mesh.unset_has_cached_elem_data();
 
   for (unsigned int i = 0; i < _azimuthal_angle_meta.size(); i++)

--- a/modules/reactor/src/meshgenerators/AzimuthalBlockSplitGenerator.C
+++ b/modules/reactor/src/meshgenerators/AzimuthalBlockSplitGenerator.C
@@ -417,10 +417,17 @@ AzimuthalBlockSplitGenerator::generate()
                (p_cent_azi >= _start_angle || p_cent_azi <= _end_angle))
         elem->subdomain_id() = _new_block_ids[block_id_index];
     }
+
   // Assign new Block Names if applicable
   for (unsigned int i = 0; i < _new_block_names.size(); i++)
     mesh.subdomain_name(_new_block_ids[i]) = _new_block_names[i];
+
   MeshTools::Modification::rotate(mesh, -90.0, 0.0, 0.0);
+
+  // Workaround - this flagging should be done by libMesh rotate()
+  mesh.clear_point_locator();
+  mesh.unset_has_cached_elem_data();
+
   for (unsigned int i = 0; i < _azimuthal_angle_meta.size(); i++)
     _azimuthal_angle_meta[i] = (_azimuthal_angle_meta[i] - 90.0 <= -180.0)
                                    ? (_azimuthal_angle_meta[i] + 270.0)

--- a/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
@@ -155,6 +155,9 @@ PeripheralRingMeshGenerator::generate()
   auto input_mesh = dynamic_cast<ReplicatedMesh *>(_input.get());
   if (!input_mesh)
     paramError("input", "Input is not a replicated mesh, which is required.");
+
+  if (!input_mesh->preparation().has_cached_elem_data)
+    input_mesh->cache_elem_data();
   if (*(input_mesh->elem_dimensions().begin()) != 2 ||
       *(input_mesh->elem_dimensions().rbegin()) != 2)
     paramError("input", "Only 2D meshes are supported.");

--- a/modules/reactor/src/meshgenerators/PolygonMeshTrimmerBase.C
+++ b/modules/reactor/src/meshgenerators/PolygonMeshTrimmerBase.C
@@ -110,6 +110,8 @@ PolygonMeshTrimmerBase::generate()
     paramError("external_boundary",
                "the provided external boundary does not exist in the input mesh.");
 
+  if (!mesh.preparation().has_cached_elem_data)
+    mesh.cache_elem_data();
   std::set<subdomain_id_type> subdomain_ids_set;
   mesh.subdomain_ids(subdomain_ids_set);
 

--- a/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
+++ b/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
@@ -120,6 +120,8 @@ ReactorGeometryMeshBuilderBase::updateElementBlockNameId(
     elem_block_id = name_id_map[elem_block_name];
     elem->subdomain_id() = elem_block_id;
   }
+
+  input_mesh.unset_has_cached_elem_data();
 }
 
 void

--- a/modules/reactor/src/meshgenerators/RevolveGenerator.C
+++ b/modules/reactor/src/meshgenerators/RevolveGenerator.C
@@ -266,6 +266,8 @@ RevolveGenerator::generate()
     }
 
   // Subdomain IDs for on-axis elements must be new
+  if (!input->preparation().has_cached_elem_data)
+    input->cache_elem_data();
   std::set<subdomain_id_type> subdomain_ids_set;
   input->subdomain_ids(subdomain_ids_set);
   const subdomain_id_type max_subdomain_id = *subdomain_ids_set.rbegin();

--- a/modules/reactor/src/meshgenerators/RevolveGenerator.C
+++ b/modules/reactor/src/meshgenerators/RevolveGenerator.C
@@ -253,6 +253,10 @@ RevolveGenerator::generate()
   if (!input->is_serial())
     mesh->delete_remote_elements();
 
+  // Subdomain IDs for on-axis elements must be new
+  if (!input->preparation().has_cached_elem_data)
+    input->cache_elem_data();
+
   // check that subdomain swap sources exist in the mesh
   std::set<subdomain_id_type> blocks;
   input->subdomain_ids(blocks, true);
@@ -265,9 +269,6 @@ RevolveGenerator::generate()
                    "Source subdomain " + std::to_string(bid) + " was not found in the mesh");
     }
 
-  // Subdomain IDs for on-axis elements must be new
-  if (!input->preparation().has_cached_elem_data)
-    input->cache_elem_data();
   std::set<subdomain_id_type> subdomain_ids_set;
   input->subdomain_ids(subdomain_ids_set);
   const subdomain_id_type max_subdomain_id = *subdomain_ids_set.rbegin();

--- a/modules/reactor/src/meshgenerators/SubdomainExtraElementIDGenerator.C
+++ b/modules/reactor/src/meshgenerators/SubdomainExtraElementIDGenerator.C
@@ -67,6 +67,10 @@ SubdomainExtraElementIDGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
+  // We'll be querying the mesh for subdomain ids
+  if (!mesh->preparation().has_cached_elem_data)
+    mesh->cache_elem_data();
+
   // construct a map from the subdomain ID to the index in 'subdomains'
   const auto subdomain_ids = MooseMeshUtils::getSubdomainIDs(*mesh, _subdomain_names);
 

--- a/modules/reactor/src/meshgenerators/TriPinHexAssemblyGenerator.C
+++ b/modules/reactor/src/meshgenerators/TriPinHexAssemblyGenerator.C
@@ -500,6 +500,7 @@ TriPinHexAssemblyGenerator::buildSinglePinSection(
 
   for (const auto & elem : mesh0->element_ptr_range())
     elem->subdomain_id() = block_ids_new[elem->subdomain_id() - 1];
+  mesh0->unset_has_cached_elem_data();
 
   return mesh0;
 }

--- a/modules/reactor/src/utils/ReportingIDGeneratorUtils.C
+++ b/modules/reactor/src/utils/ReportingIDGeneratorUtils.C
@@ -80,7 +80,10 @@ ReportingIDGeneratorUtils::getCellBlockIDs(
     for (MooseIndex(pattern[i]) j = 0; j < pattern[i].size(); ++j)
     {
       std::set<SubdomainID> mesh_blks;
-      meshes[pattern[i][j]]->subdomain_ids(mesh_blks);
+      ReplicatedMesh & mesh = *meshes[pattern[i][j]];
+      if (!mesh.preparation().has_cached_elem_data)
+        mesh.cache_elem_data();
+      mesh.subdomain_ids(mesh_blks);
       blks.insert(mesh_blks.begin(), mesh_blks.end());
     }
   return blks;


### PR DESCRIPTION
## Reason
#32698 tries to weaken mesh non-preparedness flag setting (to enable more efficient mesh generation with webs of different generators that aren't reducing intermediate preparedness completely), and in tests it turns out that doing this exposes bugs from generators that aren't robustly testing for aspects of preparedness that they implicitly rely on.

Let's see if we can just add some of the robustness improvement commits first and then work on adding the efficiency improvements a few at a time later.

## Design
Add tests in MeshGenerators for the preparedness aspects relied upon by those generators.

## Impact
This could turn some correctness bugs into performance reductions, which IMHO is still a pure improvement ... unless we've already golded any test outputs that depended on incorrect mesh generation.  Fingers crossed.
