### PR TITLE
Add more citation support

### DIFF
--- a/python/MooseDocs/extensions/bibtex.py
+++ b/python/MooseDocs/extensions/bibtex.py
@@ -300,38 +300,7 @@ class RenderBibtexCite(components.RenderComponent):
                 continue
 
             entry = self.extension.database().entries[key]
-            author_found = True
-            if (
-                not "author" in entry.persons.keys()
-                and not "Author" in entry.persons.keys()
-            ):
-                author_found = False
-                entities = ["institution", "organization"]
-                for entity in entities:
-                    if entity in entry.fields.keys():
-                        author_found = True
-                        name = ""
-                        for word in entry.fields[entity]:
-                            if word[0].isupper():
-                                name += word[0]
-                        entry.persons["author"] = [Person(name)]
-
-            if not author_found:
-                msg = "No author, institution, or organization for {}"
-                raise exceptions.MooseDocsException(msg, key)
-
-            a = entry.persons["author"]
-            n = len(a)
-            if n > 2:
-                author = "{} et al.".format(" ".join(a[0].last_names))
-            elif n == 2:
-                a0 = " ".join(a[0].last_names)
-                a1 = " ".join(a[1].last_names)
-                author = "{} and {}".format(a0, a1)
-            else:
-                author = " ".join(a[0].last_names)
-
-            author = LatexNodes2Text().latex_to_text(author)
+            author = self._authorString(key, entry)
 
             form = "{}, {}" if citep else "{} ({})"
             year = entry.fields.get("year", None)
@@ -359,16 +328,70 @@ class RenderBibtexCite(components.RenderComponent):
 
         return parent
 
+    def _authorString(self, key, entry):
+        """Return the inline author label for an entry, e.g. 'Slaughter et al.'.
+
+        Falls back to initials of the institution or organization when the entry
+        has no author."""
+        author_found = True
+        if (
+            not "author" in entry.persons.keys()
+            and not "Author" in entry.persons.keys()
+        ):
+            author_found = False
+            entities = ["institution", "organization"]
+            for entity in entities:
+                if entity in entry.fields.keys():
+                    author_found = True
+                    name = ""
+                    for word in entry.fields[entity]:
+                        if word[0].isupper():
+                            name += word[0]
+                    entry.persons["author"] = [Person(name)]
+
+        if not author_found:
+            msg = "No author, institution, or organization for {}"
+            raise exceptions.MooseDocsException(msg, key)
+
+        a = entry.persons["author"]
+        n = len(a)
+        if n > 2:
+            author = "{} et al.".format(" ".join(a[0].last_names))
+        elif n == 2:
+            a0 = " ".join(a[0].last_names)
+            a1 = " ".join(a[1].last_names)
+            author = "{} and {}".format(a0, a1)
+        else:
+            author = " ".join(a[0].last_names)
+
+        return LatexNodes2Text().latex_to_text(author)
+
     def _createNumberHTML(self, parent, token, page):
-        """Render citations as bracketed numbers, e.g. '[1, 2]', that match the
-        numbering of the reference list."""
+        """Render citations using bracketed numbers that match the reference list.
+
+        Parenthetical citations (!citep) render as just the number, e.g. '[1, 2]'.
+        Textual citations (!cite, !citet) prepend the author so the citation reads
+        as part of the sentence, e.g. 'Slaughter et al. [1]'."""
         numbers = self.extension.citationNumbers(page)
+        textual = token["cite"] != "citep"
         num_keys = len(token["keys"])
-        html.String(parent, content="[")
+        if not textual:
+            html.String(parent, content="[")
         for i, key in enumerate(token["keys"]):
             if key not in self.extension.database().entries:
                 LOG.error("Unknown BibTeX key: %s", key)
                 html.Tag(parent, "span", string=key, style="color:red;")
+            elif textual:
+                entry = self.extension.database().entries[key]
+                html.String(
+                    parent, content="{} ".format(self._authorString(key, entry))
+                )
+                html.Tag(
+                    parent,
+                    "a",
+                    href="#{}".format(key),
+                    string="[{}]".format(numbers.get(key)),
+                )
             else:
                 html.Tag(
                     parent,
@@ -378,7 +401,8 @@ class RenderBibtexCite(components.RenderComponent):
                 )
             if i != num_keys - 1:
                 html.String(parent, content=", ")
-        html.String(parent, content="]")
+        if not textual:
+            html.String(parent, content="]")
         return parent
 
     def createMaterialize(self, parent, token, page):

--- a/python/MooseDocs/extensions/bibtex.py
+++ b/python/MooseDocs/extensions/bibtex.py
@@ -463,10 +463,18 @@ class RenderBibtexBibliography(components.RenderComponent):
 
             db = BibliographyData()
             db.add_entry(key, entry)
+            # The 'language-*' class lets Prism wrap each block in its toolbar
+            # (adding the Copy button and overflow scrolling). RIS and plain text
+            # have no Prism grammar, so 'language-none' gives them the same toolbar
+            # without syntax coloring.
             formats = [
                 ("BibTeX", db.to_string("bibtex"), "language-latex"),
-                ("RIS", bibtex_to_ris(entry), None),
-                ("Plain Text", self._plainText(key, token["bib_style"]), None),
+                ("RIS", bibtex_to_ris(entry), "language-none"),
+                (
+                    "Plain Text",
+                    self._plainText(key, token["bib_style"]),
+                    "language-none",
+                ),
             ]
 
             m_id = uuid.uuid4()

--- a/python/MooseDocs/extensions/bibtex.py
+++ b/python/MooseDocs/extensions/bibtex.py
@@ -66,9 +66,14 @@ def bibtex_to_ris(entry):
 
     persons = entry.persons.get("author") or entry.persons.get("editor") or []
     for person in persons:
-        last = to_text(" ".join(person.last_names))
+        # RIS author names are "family, given, suffix"; the family name keeps any
+        # particle (e.g. "van") and the suffix holds the lineage (e.g. "Jr.").
+        last = to_text(" ".join(person.prelast_names + person.last_names))
         given = to_text(" ".join(person.first_names + person.middle_names))
-        lines.append(("AU", "{}, {}".format(last, given) if given else last))
+        name = "{}, {}".format(last, given) if given else last
+        if person.lineage_names:
+            name += ", {}".format(to_text(" ".join(person.lineage_names)))
+        lines.append(("AU", name))
 
     field_map = [
         ("TI", "title"),

--- a/python/MooseDocs/extensions/bibtex.py
+++ b/python/MooseDocs/extensions/bibtex.py
@@ -48,6 +48,11 @@ class BibtexExtension(command.CommandExtension):
             "Show a warning when duplicate entries detected.",
         )
         config["duplicates"] = (list(), "A list of duplicates that are allowed.")
+        config["citation_style"] = (
+            "author-year",
+            "The inline citation style: 'author-year' (e.g. 'Smith et al. (2024)') "
+            "or 'number' (e.g. '[1]').",
+        )
         return config
 
     def __init__(self, *args, **kwargs):
@@ -90,6 +95,19 @@ class BibtexExtension(command.CommandExtension):
     def preRead(self, page):
         """Initialize the page citations list."""
         page["citations"] = list()
+        page["citation_numbers"] = None
+
+    def citationNumbers(self, page):
+        """Return a {key: number} map for a page, numbered in order of first
+        citation appearance (deduplicated). Used by the 'number' citation style."""
+        numbers = page.get("citation_numbers")
+        if numbers is None:
+            numbers = dict()
+            for key in page.get("citations", list()):
+                if key not in numbers:
+                    numbers[key] = len(numbers) + 1
+            page["citation_numbers"] = numbers
+        return numbers
 
     def postTokenize(self, page, ast):
         if page["citations"]:
@@ -200,6 +218,9 @@ class RenderBibtexCite(components.RenderComponent):
         if cite == "nocite":
             return parent
 
+        if self.extension.get("citation_style") == "number":
+            return self._createNumberHTML(parent, token, page)
+
         citep = cite == "citep"
         if citep:
             html.String(parent, content="(")
@@ -272,6 +293,28 @@ class RenderBibtexCite(components.RenderComponent):
 
         return parent
 
+    def _createNumberHTML(self, parent, token, page):
+        """Render citations as bracketed numbers, e.g. '[1, 2]', that match the
+        numbering of the reference list."""
+        numbers = self.extension.citationNumbers(page)
+        num_keys = len(token["keys"])
+        html.String(parent, content="[")
+        for i, key in enumerate(token["keys"]):
+            if key not in self.extension.database().entries:
+                LOG.error("Unknown BibTeX key: %s", key)
+                html.Tag(parent, "span", string=key, style="color:red;")
+            else:
+                html.Tag(
+                    parent,
+                    "a",
+                    href="#{}".format(key),
+                    string=str(numbers.get(key)),
+                )
+            if i != num_keys - 1:
+                html.String(parent, content=", ")
+        html.String(parent, content="]")
+        return parent
+
     def createMaterialize(self, parent, token, page):
         self.createHTML(parent, token, page)
 
@@ -306,7 +349,11 @@ class RenderBibtexBibliography(components.RenderComponent):
             ol = html.Tag(div, "ol")
 
             backend = html_backend(encoding="utf-8")
-            for entry in formatted_bibliography:
+            entries = list(formatted_bibliography)
+            if self.extension.get("citation_style") == "number":
+                numbers = self.extension.citationNumbers(page)
+                entries.sort(key=lambda e: numbers.get(e.key, len(numbers) + 1))
+            for entry in entries:
                 text = entry.text.render(backend)
                 html.Tag(ol, "li", id_=entry.key, string=text)
 

--- a/python/MooseDocs/extensions/bibtex.py
+++ b/python/MooseDocs/extensions/bibtex.py
@@ -34,6 +34,67 @@ BibtexCite = tokens.newToken("BibtexCite", keys=[])
 BibtexBibliography = tokens.newToken("BibtexBibliography", bib_style="")
 BibtexList = tokens.newToken("BibtexList", BibtexBibliography, bib_files=None)
 
+# Maps BibTeX entry types to RIS reference types; unknown types fall back to GEN.
+RIS_TYPES = {
+    "article": "JOUR",
+    "book": "BOOK",
+    "booklet": "BOOK",
+    "inbook": "CHAP",
+    "incollection": "CHAP",
+    "inproceedings": "CPAPER",
+    "conference": "CPAPER",
+    "manual": "GEN",
+    "mastersthesis": "THES",
+    "phdthesis": "THES",
+    "proceedings": "CONF",
+    "techreport": "RPRT",
+    "unpublished": "UNPB",
+    "misc": "GEN",
+}
+
+
+def bibtex_to_ris(entry):
+    """Convert a pybtex bibliography entry into an RIS-formatted string.
+
+    RIS is the interchange format imported by reference managers used outside of
+    LaTeX, such as Microsoft Word, EndNote, Zotero, and Mendeley. pybtex provides
+    no RIS writer, so the common fields are mapped here by hand.
+    """
+    to_text = LatexNodes2Text().latex_to_text
+    fields = entry.fields
+    lines = [("TY", RIS_TYPES.get(entry.type, "GEN"))]
+
+    persons = entry.persons.get("author") or entry.persons.get("editor") or []
+    for person in persons:
+        last = to_text(" ".join(person.last_names))
+        given = to_text(" ".join(person.first_names + person.middle_names))
+        lines.append(("AU", "{}, {}".format(last, given) if given else last))
+
+    field_map = [
+        ("TI", "title"),
+        ("JO", "journal"),
+        ("T2", "booktitle"),
+        ("PY", "year"),
+        ("VL", "volume"),
+        ("IS", "number"),
+        ("PB", "publisher"),
+        ("CY", "address"),
+        ("DO", "doi"),
+        ("UR", "url"),
+    ]
+    for tag, field in field_map:
+        if field in fields:
+            lines.append((tag, to_text(fields[field])))
+
+    if "pages" in fields:
+        parts = fields["pages"].replace("--", "-").split("-")
+        lines.append(("SP", parts[0].strip()))
+        if len(parts) > 1:
+            lines.append(("EP", parts[-1].strip()))
+
+    lines.append(("ER", ""))
+    return "\n".join("{}  - {}".format(tag, value) for tag, value in lines)
+
 
 class BibtexExtension(command.CommandExtension):
     """
@@ -369,9 +430,15 @@ class RenderBibtexBibliography(components.RenderComponent):
 
         for child in ol.children:
             key = child["id"]
+            entry = self.extension.database().entries[key]
+
             db = BibliographyData()
-            db.add_entry(key, self.extension.database().entries[key])
-            btex = db.to_string("bibtex")
+            db.add_entry(key, entry)
+            formats = [
+                ("BibTeX", db.to_string("bibtex"), "language-latex"),
+                ("RIS", bibtex_to_ris(entry), None),
+                ("Plain Text", self._plainText(key, token["bib_style"]), None),
+            ]
 
             m_id = uuid.uuid4()
             html.Tag(
@@ -380,15 +447,26 @@ class RenderBibtexBibliography(components.RenderComponent):
                 style="padding-left:10px;",
                 class_="modal-trigger moose-bibtex-modal",
                 href="#{}".format(m_id),
-                string="[BibTeX]",
+                string="[Export]",
             )
 
             modal = html.Tag(child, "div", class_="modal", id_=m_id)
             content = html.Tag(modal, "div", class_="modal-content")
-            pre = html.Tag(content, "pre", style="line-height:1.25;")
-            html.Tag(pre, "code", class_="language-latex", string=btex)
+            for name, text, lang in formats:
+                html.Tag(content, "h6", string=name)
+                pre = html.Tag(content, "pre", style="line-height:1.25;")
+                html.Tag(pre, "code", class_=lang, string=text)
 
         return ol
+
+    def _plainText(self, key, bib_style):
+        """Render a single citation as a plain-text reference string."""
+        style = find_plugin("pybtex.style.formatting", bib_style or "plain")
+        formatted = style().format_bibliography(self.extension.database(), [key])
+        backend = find_plugin("pybtex.backends", "plaintext")(encoding="utf-8")
+        for entry in formatted:
+            return entry.text.render(backend)
+        return ""
 
     def createLatex(self, parent, token, page):
         pass

--- a/python/MooseDocs/test/extensions/test_bibtex.py
+++ b/python/MooseDocs/test/extensions/test_bibtex.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# This file is part of the MOOSE framework
+# https://mooseframework.inl.gov
+#
+# All rights reserved, see COPYRIGHT for full restrictions
+# https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#
+# Licensed under LGPL 2.1, please see LICENSE for details
+# https://www.gnu.org/licenses/lgpl-2.1.html
+
+import unittest
+import logging
+from MooseDocs.test import MooseDocsTestCase
+from MooseDocs.extensions import core, command, floats, bibtex
+from MooseDocs import common
+
+logging.basicConfig()
+
+
+class TestBibtexCite(MooseDocsTestCase):
+    EXTENSIONS = [core, command, floats, bibtex]
+    TEXT = "[!cite](slaughter2014framework, gaston2015physics)\n\n!bibtex bibliography"
+
+    def setupContent(self):
+        config = [
+            dict(
+                root_dir="framework/doc/content", content=["bib/moose.bib"]
+            )
+        ]
+        return common.get_content(config, ".bib")
+
+    def testAuthorYearHTML(self):
+        _, res = self.execute(self.TEXT)
+        # Inline citation is rendered as author-year links.
+        p = res(0)
+        self.assertHTMLTag(p, "p")
+        self.assertHTMLTag(p(0), "a", string="Slaughter et al. (2014)")
+        self.assertHTMLString(p(1), " and ")
+        self.assertHTMLTag(p(2), "a", string="Gaston et al. (2015)")
+
+
+class TestBibtexNumber(MooseDocsTestCase):
+    EXTENSIONS = [core, command, floats, bibtex]
+    TEXT = "[!cite](slaughter2014framework, gaston2015physics)\n\n!bibtex bibliography"
+
+    def setupExtension(self, ext):
+        if ext == bibtex:
+            return dict(citation_style="number")
+
+    def setupContent(self):
+        config = [
+            dict(
+                root_dir="framework/doc/content", content=["bib/moose.bib"]
+            )
+        ]
+        return common.get_content(config, ".bib")
+
+    def testNumberHTML(self):
+        _, res = self.execute(self.TEXT)
+        # Inline citation is rendered as bracketed numbers in citation order.
+        p = res(0)
+        self.assertHTMLTag(p, "p")
+        self.assertHTMLString(p(0), "[")
+        self.assertHTMLTag(p(1), "a", string="1", href="#slaughter2014framework")
+        self.assertHTMLString(p(2), ", ")
+        self.assertHTMLTag(p(3), "a", string="2", href="#gaston2015physics")
+        self.assertHTMLString(p(4), "]")
+
+    def testBibliographyOrder(self):
+        _, res = self.execute(self.TEXT)
+        # The reference list is ordered to match the inline numbering.
+        ol = res(2)(0)
+        self.assertHTMLTag(ol, "ol")
+        self.assertEqual(ol(0)["id"], "slaughter2014framework")
+        self.assertEqual(ol(1)["id"], "gaston2015physics")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/python/MooseDocs/test/extensions/test_bibtex.py
+++ b/python/MooseDocs/test/extensions/test_bibtex.py
@@ -10,9 +10,11 @@
 
 import unittest
 import logging
+import moosetree
+from pybtex.database import parse_file
 from MooseDocs.test import MooseDocsTestCase
 from MooseDocs.extensions import core, command, floats, bibtex
-from MooseDocs import common
+from MooseDocs import base, common
 
 logging.basicConfig()
 
@@ -73,6 +75,60 @@ class TestBibtexNumber(MooseDocsTestCase):
         self.assertHTMLTag(ol, "ol")
         self.assertEqual(ol(0)["id"], "slaughter2014framework")
         self.assertEqual(ol(1)["id"], "gaston2015physics")
+
+
+class TestBibtexToRIS(unittest.TestCase):
+    def testRIS(self):
+        db = parse_file("framework/doc/content/bib/moose.bib")
+        ris = bibtex.bibtex_to_ris(db.entries["slaughter2015continuous"]).splitlines()
+        self.assertEqual(ris[0], "TY  - JOUR")
+        self.assertIn("AU  - Slaughter, Andrew E", ris)
+        self.assertIn(
+            "TI  - Continuous integration for concurrent MOOSE framework and "
+            "application development on GitHub",
+            ris,
+        )
+        self.assertIn("JO  - Journal of Open Research Software", ris)
+        self.assertIn("PY  - 2015", ris)
+        self.assertIn("VL  - 3", ris)
+        self.assertEqual(ris[-1], "ER  - ")
+
+    def testRISLatexAuthor(self):
+        # Author names containing LaTeX must be converted to plain text.
+        db = parse_file("framework/doc/content/bib/moose.bib")
+        ris = bibtex.bibtex_to_ris(db.entries["slaughter2014framework"])
+        self.assertIn("AU  - Andrš, D.", ris)
+        self.assertNotIn("\\v", ris)
+
+
+class TestBibtexExport(MooseDocsTestCase):
+    EXTENSIONS = [core, command, floats, bibtex]
+    TEXT = "[!cite](slaughter2014framework)\n\n!bibtex bibliography"
+
+    def setupContent(self):
+        config = [
+            dict(
+                root_dir="framework/doc/content", content=["bib/moose.bib"]
+            )
+        ]
+        return common.get_content(config, ".bib")
+
+    def testModalFormats(self):
+        _, res = self.execute(self.TEXT, renderer=base.MaterializeRenderer())
+
+        # The references list shows a single [Export] modal trigger.
+        trigger = moosetree.find(
+            res, lambda n: "moose-bibtex-modal" in (n.get("class") or "")
+        )
+        self.assertIsNotNone(trigger)
+        self.assertEqual(trigger(0)["content"], "[Export]")
+
+        # The modal offers BibTeX, RIS, and Plain Text exports.
+        content = moosetree.find(
+            res, lambda n: n.name == "div" and "modal-content" in (n.get("class") or "")
+        )
+        headings = [c(0)["content"] for c in content if c.name == "h6"]
+        self.assertEqual(headings, ["BibTeX", "RIS", "Plain Text"])
 
 
 if __name__ == "__main__":

--- a/python/MooseDocs/test/extensions/test_bibtex.py
+++ b/python/MooseDocs/test/extensions/test_bibtex.py
@@ -51,7 +51,19 @@ class TestBibtexNumber(MooseDocsTestCase):
 
     def testNumberHTML(self):
         _, res = self.execute(self.TEXT)
-        # Inline citation is rendered as bracketed numbers in citation order.
+        # Textual (!cite) citations prepend the author to the bracketed number.
+        p = res(0)
+        self.assertHTMLTag(p, "p")
+        self.assertHTMLString(p(0), "Slaughter et al. ")
+        self.assertHTMLTag(p(1), "a", string="[1]", href="#slaughter2014framework")
+        self.assertHTMLString(p(2), ", ")
+        self.assertHTMLString(p(3), "Gaston et al. ")
+        self.assertHTMLTag(p(4), "a", string="[2]", href="#gaston2015physics")
+
+    def testNumberParentheticalHTML(self):
+        text = "[!citep](slaughter2014framework, gaston2015physics)\n\n!bibtex bibliography"
+        _, res = self.execute(text)
+        # Parenthetical (!citep) citations render as just bracketed numbers.
         p = res(0)
         self.assertHTMLTag(p, "p")
         self.assertHTMLString(p(0), "[")

--- a/python/MooseDocs/test/extensions/test_bibtex.py
+++ b/python/MooseDocs/test/extensions/test_bibtex.py
@@ -11,7 +11,7 @@
 import unittest
 import logging
 import moosetree
-from pybtex.database import parse_file
+from pybtex.database import Entry, Person
 from MooseDocs.test import MooseDocsTestCase
 from MooseDocs.extensions import core, command, floats, bibtex
 from MooseDocs import base, common
@@ -24,11 +24,7 @@ class TestBibtexCite(MooseDocsTestCase):
     TEXT = "[!cite](slaughter2014framework, gaston2015physics)\n\n!bibtex bibliography"
 
     def setupContent(self):
-        config = [
-            dict(
-                root_dir="framework/doc/content", content=["bib/moose.bib"]
-            )
-        ]
+        config = [dict(root_dir="framework/doc/content", content=["bib/moose.bib"])]
         return common.get_content(config, ".bib")
 
     def testAuthorYearHTML(self):
@@ -50,11 +46,7 @@ class TestBibtexNumber(MooseDocsTestCase):
             return dict(citation_style="number")
 
     def setupContent(self):
-        config = [
-            dict(
-                root_dir="framework/doc/content", content=["bib/moose.bib"]
-            )
-        ]
+        config = [dict(root_dir="framework/doc/content", content=["bib/moose.bib"])]
         return common.get_content(config, ".bib")
 
     def testNumberHTML(self):
@@ -79,10 +71,23 @@ class TestBibtexNumber(MooseDocsTestCase):
 
 class TestBibtexToRIS(unittest.TestCase):
     def testRIS(self):
-        db = parse_file("framework/doc/content/bib/moose.bib")
-        ris = bibtex.bibtex_to_ris(db.entries["slaughter2015continuous"]).splitlines()
+        entry = Entry(
+            "article",
+            persons={
+                "author": [Person("Slaughter, Andrew E."), Person("Peterson, John W.")]
+            },
+            fields={
+                "title": "Continuous integration for concurrent MOOSE framework and "
+                "application development on GitHub",
+                "journal": "Journal of Open Research Software",
+                "year": "2015",
+                "volume": "3",
+                "number": "1",
+            },
+        )
+        ris = bibtex.bibtex_to_ris(entry).splitlines()
         self.assertEqual(ris[0], "TY  - JOUR")
-        self.assertIn("AU  - Slaughter, Andrew E", ris)
+        self.assertIn("AU  - Slaughter, Andrew E.", ris)
         self.assertIn(
             "TI  - Continuous integration for concurrent MOOSE framework and "
             "application development on GitHub",
@@ -95,10 +100,27 @@ class TestBibtexToRIS(unittest.TestCase):
 
     def testRISLatexAuthor(self):
         # Author names containing LaTeX must be converted to plain text.
-        db = parse_file("framework/doc/content/bib/moose.bib")
-        ris = bibtex.bibtex_to_ris(db.entries["slaughter2014framework"])
-        self.assertIn("AU  - Andrš, D.", ris)
+        entry = Entry(
+            "inproceedings",
+            persons={"author": [Person("Andr\\v{s}, D.")]},
+            fields={"title": "X", "year": "2014"},
+        )
+        ris = bibtex.bibtex_to_ris(entry)
+        self.assertIn("AU  - Andr\u0161, D.", ris)
         self.assertNotIn("\\v", ris)
+
+    def testRISNameParticles(self):
+        # Name particles (e.g. "van") and suffixes (e.g. "Jr.") must be retained.
+        entry = Entry(
+            "article",
+            persons={
+                "author": [Person("van Genuchten, M. Th."), Person("Smith, Jr., John")]
+            },
+            fields={"title": "A closed-form equation", "year": "1980"},
+        )
+        ris = bibtex.bibtex_to_ris(entry).splitlines()
+        self.assertIn("AU  - van Genuchten, M. Th.", ris)
+        self.assertIn("AU  - Smith, John, Jr.", ris)
 
 
 class TestBibtexExport(MooseDocsTestCase):
@@ -106,11 +128,7 @@ class TestBibtexExport(MooseDocsTestCase):
     TEXT = "[!cite](slaughter2014framework)\n\n!bibtex bibliography"
 
     def setupContent(self):
-        config = [
-            dict(
-                root_dir="framework/doc/content", content=["bib/moose.bib"]
-            )
-        ]
+        config = [dict(root_dir="framework/doc/content", content=["bib/moose.bib"])]
         return common.get_content(config, ".bib")
 
     def testModalFormats(self):

--- a/python/MooseDocs/test/extensions/tests
+++ b/python/MooseDocs/test/extensions/tests
@@ -1,7 +1,7 @@
 [Tests]
   [all]
     design = 'MooseDocs/index.md'
-    issues = '#6699 #9466 #9638 #9728 #12049 #13580 #13611 #15232 #15927 #16176 #16248 #16401 #16617 #16622 #16807 #17218 #17505 #20202 #25387 #28573'
+    issues = '#6699 #9466 #9638 #9728 #12049 #13580 #13611 #15232 #15927 #16176 #16248 #16401 #16617 #16622 #16807 #17218 #17505 #20202 #25387 #28573 #22982'
 
     requirement = "The system shall include documentation tools that provide support for"
     [core]
@@ -142,6 +142,12 @@
       input = test_tagging.py
       min_slots = 2 # uses threads
       detail = "support documentation tags for filtering,"
+    []
+    [bibtex]
+      type = PythonUnitTest
+      input = test_bibtex.py
+      min_slots = 2 # uses threads
+      detail = "managing citations and bibliographies,"
     []
     [navigation]
       type = PythonUnitTest

--- a/python/MooseDocs/test/gold/materialize/extensions/bibtex.html
+++ b/python/MooseDocs/test/gold/materialize/extensions/bibtex.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html><head><meta charset="UTF-8"><title>Bibtex Extension | MOOSEDocs</title><link href="../contrib/materialize/materialize.min.css" type="text/css" rel="stylesheet" media="screen,projection"></link><link href="../contrib/prism/prism.min.css" type="text/css" rel="stylesheet"></link><link href="../css/moose.css" type="text/css" rel="stylesheet"></link><link href="../css/devel_moose.css" type="text/css" rel="stylesheet"></link><link href="../css/alert_moose.css" type="text/css" rel="stylesheet"></link><link href="../css/content_moose.css" type="text/css" rel="stylesheet"></link><link href="../css/sqa_moose.css" type="text/css" rel="stylesheet"></link><link href="../css/civet_moose.css" type="text/css" rel="stylesheet"></link><script type="text/javascript" src="../contrib/jquery/jquery.min.js"></script><script src="https://www.googletagmanager.com/gtag/js?id=G-RH7BY5XXNW" type="text/javascript"></script><script type="text/javascript">window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'G-RH7BY5XXNW');</script></head><body><div class="page-wrap"><header><nav><div class="nav-wrapper container"><a href="../index.html" class="left moose-logo hide-on-med-and-down" id="home-button">MOOSEDocs</a><a href="https://github.com/idaholab/moose" class="right"><img alt="GitHub wordmark" src="../media/framework/github-logo.png" class="github-mark"></img><img alt="GitHub logo" src="../media/framework/github-mark.png" class="github-logo"></img></a><ul class="right hide-on-med-and-down"><li><a href="core.html">Direct</a></li><li class="moose-mega-menu-trigger" data-target="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><a>Mega<i class="material-icons right">arrow_drop_down</i></a></li><li><a href="#!" class="dropdown-trigger" data-target="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" data-constrainWidth="false">Dict<i class="material-icons right">arrow_drop_down</i></a></li></ul><a href="#" class="sidenav-trigger" data-target="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><i class="material-icons">menu</i></a><ul class="sidenav" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><li><a href="core.html">Direct</a></li><li><a href="../mega.menu.html">Mega</a></li><li><a href="#!" class="dropdown-trigger" data-target="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" data-constrainWidth="false">Dict<i class="material-icons right">arrow_drop_down</i></a></li></ul></div><ul class="dropdown-content" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><li><a href="core.html">Core</a></li><li><a href="autolink.html">AutoLink</a></li></ul><ul class="dropdown-content" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><li><a href="core.html">Core</a></li><li><a href="autolink.html">AutoLink</a></li></ul></nav><div class="moose-mega-menu-content" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><div class="moose-mega-menu-wrapper"><h2>Main Extensions</h2><ul class="browser-default"><li><p><a href="core.html">Core</a> </p></li><li><p><a href="autolink.html">AutoLink</a></p></li></ul></div></div></header><main class="main"><div class="container"><div class="row"><div class="col hide-on-med-and-down l12"><nav class="breadcrumb-nav"><div class="nav-wrapper"><span class="breadcrumb">extensions</span><a href="#" class="breadcrumb">bibtex</a></div></nav></div></div><div class="row"><div class="moose-content col s12 m12 l10"><section id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" data-section-level="1" data-section-text="Bibtex Extension"><h1 id="bibtex-extension">Bibtex Extension</h1><p>I did some work <a href="#slaughter2014framework">Slaughter et al. (2014)</a></p><p><a href="#slaughter2014framework">Slaughter et al. (2014)</a> and <a href="#slaughter2015continuous">Slaughter et al. (2015)</a></p><p><a href="#slaughter2014framework">Slaughter et al. (2014)</a>, <a href="#slaughter2015continuous">Slaughter et al. (2015)</a>, and <a href="#gaston2015physics">Gaston et al. (2015)</a></p><p>(<a href="#slaughter2014framework">Slaughter et al., 2014</a>)</p><p>(<a href="#slaughter2014framework">Slaughter et al., 2014</a>; <a href="#slaughter2015continuous">Slaughter et al., 2015</a>)</p><section class="scrollspy" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" data-section-level="2" data-section-text="References"><h2 id="references">References</h2><div class="moose-bibliography"><ol><li id="gaston2015physics">D.&nbsp;R. Gaston, C.&nbsp;J. Permann, J.&nbsp;W. Peterson, A.&nbsp;E. Slaughter, D.&nbsp;Andr<span class="bibtex-protected">š</span>, Y.&nbsp;Wang, M.&nbsp;P. Short, D.&nbsp;M. Perez, M.&nbsp;R. Tonks, J.&nbsp;Ortensi, and R.&nbsp;C. Martineau.
 Physics-based multiscale coupling for full core nuclear reactor simulation.
 <em>Annals of Nuclear Energy, Special Issue on Multi-Physics Modelling of LWR Static and Transient Behaviour</em>, 84:45–54, October 2015.
-URL: <a href="http://dx.doi.org/10.1016/j.anucene.2014.09.060">http://dx.doi.org/10.1016/j.anucene.2014.09.060</a>.<a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="modal-trigger moose-bibtex-modal" style="padding-left:10px;">[BibTeX]</a><div class="modal" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><div class="modal-content"><pre style="line-height:1.25;"><code class="language-latex">@article{gaston2015physics,
+URL: <a href="http://dx.doi.org/10.1016/j.anucene.2014.09.060">http://dx.doi.org/10.1016/j.anucene.2014.09.060</a>.<a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="modal-trigger moose-bibtex-modal" style="padding-left:10px;">[Export]</a><div class="modal" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><div class="modal-content"><h6>BibTeX</h6><pre style="line-height:1.25;"><code class="language-latex">@article{gaston2015physics,
     author = "Gaston, D. R. and Permann, C. J. and Peterson, J. W. and Slaughter, A. E. and Andr\v{s}, D. and Wang, Y. and Short, M. P. and Perez, D. M. and Tonks, M. R. and Ortensi, J. and Martineau, R. C.",
     title = "Physics-based multiscale coupling for full core nuclear reactor simulation",
     journal = "Annals of Nuclear Energy, Special Issue on Multi-Physics Modelling of LWR Static and Transient Behaviour",
@@ -11,10 +11,29 @@ URL: <a href="http://dx.doi.org/10.1016/j.anucene.2014.09.060">http://dx.doi.org
     pages = "45--54",
     url = "http://dx.doi.org/10.1016/j.anucene.2014.09.060"
 }
-</code></pre></div></div></li><li id="slaughter2014framework">A.E. Slaughter, M.J. Johnson, M.R. Tonks, D.R. Gaston, C.J. Permann, J.W. Peterson, D.&nbsp;Andr<span class="bibtex-protected">š</span>, J.M. Miller, E.E. Adams, and D.J. Walters.
+</code></pre><h6>RIS</h6><pre style="line-height:1.25;"><code>TY  - JOUR
+AU  - Gaston, D. R.
+AU  - Permann, C. J.
+AU  - Peterson, J. W.
+AU  - Slaughter, A. E.
+AU  - Andrš, D.
+AU  - Wang, Y.
+AU  - Short, M. P.
+AU  - Perez, D. M.
+AU  - Tonks, M. R.
+AU  - Ortensi, J.
+AU  - Martineau, R. C.
+TI  - Physics-based multiscale coupling for full core nuclear reactor simulation
+JO  - Annals of Nuclear Energy, Special Issue on Multi-Physics Modelling of LWR Static and Transient Behaviour
+PY  - 2015
+VL  - 84
+UR  - http://dx.doi.org/10.1016/j.anucene.2014.09.060
+SP  - 45
+EP  - 54
+ER  - </code></pre><h6>Plain Text</h6><pre style="line-height:1.25;"><code>D. R. Gaston, C. J. Permann, J. W. Peterson, A. E. Slaughter, D. Andrš, Y. Wang, M. P. Short, D. M. Perez, M. R. Tonks, J. Ortensi, and R. C. Martineau. Physics-based multiscale coupling for full core nuclear reactor simulation. Annals of Nuclear Energy, Special Issue on Multi-Physics Modelling of LWR Static and Transient Behaviour, 84:45–54, October 2015. URL: http://dx.doi.org/10.1016/j.anucene.2014.09.060.</code></pre></div></div></li><li id="slaughter2014framework">A.E. Slaughter, M.J. Johnson, M.R. Tonks, D.R. Gaston, C.J. Permann, J.W. Peterson, D.&nbsp;Andr<span class="bibtex-protected">š</span>, J.M. Miller, E.E. Adams, and D.J. Walters.
 <span class="bibtex-protected">MOOSE</span>: a framework to enable rapid advances and collaboration in modeling snow and avalanches.
 In <em>International Snow Science Workshop</em>. Banff, AB, 2014.
-URL: <a href="http://arc.lib.montana.edu/snow-science/item.php?id=2120">http://arc.lib.montana.edu/snow-science/item.php?id=2120</a>.<a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="modal-trigger moose-bibtex-modal" style="padding-left:10px;">[BibTeX]</a><div class="modal" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><div class="modal-content"><pre style="line-height:1.25;"><code class="language-latex">@inproceedings{slaughter2014framework,
+URL: <a href="http://arc.lib.montana.edu/snow-science/item.php?id=2120">http://arc.lib.montana.edu/snow-science/item.php?id=2120</a>.<a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="modal-trigger moose-bibtex-modal" style="padding-left:10px;">[Export]</a><div class="modal" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><div class="modal-content"><h6>BibTeX</h6><pre style="line-height:1.25;"><code class="language-latex">@inproceedings{slaughter2014framework,
     author = "Slaughter, A.E. and Johnson, M.J. and Tonks, M.R. and Gaston, D.R. and Permann, C.J. and Peterson, J.W. and Andr\v{s}, D. and Miller, J.M. and Adams, E.E. and Walters, D.J.",
     title = "{MOOSE}: A Framework to Enable Rapid Advances and Collaboration in Modeling Snow and Avalanches",
     booktitle = "International Snow Science Workshop",
@@ -22,10 +41,26 @@ URL: <a href="http://arc.lib.montana.edu/snow-science/item.php?id=2120">http://a
     address = "Banff, AB",
     url = "http://arc.lib.montana.edu/snow-science/item.php?id=2120"
 }
-</code></pre></div></div></li><li id="slaughter2015continuous">Andrew&nbsp;E Slaughter, John&nbsp;W Peterson, Derek&nbsp;R Gaston, Cody&nbsp;J Permann, David Andr<span class="bibtex-protected"><span class="bibtex-protected">š</span></span>, and Jason&nbsp;M Miller.
+</code></pre><h6>RIS</h6><pre style="line-height:1.25;"><code>TY  - CPAPER
+AU  - Slaughter, A.E.
+AU  - Johnson, M.J.
+AU  - Tonks, M.R.
+AU  - Gaston, D.R.
+AU  - Permann, C.J.
+AU  - Peterson, J.W.
+AU  - Andrš, D.
+AU  - Miller, J.M.
+AU  - Adams, E.E.
+AU  - Walters, D.J.
+TI  - MOOSE: A Framework to Enable Rapid Advances and Collaboration in Modeling Snow and Avalanches
+T2  - International Snow Science Workshop
+PY  - 2014
+CY  - Banff, AB
+UR  - http://arc.lib.montana.edu/snow-science/item.php?id=2120
+ER  - </code></pre><h6>Plain Text</h6><pre style="line-height:1.25;"><code>A.E. Slaughter, M.J. Johnson, M.R. Tonks, D.R. Gaston, C.J. Permann, J.W. Peterson, D. Andrš, J.M. Miller, E.E. Adams, and D.J. Walters. MOOSE: a framework to enable rapid advances and collaboration in modeling snow and avalanches. In International Snow Science Workshop. Banff, AB, 2014. URL: http://arc.lib.montana.edu/snow-science/item.php?id=2120.</code></pre></div></div></li><li id="slaughter2015continuous">Andrew&nbsp;E Slaughter, John&nbsp;W Peterson, Derek&nbsp;R Gaston, Cody&nbsp;J Permann, David Andr<span class="bibtex-protected"><span class="bibtex-protected">š</span></span>, and Jason&nbsp;M Miller.
 Continuous integration for concurrent moose framework and application development on github.
 <em>Journal of Open Research Software</em>, 2015.
-URL: <a href="http://doi.org/10.5334/jors.bx">http://doi.org/10.5334/jors.bx</a>.<a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="modal-trigger moose-bibtex-modal" style="padding-left:10px;">[BibTeX]</a><div class="modal" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><div class="modal-content"><pre style="line-height:1.25;"><code class="language-latex">@article{slaughter2015continuous,
+URL: <a href="http://doi.org/10.5334/jors.bx">http://doi.org/10.5334/jors.bx</a>.<a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="modal-trigger moose-bibtex-modal" style="padding-left:10px;">[Export]</a><div class="modal" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><div class="modal-content"><h6>BibTeX</h6><pre style="line-height:1.25;"><code class="language-latex">@article{slaughter2015continuous,
     author = "Slaughter, Andrew E and Peterson, John W and Gaston, Derek R and Permann, Cody J and Andr{\v{s}}, David and Miller, Jason M",
     title = "Continuous integration for concurrent MOOSE framework and application development on GitHub",
     journal = "Journal of Open Research Software",
@@ -35,4 +70,18 @@ URL: <a href="http://doi.org/10.5334/jors.bx">http://doi.org/10.5334/jors.bx</a>
     publisher = "Ubiquity Press",
     url = "http://doi.org/10.5334/jors.bx"
 }
-</code></pre></div></div></li></ol></div></section></section></div><div class="col hide-on-med-and-down l2"><div class="toc-wrapper pin-top"><ul class="section table-of-contents"><li><a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="tooltipped" data-position="left" data-tooltip="References">References</a></li></ul></div></div></div></div></main></div></body><script type="text/javascript" src="../contrib/materialize/materialize.min.js"></script><script type="text/javascript" src="../contrib/clipboard/clipboard.min.js"></script><script type="text/javascript" src="../contrib/prism/prism.min.js"></script><script type="text/javascript" src="../js/init.js"></script><script type="text/javascript" src="../js/sqa_moose.js"></script><script type="text/javascript" src="../js/navigation.js"></script>
+</code></pre><h6>RIS</h6><pre style="line-height:1.25;"><code>TY  - JOUR
+AU  - Slaughter, Andrew E
+AU  - Peterson, John W
+AU  - Gaston, Derek R
+AU  - Permann, Cody J
+AU  - Andrš, David
+AU  - Miller, Jason M
+TI  - Continuous integration for concurrent MOOSE framework and application development on GitHub
+JO  - Journal of Open Research Software
+PY  - 2015
+VL  - 3
+IS  - 1
+PB  - Ubiquity Press
+UR  - http://doi.org/10.5334/jors.bx
+ER  - </code></pre><h6>Plain Text</h6><pre style="line-height:1.25;"><code>Andrew E Slaughter, John W Peterson, Derek R Gaston, Cody J Permann, David Andrš, and Jason M Miller. Continuous integration for concurrent moose framework and application development on github. Journal of Open Research Software, 2015. URL: http://doi.org/10.5334/jors.bx.</code></pre></div></div></li></ol></div></section></section></div><div class="col hide-on-med-and-down l2"><div class="toc-wrapper pin-top"><ul class="section table-of-contents"><li><a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="tooltipped" data-position="left" data-tooltip="References">References</a></li></ul></div></div></div></div></main></div></body><script type="text/javascript" src="../contrib/materialize/materialize.min.js"></script><script type="text/javascript" src="../contrib/clipboard/clipboard.min.js"></script><script type="text/javascript" src="../contrib/prism/prism.min.js"></script><script type="text/javascript" src="../js/init.js"></script><script type="text/javascript" src="../js/sqa_moose.js"></script><script type="text/javascript" src="../js/navigation.js"></script>

--- a/python/MooseDocs/test/gold/materialize/extensions/bibtex.html
+++ b/python/MooseDocs/test/gold/materialize/extensions/bibtex.html
@@ -11,7 +11,7 @@ URL: <a href="http://dx.doi.org/10.1016/j.anucene.2014.09.060">http://dx.doi.org
     pages = "45--54",
     url = "http://dx.doi.org/10.1016/j.anucene.2014.09.060"
 }
-</code></pre><h6>RIS</h6><pre style="line-height:1.25;"><code>TY  - JOUR
+</code></pre><h6>RIS</h6><pre style="line-height:1.25;"><code class="language-none">TY  - JOUR
 AU  - Gaston, D. R.
 AU  - Permann, C. J.
 AU  - Peterson, J. W.
@@ -30,7 +30,7 @@ VL  - 84
 UR  - http://dx.doi.org/10.1016/j.anucene.2014.09.060
 SP  - 45
 EP  - 54
-ER  - </code></pre><h6>Plain Text</h6><pre style="line-height:1.25;"><code>D. R. Gaston, C. J. Permann, J. W. Peterson, A. E. Slaughter, D. Andrš, Y. Wang, M. P. Short, D. M. Perez, M. R. Tonks, J. Ortensi, and R. C. Martineau. Physics-based multiscale coupling for full core nuclear reactor simulation. Annals of Nuclear Energy, Special Issue on Multi-Physics Modelling of LWR Static and Transient Behaviour, 84:45–54, October 2015. URL: http://dx.doi.org/10.1016/j.anucene.2014.09.060.</code></pre></div></div></li><li id="slaughter2014framework">A.E. Slaughter, M.J. Johnson, M.R. Tonks, D.R. Gaston, C.J. Permann, J.W. Peterson, D.&nbsp;Andr<span class="bibtex-protected">š</span>, J.M. Miller, E.E. Adams, and D.J. Walters.
+ER  - </code></pre><h6>Plain Text</h6><pre style="line-height:1.25;"><code class="language-none">D. R. Gaston, C. J. Permann, J. W. Peterson, A. E. Slaughter, D. Andrš, Y. Wang, M. P. Short, D. M. Perez, M. R. Tonks, J. Ortensi, and R. C. Martineau. Physics-based multiscale coupling for full core nuclear reactor simulation. Annals of Nuclear Energy, Special Issue on Multi-Physics Modelling of LWR Static and Transient Behaviour, 84:45–54, October 2015. URL: http://dx.doi.org/10.1016/j.anucene.2014.09.060.</code></pre></div></div></li><li id="slaughter2014framework">A.E. Slaughter, M.J. Johnson, M.R. Tonks, D.R. Gaston, C.J. Permann, J.W. Peterson, D.&nbsp;Andr<span class="bibtex-protected">š</span>, J.M. Miller, E.E. Adams, and D.J. Walters.
 <span class="bibtex-protected">MOOSE</span>: a framework to enable rapid advances and collaboration in modeling snow and avalanches.
 In <em>International Snow Science Workshop</em>. Banff, AB, 2014.
 URL: <a href="http://arc.lib.montana.edu/snow-science/item.php?id=2120">http://arc.lib.montana.edu/snow-science/item.php?id=2120</a>.<a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="modal-trigger moose-bibtex-modal" style="padding-left:10px;">[Export]</a><div class="modal" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><div class="modal-content"><h6>BibTeX</h6><pre style="line-height:1.25;"><code class="language-latex">@inproceedings{slaughter2014framework,
@@ -41,7 +41,7 @@ URL: <a href="http://arc.lib.montana.edu/snow-science/item.php?id=2120">http://a
     address = "Banff, AB",
     url = "http://arc.lib.montana.edu/snow-science/item.php?id=2120"
 }
-</code></pre><h6>RIS</h6><pre style="line-height:1.25;"><code>TY  - CPAPER
+</code></pre><h6>RIS</h6><pre style="line-height:1.25;"><code class="language-none">TY  - CPAPER
 AU  - Slaughter, A.E.
 AU  - Johnson, M.J.
 AU  - Tonks, M.R.
@@ -57,7 +57,7 @@ T2  - International Snow Science Workshop
 PY  - 2014
 CY  - Banff, AB
 UR  - http://arc.lib.montana.edu/snow-science/item.php?id=2120
-ER  - </code></pre><h6>Plain Text</h6><pre style="line-height:1.25;"><code>A.E. Slaughter, M.J. Johnson, M.R. Tonks, D.R. Gaston, C.J. Permann, J.W. Peterson, D. Andrš, J.M. Miller, E.E. Adams, and D.J. Walters. MOOSE: a framework to enable rapid advances and collaboration in modeling snow and avalanches. In International Snow Science Workshop. Banff, AB, 2014. URL: http://arc.lib.montana.edu/snow-science/item.php?id=2120.</code></pre></div></div></li><li id="slaughter2015continuous">Andrew&nbsp;E Slaughter, John&nbsp;W Peterson, Derek&nbsp;R Gaston, Cody&nbsp;J Permann, David Andr<span class="bibtex-protected"><span class="bibtex-protected">š</span></span>, and Jason&nbsp;M Miller.
+ER  - </code></pre><h6>Plain Text</h6><pre style="line-height:1.25;"><code class="language-none">A.E. Slaughter, M.J. Johnson, M.R. Tonks, D.R. Gaston, C.J. Permann, J.W. Peterson, D. Andrš, J.M. Miller, E.E. Adams, and D.J. Walters. MOOSE: a framework to enable rapid advances and collaboration in modeling snow and avalanches. In International Snow Science Workshop. Banff, AB, 2014. URL: http://arc.lib.montana.edu/snow-science/item.php?id=2120.</code></pre></div></div></li><li id="slaughter2015continuous">Andrew&nbsp;E Slaughter, John&nbsp;W Peterson, Derek&nbsp;R Gaston, Cody&nbsp;J Permann, David Andr<span class="bibtex-protected"><span class="bibtex-protected">š</span></span>, and Jason&nbsp;M Miller.
 Continuous integration for concurrent moose framework and application development on github.
 <em>Journal of Open Research Software</em>, 2015.
 URL: <a href="http://doi.org/10.5334/jors.bx">http://doi.org/10.5334/jors.bx</a>.<a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="modal-trigger moose-bibtex-modal" style="padding-left:10px;">[Export]</a><div class="modal" id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"><div class="modal-content"><h6>BibTeX</h6><pre style="line-height:1.25;"><code class="language-latex">@article{slaughter2015continuous,
@@ -70,7 +70,7 @@ URL: <a href="http://doi.org/10.5334/jors.bx">http://doi.org/10.5334/jors.bx</a>
     publisher = "Ubiquity Press",
     url = "http://doi.org/10.5334/jors.bx"
 }
-</code></pre><h6>RIS</h6><pre style="line-height:1.25;"><code>TY  - JOUR
+</code></pre><h6>RIS</h6><pre style="line-height:1.25;"><code class="language-none">TY  - JOUR
 AU  - Slaughter, Andrew E
 AU  - Peterson, John W
 AU  - Gaston, Derek R
@@ -84,4 +84,4 @@ VL  - 3
 IS  - 1
 PB  - Ubiquity Press
 UR  - http://doi.org/10.5334/jors.bx
-ER  - </code></pre><h6>Plain Text</h6><pre style="line-height:1.25;"><code>Andrew E Slaughter, John W Peterson, Derek R Gaston, Cody J Permann, David Andrš, and Jason M Miller. Continuous integration for concurrent moose framework and application development on github. Journal of Open Research Software, 2015. URL: http://doi.org/10.5334/jors.bx.</code></pre></div></div></li></ol></div></section></section></div><div class="col hide-on-med-and-down l2"><div class="toc-wrapper pin-top"><ul class="section table-of-contents"><li><a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="tooltipped" data-position="left" data-tooltip="References">References</a></li></ul></div></div></div></div></main></div></body><script type="text/javascript" src="../contrib/materialize/materialize.min.js"></script><script type="text/javascript" src="../contrib/clipboard/clipboard.min.js"></script><script type="text/javascript" src="../contrib/prism/prism.min.js"></script><script type="text/javascript" src="../js/init.js"></script><script type="text/javascript" src="../js/sqa_moose.js"></script><script type="text/javascript" src="../js/navigation.js"></script>
+ER  - </code></pre><h6>Plain Text</h6><pre style="line-height:1.25;"><code class="language-none">Andrew E Slaughter, John W Peterson, Derek R Gaston, Cody J Permann, David Andrš, and Jason M Miller. Continuous integration for concurrent moose framework and application development on github. Journal of Open Research Software, 2015. URL: http://doi.org/10.5334/jors.bx.</code></pre></div></div></li></ol></div></section></section></div><div class="col hide-on-med-and-down l2"><div class="toc-wrapper pin-top"><ul class="section table-of-contents"><li><a href="#XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" class="tooltipped" data-position="left" data-tooltip="References">References</a></li></ul></div></div></div></div></main></div></body><script type="text/javascript" src="../contrib/materialize/materialize.min.js"></script><script type="text/javascript" src="../contrib/clipboard/clipboard.min.js"></script><script type="text/javascript" src="../contrib/prism/prism.min.js"></script><script type="text/javascript" src="../js/init.js"></script><script type="text/javascript" src="../js/sqa_moose.js"></script><script type="text/javascript" src="../js/navigation.js"></script>

--- a/python/doc/content/python/MooseDocs/extensions/bibtex.md
+++ b/python/doc/content/python/MooseDocs/extensions/bibtex.md
@@ -35,6 +35,12 @@ To generate the list of references cited on a page, the `!bibtex bibliography`
 command is used. If it is not used, then it will automatically be placed at the
 bottom of the page.
 
+Each entry in the reference list provides an "[Export]" link that opens the
+citation in three formats: BibTeX, [RIS](https://en.wikipedia.org/wiki/RIS_(file_format))
+(for import into Microsoft Word, EndNote, Zotero, or Mendeley), and a plain-text
+reference string. The RIS and plain-text formats are intended for those who do
+not write in LaTeX.
+
 See [citation_examples] for examples.
 
 !devel! example caption=Citation examples. id=citation_examples

--- a/python/doc/content/python/MooseDocs/extensions/bibtex.md
+++ b/python/doc/content/python/MooseDocs/extensions/bibtex.md
@@ -16,12 +16,7 @@ option, which applies to every page:
 - `number`: inline citations render as bracketed numbers, numbered in the order
   they are first cited. The reference list is ordered to match, so `[1]` always
   points to the first entry. This is useful on pages that cite many works by the
-  same authors or year, where author-year labels are hard to tell apart. As with
-  `author-year`, the textual (`!cite`) and parenthetical (`!citep`) commands
-  differ: `!citep` renders just the number, e.g. `[1]`, for use inside or at the
-  end of a sentence, while `!cite` keeps the author so it reads as part of the
-  sentence, e.g. "Slaughter et al. `[1]`" (a bare number would not read well in
-  running text).
+  same authors or year, where author-year labels are hard to tell apart.
 
 ```yaml
 Extensions:
@@ -32,8 +27,17 @@ Extensions:
 ## Usage
 
 Two commands are provided for citing BibTeX references: `!cite` and `!citep`.
-The latter includes parentheses, while the former does not. To cite multiple
-references, they are separated with a comma.
+`!cite` is textual, so the citation reads as part of the sentence, while `!citep`
+is parenthetical, for use inside or at the end of a sentence. How each renders
+depends on the `citation_style` configured above:
+
+- With `author-year`, `!cite` reads as "Slaughter et al. (2014)" and `!citep`
+  wraps the author and year in parentheses, e.g. "(Slaughter et al., 2014)".
+- With `number`, `!citep` renders just the bracketed number, e.g. `[1]`, while
+  `!cite` keeps the author so it still reads in running text, e.g.
+  "Slaughter et al. `[1]`" (a bare number would not read well there).
+
+To cite multiple references, they are separated with a comma.
 
 To generate the list of references cited on a page, the `!bibtex bibliography`
 command is used. If it is not used, then it will automatically be placed at the
@@ -44,9 +48,10 @@ citation in three formats: BibTeX, RIS (for import into Microsoft Word, EndNote,
 Zotero, or Mendeley), and a plain-text reference string. The RIS and plain-text
 formats are intended for those who do not write in LaTeX.
 
-See [citation_examples] for examples.
+The examples in [citation_examples] use the default `author-year` style, which is
+the style used throughout the MOOSE documentation website.
 
-!devel! example caption=Citation examples. id=citation_examples
+!devel! example caption=Citation examples using the default author-year style. id=citation_examples
 [!cite](slaughter2014framework)
 
 [!cite](slaughter2014framework, slaughter2015continuous)

--- a/python/doc/content/python/MooseDocs/extensions/bibtex.md
+++ b/python/doc/content/python/MooseDocs/extensions/bibtex.md
@@ -8,6 +8,23 @@ The `bibtex` extension is enabled by default. The only thing necessary for using
 the citation commands is to provide properly-formatted `.bib` file(s) within the
 included content in your configuration file.
 
+The inline citation style is controlled by the `citation_style` configuration
+option, which applies to every page:
+
+- `author-year` (default): inline citations render as author and year, e.g.
+  "Slaughter et al. (2014)".
+- `number`: inline citations render as bracketed numbers, e.g. "[1]", numbered
+  in the order they are first cited. The reference list is ordered to match, so
+  "[1]" always points to the first entry. This is useful on pages that cite many
+  works by the same authors or year, where author-year labels are hard to tell
+  apart.
+
+```yaml
+Extensions:
+    MooseDocs.extensions.bibtex:
+        citation_style: number
+```
+
 ## Usage
 
 Two commands are provided for citing BibTeX references: `!cite` and `!citep`.

--- a/python/doc/content/python/MooseDocs/extensions/bibtex.md
+++ b/python/doc/content/python/MooseDocs/extensions/bibtex.md
@@ -20,7 +20,7 @@ option, which applies to every page:
   `author-year`, the textual (`!cite`) and parenthetical (`!citep`) commands
   differ: `!citep` renders just the number, e.g. `[1]`, for use inside or at the
   end of a sentence, while `!cite` keeps the author so it reads as part of the
-  sentence, e.g. "Slaughter et al. [1]" (a bare number would not read well in
+  sentence, e.g. "Slaughter et al. `[1]`" (a bare number would not read well in
   running text).
 
 ```yaml

--- a/python/doc/content/python/MooseDocs/extensions/bibtex.md
+++ b/python/doc/content/python/MooseDocs/extensions/bibtex.md
@@ -13,11 +13,15 @@ option, which applies to every page:
 
 - `author-year` (default): inline citations render as author and year, e.g.
   "Slaughter et al. (2014)".
-- `number`: inline citations render as bracketed numbers, e.g. `[1]`, numbered
-  in the order they are first cited. The reference list is ordered to match, so
-  `[1]` always points to the first entry. This is useful on pages that cite many
-  works by the same authors or year, where author-year labels are hard to tell
-  apart.
+- `number`: inline citations render as bracketed numbers, numbered in the order
+  they are first cited. The reference list is ordered to match, so `[1]` always
+  points to the first entry. This is useful on pages that cite many works by the
+  same authors or year, where author-year labels are hard to tell apart. As with
+  `author-year`, the textual (`!cite`) and parenthetical (`!citep`) commands
+  differ: `!citep` renders just the number, e.g. `[1]`, for use inside or at the
+  end of a sentence, while `!cite` keeps the author so it reads as part of the
+  sentence, e.g. "Slaughter et al. [1]" (a bare number would not read well in
+  running text).
 
 ```yaml
 Extensions:

--- a/python/doc/content/python/MooseDocs/extensions/bibtex.md
+++ b/python/doc/content/python/MooseDocs/extensions/bibtex.md
@@ -35,7 +35,7 @@ depends on the `citation_style` configured above:
   wraps the author and year in parentheses, e.g. "(Slaughter et al., 2014)".
 - With `number`, `!citep` renders just the bracketed number, e.g. `[1]`, while
   `!cite` keeps the author so it still reads in running text, e.g.
-  "Slaughter et al. `[1]`" (a bare number would not read well there).
+  "Slaughter et al. `[1]`".
 
 To cite multiple references, they are separated with a comma.
 

--- a/python/doc/content/python/MooseDocs/extensions/bibtex.md
+++ b/python/doc/content/python/MooseDocs/extensions/bibtex.md
@@ -13,9 +13,9 @@ option, which applies to every page:
 
 - `author-year` (default): inline citations render as author and year, e.g.
   "Slaughter et al. (2014)".
-- `number`: inline citations render as bracketed numbers, e.g. "[1]", numbered
+- `number`: inline citations render as bracketed numbers, e.g. `[1]`, numbered
   in the order they are first cited. The reference list is ordered to match, so
-  "[1]" always points to the first entry. This is useful on pages that cite many
+  `[1]` always points to the first entry. This is useful on pages that cite many
   works by the same authors or year, where author-year labels are hard to tell
   apart.
 
@@ -35,11 +35,10 @@ To generate the list of references cited on a page, the `!bibtex bibliography`
 command is used. If it is not used, then it will automatically be placed at the
 bottom of the page.
 
-Each entry in the reference list provides an "[Export]" link that opens the
-citation in three formats: BibTeX, [RIS](https://en.wikipedia.org/wiki/RIS_(file_format))
-(for import into Microsoft Word, EndNote, Zotero, or Mendeley), and a plain-text
-reference string. The RIS and plain-text formats are intended for those who do
-not write in LaTeX.
+Each entry in the reference list provides an `[Export]` link that opens the
+citation in three formats: BibTeX, RIS (for import into Microsoft Word, EndNote,
+Zotero, or Mendeley), and a plain-text reference string. The RIS and plain-text
+formats are intended for those who do not write in LaTeX.
 
 See [citation_examples] for examples.
 


### PR DESCRIPTION
This Pr resolves issue #22982 :

This PR enhances the MooseDocs bibtex extension, which renders citations on the MOOSE documentation website. Previously the extension supported only author-year inline citations and a static reference list. The PR adds two reader-facing capabilities and refines the documentation.

Numbered inline citation style. A new citation_style configuration option (author-year default, or number) controls how every in-text marker renders site-wide. In number mode, inline citations appear as bracketed numbers ([1], [2]) assigned in order of first appearance, and the reference list is reordered to match. This helps pages that cite many works by the same authors or year, where author-year labels collide. The textual/parenthetical distinction is preserved under both styles: !cite/!citet keep the author ("Slaughter et al. [1]" or "Slaughter et al. (2014)"), while !citep renders just the bracketed number ("[1]") or the parenthetical form ("(Slaughter et al., 2014)").

Citation export formats. Each entry in the reference list gains an [Export] modal offering the same citation in three machine-readable formats — BibTeX (for LaTeX), RIS (for Word/EndNote/Zotero/Mendeley), and plain text — so people who don't write in LaTeX can reuse MOOSE citations. Because pybtex has no RIS writer, RIS is produced by a hand-written bibtex_to_ris() with a BibTeX-to-RIS type map, preserving author name particles and suffixes. The three export blocks are each tagged with a language-* class so Prism wraps them consistently with a Copy button and contained side-scrolling (RIS and plain text use language-none, which gives the toolbar without syntax coloring).

Documentation. bibtex.md was updated so the !cite/!citep usage guidance lives in the Usage section (covering both styles) rather than buried in the configuration descriptions, the worked examples are clarified as rendering in the default author-year style used across the site, and a bare [1] was escaped to fix the doc build.

Testing and status. New tests in test_bibtex.py cover author-year rendering, the numbered style (textual, parenthetical, and reference ordering), RIS conversion (including LaTeX authors and name particles), and the export modal's three formats. The materialize gold fixture was regenerated to match. The bibtex page was built locally and verified against gold in both materialize and html forms; the work is committed and pushed to kyriv-lab/moose, with CIVET running.
