### PR TITLE
Make large_media submodule optional in MooseDocs

### DIFF
--- a/python/MooseDocs/__init__.py
+++ b/python/MooseDocs/__init__.py
@@ -48,7 +48,11 @@ if MOOSE_DIR is None:
 # reference its content may opt out by setting MOOSEDOCS_LARGE_MEDIA to a false value (e.g. "false",
 # "0", "no"). This check happens here, at import time, because the submodule must be available before
 # any command parses its configuration files.
-USE_LARGE_MEDIA = os.getenv("MOOSEDOCS_LARGE_MEDIA", "true").lower() in ("true", "1", "yes")
+USE_LARGE_MEDIA = os.getenv("MOOSEDOCS_LARGE_MEDIA", "true").lower() in (
+    "true",
+    "1",
+    "yes",
+)
 
 # Initialize submodule(s) with progress output
 if USE_LARGE_MEDIA:

--- a/python/MooseDocs/__init__.py
+++ b/python/MooseDocs/__init__.py
@@ -44,11 +44,19 @@ if MOOSE_DIR is None:
     )
     sys.exit(1)
 
+# The large_media submodule is initialized and indexed by default, but applications that do not
+# reference its content may opt out by setting MOOSEDOCS_LARGE_MEDIA to a false value (e.g. "false",
+# "0", "no"). This check happens here, at import time, because the submodule must be available before
+# any command parses its configuration files.
+USE_LARGE_MEDIA = os.getenv("MOOSEDOCS_LARGE_MEDIA", "true").lower() in ("true", "1", "yes")
+
 # Initialize submodule(s) with progress output
-mooseutils.git_init_submodule("large_media", MOOSE_DIR, True)
+if USE_LARGE_MEDIA:
+    mooseutils.git_init_submodule("large_media", MOOSE_DIR, True)
 
 # List all files, this is done here to avoid running this command many times
 ls_files = mooseutils.git_ls_files if is_git_repo else mooseutils.list_files
 PROJECT_FILES = ls_files(ROOT_DIR)
 PROJECT_FILES.update(ls_files(MOOSE_DIR))
-PROJECT_FILES.update(ls_files(os.path.join(MOOSE_DIR, "large_media")))
+if USE_LARGE_MEDIA:
+    PROJECT_FILES.update(ls_files(os.path.join(MOOSE_DIR, "large_media")))

--- a/python/MooseDocs/__init__.py
+++ b/python/MooseDocs/__init__.py
@@ -44,23 +44,20 @@ if MOOSE_DIR is None:
     )
     sys.exit(1)
 
-# The large_media submodule is initialized and indexed by default, but applications that do not
-# reference its content may opt out by setting MOOSEDOCS_LARGE_MEDIA to a false value (e.g. "false",
-# "0", "no"). This check happens here, at import time, because the submodule must be available before
-# any command parses its configuration files.
-USE_LARGE_MEDIA = os.getenv("MOOSEDOCS_LARGE_MEDIA", "true").lower() in (
-    "true",
-    "1",
-    "yes",
-)
-
-# Initialize submodule(s) with progress output
-if USE_LARGE_MEDIA:
-    mooseutils.git_init_submodule("large_media", MOOSE_DIR, True)
-
 # List all files, this is done here to avoid running this command many times
 ls_files = mooseutils.git_ls_files if is_git_repo else mooseutils.list_files
 PROJECT_FILES = ls_files(ROOT_DIR)
 PROJECT_FILES.update(ls_files(MOOSE_DIR))
-if USE_LARGE_MEDIA:
-    PROJECT_FILES.update(ls_files(os.path.join(MOOSE_DIR, "large_media")))
+
+
+def init_large_media(enable=True):
+    """
+    Initialize and index the large_media submodule, unless the caller opts out.
+
+    This is called from main.run() rather than performed unconditionally at import time,
+    so that applications that do not reference any large_media content can opt out by
+    passing large_media=False to run().
+    """
+    if enable:
+        mooseutils.git_init_submodule("large_media", MOOSE_DIR, True)
+        PROJECT_FILES.update(ls_files(os.path.join(MOOSE_DIR, "large_media")))

--- a/python/MooseDocs/main.py
+++ b/python/MooseDocs/main.py
@@ -15,6 +15,7 @@ MOOSE run_tests.
 import argparse
 import logging
 
+from . import init_large_media
 from .commands import build, verify, check, generate, syntax, init
 from .common import log
 
@@ -50,10 +51,15 @@ def command_line_options() -> object:
     return parser.parse_args()
 
 
-def run():
+def run(large_media=True):
     """
     Parse the command line options and run the correct command.
+
+    The large_media kwarg controls whether the large_media submodule is initialized and
+    indexed, see MooseDocs.init_large_media().
     """
+    init_large_media(large_media)
+
     options = command_line_options()
     log.init_logging(getattr(logging, options.level))
 

--- a/python/MooseDocs/test/test_init.py
+++ b/python/MooseDocs/test/test_init.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# This file is part of the MOOSE framework
+# https://mooseframework.inl.gov
+#
+# All rights reserved, see COPYRIGHT for full restrictions
+# https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#
+# Licensed under LGPL 2.1, please see LICENSE for details
+# https://www.gnu.org/licenses/lgpl-2.1.html
+
+import unittest
+from unittest import mock
+
+import MooseDocs
+
+
+class TestInitLargeMedia(unittest.TestCase):
+    def setUp(self):
+        self._orig_project_files = MooseDocs.PROJECT_FILES
+        MooseDocs.PROJECT_FILES = set()
+
+    def tearDown(self):
+        MooseDocs.PROJECT_FILES = self._orig_project_files
+
+    def testEnabled(self):
+        """init_large_media(True) initializes the submodule and indexes its files."""
+        with (
+            mock.patch("mooseutils.git_init_submodule") as git_init_submodule,
+            mock.patch.object(MooseDocs, "ls_files") as ls_files,
+        ):
+            ls_files.return_value = {"large_media/foo.png"}
+            MooseDocs.init_large_media(True)
+
+        git_init_submodule.assert_called_once_with(
+            "large_media", MooseDocs.MOOSE_DIR, True
+        )
+        ls_files.assert_called_once()
+        self.assertIn("large_media/foo.png", MooseDocs.PROJECT_FILES)
+
+    def testDisabled(self):
+        """init_large_media(False) skips submodule initialization and file indexing."""
+        with (
+            mock.patch("mooseutils.git_init_submodule") as git_init_submodule,
+            mock.patch.object(MooseDocs, "ls_files") as ls_files,
+        ):
+            MooseDocs.init_large_media(False)
+
+        git_init_submodule.assert_not_called()
+        ls_files.assert_not_called()
+        self.assertEqual(MooseDocs.PROJECT_FILES, set())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/python/doc/content/python/MooseDocs/setup.md
+++ b/python/doc/content/python/MooseDocs/setup.md
@@ -73,6 +73,25 @@ objects. Information to get started follows in the next section of this document
 applications mimic the MOOSE process, so it is best to also refer to the MOOSE instructions for
 documentation (see [framework/documenting.md]).
 
+## Disabling the large_media Submodule
+
+By default, MooseDocs initializes and indexes the [large_media](https://github.com/idaholab/large_media)
+submodule, which contains the large image and video assets used by the MOOSE documentation. Applications
+that do not reference any `large_media` content can opt out of this by setting the
+`MOOSEDOCS_LARGE_MEDIA` environment variable to a false value (e.g. `false`, `0`, or `no`) before
+MooseDocs is imported. The most convenient place to do this is the application's `moosedocs.py`
+script, alongside the other environment variables it sets:
+
+```python
+os.environ.setdefault("MOOSEDOCS_LARGE_MEDIA", "false")
+```
+
+!alert note title=Only disable if unused
+If any page references content from `large_media` (for example through the
+[media](MooseDocs/extensions/media.md) or [gallery](MooseDocs/extensions/gallery.md) extensions), the
+build will report missing files. Only disable the submodule for applications that do not use any of
+its content.
+
 ## Generating Object Documentation Files
 
 During the course of development, especially during the creation of new application objects (e.g., kernels,

--- a/python/doc/content/python/MooseDocs/setup.md
+++ b/python/doc/content/python/MooseDocs/setup.md
@@ -77,13 +77,11 @@ documentation (see [framework/documenting.md]).
 
 By default, MooseDocs initializes and indexes the [large_media](https://github.com/idaholab/large_media)
 submodule, which contains the large image and video assets used by the MOOSE documentation. Applications
-that do not reference any `large_media` content can opt out of this by setting the
-`MOOSEDOCS_LARGE_MEDIA` environment variable to a false value (e.g. `false`, `0`, or `no`) before
-MooseDocs is imported. The most convenient place to do this is the application's `moosedocs.py`
-script, alongside the other environment variables it sets:
+that do not reference any `large_media` content can opt out of this by passing `large_media=False` to
+`main.run()` in the application's `moosedocs.py` script:
 
 ```python
-os.environ.setdefault("MOOSEDOCS_LARGE_MEDIA", "false")
+sys.exit(main.run(large_media=False))
 ```
 
 !alert note title=Only disable if unused

--- a/stork/doc/moosedocs.py.app
+++ b/stork/doc/moosedocs.py.app
@@ -24,6 +24,10 @@ MOOSE_PYTHON_DIR = os.path.join(MOOSE_DIR, 'python')
 if MOOSE_PYTHON_DIR not in sys.path:
     sys.path.append(MOOSE_PYTHON_DIR)
 
+# Uncomment the following line if this application does not reference any 'large_media' content, to
+# skip initializing and indexing the large_media submodule. See MooseDocs/setup.md for details.
+# os.environ.setdefault('MOOSEDOCS_LARGE_MEDIA', 'false')
+
 from MooseDocs import main
 if __name__ == '__main__':
     sys.exit(main.run())

--- a/stork/doc/moosedocs.py.app
+++ b/stork/doc/moosedocs.py.app
@@ -24,10 +24,9 @@ MOOSE_PYTHON_DIR = os.path.join(MOOSE_DIR, 'python')
 if MOOSE_PYTHON_DIR not in sys.path:
     sys.path.append(MOOSE_PYTHON_DIR)
 
-# Uncomment the following line if this application does not reference any 'large_media' content, to
-# skip initializing and indexing the large_media submodule. See MooseDocs/setup.md for details.
-# os.environ.setdefault('MOOSEDOCS_LARGE_MEDIA', 'false')
-
 from MooseDocs import main
 if __name__ == '__main__':
+    # Pass large_media=False if this application does not reference any 'large_media' content, to
+    # skip initializing and indexing the large_media submodule. See MooseDocs/setup.md for details.
+    # sys.exit(main.run(large_media=False))
     sys.exit(main.run())


### PR DESCRIPTION
Closes #26403 

Working with Claude, I considered a few approaches.

- **Environment variable (chosen)** — Gate the submodule init/indexing on MOOSEDOCS_LARGE_MEDIA (default on), read at import time in __init__.py. Minimal, low-risk, and respects the import-time timing constraint. Default-on preserves all existing behavior.

- **CLI flag (`--no-large-media`)** — Rejected as overkill. Args are parsed after `import MooseDocs`, so this would require deferring the init out of import scope and making `PROJECT_FILES` populate lazily — touching `get_content`/`project_find` for a per-invocation toggle that isn't needed.

- **`config.yml` option** — Rejected. Still defers the issue, but the config is read even deeper in the build pipeline. A wrapper that peeks at config early to set an environment condition essentially defers back to the first option.

Since large_media is initialized/indexed at `import MooseDocs` time, before any command parses CLI args or config, so the any gating step must be readable at import. An environment variable seems to be the cleanest mechanism that satisfies this without restructuring how the global file index is built. This was the initial fallback I discussed in #26403, but Claude helped me reason through the structure of the more intrusive options. I like the centrality of having all the metadata for the build in the config, but we have also set the precedent to set important vars in `moosedocs.py`....so I think I'll settle for the latter.