### PR TITLE
Change warning to info for an implementation notice in the physics

### DIFF
--- a/framework/doc/content/source/postprocessors/SumPostprocessor.md
+++ b/framework/doc/content/source/postprocessors/SumPostprocessor.md
@@ -4,6 +4,10 @@
 
 For a more complex operation than a sum, please consider the [ParsedPostprocessor.md].
 
+!alert note
+If you are looking for the sum of a postprocessor accumulated over multiple time steps,
+please consider the [CumulativeValuePostprocessor.md].
+
 !syntax parameters /Postprocessors/SumPostprocessor
 
 !syntax inputs /Postprocessors/SumPostprocessor

--- a/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
+++ b/modules/navier_stokes/src/physics/WCNSFVFlowPhysicsBase.C
@@ -370,7 +370,7 @@ WCNSFVFlowPhysicsBase::addFluidPropertiesFunctorMaterial()
   }
   else
     // not implemented yet
-    paramWarning(
+    paramInfo(
         NS::fluid,
         "Specifying the fluid properties user object does not define the GeneralFunctorFluidProps "
         "when using the porous medium treatment. You have to define this object in the input");


### PR DESCRIPTION
refs #31218

I'm making the HTR PM inputs fully clean and releasable and in retrospect returning a warning there was not appropriate