### PR TITLE
Catch NaN/Inf in CSV(Diff) outputs

### DIFF
--- a/modules/fluid_properties/test/tests/temperature_pressure_function/tests
+++ b/modules/fluid_properties/test/tests/temperature_pressure_function/tests
@@ -6,6 +6,7 @@
     input = 'exact.i'
     csvdiff = 'exact_out.csv'
     abs_zero = 1e-9
+    ignore_columns = cp_avg
     requirement = 'The system shall be able to compute functionalized fluid properties.'
   []
   [example]

--- a/modules/stochastic_tools/test/tests/multiapps/batch_sampler_transient_multiapp/parent_transient.i
+++ b/modules/stochastic_tools/test/tests/multiapps/batch_sampler_transient_multiapp/parent_transient.i
@@ -47,6 +47,7 @@
     sampler = mc
     to_vector_postprocessor = storage
     from_postprocessor = average
+    keep_solve_fail_value = true
   []
 []
 

--- a/modules/stochastic_tools/test/tests/vectorpostprocessors/stochastic_results_complete_history/parent.i
+++ b/modules/stochastic_tools/test/tests/vectorpostprocessors/stochastic_results_complete_history/parent.i
@@ -46,6 +46,7 @@
     sampler = sample
     to_vector_postprocessor = storage
     from_postprocessor = avg
+    keep_solve_fail_value = true
   []
 []
 

--- a/python/mooseutils/csvdiff.py
+++ b/python/mooseutils/csvdiff.py
@@ -375,19 +375,14 @@ class CSVDiffer(CSVTools):
                 if abs(val2) < abs_zero:
                     val2 = 0
 
-                # disallow nan in the gold file
-                if math.isnan(val1):
-                    self.addError(
-                        self.files[0],
-                        'The values in column "' + key.strip() + '" contain NaN',
-                    )
+                # disallow nan and inf in both files
+                ne = self.getNumErrors()
+                for f, v in [(self.files[0], val1), (self.files[1], val2)]:
+                    if not math.isfinite(v):
+                        self.addError(f, f'Column "{key.strip()}" has NaN/Inf value(s)')
 
-                # disallow inf in the gold file
-                if math.isinf(val1):
-                    self.addError(
-                        self.files[0],
-                        'The values in column "' + key.strip() + '" contain Inf',
-                    )
+                if self.getNumErrors() != ne:
+                    break
 
                 # if they're both exactly zero (due to the threshold above) then they're equal so pass this test
                 if val1 == 0 and val2 == 0:


### PR DESCRIPTION
## Reason
If the code changes such that the result of a CSVDiff test is now NaN, the test harness will happily give it a pass.

## Design
In addition to disallowing NaN/Inf in the gold .csv, we now also disallow those values in the test output file.

## Impact
Preventing regressions.
