### PR TITLE
Improve diagnostic for unsupported 1D mortar constraints

### DIFF
--- a/framework/src/constraints/AutomaticMortarGeneration.C
+++ b/framework/src/constraints/AutomaticMortarGeneration.C
@@ -1828,6 +1828,9 @@ AutomaticMortarGeneration::computeNodalGeometry()
   // The dimension according to Mesh::mesh_dimension().
   const auto dim = _mesh.mesh_dimension();
 
+  mooseAssert(dim == 2 || dim == 3,
+              "AutomaticMortarGeneration::computeNodalGeometry() is only valid for "
+              "mortar constraints on 2D or 3D meshes.");
   // A nodal lower-dimensional nodal quadrature rule to be used on faces.
   QNodal qface(dim - 1);
 

--- a/framework/src/constraints/MortarInterfaceWarehouse.C
+++ b/framework/src/constraints/MortarInterfaceWarehouse.C
@@ -166,6 +166,13 @@ MortarInterfaceWarehouse::update(AutomaticMortarGeneration & amg)
   // Clear exiting data
   amg.clear();
 
+  const auto dim = amg.dim();
+
+  if (dim == 1)
+    mooseError("Mortar constraints are not currently supported for 1D meshes");
+  else if (dim != 2 && dim != 3)
+    mooseError("Invalid mesh dimension for mortar constraint");
+
   // Construct maps from nodes -> lower dimensional elements on the primary and secondary
   // boundaries.
   amg.buildNodeToElemMaps();
@@ -173,7 +180,6 @@ MortarInterfaceWarehouse::update(AutomaticMortarGeneration & amg)
   // Compute nodal geometry (normals and tangents).
   amg.computeNodalGeometry();
 
-  const auto dim = amg.dim();
   if (dim == 2)
   {
     // Project secondary nodes (find xi^(2) values).
@@ -185,10 +191,8 @@ MortarInterfaceWarehouse::update(AutomaticMortarGeneration & amg)
     // Build the mortar segment mesh on the secondary boundary.
     amg.buildMortarSegmentMesh();
   }
-  else if (dim == 3)
+  else // dim == 3
     amg.buildMortarSegmentMesh3d();
-  else
-    mooseError("Invalid mesh dimension for mortar constraint");
 
   amg.computeInactiveLMNodes();
   amg.computeInactiveLMElems();

--- a/test/tests/mortar/unsupported_1d_mortar/tests
+++ b/test/tests/mortar/unsupported_1d_mortar/tests
@@ -1,0 +1,10 @@
+[Tests]
+  [unsupported_1d_mortar]
+    type = RunException
+    input = unsupported_1d_mortar.i
+    expect_err = 'Mortar constraints are not currently supported for 1D meshes'
+    design = 'syntax/Constraints/index.md source/constraints/EqualValueConstraint.md'
+    requirement = 'The system shall report a clear error when mortar constraints are used with a 1D mesh.'
+    issues = '#30179'
+  []
+[]

--- a/test/tests/mortar/unsupported_1d_mortar/unsupported_1d_mortar.i
+++ b/test/tests/mortar/unsupported_1d_mortar/unsupported_1d_mortar.i
@@ -1,0 +1,107 @@
+[Mesh]
+  [lefttest]
+    type = GeneratedMeshGenerator
+    dim = 1
+    nx = 20
+    xmin = 0
+    xmax = 1
+    boundary_name_prefix = compact
+    elem_type = EDGE2
+  []
+  [compact]
+    type = SubdomainIDGenerator
+    input = lefttest
+    subdomain_id = 1
+  []
+  [righttest]
+    type = GeneratedMeshGenerator
+    dim = 1
+    nx = 20
+    xmin = 2
+    xmax = 3
+    boundary_name_prefix = IR
+    boundary_id_offset = 5
+    elem_type = EDGE2
+  []
+  [IR]
+    type = SubdomainIDGenerator
+    input = righttest
+    subdomain_id = 2
+  []
+  [full_test]
+    type = MeshCollectionGenerator
+    inputs = 'compact IR'
+  []
+  [block_rename]
+    input = full_test
+    type = RenameBlockGenerator
+    old_block = '1 2'
+    new_block = 'compact IR'
+  []
+  [left_interface]
+    type = LowerDBlockFromSidesetGenerator
+    input = block_rename
+    sidesets = 'compact_right'
+    new_block_id = 10
+    new_block_name = 'interface_primary_subdomain'
+  []
+  [right_interface]
+    type = LowerDBlockFromSidesetGenerator
+    input = left_interface
+    sidesets = 'IR_left'
+    new_block_id = 20
+    new_block_name = 'interface_secondary_subdomain'
+  []
+[]
+
+[Variables]
+  [u]
+    initial_condition = 0
+  []
+  [lm]
+    block = 'interface_secondary_subdomain'
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+    block = 'compact IR'
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    boundary = compact_left
+    variable = u
+    value = 1
+  []
+  [right]
+    type = DirichletBC
+    boundary = IR_right
+    variable = u
+    value = 0
+  []
+[]
+
+[Constraints]
+  [mortar]
+    type = EqualValueConstraint
+    variable = lm
+    secondary_variable = u
+    primary_boundary = compact_right
+    primary_subdomain = interface_primary_subdomain
+    secondary_boundary = IR_left
+    secondary_subdomain = interface_secondary_subdomain
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  exodus = false
+[]


### PR DESCRIPTION
Closes #30179

## Reason
<!--Why do you need this feature or what is the enhancement?-->

A 1D mortar constraint input currently fails with a confusing lower-level libMesh error:

```text
Bad ElemType = EDGE2 for CONSTANT order approximation!
```

## Design
This PR adds an early MOOSE-side diagnostic in MortarInterfaceWarehouse::update() for 1D mortar constraints:

"Mortar constraints are not currently supported for 1D meshes because the mortar interface is 0D."

The dimension check now happens before buildNodeToElemMaps() and computeNodalGeometry(), preventing the unsupported 1D/0D case from reaching the lower-level libMesh FE path.

A defensive assertion was also added in AutomaticMortarGeneration::computeNodalGeometry() to document that this path is only valid for mortar constraints on 2D or 3D meshes.

This PR does not add 1D/0D mortar contact support.

## Impact
No API changes.

Unsupported 1D mortar constraints now fail earlier with a clearer MOOSE error message instead of a lower-level libMesh FE error.

A regression test was added to verify the expected diagnostic.

Test:

METHOD=dbg python ./run_tests --spec-file test/tests/constraints/unsupported_1d_mortar/tests -p 1

Result:

1 passed, 0 skipped, 0 failed