### PR TITLE
Improve early Distribution and Sampler getter diagnostics (#28131)

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -2846,7 +2846,13 @@ FEProblemBase::getDistribution(const std::string & name)
       .condition<AttribName>(name)
       .queryInto(objs);
   if (objs.empty())
+  {
+    mooseAssert(getMooseApp().actionWarehouse().isTaskComplete("add_distribution"),
+                "A Distribution getter was called before Distributions have been constructed. "
+                "If you are attempting to access this object in the constructor of another object "
+                "then make sure that the Distribution is constructed before the object using it.");
     mooseError("Unable to find Distribution with name '" + name + "'");
+  }
   return *(objs[0]);
 }
 
@@ -2871,10 +2877,17 @@ FEProblemBase::getSampler(const std::string & name, const THREAD_ID tid)
       .condition<AttribName>(name)
       .queryInto(objs);
   if (objs.empty())
+  {
+    mooseAssert(getMooseApp().actionWarehouse().isTaskComplete("add_sampler"),
+                "A Sampler getter was called before Samplers have been constructed. "
+                "If you are attempting to access this object in the constructor of another object "
+                "then make sure that the Sampler is constructed before the object using it.");
+
     mooseError(
         "Unable to find Sampler with name '" + name +
         "', if you are attempting to access this object in the constructor of another object then "
-        "the object being retrieved must occur prior to the caller within the input file.");
+        "make sure that the Sampler is constructed before the object using it.");
+  }
   return *(objs[0]);
 }
 

--- a/test/include/distributions/TestDistribution.h
+++ b/test/include/distributions/TestDistribution.h
@@ -1,0 +1,24 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Distribution.h"
+
+class TestDistribution : public Distribution
+{
+public:
+  static InputParameters validParams();
+
+  TestDistribution(const InputParameters & parameters);
+
+  virtual Real pdf(const Real & x) const override;
+  virtual Real cdf(const Real & x) const override;
+  virtual Real quantile(const Real & y) const override;
+};

--- a/test/src/distributions/TestDistribution.C
+++ b/test/src/distributions/TestDistribution.C
@@ -1,0 +1,39 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "TestDistribution.h"
+
+registerMooseObject("MooseTestApp", TestDistribution);
+
+InputParameters
+TestDistribution::validParams()
+{
+  InputParameters params = Distribution::validParams();
+  return params;
+}
+
+TestDistribution::TestDistribution(const InputParameters & parameters) : Distribution(parameters) {}
+
+Real
+TestDistribution::pdf(const Real & /* x */) const
+{
+  return 1.0;
+}
+
+Real
+TestDistribution::cdf(const Real & x) const
+{
+  return x;
+}
+
+Real
+TestDistribution::quantile(const Real & y) const
+{
+  return y;
+}

--- a/test/src/problems/GetterTooEarlyProblem.C
+++ b/test/src/problems/GetterTooEarlyProblem.C
@@ -12,10 +12,14 @@ GetterTooEarlyProblem::validParams()
 {
   InputParameters params = FEProblem::validParams();
   params.addRequiredParam<MooseEnum>(
-      "getter", MooseEnum("function user_object multi_app"), "The getter to call too early");
+      "getter",
+      MooseEnum("function user_object multi_app distribution sampler"),
+      "The getter to call too early");
   params.addParam<FunctionName>("function", "Function to request too early");
   params.addParam<UserObjectName>("user_object", "UserObject to request too early");
   params.addParam<MultiAppName>("multi_app", "MultiApp to request too early");
+  params.addParam<DistributionName>("distribution", "Distribution to request too early");
+  params.addParam<SamplerName>("sampler", "Sampler to request too early");
   return params;
 }
 
@@ -30,4 +34,8 @@ GetterTooEarlyProblem::GetterTooEarlyProblem(const InputParameters & params)
     _user_object = &getUserObjectBase(getParam<UserObjectName>("user_object"));
   else if (getter == "multi_app")
     static_cast<void>(getMultiApp(getParam<MultiAppName>("multi_app")));
+  else if (getter == "distribution")
+    static_cast<void>(getDistribution(getParam<DistributionName>("distribution")));
+  else if (getter == "sampler")
+    static_cast<void>(getSampler(getParam<SamplerName>("sampler")));
 }

--- a/test/tests/problems/getter_too_early/get_distribution_sampler_too_early.i
+++ b/test/tests/problems/getter_too_early/get_distribution_sampler_too_early.i
@@ -1,0 +1,55 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  []
+[]
+
+[Problem]
+  type = GetterTooEarlyProblem
+  getter = distribution
+  distribution = dist
+  sampler = sample
+[]
+
+[Distributions]
+  [dist]
+    type = TestDistribution
+  []
+[]
+
+[Samplers]
+  [sample]
+    type = TestSampler
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/problems/getter_too_early/tests
+++ b/test/tests/problems/getter_too_early/tests
@@ -1,12 +1,11 @@
 [Tests]
-  design = 'source/problems/FEProblemBase.md'
-
+  design = 'problems/FEProblemBase.md'
   [get_function_too_early]
     type = RunException
     input = get_function_too_early.i
     capabilities = 'method=dbg'
     expect_err = 'getFunction\(\) was called before Functions have been constructed'
-    requirement = 'The system shall assert that getFunction() was called too early when a Function is requested before Functions have been constructed.'
+    requirement = 'The system shall report an error when a function object is requested before function objects are available.'
     issues = '#28131'
   []
 
@@ -14,8 +13,8 @@
     type = RunException
     input = get_user_object_too_early.i
     capabilities = 'method=dbg'
-    expect_err = "A UserObject getter was called before UserObjects have been constructed"
-    requirement = 'The system shall assert that a UserObject getter was called too early when a UserObject is requested before UserObjects have been constructed.'
+    expect_err = 'A UserObject getter was called before UserObjects have been constructed'
+    requirement = 'The system shall report an error when a user object is requested before user objects are available.'
     issues = '#28131'
   []
 
@@ -23,8 +22,8 @@
     type = RunException
     input = get_vector_postprocessor_too_early.i
     capabilities = 'method=dbg'
-    expect_err = "A VectorPostprocessor getter was called before VectorPostprocessors have been constructed"
-    requirement = 'The system shall assert that a VectorPostprocessor getter was called too early when a VectorPostprocessor is requested before VectorPostprocessors have been constructed.'
+    expect_err = 'A VectorPostprocessor getter was called before VectorPostprocessors have been constructed'
+    requirement = 'The system shall report an error when a vector postprocessor is requested before vector postprocessors are available.'
     issues = '#28131'
   []
 
@@ -32,8 +31,28 @@
     type = RunException
     input = get_multiapp_too_early.i
     capabilities = 'method=dbg'
-    expect_err = "A MultiApp getter was called before MultiApps have been constructed"
-    requirement = "The system shall assert that a MultiApp getter was called too early when a MultiApp is requested before MultiApps have been constructed."
+    expect_err = 'A MultiApp getter was called before MultiApps have been constructed'
+    requirement = 'The system shall report an error when a multi-application object is requested before multi-application objects are available.'
+    issues = '#28131'
+  []
+
+  [get_distribution_too_early]
+    type = RunException
+    input = get_distribution_sampler_too_early.i
+    cli_args = 'Problem/getter=distribution'
+    capabilities = 'method=dbg'
+    expect_err = 'A Distribution getter was called before Distributions have been constructed'
+    requirement = 'The system shall report an error when a distribution object is requested before distribution objects are available.'
+    issues = '#28131'
+  []
+
+  [get_sampler_too_early]
+    type = RunException
+    input = get_distribution_sampler_too_early.i
+    cli_args = 'Problem/getter=sampler'
+    capabilities = 'method=dbg'
+    expect_err = 'A Sampler getter was called before Samplers have been constructed'
+    requirement = 'The system shall report an error when a sampler object is requested before sampler objects are available.'
     issues = '#28131'
   []
 []


### PR DESCRIPTION
refs #28131

## Reason
Calling `FEProblemBase::getDistribution()` or `FEProblemBase::getSampler()` before those objects have been constructed currently falls through to the generic missing-object error path. This can make a developer ordering issue look like the object is genuinely missing from the input.

`getSampler()` already included a constructor-order hint in its user-facing error message, but it still did not distinguish “called too early” from “actually missing.” This PR adds the same debug-mode task-complete diagnostic pattern used for the other getter-too-early cases.

## Design
This adds debug-mode assertions in:

```cpp
FEProblemBase::getDistribution()
FEProblemBase::getSampler()
