### PR TITLE
Improve early MultiApp getter diagnostics

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5795,6 +5795,12 @@ FEProblemBase::hasMultiApp(const std::string & multi_app_name) const
 std::shared_ptr<MultiApp>
 FEProblemBase::getMultiApp(const std::string & multi_app_name) const
 {
+  if (!hasMultiApp(multi_app_name))
+    mooseAssert(getMooseApp().actionWarehouse().isTaskComplete("add_multi_app"),
+                "A MultiApp getter was called before MultiApps have been constructed. "
+                "If you are attempting to access this object in the constructor of another object "
+                "then make sure that the MultiApp is constructed before the object using it.");
+
   return _multi_apps.getObject(multi_app_name);
 }
 

--- a/test/src/problems/GetterTooEarlyProblem.C
+++ b/test/src/problems/GetterTooEarlyProblem.C
@@ -12,9 +12,10 @@ GetterTooEarlyProblem::validParams()
 {
   InputParameters params = FEProblem::validParams();
   params.addRequiredParam<MooseEnum>(
-      "getter", MooseEnum("function user_object"), "The getter to call too early");
+      "getter", MooseEnum("function user_object multi_app"), "The getter to call too early");
   params.addParam<FunctionName>("function", "Function to request too early");
   params.addParam<UserObjectName>("user_object", "UserObject to request too early");
+  params.addParam<MultiAppName>("multi_app", "MultiApp to request too early");
   return params;
 }
 
@@ -27,4 +28,6 @@ GetterTooEarlyProblem::GetterTooEarlyProblem(const InputParameters & params)
     _function = &getFunction(getParam<FunctionName>("function"));
   else if (getter == "user_object")
     _user_object = &getUserObjectBase(getParam<UserObjectName>("user_object"));
+  else if (getter == "multi_app")
+    static_cast<void>(getMultiApp(getParam<MultiAppName>("multi_app")));
 }

--- a/test/tests/problems/getter_too_early/get_multiapp_too_early.i
+++ b/test/tests/problems/getter_too_early/get_multiapp_too_early.i
@@ -1,0 +1,51 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  []
+[]
+
+[Problem]
+  type = GetterTooEarlyProblem
+  getter = multi_app
+  multi_app = sub
+[]
+
+[MultiApps]
+  [sub]
+    type = TransientMultiApp
+    input_files = 'unused_sub.i'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+  dt = 1
+[]

--- a/test/tests/problems/getter_too_early/tests
+++ b/test/tests/problems/getter_too_early/tests
@@ -27,4 +27,13 @@
     requirement = 'The system shall assert that a VectorPostprocessor getter was called too early when a VectorPostprocessor is requested before VectorPostprocessors have been constructed.'
     issues = '#28131'
   []
+
+  [get_multiapp_too_early]
+    type = RunException
+    input = get_multiapp_too_early.i
+    capabilities = 'method=dbg'
+    expect_err = "A MultiApp getter was called before MultiApps have been constructed"
+    requirement = "The system shall assert that a MultiApp getter was called too early when a MultiApp is requested before MultiApps have been constructed."
+    issues = '#28131'
+  []
 []

--- a/test/tests/problems/getter_too_early/unused_sub.i
+++ b/test/tests/problems/getter_too_early/unused_sub.i
@@ -1,0 +1,38 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  []
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+  dt = 1
+[]


### PR DESCRIPTION
refs #28131

## Reason
Calling `FEProblemBase::getMultiApp()` before MultiApps have been constructed currently falls through to the generic warehouse missing-object error. In debug builds, this can make a developer timing issue look like a genuinely missing MultiApp. This PR improves the diagnostic so constructor-time or otherwise too-early MultiApp getter calls are reported more clearly.

## Design
This adds a debug-mode assertion in `FEProblemBase::getMultiApp()` when the requested MultiApp is not currently active and the `add_multi_app` task has not completed.

## Additional comment
hasMultiApp() checks whether the named MultiApp is active via hasActiveObject(), while getMultiApp() ultimately retrieves from the warehouse with getObject(). This PR does not change that existing distinction; it only uses hasMultiApp() as a guard to distinguish “getter called too early” from “object actually missing.”

The normal lookup still delegates to the existing warehouse call:

```cpp
return _multi_apps.getObject(multi_app_name);
