### PR TITLE
Fix conda application build

### DIFF
--- a/conda/empty_shell/conda_build_config.yaml
+++ b/conda/empty_shell/conda_build_config.yaml
@@ -1,1 +1,0 @@
-../template/conda_build_config.yaml

--- a/conda/empty_shell/meta.yaml
+++ b/conda/empty_shell/meta.yaml
@@ -1,6 +1,4 @@
-{% set build = "<BUILD>" %}
 {% set version = "<VERSION>" %}
-{% set strbuild = "build_" + build|string %}
 
 package:
   name: <PREFIX_PACKAGE_WITH><FORMATTED_APPLICATION>
@@ -10,8 +8,8 @@ source:
   path: .
 
 build:
-  number: {{ build }}  # [linux,osx]
-  string: {{ strbuild }}
+  number: 0  # [linux,osx]
+  string: build_0
   skip: true # [win]
   script_env:
     - REQUESTS_CA_BUNDLE

--- a/conda/generate_recipe.sh
+++ b/conda/generate_recipe.sh
@@ -62,7 +62,7 @@ function string_replace()
     local REPLACE ARG
     printf 'Creating recipes at %s/%s\n' "${TMP_DIR}" "${RECIPES}"
     REPLACE=(APPLICATION FORMATTED_APPLICATION EXECUTABLE REPO BUILD VERSION MOOSE_JOBS MOOSE \
-IS_MOOSE TMP_DIR RECIPES SKIP_DOCS PREFIX_PACKAGE_WITH MOOSE_OPTIONS)
+IS_MOOSE TMP_DIR RECIPES SKIP_DOCS PREFIX_PACKAGE_WITH MOOSE_OPTIONS MOOSE_DOCS_FLAGS)
     # shellcheck disable=SC2044  # we will never allow spaces in our filesnames
     for sfile in $(find "${SCRIPT_DIR}/${TEMPLATE}" -type l); do
         cat "${sfile}" > "${TMP_DIR}/${RECIPES}/$(basename "${sfile}")"
@@ -93,7 +93,7 @@ function conda_build()
         string_replace || exit 1
         cd "${TMP_DIR}/${RECIPES}" || exit 1
         mkdir -p "${SCRIPT_DIR}/packages/${APPLICATION}" || exit 1
-        conda-build . --output-folder "${SCRIPT_DIR}/packages/${APPLICATION}" || exit 1
+        conda-build . --output-folder "${SCRIPT_DIR}/packages/${APPLICATION}" -m "${REPO}/moose/conda/conda_build_config.yaml" || exit 1
         printf 'Built: %s/packages/%s/%s/%s%s-%s-build_%s.conda\n' \
           "${SCRIPT_DIR}" \
           "${APPLICATION}" \

--- a/conda/generate_recipe.sh
+++ b/conda/generate_recipe.sh
@@ -138,7 +138,7 @@ else
     ARCH='linux-64'
 fi
 
-if [[ ! -v PREFIX_PACKAGE_WITH ]]; then
+if [ -z "${PREFIX_PACKAGE_WITH+x}" ]; then
     export PREFIX_PACKAGE_WITH="ncrc-"
 fi
 

--- a/conda/generate_recipe.sh
+++ b/conda/generate_recipe.sh
@@ -59,10 +59,13 @@ CTRL-C to Cancel. "
 
 function string_replace()
 {
-    local REPLACE ARG
+    local REPLACE
     printf 'Creating recipes at %s/%s\n' "${TMP_DIR}" "${RECIPES}"
-    REPLACE=(APPLICATION FORMATTED_APPLICATION EXECUTABLE REPO BUILD VERSION MOOSE_JOBS MOOSE \
-IS_MOOSE TMP_DIR RECIPES SKIP_DOCS PREFIX_PACKAGE_WITH MOOSE_OPTIONS MOOSE_DOCS_FLAGS)
+    REPLACE=(
+        "APPLICATION" "FORMATTED_APPLICATION" "EXECUTABLE" "REPO"
+        "VERSION" "MOOSE_JOBS" "SKIP_DOCS" "PREFIX_PACKAGE_WITH"
+        "MOOSE_OPTIONS" "MOOSE_DOCS_FLAGS"
+    )
     # shellcheck disable=SC2044  # we will never allow spaces in our filesnames
     for sfile in $(find "${SCRIPT_DIR}/${TEMPLATE}" -type l); do
         cat "${sfile}" > "${TMP_DIR}/${RECIPES}/$(basename "${sfile}")"
@@ -94,14 +97,13 @@ function conda_build()
         cd "${TMP_DIR}/${RECIPES}" || exit 1
         mkdir -p "${SCRIPT_DIR}/packages/${APPLICATION}" || exit 1
         conda-build . --output-folder "${SCRIPT_DIR}/packages/${APPLICATION}" -m "${REPO}/moose/conda/conda_build_config.yaml" || exit 1
-        printf 'Built: %s/packages/%s/%s/%s%s-%s-build_%s.conda\n' \
+        printf 'Built: %s/packages/%s/%s/%s%s-%s-build_0.conda\n' \
           "${SCRIPT_DIR}" \
           "${APPLICATION}" \
           "${ARCH}" \
           "${PREFIX_PACKAGE_WITH}" \
           "${FORMATTED_APPLICATION}" \
-          "${VERSION}" \
-          "${BUILD}"
+          "${VERSION}"
     else
         TMP_DIR="$BUILD_ROOT"
         clean_repo
@@ -135,18 +137,11 @@ if [ "$(uname)" == 'Darwin' ]; then
 else
     ARCH='linux-64'
 fi
-# We are building moose
-if [ "$(basename "${REPO}" .git)" == 'moose' ]; then
-    export IS_MOOSE='/modules'
-    export MOOSE=''
-    export EXECUTABLE='combined'
-    export PREFIX_PACKAGE_WITH=''
-    export MOOSE_SKIP_DOCS='true'
-else
-    export IS_MOOSE=''
-    export MOOSE='/moose'
-    export PREFIX_PACKAGE_WITH="${PREFIX_PACKAGE_WITH:-ncrc-}"
+
+if [[ ! -v PREFIX_PACKAGE_WITH ]]; then
+    export PREFIX_PACKAGE_WITH="ncrc-"
 fi
+
 SKIP_DOCS='False'
 if [ -n "${MOOSE_SKIP_DOCS}" ]; then
     printf "Influential environment variable: MOOSE_SKIP_DOCS detected.\n"

--- a/conda/moose/meta.yaml
+++ b/conda/moose/meta.yaml
@@ -62,6 +62,10 @@ requirements:
   run_constrained:
     - {{ moose_python_constrained }}
 
+test:
+  source_files:
+    - test/tests/kernels/simple_diffusion/simple_diffusion.i
+
 about:
   home: https://mooseframework.inl.gov/
   license: LGPL 2.1

--- a/conda/moose/meta.yaml.template
+++ b/conda/moose/meta.yaml.template
@@ -62,6 +62,10 @@ requirements:
   run_constrained:
     - {{ moose_python_constrained }}
 
+test:
+  source_files:
+    - test/tests/kernels/simple_diffusion/simple_diffusion.i
+
 about:
   home: https://mooseframework.inl.gov/
   license: LGPL 2.1

--- a/conda/moose/run_test.sh
+++ b/conda/moose/run_test.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 set -eux
 
+# Activation variables for JIT
 test "$MOOSE_ADFPARSER_JIT_INCLUDE" == "${PREFIX}/include/moose/ADRealMonolithic.h"
 test -f "$MOOSE_ADFPARSER_JIT_INCLUDE"
 
+# Activation executable basic tests
 for BINARY in moose moose-opt moose_test-opt combined-opt; do
     test "$(which "$BINARY")" == "${PREFIX}/bin/${BINARY}"
+    "$BINARY" -i test/tests/kernels/simple_diffusion/simple_diffusion.i
+    mpiexec -n 2 "$BINARY" -i test/tests/kernels/simple_diffusion/simple_diffusion.i
     "$BINARY" --show-capabilities
 done
 
+# Copy basic tests and run simple diffusion + a test that needs JIT
 moose_test-opt --copy-inputs tests
 cd moose_test/tests
 moose_test-opt --run '-p 2 --re=kernels/simple_diffusion'

--- a/conda/template/build.sh
+++ b/conda/template/build.sh
@@ -40,7 +40,11 @@ function do_build(){
 
     # Strip unneeded symbols from executables and libraries
     find "${PREFIX:?}/bin" -newer "$FILE_MARKER" -type f -print -exec strip -S {} \;
-    ([[ "$(uname)" == "Darwin" ]] && LIB_SUFFIX="dylib") || LIB_SUFFIX="so"
+    if [[ "$(uname)" == "Darwin" ]]; then
+        LIB_SUFFIX="dylib"
+    else
+        LIB_SUFFIX="so"
+    fi
     find "${PREFIX:?}/lib" -newer "$FILE_MARKER" -type f -name "*.${LIB_SUFFIX}*" -print -exec strip -S {} \;
 }
 

--- a/conda/template/build.sh
+++ b/conda/template/build.sh
@@ -29,7 +29,7 @@ function do_build(){
 
     # Configure MOOSE
     cd "${SRC_DIR:?}/moose"
-    local -a moose_options
+    local -a moose_options=()
     read -ra moose_options <<< "$MOOSE_OPTIONS"
     ./configure --prefix=${PREFIX:?} "${moose_options[@]}"
 

--- a/conda/template/build.sh
+++ b/conda/template/build.sh
@@ -30,8 +30,8 @@ function do_build(){
     # Configure MOOSE
     cd "${SRC_DIR:?}/moose"
     local -a moose_options=()
-    read -ra moose_options <<< "$MOOSE_OPTIONS"
-    ./configure --prefix=${PREFIX:?} "${moose_options[@]}"
+    read -rA moose_options <<< "$MOOSE_OPTIONS" || true
+    ./configure --prefix=${PREFIX:?} "${moose_options[@]+"${moose_options[@]}"}"
 
     # Build and install application
     cd "${SRC_DIR:?}"

--- a/conda/template/build.sh
+++ b/conda/template/build.sh
@@ -4,63 +4,85 @@ set -eux
 # shellcheck disable=SC1073
 # shellcheck disable=SC1009
 # shellcheck disable=SC1072  # these values are templated
-export APPLICATION=<APPLICATION>
-export MOOSE_JOBS=<MOOSE_JOBS>
-export SKIP_DOCS=<SKIP_DOCS>
-export MOOSE_OPTIONS=<MOOSE_OPTIONS>
-export INSTALL_DIR="${PREFIX:?}/${APPLICATION:?}"
+export APPLICATION="<APPLICATION>"
+export MOOSE_JOBS="<MOOSE_JOBS>"
+export SKIP_DOCS="<SKIP_DOCS>"
+export MOOSE_OPTIONS="<MOOSE_OPTIONS>"
+export MOOSE_DOCS_FLAGS="<MOOSE_DOCS_FLAGS>"
+
+# Keep a marker so we can act on only new files within the PREFIX
+FILE_MARKER="${PREFIX:?}/file_marker"
+touch "$FILE_MARKER"
 
 function do_build(){
-    rm -rf "${INSTALL_DIR:?}"
+    # Perform cleanup in case we're trying again
+    cd "${SRC_DIR:?}"
+    git clean -xfd; git submodule foreach --recursive git clean -xfd
 
-    export EXTERNAL_FLAGS="-Wl,-headerpad_max_install_names"
+    # Expose python from MOOSE
     export PYTHONPATH=${SRC_DIR:?}<MOOSE>/python
+
+    # Set variable for skipping documentation if applicable
     if [[ "${SKIP_DOCS}" == "True" ]]; then
         export MOOSE_SKIP_DOCS="True"
     fi
+
+    # Configure MOOSE
+    cd "${SRC_DIR:?}/moose"
+    local -a moose_options
+    read -ra moose_options <<< "$MOOSE_OPTIONS"
+    ./configure --prefix=${PREFIX:?} "${moose_options[@]}"
+
+    # Build and install application
     cd "${SRC_DIR:?}"
-    git clean -xfd; git submodule foreach --recursive git clean -xfd
-    cd "${SRC_DIR:?}<MOOSE>"
-    ./configure --prefix=${INSTALL_DIR:?} ${MOOSE_OPTIONS}
-    cd "${SRC_DIR:?}<IS_MOOSE>"
-    make -j <MOOSE_JOBS> || return 1
-    make install -j <MOOSE_JOBS> || return 1
+    make -j <MOOSE_JOBS> || return $?
+    make install -j <MOOSE_JOBS> || return $?
 
     # Strip unneeded symbols from executables and libraries
-    find "${INSTALL_DIR}/bin" -type f -print -exec strip -S {} \;
-    if [[ "$(uname)" == "Darwin" ]]; then
-        LIB_SUFFIX="dylib"
-    else
-        LIB_SUFFIX="so"
-    fi
-    find "${INSTALL_DIR}/lib" -type f -name "*.${LIB_SUFFIX}*" -print -exec strip -S {} \;
+    find "${PREFIX:?}/bin" -newer "$FILE_MARKER" -type f -print -exec strip -S {} \;
+    ([[ "$(uname)" == "Darwin" ]] && LIB_SUFFIX="dylib") || LIB_SUFFIX="so"
+    find "${PREFIX:?}/lib" -newer "$FILE_MARKER" -type f -name "*.${LIB_SUFFIX}*" -print -exec strip -S {} \;
 }
 
 # shellcheck disable=SC1091  # made available through meta.yaml src path
 source "${SRC_DIR:?}/retry_build.sh"
 
+# Conda on mac sets "-Wl,-dead_strip_dylibs" in LDFLAGS, which is picked up
+# during the application executable linking. Unfortunately, we end up with
+# intermediate dead dylibs during our build/install (which we do fix later!).
+# So... remove that flag on macs? Good, try conda.
+if [[ "$(uname)" == "Darwin" ]]; then
+  export LDFLAGS="${LDFLAGS//-Wl,-dead_strip_dylibs/}"
+fi
+
 # Sets up retry functions and calls do_build. Blocking until success
 # or 3 failed attempts, or 1 unknown/unhandled failure
 retry_build
 
+# Remove the file marker
+rm "$FILE_MARKER"
+
 mkdir -p "${PREFIX:?}/etc/conda/activate.d" "${PREFIX:?}/etc/conda/deactivate.d"
 cat <<EOF > "${PREFIX:?}/etc/conda/activate.d/activate_${PKG_NAME:?}.sh"
-export MOOSE_ADFPARSER_JIT_INCLUDE=${INSTALL_DIR}/include/moose/ADRealMonolithic.h
-export <FORMATTED_APPLICATION>_DOCS=${INSTALL_DIR}/share/<APPLICATION>/doc/index.html
-export NCRC_APP=<FORMATTED_APPLICATION>
-export PATH=\$PATH:\${CONDA_PREFIX}/${APPLICATION}/bin
+export MOOSE_ADFPARSER_JIT_INCLUDE="${PREFIX}/include/moose/ADRealMonolithic.h"
+export <FORMATTED_APPLICATION>_DOCS="${PREFIX}/share/<APPLICATION>/doc/index.html"
+export NCRC_APP="<FORMATTED_APPLICATION>"
+export NCRC_APP_RAW="<APPLICATION>"
 EOF
+
 cat <<EOF > "${PREFIX:?}/etc/conda/deactivate.d/deactivate_${PKG_NAME:?}.sh"
 unset MOOSE_ADFPARSER_JIT_INCLUDE
 unset <FORMATTED_APPLICATION>_DOCS
 unset NCRC_APP
-export PATH=\${PATH%":\${CONDA_PREFIX}/${APPLICATION}/bin"}
+unset NCRC_APP_RAW
 EOF
-if [[ "${APPLICATION:?}" == "moose" ]]; then
-    cat <<EOF >> "${PREFIX:?}/etc/conda/activate.d/activate_${PKG_NAME:?}.sh"
-alias moose-opt="combined-opt"
+
+cat <<EOF >> "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
+export FI_PROVIDER=tcp
+export MPICH_CH4_NETMOD=ofi
 EOF
-    cat <<EOF >> "${PREFIX:?}/etc/conda/deactivate.d/deactivate_${PKG_NAME:?}.sh"
-unalias moose-opt
+
+cat <<EOF >> "${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
+unset FI_PROVIDER
+unset MPICH_CH4_NETMOD
 EOF
-fi

--- a/conda/template/meta.yaml.template
+++ b/conda/template/meta.yaml.template
@@ -30,14 +30,14 @@ requirements:
     - {{ compiler('fortran') }}
     - {{ stdlib('c') }}
     # for libmesh libtool
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh __VERSIONER_LIBMESH_VERSION__ mpich___VERSIONER_LIBMESH_BUILD_NUMBER__
     # build utilities
     - make
     - packaging
     - patchelf # [linux]
     # python; for doc build + premake
     - python 3.14.*
-    - moose-tools 2026.06.07
+    - moose-tools __VERSIONER_TOOLS_VERSION__
   host:
     # should eventually become 'mpich {{ mpich_version }}'
     - mpich 5.0.1
@@ -46,20 +46,20 @@ requirements:
     # see libfabric entry in conda/conda_build_config.yaml
     - libfabric {{ libfabric }} # [linux]
     - libpng
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
-    - moose-wasp 2026.05.24_2cdbeb7 build_0
+    - moose-libmesh __VERSIONER_LIBMESH_VERSION__ mpich___VERSIONER_LIBMESH_BUILD_NUMBER__
+    - moose-wasp __VERSIONER_WASP_VERSION__ build___VERSIONER_WASP_BUILD_NUMBER__
     - zlib
   run:
     # should eventually become 'mpich {{ mpich_version }}'
     - mpich 5.0.1
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
-    - moose-wasp 2026.05.24_2cdbeb7 build_0
+    - moose-libmesh __VERSIONER_LIBMESH_VERSION__ mpich___VERSIONER_LIBMESH_BUILD_NUMBER__
+    - moose-wasp __VERSIONER_WASP_VERSION__ build___VERSIONER_WASP_BUILD_NUMBER__
     # c++ compiler for jit
     - gxx_linux-64 {{ cxx_compiler_version }}.*               # [linux]
     - clangxx_osx-64 {{ cxx_compiler_version }}.*             # [osx and x86_64]
     - clangxx_osx-arm64 {{ cxx_compiler_version }}.*          # [osx and arm64]
     # for testharness/python utilities
-    - moose-tools 2026.06.07
+    - moose-tools __VERSIONER_TOOLS_VERSION__
     # for running app --copy-inputs
     - rsync
   run_constrained:

--- a/conda/template/run_test.sh
+++ b/conda/template/run_test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -eux
+
+# Activation variables that define the app name
+printenv NCRC_APP
+printenv NCRC_APP_RAW
+
+# Activation variables for JIT
+test "$MOOSE_ADFPARSER_JIT_INCLUDE" == "${PREFIX}/include/moose/ADRealMonolithic.h"
+test -f "$MOOSE_ADFPARSER_JIT_INCLUDE"
+
+# Activation executable
+BINARY="${NCRC_APP_RAW}-opt"
+test "$(which "$BINARY")" == "${PREFIX}/bin/${BINARY}"
+
+# Basic app test with simple diffusion
+"$BINARY" -i moose/test/tests/kernels/simple_diffusion/simple_diffusion.i
+mpiexec -n 2 "$BINARY" -i moose/test/tests/kernels/simple_diffusion/simple_diffusion.i
+
+# Show app capabilities
+"$BINARY" --show-capabilities
+
+# Show inputs that can be copied
+"$BINARY" --show-copyable-inputs
+
+# Copy basic tests and do a dry run of runnining them
+"$BINARY" --copy-inputs tests
+cd "${NCRC_APP_RAW}/tests"
+"$BINARY" --run "--dry-run"
+cd ../..
+rm -rf "$NCRC_APP_RAW"

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -171,6 +171,7 @@ packages:
   app:
     templates:
       conda/moose/meta.yaml.template: conda/moose/meta.yaml
+      conda/template/meta.yaml.template: conda/template/meta.yaml
     dependencies:
       - moose-dev
     apptainer:


### PR DESCRIPTION
## Reason

https://github.com/idaholab/moose/pull/32572 reworked the conda moose application build but failed to update the template application build.

## Design

Get the template application build working again in `conda/template`, aligned wih the build in `conda/moose`.

## Impact

Will get conda application builds working again.

## Added testing

Previously, testing didn't exist for the "template" package on MOOSE itself. Which means we'd never see the failures until the downstream apps. That testing now exists:

- https://civet.inl.gov/job/3893072/ (linux)
- https://civet.inl.gov/job/3893071/ (arm mac)