### PR TITLE
Reference PiecewiseConstantByBlockMaterial no-FV issue

### DIFF
--- a/test/tests/materials/piecewise_by_block_material/tests
+++ b/test/tests/materials/piecewise_by_block_material/tests
@@ -1,5 +1,5 @@
 [Tests]
-  issues = '#16758 #26324'
+  issues = '#16758 #26250 #26324'
   [continuous]
     type = Exodiff
     input = continuous.i


### PR DESCRIPTION
The no-FV `PiecewiseConstantByBlockMaterial` failure from #26250 appears to have been fixed by cf5754c170 under #26324. This adds #26250 to the existing regression test metadata.

## Testing

```bash
METHOD=dbg python ./run_tests --spec-file tests/materials/piecewise_by_block_material/tests -p 1

3 passed, 0 skipped, 0 failed

Refs #26250