### PR TITLE
Change Kokkos reducer join/init signatures

### DIFF
--- a/framework/doc/content/syntax/Kokkos/index.md
+++ b/framework/doc/content/syntax/Kokkos/index.md
@@ -334,7 +334,7 @@ The vtable lookup itself incurs overheads, and using function pointers prevents 
 GPU compilers heavily rely on the inlining to generate an optimized code, and being unable to inline functions will likely lead to a performance hit.
 Therefore, any polymorphism on GPU should be implemented statically.
 
-While not directly being used in Kokkos-MOOSE, the most famous static polymorphism design pattern is the Curiously Recurring Template Pattern (CRTP).
+While not directly used in Kokkos-MOOSE, the most famous static polymorphism design pattern is the Curiously Recurring Template Pattern (CRTP).
 The CRTP is a programming idiom that involves a class template inheriting from a template instantiation of itself, which is a technique used to achieve static (compile-time) polymorphism.
 The following pseudo-codes demonstrate a typical template method pattern implemented with the dynamic polymorphism and its equivalent implementation with the static polymorphism using the CRTP:
 

--- a/framework/doc/content/syntax/KokkosUserObjects/index.md
+++ b/framework/doc/content/syntax/KokkosUserObjects/index.md
@@ -60,12 +60,14 @@ A reducer also requires two more hook methods to be defined in your derived obje
 They have the following signatures:
 
 ```cpp
-KOKKOS_FUNCTION void join(ReducerLoop, Real * result, const Real * source) const;
-KOKKOS_FUNCTION void init(ReducerLoop, Real * result) const;
+template <typename Derived>
+KOKKOS_FUNCTION void join(Real * result, const Real * source) const;
+template <typename Derived>
+KOKKOS_FUNCTION void init(Real * result) const;
 ```
 
 `join()` can be considered as a replacement of `threadJoin()` in the original MOOSE objects.
-It combines the values of `source` into `result` and should typically implement the same reduction operation with `execute()`.
+It combines the values of `source` into `result` and should typically implement the same reduction operation with `reduce()`.
 `init()` can be considered as a replacement of `initialize()` in the original MOOSE objects where you used to initialize your reduction variables.
 It initializes the Kokkos internal buffer on GPU.
 Note that initializing `_reduction_buffer` has no effect on GPU and thus is not required.
@@ -92,7 +94,7 @@ The reporter values defined by Kokkos-MOOSE postprocessors, vector postprocessor
 ### Performance Considerations id=reducer_atomic
 
 The [Kokkos Reducer concept](https://kokkos.org/kokkos-core-wiki/API/core/builtinreducers/ReducerConcept.html) leveraged to implement Kokkos-MOOSE reducers is suitable for small arrays and "dense" reduction operations.
-Assume you are reducing a large array, where a single call to `execute()` only accumulates values to one or a few entries of the array at most.
+Assume you are reducing a large array, where a single call to `reduce()` only accumulates values to one or a few entries of the array at most.
 This can be considered as a "sparse" reduction operation and is not suitable for a reducer.
 A massively-parallel reduction is implemented by many partial reductions where many temporary buffers are internally created and initialized.
 Even though most of the entries of a temporary buffer are unused in each partial reduction, it still has to initialize and join all the entries.

--- a/framework/include/kokkos/base/KokkosDispatcher.h
+++ b/framework/include/kokkos/base/KokkosDispatcher.h
@@ -160,9 +160,12 @@ public:
   ///@{
   KOKKOS_FUNCTION void join(value_type result, const value_type source) const
   {
-    _functor_device.join(Operation{}, result, source);
+    _functor_device.template join<Object>(result, source);
   }
-  KOKKOS_FUNCTION void init(value_type result) const { _functor_device.init(Operation{}, result); }
+  KOKKOS_FUNCTION void init(value_type result) const
+  {
+    _functor_device.template init<Object>(result);
+  }
   ///@}
 
 private:

--- a/framework/include/kokkos/postprocessors/KokkosExtremeValueBase.h
+++ b/framework/include/kokkos/postprocessors/KokkosExtremeValueBase.h
@@ -29,8 +29,10 @@ public:
   template <typename Derived>
   KOKKOS_FUNCTION void
   computeExtremeValue(const unsigned int qp, Datum & datum, Real * result) const;
-  KOKKOS_FUNCTION void join(typename Base::ReducerLoop, Real * result, const Real * source) const;
-  KOKKOS_FUNCTION void init(typename Base::ReducerLoop, Real * result) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void join(Real * result, const Real * source) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void init(Real * result) const;
 
 protected:
   /**
@@ -67,10 +69,9 @@ KokkosExtremeValueBase<Base>::computeExtremeValue(const unsigned int qp,
 }
 
 template <typename Base>
+template <typename Derived>
 KOKKOS_FUNCTION void
-KokkosExtremeValueBase<Base>::join(typename Base::ReducerLoop,
-                                   Real * result,
-                                   const Real * source) const
+KokkosExtremeValueBase<Base>::join(Real * result, const Real * source) const
 {
   auto rpv = Kokkos::make_pair(result[0], result[1]);
   auto spv = Kokkos::make_pair(source[0], source[1]);
@@ -88,8 +89,9 @@ KokkosExtremeValueBase<Base>::join(typename Base::ReducerLoop,
 }
 
 template <typename Base>
+template <typename Derived>
 KOKKOS_FUNCTION void
-KokkosExtremeValueBase<Base>::init(typename Base::ReducerLoop, Real * result) const
+KokkosExtremeValueBase<Base>::init(Real * result) const
 {
   if (_type == ExtremeType::MAX || _type == ExtremeType::MAX_ABS)
   {

--- a/framework/include/kokkos/postprocessors/KokkosIntegralPostprocessor.h
+++ b/framework/include/kokkos/postprocessors/KokkosIntegralPostprocessor.h
@@ -26,9 +26,10 @@ public:
 
   template <typename Derived>
   KOKKOS_FUNCTION void reduce(Datum & datum, Real * result) const;
-
-  KOKKOS_FUNCTION void join(typename Base::ReducerLoop, Real * result, const Real * source) const;
-  KOKKOS_FUNCTION void init(typename Base::ReducerLoop, Real * result) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void join(Real * result, const Real * source) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void init(Real * result) const;
 
 protected:
   const bool _average;
@@ -55,10 +56,9 @@ KokkosIntegralPostprocessor<Base>::reduce(Datum & datum, Real * result) const
 }
 
 template <typename Base>
+template <typename Derived>
 KOKKOS_FUNCTION void
-KokkosIntegralPostprocessor<Base>::join(typename Base::ReducerLoop,
-                                        Real * result,
-                                        const Real * source) const
+KokkosIntegralPostprocessor<Base>::join(Real * result, const Real * source) const
 {
   result[0] += source[0];
 
@@ -67,8 +67,9 @@ KokkosIntegralPostprocessor<Base>::join(typename Base::ReducerLoop,
 }
 
 template <typename Base>
+template <typename Derived>
 KOKKOS_FUNCTION void
-KokkosIntegralPostprocessor<Base>::init(typename Base::ReducerLoop, Real * result) const
+KokkosIntegralPostprocessor<Base>::init(Real * result) const
 {
   result[0] = 0;
 

--- a/framework/include/kokkos/postprocessors/KokkosNodalMaxValueId.h
+++ b/framework/include/kokkos/postprocessors/KokkosNodalMaxValueId.h
@@ -30,8 +30,10 @@ public:
     return _u(datum, qp);
   }
 
-  KOKKOS_FUNCTION void join(ReducerLoop, Real * result, const Real * source) const;
-  KOKKOS_FUNCTION void init(ReducerLoop, Real * result) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void join(Real * result, const Real * source) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void init(Real * result) const;
 
 protected:
   dof_id_type _node_id = libMesh::DofObject::invalid_id;
@@ -53,8 +55,9 @@ KokkosNodalMaxValueId::reduce(Datum & datum, Real * result) const
   }
 }
 
-KOKKOS_FUNCTION inline void
-KokkosNodalMaxValueId::join(ReducerLoop, Real * result, const Real * source) const
+template <typename Derived>
+KOKKOS_FUNCTION void
+KokkosNodalMaxValueId::join(Real * result, const Real * source) const
 {
   if (source[0] > result[0])
   {
@@ -63,8 +66,9 @@ KokkosNodalMaxValueId::join(ReducerLoop, Real * result, const Real * source) con
   }
 }
 
-KOKKOS_FUNCTION inline void
-KokkosNodalMaxValueId::init(ReducerLoop, Real * result) const
+template <typename Derived>
+KOKKOS_FUNCTION void
+KokkosNodalMaxValueId::init(Real * result) const
 {
   result[0] = Kokkos::Experimental::finite_min_v<Real>;
 }

--- a/framework/include/kokkos/postprocessors/KokkosNodalSum.h
+++ b/framework/include/kokkos/postprocessors/KokkosNodalSum.h
@@ -30,8 +30,10 @@ public:
     return _u(datum, qp);
   }
 
-  KOKKOS_FUNCTION void join(ReducerLoop, Real * result, const Real * source) const;
-  KOKKOS_FUNCTION void init(ReducerLoop, Real * result) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void join(Real * result, const Real * source) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void init(Real * result) const;
 };
 
 template <typename Derived>
@@ -42,14 +44,16 @@ KokkosNodalSum::reduce(Datum & datum, Real * result) const
     result[0] += static_cast<const Derived *>(this)->computeValue(0, datum);
 }
 
-KOKKOS_FUNCTION inline void
-KokkosNodalSum::join(ReducerLoop, Real * result, const Real * source) const
+template <typename Derived>
+KOKKOS_FUNCTION void
+KokkosNodalSum::join(Real * result, const Real * source) const
 {
   result[0] += source[0];
 }
 
-KOKKOS_FUNCTION inline void
-KokkosNodalSum::init(ReducerLoop, Real * result) const
+template <typename Derived>
+KOKKOS_FUNCTION void
+KokkosNodalSum::init(Real * result) const
 {
   result[0] = 0;
 }

--- a/framework/include/kokkos/reporters/KokkosElementStatistics.h
+++ b/framework/include/kokkos/reporters/KokkosElementStatistics.h
@@ -21,8 +21,10 @@ public:
   template <typename Derived>
   KOKKOS_FUNCTION void reduce(Datum & datum, Real * result) const;
 
-  KOKKOS_FUNCTION void join(ReducerLoop, Real * result, const Real * source) const;
-  KOKKOS_FUNCTION void init(ReducerLoop, Real * result) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void join(Real * result, const Real * source) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void init(Real * result) const;
 
 protected:
   virtual void initialize() override;
@@ -57,8 +59,9 @@ KokkosElementStatistics::reduce(Datum & datum, Real * result) const
   result[4]++;
 }
 
-KOKKOS_FUNCTION inline void
-KokkosElementStatistics::join(ReducerLoop, Real * result, const Real * source) const
+template <typename Derived>
+KOKKOS_FUNCTION void
+KokkosElementStatistics::join(Real * result, const Real * source) const
 {
   result[0] = Kokkos::max(result[0], source[0]);
   result[1] = Kokkos::min(result[1], source[1]);
@@ -67,8 +70,9 @@ KokkosElementStatistics::join(ReducerLoop, Real * result, const Real * source) c
   result[4] += source[4];
 }
 
-KOKKOS_FUNCTION inline void
-KokkosElementStatistics::init(ReducerLoop, Real * result) const
+template <typename Derived>
+KOKKOS_FUNCTION void
+KokkosElementStatistics::init(Real * result) const
 {
   result[0] = Kokkos::Experimental::finite_min_v<Real>;
   result[1] = Kokkos::Experimental::finite_max_v<Real>;

--- a/framework/include/kokkos/reporters/KokkosNodalStatistics.h
+++ b/framework/include/kokkos/reporters/KokkosNodalStatistics.h
@@ -21,8 +21,10 @@ public:
   template <typename Derived>
   KOKKOS_FUNCTION void reduce(Datum & datum, Real * result) const;
 
-  KOKKOS_FUNCTION void join(ReducerLoop, Real * result, const Real * source) const;
-  KOKKOS_FUNCTION void init(ReducerLoop, Real * result) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void join(Real * result, const Real * source) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void init(Real * result) const;
 
 protected:
   virtual void initialize() override;
@@ -54,8 +56,9 @@ KokkosNodalStatistics::reduce(Datum & datum, Real * result) const
   result[3]++;
 }
 
-KOKKOS_FUNCTION inline void
-KokkosNodalStatistics::join(ReducerLoop, Real * result, const Real * source) const
+template <typename Derived>
+KOKKOS_FUNCTION void
+KokkosNodalStatistics::join(Real * result, const Real * source) const
 {
   result[0] = Kokkos::max(result[0], source[0]);
   result[1] = Kokkos::min(result[1], source[1]);
@@ -63,8 +66,9 @@ KokkosNodalStatistics::join(ReducerLoop, Real * result, const Real * source) con
   result[3] += source[3];
 }
 
-KOKKOS_FUNCTION inline void
-KokkosNodalStatistics::init(ReducerLoop, Real * result) const
+template <typename Derived>
+KOKKOS_FUNCTION void
+KokkosNodalStatistics::init(Real * result) const
 {
   result[0] = Kokkos::Experimental::finite_min_v<Real>;
   result[1] = Kokkos::Experimental::finite_max_v<Real>;

--- a/framework/include/kokkos/systems/KokkosSystem.h
+++ b/framework/include/kokkos/systems/KokkosSystem.h
@@ -15,6 +15,7 @@
 #include "KokkosAssembly.h"
 
 #include "SystemBase.h"
+#include "PerfGraphInterface.h"
 
 #include "libmesh/communicator.h"
 
@@ -30,7 +31,7 @@ class NodalBCBase;
  * The Kokkos system class. Each nonlinear and auxiliary system in MOOSE has a corresponding Kokkos
  * system.
  */
-class System : public MeshHolder, public AssemblyHolder
+class System : public PerfGraphInterface, public MeshHolder, public AssemblyHolder
 {
 public:
   /**

--- a/framework/include/kokkos/userobjects/KokkosReducerBase.h
+++ b/framework/include/kokkos/userobjects/KokkosReducerBase.h
@@ -48,12 +48,14 @@ public:
     ::Kokkos::abort("Default reduce() should never be called. Make sure you properly redefined "
                     "this method in your class without typos.");
   }
-  KOKKOS_FUNCTION void join(ReducerLoop, Real * /* result */, const Real * /* source */) const
+  template <typename Derived>
+  KOKKOS_FUNCTION void join(Real * /* result */, const Real * /* source */) const
   {
     ::Kokkos::abort("Default join() should never be called. Make sure you properly redefined this "
                     "method in your class without typos.");
   }
-  KOKKOS_FUNCTION void init(ReducerLoop, Real * /* result */) const
+  template <typename Derived>
+  KOKKOS_FUNCTION void init(Real * /* result */) const
   {
     ::Kokkos::abort("Default init() should never be called. Make sure you properly redefined this "
                     "method in your class without typos.");

--- a/framework/include/kokkos/vectorpostprocessors/KokkosExtraIDIntegralVectorPostprocessor.h
+++ b/framework/include/kokkos/vectorpostprocessors/KokkosExtraIDIntegralVectorPostprocessor.h
@@ -32,8 +32,10 @@ public:
   virtual void compute() override;
   virtual void finalize() override;
 
-  KOKKOS_FUNCTION void join(ReducerLoop, Real * result, const Real * source) const;
-  KOKKOS_FUNCTION void init(ReducerLoop, Real * result) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void join(Real * result, const Real * source) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void init(Real * result) const;
   template <typename Derived>
   KOKKOS_FUNCTION void reduce(Datum & datum, Real * result) const;
   template <typename Derived>
@@ -76,10 +78,9 @@ protected:
   static constexpr unsigned int _cache_size = 10;
 };
 
-KOKKOS_FUNCTION inline void
-KokkosExtraIDIntegralVectorPostprocessor::join(ReducerLoop,
-                                               Real * result,
-                                               const Real * source) const
+template <typename Derived>
+KOKKOS_FUNCTION void
+KokkosExtraIDIntegralVectorPostprocessor::join(Real * result, const Real * source) const
 {
   auto size = _vector_size * (_nvar + _nprop + _average);
 
@@ -87,8 +88,9 @@ KokkosExtraIDIntegralVectorPostprocessor::join(ReducerLoop,
     result[i] += source[i];
 }
 
-KOKKOS_FUNCTION inline void
-KokkosExtraIDIntegralVectorPostprocessor::init(ReducerLoop, Real * result) const
+template <typename Derived>
+KOKKOS_FUNCTION void
+KokkosExtraIDIntegralVectorPostprocessor::init(Real * result) const
 {
   auto size = _vector_size * (_nvar + _nprop + _average);
 

--- a/framework/src/kokkos/systems/KokkosMatrix.K
+++ b/framework/src/kokkos/systems/KokkosMatrix.K
@@ -78,6 +78,8 @@ Matrix::close()
 
   LibmeshPetscCallQ(
       MatSetValuesCOO(_matrix, _is_host ? _val.hostData() : _val.deviceData(), ADD_VALUES));
+
+  ::Kokkos::fence();
 }
 
 } // namespace Moose::Kokkos

--- a/framework/src/kokkos/systems/KokkosNonlinearSystemBase.K
+++ b/framework/src/kokkos/systems/KokkosNonlinearSystemBase.K
@@ -218,7 +218,7 @@ NonlinearSystemBase::computeKokkosResidual(const std::set<TagID> & tags)
   // Close and restore vectors
 
   {
-    TIME_SECTION("KokkosCopy", 1);
+    TIME_SECTION("KokkosClose", 1);
 
     for (auto & system : systems)
       system.sync(Moose::Kokkos::MemcpyType::DEVICE_TO_HOST);
@@ -286,7 +286,7 @@ NonlinearSystemBase::computeKokkosNodalBCsResidual(const std::set<TagID> & tags)
   // Close and restore vectors
 
   {
-    TIME_SECTION("KokkosCopy", 1);
+    TIME_SECTION("KokkosClose", 1);
 
     for (auto & system : systems)
       system.sync(Moose::Kokkos::MemcpyType::DEVICE_TO_HOST);
@@ -359,7 +359,7 @@ NonlinearSystemBase::computeKokkosJacobian(const std::set<TagID> & tags)
     system.setActiveSolutionTags(needed_fe_var_vector_tags);
 
     {
-      TIME_SECTION("KokkosPreallocate", 1);
+      TIME_SECTION("KokkosCopy", 1);
       system.sync(Moose::Kokkos::MemcpyType::HOST_TO_DEVICE);
     }
     {
@@ -403,7 +403,7 @@ NonlinearSystemBase::computeKokkosJacobian(const std::set<TagID> & tags)
   // Close and restore vectors and matrices
 
   {
-    TIME_SECTION("KokkosCopy", 1);
+    TIME_SECTION("KokkosClose", 1);
 
     for (auto & system : systems)
       system.sync(Moose::Kokkos::MemcpyType::DEVICE_TO_HOST);
@@ -474,7 +474,7 @@ NonlinearSystemBase::computeKokkosResidualAndJacobian(const std::set<TagID> & ve
     system.setActiveSolutionTags(needed_fe_var_vector_tags);
 
     {
-      TIME_SECTION("KokkosPreallocateAndCopy", 1);
+      TIME_SECTION("KokkosCopy", 1);
       system.sync(Moose::Kokkos::MemcpyType::HOST_TO_DEVICE);
     }
     {
@@ -519,7 +519,7 @@ NonlinearSystemBase::computeKokkosResidualAndJacobian(const std::set<TagID> & ve
   // Close and restore vectors and matrices
 
   {
-    TIME_SECTION("KokkosCopy", 1);
+    TIME_SECTION("KokkosClose", 1);
 
     for (auto & system : systems)
       system.sync(Moose::Kokkos::MemcpyType::DEVICE_TO_HOST);

--- a/framework/src/kokkos/systems/KokkosSystem.K
+++ b/framework/src/kokkos/systems/KokkosSystem.K
@@ -21,7 +21,8 @@ namespace Moose::Kokkos
 {
 
 System::System(SystemBase & system)
-  : MeshHolder(*system.mesh().getKokkosMesh()),
+  : PerfGraphInterface(system.feProblem().getMooseApp().perfGraph(), "KokkosSystem"),
+    MeshHolder(*system.mesh().getKokkosMesh()),
     AssemblyHolder(system.feProblem().kokkosAssembly()),
     _system(system),
     _mesh(system.mesh()),
@@ -348,7 +349,11 @@ System::sync(const MemcpyType dir)
     {
       auto & matrix = _system.getMatrix(tag);
 
-      _matrices[tag].create(matrix, *this);
+      {
+        TIME_SECTION("MatSetPreallocation", 1);
+        _matrices[tag].create(matrix, *this);
+      }
+
       _matrices[tag] = 0;
     }
 
@@ -364,7 +369,10 @@ System::sync(const MemcpyType dir)
       _vectors[tag].close();
 
     for (auto tag : _active_matrix_tags)
+    {
+      TIME_SECTION("MatSetValues", 1);
       _matrices[tag].close();
+    }
   }
 }
 

--- a/unit/include/KokkosDispatcherTest.h
+++ b/unit/include/KokkosDispatcherTest.h
@@ -55,13 +55,15 @@ public:
       result[i] += (i + 1) * tid;
   }
 
-  KOKKOS_FUNCTION void join(TestLoop, Real * result, const Real * source) const
+  template <typename Derived>
+  KOKKOS_FUNCTION void join(Real * result, const Real * source) const
   {
     for (unsigned int i = 0; i < _n; ++i)
       result[i] += source[i];
   }
 
-  KOKKOS_FUNCTION void init(TestLoop, Real * result) const
+  template <typename Derived>
+  KOKKOS_FUNCTION void init(Real * result) const
   {
     for (unsigned int i = 0; i < _n; ++i)
       result[i] = 0;


### PR DESCRIPTION
## Reason
It makes sense to make `init` and `join` be template functions like other hook methods in case users want to implement polymorphism in those functions. On the other hand, having them receive the internal work tag `ReducerLoop` is not very intuitive.

## Design
Remove the work tag argument and make them template functions.

## Impact
More intuitive and consistent interfaces.