### PR TITLE
Add finite element boundary integral value constraint

### DIFF
--- a/framework/doc/content/source/bcs/BoundaryIntegralValueConstraint.md
+++ b/framework/doc/content/source/bcs/BoundaryIntegralValueConstraint.md
@@ -9,7 +9,7 @@
 !equation
 \int_{\Gamma} \left(u - \phi_0\right) \, d\Gamma = 0
 
-on a boundary $\Gamma$ using a first-order scalar Lagrange multiplier variable. This makes the
+on a boundary $\Gamma$ using a `SCALAR` Lagrange multiplier variable. This makes the
 average value of the finite element variable `u` on the specified `boundary` equal to `phi0`.
 The variable supplied to [!param](/BCs/BoundaryIntegralValueConstraint/lambda) must use
 `family = SCALAR` and `order = FIRST`.
@@ -17,6 +17,13 @@ The variable supplied to [!param](/BCs/BoundaryIntegralValueConstraint/lambda) m
 The object assembles both the field-variable equation and the scalar Lagrange multiplier equation,
 so no separate `ScalarKernel` is required for the Lagrange multiplier variable. It is the finite
 element boundary analogue of [FVBoundaryIntegralValueConstraint.md].
+
+The scalar Lagrange multiplier $\lambda$ has the physical meaning of the uniform boundary loading
+needed to enforce the average value constraint. For example, in a mechanical problem where $u$ is a
+displacement field, $\lambda$ represents the uniform traction applied on $\Gamma$ to enforce the
+prescribed average displacement. In a heat-conduction problem where $u$ is temperature, $\lambda$
+represents the uniform boundary source term or flux needed to enforce the prescribed average
+temperature.
 
 !alert warning
 This constraint introduces a saddle-point block with zero diagonal terms. Use a preconditioner that

--- a/framework/doc/content/source/bcs/BoundaryIntegralValueConstraint.md
+++ b/framework/doc/content/source/bcs/BoundaryIntegralValueConstraint.md
@@ -1,0 +1,42 @@
+# BoundaryIntegralValueConstraint
+
+!syntax description /BCs/BoundaryIntegralValueConstraint
+
+## Description
+
+`BoundaryIntegralValueConstraint` enforces
+
+!equation
+\int_{\Gamma} \left(u - \phi_0\right) \, d\Gamma = 0
+
+on a boundary $\Gamma$ using a first-order scalar Lagrange multiplier variable. This makes the
+average value of the finite element variable `u` on the specified `boundary` equal to `phi0`.
+The variable supplied to [!param](/BCs/BoundaryIntegralValueConstraint/lambda) must use
+`family = SCALAR` and `order = FIRST`.
+
+The object assembles both the field-variable equation and the scalar Lagrange multiplier equation,
+so no separate `ScalarKernel` is required for the Lagrange multiplier variable. It is the finite
+element boundary analogue of [FVBoundaryIntegralValueConstraint.md].
+
+!alert warning
+This constraint introduces a saddle-point block with zero diagonal terms. Use a preconditioner that
+includes the field and scalar variables. `SMP` with `full = true` is required for the complete
+off-diagonal Jacobian block structure, and a suitable shift or factorization is typically needed for
+the indefinite matrix.
+
+If `phi0` is supplied as a postprocessor, set its `execute_on` to include `LINEAR` (or `NONLINEAR`)
+so the value is current during residual and Jacobian evaluation.
+
+## Example Input Syntax
+
+The Lagrange multiplier variable is declared as a first-order scalar variable:
+
+!listing test/tests/bcs/boundary_integral_value_constraint/boundary_integral_value_constraint.i block=Variables
+
+!listing test/tests/bcs/boundary_integral_value_constraint/boundary_integral_value_constraint.i block=BCs
+
+!syntax parameters /BCs/BoundaryIntegralValueConstraint
+
+!syntax inputs /BCs/BoundaryIntegralValueConstraint
+
+!syntax children /BCs/BoundaryIntegralValueConstraint

--- a/framework/include/bcs/BoundaryIntegralValueConstraint.h
+++ b/framework/include/bcs/BoundaryIntegralValueConstraint.h
@@ -34,7 +34,6 @@ public:
 protected:
   virtual Real computeQpResidual() override;
   virtual void computeResidual() override;
-  virtual void computeJacobian() override;
   virtual void computeOffDiagJacobian(unsigned int jvar) override;
   virtual void computeOffDiagJacobianScalar(unsigned int jvar) override;
   virtual void computeResidualAndJacobian() override;
@@ -49,7 +48,7 @@ protected:
   void computeFieldScalarJacobian();
 
   /// Compute the Jacobian contribution from the field variable to the Lagrange multiplier equation
-  void computeScalarFieldJacobian(unsigned int jvar);
+  void computeScalarFieldJacobian();
 
   /// The value that the boundary average of the field variable is constrained to
   const PostprocessorValue & _phi0;

--- a/framework/include/bcs/BoundaryIntegralValueConstraint.h
+++ b/framework/include/bcs/BoundaryIntegralValueConstraint.h
@@ -1,0 +1,62 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "IntegratedBC.h"
+
+class MooseVariableScalar;
+
+/**
+ * Enforces the average value of a finite element variable on a boundary using a scalar Lagrange
+ * multiplier.
+ *
+ * This object owns both sides of the saddle-point constraint:
+ * R_u += int_Gamma lambda test_i dGamma and R_lambda += int_Gamma (u - phi0) dGamma.
+ */
+class BoundaryIntegralValueConstraint : public IntegratedBC
+{
+public:
+  static InputParameters validParams();
+
+  BoundaryIntegralValueConstraint(const InputParameters & parameters);
+
+  const MooseVariableScalar & lambdaVariable() const { return _lambda_var; }
+
+  virtual std::set<std::string> additionalROVariables() override;
+
+protected:
+  virtual Real computeQpResidual() override;
+  virtual void computeResidual() override;
+  virtual void computeJacobian() override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
+  virtual void computeOffDiagJacobianScalar(unsigned int jvar) override;
+  virtual void computeResidualAndJacobian() override;
+
+  /// Compute the Lagrange multiplier residual contribution
+  void computeScalarResidual();
+
+  /// Compute the zero diagonal block for the Lagrange multiplier equation
+  void computeScalarJacobian();
+
+  /// Compute the Jacobian contribution from the Lagrange multiplier to the field equation
+  void computeFieldScalarJacobian();
+
+  /// Compute the Jacobian contribution from the field variable to the Lagrange multiplier equation
+  void computeScalarFieldJacobian(unsigned int jvar);
+
+  /// The value that the boundary average of the field variable is constrained to
+  const PostprocessorValue & _phi0;
+
+  /// Lagrange multiplier scalar variable
+  const MooseVariableScalar & _lambda_var;
+
+  /// Lagrange multiplier scalar variable value
+  const VariableValue & _lambda;
+};

--- a/framework/src/bcs/BoundaryIntegralValueConstraint.C
+++ b/framework/src/bcs/BoundaryIntegralValueConstraint.C
@@ -80,13 +80,13 @@ BoundaryIntegralValueConstraint::computeResidualAndJacobian()
 
   if (_is_implicit)
   {
+    prepareShapes(_var.number());
     IntegratedBC::computeJacobian();
     computeScalarJacobian();
 
     // The residual-and-Jacobian-together path bypasses ComputeFullJacobianThread, so assemble the
     // scalar off-diagonal blocks here.
     computeFieldScalarJacobian();
-    prepareShapes(_var.number());
     computeScalarFieldJacobian();
   }
 }

--- a/framework/src/bcs/BoundaryIntegralValueConstraint.C
+++ b/framework/src/bcs/BoundaryIntegralValueConstraint.C
@@ -1,0 +1,166 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "BoundaryIntegralValueConstraint.h"
+
+#include "MooseVariableScalar.h"
+
+#include <array>
+
+registerMooseObject("MooseApp", BoundaryIntegralValueConstraint);
+
+InputParameters
+BoundaryIntegralValueConstraint::validParams()
+{
+  InputParameters params = IntegratedBC::validParams();
+  params.addClassDescription(
+      "Enforces a prescribed average value for a finite element variable on a boundary using a "
+      "scalar Lagrange multiplier.");
+  params.addParam<PostprocessorName>("phi0", "0", "The value that the constraint will enforce.");
+  params.addRequiredCoupledVar("lambda", "Lagrange multiplier scalar variable");
+  return params;
+}
+
+BoundaryIntegralValueConstraint::BoundaryIntegralValueConstraint(const InputParameters & parameters)
+  : IntegratedBC(parameters),
+    _phi0(getPostprocessorValue("phi0")),
+    _lambda_var(*getScalarVar("lambda", 0)),
+    _lambda(coupledScalarValue("lambda"))
+{
+  if (_lambda_var.order() != 1)
+    paramError("lambda", "The lambda variable must be a first-order scalar variable.");
+}
+
+std::set<std::string>
+BoundaryIntegralValueConstraint::additionalROVariables()
+{
+  return {_lambda_var.name()};
+}
+
+Real
+BoundaryIntegralValueConstraint::computeQpResidual()
+{
+  return _lambda[0] * _test[_i][_qp];
+}
+
+void
+BoundaryIntegralValueConstraint::computeResidual()
+{
+  IntegratedBC::computeResidual();
+  computeScalarResidual();
+}
+
+void
+BoundaryIntegralValueConstraint::computeJacobian()
+{
+  // The field equation has no diagonal dependence from this constraint, but we still assemble the
+  // zero block so the matrix structure is complete.
+  IntegratedBC::computeJacobian();
+  computeScalarJacobian();
+}
+
+void
+BoundaryIntegralValueConstraint::computeOffDiagJacobian(const unsigned int jvar)
+{
+  if (jvar == _var.number())
+  {
+    computeJacobian();
+    computeScalarFieldJacobian(jvar);
+  }
+  else
+    IntegratedBC::computeOffDiagJacobian(jvar);
+}
+
+void
+BoundaryIntegralValueConstraint::computeOffDiagJacobianScalar(const unsigned int jvar)
+{
+  if (jvar == _lambda_var.number())
+    computeFieldScalarJacobian();
+}
+
+void
+BoundaryIntegralValueConstraint::computeResidualAndJacobian()
+{
+  computeResidual();
+
+  if (_is_implicit)
+  {
+    computeJacobian();
+    // The residual-and-Jacobian-together path bypasses ComputeFullJacobianThread, so assemble the
+    // scalar off-diagonal blocks here.
+    computeFieldScalarJacobian();
+    computeScalarFieldJacobian(_var.number());
+  }
+}
+
+void
+BoundaryIntegralValueConstraint::computeScalarResidual()
+{
+  mooseAssert(_lambda_var.dofIndices().size() == 1, "The lambda variable should have one dof");
+
+  std::array<Real, 1> residual{{0.0}};
+
+  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    residual[0] += _JxW[_qp] * _coord[_qp] * (_u[_qp] - _phi0);
+
+  addResiduals(_assembly, residual, _lambda_var.dofIndices(), _lambda_var.scalingFactor());
+}
+
+void
+BoundaryIntegralValueConstraint::computeScalarJacobian()
+{
+  mooseAssert(_lambda_var.dofIndices().size() == 1, "The lambda variable should have one dof");
+
+  DenseMatrix<Real> zero(1, 1);
+  addJacobian(_assembly,
+              zero,
+              _lambda_var.dofIndices(),
+              _lambda_var.dofIndices(),
+              _lambda_var.scalingFactor());
+}
+
+void
+BoundaryIntegralValueConstraint::computeFieldScalarJacobian()
+{
+  mooseAssert(_lambda_var.dofIndices().size() == 1, "The lambda variable should have one dof");
+
+  DenseMatrix<Real> jacobian(_test.size(), 1);
+
+  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    for (_i = 0; _i < _test.size(); _i++)
+      jacobian(_i, 0) += _JxW[_qp] * _coord[_qp] * _test[_i][_qp];
+
+  addJacobian(
+      _assembly, jacobian, _var.dofIndices(), _lambda_var.dofIndices(), _var.scalingFactor());
+}
+
+void
+BoundaryIntegralValueConstraint::computeScalarFieldJacobian(const unsigned int jvar)
+{
+  if (jvar != _var.number())
+    return;
+
+  // _phi is bound to the assembly's _phi_face slot, which holds whichever variable was last
+  // prepared. Re-prepare _var so _phi corresponds to _var.
+  prepareShapes(jvar);
+
+  mooseAssert(_lambda_var.dofIndices().size() == 1, "The lambda variable should have one dof");
+
+  DenseMatrix<Real> jacobian(1, _phi.size());
+
+  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    for (_j = 0; _j < _phi.size(); _j++)
+      jacobian(0, _j) += _JxW[_qp] * _coord[_qp] * _phi[_j][_qp];
+
+  addJacobian(_assembly,
+              jacobian,
+              _lambda_var.dofIndices(),
+              _var.dofIndices(),
+              _lambda_var.scalingFactor());
+}

--- a/framework/src/bcs/BoundaryIntegralValueConstraint.C
+++ b/framework/src/bcs/BoundaryIntegralValueConstraint.C
@@ -57,31 +57,20 @@ BoundaryIntegralValueConstraint::computeResidual()
 }
 
 void
-BoundaryIntegralValueConstraint::computeJacobian()
-{
-  // The field equation has no diagonal dependence from this constraint, but we still assemble the
-  // zero block so the matrix structure is complete.
-  IntegratedBC::computeJacobian();
-  computeScalarJacobian();
-}
-
-void
 BoundaryIntegralValueConstraint::computeOffDiagJacobian(const unsigned int jvar)
 {
   if (jvar == _var.number())
-  {
-    computeJacobian();
-    computeScalarFieldJacobian(jvar);
-  }
-  else
-    IntegratedBC::computeOffDiagJacobian(jvar);
+    computeScalarFieldJacobian();
 }
 
 void
 BoundaryIntegralValueConstraint::computeOffDiagJacobianScalar(const unsigned int jvar)
 {
   if (jvar == _lambda_var.number())
+  {
+    computeScalarJacobian();
     computeFieldScalarJacobian();
+  }
 }
 
 void
@@ -91,11 +80,14 @@ BoundaryIntegralValueConstraint::computeResidualAndJacobian()
 
   if (_is_implicit)
   {
-    computeJacobian();
+    IntegratedBC::computeJacobian();
+    computeScalarJacobian();
+
     // The residual-and-Jacobian-together path bypasses ComputeFullJacobianThread, so assemble the
     // scalar off-diagonal blocks here.
     computeFieldScalarJacobian();
-    computeScalarFieldJacobian(_var.number());
+    prepareShapes(_var.number());
+    computeScalarFieldJacobian();
   }
 }
 
@@ -141,15 +133,8 @@ BoundaryIntegralValueConstraint::computeFieldScalarJacobian()
 }
 
 void
-BoundaryIntegralValueConstraint::computeScalarFieldJacobian(const unsigned int jvar)
+BoundaryIntegralValueConstraint::computeScalarFieldJacobian()
 {
-  if (jvar != _var.number())
-    return;
-
-  // _phi is bound to the assembly's _phi_face slot, which holds whichever variable was last
-  // prepared. Re-prepare _var so _phi corresponds to _var.
-  prepareShapes(jvar);
-
   mooseAssert(_lambda_var.dofIndices().size() == 1, "The lambda variable should have one dof");
 
   DenseMatrix<Real> jacobian(1, _phi.size());

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -3790,6 +3790,13 @@ NonlinearSystemBase::checkKernelCoverage(const std::set<SubdomainID> & mesh_subd
         kernel_variables.insert(scalar_fvbc->lambdaVariable().name());
   }
 
+  for (const auto & ibc : _integrated_bcs.getActiveObjects())
+  {
+    const auto additional_variables_covered = ibc->additionalROVariables();
+    kernel_variables.insert(additional_variables_covered.begin(),
+                            additional_variables_covered.end());
+  }
+
   // Check kernel coverage of subdomains (blocks) in your mesh
   if (!global_kernels_exist)
   {

--- a/modules/solid_mechanics/test/tests/boundary_integral_value_constraint/boundary_integral_value_constraint.i
+++ b/modules/solid_mechanics/test/tests/boundary_integral_value_constraint/boundary_integral_value_constraint.i
@@ -1,0 +1,129 @@
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+  nx = 4
+  ny = 4
+  elem_type = QUAD4
+[]
+
+[Variables]
+  [lambda_left_x]
+    family = SCALAR
+    order = FIRST
+  []
+  [lambda_bottom_x]
+    family = SCALAR
+    order = FIRST
+  []
+  [lambda_bottom_y]
+    family = SCALAR
+    order = FIRST
+  []
+  [lambda_top_y]
+    family = SCALAR
+    order = FIRST
+  []
+[]
+
+[Physics/SolidMechanics/QuasiStatic]
+  [all]
+    strain = SMALL
+    planar_formulation = PLANE_STRAIN
+    add_variables = true
+  []
+[]
+
+[BCs]
+  [left_x_average]
+    type = BoundaryIntegralValueConstraint
+    variable = disp_x
+    boundary = left
+    lambda = lambda_left_x
+  []
+  [bottom_x_average]
+    type = BoundaryIntegralValueConstraint
+    variable = disp_x
+    boundary = bottom
+    lambda = lambda_bottom_x
+  []
+  [bottom_y_average]
+    type = BoundaryIntegralValueConstraint
+    variable = disp_y
+    boundary = bottom
+    lambda = lambda_bottom_y
+  []
+  [top_y_average]
+    type = BoundaryIntegralValueConstraint
+    variable = disp_y
+    boundary = top
+    lambda = lambda_top_y
+    phi0 = 1e-3
+  []
+[]
+
+[Materials]
+  [elasticity_tensor]
+    type = ComputeIsotropicElasticityTensor
+    youngs_modulus = 1e6
+    poissons_ratio = 0.25
+  []
+  [stress]
+    type = ComputeLinearElasticStress
+  []
+[]
+
+[Postprocessors]
+  [left_x_average]
+    type = SideAverageValue
+    variable = disp_x
+    boundary = left
+    execute_on = timestep_end
+  []
+  [bottom_x_average]
+    type = SideAverageValue
+    variable = disp_x
+    boundary = bottom
+    execute_on = timestep_end
+  []
+  [bottom_y_average]
+    type = SideAverageValue
+    variable = disp_y
+    boundary = bottom
+    execute_on = timestep_end
+  []
+  [top_y_average]
+    type = SideAverageValue
+    variable = disp_y
+    boundary = top
+    execute_on = timestep_end
+  []
+[]
+
+[Preconditioning]
+  [full]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+  nl_abs_tol = 1e-12
+  nl_rel_tol = 1e-12
+  petsc_options_iname = '-pc_type -pc_factor_shift_type'
+  petsc_options_value = 'lu       NONZERO'
+[]
+
+[Outputs]
+  csv = true
+  hide = 'lambda_left_x lambda_bottom_x lambda_bottom_y lambda_top_y'
+[]

--- a/modules/solid_mechanics/test/tests/boundary_integral_value_constraint/gold/boundary_integral_value_constraint_out.csv
+++ b/modules/solid_mechanics/test/tests/boundary_integral_value_constraint/gold/boundary_integral_value_constraint_out.csv
@@ -1,0 +1,3 @@
+time,bottom_x_average,bottom_y_average,left_x_average,top_y_average
+0,0,0,0,0
+1,0,6.7762635780344e-21,0,0.001

--- a/modules/solid_mechanics/test/tests/boundary_integral_value_constraint/tests
+++ b/modules/solid_mechanics/test/tests/boundary_integral_value_constraint/tests
@@ -1,0 +1,23 @@
+[Tests]
+  issues = '#32963'
+  design = 'source/bcs/BoundaryIntegralValueConstraint.md'
+
+  [mechanics_average_value]
+    type = CSVDiff
+    input = 'boundary_integral_value_constraint.i'
+    csvdiff = 'boundary_integral_value_constraint_out.csv'
+    abs_zero = 1e-12
+    requirement = 'The system shall enforce prescribed boundary average displacement values in a solid mechanics solve using scalar Lagrange multipliers.'
+  []
+
+  [jacobian]
+    type = PetscJacobianTester
+    input = 'boundary_integral_value_constraint.i'
+    ratio_tol = 1e-8
+    difference_tol = 1e-5
+    run_sim = True
+    cli_args = 'Outputs/csv=false'
+    prereq = mechanics_average_value
+    requirement = 'The system shall compute the complete saddle-point Jacobian for boundary average constraints on displacement fields.'
+  []
+[]

--- a/test/tests/bcs/boundary_integral_value_constraint/boundary_integral_value_constraint.i
+++ b/test/tests/bcs/boundary_integral_value_constraint/boundary_integral_value_constraint.i
@@ -1,0 +1,89 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+  nx = 4
+  ny = 4
+  elem_type = QUAD4
+[]
+
+[Variables]
+  [u]
+  []
+  [lambda_left]
+    family = SCALAR
+    order = FIRST
+  []
+  [lambda_bottom]
+    family = SCALAR
+    order = FIRST
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+  [source]
+    type = BodyForce
+    variable = u
+    value = 1
+  []
+[]
+
+[BCs]
+  [left_average]
+    type = BoundaryIntegralValueConstraint
+    variable = u
+    boundary = left
+    lambda = lambda_left
+    phi0 = 0.25
+  []
+  [bottom_average]
+    type = BoundaryIntegralValueConstraint
+    variable = u
+    boundary = bottom
+    lambda = lambda_bottom
+    phi0 = 0.5
+  []
+[]
+
+[Postprocessors]
+  [left_average]
+    type = SideAverageValue
+    variable = u
+    boundary = left
+    execute_on = timestep_end
+  []
+  [bottom_average]
+    type = SideAverageValue
+    variable = u
+    boundary = bottom
+    execute_on = timestep_end
+  []
+[]
+
+[Preconditioning]
+  [full]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+  nl_abs_tol = 1e-12
+  nl_rel_tol = 1e-12
+  petsc_options_iname = '-pc_type -pc_factor_shift_type'
+  petsc_options_value = 'lu       NONZERO'
+[]
+
+[Outputs]
+  csv = true
+  hide = 'lambda_left lambda_bottom'
+[]

--- a/test/tests/bcs/boundary_integral_value_constraint/gold/boundary_integral_value_constraint_out.csv
+++ b/test/tests/bcs/boundary_integral_value_constraint/gold/boundary_integral_value_constraint_out.csv
@@ -1,0 +1,3 @@
+time,bottom_average,left_average
+0,0,0
+1,0.5,0.25

--- a/test/tests/bcs/boundary_integral_value_constraint/gold/boundary_integral_value_constraint_rj_out.csv
+++ b/test/tests/bcs/boundary_integral_value_constraint/gold/boundary_integral_value_constraint_rj_out.csv
@@ -1,0 +1,3 @@
+time,bottom_average,left_average
+0,0,0
+1,0.5,0.25

--- a/test/tests/bcs/boundary_integral_value_constraint/tests
+++ b/test/tests/bcs/boundary_integral_value_constraint/tests
@@ -6,7 +6,6 @@
     type = CSVDiff
     input = 'boundary_integral_value_constraint.i'
     csvdiff = 'boundary_integral_value_constraint_out.csv'
-    abs_zero = 1e-12
     requirement = 'The system shall enforce prescribed finite element boundary average values using scalar Lagrange multipliers.'
   []
 
@@ -15,7 +14,6 @@
     input = 'boundary_integral_value_constraint.i'
     cli_args = 'Executioner/residual_and_jacobian_together=true Outputs/file_base=boundary_integral_value_constraint_rj_out'
     csvdiff = 'boundary_integral_value_constraint_rj_out.csv'
-    abs_zero = 1e-12
     requirement = 'The system shall enforce prescribed finite element boundary average values when computing the residual and Jacobian together.'
   []
 

--- a/test/tests/bcs/boundary_integral_value_constraint/tests
+++ b/test/tests/bcs/boundary_integral_value_constraint/tests
@@ -1,0 +1,43 @@
+[Tests]
+  issues = '#32963'
+  design = 'source/bcs/BoundaryIntegralValueConstraint.md'
+
+  [average_value]
+    type = CSVDiff
+    input = 'boundary_integral_value_constraint.i'
+    csvdiff = 'boundary_integral_value_constraint_out.csv'
+    abs_zero = 1e-12
+    requirement = 'The system shall enforce prescribed finite element boundary average values using scalar Lagrange multipliers.'
+  []
+
+  [residual_and_jacobian_together]
+    type = CSVDiff
+    input = 'boundary_integral_value_constraint.i'
+    cli_args = 'Executioner/residual_and_jacobian_together=true Outputs/file_base=boundary_integral_value_constraint_rj_out'
+    csvdiff = 'boundary_integral_value_constraint_rj_out.csv'
+    abs_zero = 1e-12
+    requirement = 'The system shall enforce prescribed finite element boundary average values when computing the residual and Jacobian together.'
+  []
+
+  [jacobian]
+    type = PetscJacobianTester
+    input = 'boundary_integral_value_constraint.i'
+    ratio_tol = 1e-8
+    difference_tol = 1e-7
+    run_sim = True
+    cli_args = 'Outputs/csv=false'
+    prereq = average_value
+    requirement = 'The system shall compute the complete saddle-point Jacobian for finite element boundary average constraints.'
+  []
+
+  [jacobian_residual_and_jacobian_together]
+    type = PetscJacobianTester
+    input = 'boundary_integral_value_constraint.i'
+    ratio_tol = 1e-8
+    difference_tol = 1e-7
+    run_sim = True
+    cli_args = 'Executioner/residual_and_jacobian_together=true Outputs/csv=false'
+    prereq = residual_and_jacobian_together
+    requirement = 'The system shall compute the complete saddle-point Jacobian for finite element boundary average constraints when computing the residual and Jacobian together.'
+  []
+[]


### PR DESCRIPTION

closes #32963

## Reason

This adds a finite element analogue of `FVBoundaryIntegralValueConstraint`.


This constraint can be viewed as adding a scalar Lagrange multiplier term to the variational functional:

$$ \mathcal{L}(u,\lambda) = \mathcal{J}(u) + \int_{\Gamma} \lambda \left(u - \phi_0\right) d\Gamma . $$

Here $u$ is the finite element field variable being constrained, $\phi_0$ is the prescribed target boundary-average value, $\Gamma$ is the constrained boundary, $\lambda$ is the scalar Lagrange multiplier, and $\mathcal{J}(u)$ represents the original problem functional before adding the constraint.

For interpretation, the scalar Lagrange multiplier $\lambda$ represents the uniform boundary loading needed to enforce the average value constraint. In mechanics, where $u$ is displacement, $\lambda$ is the uniform traction on the boundary. In heat conduction, where $u$ is temperature, $\lambda$ is the uniform boundary source/flux needed to enforce the prescribed average temperature.

The new `BoundaryIntegralValueConstraint` lets users enforce a prescribed average value of a finite
element variable on a boundary using one scalar Lagrange multiplier variable, instead of building
this constraint from multiple objects.

Before this change, the closest built-in capability was the finite volume
`FVBoundaryIntegralValueConstraint`. Related FE objects cover domain-average constraints or other
Lagrange-multiplier constraints, but not a single FE `[BCs]` object that enforces
`int_Gamma (u - phi0) dGamma = 0` on a sideset.

## Example
Hyperelastic material block with the boundary integral value constraint enforced on the right boundary and a load applied on a part of the right boundary. 
<img width="1100" height="720" alt="andreas_test_schematic" src="https://github.com/user-attachments/assets/00828338-884d-426e-bebc-0cac57e74f80" />

https://github.com/user-attachments/assets/92985f21-c6ce-46db-84da-288de5d5bc01

## Design

Added `BoundaryIntegralValueConstraint` as a framework `[BCs]` object deriving from `IntegratedBC`.

The object enforces

```
int_Gamma (u - phi0) dGamma = 0
```

by assembling both sides of the saddle-point system:

- `R_u += int_Gamma lambda test_i dGamma`
- `R_lambda += int_Gamma (u - phi0) dGamma`
- `dR_u/dlambda`
- `dR_lambda/du`
- the zero scalar diagonal block needed for complete matrix structure

The coupled `lambda` variable is required to be a first-order scalar variable:

```
[Variables]
  [lambda_left]
    family = SCALAR
    order = FIRST
  []
[]
```

The object reports the scalar Lagrange multiplier through `additionalROVariables()`, and
`NonlinearSystemBase::checkKernelCoverage()` now consumes additional variables from integrated BCs
generically. This avoids coupling the system code to this concrete BC and lets future integrated BCs
register similar scalar variables through the existing `ResidualObject` hook.

The residual-and-Jacobian-together path explicitly assembles the scalar off-diagonal blocks because
that path bypasses `ComputeFullJacobianThread`.

Added documentation and tests for:

- nonzero prescribed FE boundary averages
- multiple boundary faces
- standard and residual-and-Jacobian-together assembly paths
- PETSc Jacobian checking
- a solid mechanics displacement constraint example

## Existing objects checked

I checked the framework and module BCs and the related scalar/FV constraint objects. No existing FE
boundary condition provides this exact behavior for a standard FE variable.

The similar and related objects are:

- `FVBoundaryIntegralValueConstraint`: finite volume boundary-average analogue. This PR adds the FE
  counterpart.
- `INSFVAveragePressureValueBC`: Navier-Stokes finite volume pressure-average specialization based
  on `FVBoundaryIntegralValueConstraint`.
- `FVIntegralValueConstraint`: finite volume domain-average constraint, not a boundary FE BC.
- `AverageValueConstraint` plus `ScalarLagrangeMultiplier`: finite element domain-average
  constraint assembled through separate kernel/scalar-kernel objects, not a boundary-average BC.
- `OneDEqualValueConstraintBC`, `HFEMDirichletBC`, lower-dimensional BCs, and mortar constraints:
  Lagrange-multiplier-related FE boundary/interface constraints, but not a prescribed average over a
  sideset.

## Review notes

The comments in `BoundaryIntegralValueConstraint` call out the two non-obvious implementation
points:

- the object owns both equations in the saddle-point constraint
- the residual-and-Jacobian-together path needs explicit scalar off-diagonal block assembly because
  it does not use `ComputeFullJacobianThread`

The zero scalar diagonal block is intentionally assembled to keep the matrix structure complete.

## Impact

This adds a new public framework BC:

```
type = BoundaryIntegralValueConstraint
```

No existing input files or APIs are changed.

`NonlinearSystemBase::checkKernelCoverage()` now generically consumes
`additionalROVariables()` from active integrated BCs. Existing BCs do not report additional
variables, so this does not change their behavior.

Users must provide a scalar Lagrange multiplier variable with `family = SCALAR` and
`order = FIRST`. Because the constraint creates a saddle-point block, users also need a
preconditioner that includes the field and scalar variables; the documentation recommends `SMP` with
`full = true`.
