### PR TITLE
Improve early FV interpolation method getter diagnostics (#28131)

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4773,7 +4773,15 @@ FEProblemBase::getFVInterpolationMethod(const InterpolationMethodName & name,
       .queryInto(methods);
 
   if (methods.empty())
+  {
+    mooseAssert(getMooseApp().actionWarehouse().isTaskComplete("add_interpolation_method"),
+                "An FVInterpolationMethod getter was called before FVInterpolationMethods have "
+                "been constructed. If you are attempting to access this object in the constructor "
+                "of another object then make sure that the FVInterpolationMethod is constructed "
+                "before the object using it.");
+
     mooseError("Unable to find FVInterpolationMethod with name '", name, "'");
+  }
 
   mooseAssert(methods.size() == 1, "Expected a single FVInterpolationMethod per thread");
   return *(methods[0]);

--- a/test/src/problems/GetterTooEarlyProblem.C
+++ b/test/src/problems/GetterTooEarlyProblem.C
@@ -13,13 +13,15 @@ GetterTooEarlyProblem::validParams()
   InputParameters params = FEProblem::validParams();
   params.addRequiredParam<MooseEnum>(
       "getter",
-      MooseEnum("function user_object multi_app distribution sampler"),
+      MooseEnum("function user_object multi_app distribution sampler fv_interpolation_method"),
       "The getter to call too early");
   params.addParam<FunctionName>("function", "Function to request too early");
   params.addParam<UserObjectName>("user_object", "UserObject to request too early");
   params.addParam<MultiAppName>("multi_app", "MultiApp to request too early");
   params.addParam<DistributionName>("distribution", "Distribution to request too early");
   params.addParam<SamplerName>("sampler", "Sampler to request too early");
+  params.addParam<InterpolationMethodName>("fv_interpolation_method",
+                                           "FVInterpolationMethod to request too early");
   return params;
 }
 
@@ -38,4 +40,7 @@ GetterTooEarlyProblem::GetterTooEarlyProblem(const InputParameters & params)
     static_cast<void>(getDistribution(getParam<DistributionName>("distribution")));
   else if (getter == "sampler")
     static_cast<void>(getSampler(getParam<SamplerName>("sampler")));
+  else if (getter == "fv_interpolation_method")
+    static_cast<void>(
+        getFVInterpolationMethod(getParam<InterpolationMethodName>("fv_interpolation_method")));
 }

--- a/test/tests/problems/getter_too_early/get_distribution_sampler_too_early.i
+++ b/test/tests/problems/getter_too_early/get_distribution_sampler_too_early.i
@@ -36,6 +36,7 @@
   getter = distribution
   distribution = dist
   sampler = sample
+  fv_interpolation_method = interp
 []
 
 [Distributions]
@@ -47,6 +48,12 @@
 [Samplers]
   [sample]
     type = TestSampler
+  []
+[]
+
+[FVInterpolationMethods]
+  [interp]
+    type = FVGeometricAverage
   []
 []
 

--- a/test/tests/problems/getter_too_early/tests
+++ b/test/tests/problems/getter_too_early/tests
@@ -55,4 +55,13 @@
     requirement = 'The system shall report an error when a sampler object is requested before sampler objects are available.'
     issues = '#28131'
   []
+  [get_fv_interpolation_method_too_early]
+    type = RunException
+    input = get_distribution_sampler_too_early.i
+    cli_args = 'Problem/getter=fv_interpolation_method'
+    capabilities = 'method=dbg'
+    expect_err = 'An FVInterpolationMethod getter was called before FVInterpolationMethods have been constructed'
+    requirement = 'The system shall report an error when a finite-volume interpolation method object is requested before finite-volume interpolation method objects are available.'
+    issues = '#28131'
+  []
 []


### PR DESCRIPTION
Title:
Improve early FV interpolation method getter diagnostics

Body:
refs #28131

## Reason
Calling FEProblemBase::getFVInterpolationMethod() before FVInterpolationMethods have been constructed currently falls through to a generic missing-object error. Linear FV kernels are expected to fetch interpolation methods only after add_interpolation_method has completed, and MOOSE already declares that task dependency.

## Design
Adds a debug-mode assertion in FEProblemBase::getFVInterpolationMethod() when the requested method is not found and add_interpolation_method has not completed. The existing missing-object mooseError is preserved after construction is complete.

The regression test extends GetterTooEarlyProblem with an fv_interpolation_method mode and uses the shared getter-too-early input selected through cli_args.

Positions, MeshDivision, Convergence, and Postprocessor direct-object getters were inspected but intentionally not included: Positions and MeshDivision have valid same-task dependency/order semantics; Convergence has default-action timing nuance; and postprocessor value/name access already has PostprocessorInterface lifecycle checks.

## Impact
No API changes. Optimized-build behavior unchanged. Debug builds produce clearer diagnostics for too-early FV interpolation method getter calls.

Tested:
METHOD=dbg ./run_tests --spec-file tests/problems/getter_too_early/tests -p 1 --re get_fv_interpolation_method_too_early
METHOD=dbg ./run_tests --spec-file tests/problems/getter_too_early/tests -p 1