### PR TITLE
Typo fixes

### DIFF
--- a/framework/doc/content/source/problems/FEProblemBase.md
+++ b/framework/doc/content/source/problems/FEProblemBase.md
@@ -70,7 +70,7 @@ of time on systems that have several active variables.
 - Shape Functions are the functions that get multiplied by coefficients and summed to form the solution.
 - Individual shape functions are restrictions of the global basis functions to individual elements.
 - They are analogous to the $x^n$ functions from polynomial fitting (in fact, you can use those as shape functions).
-- Typical shape function families: Lagrange, Hermite, Hierarchic, Monomial, Clough-Toucher
+- Typical shape function families: Lagrange, Hermite, Hierarchic, Monomial, Clough-Tocher
     - MOOSE has support for all of these.
 - Lagrange shape functions are the most common.
     -  They are interpolary at the nodes, i.e., the coefficients correspond to the values of the functions at the nodes.

--- a/tutorials/darcy_thermo_mech/doc/content/workshop/numerical/fem_shape.md
+++ b/tutorials/darcy_thermo_mech/doc/content/workshop/numerical/fem_shape.md
@@ -72,7 +72,7 @@ Individual shape functions are restrictions of the global basis functions to ind
 They are analogous to the $x^n$ functions from polynomial fitting (in fact, you can use those as
 shape functions).
 
-Typical shape function families: Lagrange, Hermite, Hierarchic, Monomial, Clough-Toucher
+Typical shape function families: Lagrange, Hermite, Hierarchic, Monomial, Clough-Tocher
 
 Lagrange shape functions are the most common, which are interpolatory at the nodes, i.e., the
 coefficients correspond to the values of the functions at the nodes.


### PR DESCRIPTION
Refs #32191 (the currently-proceeding MOOSE training now counts as "latest MOOSE training", right?)

The pronunciation of "Tocher" ("toe-sure", I believe) isn't obvious, but it's not "toucher".

I swear I've looked at this slide a dozen times and I have no idea how I only noticed the typo now.