### PR TITLE
P-Refinement Treatment Fixes

### DIFF
--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -1016,6 +1016,12 @@ public:
   [[nodiscard]] bool havePRefinement() const { return _have_p_refinement; }
 
   /**
+   * Mark a variable family for either disabling or enabling p-refinement with valid parameters of a
+   * variable
+   */
+  void markFamilyPRefinement(const InputParameters & params);
+
+  /**
    * Set the current lower dimensional element. This can be null
    */
   virtual void setCurrentLowerDElem(const Elem * const lower_d_elem, const THREAD_ID tid);
@@ -1037,12 +1043,6 @@ protected:
    * Verify the integrity of _vector_tags and _typed_vector_tags
    */
   bool verifyVectorTags() const;
-
-  /**
-   * Mark a variable family for either disabling or enabling p-refinement with valid parameters of a
-   * variable
-   */
-  void markFamilyPRefinement(const InputParameters & params);
 
   /// The currently declared tags
   std::map<TagName, TagID> _matrix_tag_name_to_tag_id;

--- a/framework/src/ics/InitialConditionTempl.C
+++ b/framework/src/ics/InitialConditionTempl.C
@@ -125,9 +125,13 @@ InitialConditionTempl<T>::compute()
   // Interpolate node values first
   _current_dof = 0;
 
+  auto & dof_map = _var.dofMap();
+  const bool add_p_level =
+      dof_map.should_p_refine(dof_map.var_group_from_var_number(_var.number()));
+
   for (_n = 0; _n != n_nodes; ++_n)
   {
-    _nc = FEInterface::n_dofs_at_node(_fe_type, _current_elem, _n);
+    _nc = FEInterface::n_dofs_at_node(_fe_type, _current_elem, _n, add_p_level);
 
     // for nodes that are in more than one subdomain, only compute the initial
     // condition once on the lowest numbered block
@@ -174,10 +178,6 @@ InitialConditionTempl<T>::compute()
 
   // From here on out we won't be sampling at nodes anymore
   _current_node = nullptr;
-
-  auto & dof_map = _var.dofMap();
-  const bool add_p_level =
-      dof_map.should_p_refine(dof_map.var_group_from_var_number(_var.number()));
 
   // In 3D, project any edge values next
   if (_dim > 2 && _cont != DISCONTINUOUS)

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3022,6 +3022,8 @@ FEProblemBase::addVariable(const std::string & var_type,
   _solver_var_to_sys_num[var_name] = solver_system_number;
 
   markFamilyPRefinement(params);
+  if (_displaced_problem)
+    _displaced_problem->markFamilyPRefinement(params);
 }
 
 std::pair<bool, unsigned int>
@@ -3322,6 +3324,8 @@ FEProblemBase::addAuxVariable(const std::string & var_type,
     _displaced_problem->addAuxVariable(var_type, var_name, params);
 
   markFamilyPRefinement(params);
+  if (_displaced_problem)
+    _displaced_problem->markFamilyPRefinement(params);
 }
 
 void
@@ -3370,6 +3374,8 @@ FEProblemBase::addAuxVariable(const std::string & var_name,
     _displaced_problem->addAuxVariable("MooseVariable", var_name, params);
 
   markFamilyPRefinement(params);
+  if (_displaced_problem)
+    _displaced_problem->markFamilyPRefinement(params);
 }
 
 void
@@ -3402,6 +3408,8 @@ FEProblemBase::addAuxArrayVariable(const std::string & var_name,
     _displaced_problem->addAuxVariable("ArrayMooseVariable", var_name, params);
 
   markFamilyPRefinement(params);
+  if (_displaced_problem)
+    _displaced_problem->markFamilyPRefinement(params);
 }
 
 void


### PR DESCRIPTION
## Reason
MOOSE has a couple of issues regarding p-refinement treatment:
1. ICs are not properly respecting whether the variable is doing p-refinement or not,
2. `markFamilyPRefinement` is not being called for displaced problem.

## Design
1. Make ICs respect whether the variable is doing p-refinement or not.
2. Call `markFamilyPRefinement` for displaced problem.

## Impact
No surprise from using Lagrange variables and p-refinement together.