### PR TITLE
[WIP] Give MUMPS the libraries it needs to not have undefined refs

### DIFF
--- a/scripts/update_and_rebuild_mfem.sh
+++ b/scripts/update_and_rebuild_mfem.sh
@@ -154,6 +154,7 @@ do
       -DHYPRE_DIR="$PETSC_DIR/$PETSC_ARCH" \
       -DMETIS_DIR="$PETSC_DIR/$PETSC_ARCH" \
       -DMUMPS_DIR="$PETSC_DIR/$PETSC_ARCH" \
+      -DMUMPS_REQUIRED_LIBRARIES="-fopenmp;-Wl,-rpath,$PETSC_DIR/$PETSC_ARCH/lib;-L$PETSC_DIR/$PETSC_ARCH/lib;-lptesmumps;-lptscotchparmetisv3;-lptscotch;-lptscotcherr;-lesmumps;-lscotch;-lscotcherr" \
       -DNETCDF_DIR="$LIBMESH_DIR" \
       -DParMETIS_DIR="$PETSC_DIR/$PETSC_ARCH" \
       -DPETSC_ARCH="$PETSC_ARCH" \


### PR DESCRIPTION
This doesn't crop up when building the MFEM shared libraries themselves. The issue only arises when building unit tests in MFEM in which case we're not saved by MOOSE bringing in all the required libraries through libmesh_LDFLAGS etc.

@loganharbour I think I'll just store this on github until the next package update PR as this is not a high priority to have in upstream MOOSE