### PR TITLE
Add dataStore/dataLoad for RestartableDataReporter::Value

### DIFF
--- a/framework/include/reporters/RestartableDataReporter.h
+++ b/framework/include/reporters/RestartableDataReporter.h
@@ -57,3 +57,10 @@ private:
 };
 
 void to_json(nlohmann::json & json, const RestartableDataReporter::Value & value);
+
+// The pointer member of Value is ephemeral (repopulated by execute()), so only
+// store params to avoid writing uninitialized padding bytes from the raw struct.
+template <>
+void dataStore(std::ostream & stream, RestartableDataReporter::Value & v, void * context);
+template <>
+void dataLoad(std::istream & stream, RestartableDataReporter::Value & v, void * context);

--- a/framework/src/reporters/RestartableDataReporter.C
+++ b/framework/src/reporters/RestartableDataReporter.C
@@ -134,3 +134,18 @@ to_json(nlohmann::json & json, const RestartableDataReporter::Value & value)
   mooseAssert(value.value, "Not set");
   value.value->store(json, value.params);
 }
+
+template <>
+void
+dataStore(std::ostream & stream, RestartableDataReporter::Value & v, void * context)
+{
+  dataStore(stream, v.params, context);
+}
+
+template <>
+void
+dataLoad(std::istream & stream, RestartableDataReporter::Value & v, void * context)
+{
+  v.value = nullptr;
+  dataLoad(stream, v.params, context);
+}


### PR DESCRIPTION
The alignment of Value will be 8 bytes because that's the maximum size of its two data members (the pointer). This means that when writing Value's params member, one extra byte of padding will be added since the sizeof(params) is 7 bytes. So the trivially copyable base template will write one byte of uninitialized data. The solution is to write explicit dataStore and dataLoad overloads for the type.

Refs #26304