### PR TITLE
Set ThreadedGeneralUserObject grain size manually

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5488,7 +5488,12 @@ FEProblemBase::computeUserObjectsInternal(const ExecFlagType & type, TheWarehous
       q.queryInto(tguos);
 
       ComputeThreadedGeneralUserObjectsThread ctguot(*this);
-      Threads::parallel_reduce(GeneralUserObjectRange(tguos.begin(), tguos.end()), ctguot);
+
+      // Force one thread per ThreadedGeneralUserObject via grainsize
+      Threads::parallel_reduce(GeneralUserObjectRange(tguos.begin(),
+                                                      tguos.end(),
+                                                      /*grainsize=*/1),
+                               ctguot);
       joinAndFinalize(q);
     }
 


### PR DESCRIPTION
This ensures that we have one threaded object per thread even when the backend respects grain size.

Yeah, I know I said this was a 2 char fix, but ",1" without explanatory comment felt like it would be contributing to deeper problems.

This fixes #33048 on my system