### PR TITLE
Kokkos AMD HIP build

### DIFF
--- a/framework/include/utils/EigenADReal.h
+++ b/framework/include/utils/EigenADReal.h
@@ -154,28 +154,28 @@ namespace Eigen::internal
 {
 
 template <>
-inline long double
+EIGEN_DEVICE_FUNC inline long double
 cast<ADReal, long double>(const ADReal & x)
 {
   return MetaPhysicL::raw_value(x);
 }
 
 template <>
-inline double
+EIGEN_DEVICE_FUNC inline double
 cast<ADReal, double>(const ADReal & x)
 {
   return MetaPhysicL::raw_value(x);
 }
 
 template <>
-inline long
+EIGEN_DEVICE_FUNC inline long
 cast<ADReal, long>(const ADReal & x)
 {
   return MetaPhysicL::raw_value(x);
 }
 
 template <>
-inline int
+EIGEN_DEVICE_FUNC inline int
 cast<ADReal, int>(const ADReal & x)
 {
   return MetaPhysicL::raw_value(x);

--- a/framework/kokkos.mk
+++ b/framework/kokkos.mk
@@ -18,6 +18,13 @@ KOKKOS_CUDA_ARCH_90  := Hopper CC 9.0
 KOKKOS_CUDA_ARCH_100 := Blackwell CC 10.0
 KOKKOS_CUDA_ARCH_120 := Blackwell CC 12.0
 
+# HIP architecture strings
+KOKKOS_HIP_ARCH_gfx900 := GCN 5.0
+KOKKOS_HIP_ARCH_gfx906 := GCN 5.1
+KOKKOS_HIP_ARCH_gfx908 := CDNA 1.0
+KOKKOS_HIP_ARCH_gfx90a := CDNA 2.0
+KOKKOS_HIP_ARCH_gfx942 := CDNA 3.0
+
 # SYCL architecture strings
 KOKKOS_SYCL_ARCH_        := SPIR-V
 KOKKOS_SYCL_ARCH_gen9-   := Gen9+
@@ -55,6 +62,7 @@ ifeq ($(PETSC_HAVE_KOKKOS),1)
     ifeq ($(PETSC_HAVE_HIPCUDA),1)
       $(error For NVIDIA GPUs, use CUDA instead of HIP)
     endif
+    HIP_ARCH := $(shell sed -n 's/\#define PETSC_HIP_ROCM_ARCH //p' $(PETSC_CONF))
   endif
   ifeq ($(PETSC_HAVE_SYCL),1)
     SYCL_ARCH := $(shell sed -n 's/\#define PETSC_SYCL_DEVICE //p' $(PETSC_CONF))
@@ -89,14 +97,14 @@ ifneq ($(PETSC_HAVE_CUDA),)
   KOKKOS_CXXFLAGS   += $(filter-out -Werror=return-type,$(CXXFLAGS) $(libmesh_CXXFLAGS)) # Incompatible with NVCC
   KOKKOS_CPPFLAGS    = $(subst -Werror,-Werror=all-warnings,$(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS})
   KOKKOS_LDFLAGS     = --forward-unknown-to-host-compiler -arch=sm_$(CUDA_ARCH)
-else ifneq ($(PETSC_HAVE_HIP),) # To be determined for HIP
+else ifneq ($(PETSC_HAVE_HIP),)
   KOKKOS_DEVICE     := HIP
-  KOKKOS_ARCH       :=
+  KOKKOS_ARCH       := $(KOKKOS_HIP_ARCH_$(HIP_ARCH))
   KOKKOS_COMPILER   := HIPCC
   KOKKOS_CXX         = $(HIP_COMPILER)
-  KOKKOS_CXXFLAGS    =
-  KOKKOS_CPPFLAGS    =
-  KOKKOS_LDFLAGS     =
+  KOKKOS_CXXFLAGS    = --offload-arch=$(HIP_ARCH) -x hip $(CXXFLAGS) $(libmesh_CXXFLAGS)
+  KOKKOS_CPPFLAGS    = $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS}
+  KOKKOS_LDFLAGS     = --offload-arch=$(HIP_ARCH)
 else ifneq ($(PETSC_HAVE_SYCL),)
   KOKKOS_DEVICE     := SYCL
   KOKKOS_ARCH       := $(KOKKOS_SYCL_ARCH_$(SYCL_ARCH))

--- a/framework/src/base/Capabilities.C
+++ b/framework/src/base/Capabilities.C
@@ -243,6 +243,17 @@ Capabilities::registerMooseCapabilities()
   }
 
   {
+    const auto doc = "AMD GPU parallel computing platform";
+#ifdef PETSC_HAVE_HIPROCM
+    const std::string version = QUOTE(PETSC_PKG_HIP_VERSION_MAJOR) "." QUOTE(
+        PETSC_PKG_HIP_VERSION_MINOR) "." QUOTE(PETSC_PKG_HIP_VERSION_SUBMINOR);
+    add_string("hip", version, doc);
+#else
+    missing("hip", doc, "Add the HIP bin directory to your path and rebuild PETSc.");
+#endif
+  }
+
+  {
     const auto doc = "Kokkos performance portability programming ecosystem";
 #ifdef MOOSE_KOKKOS_ENABLED
     const std::string version = QUOTE(PETSC_PKG_KOKKOS_VERSION_MAJOR) "." QUOTE(


### PR DESCRIPTION
Prerequisites:

- The latest version of PETSc containing SuperLU_DIST patch (https://gitlab.com/petsc/petsc/-/commit/eaa2263becb8845166c2ffa237b583221ed07916) and my HYPRE and config patch (https://gitlab.com/petsc/petsc/-/merge_requests/9329)
- PETSc configured with the libCEED version containing missing `cstring` header patch in `hip-gen` (https://github.com/CEED/libCEED/commit/e85e3fbe59e252b87d679aff1251afb2eaaa7540)
- PETSc configured with the STRUMPACK version containing HIP complex type patch (https://github.com/pghysels/STRUMPACK/commit/cfba574f60b792433ee87e7e2a874eeb96c74d1f)

HIP build should exclusively use AMD Clang compiler suite (`amdclang`, `amdclang++`, `amdflang`) for ABI sanity as `hipcc` does not allow changing the host compiler.