### PR TITLE
Make ASCII character requirement more isolated to code comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,17 +55,14 @@ The test: Every changed line should trace directly to the user's request.
 
 - Never delete correct preexisting code comments.
 - Add comments when the code alone does not make clear what's happening.
+- Use ASCII characters.
 
-## 5. Repository Requirements
-
-- Comments and documentation must use ASCII characters.
-
-## 6. Tool Use
+## 5. Tool Use
 
 - Prefer builtin tools over bash commands whenever possible in the vein of
   reducing permission prompting.
 
-## 7. Goal-Driven Execution
+## 6. Goal-Driven Execution
 
 **Define success criteria. Loop until verified.**
 


### PR DESCRIPTION
Code is where we apply our ASCII precheck. And we have people, particulary from the UKAEA, using non-ASCII in documentation, which is honestly a good thing for doing things like correctly writing people's names (e.g. Nedelec here written incorrectly)

Refs #32497