### PR TITLE
Improve early VectorPostprocessor getter diagnostics

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4883,7 +4883,16 @@ FEProblemBase::getVectorPostprocessorObjectByName(const std::string & object_nam
       .queryInto(objs);
 
   if (objs.empty())
+  {
+    mooseAssert(
+        getMooseApp().actionWarehouse().isTaskComplete("add_vector_postprocessor"),
+        "A VectorPostprocessor getter was called before VectorPostprocessors have been "
+        "constructed. The requested VectorPostprocessor '" +
+            object_name +
+            "' may exist in the input file, but VectorPostprocessors are not available yet.");
+
     mooseError("Unable to find VectorPostprocessor with name '", object_name, "'");
+  }
   mooseAssert(objs.size() == 1,
               "We shouldn't find more than one vector postprocessor object for a given name");
   return *(objs[0]);

--- a/test/src/userobjects/VectorPostprocessorInterfaceErrorTest.C
+++ b/test/src/userobjects/VectorPostprocessorInterfaceErrorTest.C
@@ -34,6 +34,10 @@ VectorPostprocessorInterfaceErrorTest::validParams()
   params.addParam<bool>(
       "has_early_by_name", false, "Test the error for seeing if a vpp exists by name too early");
 
+  params.addParam<bool>("call_getter_too_early",
+                        false,
+                        "Test the error for querying a VPP from the problem too early");
+
   params.addParam<bool>(
       "missing_vpp",
       false,
@@ -70,6 +74,8 @@ VectorPostprocessorInterfaceErrorTest::VectorPostprocessorInterfaceErrorTest(
     hasVectorPostprocessor("vpp");
   if (getParam<bool>("has_early_by_name"))
     hasVectorPostprocessorByName("vpp");
+  if (getParam<bool>("call_getter_too_early"))
+    isVectorPostprocessorDistributed("vpp");
 }
 
 void

--- a/test/tests/problems/getter_too_early/get_vector_postprocessor_too_early.i
+++ b/test/tests/problems/getter_too_early/get_vector_postprocessor_too_early.i
@@ -1,0 +1,36 @@
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 1
+    nx = 1
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[UserObjects]
+  [test]
+    type = VectorPostprocessorInterfaceErrorTest
+    vpp = constant_vpp
+    call_getter_too_early = true
+  []
+[]
+
+[VectorPostprocessors]
+  [constant_vpp]
+    type = ConstantVectorPostprocessor
+    vector_names = 'value'
+    value = '1'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 0
+[]
+
+[Outputs]
+  console = false
+[]

--- a/test/tests/problems/getter_too_early/tests
+++ b/test/tests/problems/getter_too_early/tests
@@ -18,4 +18,13 @@
     requirement = 'The system shall assert that a UserObject getter was called too early when a UserObject is requested before UserObjects have been constructed.'
     issues = '#28131'
   []
+
+  [get_vector_postprocessor_too_early]
+    type = RunException
+    input = get_vector_postprocessor_too_early.i
+    capabilities = 'method=dbg'
+    expect_err = "A VectorPostprocessor getter was called before VectorPostprocessors have been constructed"
+    requirement = 'The system shall assert that a VectorPostprocessor getter was called too early when a VectorPostprocessor is requested before VectorPostprocessors have been constructed.'
+    issues = '#28131'
+  []
 []


### PR DESCRIPTION
Refs #28131

Reason

This is a follow-up to #32907, which improved early getter diagnostics for the Function and UserObject getter paths and intentionally left VPP handling for a follow-up.

This PR handles the VectorPostprocessor object getter path. Previously, when a VectorPostprocessor was defined in the input file but requested before the add_vector_postprocessor task completed, MOOSE could report:

Unable to find VectorPostprocessor with name 'constant_vpp'

That message is misleading for this construction-order case because the VectorPostprocessor may exist in the input file but has not been constructed yet.

Design

This adds a debug assertion to the central non-inline VectorPostprocessor object getter:

FEProblemBase::getVectorPostprocessorObjectByName(...)

When the warehouse lookup finds no VectorPostprocessor object and add_vector_postprocessor is not complete, the getter now asserts with a clearer too-early diagnostic. The existing runtime missing-object error is preserved for cases where VectorPostprocessors have already been constructed.

The regression test uses VectorPostprocessorInterfaceErrorTest. A new test option calls isVectorPostprocessorDistributed("vpp") during UserObject construction. This routes through:

VectorPostprocessorInterface::isVectorPostprocessorDistributed(...)
VectorPostprocessorInterface::isVectorPostprocessorDistributedByName(...)
FEProblemBase::getVectorPostprocessorObjectByName(...)

The test input defines the requested VectorPostprocessor later in [VectorPostprocessors], reproducing the too-early object lookup.

I also checked the surrounding VectorPostprocessor getter paths before limiting the fix to this location:

1. getVectorPostprocessorObjectByName(...) is the central object lookup used by VectorPostprocessorInterface, outputs, CombinedVectorPostprocessor, and stochastic tools callers.
2. Other direct warehouse queries for VectorPostprocessor objects are in VectorPostprocessorInterface::hasVectorPostprocessorByName(...), which already has an explicit too-early guard.
3. The possiblyCheckHasVectorPostprocessor... paths intentionally skip validation before VectorPostprocessors are added and only report normal missing-VPP or missing-vector errors after construction.
4. The value getter paths, such as getVectorPostprocessorValueByName(...), go through ReporterData; a valid early value-getter reproducer did not fail and appears to be handled differently from the object getter path.
5. Other VectorPostprocessor-related mooseError messages found in transfer/output code were size or usage checks, not central object lookup “not found” errors.

Tests run:

METHOD=dbg ./run_tests -j 8 --re='getter_too_early'
METHOD=dbg ./run_tests -j 8 --re='vectorpostprocessorinterface|vector_postprocessor_interface'
Impact

No API changes.

In debug/assert-enabled builds, calling the VectorPostprocessor object getter before VectorPostprocessors have been constructed now produces a clearer assertion explaining the construction-order problem.

Optimized/user builds preserve the existing runtime missing-object behavior.