### PR TITLE
Do not fail tests due to deprecation warnings on tests marked as deprecated

### DIFF
--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -447,6 +447,7 @@ class RunApp(Tester):
         if (
             "--error-deprecated" not in cli_args
             and not specs["no_error_deprecated"]
+            and not specs["deprecated"]
             and (not specs["allow_deprecated"] or options.error_deprecated)
         ):
             cli_args.append("--error-deprecated")

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -118,11 +118,6 @@ class RunApp(Tester):
             "Whether or not deprecated warnings are allowed.  Setting to False will cause deprecation warnings to be treated as test failures.  We do NOT recommend you globally set this permanently to False!  Deprecations are a part of the normal development flow and _SHOULD_ be allowed!",
         )
         params.addParam(
-            "no_error_deprecated",
-            False,
-            "Don't pass --error-deprecated on the command line even when running the TestHarness with --error-deprecated",
-        )
-        params.addParam(
             "no_additional_cli_args",
             False,
             "A Boolean indicating that no additional CLI args should be added from the TestHarness. Note: This parameter should be rarely used as it will not pass on additional options such as those related to mpi, threads, distributed mesh, errors, etc.",
@@ -446,7 +441,6 @@ class RunApp(Tester):
 
         if (
             "--error-deprecated" not in cli_args
-            and not specs["no_error_deprecated"]
             and not specs["deprecated"]
             and (not specs["allow_deprecated"] or options.error_deprecated)
         ):

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -219,7 +219,7 @@ class Tester(MooseObject, OutputInterface):
         params.addParam(
             "deprecated",
             False,
-            "When True the test is no longer considered part SQA process and as such does not include the need for a requirement definition.",
+            "When True the test is no longer considered part SQA process and as such does not include the need for a requirement definition. Also prevents errors from being raised if a deprecation warning is encountered.",
         )
         params.addParam(
             "collections",

--- a/test/tests/geomsearch/patch_update_strategy/tests
+++ b/test/tests/geomsearch/patch_update_strategy/tests
@@ -47,6 +47,6 @@
     issues = '#14166'
     design = 'syntax/Mesh/index.md source/auxkernels/GapValueAux.md FEProblemBase.md'
     requirement = 'The system shall be able to perform patch updates on every non-linear iteration while performing uniform coarsening and refinement from grid sequencing.'
-    no_error_deprecated = true
+    deprecated = true
   []
 []

--- a/test/tests/mesh/mesh_generation/tests
+++ b/test/tests/mesh/mesh_generation/tests
@@ -160,28 +160,24 @@
     type = RunException
     input = annular_except1_deprecated.i
     expect_err = 'rmax must be greater than rmin'
-    no_error_deprecated = true
     deprecated = true
   []
   [annular_except2_deprecated]
     type = RunException
     input = annular_except2_deprecated.i
     expect_err = 'dmax must be greater than dmin'
-    no_error_deprecated = true
     deprecated = true
   []
   [annular_except3_deprecated]
     type = RunException
     input = annular_except3_deprecated.i
     expect_err = 'dmax - dmin must be <= 360'
-    no_error_deprecated = true
     deprecated = true
   []
   [annular_except5_deprecated]
     type = RunException
     input = annular_except5_deprecated.i
     expect_err = 'nt must be greater than \(dmax - dmin\) / 180 in order to avoid inverted elements'
-    no_error_deprecated = true
     deprecated = true
   []
   [annulus_sector_deprecated]
@@ -189,7 +185,6 @@
     input = annulus_sector_deprecated.i
     exodiff = 'annulus_sector_deprecated_out.e'
     prereq = annular/annulus_sector
-    no_error_deprecated = true
     deprecated = true
   []
   [disc_sector_deprecated]
@@ -197,7 +192,6 @@
     input = disc_sector_deprecated.i
     exodiff = 'disc_sector_deprecated_out.e'
     prereq = annular/disc_sector
-    no_error_deprecated = true
     deprecated = true
   []
 []

--- a/test/tests/meshgenerators/annular_mesh_generator/tests
+++ b/test/tests/meshgenerators/annular_mesh_generator/tests
@@ -30,7 +30,6 @@
     mesh_mode = 'REPLICATED'
     recover = false
     deprecated = true
-    no_error_deprecated = true
   [../]
   [./annular_mesh_generator_radial_positions]
     type = 'Exodiff'

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -156,7 +156,7 @@
     input = 'deprecated_param_test.i'
     expect_out = "The parameter '\w+' is deprecated."
     cli_args = 'Kernels/nan/deprecated_default=1 Outputs/exodus=false'
-    no_error_deprecated = true
+    deprecated = true
 
     requirement = 'The system shall report a warning when a deprecated parameter with a default value is explicitly set by the user.'
     issues = '#1951'
@@ -167,7 +167,7 @@
     input = 'deprecated_param_test.i'
     expect_out = "The parameter '\w+' is deprecated."
     cli_args = 'Kernels/nan/deprecated_no_default=1 Outputs/exodus=false'
-    no_error_deprecated = true
+    deprecated = true
 
     requirement = 'The system shall report a warning when an optional deprecated parameter is explicitly set by the user.'
     issues = '#1951'

--- a/test/tests/misc/deprecation/tests
+++ b/test/tests/misc/deprecation/tests
@@ -2,7 +2,7 @@
   design = 'MooseApp.md'
   issues = '#10745'
 
-  # Note: The no_error_deprecated flag prevents the TestHarness
+  # Note: The deprecated flag prevents the TestHarness
   # from passing the --error-deprecated flag to MOOSE.
 
   [deprecated]
@@ -10,7 +10,7 @@
     input = 'deprecation.i'
     cli_args = 'Kernels/diff/type=DeprecatedKernel'
     expect_out = 'Deprecated Object: DeprecatedKernel'
-    no_error_deprecated = true
+    deprecated = true
 
     requirement = 'The system shall produce a warning when non-expired deprecated code is executed.'
   []
@@ -19,7 +19,7 @@
     input = 'deprecation.i'
     cli_args = 'Kernels/diff/type=ExpiredKernel'
     expect_out = 'Expired on Mon Jan'
-    no_error_deprecated = true
+    deprecated = true
 
     requirement = 'The system shall produce a warning when expired deprecated code is executed.'
   []
@@ -37,7 +37,7 @@
     input = 'deprecation.i'
     cli_args = 'Kernels/diff/type=OldNamedKernel'
     expect_out = 'Replace OldNamedKernel with RenamedKernel'
-    no_error_deprecated = true
+    deprecated = true
 
     requirement = 'The system shall produce a warning indicating a possible replacement when deprecated code is superseded.'
   []
@@ -48,7 +48,7 @@
     requirement = 'The system shall be able to deprecate parameter names, while enabling user code to only use the new, blessed name'
     design = 'InputParameters.md'
     issues = '#15497'
-    no_error_deprecated = True
+    deprecated = True
     expect_out = "deprecate-old-for-new-param.i:28.5:\nKernels/diff/coef: 'coef' has been deprecated and will be removed on 01/01/2040. Please use 'coeff' instead."
   []
 
@@ -59,7 +59,7 @@
     requirement = 'The system shall be able to deprecate coupled variable names, while enabling user code to only use the new, blessed name'
     design = 'InputParameters.md'
     issues = '#15497'
-    no_error_deprecated = True
+    deprecated = True
     expect_out = "deprecated_coupled_var.i:33.5:\nKernels/deprecated_coupled_v/stupid_name: 'stupid_name' has been deprecated and will be removed on 01/01/2040. Please use 'source' instead."
   []
 


### PR DESCRIPTION
## Reason
Right now, if a test is marked `deprecated`, it must also be marked `no_error_deprecated` or else it would fail when invoked with `—error-deprecated`. This is redundant. This PR makes `deprecated` tests ignore the `—error-deprecated` option as well.

Resolves #15283 

## Design
In addition to looking if the test was marked for `no_error_deprecated`, we also now look for `deprecated`.

## Impact
Should be minor impact and hopefully make it easier to handle tests for deprecated objects in the future.
