### PR TITLE
Hackathon follow-up

### DIFF
--- a/configure
+++ b/configure
@@ -614,14 +614,14 @@ LIBPNG_INCLUDES
 LIBPNG_LIBS
 LIBPNG
 PKG_CONFIG
+kokkos_gpu
+kokkos_support
 neml2_library
 neml2_support
 mfem_library
 mfem_support
 libtorch_library
 libtorch_support
-kokkos_support
-kokkos_gpu
 target_alias
 host_alias
 build_alias
@@ -669,6 +669,7 @@ with_libtorch
 with_mfem
 with_neml2
 with_kokkos
+with_kokkos_index_size
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1300,6 +1301,8 @@ Optional Packages:
                           or neml2 directory]
   --with-kokkos[=ARG]     Specify if Kokkos support should be enabled [ARG=yes
                           or cpu to disable GPU capabilities]
+  --with-kokkos-index-size=ARG
+                          Specify Kokkos index size [ARG=4 (default) or 8]
 
 Report bugs to <https://github.com/idaholab/moose/discussions>.
 moose home page: <https://mooseframework.inl.gov>.
@@ -1936,31 +1939,83 @@ fi
 if test ${with_kokkos+y}
 then :
   withval=$with_kokkos; kokkos_support=yes
-else $as_nop
-  kokkos_support=no
+else case e in #(
+  e) kokkos_support=no ;;
+esac
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: configuring with Kokkos support: $kokkos_support" >&5
-printf "%s\n" "configuring with Kokkos support: $kokkos_support" >&6; }
+
+
+# Check whether --with-kokkos-index-size was given.
+if test ${with_kokkos_index_size+y}
+then :
+  withval=$with_kokkos_index_size;
+fi
+
+
+if test "x$with_kokkos_index_size" != x && test "$kokkos_support" != yes
+then :
+  as_fn_error $? "--with-kokkos-index-size requires --with-kokkos" "$LINENO" 5
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: configuring with kokkos support: $kokkos_support" >&5
+printf "%s\n" "configuring with kokkos support: $kokkos_support" >&6; }
 
 if test "$kokkos_support" = yes
 then :
-  printf "%s\n" "#define KOKKOS_ENABLED 1" >>confdefs.h
-  kokkos_support=true
+
+
+printf "%s\n" "#define KOKKOS_ENABLED 1" >>confdefs.h
+
+        kokkos_support=true
+
+
+        if test "x$with_kokkos_index_size" = x
+then :
+  with_kokkos_index_size=4
 fi
 
-if test ${with_kokkos+y}
+        case $with_kokkos_index_size in #(
+  4) :
+
+                  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Kokkos index size: 4 bytes" >&5
+printf "%s\n" "Kokkos index size: 4 bytes" >&6; }
+
+printf "%s\n" "#define KOKKOS_INDEX_TYPE uint32_t" >>confdefs.h
+
+                 ;; #(
+  8) :
+
+                  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Kokkos index size: 8 bytes" >&5
+printf "%s\n" "Kokkos index size: 8 bytes" >&6; }
+
+printf "%s\n" "#define KOKKOS_INDEX_TYPE uint64_t" >>confdefs.h
+
+                 ;; #(
+  *) :
+
+                  as_fn_error $? "invalid value for --with-kokkos-index-size: $with_kokkos_index_size (valid values are 4 or 8)" "$LINENO" 5
+                 ;;
+esac
+
+        if test "$with_kokkos" = cpu
 then :
-  if test "$with_kokkos" = cpu
-  then :
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Kokkos GPU capabilities disabled" >&5
-    printf "%s\n" "Kokkos GPU capabilities disabled" >&6; }
-    kokkos_gpu=false
-  else
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Kokkos GPU capabilities enabled" >&5
-    printf "%s\n" "Kokkos GPU capabilities enabled" >&6; }
-    kokkos_gpu=true
-  fi
+
+                  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Kokkos GPU capabilities disabled" >&5
+printf "%s\n" "Kokkos GPU capabilities disabled" >&6; }
+                  kokkos_gpu=false
+
+
+else case e in #(
+  e)
+                  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Kokkos GPU capabilities enabled" >&5
+printf "%s\n" "Kokkos GPU capabilities enabled" >&6; }
+                  kokkos_gpu=true
+
+               ;;
+esac
+fi
+
 fi
 
 if test -n "$ac_tool_prefix"; then

--- a/configure.ac
+++ b/configure.ac
@@ -112,12 +112,36 @@ AC_ARG_WITH(kokkos,
             [kokkos_support=yes],
             [kokkos_support=no])
 
+AC_ARG_WITH(kokkos-index-size,
+            AS_HELP_STRING([--with-kokkos-index-size=ARG],[Specify Kokkos index size @<:@ARG=4 (default) or 8@:>@]))
+
+AS_IF([test "x$with_kokkos_index_size" != x && test "$kokkos_support" != yes],
+      [AC_MSG_ERROR([--with-kokkos-index-size requires --with-kokkos])])
+
 AC_MSG_RESULT([configuring with kokkos support: $kokkos_support])
 
 AS_IF([test "$kokkos_support" = yes],
       [
         AC_DEFINE(KOKKOS_ENABLED, 1, [Whether to use Kokkos-related code or not])
         AC_SUBST([kokkos_support],[true])
+
+        AS_IF([test "x$with_kokkos_index_size" = x],
+              [with_kokkos_index_size=4])
+
+        AS_CASE([$with_kokkos_index_size],
+                [4],
+                [
+                  AC_MSG_RESULT([Kokkos index size: 4 bytes])
+                  AC_DEFINE([KOKKOS_INDEX_TYPE], [uint32_t], [Kokkos index type])
+                ],
+                [8],
+                [
+                  AC_MSG_RESULT([Kokkos index size: 8 bytes])
+                  AC_DEFINE([KOKKOS_INDEX_TYPE], [uint64_t], [Kokkos index type])
+                ],
+                [
+                  AC_MSG_ERROR([invalid value for --with-kokkos-index-size: $with_kokkos_index_size (valid values are 4 or 8)])
+                ])
 
         AS_IF([test "$with_kokkos" = cpu],
               [

--- a/framework/include/base/MooseConfig.h.in
+++ b/framework/include/base/MooseConfig.h.in
@@ -27,6 +27,9 @@
 /* Whether to use Kokkos-related code or not */
 #undef KOKKOS_ENABLED
 
+/* Define to specify Kokkos default array and thread index type */
+#undef KOKKOS_INDEX_TYPE
+
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT
 

--- a/framework/include/kokkos/base/KokkosArray.h
+++ b/framework/include/kokkos/base/KokkosArray.h
@@ -59,7 +59,7 @@ enum class LayoutType
  */
 template <typename T,
           unsigned int dimension = 1,
-          typename index_type = dof_id_type,
+          typename index_type = MOOSE_KOKKOS_INDEX_TYPE,
           LayoutType layout = LayoutType::LEFT>
 class Array;
 
@@ -110,6 +110,7 @@ class ArrayBase
   static_assert(!std::is_same_v<bool, index_type>, "Kokkos array index type must not be bool");
 
 public:
+  using unsigned_index_type = index_type;
   using signed_index_type = typename std::make_signed<index_type>::type;
 
   /**
@@ -1635,15 +1636,23 @@ public:
 };
 ///@}
 
-template <typename T, typename index_type = dof_id_type>
+template <typename T, typename index_type = MOOSE_KOKKOS_INDEX_TYPE>
 using Array1D = Array<T, 1, index_type, LayoutType::LEFT>;
-template <typename T, typename index_type = dof_id_type, LayoutType layout = LayoutType::LEFT>
+template <typename T,
+          typename index_type = MOOSE_KOKKOS_INDEX_TYPE,
+          LayoutType layout = LayoutType::LEFT>
 using Array2D = Array<T, 2, index_type, layout>;
-template <typename T, typename index_type = dof_id_type, LayoutType layout = LayoutType::LEFT>
+template <typename T,
+          typename index_type = MOOSE_KOKKOS_INDEX_TYPE,
+          LayoutType layout = LayoutType::LEFT>
 using Array3D = Array<T, 3, index_type, layout>;
-template <typename T, typename index_type = dof_id_type, LayoutType layout = LayoutType::LEFT>
+template <typename T,
+          typename index_type = MOOSE_KOKKOS_INDEX_TYPE,
+          LayoutType layout = LayoutType::LEFT>
 using Array4D = Array<T, 4, index_type, layout>;
-template <typename T, typename index_type = dof_id_type, LayoutType layout = LayoutType::LEFT>
+template <typename T,
+          typename index_type = MOOSE_KOKKOS_INDEX_TYPE,
+          LayoutType layout = LayoutType::LEFT>
 using Array5D = Array<T, 5, index_type, layout>;
 
 } // namespace Moose::Kokkos

--- a/framework/include/kokkos/base/KokkosJaggedArray.h
+++ b/framework/include/kokkos/base/KokkosJaggedArray.h
@@ -159,7 +159,7 @@ JaggedArrayInnerData<T, inner, layout>::operator()(indices... i) const
 template <typename T,
           unsigned int inner,
           unsigned int outer,
-          typename index_type = dof_id_type,
+          typename index_type = MOOSE_KOKKOS_INDEX_TYPE,
           LayoutType layout = LayoutType::LEFT>
 class JaggedArray
 {

--- a/framework/include/kokkos/base/KokkosResidualObject.h
+++ b/framework/include/kokkos/base/KokkosResidualObject.h
@@ -230,7 +230,7 @@ ResidualObject::accumulateTaggedElementalResidual(const Real local_re,
   auto & sys = kokkosSystem(_kokkos_var.sys(comp));
   auto dof = sys.getElemLocalDofIndex(elem, i, _kokkos_var.var(comp));
 
-  for (dof_id_type t = 0; t < _vector_tags.size(); ++t)
+  for (unsigned int t = 0; t < _vector_tags.size(); ++t)
   {
     auto tag = _vector_tags[t];
 
@@ -251,7 +251,7 @@ ResidualObject::accumulateTaggedNodalResidual(const bool add,
   auto & sys = kokkosSystem(_kokkos_var.sys(comp));
   auto dof = sys.getNodeLocalDofIndex(node, 0, _kokkos_var.var(comp));
 
-  for (dof_id_type t = 0; t < _vector_tags.size(); ++t)
+  for (unsigned int t = 0; t < _vector_tags.size(); ++t)
   {
     auto tag = _vector_tags[t];
 
@@ -280,7 +280,7 @@ ResidualObject::accumulateTaggedElementalMatrix(const Real local_ke,
   auto row = sys.getElemLocalDofIndex(elem, i, _kokkos_var.var(comp));
   auto col = sys.getElemGlobalDofIndex(elem, j, jvar);
 
-  for (dof_id_type t = 0; t < _matrix_tags.size(); ++t)
+  for (unsigned int t = 0; t < _matrix_tags.size(); ++t)
   {
     auto tag = _matrix_tags[t];
 
@@ -298,7 +298,7 @@ ResidualObject::accumulateTaggedElementalMatrix(const DNDerivativeType & local_k
   auto & sys = kokkosSystem(_kokkos_var.sys(comp));
   auto row = sys.getElemLocalDofIndex(datum.elem().id, i, _kokkos_var.var(comp));
 
-  for (dof_id_type t = 0; t < _matrix_tags.size(); ++t)
+  for (unsigned int t = 0; t < _matrix_tags.size(); ++t)
   {
     auto tag = _matrix_tags[t];
 
@@ -326,7 +326,7 @@ ResidualObject::accumulateTaggedNodalMatrix(const bool add,
   auto row = sys.getNodeLocalDofIndex(node, 0, _kokkos_var.var(comp));
   auto col = sys.getNodeGlobalDofIndex(node, jvar);
 
-  for (dof_id_type t = 0; t < _matrix_tags.size(); ++t)
+  for (unsigned int t = 0; t < _matrix_tags.size(); ++t)
   {
     auto tag = _matrix_tags[t];
 
@@ -354,7 +354,7 @@ ResidualObject::accumulateTaggedNodalMatrix(const bool add,
   auto & sys = kokkosSystem(_kokkos_var.sys(comp));
   auto row = sys.getNodeLocalDofIndex(node, 0, _kokkos_var.var(comp));
 
-  for (dof_id_type t = 0; t < _matrix_tags.size(); ++t)
+  for (unsigned int t = 0; t < _matrix_tags.size(); ++t)
   {
     auto tag = _matrix_tags[t];
     auto & matrix = sys.getMatrix(tag);

--- a/framework/include/kokkos/base/KokkosThread.h
+++ b/framework/include/kokkos/base/KokkosThread.h
@@ -19,7 +19,7 @@
 namespace Moose::Kokkos
 {
 
-using ThreadID = dof_id_type;
+using ThreadID = MOOSE_KOKKOS_INDEX_TYPE;
 
 /**
  * The Kokkos thread object that aids in converting the one-dimensional thread index into

--- a/framework/include/kokkos/base/KokkosTypes.h
+++ b/framework/include/kokkos/base/KokkosTypes.h
@@ -284,7 +284,7 @@ template <>
 KOKKOS_INLINE_FUNCTION Real
 Vector3<Real>::norm() const
 {
-  return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+  return ::Kokkos::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
 }
 
 template <>

--- a/framework/include/kokkos/bcs/KokkosIntegratedBCBase.h
+++ b/framework/include/kokkos/bcs/KokkosIntegratedBCBase.h
@@ -41,7 +41,10 @@ protected:
   /**
    * Number of threads for local DOF parallelization
    */
-  const unsigned int _num_local_threads;
+  ///@{
+  const unsigned int _num_local_residual_threads = 1;
+  const unsigned int _num_local_jacobian_threads = 1;
+  ///@}
 };
 
 } // namespace Moose::Kokkos

--- a/framework/include/kokkos/bcs/KokkosIntegratedBCBase.h
+++ b/framework/include/kokkos/bcs/KokkosIntegratedBCBase.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "KokkosBoundaryCondition.h"
+#include "KokkosLocalParallelInterface.h"
 
 #include "MaterialPropertyInterface.h"
 #include "CoupleableMooseVariableDependencyIntermediateInterface.h"
@@ -22,7 +23,8 @@ namespace Moose::Kokkos
  */
 class IntegratedBCBase : public BoundaryCondition,
                          public CoupleableMooseVariableDependencyIntermediateInterface,
-                         public MaterialPropertyInterface
+                         public MaterialPropertyInterface,
+                         public LocalParallelInterface
 {
 public:
   static InputParameters validParams();
@@ -36,15 +38,6 @@ public:
    * Copy constructor for parallel dispatch
    */
   IntegratedBCBase(const IntegratedBCBase & object);
-
-protected:
-  /**
-   * Number of threads for local DOF parallelization
-   */
-  ///@{
-  const unsigned int _num_local_residual_threads = 1;
-  const unsigned int _num_local_jacobian_threads = 1;
-  ///@}
 };
 
 } // namespace Moose::Kokkos

--- a/framework/include/kokkos/interfaces/KokkosLocalParallelInterface.h
+++ b/framework/include/kokkos/interfaces/KokkosLocalParallelInterface.h
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseObject.h"
+
+namespace Moose::Kokkos
+{
+
+/**
+ * Interface class for controlling local DOF parallelization of kernels and integrated BCs
+ */
+class LocalParallelInterface
+{
+public:
+  static InputParameters validParams();
+  LocalParallelInterface(const MooseObject * moose_object);
+
+protected:
+  /**
+   * Number of threads for local DOF parallelization
+   */
+  ///@{
+  const unsigned int _num_local_residual_threads;
+  const unsigned int _num_local_jacobian_threads;
+  ///@}
+};
+
+} // namespace Moose::Kokkos

--- a/framework/include/kokkos/kernels/KokkosKernelBase.h
+++ b/framework/include/kokkos/kernels/KokkosKernelBase.h
@@ -43,7 +43,10 @@ protected:
   /**
    * Number of threads for local DOF parallelization
    */
-  const unsigned int _num_local_threads;
+  ///@{
+  const unsigned int _num_local_residual_threads = 1;
+  const unsigned int _num_local_jacobian_threads = 1;
+  ///@}
 };
 
 } // namespace Moose::Kokkos

--- a/framework/include/kokkos/kernels/KokkosKernelBase.h
+++ b/framework/include/kokkos/kernels/KokkosKernelBase.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "KokkosResidualObject.h"
+#include "KokkosLocalParallelInterface.h"
 
 #include "BlockRestrictable.h"
 #include "MaterialPropertyInterface.h"
@@ -24,7 +25,8 @@ namespace Moose::Kokkos
 class KernelBase : public ResidualObject,
                    public BlockRestrictable,
                    public CoupleableMooseVariableDependencyIntermediateInterface,
-                   public MaterialPropertyInterface
+                   public MaterialPropertyInterface,
+                   public LocalParallelInterface
 {
 public:
   static InputParameters validParams();
@@ -38,15 +40,6 @@ public:
    * Copy constructor for parallel dispatch
    */
   KernelBase(const KernelBase & object);
-
-protected:
-  /**
-   * Number of threads for local DOF parallelization
-   */
-  ///@{
-  const unsigned int _num_local_residual_threads = 1;
-  const unsigned int _num_local_jacobian_threads = 1;
-  ///@}
 };
 
 } // namespace Moose::Kokkos

--- a/framework/include/kokkos/materials/KokkosMaterialProperty.h
+++ b/framework/include/kokkos/materials/KokkosMaterialProperty.h
@@ -128,7 +128,9 @@ MaterialProperty<T, dimension>::allocate(const Mesh & mesh,
     auto sid = mesh.getContiguousSubdomainID(subdomain);
     auto constant_option = libmesh_map_find(_record->constant_option, subdomain);
 
-    std::vector<dof_id_type> n;
+    using index_type = typename std::remove_reference_t<decltype(_data[sid])>::unsigned_index_type;
+
+    std::vector<index_type> n;
 
     for (unsigned int i = 0; i < dimension; ++i)
       n.push_back(libmesh_map_find(_record->dims, subdomain)[i]);

--- a/framework/include/kokkos/systems/KokkosSystem.h
+++ b/framework/include/kokkos/systems/KokkosSystem.h
@@ -213,7 +213,7 @@ public:
                                                    unsigned int i,
                                                    unsigned int var) const
   {
-    return _local_elem_dof_index[var](elem, i);
+    return _local_elem_dof_index[var](i, elem);
   }
   /**
    * Get the local DOF index of a variable for a node
@@ -239,7 +239,7 @@ public:
                                                     unsigned int i,
                                                     unsigned int var) const
   {
-    return _local_to_global_dof_index[_local_elem_dof_index[var](elem, i)];
+    return _local_to_global_dof_index[_local_elem_dof_index[var](i, elem)];
   }
   /**
    * Get the global DOF index of a variable for a node

--- a/framework/src/kokkos/bcs/KokkosADIntegratedBC.K
+++ b/framework/src/kokkos/bcs/KokkosADIntegratedBC.K
@@ -61,7 +61,8 @@ ADIntegratedBC::computeResidualAndJacobian()
 void
 ADIntegratedBC::dispatch()
 {
-  _thread.resize(_num_local_threads, numKokkosBoundarySides());
+  _thread.resize(_computing_jacobian ? _num_local_jacobian_threads : _num_local_residual_threads,
+                 numKokkosBoundarySides());
 
   Policy policy(0, _thread.size());
 

--- a/framework/src/kokkos/bcs/KokkosIntegratedBC.K
+++ b/framework/src/kokkos/bcs/KokkosIntegratedBC.K
@@ -34,7 +34,7 @@ IntegratedBC::IntegratedBC(const InputParameters & parameters)
 void
 IntegratedBC::computeResidual()
 {
-  _thread.resize(_num_local_threads, numKokkosBoundarySides());
+  _thread.resize(_num_local_residual_threads, numKokkosBoundarySides());
 
   Policy policy(0, _thread.size());
 
@@ -49,7 +49,7 @@ IntegratedBC::computeJacobian()
 {
   if (DispatcherRegistry::hasUserMethod<JacobianLoop>(type()))
   {
-    _thread.resize(_num_local_threads, numKokkosBoundarySides());
+    _thread.resize(_num_local_jacobian_threads, numKokkosBoundarySides());
 
     Policy policy(0, _thread.size());
 
@@ -63,8 +63,9 @@ IntegratedBC::computeJacobian()
   {
     auto & sys = kokkosSystem(_kokkos_var.sys());
 
-    _thread.resize(
-        _num_local_threads, sys.getCoupling(_kokkos_var.var()).size(), numKokkosBoundarySides());
+    _thread.resize(_num_local_jacobian_threads,
+                   sys.getCoupling(_kokkos_var.var()).size(),
+                   numKokkosBoundarySides());
 
     Policy policy(0, _thread.size());
 

--- a/framework/src/kokkos/bcs/KokkosIntegratedBCBase.K
+++ b/framework/src/kokkos/bcs/KokkosIntegratedBCBase.K
@@ -18,10 +18,14 @@ IntegratedBCBase::validParams()
   auto params = BoundaryCondition::validParams();
   params += MaterialPropertyInterface::validParams();
 
-  params.addParam<unsigned int>(
-      "num_local_threads",
-      4,
-      "The number of threads for additional parallelization of local DOFs.");
+  params.addParam<unsigned int>("num_local_residual_threads",
+                                2,
+                                "The number of threads for additional parallelization of local "
+                                "DOFs in residual calculation.");
+  params.addParam<unsigned int>("num_local_jacobian_threads",
+                                4,
+                                "The number of threads for additional parallelization of local "
+                                "DOFs in Jacobian calculation.");
 
   // Integrated BCs always rely on Boundary MaterialData
   params.set<Moose::MaterialDataType>("_material_data_type") = Moose::BOUNDARY_MATERIAL_DATA;
@@ -33,16 +37,27 @@ IntegratedBCBase::IntegratedBCBase(const InputParameters & parameters,
                                    Moose::VarFieldType field_type)
   : BoundaryCondition(parameters, field_type, false),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs()),
-    _num_local_threads(getParam<unsigned int>("num_local_threads"))
+    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs())
+#ifdef MOOSE_ENABLE_KOKKOS_GPU
+    ,
+    _num_local_residual_threads(getParam<unsigned int>("num_local_residual_threads")),
+    _num_local_jacobian_threads(getParam<unsigned int>("num_local_jacobian_threads"))
+#endif
 {
+#ifndef MOOSE_ENABLE_KOKKOS_GPU
+  if (isParamSetByUser("num_local_residual_threads"))
+    paramWarning("num_local_residual_threads", "Ignored when using Kokkos CPU backend.");
+  if (isParamSetByUser("num_local_jacobian_threads"))
+    paramWarning("num_local_jacobian_threads", "Ignored when using Kokkos CPU backend.");
+#endif
 }
 
 IntegratedBCBase::IntegratedBCBase(const IntegratedBCBase & object)
   : BoundaryCondition(object),
     CoupleableMooseVariableDependencyIntermediateInterface(object, {}),
     MaterialPropertyInterface(object, {}),
-    _num_local_threads(object._num_local_threads)
+    _num_local_residual_threads(object._num_local_residual_threads),
+    _num_local_jacobian_threads(object._num_local_jacobian_threads)
 {
 }
 

--- a/framework/src/kokkos/bcs/KokkosIntegratedBCBase.K
+++ b/framework/src/kokkos/bcs/KokkosIntegratedBCBase.K
@@ -17,15 +17,7 @@ IntegratedBCBase::validParams()
 {
   auto params = BoundaryCondition::validParams();
   params += MaterialPropertyInterface::validParams();
-
-  params.addParam<unsigned int>("num_local_residual_threads",
-                                2,
-                                "The number of threads for additional parallelization of local "
-                                "DOFs in residual calculation.");
-  params.addParam<unsigned int>("num_local_jacobian_threads",
-                                4,
-                                "The number of threads for additional parallelization of local "
-                                "DOFs in Jacobian calculation.");
+  params += LocalParallelInterface::validParams();
 
   // Integrated BCs always rely on Boundary MaterialData
   params.set<Moose::MaterialDataType>("_material_data_type") = Moose::BOUNDARY_MATERIAL_DATA;
@@ -37,27 +29,16 @@ IntegratedBCBase::IntegratedBCBase(const InputParameters & parameters,
                                    Moose::VarFieldType field_type)
   : BoundaryCondition(parameters, field_type, false),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs())
-#ifdef MOOSE_ENABLE_KOKKOS_GPU
-    ,
-    _num_local_residual_threads(getParam<unsigned int>("num_local_residual_threads")),
-    _num_local_jacobian_threads(getParam<unsigned int>("num_local_jacobian_threads"))
-#endif
+    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs()),
+    LocalParallelInterface(this)
 {
-#ifndef MOOSE_ENABLE_KOKKOS_GPU
-  if (isParamSetByUser("num_local_residual_threads"))
-    paramWarning("num_local_residual_threads", "Ignored when using Kokkos CPU backend.");
-  if (isParamSetByUser("num_local_jacobian_threads"))
-    paramWarning("num_local_jacobian_threads", "Ignored when using Kokkos CPU backend.");
-#endif
 }
 
 IntegratedBCBase::IntegratedBCBase(const IntegratedBCBase & object)
   : BoundaryCondition(object),
     CoupleableMooseVariableDependencyIntermediateInterface(object, {}),
     MaterialPropertyInterface(object, {}),
-    _num_local_residual_threads(object._num_local_residual_threads),
-    _num_local_jacobian_threads(object._num_local_jacobian_threads)
+    LocalParallelInterface(object)
 {
 }
 

--- a/framework/src/kokkos/interfaces/KokkosLocalParallelInterface.K
+++ b/framework/src/kokkos/interfaces/KokkosLocalParallelInterface.K
@@ -1,0 +1,55 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "KokkosLocalParallelInterface.h"
+
+namespace Moose::Kokkos
+{
+
+InputParameters
+LocalParallelInterface::validParams()
+{
+  auto params = emptyInputParameters();
+
+  // The default values are chosen empirically for first-order Lagrange shape functions in 3D
+  // geometries. Higher-order shape functions can benefit from using more local threads, but the
+  // default values will still provide moderate performance improvement. Residual calculation
+  // shows negative impacts after certain thread count, so its default value is smaller than that of
+  // Jacobian calculation.
+  params.addParam<unsigned int>("num_local_residual_threads",
+                                2,
+                                "The number of threads for additional parallelization of local "
+                                "DOFs in residual calculation.");
+  params.addParam<unsigned int>("num_local_jacobian_threads",
+                                4,
+                                "The number of threads for additional parallelization of local "
+                                "DOFs in Jacobian calculation.");
+
+  return params;
+}
+
+LocalParallelInterface::LocalParallelInterface(const MooseObject * moose_object)
+#ifdef MOOSE_ENABLE_KOKKOS_GPU
+  : _num_local_residual_threads(moose_object->getParam<unsigned int>("num_local_residual_threads")),
+    _num_local_jacobian_threads(moose_object->getParam<unsigned int>("num_local_jacobian_threads"))
+#else
+  : _num_local_residual_threads(1), _num_local_jacobian_threads(1)
+#endif
+{
+#ifndef MOOSE_ENABLE_KOKKOS_GPU
+  if (moose_object->isParamSetByUser("num_local_residual_threads"))
+    moose_object->paramError("num_local_residual_threads",
+                             "Should not be set when using Kokkos CPU backend.");
+  if (moose_object->isParamSetByUser("num_local_jacobian_threads"))
+    moose_object->paramError("num_local_jacobian_threads",
+                             "Should not be set when using Kokkos CPU backend.");
+#endif
+}
+
+} // namespace Moose::Kokkos

--- a/framework/src/kokkos/kernels/KokkosADKernel.K
+++ b/framework/src/kokkos/kernels/KokkosADKernel.K
@@ -61,7 +61,8 @@ ADKernel::computeResidualAndJacobian()
 void
 ADKernel::dispatch()
 {
-  _thread.resize(_num_local_threads, numKokkosBlockElements());
+  _thread.resize(_computing_jacobian ? _num_local_jacobian_threads : _num_local_residual_threads,
+                 numKokkosBlockElements());
 
   Policy policy(0, _thread.size());
 

--- a/framework/src/kokkos/kernels/KokkosKernel.K
+++ b/framework/src/kokkos/kernels/KokkosKernel.K
@@ -34,7 +34,7 @@ Kernel::Kernel(const InputParameters & parameters)
 void
 Kernel::computeResidual()
 {
-  _thread.resize(_num_local_threads, numKokkosBlockElements());
+  _thread.resize(_num_local_residual_threads, numKokkosBlockElements());
 
   Policy policy(0, _thread.size());
 
@@ -49,7 +49,7 @@ Kernel::computeJacobian()
 {
   if (DispatcherRegistry::hasUserMethod<JacobianLoop>(type()))
   {
-    _thread.resize(_num_local_threads, numKokkosBlockElements());
+    _thread.resize(_num_local_jacobian_threads, numKokkosBlockElements());
 
     Policy policy(0, _thread.size());
 
@@ -63,8 +63,9 @@ Kernel::computeJacobian()
   {
     auto & sys = kokkosSystem(_kokkos_var.sys());
 
-    _thread.resize(
-        _num_local_threads, sys.getCoupling(_kokkos_var.var()).size(), numKokkosBlockElements());
+    _thread.resize(_num_local_jacobian_threads,
+                   sys.getCoupling(_kokkos_var.var()).size(),
+                   numKokkosBlockElements());
 
     Policy policy(0, _thread.size());
 

--- a/framework/src/kokkos/kernels/KokkosKernelBase.K
+++ b/framework/src/kokkos/kernels/KokkosKernelBase.K
@@ -24,15 +24,7 @@ KernelBase::validParams()
   auto params = ResidualObject::validParams();
   params += BlockRestrictable::validParams();
   params += MaterialPropertyInterface::validParams();
-
-  params.addParam<unsigned int>("num_local_residual_threads",
-                                2,
-                                "The number of threads for additional parallelization of local "
-                                "DOFs in residual calculation.");
-  params.addParam<unsigned int>("num_local_jacobian_threads",
-                                4,
-                                "The number of threads for additional parallelization of local "
-                                "DOFs in Jacobian calculation.");
+  params += LocalParallelInterface::validParams();
 
   // Kernels always couple within their element
   params.addRelationshipManager("ElementSideNeighborLayers",
@@ -49,19 +41,9 @@ KernelBase::KernelBase(const InputParameters & parameters, Moose::VarFieldType f
   : ResidualObject(parameters, field_type),
     BlockRestrictable(this),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    MaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS)
-#ifdef MOOSE_ENABLE_KOKKOS_GPU
-    ,
-    _num_local_residual_threads(getParam<unsigned int>("num_local_residual_threads")),
-    _num_local_jacobian_threads(getParam<unsigned int>("num_local_jacobian_threads"))
-#endif
+    MaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS),
+    LocalParallelInterface(this)
 {
-#ifndef MOOSE_ENABLE_KOKKOS_GPU
-  if (isParamSetByUser("num_local_residual_threads"))
-    paramWarning("num_local_residual_threads", "Ignored when using Kokkos CPU backend.");
-  if (isParamSetByUser("num_local_jacobian_threads"))
-    paramWarning("num_local_jacobian_threads", "Ignored when using Kokkos CPU backend.");
-#endif
 }
 
 KernelBase::KernelBase(const KernelBase & object)
@@ -69,8 +51,7 @@ KernelBase::KernelBase(const KernelBase & object)
     BlockRestrictable(object, {}),
     CoupleableMooseVariableDependencyIntermediateInterface(object, {}),
     MaterialPropertyInterface(object, {}),
-    _num_local_residual_threads(object._num_local_residual_threads),
-    _num_local_jacobian_threads(object._num_local_jacobian_threads)
+    LocalParallelInterface(object)
 {
 }
 

--- a/framework/src/kokkos/kernels/KokkosKernelBase.K
+++ b/framework/src/kokkos/kernels/KokkosKernelBase.K
@@ -25,10 +25,14 @@ KernelBase::validParams()
   params += BlockRestrictable::validParams();
   params += MaterialPropertyInterface::validParams();
 
-  params.addParam<unsigned int>(
-      "num_local_threads",
-      4,
-      "The number of threads for additional parallelization of local DOFs.");
+  params.addParam<unsigned int>("num_local_residual_threads",
+                                2,
+                                "The number of threads for additional parallelization of local "
+                                "DOFs in residual calculation.");
+  params.addParam<unsigned int>("num_local_jacobian_threads",
+                                4,
+                                "The number of threads for additional parallelization of local "
+                                "DOFs in Jacobian calculation.");
 
   // Kernels always couple within their element
   params.addRelationshipManager("ElementSideNeighborLayers",
@@ -45,9 +49,19 @@ KernelBase::KernelBase(const InputParameters & parameters, Moose::VarFieldType f
   : ResidualObject(parameters, field_type),
     BlockRestrictable(this),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    MaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS),
-    _num_local_threads(getParam<unsigned int>("num_local_threads"))
+    MaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS)
+#ifdef MOOSE_ENABLE_KOKKOS_GPU
+    ,
+    _num_local_residual_threads(getParam<unsigned int>("num_local_residual_threads")),
+    _num_local_jacobian_threads(getParam<unsigned int>("num_local_jacobian_threads"))
+#endif
 {
+#ifndef MOOSE_ENABLE_KOKKOS_GPU
+  if (isParamSetByUser("num_local_residual_threads"))
+    paramWarning("num_local_residual_threads", "Ignored when using Kokkos CPU backend.");
+  if (isParamSetByUser("num_local_jacobian_threads"))
+    paramWarning("num_local_jacobian_threads", "Ignored when using Kokkos CPU backend.");
+#endif
 }
 
 KernelBase::KernelBase(const KernelBase & object)
@@ -55,7 +69,8 @@ KernelBase::KernelBase(const KernelBase & object)
     BlockRestrictable(object, {}),
     CoupleableMooseVariableDependencyIntermediateInterface(object, {}),
     MaterialPropertyInterface(object, {}),
-    _num_local_threads(object._num_local_threads)
+    _num_local_residual_threads(object._num_local_residual_threads),
+    _num_local_jacobian_threads(object._num_local_jacobian_threads)
 {
 }
 

--- a/framework/src/kokkos/systems/KokkosSystem.K
+++ b/framework/src/kokkos/systems/KokkosSystem.K
@@ -130,7 +130,7 @@ System::setupDofs()
           std::max(_max_dofs_per_elem[var], static_cast<unsigned int>(dof_indices.size()));
     }
 
-    _local_elem_dof_index[var].create(num_elems, _max_dofs_per_elem[var]);
+    _local_elem_dof_index[var].create(_max_dofs_per_elem[var], num_elems);
     _local_elem_dof_index[var] = libMesh::DofObject::invalid_id;
 
     _local_node_dof_index[var].create(num_nodes);
@@ -144,8 +144,8 @@ System::setupDofs()
 
       for (unsigned int dof = 0; dof < dof_indices.size(); ++dof)
       {
-        _local_elem_dof_index[var](id, dof) = solution->map_global_to_local_index(dof_indices[dof]);
-        _local_to_global_dof_index[_local_elem_dof_index[var](id, dof)] = dof_indices[dof];
+        _local_elem_dof_index[var](dof, id) = solution->map_global_to_local_index(dof_indices[dof]);
+        _local_to_global_dof_index[_local_elem_dof_index[var](dof, id)] = dof_indices[dof];
       }
     }
 

--- a/unit/include/KokkosArrayTest.h
+++ b/unit/include/KokkosArrayTest.h
@@ -26,7 +26,7 @@ protected:
   Moose::Kokkos::Array<unsigned int, dimension, index_type, layout> _array;
 };
 
-template <typename index_type = dof_id_type>
+template <typename index_type>
 class KokkosArrayTestObject1D
   : public KokkosArrayTestObjectBase<1, index_type, Moose::Kokkos::LayoutType::LEFT>
 {
@@ -39,8 +39,7 @@ public:
   KOKKOS_FUNCTION void operator()(const int i) const { this->_array(i) = i; }
 };
 
-template <typename index_type = dof_id_type,
-          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+template <typename index_type, Moose::Kokkos::LayoutType layout>
 class KokkosArrayTestObject2D : public KokkosArrayTestObjectBase<2, index_type, layout>
 {
 public:
@@ -52,8 +51,7 @@ public:
   KOKKOS_FUNCTION void operator()(const int i, const int j) const { this->_array(i, j) = i + j; }
 };
 
-template <typename index_type = dof_id_type,
-          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+template <typename index_type, Moose::Kokkos::LayoutType layout>
 class KokkosArrayTestObject3D : public KokkosArrayTestObjectBase<3, index_type, layout>
 {
 public:
@@ -68,8 +66,7 @@ public:
   }
 };
 
-template <typename index_type = dof_id_type,
-          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+template <typename index_type, Moose::Kokkos::LayoutType layout>
 class KokkosArrayTestObject4D : public KokkosArrayTestObjectBase<4, index_type, layout>
 {
 public:
@@ -84,8 +81,7 @@ public:
   }
 };
 
-template <typename index_type = dof_id_type,
-          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+template <typename index_type, Moose::Kokkos::LayoutType layout>
 class KokkosArrayTestObject5D : public KokkosArrayTestObjectBase<5, index_type, layout>
 {
 public:
@@ -119,27 +115,25 @@ protected:
   fillInner(const Moose::Kokkos::JaggedArrayInnerData<unsigned int, inner, layout> data) const
   {
     if constexpr (inner == 1)
-      for (dof_id_type i = 0; i < data.n(0); ++i)
+      for (unsigned int i = 0; i < data.n(0); ++i)
         data(i) = i;
 
     if constexpr (inner == 2)
-      for (dof_id_type i = 0; i < data.n(0); ++i)
-        for (dof_id_type j = 0; j < data.n(1); ++j)
+      for (unsigned int i = 0; i < data.n(0); ++i)
+        for (unsigned int j = 0; j < data.n(1); ++j)
           data(i, j) = i + j;
 
     if constexpr (inner == 3)
-      for (dof_id_type i = 0; i < data.n(0); ++i)
-        for (dof_id_type j = 0; j < data.n(1); ++j)
-          for (dof_id_type k = 0; k < data.n(2); ++k)
+      for (unsigned int i = 0; i < data.n(0); ++i)
+        for (unsigned int j = 0; j < data.n(1); ++j)
+          for (unsigned int k = 0; k < data.n(2); ++k)
             data(i, j, k) = i + j + k;
   }
 
   Moose::Kokkos::JaggedArray<unsigned int, inner, outer, index_type, layout> _array;
 };
 
-template <unsigned int inner,
-          typename index_type = dof_id_type,
-          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+template <unsigned int inner, typename index_type, Moose::Kokkos::LayoutType layout>
 class KokkosJaggedArrayTestObject1D
   : public KokkosJaggedArrayTestObjectBase<inner, 1, index_type, layout>
 {
@@ -153,9 +147,7 @@ public:
   KOKKOS_FUNCTION void operator()(const int i) const { this->fillInner(this->_array(i)); }
 };
 
-template <unsigned int inner,
-          typename index_type = dof_id_type,
-          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+template <unsigned int inner, typename index_type, Moose::Kokkos::LayoutType layout>
 class KokkosJaggedArrayTestObject2D
   : public KokkosJaggedArrayTestObjectBase<inner, 2, index_type, layout>
 {
@@ -172,9 +164,7 @@ public:
   }
 };
 
-template <unsigned int inner,
-          typename index_type = dof_id_type,
-          Moose::Kokkos::LayoutType layout = Moose::Kokkos::LayoutType::LEFT>
+template <unsigned int inner, typename index_type, Moose::Kokkos::LayoutType layout>
 class KokkosJaggedArrayTestObject3D
   : public KokkosJaggedArrayTestObjectBase<inner, 3, index_type, layout>
 {

--- a/unit/src/KokkosArrayTest.K
+++ b/unit/src/KokkosArrayTest.K
@@ -101,104 +101,13 @@ TEST_F(KokkosArrayTest, Array5D)
           }
 }
 
-TEST_F(KokkosArrayTest, Array1D4ByteIndex)
-{
-  Moose::Kokkos::Array<unsigned int, 1, unsigned int> array(3);
-
-  Kokkos::RangePolicy<> policy(0, 3);
-  KokkosArrayTestObject1D<unsigned int> object(array);
-  Kokkos::parallel_for(policy, object);
-
-  array.copyToHost();
-
-  for (unsigned int i = 0; i < 3; ++i)
-    EXPECT_EQ(array[i], i);
-}
-
-TEST_F(KokkosArrayTest, Array2D4ByteIndex)
-{
-  Moose::Kokkos::Array<unsigned int, 2, unsigned int> array(3, 4);
-
-  Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 4});
-  KokkosArrayTestObject2D<unsigned int> object(array);
-  Kokkos::parallel_for(policy, object);
-
-  array.copyToHost();
-
-  for (unsigned int i = 0; i < 3; ++i)
-    for (unsigned int j = 0; j < 4; ++j)
-    {
-      unsigned int idx = i + j * 3;
-      EXPECT_EQ(array[idx], i + j);
-    }
-}
-
-TEST_F(KokkosArrayTest, Array3D4ByteIndex)
-{
-  Moose::Kokkos::Array<unsigned int, 3, unsigned int> array(3, 4, 5);
-
-  Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 4, 5});
-  KokkosArrayTestObject3D<unsigned int> object(array);
-  Kokkos::parallel_for(policy, object);
-
-  array.copyToHost();
-
-  for (unsigned int i = 0; i < 3; ++i)
-    for (unsigned int j = 0; j < 4; ++j)
-      for (unsigned int k = 0; k < 5; ++k)
-      {
-        unsigned int idx = i + j * 3 + k * 3 * 4;
-        EXPECT_EQ(array[idx], i + j + k);
-      }
-}
-
-TEST_F(KokkosArrayTest, Array4D4ByteIndex)
-{
-  Moose::Kokkos::Array<unsigned int, 4, unsigned int> array(3, 4, 5, 6);
-
-  Kokkos::MDRangePolicy<Kokkos::Rank<4>> policy({0, 0, 0, 0}, {3, 4, 5, 6});
-  KokkosArrayTestObject4D<unsigned int> object(array);
-  Kokkos::parallel_for(policy, object);
-
-  array.copyToHost();
-
-  for (unsigned int i = 0; i < 3; ++i)
-    for (unsigned int j = 0; j < 4; ++j)
-      for (unsigned int k = 0; k < 5; ++k)
-        for (unsigned int l = 0; l < 6; ++l)
-        {
-          unsigned int idx = i + j * 3 + k * 3 * 4 + l * 3 * 4 * 5;
-          EXPECT_EQ(array[idx], i + j + k + l);
-        }
-}
-
-TEST_F(KokkosArrayTest, Array5D4ByteIndex)
-{
-  Moose::Kokkos::Array<unsigned int, 5, unsigned int> array(3, 4, 5, 6, 7);
-
-  Kokkos::MDRangePolicy<Kokkos::Rank<5>> policy({0, 0, 0, 0, 0}, {3, 4, 5, 6, 7});
-  KokkosArrayTestObject5D<unsigned int> object(array);
-  Kokkos::parallel_for(policy, object);
-
-  array.copyToHost();
-
-  for (unsigned int i = 0; i < 3; ++i)
-    for (unsigned int j = 0; j < 4; ++j)
-      for (unsigned int k = 0; k < 5; ++k)
-        for (unsigned int l = 0; l < 6; ++l)
-          for (unsigned int m = 0; m < 7; ++m)
-          {
-            unsigned int idx = i + j * 3 + k * 3 * 4 + l * 3 * 4 * 5 + m * 3 * 4 * 5 * 6;
-            EXPECT_EQ(array[idx], i + j + k + l + m);
-          }
-}
-
 TEST_F(KokkosArrayTest, Array2DRightLayout)
 {
-  Moose::Kokkos::Array<unsigned int, 2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> array(3, 4);
+  Moose::Kokkos::Array<unsigned int, 2, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+      array(3, 4);
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 4});
-  KokkosArrayTestObject2D<dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosArrayTestObject2D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -213,11 +122,11 @@ TEST_F(KokkosArrayTest, Array2DRightLayout)
 
 TEST_F(KokkosArrayTest, Array3DRightLayout)
 {
-  Moose::Kokkos::Array<unsigned int, 3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> array(
-      3, 4, 5);
+  Moose::Kokkos::Array<unsigned int, 3, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+      array(3, 4, 5);
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 4, 5});
-  KokkosArrayTestObject3D<dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosArrayTestObject3D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -233,11 +142,11 @@ TEST_F(KokkosArrayTest, Array3DRightLayout)
 
 TEST_F(KokkosArrayTest, Array4DRightLayout)
 {
-  Moose::Kokkos::Array<unsigned int, 4, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> array(
-      3, 4, 5, 6);
+  Moose::Kokkos::Array<unsigned int, 4, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+      array(3, 4, 5, 6);
 
   Kokkos::MDRangePolicy<Kokkos::Rank<4>> policy({0, 0, 0, 0}, {3, 4, 5, 6});
-  KokkosArrayTestObject4D<dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosArrayTestObject4D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -254,11 +163,11 @@ TEST_F(KokkosArrayTest, Array4DRightLayout)
 
 TEST_F(KokkosArrayTest, Array5DRightLayout)
 {
-  Moose::Kokkos::Array<unsigned int, 5, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> array(
-      3, 4, 5, 6, 7);
+  Moose::Kokkos::Array<unsigned int, 5, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+      array(3, 4, 5, 6, 7);
 
   Kokkos::MDRangePolicy<Kokkos::Rank<5>> policy({0, 0, 0, 0, 0}, {3, 4, 5, 6, 7});
-  KokkosArrayTestObject5D<dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosArrayTestObject5D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -284,7 +193,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D1D)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<1> object(array);
+  KokkosJaggedArrayTestObject1D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -304,7 +213,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D1D)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<2> object(array);
+  KokkosJaggedArrayTestObject1D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -328,7 +237,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D1D)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<3> object(array);
+  KokkosJaggedArrayTestObject1D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -354,7 +263,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D2D)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<1> object(array);
+  KokkosJaggedArrayTestObject2D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -376,7 +285,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D2D)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<2> object(array);
+  KokkosJaggedArrayTestObject2D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -402,7 +311,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D2D)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<3> object(array);
+  KokkosJaggedArrayTestObject2D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -430,7 +339,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D3D)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<1> object(array);
+  KokkosJaggedArrayTestObject3D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -454,7 +363,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D3D)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<2> object(array);
+  KokkosJaggedArrayTestObject3D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -482,7 +391,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D3D)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<3> object(array);
+  KokkosJaggedArrayTestObject3D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -501,7 +410,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D3D)
 
 TEST_F(KokkosArrayTest, jaggedArray1D1D4ByteIndex)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 1, 1, unsigned int> array(3);
+  Moose::Kokkos::JaggedArray<unsigned int, 1, 1> array(3);
 
   for (unsigned int I = 0; I < 3; ++I)
     array.reserve({I}, {I + 1});
@@ -509,7 +418,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D1D4ByteIndex)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<1, unsigned int> object(array);
+  KokkosJaggedArrayTestObject1D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -521,7 +430,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D1D4ByteIndex)
 
 TEST_F(KokkosArrayTest, jaggedArray2D1D4ByteIndex)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 2, 1, unsigned int> array(3);
+  Moose::Kokkos::JaggedArray<unsigned int, 2, 1> array(3);
 
   for (unsigned int I = 0; I < 3; ++I)
     array.reserve({I}, {I + 1, I + 1});
@@ -529,7 +438,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D1D4ByteIndex)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<2, unsigned int> object(array);
+  KokkosJaggedArrayTestObject1D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -545,7 +454,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D1D4ByteIndex)
 
 TEST_F(KokkosArrayTest, jaggedArray3D1D4ByteIndex)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 3, 1, unsigned int> array(3);
+  Moose::Kokkos::JaggedArray<unsigned int, 3, 1> array(3);
 
   for (unsigned int I = 0; I < 3; ++I)
     array.reserve({I}, {I + 1, I + 1, I + 1});
@@ -553,7 +462,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D1D4ByteIndex)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<3, unsigned int> object(array);
+  KokkosJaggedArrayTestObject1D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -570,7 +479,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D1D4ByteIndex)
 
 TEST_F(KokkosArrayTest, jaggedArray1D2D4ByteIndex)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 1, 2, unsigned int> array(3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 1, 2> array(3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -579,7 +488,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D2D4ByteIndex)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<1, unsigned int> object(array);
+  KokkosJaggedArrayTestObject2D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -592,7 +501,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D2D4ByteIndex)
 
 TEST_F(KokkosArrayTest, jaggedArray2D2D4ByteIndex)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 2, 2, unsigned int> array(3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 2, 2> array(3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -601,7 +510,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D2D4ByteIndex)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<2, unsigned int> object(array);
+  KokkosJaggedArrayTestObject2D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -618,7 +527,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D2D4ByteIndex)
 
 TEST_F(KokkosArrayTest, jaggedArray3D2D4ByteIndex)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 3, 2, unsigned int> array(3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 3, 2> array(3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -627,7 +536,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D2D4ByteIndex)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<3, unsigned int> object(array);
+  KokkosJaggedArrayTestObject2D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -645,7 +554,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D2D4ByteIndex)
 
 TEST_F(KokkosArrayTest, jaggedArray1D3D4ByteIndex)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 1, 3, unsigned int> array(3, 3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 1, 3> array(3, 3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -655,7 +564,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D3D4ByteIndex)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<1, unsigned int> object(array);
+  KokkosJaggedArrayTestObject3D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -669,7 +578,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D3D4ByteIndex)
 
 TEST_F(KokkosArrayTest, jaggedArray2D3D4ByteIndex)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 2, 3, unsigned int> array(3, 3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 2, 3> array(3, 3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -679,7 +588,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D3D4ByteIndex)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<2, unsigned int> object(array);
+  KokkosJaggedArrayTestObject3D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -697,7 +606,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D3D4ByteIndex)
 
 TEST_F(KokkosArrayTest, jaggedArray3D3D4ByteIndex)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 3, 3, unsigned int> array(3, 3, 3);
+  Moose::Kokkos::JaggedArray<unsigned int, 3, 3> array(3, 3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -707,7 +616,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D3D4ByteIndex)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<3, unsigned int> object(array);
+  KokkosJaggedArrayTestObject3D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -726,8 +635,9 @@ TEST_F(KokkosArrayTest, jaggedArray3D3D4ByteIndex)
 
 TEST_F(KokkosArrayTest, jaggedArray1D1DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 1, 1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
-      array(3);
+  Moose::Kokkos::
+      JaggedArray<unsigned int, 1, 1, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+          array(3);
 
   for (unsigned int I = 0; I < 3; ++I)
     array.reserve({I}, {I + 1});
@@ -735,7 +645,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D1DRightLayout)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject1D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -747,8 +657,9 @@ TEST_F(KokkosArrayTest, jaggedArray1D1DRightLayout)
 
 TEST_F(KokkosArrayTest, jaggedArray2D1DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 2, 1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
-      array(3);
+  Moose::Kokkos::
+      JaggedArray<unsigned int, 2, 1, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+          array(3);
 
   for (unsigned int I = 0; I < 3; ++I)
     array.reserve({I}, {I + 1, I + 1});
@@ -756,7 +667,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D1DRightLayout)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject1D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -772,8 +683,9 @@ TEST_F(KokkosArrayTest, jaggedArray2D1DRightLayout)
 
 TEST_F(KokkosArrayTest, jaggedArray3D1DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 3, 1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
-      array(3);
+  Moose::Kokkos::
+      JaggedArray<unsigned int, 3, 1, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+          array(3);
 
   for (unsigned int I = 0; I < 3; ++I)
     array.reserve({I}, {I + 1, I + 1, I + 1});
@@ -781,7 +693,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D1DRightLayout)
   array.finalize();
 
   Kokkos::RangePolicy<> policy(0, 3);
-  KokkosJaggedArrayTestObject1D<3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject1D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -798,8 +710,9 @@ TEST_F(KokkosArrayTest, jaggedArray3D1DRightLayout)
 
 TEST_F(KokkosArrayTest, jaggedArray1D2DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 1, 2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
-      array(3, 3);
+  Moose::Kokkos::
+      JaggedArray<unsigned int, 1, 2, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+          array(3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -808,7 +721,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D2DRightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject2D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -821,8 +734,9 @@ TEST_F(KokkosArrayTest, jaggedArray1D2DRightLayout)
 
 TEST_F(KokkosArrayTest, jaggedArray2D2DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 2, 2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
-      array(3, 3);
+  Moose::Kokkos::
+      JaggedArray<unsigned int, 2, 2, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+          array(3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -831,7 +745,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D2DRightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject2D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -848,8 +762,9 @@ TEST_F(KokkosArrayTest, jaggedArray2D2DRightLayout)
 
 TEST_F(KokkosArrayTest, jaggedArray3D2DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 3, 2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
-      array(3, 3);
+  Moose::Kokkos::
+      JaggedArray<unsigned int, 3, 2, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+          array(3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -858,7 +773,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D2DRightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> policy({0, 0}, {3, 3});
-  KokkosJaggedArrayTestObject2D<3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject2D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -876,8 +791,9 @@ TEST_F(KokkosArrayTest, jaggedArray3D2DRightLayout)
 
 TEST_F(KokkosArrayTest, jaggedArray1D3DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 1, 3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
-      array(3, 3, 3);
+  Moose::Kokkos::
+      JaggedArray<unsigned int, 1, 3, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+          array(3, 3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -887,7 +803,7 @@ TEST_F(KokkosArrayTest, jaggedArray1D3DRightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<1, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject3D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -901,8 +817,9 @@ TEST_F(KokkosArrayTest, jaggedArray1D3DRightLayout)
 
 TEST_F(KokkosArrayTest, jaggedArray2D3DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 2, 3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
-      array(3, 3, 3);
+  Moose::Kokkos::
+      JaggedArray<unsigned int, 2, 3, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+          array(3, 3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -912,7 +829,7 @@ TEST_F(KokkosArrayTest, jaggedArray2D3DRightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<2, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject3D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();
@@ -930,8 +847,9 @@ TEST_F(KokkosArrayTest, jaggedArray2D3DRightLayout)
 
 TEST_F(KokkosArrayTest, jaggedArray3D3DRightLayout)
 {
-  Moose::Kokkos::JaggedArray<unsigned int, 3, 3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT>
-      array(3, 3, 3);
+  Moose::Kokkos::
+      JaggedArray<unsigned int, 3, 3, MOOSE_KOKKOS_INDEX_TYPE, Moose::Kokkos::LayoutType::RIGHT>
+          array(3, 3, 3);
 
   for (unsigned int I = 0; I < 3; ++I)
     for (unsigned int J = 0; J < 3; ++J)
@@ -941,7 +859,7 @@ TEST_F(KokkosArrayTest, jaggedArray3D3DRightLayout)
   array.finalize();
 
   Kokkos::MDRangePolicy<Kokkos::Rank<3>> policy({0, 0, 0}, {3, 3, 3});
-  KokkosJaggedArrayTestObject3D<3, dof_id_type, Moose::Kokkos::LayoutType::RIGHT> object(array);
+  KokkosJaggedArrayTestObject3D object(array);
   Kokkos::parallel_for(policy, object);
 
   array.copyToHost();


### PR DESCRIPTION
## Reason
Some optimization items were found during the hackathon:
1. 8-byte integer operation adds a significant register pressure (especially 50-60 per thread for division and modulo). Using 4-byte integer operations gives noticeable speedup.
2. Uncoalesced loads to the local DOF map was found.
3. The optimal number of local threads for residual and Jacobian are very different.

## Design
1. Change default index size for Kokkos arrays and thread IDs to 4 bytes and make it configurable.
2. Fix map ordering.
3. Allow independent control of residual and Jacobian local thread counts.

## Impact
Improved performance.