### PR TITLE
Use static_cast where possible in TheWarehouse

### DIFF
--- a/framework/include/base/TheWarehouse.h
+++ b/framework/include/base/TheWarehouse.h
@@ -498,8 +498,8 @@ public:
       // succeeds, but if we know the correct type T then often we can
       // use a much-cheaper static_cast.  libMesh::cast_ptr will still
       // use a dynamic_cast + assertion in devel/dbg modes.
-      if constexpr (std::is_convertible_v<MooseObject *, T *> ||
-                    std::is_convertible_v<T *, MooseObject *>)
+      if constexpr (std::is_convertible_v<MooseObject *, std::remove_cv_t<T> *> ||
+                    std::is_convertible_v<std::remove_cv_t<T> *, MooseObject *>)
       {
         cast_obj = cast_ptr<T *>(obj);
       }

--- a/framework/include/base/TheWarehouse.h
+++ b/framework/include/base/TheWarehouse.h
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <iostream>
 #include <mutex>
+#include <type_traits>
 
 #include "MooseObject.h"
 #include "MooseHashing.h"
@@ -492,10 +493,26 @@ public:
     for (auto & obj : objs)
     {
       mooseAssert(obj, "Null object");
-      auto cast_obj = dynamic_cast<T *>(obj);
-      mooseAssert(cast_obj,
-                  "Queried object " + obj->typeAndName() + " has incompatible c++ type with " +
-                      MooseUtils::prettyCppType<T>());
+      T * cast_obj;
+      // We've been using dynamic_cast plus an assert that it
+      // succeeds, but if we know the correct type T then often we can
+      // use a much-cheaper static_cast.  libMesh::cast_ptr will still
+      // use a dynamic_cast + assertion in devel/dbg modes.
+      if constexpr (std::is_convertible_v<MooseObject *, T *> ||
+                    std::is_convertible_v<T *, MooseObject *>)
+      {
+        cast_obj = cast_ptr<T *>(obj);
+      }
+      // Side-casts or virtual inheritence are always expensive.
+      // Someone should figure out how to get rid of this code path.
+      else
+      {
+        cast_obj = dynamic_cast<T *>(obj);
+        mooseAssert(cast_obj,
+                    "Queried object " + obj->typeAndName() + " has incompatible c++ type with " +
+                        MooseUtils::prettyCppType<T>());
+      }
+
       mooseAssert(std::find(results.begin(), results.end(), cast_obj) == results.end(),
                   "Duplicate object");
       if (show_all || obj->enabled())


### PR DESCRIPTION
Refs #33058

I get a 5x speedup when re-running the reproducer in that issue with this patch.

I'm not going to say this is a "fix", because the root problem isn't just that this function was slower than it should be, it's that this function shouldn't be getting called 50,000 times per element evaluation.