### PR TITLE
Couple more tweaks to moose.mk for MacOS

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -557,7 +557,7 @@ moose: wasp_submodule_status $(moose_revision_header) $(moose_LIB) $(MOOSE_KOKKO
 # the output because they are printed many times
 CHECK_PROCESS_SUBSTITUTION := $(shell bash -c 'echo hello > >(cat)')
 ifeq ($(CHECK_PROCESS_SUBSTITUTION),hello)
-  SILENCE_SOME_WARNINGS = 1> >(cat >&1) 2> >(grep -Ev "could not create compact unwind for|duplicate -rpath" >&2)
+  SILENCE_SOME_WARNINGS = 1> >(cat >&1) 2> >(grep -Ev "could not create compact unwind for|duplicate -rpath|^(ld: warning: )+[[:space:]]*$$|^$$" >&2)
 endif
 
 # [JWP] With libtool, there is only one link command, it should work whether you are creating


### PR DESCRIPTION
My previous changes seem to have led to erasing a bunch of warning output ... leaving blank lines in their place. That's not a whole lot better IMO. These regexes should stop that based off my testing

Refs #31412