### PR TITLE
Make PorousFlow kernels capable of using AD materials

### DIFF
--- a/modules/porous_flow/doc/content/source/kernels/PorousFlowAdvectiveFlux.md
+++ b/modules/porous_flow/doc/content/source/kernels/PorousFlowAdvectiveFlux.md
@@ -9,7 +9,7 @@ This `Kernel` implements the weak form of
 where all parameters are defined in the [nomenclature](/nomenclature.md).
 
 !alert note
-A fully-upwinded version is implemented, where the mobility of the upstream nodes is used.
+A fully-upwinded version is implemented, where the mobility of the upstream nodes is used.  This Kernel requires a nodal (Lagrange) variable, because upwinding associates each element degree of freedom with a mesh node; using a non-nodal variable (such as a monomial variable) is an error.
 
 See [upwinding](/upwinding.md) for details.  Other Kernels implement [Kuzmin-Turek TVD stabilization](kt.md).
 

--- a/modules/porous_flow/doc/content/source/kernels/PorousFlowEnergyTimeDerivative.md
+++ b/modules/porous_flow/doc/content/source/kernels/PorousFlowEnergyTimeDerivative.md
@@ -9,7 +9,7 @@ This `Kernel` implements the weak form of
 where all parameters are defined in the [nomenclature](/nomenclature.md).
 
 !alert note
-An energy-lumped version is implemented.
+An energy-lumped version is implemented.  This Kernel requires a nodal (Lagrange) variable, because mass lumping associates each element degree of freedom with a mesh node; using a non-nodal variable (such as a monomial variable) is an error.
 
 See [mass lumping](/mass_lumping.md) for details.
 

--- a/modules/porous_flow/doc/content/source/kernels/PorousFlowFullySaturatedAdvectiveFlux.md
+++ b/modules/porous_flow/doc/content/source/kernels/PorousFlowFullySaturatedAdvectiveFlux.md
@@ -12,6 +12,9 @@ The factor $(\rho)$ appears in parentheses because it is optional and controlled
 
 [Full upwinding](upwinding.md) is used in this Kernel.  See the [numerical stabilization lead page](stabilization.md) page for more details.
 
+!alert note
+This Kernel requires a nodal (Lagrange) variable, because upwinding associates each element degree of freedom with a mesh node; using a non-nodal variable (such as a monomial variable) is an error.
+
 This Kernel may be added automatically by the [PorousFlowFullySaturated](PorousFlowFullySaturated.md) Action: see more discussion on that page.
 
 !syntax parameters /Kernels/PorousFlowFullySaturatedAdvectiveFlux

--- a/modules/porous_flow/doc/content/source/kernels/PorousFlowFullySaturatedUpwindHeatAdvection.md
+++ b/modules/porous_flow/doc/content/source/kernels/PorousFlowFullySaturatedUpwindHeatAdvection.md
@@ -11,7 +11,7 @@ where all parameters are defined in the [nomenclature](/nomenclature.md).  This 
 This `Kernel` is usually added by the [PorousFlowFullySaturated](PorousFlowFullySaturated.md) Action (and more discussion is included on that page).
 
 !alert note
-A fully-upwinded version is implemented, where the mobility of the upstream nodes is used.
+A fully-upwinded version is implemented, where the mobility of the upstream nodes is used.  This Kernel requires a nodal (Lagrange) variable, because upwinding associates each element degree of freedom with a mesh node; using a non-nodal variable (such as a monomial variable) is an error.
 
 See [upwinding](/upwinding.md) for details.  If you desire no upwinding, use [PorousFlowFullySaturatedHeatAdvection](PorousFlowFullySaturatedHeatAdvection.md) instead.  If you desire [Kuzmin-Turek TVD stabilization](kt.md), use [PorousFlowFluxLimitedTVDAdvection](PorousFlowFluxLimitedTVDAdvection.md).
 

--- a/modules/porous_flow/doc/content/source/kernels/PorousFlowHeatAdvection.md
+++ b/modules/porous_flow/doc/content/source/kernels/PorousFlowHeatAdvection.md
@@ -9,7 +9,7 @@ This `Kernel` implements the weak form of
 where all parameters are defined in the [nomenclature](/nomenclature.md).
 
 !alert note
-A fully-upwinded version is implemented, where the mobility of the upstream nodes is used.
+A fully-upwinded version is implemented, where the mobility of the upstream nodes is used.  This Kernel requires a nodal (Lagrange) variable, because upwinding associates each element degree of freedom with a mesh node; using a non-nodal variable (such as a monomial variable) is an error.
 
 See [upwinding](/upwinding.md) for details.  Other Kernels implement [Kuzmin-Turek TVD stabilization](kt.md).
 

--- a/modules/porous_flow/doc/content/source/kernels/PorousFlowMassRadioactiveDecay.md
+++ b/modules/porous_flow/doc/content/source/kernels/PorousFlowMassRadioactiveDecay.md
@@ -8,6 +8,11 @@ This `Kernel` implements the weak form of
 \end{equation*}
 where all parameters are defined in the [nomenclature](/nomenclature.md).
 
+!alert note
+A mass-lumped version is implemented.  This Kernel requires a nodal (Lagrange) variable, because mass lumping associates each element degree of freedom with a mesh node; using a non-nodal variable (such as a monomial variable) is an error.
+
+See [mass lumping](/mass_lumping.md) for details.
+
 !syntax parameters /Kernels/PorousFlowMassRadioactiveDecay
 
 !syntax inputs /Kernels/PorousFlowMassRadioactiveDecay

--- a/modules/porous_flow/doc/content/source/kernels/PorousFlowMassTimeDerivative.md
+++ b/modules/porous_flow/doc/content/source/kernels/PorousFlowMassTimeDerivative.md
@@ -9,7 +9,7 @@ This `Kernel` implements the weak form of
 where all parameters are defined in the [nomenclature](/nomenclature.md).
 
 !alert note
-A mass-lumped version is implemented.
+A mass-lumped version is implemented.  This Kernel requires a nodal (Lagrange) variable, because mass lumping associates each element degree of freedom with a mesh node; using a non-nodal variable (such as a monomial variable) is an error.
 
 See [mass lumping](/mass_lumping.md) for details.
 

--- a/modules/porous_flow/doc/content/source/kernels/PorousFlowPreDis.md
+++ b/modules/porous_flow/doc/content/source/kernels/PorousFlowPreDis.md
@@ -51,7 +51,9 @@ Then the stoichiometric coefficients for the `PorousFlowPreDis` Kernels would be
 
 !alert note
 This `Kernel` lumps the mineral masses to the nodes.  It also only uses the *old* values of porosity,
-which is an approximation: see [porosity](/porous_flow/porosity.md) for a discussion.
+which is an approximation: see [porosity](/porous_flow/porosity.md) for a discussion.  Because it lumps
+to the nodes, this Kernel requires a nodal (Lagrange) variable; using a non-nodal variable (such as a
+monomial variable) is an error.
 
 See [mass lumping](/porous_flow/mass_lumping.md) for details.
 

--- a/modules/porous_flow/include/kernels/PorousFlowAdvectiveFlux.h
+++ b/modules/porous_flow/include/kernels/PorousFlowAdvectiveFlux.h
@@ -15,30 +15,44 @@
  * Convective flux of component k in fluid phase alpha.
  * A fully-updwinded version is implemented, where the mobility
  * of the upstream nodes is used.
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowAdvectiveFlux : public PorousFlowDarcyBase
+template <bool is_ad>
+class PorousFlowAdvectiveFluxTempl : public PorousFlowDarcyBaseTempl<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowAdvectiveFlux(const InputParameters & parameters);
+  PorousFlowAdvectiveFluxTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real mobility(unsigned nodenum, unsigned phase) const override;
+  virtual GenericReal<is_ad> mobility(unsigned nodenum, unsigned phase) const override;
   virtual Real dmobility(unsigned nodenum, unsigned phase, unsigned pvar) const override;
 
   /// Mass fraction of each component in each phase
-  const MaterialProperty<std::vector<std::vector<Real>>> & _mass_fractions;
+  const GenericMaterialProperty<std::vector<std::vector<Real>>, is_ad> & _mass_fractions;
 
-  /// Derivative of the mass fraction of each component in each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> & _dmass_fractions_dvar;
+  /// Derivative of the mass fraction of each component in each phase wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> * const _dmass_fractions_dvar;
 
   /// Relative permeability of each phase
-  const MaterialProperty<std::vector<Real>> & _relative_permeability;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _relative_permeability;
 
-  /// Derivative of relative permeability of each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _drelative_permeability_dvar;
+  /// Derivative of relative permeability of each phase wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _drelative_permeability_dvar;
 
   /// Index of the fluid component that this kernel acts on
   const unsigned int _fluid_component;
+
+  using PorousFlowDarcyBaseTempl<is_ad>::_dictator;
+  using PorousFlowDarcyBaseTempl<is_ad>::_fluid_density_node;
+  using PorousFlowDarcyBaseTempl<is_ad>::_fluid_viscosity;
+  using PorousFlowDarcyBaseTempl<is_ad>::_dfluid_density_node_dvar;
+  using PorousFlowDarcyBaseTempl<is_ad>::_dfluid_viscosity_dvar;
+  usingGenericKernelMembers;
 };
+
+typedef PorousFlowAdvectiveFluxTempl<false> PorousFlowAdvectiveFlux;
+typedef PorousFlowAdvectiveFluxTempl<true> ADPorousFlowAdvectiveFlux;

--- a/modules/porous_flow/include/kernels/PorousFlowBasicAdvection.h
+++ b/modules/porous_flow/include/kernels/PorousFlowBasicAdvection.h
@@ -9,21 +9,25 @@
 
 #pragma once
 
-#include "Kernel.h"
+#include "GenericKernel.h"
 #include "PorousFlowDictator.h"
 
 /**
  * Kernel = grad(test) * darcy_velocity * u
+ *
+ * Templated on is_ad: the false instantiation uses the hand-coded Jacobian;
+ * the true instantiation propagates derivatives through the AD Darcy velocity and u.
  */
-class PorousFlowBasicAdvection : public Kernel
+template <bool is_ad>
+class PorousFlowBasicAdvectionTempl : public GenericKernel<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowBasicAdvection(const InputParameters & parameters);
+  PorousFlowBasicAdvectionTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
@@ -34,19 +38,27 @@ protected:
   const unsigned _ph;
 
   /// _darcy_velocity[_qp][ph](j) = j^th component of the Darcy velocity of phase ph
-  const MaterialProperty<std::vector<RealVectorValue>> & _darcy_velocity;
+  const GenericMaterialProperty<std::vector<RealVectorValue>, is_ad> & _darcy_velocity;
 
   /**
    * _ddarcy_velocity_dvar[_qp][ph][v](j)
    *  = d(j^th component of the Darcy velocity of phase ph)/d(PorousFlow variable v)
+   * Null for the AD path.
    */
-  const MaterialProperty<std::vector<std::vector<RealVectorValue>>> & _ddarcy_velocity_dvar;
+  const MaterialProperty<std::vector<std::vector<RealVectorValue>>> * const _ddarcy_velocity_dvar;
 
   /**
    * _ddarcy_velocity_dgradvar[_qp][ph][j][v](k)
    *  = d(k^th component of the Darcy velocity of phase ph)/d(j^th component of grad(PorousFlow
    * variable v))
+   * Null for the AD path.
    */
-  const MaterialProperty<std::vector<std::vector<std::vector<RealVectorValue>>>> &
+  const MaterialProperty<std::vector<std::vector<std::vector<RealVectorValue>>>> * const
       _ddarcy_velocity_dgradvar;
+
+  usingGenericKernelMembers;
+  using GenericKernel<is_ad>::_grad_phi;
 };
+
+typedef PorousFlowBasicAdvectionTempl<false> PorousFlowBasicAdvection;
+typedef PorousFlowBasicAdvectionTempl<true> ADPorousFlowBasicAdvection;

--- a/modules/porous_flow/include/kernels/PorousFlowDarcyBase.h
+++ b/modules/porous_flow/include/kernels/PorousFlowDarcyBase.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "Kernel.h"
+#include "GenericKernel.h"
 #include "PorousFlowDictator.h"
 
 /**
@@ -19,25 +19,30 @@
  * Alternately, after some number of upwind-downwind swaps,
  * another type of handling of the mobility may be employed
  * (see fallback_scheme, below)
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowDarcyBase : public Kernel
+template <bool is_ad>
+class PorousFlowDarcyBaseTempl : public GenericKernel<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowDarcyBase(const InputParameters & parameters);
+  PorousFlowDarcyBaseTempl(const InputParameters & parameters);
 
 protected:
   virtual void timestepSetup() override;
-  virtual Real computeQpResidual() override;
+  virtual void jacobianSetup() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
   virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /// The Darcy part of the flux (this is the non-upwinded part)
-  virtual Real darcyQp(unsigned int ph) const;
+  virtual GenericReal<is_ad> darcyQp(unsigned int ph) const;
 
-  /// Jacobian of the Darcy part of the flux
+  /// Jacobian of the Darcy part of the flux -- non-AD path only
   virtual Real darcyQpJacobian(unsigned int jvar, unsigned int ph) const;
 
   /**
@@ -46,10 +51,10 @@ protected:
    * @param nodenum The node-number to evaluate the mobility for
    * @param phase the fluid phase number
    */
-  virtual Real mobility(unsigned nodenum, unsigned phase) const;
+  virtual GenericReal<is_ad> mobility(unsigned nodenum, unsigned phase) const;
 
   /**
-   * The derivative of mobility with respect to PorousFlow variable pvar
+   * The derivative of mobility with respect to PorousFlow variable pvar -- non-AD path only
    * @param nodenum The node-number to evaluate the mobility for
    * @param phase the fluid phase number
    * @param pvar the PorousFlow variable pvar
@@ -65,7 +70,7 @@ protected:
   using ResidualObject::computeResidualAndJacobian;
 
   /**
-   * Computation of the residual and Jacobian.
+   * Computation of the residual and Jacobian (non-AD path only).
    *
    * If res_or_jac=CALCULATE_JACOBIAN then the residual
    * gets calculated anyway (becuase we have to know which
@@ -82,43 +87,43 @@ protected:
   void computeResidualAndJacobian(JacRes res_or_jac, unsigned int jvar);
 
   /// Permeability of porous material
-  const MaterialProperty<RealTensorValue> & _permeability;
+  const GenericMaterialProperty<RealTensorValue, is_ad> & _permeability;
 
-  /// d(permeabiity)/d(PorousFlow variable)
-  const MaterialProperty<std::vector<RealTensorValue>> & _dpermeability_dvar;
+  /// d(permeabiity)/d(PorousFlow variable) -- null for AD path
+  const MaterialProperty<std::vector<RealTensorValue>> * const _dpermeability_dvar;
 
-  /// d(permeabiity)/d(grad(PorousFlow variable))
-  const MaterialProperty<std::vector<std::vector<RealTensorValue>>> & _dpermeability_dgradvar;
+  /// d(permeabiity)/d(grad(PorousFlow variable)) -- null for AD path
+  const MaterialProperty<std::vector<std::vector<RealTensorValue>>> * const _dpermeability_dgradvar;
 
   /// Fluid density for each phase (at the node)
-  const MaterialProperty<std::vector<Real>> & _fluid_density_node;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_density_node;
 
-  /// Derivative of the fluid density for each phase wrt PorousFlow variables (at the node)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dfluid_density_node_dvar;
+  /// Derivative of the fluid density for each phase wrt PorousFlow variables (at the node) -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_node_dvar;
 
   /// Fluid density for each phase (at the qp)
-  const MaterialProperty<std::vector<Real>> & _fluid_density_qp;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_density_qp;
 
-  /// Derivative of the fluid density for each phase wrt PorousFlow variables (at the qp)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dfluid_density_qp_dvar;
+  /// Derivative of the fluid density for each phase wrt PorousFlow variables (at the qp) -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_qp_dvar;
 
   /// Viscosity of each component in each phase
-  const MaterialProperty<std::vector<Real>> & _fluid_viscosity;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_viscosity;
 
-  /// Derivative of the fluid viscosity for each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dfluid_viscosity_dvar;
+  /// Derivative of the fluid viscosity for each phase wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_viscosity_dvar;
 
   /// Nodal pore pressure in each phase
-  const MaterialProperty<std::vector<Real>> & _pp;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _pp;
 
   /// Gradient of the pore pressure in each phase
-  const MaterialProperty<std::vector<RealGradient>> & _grad_p;
+  const GenericMaterialProperty<std::vector<RealGradient>, is_ad> & _grad_p;
 
-  /// Derivative of Grad porepressure in each phase wrt grad(PorousFlow variables)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dgrad_p_dgrad_var;
+  /// Derivative of Grad porepressure in each phase wrt grad(PorousFlow variables) -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dgrad_p_dgrad_var;
 
-  /// Derivative of Grad porepressure in each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<RealGradient>>> & _dgrad_p_dvar;
+  /// Derivative of Grad porepressure in each phase wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<RealGradient>>> * const _dgrad_p_dvar;
 
   /// PorousFlowDictator UserObject
   const PorousFlowDictator & _dictator;
@@ -155,12 +160,12 @@ protected:
    * during the formation of the residual and Jacobian.
    * _proto_flux[num_phases][num_nodes]
    */
-  std::vector<std::vector<Real>> _proto_flux;
+  std::vector<std::vector<GenericReal<is_ad>>> _proto_flux;
 
   /**
    * Derivative of _proto_flux with respect to nodal variables.
    * This gets modified with the mobility and its derivative during
-   * computation of MOOSE's Jacobian
+   * computation of MOOSE's Jacobian. Only used on the non-AD path.
    */
   std::vector<std::vector<std::vector<Real>>> _jacobian;
 
@@ -180,7 +185,8 @@ protected:
 
   /**
    * Calculate the residual or Jacobian using full upwinding
-   * @param res_or_jac whether to compute the residual or jacobian
+   * @param res_or_jac whether to compute the residual or jacobian (non-AD: CALCULATE_JACOBIAN
+   *   fills _jacobian; AD: always pass CALCULATE_RESIDUAL)
    * @param ph fluid phase number
    * @param pvar differentiate wrt to this PorousFlow variable (when computing the jacobian)
    */
@@ -203,4 +209,51 @@ protected:
    * @param pvar differentiate wrt to this PorousFlow variable (when computing the jacobian)
    */
   void harmonicMean(JacRes res_or_jac, unsigned int ph, unsigned int pvar);
+
+  usingGenericKernelMembers;
+  using GenericKernel<is_ad>::_grad_phi;
+
+private:
+  /// Build proto fluxes (without mobility weighting) for all phases and nodes
+  void computeProtoFluxWithoutMobility();
+
+  /// Ensure per-element upwind/downwind counters are allocated for this element
+  void initializeUpwindTracking(unsigned elem, unsigned int num_nodes);
+
+  /// Update upwind/downwind counters from the sign of _proto_flux
+  void updateUpwindCounts(unsigned elem, unsigned int num_nodes);
+
+  /// Compute per-phase maximum upwind/downwind swap counts for this element
+  std::vector<unsigned> computeMaxSwaps(unsigned elem, unsigned int num_nodes) const;
+
+  /// Apply selected upwinding/fallback scheme for all phases
+  void
+  applyUpwinding(const std::vector<unsigned> & max_swaps, JacRes res_or_jac, unsigned int pvar);
+
+  /**
+   * For the AD path: fills _proto_flux (per-phase, per-node ADReal) by integrating
+   * darcyQp and applying the upwinding scheme with GenericReal<is_ad> mobility.
+   * Also optionally records upwind/downwind counts for the fallback-scheme heuristic.
+   * @param do_counting whether to update _num_upwinds/_num_downwinds
+   */
+  void adComputeProtoFlux(bool do_counting);
+
+  /**
+   * For the AD path: performs the proto-flux/upwinding pass and hands the per-node
+   * ADReal residuals to addJacobianWithoutConstraints, which extracts every Jacobian
+   * block (diagonal and off-diagonal) from the ADReal derivatives in a single pass.
+   */
+  void adComputeJacobian();
+
+  /// Assemble the real-valued residual vector from _proto_flux into the tagged local residual
+  /// (and apply save_in). Shared by the AD and non-AD residual paths.
+  void assembleProtoFluxResidual();
+
+  /// Element pointer cached on the first AD computeOffDiagJacobian() call for an element so
+  /// that the remaining off-diagonal calls (one per coupled variable) become no-ops; the
+  /// single AD pass already filled all blocks. Reset each Jacobian evaluation in jacobianSetup().
+  const Elem * _my_elem_darcy = nullptr;
 };
+
+typedef PorousFlowDarcyBaseTempl<false> PorousFlowDarcyBase;
+typedef PorousFlowDarcyBaseTempl<true> ADPorousFlowDarcyBase;

--- a/modules/porous_flow/include/kernels/PorousFlowDesorpedMassTimeDerivative.h
+++ b/modules/porous_flow/include/kernels/PorousFlowDesorpedMassTimeDerivative.h
@@ -9,22 +9,26 @@
 
 #pragma once
 
-#include "TimeDerivative.h"
+#include "GenericKernel.h"
 #include "PorousFlowDictator.h"
 
 /**
  * Kernel = (desorped_mass - desorped_mass_old)/dt
  * It is NOT lumped to the nodes
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowDesorpedMassTimeDerivative : public TimeKernel
+template <bool is_ad>
+class PorousFlowDesorpedMassTimeDerivativeTempl : public GenericKernel<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowDesorpedMassTimeDerivative(const InputParameters & parameters);
+  PorousFlowDesorpedMassTimeDerivativeTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
@@ -34,28 +38,32 @@ protected:
   /// The MOOSE variable number of the concentration variable
   const unsigned int _conc_var_number;
 
-  /// The concentration variable
-  const VariableValue & _conc;
+  /// The concentration variable (AD or non-AD)
+  const GenericVariableValue<is_ad> & _conc;
 
-  /// Old value of the concentration variable
+  /// Old value of the concentration variable (always non-AD)
   const VariableValue & _conc_old;
 
-  /// Porosity at the qps
-  const MaterialProperty<Real> & _porosity;
+  /// Porosity at the qps (AD or non-AD)
+  const GenericMaterialProperty<Real, is_ad> & _porosity;
 
   /// Old value of porosity
   const MaterialProperty<Real> & _porosity_old;
 
-  /// d(porosity)/d(PorousFlow variable) - these derivatives will be wrt variables at the qps
-  const MaterialProperty<std::vector<Real>> & _dporosity_dvar;
+  /// d(porosity)/d(PorousFlow variable) -- null for AD
+  const MaterialProperty<std::vector<Real>> * const _dporosity_dvar;
 
-  /// d(porosity)/d(grad PorousFlow variable) - these derivatives will be wrt grad(vars) at qps
-  const MaterialProperty<std::vector<RealGradient>> & _dporosity_dgradvar;
+  /// d(porosity)/d(grad PorousFlow variable) -- null for AD
+  const MaterialProperty<std::vector<RealGradient>> * const _dporosity_dgradvar;
 
   /**
-   * Derivative of residual with respect to variable number jvar
-   * This is used by both computeQpJacobian and computeQpOffDiagJacobian
-   * @param jvar take the derivative of the residual wrt this Moose variable
+   * Derivative of residual with respect to variable number jvar (non-AD path only)
    */
-  Real computeQpJac(unsigned int jvar) const;
+  Real computeQpJac(unsigned int jvar);
+
+  usingGenericKernelMembers;
+  using GenericKernel<is_ad>::_grad_phi;
 };
+
+typedef PorousFlowDesorpedMassTimeDerivativeTempl<false> PorousFlowDesorpedMassTimeDerivative;
+typedef PorousFlowDesorpedMassTimeDerivativeTempl<true> ADPorousFlowDesorpedMassTimeDerivative;

--- a/modules/porous_flow/include/kernels/PorousFlowDispersiveFlux.h
+++ b/modules/porous_flow/include/kernels/PorousFlowDispersiveFlux.h
@@ -9,66 +9,66 @@
 
 #pragma once
 
-#include "Kernel.h"
+#include "GenericKernel.h"
 #include "PorousFlowDictator.h"
 #include "RankTwoTensor.h"
 
 /**
  * Dispersive flux of component k in fluid phase alpha. Includes the effects
  * of both molecular diffusion and hydrodynamic dispersion.
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowDispersiveFlux : public Kernel
+template <bool is_ad>
+class PorousFlowDispersiveFluxTempl : public GenericKernel<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowDispersiveFlux(const InputParameters & parameters);
+  PorousFlowDispersiveFluxTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
-
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
-
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   /**
-   * Derivative of the residual with respect to the PorousFLow Variable
-   * with variable number jvar.
-   * This is used by both computeQpJacobian and computeQpOffDiagJacobian
-   * @param jvar take the derivative wrt this variable number
-   * @return dResidual_dVar
+   * Derivative of the residual with respect to the PorousFlow variable
+   * with variable number jvar. Only used for the non-AD path.
    */
   Real computeQpJac(unsigned int jvar) const;
 
   /// Fluid density for each phase (at the qp)
-  const MaterialProperty<std::vector<Real>> & _fluid_density_qp;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_density_qp;
 
-  /// Derivative of the fluid density for each phase wrt PorousFlow variables (at the qp)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dfluid_density_qp_dvar;
+  /// Derivative of the fluid density for each phase wrt PorousFlow variables -- null for AD
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_qp_dvar;
 
   /// Gradient of mass fraction of each component in each phase
-  const MaterialProperty<std::vector<std::vector<RealGradient>>> & _grad_mass_frac;
+  const GenericMaterialProperty<std::vector<std::vector<RealGradient>>, is_ad> & _grad_mass_frac;
 
-  /// Derivative of mass fraction wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> & _dmass_frac_dvar;
+  /// Derivative of mass fraction wrt PorousFlow variables -- null for AD
+  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> * const _dmass_frac_dvar;
 
   /// Porosity at the qps
-  const MaterialProperty<Real> & _porosity_qp;
+  const GenericMaterialProperty<Real, is_ad> & _porosity_qp;
 
-  /// Derivative of porosity wrt PorousFlow variables (at the qps)
-  const MaterialProperty<std::vector<Real>> & _dporosity_qp_dvar;
+  /// Derivative of porosity wrt PorousFlow variables -- null for AD
+  const MaterialProperty<std::vector<Real>> * const _dporosity_qp_dvar;
 
   /// Tortuosity tau_0 * tau_{alpha} for fluid phase alpha
-  const MaterialProperty<std::vector<Real>> & _tortuosity;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _tortuosity;
 
-  /// Derivative of tortuosity wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dtortuosity_dvar;
+  /// Derivative of tortuosity wrt PorousFlow variables -- null for AD
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dtortuosity_dvar;
 
   /// Diffusion coefficients of component k in fluid phase alpha
   const MaterialProperty<std::vector<std::vector<Real>>> & _diffusion_coeff;
 
-  /// Derivative of the diffusion coefficients wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> & _ddiffusion_coeff_dvar;
+  /// Derivative of the diffusion coefficients wrt PorousFlow variables -- null for AD
+  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> * const
+      _ddiffusion_coeff_dvar;
 
   /// PorousFlowDictator UserObject
   const PorousFlowDictator & _dictator;
@@ -79,38 +79,38 @@ protected:
   /// The number of fluid phases
   const unsigned int _num_phases;
 
-  /// Identity tensor
-  const RankTwoTensor _identity_tensor;
+  /// Identity tensor (generic type to support AD arithmetic)
+  const GenericRankTwoTensor<is_ad> _identity_tensor;
 
   /// Relative permeability of each phase
-  const MaterialProperty<std::vector<Real>> & _relative_permeability;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _relative_permeability;
 
-  /// Derivative of relative permeability wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _drelative_permeability_dvar;
+  /// Derivative of relative permeability wrt PorousFlow variables -- null for AD
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _drelative_permeability_dvar;
 
   /// Viscosity of each component in each phase
-  const MaterialProperty<std::vector<Real>> & _fluid_viscosity;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_viscosity;
 
-  /// Derivative of viscosity wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dfluid_viscosity_dvar;
+  /// Derivative of viscosity wrt PorousFlow variables -- null for AD
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_viscosity_dvar;
 
   /// Permeability of porous material
-  const MaterialProperty<RealTensorValue> & _permeability;
+  const GenericMaterialProperty<RealTensorValue, is_ad> & _permeability;
 
-  /// Derivative of permeability wrt PorousFlow variables
-  const MaterialProperty<std::vector<RealTensorValue>> & _dpermeability_dvar;
+  /// Derivative of permeability wrt PorousFlow variables -- null for AD
+  const MaterialProperty<std::vector<RealTensorValue>> * const _dpermeability_dvar;
 
-  /// d(permeabiity)/d(grad(PorousFlow variable))
-  const MaterialProperty<std::vector<std::vector<RealTensorValue>>> & _dpermeability_dgradvar;
+  /// d(permeability)/d(grad(PorousFlow variable)) -- null for AD
+  const MaterialProperty<std::vector<std::vector<RealTensorValue>>> * const _dpermeability_dgradvar;
 
   /// Gradient of the pore pressure in each phase
-  const MaterialProperty<std::vector<RealGradient>> & _grad_p;
+  const GenericMaterialProperty<std::vector<RealGradient>, is_ad> & _grad_p;
 
-  /// Derivative of Grad porepressure in each phase wrt grad(PorousFlow variables)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dgrad_p_dgrad_var;
+  /// Derivative of Grad porepressure in each phase wrt grad(PorousFlow variables) -- null for AD
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dgrad_p_dgrad_var;
 
-  /// Derivative of Grad porepressure in each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<RealGradient>>> & _dgrad_p_dvar;
+  /// Derivative of Grad porepressure in each phase wrt PorousFlow variables -- null for AD
+  const MaterialProperty<std::vector<std::vector<RealGradient>>> * const _dgrad_p_dvar;
 
   /// Gravitational acceleration
   const RealVectorValue _gravity;
@@ -121,6 +121,12 @@ protected:
   /// Transverse dispersivity for each phase
   const std::vector<Real> _disp_trans;
 
-  /// Flag to check whether permeabiity derivatives are non-zero
+  /// Flag to check whether permeability derivatives are non-zero
   const bool _perm_derivs;
+
+  usingGenericKernelMembers;
+  using GenericKernel<is_ad>::_grad_phi;
 };
+
+typedef PorousFlowDispersiveFluxTempl<false> PorousFlowDispersiveFlux;
+typedef PorousFlowDispersiveFluxTempl<true> ADPorousFlowDispersiveFlux;

--- a/modules/porous_flow/include/kernels/PorousFlowEffectiveStressCoupling.h
+++ b/modules/porous_flow/include/kernels/PorousFlowEffectiveStressCoupling.h
@@ -9,24 +9,27 @@
 
 #pragma once
 
-#include "Kernel.h"
+#include "GenericKernel.h"
 #include "PorousFlowDictator.h"
 
 /**
  * PorousFlowEffectiveStressCoupling computes
  * -coefficient*effective_porepressure*grad_component(test)
- * where component is the spatial component (not
- * a fluid component!)
+ * where component is the spatial component (not a fluid component!)
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowEffectiveStressCoupling : public Kernel
+template <bool is_ad>
+class PorousFlowEffectiveStressCouplingTempl : public GenericKernel<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowEffectiveStressCoupling(const InputParameters & parameters);
+  PorousFlowEffectiveStressCouplingTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
@@ -40,11 +43,16 @@ protected:
   const unsigned int _component;
 
   /// Effective porepressure
-  const MaterialProperty<Real> & _pf;
+  const GenericMaterialProperty<Real, is_ad> & _pf;
 
-  /// d(effective porepressure)/(d porflow variable)
-  const MaterialProperty<std::vector<Real>> & _dpf_dvar;
+  /// d(effective porepressure)/(d porflow variable) -- null for AD
+  const MaterialProperty<std::vector<Real>> * const _dpf_dvar;
 
   /// Whether an RZ coordinate system is being used
   const bool _rz;
+
+  usingGenericKernelMembers;
 };
+
+typedef PorousFlowEffectiveStressCouplingTempl<false> PorousFlowEffectiveStressCoupling;
+typedef PorousFlowEffectiveStressCouplingTempl<true> ADPorousFlowEffectiveStressCoupling;

--- a/modules/porous_flow/include/kernels/PorousFlowEnergyTimeDerivative.h
+++ b/modules/porous_flow/include/kernels/PorousFlowEnergyTimeDerivative.h
@@ -68,10 +68,10 @@ protected:
   /// Old value of porosity (always non-AD)
   const MaterialProperty<Real> & _porosity_old;
 
-  /// d(porosity)/d(PorousFlow variable) at nodes — null for AD path
+  /// d(porosity)/d(PorousFlow variable) at nodes -- null for AD path
   const MaterialProperty<std::vector<Real>> * const _dporosity_dvar;
 
-  /// d(porosity)/d(grad PorousFlow variable) at qps — null for AD path
+  /// d(porosity)/d(grad PorousFlow variable) at qps -- null for AD path
   const MaterialProperty<std::vector<RealGradient>> * const _dporosity_dgradvar;
 
   /// The nearest qp to the node (always non-AD)
@@ -83,7 +83,7 @@ protected:
   /// Old value of nodal rock energy density (always non-AD)
   const MaterialProperty<Real> & _rock_energy_nodal_old;
 
-  /// d(nodal rock energy density)/d(PorousFlow variable) — null for AD path
+  /// d(nodal rock energy density)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<Real>> * const _drock_energy_nodal_dvar;
 
   /// Nodal fluid density (AD or non-AD); null if !_fluid_present
@@ -92,7 +92,7 @@ protected:
   /// Old value of nodal fluid density (always non-AD); null if !_fluid_present
   const MaterialProperty<std::vector<Real>> * const _fluid_density_old;
 
-  /// d(nodal fluid density)/d(PorousFlow variable) — null for AD path or if !_fluid_present
+  /// d(nodal fluid density)/d(PorousFlow variable) -- null for AD path or if !_fluid_present
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_dvar;
 
   /// Nodal fluid saturation (AD or non-AD); null if !_fluid_present
@@ -101,7 +101,7 @@ protected:
   /// Old value of fluid saturation (always non-AD); null if !_fluid_present
   const MaterialProperty<std::vector<Real>> * const _fluid_saturation_nodal_old;
 
-  /// d(nodal fluid saturation)/d(PorousFlow variable) — null for AD path or if !_fluid_present
+  /// d(nodal fluid saturation)/d(PorousFlow variable) -- null for AD path or if !_fluid_present
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_saturation_nodal_dvar;
 
   /// Internal energy of the phases, evaluated at the nodes (AD or non-AD); null if !_fluid_present
@@ -110,7 +110,7 @@ protected:
   /// Old value of internal energy of the phases, evaluated at the nodes (always non-AD); null if !_fluid_present
   const MaterialProperty<std::vector<Real>> * const _energy_nodal_old;
 
-  /// d(internal energy)/d(PorousFlow variable) — null for AD path or if !_fluid_present
+  /// d(internal energy)/d(PorousFlow variable) -- null for AD path or if !_fluid_present
   const MaterialProperty<std::vector<std::vector<Real>>> * const _denergy_nodal_dvar;
 
   usingGenericKernelMembers;

--- a/modules/porous_flow/include/kernels/PorousFlowEnergyTimeDerivative.h
+++ b/modules/porous_flow/include/kernels/PorousFlowEnergyTimeDerivative.h
@@ -9,24 +9,34 @@
 
 #pragma once
 
-#include "TimeDerivative.h"
+#include "PorousFlowLumpedKernelBase.h"
 #include "PorousFlowDictator.h"
 
 /**
  * Kernel = (heat_energy - heat_energy_old)/dt
  * It is lumped to the nodes
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowEnergyTimeDerivative : public TimeKernel
+template <bool is_ad>
+class PorousFlowEnergyTimeDerivativeTempl : public PorousFlowLumpedKernelBaseTempl<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowEnergyTimeDerivative(const InputParameters & parameters);
+  PorousFlowEnergyTimeDerivativeTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+
+  /**
+   * Derivative of residual with respect to PorousFlow variable number pvar (non-AD path only)
+   * @param pvar take the derivative of the residual wrt this PorousFlow variable
+   */
+  Real computeQpJac(unsigned int pvar) const;
 
   /// PorousFlowDictator UserObject
   const PorousFlowDictator & _dictator;
@@ -52,61 +62,60 @@ protected:
   /// Old value of total strain calculated by a Tensor Mechanics strain calculator, if it exists, otherwise nullptr
   const MaterialProperty<RankTwoTensor> * const _total_strain_old;
 
-  /// Porosity at the nodes, but it can depend on grad(variables) which are actually evaluated at the qps
-  const MaterialProperty<Real> & _porosity;
+  /// Porosity at the nodes (AD or non-AD depending on is_ad)
+  const GenericMaterialProperty<Real, is_ad> & _porosity;
 
-  /// Old value of porosity
+  /// Old value of porosity (always non-AD)
   const MaterialProperty<Real> & _porosity_old;
 
-  /// d(porosity)/d(PorousFlow variable) - these derivatives will be wrt variables at the nodes
-  const MaterialProperty<std::vector<Real>> & _dporosity_dvar;
+  /// d(porosity)/d(PorousFlow variable) at nodes — null for AD path
+  const MaterialProperty<std::vector<Real>> * const _dporosity_dvar;
 
-  /// d(porosity)/d(grad PorousFlow variable) - remember these derivatives will be wrt grad(vars) at qps
-  const MaterialProperty<std::vector<RealGradient>> & _dporosity_dgradvar;
+  /// d(porosity)/d(grad PorousFlow variable) at qps — null for AD path
+  const MaterialProperty<std::vector<RealGradient>> * const _dporosity_dgradvar;
 
-  /// The nearest qp to the node
+  /// The nearest qp to the node (always non-AD)
   const MaterialProperty<unsigned int> * const _nearest_qp;
 
-  /// Nodal rock energy density
-  const MaterialProperty<Real> & _rock_energy_nodal;
+  /// Nodal rock energy density (AD or non-AD)
+  const GenericMaterialProperty<Real, is_ad> & _rock_energy_nodal;
 
-  /// Old value of nodal rock energy density
+  /// Old value of nodal rock energy density (always non-AD)
   const MaterialProperty<Real> & _rock_energy_nodal_old;
 
-  /// d(nodal rock energy density)/d(PorousFlow variable)
-  const MaterialProperty<std::vector<Real>> & _drock_energy_nodal_dvar;
+  /// d(nodal rock energy density)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<Real>> * const _drock_energy_nodal_dvar;
 
-  /// Nodal fluid density
-  const MaterialProperty<std::vector<Real>> * const _fluid_density;
+  /// Nodal fluid density (AD or non-AD); null if !_fluid_present
+  const GenericMaterialProperty<std::vector<Real>, is_ad> * const _fluid_density;
 
-  /// Old value of nodal fluid density
+  /// Old value of nodal fluid density (always non-AD); null if !_fluid_present
   const MaterialProperty<std::vector<Real>> * const _fluid_density_old;
 
-  /// d(nodal fluid density)/d(PorousFlow variable)
+  /// d(nodal fluid density)/d(PorousFlow variable) — null for AD path or if !_fluid_present
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_dvar;
 
-  /// Nodal fluid saturation
-  const MaterialProperty<std::vector<Real>> * const _fluid_saturation_nodal;
+  /// Nodal fluid saturation (AD or non-AD); null if !_fluid_present
+  const GenericMaterialProperty<std::vector<Real>, is_ad> * const _fluid_saturation_nodal;
 
-  /// Old value of fluid saturation
+  /// Old value of fluid saturation (always non-AD); null if !_fluid_present
   const MaterialProperty<std::vector<Real>> * const _fluid_saturation_nodal_old;
 
-  /// d(nodal fluid saturation)/d(PorousFlow variable)
+  /// d(nodal fluid saturation)/d(PorousFlow variable) — null for AD path or if !_fluid_present
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_saturation_nodal_dvar;
 
-  /// Internal energy of the phases, evaluated at the nodes
-  const MaterialProperty<std::vector<Real>> * const _energy_nodal;
+  /// Internal energy of the phases, evaluated at the nodes (AD or non-AD); null if !_fluid_present
+  const GenericMaterialProperty<std::vector<Real>, is_ad> * const _energy_nodal;
 
-  /// Old value of internal energy of the phases, evaluated at the nodes
+  /// Old value of internal energy of the phases, evaluated at the nodes (always non-AD); null if !_fluid_present
   const MaterialProperty<std::vector<Real>> * const _energy_nodal_old;
 
-  /// d(internal energy)/d(PorousFlow variable)
+  /// d(internal energy)/d(PorousFlow variable) — null for AD path or if !_fluid_present
   const MaterialProperty<std::vector<std::vector<Real>>> * const _denergy_nodal_dvar;
 
-  /**
-   * Derivative of residual with respect to PorousFlow variable number pvar
-   * This is used by both computeQpJacobian and computeQpOffDiagJacobian
-   * @param pvar take the derivative of the residual wrt this PorousFlow variable
-   */
-  Real computeQpJac(unsigned int pvar) const;
+  usingGenericKernelMembers;
+  using GenericKernel<is_ad>::_grad_phi;
 };
+
+typedef PorousFlowEnergyTimeDerivativeTempl<false> PorousFlowEnergyTimeDerivative;
+typedef PorousFlowEnergyTimeDerivativeTempl<true> ADPorousFlowEnergyTimeDerivative;

--- a/modules/porous_flow/include/kernels/PorousFlowExponentialDecay.h
+++ b/modules/porous_flow/include/kernels/PorousFlowExponentialDecay.h
@@ -30,10 +30,10 @@ protected:
   virtual Real computeQpJacobian() override;
 
   /// The decay rate
-  const VariableValue & _rate;
+  const GenericVariableValue<is_ad> & _rate;
 
   /// The reference
-  const VariableValue & _reference;
+  const GenericVariableValue<is_ad> & _reference;
 
   usingGenericKernelMembers;
 };

--- a/modules/porous_flow/include/kernels/PorousFlowExponentialDecay.h
+++ b/modules/porous_flow/include/kernels/PorousFlowExponentialDecay.h
@@ -9,20 +9,24 @@
 
 #pragma once
 
-#include "Kernel.h"
+#include "GenericKernel.h"
 
 /**
  * Kernel = _rate * (variable - reference)
+ *
+ * Templated on is_ad: the false instantiation uses the hand-coded Jacobian;
+ * the true instantiation propagates the derivative through the AD residual.
  */
-class PorousFlowExponentialDecay : public Kernel
+template <bool is_ad>
+class PorousFlowExponentialDecayTempl : public GenericKernel<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowExponentialDecay(const InputParameters & parameters);
+  PorousFlowExponentialDecayTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
 
   /// The decay rate
@@ -30,4 +34,9 @@ protected:
 
   /// The reference
   const VariableValue & _reference;
+
+  usingGenericKernelMembers;
 };
+
+typedef PorousFlowExponentialDecayTempl<false> PorousFlowExponentialDecay;
+typedef PorousFlowExponentialDecayTempl<true> ADPorousFlowExponentialDecay;

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedAdvectiveFlux.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedAdvectiveFlux.h
@@ -12,30 +12,44 @@
 #include "PorousFlowDarcyBase.h"
 
 /**
- * Convective flux of component k in a single-phase fluid
- * A fully-updwinded version is implemented, where the mobility
+ * Convective flux of component k in a single-phase fluid.
+ * A fully-upwinded version is implemented, where the mobility
  * of the upstream nodes is used.
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowFullySaturatedAdvectiveFlux : public PorousFlowDarcyBase
+template <bool is_ad>
+class PorousFlowFullySaturatedAdvectiveFluxTempl : public PorousFlowDarcyBaseTempl<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowFullySaturatedAdvectiveFlux(const InputParameters & parameters);
+  PorousFlowFullySaturatedAdvectiveFluxTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real mobility(unsigned nodenum, unsigned phase) const override;
+  virtual GenericReal<is_ad> mobility(unsigned nodenum, unsigned phase) const override;
   virtual Real dmobility(unsigned nodenum, unsigned phase, unsigned pvar) const override;
 
   /// Mass fraction of each component in each phase
-  const MaterialProperty<std::vector<std::vector<Real>>> & _mass_fractions;
+  const GenericMaterialProperty<std::vector<std::vector<Real>>, is_ad> & _mass_fractions;
 
-  /// Derivative of the mass fraction of each component in each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> & _dmass_fractions_dvar;
+  /// Derivative of mass fraction wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> * const _dmass_fractions_dvar;
 
   /// Index of the fluid component that this kernel acts on
   const unsigned int _fluid_component;
 
-  /// Whether the flux is multiplied by density (so it will be a mass flux) or not (it will be a volume flux)
+  /// Whether the flux is multiplied by density (mass flux) or not (volume flux)
   const bool _multiply_by_density;
+
+  using PorousFlowDarcyBaseTempl<is_ad>::_dictator;
+  using PorousFlowDarcyBaseTempl<is_ad>::_fluid_density_node;
+  using PorousFlowDarcyBaseTempl<is_ad>::_fluid_viscosity;
+  using PorousFlowDarcyBaseTempl<is_ad>::_dfluid_density_node_dvar;
+  using PorousFlowDarcyBaseTempl<is_ad>::_dfluid_viscosity_dvar;
+  usingGenericKernelMembers;
 };
+
+typedef PorousFlowFullySaturatedAdvectiveFluxTempl<false> PorousFlowFullySaturatedAdvectiveFlux;
+typedef PorousFlowFullySaturatedAdvectiveFluxTempl<true> ADPorousFlowFullySaturatedAdvectiveFlux;

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedDarcyBase.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedDarcyBase.h
@@ -9,79 +9,83 @@
 
 #pragma once
 
-#include "Kernel.h"
+#include "GenericKernel.h"
 #include "PorousFlowDictator.h"
 
 /**
- * Darcy advective flux for a fully-saturated,
- * single phase, single component fluid.
- * No upwinding or relative-permeability is used.
+ * Darcy advective flux for a fully-saturated, single-phase, single-component
+ * fluid.  No upwinding or relative-permeability effects are included.
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowFullySaturatedDarcyBase : public Kernel
+template <bool is_ad>
+class PorousFlowFullySaturatedDarcyBaseTempl : public GenericKernel<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowFullySaturatedDarcyBase(const InputParameters & parameters);
+  PorousFlowFullySaturatedDarcyBaseTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
-  /**
-   * The mobility of the fluid = density / viscosity
-   */
-  virtual Real mobility() const;
+  /// Fluid mobility = (density *) 1/viscosity.  Virtual so DarcyFlow can multiply by mass frac.
+  virtual GenericReal<is_ad> mobility() const;
 
-  /**
-   * The derivative of the mobility with respect to the PorousFlow variable pvar
-   * @param pvar Take the derivative with respect to this PorousFlow variable
-   */
-  virtual Real dmobility(unsigned pvar) const;
+  /// d(mobility)/d(PorousFlow variable pvar) — only used on the non-AD path
+  virtual Real dmobility(unsigned int pvar) const;
 
-  /// If true then the mobility contains the fluid density, otherwise it doesn't
+  /// If true the mobility includes fluid density (mass flux); otherwise volume flux
   const bool _multiply_by_density;
 
-  /// Permeability of porous material
-  const MaterialProperty<RealTensorValue> & _permeability;
+  /// Permeability tensor
+  const GenericMaterialProperty<RealTensorValue, is_ad> & _permeability;
 
-  /// d(permeabiity)/d(PorousFlow variable)
-  const MaterialProperty<std::vector<RealTensorValue>> & _dpermeability_dvar;
+  /// d(permeability)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<RealTensorValue>> * const _dpermeability_dvar;
 
-  /// d(permeabiity)/d(grad(PorousFlow variable))
-  const MaterialProperty<std::vector<std::vector<RealTensorValue>>> & _dpermeability_dgradvar;
+  /// d(permeability)/d(grad PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<RealTensorValue>>> * const _dpermeability_dgradvar;
 
-  /// Fluid density for each phase (at the qp)
-  const MaterialProperty<std::vector<Real>> & _density;
+  /// Fluid density for each phase
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _density;
 
-  /// Derivative of the fluid density for each phase wrt PorousFlow variables (at the qp)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _ddensity_dvar;
+  /// d(density)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _ddensity_dvar;
 
-  /// Viscosity of the fluid at the qp
-  const MaterialProperty<std::vector<Real>> & _viscosity;
+  /// Fluid viscosity for each phase
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _viscosity;
 
-  /// Derivative of the fluid viscosity  wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dviscosity_dvar;
+  /// d(viscosity)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dviscosity_dvar;
 
-  /// Quadpoint pore pressure in each phase
-  const MaterialProperty<std::vector<Real>> & _pp;
+  /// Quadpoint pore pressure for each phase
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _pp;
 
-  /// Gradient of the pore pressure in each phase
-  const MaterialProperty<std::vector<RealGradient>> & _grad_p;
+  /// Gradient of pore pressure for each phase
+  const GenericMaterialProperty<std::vector<RealGradient>, is_ad> & _grad_p;
 
-  /// Derivative of Grad porepressure in each phase wrt grad(PorousFlow variables)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dgrad_p_dgrad_var;
+  /// d(grad p)/d(grad PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dgrad_p_dgrad_var;
 
-  /// Derivative of Grad porepressure in each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<RealGradient>>> & _dgrad_p_dvar;
+  /// d(grad p)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<RealGradient>>> * const _dgrad_p_dvar;
 
   /// PorousFlowDictator UserObject
   const PorousFlowDictator & _dictator;
 
-  /// Gravity pointing downwards
+  /// Gravitational acceleration vector (downward)
   const RealVectorValue _gravity;
 
-  /// Flag to check whether permeabiity derivatives are non-zero
+  /// Whether permeability has non-zero derivatives w.r.t. primary variables
   const bool _perm_derivs;
+
+  usingGenericKernelMembers;
+  using GenericKernel<is_ad>::_grad_phi;
 };
+
+typedef PorousFlowFullySaturatedDarcyBaseTempl<false> PorousFlowFullySaturatedDarcyBase;
+typedef PorousFlowFullySaturatedDarcyBaseTempl<true> ADPorousFlowFullySaturatedDarcyBase;

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedDarcyBase.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedDarcyBase.h
@@ -35,7 +35,7 @@ protected:
   /// Fluid mobility = (density *) 1/viscosity.  Virtual so DarcyFlow can multiply by mass frac.
   virtual GenericReal<is_ad> mobility() const;
 
-  /// d(mobility)/d(PorousFlow variable pvar) — only used on the non-AD path
+  /// d(mobility)/d(PorousFlow variable pvar) -- only used on the non-AD path
   virtual Real dmobility(unsigned int pvar) const;
 
   /// If true the mobility includes fluid density (mass flux); otherwise volume flux
@@ -44,22 +44,22 @@ protected:
   /// Permeability tensor
   const GenericMaterialProperty<RealTensorValue, is_ad> & _permeability;
 
-  /// d(permeability)/d(PorousFlow variable) — null for AD path
+  /// d(permeability)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<RealTensorValue>> * const _dpermeability_dvar;
 
-  /// d(permeability)/d(grad PorousFlow variable) — null for AD path
+  /// d(permeability)/d(grad PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<RealTensorValue>>> * const _dpermeability_dgradvar;
 
   /// Fluid density for each phase
   const GenericMaterialProperty<std::vector<Real>, is_ad> & _density;
 
-  /// d(density)/d(PorousFlow variable) — null for AD path
+  /// d(density)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _ddensity_dvar;
 
   /// Fluid viscosity for each phase
   const GenericMaterialProperty<std::vector<Real>, is_ad> & _viscosity;
 
-  /// d(viscosity)/d(PorousFlow variable) — null for AD path
+  /// d(viscosity)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dviscosity_dvar;
 
   /// Quadpoint pore pressure for each phase
@@ -68,10 +68,10 @@ protected:
   /// Gradient of pore pressure for each phase
   const GenericMaterialProperty<std::vector<RealGradient>, is_ad> & _grad_p;
 
-  /// d(grad p)/d(grad PorousFlow variable) — null for AD path
+  /// d(grad p)/d(grad PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dgrad_p_dgrad_var;
 
-  /// d(grad p)/d(PorousFlow variable) — null for AD path
+  /// d(grad p)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<RealGradient>>> * const _dgrad_p_dvar;
 
   /// PorousFlowDictator UserObject

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedDarcyFlow.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedDarcyFlow.h
@@ -31,7 +31,7 @@ protected:
   /// Mass fraction of each component in each phase
   const GenericMaterialProperty<std::vector<std::vector<Real>>, is_ad> & _mfrac;
 
-  /// d(mass fraction)/d(PorousFlow variable) — null for AD path
+  /// d(mass fraction)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> * const _dmfrac_dvar;
 
   /// Fluid component index for this kernel

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedDarcyFlow.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedDarcyFlow.h
@@ -12,35 +12,39 @@
 #include "PorousFlowFullySaturatedDarcyBase.h"
 
 /**
- * Darcy advective flux for a fully-saturated,
- * single-phase, multi-component fluid.
- * No upwinding or relative-permeability is used.
+ * Darcy advective flux for a fully-saturated, single-phase, multi-component fluid.
+ * Extends DarcyBase by multiplying the mobility by the component mass fraction.
+ * No upwinding or relative-permeability effects are included.
  */
-class PorousFlowFullySaturatedDarcyFlow : public PorousFlowFullySaturatedDarcyBase
+template <bool is_ad>
+class PorousFlowFullySaturatedDarcyFlowTempl : public PorousFlowFullySaturatedDarcyBaseTempl<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowFullySaturatedDarcyFlow(const InputParameters & parameters);
+  PorousFlowFullySaturatedDarcyFlowTempl(const InputParameters & parameters);
 
 protected:
-  /**
-   * The mobility of the fluid = mass_fraction * density / viscosity
-   */
-  virtual Real mobility() const override;
+  virtual GenericReal<is_ad> mobility() const override;
+  virtual Real dmobility(unsigned int pvar) const override;
 
-  /**
-   * The derivative of the mobility with respect to the PorousFlow variable pvar
-   * @param pvar Take the derivative with respect to this PorousFlow variable
-   */
-  virtual Real dmobility(unsigned pvar) const override;
+  /// Mass fraction of each component in each phase
+  const GenericMaterialProperty<std::vector<std::vector<Real>>, is_ad> & _mfrac;
 
-  /// mass fraction of the components in the phase
-  const MaterialProperty<std::vector<std::vector<Real>>> & _mfrac;
+  /// d(mass fraction)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> * const _dmfrac_dvar;
 
-  /// Derivative of mass fraction wrt wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> & _dmfrac_dvar;
-
-  /// The fluid component for this Kernel
+  /// Fluid component index for this kernel
   const unsigned int _fluid_component;
+
+  using PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::_dictator;
+  using PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::_multiply_by_density;
+  using PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::_density;
+  using PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::_viscosity;
+  using PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::_ddensity_dvar;
+  using PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::_dviscosity_dvar;
+  usingGenericKernelMembers;
 };
+
+typedef PorousFlowFullySaturatedDarcyFlowTempl<false> PorousFlowFullySaturatedDarcyFlow;
+typedef PorousFlowFullySaturatedDarcyFlowTempl<true> ADPorousFlowFullySaturatedDarcyFlow;

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedHeatAdvection.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedHeatAdvection.h
@@ -14,21 +14,31 @@
 /**
  * Advection of heat via flux via Darcy flow of a single phase
  * fully-saturated fluid.  No upwinding is used.
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowFullySaturatedHeatAdvection : public PorousFlowFullySaturatedDarcyBase
+template <bool is_ad>
+class PorousFlowFullySaturatedHeatAdvectionTempl
+  : public PorousFlowFullySaturatedDarcyBaseTempl<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowFullySaturatedHeatAdvection(const InputParameters & parameters);
+  PorousFlowFullySaturatedHeatAdvectionTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real mobility() const override;
+  virtual GenericReal<is_ad> mobility() const override;
   virtual Real dmobility(unsigned pvar) const override;
 
   /// Enthalpy of each phase
-  const MaterialProperty<std::vector<Real>> & _enthalpy;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _enthalpy;
 
-  /// Derivative of the enthalpy wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _denthalpy_dvar;
+  /// Derivative of enthalpy wrt PorousFlow variables — null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _denthalpy_dvar;
+
+  usingGenericKernelMembers;
 };
+
+typedef PorousFlowFullySaturatedHeatAdvectionTempl<false> PorousFlowFullySaturatedHeatAdvection;
+typedef PorousFlowFullySaturatedHeatAdvectionTempl<true> ADPorousFlowFullySaturatedHeatAdvection;

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedHeatAdvection.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedHeatAdvection.h
@@ -34,7 +34,7 @@ protected:
   /// Enthalpy of each phase
   const GenericMaterialProperty<std::vector<Real>, is_ad> & _enthalpy;
 
-  /// Derivative of enthalpy wrt PorousFlow variables — null for AD path
+  /// Derivative of enthalpy wrt PorousFlow variables -- null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _denthalpy_dvar;
 
   usingGenericKernelMembers;

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedMassTimeDerivative.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedMassTimeDerivative.h
@@ -45,6 +45,7 @@ protected:
   /// If true the kernel is d(fluid mass)/dt, otherwise d(fluid volume)/dt
   const bool _multiply_by_density;
 
+  /// Determines whether mechanical and/or thermal contributions should be added to the residual
   enum class CouplingTypeEnum
   {
     Hydro,
@@ -54,7 +55,10 @@ protected:
   };
   const CouplingTypeEnum _coupling_type;
 
+  /// Whether thermal contributions should be added to the residual
   const bool _includes_thermal;
+
+  /// Whether mechanical contributions should be added to the residual
   const bool _includes_mechanical;
 
   /// Biot coefficient

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedMassTimeDerivative.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedMassTimeDerivative.h
@@ -9,88 +9,98 @@
 
 #pragma once
 
-#include "TimeKernel.h"
+#include "GenericKernel.h"
 #include "PorousFlowDictator.h"
 
 /**
- * Time derivative of fluid mass suitable for fully-saturated,
- * single-phase, single-component simulations.
- * No mass-lumping is used
+ * Time derivative of fluid mass for fully-saturated, single-phase,
+ * single-component simulations.  No mass-lumping is used.
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties
+ * and requires no hand-coded Jacobian.
  */
-class PorousFlowFullySaturatedMassTimeDerivative : public TimeKernel
+template <bool is_ad>
+class PorousFlowFullySaturatedMassTimeDerivativeTempl : public GenericKernel<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowFullySaturatedMassTimeDerivative(const InputParameters & parameters);
+  PorousFlowFullySaturatedMassTimeDerivativeTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
-  /// Jacobian contribution for the PorousFlow variable pvar
+  /// Jacobian contribution for PorousFlow variable pvar (non-AD path only)
   Real computeQpJac(unsigned int pvar);
 
   /// PorousFlowDictator UserObject
   const PorousFlowDictator & _dictator;
 
-  /// Whether the Variable for this Kernel is a PorousFlow variable
+  /// Whether the kernel variable is a PorousFlow variable
   const bool _var_is_porflow_var;
 
-  /// If true then the Kernel is the time derivative of the fluid mass, otherwise it is the derivative of the fluid volume
+  /// If true the kernel is d(fluid mass)/dt, otherwise d(fluid volume)/dt
   const bool _multiply_by_density;
 
-  /// Determines whether mechanical and/or thermal contributions should be added to the residual
-  const enum class CouplingTypeEnum {
+  enum class CouplingTypeEnum
+  {
     Hydro,
     ThermoHydro,
     HydroMechanical,
     ThermoHydroMechanical
-  } _coupling_type;
+  };
+  const CouplingTypeEnum _coupling_type;
 
-  /// Whether thermal contributions should be added to the residual
   const bool _includes_thermal;
-
-  /// Whether mechanical contributions should be added to the residual
   const bool _includes_mechanical;
 
-  /// Biot coefficient (used in simulations involving Mechanical deformations)
+  /// Biot coefficient
   const Real _biot_coefficient;
 
-  /// Constant Biot modulus
+  /// Constant Biot modulus (not a function of primary variables)
   const MaterialProperty<Real> & _biot_modulus;
 
   /// Constant volumetric thermal expansion coefficient
   const MaterialProperty<Real> * const _thermal_coeff;
 
-  /// Quadpoint fluid density for each phase
-  const MaterialProperty<std::vector<Real>> * const _fluid_density;
+  /// Quadpoint fluid density (AD or non-AD depending on is_ad)
+  const GenericMaterialProperty<std::vector<Real>, is_ad> * const _fluid_density;
 
-  /// derivative of fluid density for each phase with respect to the PorousFlow variables
+  /// d(fluid density)/d(PorousFlow variable) — null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_dvar;
 
-  /// Quadpoint pore pressure in each phase
-  const MaterialProperty<std::vector<Real>> & _pp;
+  /// Quadpoint pore pressure
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _pp;
 
-  /// Old value of quadpoint pore pressure in each phase
+  /// Old quadpoint pore pressure (always non-AD)
   const MaterialProperty<std::vector<Real>> & _pp_old;
 
-  /// Derivative of porepressure in each phase wrt the PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dpp_dvar;
+  /// d(pore pressure)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dpp_dvar;
 
-  /// Quadpoint temperature
-  const MaterialProperty<Real> * const _temperature;
+  /// Quadpoint temperature (only when _includes_thermal)
+  const GenericMaterialProperty<Real, is_ad> * const _temperature;
 
-  /// Old value of quadpoint temperature
+  /// Old quadpoint temperature (always non-AD)
   const MaterialProperty<Real> * const _temperature_old;
 
-  /// Derivative of temperature wrt the PorousFlow variables
+  /// d(temperature)/d(PorousFlow variable) — null for AD path
   const MaterialProperty<std::vector<Real>> * const _dtemperature_dvar;
 
-  /// Strain rate
+  /// Volumetric strain rate (only when _includes_mechanical; always non-AD)
   const MaterialProperty<Real> * const _strain_rate;
 
-  /// Derivative of strain rate wrt the PorousFlow variables
+  /// d(strain rate)/d(PorousFlow variable) — null for AD path
   const MaterialProperty<std::vector<RealGradient>> * const _dstrain_rate_dvar;
+
+  usingGenericKernelMembers;
+  using GenericKernel<is_ad>::_grad_phi;
 };
+
+typedef PorousFlowFullySaturatedMassTimeDerivativeTempl<false>
+    PorousFlowFullySaturatedMassTimeDerivative;
+typedef PorousFlowFullySaturatedMassTimeDerivativeTempl<true>
+    ADPorousFlowFullySaturatedMassTimeDerivative;

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedMassTimeDerivative.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedMassTimeDerivative.h
@@ -69,7 +69,7 @@ protected:
   /// Quadpoint fluid density (AD or non-AD depending on is_ad)
   const GenericMaterialProperty<std::vector<Real>, is_ad> * const _fluid_density;
 
-  /// d(fluid density)/d(PorousFlow variable) — null for AD path
+  /// d(fluid density)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_dvar;
 
   /// Quadpoint pore pressure
@@ -78,7 +78,7 @@ protected:
   /// Old quadpoint pore pressure (always non-AD)
   const MaterialProperty<std::vector<Real>> & _pp_old;
 
-  /// d(pore pressure)/d(PorousFlow variable) — null for AD path
+  /// d(pore pressure)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dpp_dvar;
 
   /// Quadpoint temperature (only when _includes_thermal)
@@ -87,13 +87,13 @@ protected:
   /// Old quadpoint temperature (always non-AD)
   const MaterialProperty<Real> * const _temperature_old;
 
-  /// d(temperature)/d(PorousFlow variable) — null for AD path
+  /// d(temperature)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<Real>> * const _dtemperature_dvar;
 
   /// Volumetric strain rate (only when _includes_mechanical; always non-AD)
   const MaterialProperty<Real> * const _strain_rate;
 
-  /// d(strain rate)/d(PorousFlow variable) — null for AD path
+  /// d(strain rate)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<RealGradient>> * const _dstrain_rate_dvar;
 
   usingGenericKernelMembers;

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedUpwindHeatAdvection.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedUpwindHeatAdvection.h
@@ -15,21 +15,37 @@
  * Advection of heat via flux of a single-phase fluid.
  * A fully-updwinded version is implemented, where the mobility
  * of the upstream nodes is used.
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowFullySaturatedUpwindHeatAdvection : public PorousFlowDarcyBase
+template <bool is_ad>
+class PorousFlowFullySaturatedUpwindHeatAdvectionTempl : public PorousFlowDarcyBaseTempl<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowFullySaturatedUpwindHeatAdvection(const InputParameters & parameters);
+  PorousFlowFullySaturatedUpwindHeatAdvectionTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real mobility(unsigned nodenum, unsigned phase) const override;
+  virtual GenericReal<is_ad> mobility(unsigned nodenum, unsigned phase) const override;
   virtual Real dmobility(unsigned nodenum, unsigned phase, unsigned pvar) const override;
 
   /// Enthalpy of each phase
-  const MaterialProperty<std::vector<Real>> & _enthalpy;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _enthalpy;
 
-  /// Derivative of the enthalpy wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _denthalpy_dvar;
+  /// Derivative of the enthalpy wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _denthalpy_dvar;
+
+  using PorousFlowDarcyBaseTempl<is_ad>::_dictator;
+  using PorousFlowDarcyBaseTempl<is_ad>::_fluid_density_node;
+  using PorousFlowDarcyBaseTempl<is_ad>::_fluid_viscosity;
+  using PorousFlowDarcyBaseTempl<is_ad>::_dfluid_density_node_dvar;
+  using PorousFlowDarcyBaseTempl<is_ad>::_dfluid_viscosity_dvar;
+  usingGenericKernelMembers;
 };
+
+typedef PorousFlowFullySaturatedUpwindHeatAdvectionTempl<false>
+    PorousFlowFullySaturatedUpwindHeatAdvection;
+typedef PorousFlowFullySaturatedUpwindHeatAdvectionTempl<true>
+    ADPorousFlowFullySaturatedUpwindHeatAdvection;

--- a/modules/porous_flow/include/kernels/PorousFlowHeatAdvection.h
+++ b/modules/porous_flow/include/kernels/PorousFlowHeatAdvection.h
@@ -15,27 +15,40 @@
  * Advection of heat via flux of component k in fluid phase alpha.
  * A fully-updwinded version is implemented, where the mobility
  * of the upstream nodes is used.
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowHeatAdvection : public PorousFlowDarcyBase
+template <bool is_ad>
+class PorousFlowHeatAdvectionTempl : public PorousFlowDarcyBaseTempl<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowHeatAdvection(const InputParameters & parameters);
+  PorousFlowHeatAdvectionTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real mobility(unsigned nodenum, unsigned phase) const override;
+  virtual GenericReal<is_ad> mobility(unsigned nodenum, unsigned phase) const override;
   virtual Real dmobility(unsigned nodenum, unsigned phase, unsigned pvar) const override;
 
   /// Enthalpy of each phase
-  const MaterialProperty<std::vector<Real>> & _enthalpy;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _enthalpy;
 
-  /// Derivative of the enthalpy wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _denthalpy_dvar;
+  /// Derivative of the enthalpy wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _denthalpy_dvar;
 
   /// Relative permeability of each phase
-  const MaterialProperty<std::vector<Real>> & _relative_permeability;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _relative_permeability;
 
-  /// Derivative of relative permeability of each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _drelative_permeability_dvar;
+  /// Derivative of relative permeability of each phase wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _drelative_permeability_dvar;
+
+  using PorousFlowDarcyBaseTempl<is_ad>::_fluid_density_node;
+  using PorousFlowDarcyBaseTempl<is_ad>::_fluid_viscosity;
+  using PorousFlowDarcyBaseTempl<is_ad>::_dfluid_density_node_dvar;
+  using PorousFlowDarcyBaseTempl<is_ad>::_dfluid_viscosity_dvar;
+  usingGenericKernelMembers;
 };
+
+typedef PorousFlowHeatAdvectionTempl<false> PorousFlowHeatAdvection;
+typedef PorousFlowHeatAdvectionTempl<true> ADPorousFlowHeatAdvection;

--- a/modules/porous_flow/include/kernels/PorousFlowHeatConduction.h
+++ b/modules/porous_flow/include/kernels/PorousFlowHeatConduction.h
@@ -9,21 +9,25 @@
 
 #pragma once
 
-#include "Kernel.h"
+#include "GenericKernel.h"
 #include "PorousFlowDictator.h"
 
 /**
  * Kernel = grad(test) * thermal_conductivity * grad(temperature)
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowHeatConduction : public Kernel
+template <bool is_ad>
+class PorousFlowHeatConductionTempl : public GenericKernel<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowHeatConduction(const InputParameters & parameters);
+  PorousFlowHeatConductionTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
@@ -31,17 +35,23 @@ protected:
   const PorousFlowDictator & _dictator;
 
   /// Thermal conductivity at the quadpoints
-  const MaterialProperty<RealTensorValue> & _la;
+  const GenericMaterialProperty<RealTensorValue, is_ad> & _la;
 
-  /// d(thermal conductivity at the quadpoints)/d(PorousFlow variable)
-  const MaterialProperty<std::vector<RealTensorValue>> & _dla_dvar;
+  /// d(thermal conductivity at the quadpoints)/d(PorousFlow variable) -- null for AD
+  const MaterialProperty<std::vector<RealTensorValue>> * const _dla_dvar;
 
   /// grad(temperature)
-  const MaterialProperty<RealGradient> & _grad_t;
+  const GenericMaterialProperty<RealGradient, is_ad> & _grad_t;
 
-  /// d(gradT)/d(PorousFlow variable)
-  const MaterialProperty<std::vector<RealGradient>> & _dgrad_t_dvar;
+  /// d(gradT)/d(PorousFlow variable) -- null for AD
+  const MaterialProperty<std::vector<RealGradient>> * const _dgrad_t_dvar;
 
-  /// d(gradT)/d(grad PorousFlow variable)
-  const MaterialProperty<std::vector<Real>> & _dgrad_t_dgradvar;
+  /// d(gradT)/d(grad PorousFlow variable) -- null for AD
+  const MaterialProperty<std::vector<Real>> * const _dgrad_t_dgradvar;
+
+  usingGenericKernelMembers;
+  using GenericKernel<is_ad>::_grad_phi;
 };
+
+typedef PorousFlowHeatConductionTempl<false> PorousFlowHeatConduction;
+typedef PorousFlowHeatConductionTempl<true> ADPorousFlowHeatConduction;

--- a/modules/porous_flow/include/kernels/PorousFlowHeatMassTransfer.h
+++ b/modules/porous_flow/include/kernels/PorousFlowHeatMassTransfer.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "Kernel.h"
+#include "GenericKernel.h"
 
 // Forward Declaration
 
@@ -20,22 +20,31 @@
  * documentation can be overcome.
  * Alternatively, this kernel can also be used to model simplified precipitation/dissolution,
  * where the Variable is the concentration.
+ *
+ * Templated on is_ad: the false instantiation uses the hand-coded Jacobian;
+ * the true instantiation propagates derivatives through the AD residual.
  */
-class PorousFlowHeatMassTransfer : public Kernel
+template <bool is_ad>
+class PorousFlowHeatMassTransferTempl : public GenericKernel<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowHeatMassTransfer(const InputParameters & parameters);
+  PorousFlowHeatMassTransferTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
   virtual Real jac(unsigned int jvar) const;
 
+  usingGenericKernelMembers;
+
 private:
   const unsigned int _v_var;
-  const VariableValue & _v;
+  const GenericVariableValue<is_ad> & _v;
   const VariableValue & _coef_var;
 };
+
+typedef PorousFlowHeatMassTransferTempl<false> PorousFlowHeatMassTransfer;
+typedef PorousFlowHeatMassTransferTempl<true> ADPorousFlowHeatMassTransfer;

--- a/modules/porous_flow/include/kernels/PorousFlowHeatMassTransfer.h
+++ b/modules/porous_flow/include/kernels/PorousFlowHeatMassTransfer.h
@@ -43,7 +43,7 @@ protected:
 private:
   const unsigned int _v_var;
   const GenericVariableValue<is_ad> & _v;
-  const VariableValue & _coef_var;
+  const GenericVariableValue<is_ad> & _coef_var;
 };
 
 typedef PorousFlowHeatMassTransferTempl<false> PorousFlowHeatMassTransfer;

--- a/modules/porous_flow/include/kernels/PorousFlowLumpedKernelBase.h
+++ b/modules/porous_flow/include/kernels/PorousFlowLumpedKernelBase.h
@@ -1,0 +1,44 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GenericKernel.h"
+
+/**
+ * Base class for PorousFlow kernels that use mass-lumped (nodal) material properties.
+ *
+ * These kernels index material properties at [_i] (the test-function node) rather than [_qp].
+ * That breaks the default ADKernel Jacobian assembly, which assumes every test function's residual
+ * depends on the same set of DOFs; see computeJacobian() in PorousFlowLumpedKernelBase.C for the
+ * full explanation.  This base class overrides the three Jacobian methods for the AD path to use
+ * addJacobianWithoutConstraints, which reads each row's column set from its own residual.
+ */
+template <bool is_ad>
+class PorousFlowLumpedKernelBaseTempl : public GenericKernel<is_ad>
+{
+public:
+  static InputParameters validParams();
+  PorousFlowLumpedKernelBaseTempl(const InputParameters & parameters);
+
+protected:
+  virtual void computeJacobian() override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
+  virtual void jacobianSetup() override;
+
+  usingGenericKernelMembers;
+
+private:
+  // Cache to avoid recomputing AD residuals for each off-diagonal jvar on the same element,
+  // mirroring the _my_elem guard in ADKernel::computeOffDiagJacobian.
+  const Elem * _my_elem_lma = nullptr;
+};
+
+typedef PorousFlowLumpedKernelBaseTempl<false> PorousFlowLumpedKernelBase;
+typedef PorousFlowLumpedKernelBaseTempl<true> ADPorousFlowLumpedKernelBase;

--- a/modules/porous_flow/include/kernels/PorousFlowLumpedKernelBase.h
+++ b/modules/porous_flow/include/kernels/PorousFlowLumpedKernelBase.h
@@ -24,7 +24,6 @@ template <bool is_ad>
 class PorousFlowLumpedKernelBaseTempl : public GenericKernel<is_ad>
 {
 public:
-  static InputParameters validParams();
   PorousFlowLumpedKernelBaseTempl(const InputParameters & parameters);
 
 protected:

--- a/modules/porous_flow/include/kernels/PorousFlowMassRadioactiveDecay.h
+++ b/modules/porous_flow/include/kernels/PorousFlowMassRadioactiveDecay.h
@@ -55,7 +55,8 @@ protected:
   /// Whether the porosity uses the volumetric strain at the closest quadpoint
   const bool _strain_at_nearest_qp;
 
-  /// Porosity at the nodes (AD or non-AD depending on is_ad)
+  /// Porosity at the nodes, but it can depend on grad(variables) which are actually evaluated at
+  /// the qps (AD or non-AD depending on is_ad)
   const GenericMaterialProperty<Real, is_ad> & _porosity;
 
   /// d(porosity)/d(PorousFlow variable) at nodes -- null for AD path

--- a/modules/porous_flow/include/kernels/PorousFlowMassRadioactiveDecay.h
+++ b/modules/porous_flow/include/kernels/PorousFlowMassRadioactiveDecay.h
@@ -58,10 +58,10 @@ protected:
   /// Porosity at the nodes (AD or non-AD depending on is_ad)
   const GenericMaterialProperty<Real, is_ad> & _porosity;
 
-  /// d(porosity)/d(PorousFlow variable) at nodes — null for AD path
+  /// d(porosity)/d(PorousFlow variable) at nodes -- null for AD path
   const MaterialProperty<std::vector<Real>> * const _dporosity_dvar;
 
-  /// d(porosity)/d(grad PorousFlow variable) at qps — null for AD path
+  /// d(porosity)/d(grad PorousFlow variable) at qps -- null for AD path
   const MaterialProperty<std::vector<RealGradient>> * const _dporosity_dgradvar;
 
   /// The nearest qp to the node (always non-AD)
@@ -70,19 +70,19 @@ protected:
   /// Nodal fluid density (AD or non-AD)
   const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_density;
 
-  /// d(nodal fluid density)/d(PorousFlow variable) — null for AD path
+  /// d(nodal fluid density)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_dvar;
 
   /// Nodal fluid saturation (AD or non-AD)
   const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_saturation_nodal;
 
-  /// d(nodal fluid saturation)/d(PorousFlow variable) — null for AD path
+  /// d(nodal fluid saturation)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_saturation_nodal_dvar;
 
   /// Nodal mass fraction (AD or non-AD)
   const GenericMaterialProperty<std::vector<std::vector<Real>>, is_ad> & _mass_frac;
 
-  /// d(nodal mass fraction)/d(PorousFlow variable) — null for AD path
+  /// d(nodal mass fraction)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> * const _dmass_frac_dvar;
 
   usingGenericKernelMembers;

--- a/modules/porous_flow/include/kernels/PorousFlowMassRadioactiveDecay.h
+++ b/modules/porous_flow/include/kernels/PorousFlowMassRadioactiveDecay.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "TimeDerivative.h"
+#include "PorousFlowLumpedKernelBase.h"
 #include "PorousFlowDictator.h"
 
 /**
@@ -17,18 +17,25 @@
  * where mass_component =
  * porosity*sum_phases(density_phase*saturation_phase*massfrac_phase^component)
  * It is lumped to the nodes
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowMassRadioactiveDecay : public TimeKernel
+template <bool is_ad>
+class PorousFlowMassRadioactiveDecayTempl : public PorousFlowLumpedKernelBaseTempl<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowMassRadioactiveDecay(const InputParameters & parameters);
+  PorousFlowMassRadioactiveDecayTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+
+  /// Derivative of residual wrt PorousFlow variable pvar (non-AD path only)
+  Real computeQpJac(unsigned int pvar);
 
   /// The decay rate
   const Real _decay_rate;
@@ -48,40 +55,39 @@ protected:
   /// Whether the porosity uses the volumetric strain at the closest quadpoint
   const bool _strain_at_nearest_qp;
 
-  /// Porosity at the nodes, but it can depend on grad(variables) which are actually evaluated at the qps
-  const MaterialProperty<Real> & _porosity;
+  /// Porosity at the nodes (AD or non-AD depending on is_ad)
+  const GenericMaterialProperty<Real, is_ad> & _porosity;
 
-  /// d(porosity)/d(PorousFlow variable) - these derivatives will be wrt variables at the nodes
-  const MaterialProperty<std::vector<Real>> & _dporosity_dvar;
+  /// d(porosity)/d(PorousFlow variable) at nodes — null for AD path
+  const MaterialProperty<std::vector<Real>> * const _dporosity_dvar;
 
-  /// d(porosity)/d(grad PorousFlow variable) - remember these derivatives will be wrt grad(vars) at qps
-  const MaterialProperty<std::vector<RealGradient>> & _dporosity_dgradvar;
+  /// d(porosity)/d(grad PorousFlow variable) at qps — null for AD path
+  const MaterialProperty<std::vector<RealGradient>> * const _dporosity_dgradvar;
 
-  /// The nearest qp to the node
+  /// The nearest qp to the node (always non-AD)
   const MaterialProperty<unsigned int> * const _nearest_qp;
 
-  /// Nodal fluid density
-  const MaterialProperty<std::vector<Real>> & _fluid_density;
+  /// Nodal fluid density (AD or non-AD)
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_density;
 
-  /// d(nodal fluid density)/d(PorousFlow variable)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dfluid_density_dvar;
+  /// d(nodal fluid density)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_dvar;
 
-  /// Nodal fluid saturation
-  const MaterialProperty<std::vector<Real>> & _fluid_saturation_nodal;
+  /// Nodal fluid saturation (AD or non-AD)
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_saturation_nodal;
 
-  /// d(nodal fluid saturation)/d(PorousFlow variable)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dfluid_saturation_nodal_dvar;
+  /// d(nodal fluid saturation)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_saturation_nodal_dvar;
 
-  /// Nodal mass fraction
-  const MaterialProperty<std::vector<std::vector<Real>>> & _mass_frac;
+  /// Nodal mass fraction (AD or non-AD)
+  const GenericMaterialProperty<std::vector<std::vector<Real>>, is_ad> & _mass_frac;
 
-  /// d(nodal mass fraction)/d(PorousFlow variable)
-  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> & _dmass_frac_dvar;
+  /// d(nodal mass fraction)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> * const _dmass_frac_dvar;
 
-  /**
-   * Derivative of residual with respect to PorousFlow variable number pvar
-   * This is used by both computeQpJacobian and computeQpOffDiagJacobian
-   * @param pvar take the derivative of the residual wrt this PorousFlow variable
-   */
-  Real computeQpJac(unsigned int pvar);
+  usingGenericKernelMembers;
+  using GenericKernel<is_ad>::_grad_phi;
 };
+
+typedef PorousFlowMassRadioactiveDecayTempl<false> PorousFlowMassRadioactiveDecay;
+typedef PorousFlowMassRadioactiveDecayTempl<true> ADPorousFlowMassRadioactiveDecay;

--- a/modules/porous_flow/include/kernels/PorousFlowMassTimeDerivative.h
+++ b/modules/porous_flow/include/kernels/PorousFlowMassTimeDerivative.h
@@ -72,10 +72,10 @@ protected:
   /// Old value of porosity (always non-AD)
   const MaterialProperty<Real> & _porosity_old;
 
-  /// d(porosity)/d(PorousFlow variable) at nodes — null for AD path
+  /// d(porosity)/d(PorousFlow variable) at nodes -- null for AD path
   const MaterialProperty<std::vector<Real>> * const _dporosity_dvar;
 
-  /// d(porosity)/d(grad PorousFlow variable) at qps — null for AD path
+  /// d(porosity)/d(grad PorousFlow variable) at qps -- null for AD path
   const MaterialProperty<std::vector<RealGradient>> * const _dporosity_dgradvar;
 
   /// The nearest qp to the node (unsigned int, always non-AD)
@@ -87,7 +87,7 @@ protected:
   /// Old value of nodal fluid density (always non-AD); null if !multiply_by_density
   const MaterialProperty<std::vector<Real>> * const _fluid_density_old;
 
-  /// d(nodal fluid density)/d(PorousFlow variable) — null for AD path or if !multiply_by_density
+  /// d(nodal fluid density)/d(PorousFlow variable) -- null for AD path or if !multiply_by_density
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_dvar;
 
   /// Nodal fluid saturation (AD or non-AD)
@@ -96,7 +96,7 @@ protected:
   /// Old value of fluid saturation (always non-AD)
   const MaterialProperty<std::vector<Real>> & _fluid_saturation_nodal_old;
 
-  /// d(nodal fluid saturation)/d(PorousFlow variable) — null for AD path
+  /// d(nodal fluid saturation)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_saturation_nodal_dvar;
 
   /// Nodal mass fraction (AD or non-AD)
@@ -105,7 +105,7 @@ protected:
   /// Old value of nodal mass fraction (always non-AD)
   const MaterialProperty<std::vector<std::vector<Real>>> & _mass_frac_old;
 
-  /// d(nodal mass fraction)/d(PorousFlow variable) — null for AD path
+  /// d(nodal mass fraction)/d(PorousFlow variable) - null for AD path
   const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> * const _dmass_frac_dvar;
 
   usingGenericKernelMembers;

--- a/modules/porous_flow/include/kernels/PorousFlowMassTimeDerivative.h
+++ b/modules/porous_flow/include/kernels/PorousFlowMassTimeDerivative.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "TimeDerivative.h"
+#include "PorousFlowLumpedKernelBase.h"
 #include "PorousFlowDictator.h"
 
 /**
@@ -19,18 +19,25 @@
  * It is lumped to the nodes.
  * If multiply_by_density = false, then density_phase is not included in this above sum, so the
  * Kernel is calculating the time-derivative of fluid volume
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowMassTimeDerivative : public TimeKernel
+template <bool is_ad>
+class PorousFlowMassTimeDerivativeTempl : public PorousFlowLumpedKernelBaseTempl<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowMassTimeDerivative(const InputParameters & parameters);
+  PorousFlowMassTimeDerivativeTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+
+  /// Derivative of residual wrt PorousFlow variable pvar (non-AD path only)
+  Real computeQpJac(unsigned int pvar);
 
   /// The fluid component index
   const unsigned int _fluid_component;
@@ -59,52 +66,51 @@ protected:
   /// Old value of total strain calculated by a Tensor Mechanics strain calculator, if it exists, otherwise nullptr
   const MaterialProperty<RankTwoTensor> * const _total_strain_old;
 
-  /// Porosity at the nodes, but it can depend on grad(variables) which are actually evaluated at the qps
-  const MaterialProperty<Real> & _porosity;
+  /// Porosity at the nodes (AD or non-AD depending on is_ad)
+  const GenericMaterialProperty<Real, is_ad> & _porosity;
 
-  /// Old value of porosity
+  /// Old value of porosity (always non-AD)
   const MaterialProperty<Real> & _porosity_old;
 
-  /// d(porosity)/d(PorousFlow variable) - these derivatives will be wrt variables at the nodes
-  const MaterialProperty<std::vector<Real>> & _dporosity_dvar;
+  /// d(porosity)/d(PorousFlow variable) at nodes — null for AD path
+  const MaterialProperty<std::vector<Real>> * const _dporosity_dvar;
 
-  /// d(porosity)/d(grad PorousFlow variable) - remember these derivatives will be wrt grad(vars) at qps
-  const MaterialProperty<std::vector<RealGradient>> & _dporosity_dgradvar;
+  /// d(porosity)/d(grad PorousFlow variable) at qps — null for AD path
+  const MaterialProperty<std::vector<RealGradient>> * const _dporosity_dgradvar;
 
-  /// The nearest qp to the node
+  /// The nearest qp to the node (unsigned int, always non-AD)
   const MaterialProperty<unsigned int> * const _nearest_qp;
 
-  /// Nodal fluid density
-  const MaterialProperty<std::vector<Real>> * const _fluid_density;
+  /// Nodal fluid density (AD or non-AD); null if !multiply_by_density
+  const GenericMaterialProperty<std::vector<Real>, is_ad> * const _fluid_density;
 
-  /// Old value of nodal fluid density
+  /// Old value of nodal fluid density (always non-AD); null if !multiply_by_density
   const MaterialProperty<std::vector<Real>> * const _fluid_density_old;
 
-  /// d(nodal fluid density)/d(PorousFlow variable)
+  /// d(nodal fluid density)/d(PorousFlow variable) — null for AD path or if !multiply_by_density
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_dvar;
 
-  /// Nodal fluid saturation
-  const MaterialProperty<std::vector<Real>> & _fluid_saturation_nodal;
+  /// Nodal fluid saturation (AD or non-AD)
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_saturation_nodal;
 
-  /// Old value of fluid saturation
+  /// Old value of fluid saturation (always non-AD)
   const MaterialProperty<std::vector<Real>> & _fluid_saturation_nodal_old;
 
-  /// d(nodal fluid saturation)/d(PorousFlow variable)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dfluid_saturation_nodal_dvar;
+  /// d(nodal fluid saturation)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_saturation_nodal_dvar;
 
-  /// Nodal mass fraction
-  const MaterialProperty<std::vector<std::vector<Real>>> & _mass_frac;
+  /// Nodal mass fraction (AD or non-AD)
+  const GenericMaterialProperty<std::vector<std::vector<Real>>, is_ad> & _mass_frac;
 
-  /// Old value of nodal mass fraction
+  /// Old value of nodal mass fraction (always non-AD)
   const MaterialProperty<std::vector<std::vector<Real>>> & _mass_frac_old;
 
-  /// d(nodal mass fraction)/d(PorousFlow variable)
-  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> & _dmass_frac_dvar;
+  /// d(nodal mass fraction)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<std::vector<Real>>>> * const _dmass_frac_dvar;
 
-  /**
-   * Derivative of residual with respect to PorousFlow variable number pvar
-   * This is used by both computeQpJacobian and computeQpOffDiagJacobian
-   * @param pvar take the derivative of the residual wrt this PorousFlow variable
-   */
-  Real computeQpJac(unsigned int pvar);
+  usingGenericKernelMembers;
+  using GenericKernel<is_ad>::_grad_phi;
 };
+
+typedef PorousFlowMassTimeDerivativeTempl<false> PorousFlowMassTimeDerivative;
+typedef PorousFlowMassTimeDerivativeTempl<true> ADPorousFlowMassTimeDerivative;

--- a/modules/porous_flow/include/kernels/PorousFlowPreDis.h
+++ b/modules/porous_flow/include/kernels/PorousFlowPreDis.h
@@ -51,13 +51,13 @@ protected:
   /// Saturation (AD or non-AD)
   const GenericMaterialProperty<std::vector<Real>, is_ad> & _saturation;
 
-  /// d(saturation)/d(PorousFlow var) — null for AD path
+  /// d(saturation)/d(PorousFlow var) -- null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dsaturation_dvar;
 
   /// Reaction rate of the yielding the secondary species (AD or non-AD)
   const GenericMaterialProperty<std::vector<Real>, is_ad> & _reaction_rate;
 
-  /// d(reaction rate)/d(PorousFlow variable) — null for AD path
+  /// d(reaction rate)/d(PorousFlow variable) -- null for AD path
   const MaterialProperty<std::vector<std::vector<Real>>> * const _dreaction_rate_dvar;
 
   /// Stoichiometric coefficients

--- a/modules/porous_flow/include/kernels/PorousFlowPreDis.h
+++ b/modules/porous_flow/include/kernels/PorousFlowPreDis.h
@@ -9,25 +9,32 @@
 
 #pragma once
 
-#include "TimeDerivative.h"
+#include "PorousFlowLumpedKernelBase.h"
 #include "PorousFlowDictator.h"
 
 /**
  * Kernel = sum (stoichiometry * density * porosity_old * saturation * reaction_rate)
  * where the sum is over secondary chemical species in
  * a precipitation-dissolution reaction system.
+ *
+ * Templated on is_ad: the false instantiation uses hand-coded Jacobians;
+ * the true instantiation propagates derivatives through AD material properties.
  */
-class PorousFlowPreDis : public TimeKernel
+template <bool is_ad>
+class PorousFlowPreDisTempl : public PorousFlowLumpedKernelBaseTempl<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowPreDis(const InputParameters & parameters);
+  PorousFlowPreDisTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
+  virtual GenericReal<is_ad> computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+
+  /// Derivative of residual wrt PorousFlow variable pvar (non-AD path only)
+  Real computeQpJac(unsigned int pvar);
 
   /// Density of the mineral species
   const std::vector<Real> _mineral_density;
@@ -38,28 +45,26 @@ protected:
   /// Aqueous phase number
   const unsigned int _aq_ph;
 
-  /// Old value of porosity
+  /// Old value of porosity (always non-AD: old values carry no current-timestep derivatives)
   const MaterialProperty<Real> & _porosity_old;
 
-  /// Saturation
-  const MaterialProperty<std::vector<Real>> & _saturation;
+  /// Saturation (AD or non-AD)
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _saturation;
 
-  /// d(saturation)/d(PorousFlow var)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dsaturation_dvar;
+  /// d(saturation)/d(PorousFlow var) — null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dsaturation_dvar;
 
-  /// Reaction rate of the yielding the secondary species
-  const MaterialProperty<std::vector<Real>> & _reaction_rate;
+  /// Reaction rate of the yielding the secondary species (AD or non-AD)
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _reaction_rate;
 
-  /// d(reaction rate)/d(porflow variable)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dreaction_rate_dvar;
+  /// d(reaction rate)/d(PorousFlow variable) — null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dreaction_rate_dvar;
 
   /// Stoichiometric coefficients
   const std::vector<Real> _stoichiometry;
 
-  /**
-   * Derivative of residual with respect to PorousFlow variable number pvar
-   * This is used by both computeQpJacobian and computeQpOffDiagJacobian
-   * @param pvar take the derivative of the residual wrt this PorousFlow variable
-   */
-  Real computeQpJac(unsigned int pvar);
+  usingGenericKernelMembers;
 };
+
+typedef PorousFlowPreDisTempl<false> PorousFlowPreDis;
+typedef PorousFlowPreDisTempl<true> ADPorousFlowPreDis;

--- a/modules/porous_flow/include/materials/PorousFlowDarcyVelocityMaterial.h
+++ b/modules/porous_flow/include/materials/PorousFlowDarcyVelocityMaterial.h
@@ -13,13 +13,17 @@
 
 /**
  * Material to calculate the Darcy velocity for all phases
+ *
+ * Templated on is_ad: the false instantiation also computes the hand-coded derivative
+ * properties; the true instantiation carries derivatives through the AD Darcy velocity.
  */
-class PorousFlowDarcyVelocityMaterial : public PorousFlowMaterial
+template <bool is_ad>
+class PorousFlowDarcyVelocityMaterialTempl : public PorousFlowMaterial
 {
 public:
   static InputParameters validParams();
 
-  PorousFlowDarcyVelocityMaterial(const InputParameters & parameters);
+  PorousFlowDarcyVelocityMaterialTempl(const InputParameters & parameters);
 
 protected:
   virtual void computeQpProperties() override;
@@ -31,40 +35,40 @@ protected:
   const unsigned int _num_var;
 
   /// Permeability of porous material
-  const MaterialProperty<RealTensorValue> & _permeability;
+  const GenericMaterialProperty<RealTensorValue, is_ad> & _permeability;
 
-  /// d(permeabiity)/d(PorousFlow variable)
-  const MaterialProperty<std::vector<RealTensorValue>> & _dpermeability_dvar;
+  /// d(permeabiity)/d(PorousFlow variable) -- null for AD path
+  const MaterialProperty<std::vector<RealTensorValue>> * const _dpermeability_dvar;
 
-  /// d(permeabiity)/d(grad(PorousFlow variable))
-  const MaterialProperty<std::vector<std::vector<RealTensorValue>>> & _dpermeability_dgradvar;
+  /// d(permeabiity)/d(grad(PorousFlow variable)) -- null for AD path
+  const MaterialProperty<std::vector<std::vector<RealTensorValue>>> * const _dpermeability_dgradvar;
 
   /// Fluid density for each phase
-  const MaterialProperty<std::vector<Real>> & _fluid_density;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_density;
 
-  /// Derivative of the fluid density for each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dfluid_density_dvar;
+  /// Derivative of the fluid density for each phase wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_density_dvar;
 
   /// Viscosity of each component in each phase
-  const MaterialProperty<std::vector<Real>> & _fluid_viscosity;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _fluid_viscosity;
 
-  /// Derivative of the fluid viscosity for each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dfluid_viscosity_dvar;
+  /// Derivative of the fluid viscosity for each phase wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dfluid_viscosity_dvar;
 
   /// Relative permeability of each phase
-  const MaterialProperty<std::vector<Real>> & _relative_permeability;
+  const GenericMaterialProperty<std::vector<Real>, is_ad> & _relative_permeability;
 
-  /// Derivative of relative permeability of each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<Real>>> & _drelative_permeability_dvar;
+  /// Derivative of relative permeability of each phase wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _drelative_permeability_dvar;
 
   /// Gradient of the pore pressure in each phase
-  const MaterialProperty<std::vector<RealGradient>> & _grad_p;
+  const GenericMaterialProperty<std::vector<RealGradient>, is_ad> & _grad_p;
 
-  /// Derivative of Grad porepressure in each phase wrt grad(PorousFlow variables)
-  const MaterialProperty<std::vector<std::vector<Real>>> & _dgrad_p_dgradvar;
+  /// Derivative of Grad porepressure in each phase wrt grad(PorousFlow variables) -- null for AD path
+  const MaterialProperty<std::vector<std::vector<Real>>> * const _dgrad_p_dgradvar;
 
-  /// Derivative of Grad porepressure in each phase wrt PorousFlow variables
-  const MaterialProperty<std::vector<std::vector<RealGradient>>> & _dgrad_p_dvar;
+  /// Derivative of Grad porepressure in each phase wrt PorousFlow variables -- null for AD path
+  const MaterialProperty<std::vector<std::vector<RealGradient>>> * const _dgrad_p_dvar;
 
   /// Gravity
   const RealVectorValue _gravity;
@@ -73,13 +77,14 @@ protected:
    * Computed Darcy velocity of each phase.
    * _darcy_velocity[_qp][ph](i) = i^th component of velocity of phase ph at quadpoint _qp
    */
-  MaterialProperty<std::vector<RealVectorValue>> & _darcy_velocity;
+  GenericMaterialProperty<std::vector<RealVectorValue>, is_ad> & _darcy_velocity;
 
   /**
    * _ddarcy_velocity_dvar[_qp][ph][v](i) =
    * d(i_th component of velocity of phase ph at quadpoint _qp)/d(PorousFlow variable v)
+   * Null for the AD path.
    */
-  MaterialProperty<std::vector<std::vector<RealVectorValue>>> & _ddarcy_velocity_dvar;
+  MaterialProperty<std::vector<std::vector<RealVectorValue>>> * const _ddarcy_velocity_dvar;
 
   /**
    * _ddarcy_velocity_dgradvar[_qp][ph][j][v](i)
@@ -87,7 +92,11 @@ protected:
    *          d(j_th component of grad(PorousFlow variable v))
    * In an advection Kernel, grad_test * _darcy_velocity[ph] * u, the contribution to the Jacobian
    * is grad_test * (_ddarcy_velocity_dgradvar[_qp][ph][j][v] * _grad_phi[_j][_qp](j)) * u
+   * Null for the AD path.
    */
-  MaterialProperty<std::vector<std::vector<std::vector<RealVectorValue>>>> &
+  MaterialProperty<std::vector<std::vector<std::vector<RealVectorValue>>>> * const
       _ddarcy_velocity_dgradvar;
 };
+
+typedef PorousFlowDarcyVelocityMaterialTempl<false> PorousFlowDarcyVelocityMaterial;
+typedef PorousFlowDarcyVelocityMaterialTempl<true> ADPorousFlowDarcyVelocityMaterial;

--- a/modules/porous_flow/include/materials/PorousFlowMatrixInternalEnergy.h
+++ b/modules/porous_flow/include/materials/PorousFlowMatrixInternalEnergy.h
@@ -39,10 +39,10 @@ protected:
   /// Heat capacity = _cp * _density
   const Real _heat_cap;
 
-  /// Temperature at the nodes
+  /// Temperature used to compute matrix internal energy: nodal for FE, qp for AD FV
   const GenericMaterialProperty<Real, is_ad> & _temperature;
 
-  /// d(temperature at the nodes)/d(PorousFlow variable)
+  /// d(temperature)/d(PorousFlow variable) for the non-AD FE path
   const MaterialProperty<std::vector<Real>> * const _dtemperature_dvar;
 
   /// Matrix internal_energy at the nodes

--- a/modules/porous_flow/include/userobjects/PorousFlowDictator.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowDictator.h
@@ -70,9 +70,9 @@ public:
 
   PorousFlowDictator(const InputParameters & parameters);
 
-  virtual void initialize() override{};
-  virtual void execute() override{};
-  virtual void finalize() override{};
+  virtual void initialize() override {};
+  virtual void execute() override {};
+  virtual void finalize() override {};
 
   /**
    * The number of PorousFlow variables.  Materials
@@ -145,6 +145,9 @@ public:
    */
   libMesh::FEType feType() const;
 
+  /// Whether the PorousFlow variables are finite-volume variables
+  bool isFV() const;
+
   /**
    * Check if the simulation includes derivatives of permeability
    * Note: when the permeability is constant, expensive tensor calculations
@@ -185,6 +188,9 @@ private:
 
   /// FE type used by the PorousFlow variables
   libMesh::FEType _fe_type;
+
+  /// Whether the PorousFlow variables are finite-volume variables
+  bool _is_fv;
 
   /// _moose_var_num[i] = the moose variable number corresponding to porous flow variable i
   std::vector<unsigned int> _moose_var_num;

--- a/modules/porous_flow/src/kernels/PorousFlowAdvectiveFlux.C
+++ b/modules/porous_flow/src/kernels/PorousFlowAdvectiveFlux.C
@@ -10,11 +10,13 @@
 #include "PorousFlowAdvectiveFlux.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowAdvectiveFlux);
+registerMooseObject("PorousFlowApp", ADPorousFlowAdvectiveFlux);
 
+template <bool is_ad>
 InputParameters
-PorousFlowAdvectiveFlux::validParams()
+PorousFlowAdvectiveFluxTempl<is_ad>::validParams()
 {
-  InputParameters params = PorousFlowDarcyBase::validParams();
+  InputParameters params = PorousFlowDarcyBaseTempl<is_ad>::validParams();
   params.addParam<unsigned int>(
       "fluid_component", 0, "The index corresponding to the fluid component for this kernel");
   params.addClassDescription(
@@ -22,20 +24,27 @@ PorousFlowAdvectiveFlux::validParams()
   return params;
 }
 
-PorousFlowAdvectiveFlux::PorousFlowAdvectiveFlux(const InputParameters & parameters)
-  : PorousFlowDarcyBase(parameters),
+template <bool is_ad>
+PorousFlowAdvectiveFluxTempl<is_ad>::PorousFlowAdvectiveFluxTempl(
+    const InputParameters & parameters)
+  : PorousFlowDarcyBaseTempl<is_ad>(parameters),
     _mass_fractions(
-        getMaterialProperty<std::vector<std::vector<Real>>>("PorousFlow_mass_frac_nodal")),
-    _dmass_fractions_dvar(getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
-        "dPorousFlow_mass_frac_nodal_dvar")),
-    _relative_permeability(
-        getMaterialProperty<std::vector<Real>>("PorousFlow_relative_permeability_nodal")),
-    _drelative_permeability_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_relative_permeability_nodal_dvar")),
-    _fluid_component(getParam<unsigned int>("fluid_component"))
+        this->template getGenericMaterialProperty<std::vector<std::vector<Real>>, is_ad>(
+            "PorousFlow_mass_frac_nodal")),
+    _dmass_fractions_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
+                    "dPorousFlow_mass_frac_nodal_dvar")),
+    _relative_permeability(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_relative_permeability_nodal")),
+    _drelative_permeability_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                    "dPorousFlow_relative_permeability_nodal_dvar")),
+    _fluid_component(this->template getParam<unsigned int>("fluid_component"))
 {
   if (_fluid_component >= _dictator.numComponents())
-    paramError(
+    this->paramError(
         "fluid_component",
         "The Dictator proclaims that the maximum fluid component index in this simulation is ",
         _dictator.numComponents() - 1,
@@ -44,26 +53,39 @@ PorousFlowAdvectiveFlux::PorousFlowAdvectiveFlux(const InputParameters & paramet
         ". Remember that indexing starts at 0. The Dictator does not take such mistakes lightly.");
 }
 
-Real
-PorousFlowAdvectiveFlux::mobility(unsigned nodenum, unsigned phase) const
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowAdvectiveFluxTempl<is_ad>::mobility(unsigned nodenum, unsigned phase) const
 {
   return _mass_fractions[nodenum][phase][_fluid_component] * _fluid_density_node[nodenum][phase] *
          _relative_permeability[nodenum][phase] / _fluid_viscosity[nodenum][phase];
 }
 
+template <bool is_ad>
 Real
-PorousFlowAdvectiveFlux::dmobility(unsigned nodenum, unsigned phase, unsigned pvar) const
+PorousFlowAdvectiveFluxTempl<is_ad>::dmobility(unsigned nodenum,
+                                               unsigned phase,
+                                               unsigned pvar) const
 {
-  Real dm = _dmass_fractions_dvar[nodenum][phase][_fluid_component][pvar] *
-            _fluid_density_node[nodenum][phase] * _relative_permeability[nodenum][phase] /
-            _fluid_viscosity[nodenum][phase];
-  dm += _mass_fractions[nodenum][phase][_fluid_component] *
-        _dfluid_density_node_dvar[nodenum][phase][pvar] * _relative_permeability[nodenum][phase] /
-        _fluid_viscosity[nodenum][phase];
-  dm += _mass_fractions[nodenum][phase][_fluid_component] * _fluid_density_node[nodenum][phase] *
-        _drelative_permeability_dvar[nodenum][phase][pvar] / _fluid_viscosity[nodenum][phase];
-  dm -= _mass_fractions[nodenum][phase][_fluid_component] * _fluid_density_node[nodenum][phase] *
-        _relative_permeability[nodenum][phase] * _dfluid_viscosity_dvar[nodenum][phase][pvar] /
-        std::pow(_fluid_viscosity[nodenum][phase], 2);
-  return dm;
+  if constexpr (!is_ad)
+  {
+    Real dm = (*_dmass_fractions_dvar)[nodenum][phase][_fluid_component][pvar] *
+              _fluid_density_node[nodenum][phase] * _relative_permeability[nodenum][phase] /
+              _fluid_viscosity[nodenum][phase];
+    dm += _mass_fractions[nodenum][phase][_fluid_component] *
+          (*_dfluid_density_node_dvar)[nodenum][phase][pvar] *
+          _relative_permeability[nodenum][phase] / _fluid_viscosity[nodenum][phase];
+    dm += _mass_fractions[nodenum][phase][_fluid_component] * _fluid_density_node[nodenum][phase] *
+          (*_drelative_permeability_dvar)[nodenum][phase][pvar] / _fluid_viscosity[nodenum][phase];
+    dm -= _mass_fractions[nodenum][phase][_fluid_component] * _fluid_density_node[nodenum][phase] *
+          _relative_permeability[nodenum][phase] * (*_dfluid_viscosity_dvar)[nodenum][phase][pvar] /
+          std::pow(_fluid_viscosity[nodenum][phase], 2);
+    return dm;
+  }
+  else
+    libmesh_ignore(nodenum, phase, pvar);
+  return 0.0;
 }
+
+template class PorousFlowAdvectiveFluxTempl<false>;
+template class PorousFlowAdvectiveFluxTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowBasicAdvection.C
+++ b/modules/porous_flow/src/kernels/PorousFlowBasicAdvection.C
@@ -10,11 +10,13 @@
 #include "PorousFlowBasicAdvection.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowBasicAdvection);
+registerMooseObject("PorousFlowApp", ADPorousFlowBasicAdvection);
 
+template <bool is_ad>
 InputParameters
-PorousFlowBasicAdvection::validParams()
+PorousFlowBasicAdvectionTempl<is_ad>::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
   params.addRequiredParam<UserObjectName>(
       "PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names.");
   params.addParam<unsigned int>("phase", 0, "Use the Darcy velocity of this fluid phase");
@@ -23,17 +25,22 @@ PorousFlowBasicAdvection::validParams()
   return params;
 }
 
-PorousFlowBasicAdvection::PorousFlowBasicAdvection(const InputParameters & parameters)
-  : Kernel(parameters),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-    _ph(getParam<unsigned int>("phase")),
-    _darcy_velocity(
-        getMaterialProperty<std::vector<RealVectorValue>>("PorousFlow_darcy_velocity_qp")),
-    _ddarcy_velocity_dvar(getMaterialProperty<std::vector<std::vector<RealVectorValue>>>(
-        "dPorousFlow_darcy_velocity_qp_dvar")),
-    _ddarcy_velocity_dgradvar(
-        getMaterialProperty<std::vector<std::vector<std::vector<RealVectorValue>>>>(
-            "dPorousFlow_darcy_velocity_qp_dgradvar"))
+template <bool is_ad>
+PorousFlowBasicAdvectionTempl<is_ad>::PorousFlowBasicAdvectionTempl(
+    const InputParameters & parameters)
+  : GenericKernel<is_ad>(parameters),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _ph(this->template getParam<unsigned int>("phase")),
+    _darcy_velocity(this->template getGenericMaterialProperty<std::vector<RealVectorValue>, is_ad>(
+        "PorousFlow_darcy_velocity_qp")),
+    _ddarcy_velocity_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<RealVectorValue>>>(
+                    "dPorousFlow_darcy_velocity_qp_dvar")),
+    _ddarcy_velocity_dgradvar(is_ad ? nullptr
+                                    : &this->template getMaterialProperty<
+                                          std::vector<std::vector<std::vector<RealVectorValue>>>>(
+                                          "dPorousFlow_darcy_velocity_qp_dgradvar"))
 {
   if (_ph >= _dictator.numPhases())
     paramError("phase",
@@ -45,31 +52,49 @@ PorousFlowBasicAdvection::PorousFlowBasicAdvection(const InputParameters & param
                "ensure your wellbeing.");
 }
 
-Real
-PorousFlowBasicAdvection::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowBasicAdvectionTempl<is_ad>::computeQpResidual()
 {
   return -_grad_test[_i][_qp] * _darcy_velocity[_qp][_ph] * _u[_qp];
 }
 
+template <bool is_ad>
 Real
-PorousFlowBasicAdvection::computeQpJacobian()
+PorousFlowBasicAdvectionTempl<is_ad>::computeQpJacobian()
 {
-  const Real result = -_grad_test[_i][_qp] * _darcy_velocity[_qp][_ph] * _phi[_j][_qp];
-  return result + computeQpOffDiagJacobian(_var.number());
+  if constexpr (!is_ad)
+  {
+    const Real result = -_grad_test[_i][_qp] * _darcy_velocity[_qp][_ph] * _phi[_j][_qp];
+    return result + computeQpOffDiagJacobian(_var.number());
+  }
+  return 0.0;
 }
 
+template <bool is_ad>
 Real
-PorousFlowBasicAdvection::computeQpOffDiagJacobian(unsigned int jvar)
+PorousFlowBasicAdvectionTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  if (_dictator.notPorousFlowVariable(jvar))
+  if constexpr (!is_ad)
+  {
+    if (_dictator.notPorousFlowVariable(jvar))
+      return 0.0;
+
+    const unsigned pvar = _dictator.porousFlowVariableNum(jvar);
+    Real result =
+        -_grad_test[_i][_qp] * (*_ddarcy_velocity_dvar)[_qp][_ph][pvar] * _phi[_j][_qp] * _u[_qp];
+    for (unsigned j = 0; j < LIBMESH_DIM; ++j)
+      result -= _grad_test[_i][_qp] *
+                ((*_ddarcy_velocity_dgradvar)[_qp][_ph][j][pvar] * _grad_phi[_j][_qp](j)) * _u[_qp];
+
+    return result;
+  }
+  else
+  {
+    libmesh_ignore(jvar);
     return 0.0;
-
-  const unsigned pvar = _dictator.porousFlowVariableNum(jvar);
-  Real result =
-      -_grad_test[_i][_qp] * _ddarcy_velocity_dvar[_qp][_ph][pvar] * _phi[_j][_qp] * _u[_qp];
-  for (unsigned j = 0; j < LIBMESH_DIM; ++j)
-    result -= _grad_test[_i][_qp] *
-              (_ddarcy_velocity_dgradvar[_qp][_ph][j][pvar] * _grad_phi[_j][_qp](j)) * _u[_qp];
-
-  return result;
+  }
 }
+
+template class PorousFlowBasicAdvectionTempl<false>;
+template class PorousFlowBasicAdvectionTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
@@ -95,6 +95,15 @@ PorousFlowDarcyBaseTempl<is_ad>::PorousFlowDarcyBaseTempl(const InputParameters 
     _num_upwinds(),
     _num_downwinds()
 {
+  // The full-upwinding scheme identifies each element test function with a mesh node, which is
+  // only valid for nodal (Lagrange) variables.
+  if (!_var.isNodal())
+    mooseError("The variable '",
+               _var.name(),
+               "' is not a nodal (Lagrange) variable.  This kernel uses full upwinding, which "
+               "requires a nodal variable.  For non-nodal variables use the non-upwinded "
+               "PorousFlowFullySaturated* kernels or Kuzmin-Turek (KT) stabilisation instead.");
+
 #ifdef LIBMESH_HAVE_TBB_API
   if (libMesh::n_threads() > 1)
     mooseWarning("PorousFlowDarcyBase: num_upwinds and num_downwinds may not be computed "

--- a/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
@@ -623,14 +623,12 @@ PorousFlowDarcyBaseTempl<is_ad>::harmonicMean(JacRes res_or_jac, unsigned int ph
 
   std::vector<GenericReal<is_ad>> mob(num_nodes);
   unsigned num_zero = 0;
-  unsigned zero_mobility_node = std::numeric_limits<unsigned>::max();
   GenericReal<is_ad> harmonic_mob = 0;
   for (unsigned n = 0; n < num_nodes; ++n)
   {
     mob[n] = mobility(n, ph);
     if (MetaPhysicL::raw_value(mob[n]) == 0.0)
     {
-      zero_mobility_node = n;
       num_zero++;
     }
     else
@@ -652,8 +650,12 @@ PorousFlowDarcyBaseTempl<is_ad>::harmonicMean(JacRes res_or_jac, unsigned int ph
           dharmonic_mob[n] =
               dmobility(n, ph, pvar) * harm2 / std::pow(MetaPhysicL::raw_value(mob[n]), 2);
       else if (num_zero == 1)
-        dharmonic_mob[zero_mobility_node] =
-            num_nodes * dmobility(zero_mobility_node, ph, pvar); // other derivs are zero
+        for (unsigned n = 0; n < num_nodes; ++n)
+          if (MetaPhysicL::raw_value(mob[n]) == 0.0)
+          {
+            dharmonic_mob[n] = num_nodes * dmobility(n, ph, pvar); // other derivs are zero
+            break;
+          }
       // if num_zero > 1 then all dharmonic_mob = 0.0
     }
 

--- a/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
@@ -228,8 +228,8 @@ PorousFlowDarcyBaseTempl<is_ad>::adComputeJacobian()
 
     const unsigned int num_nodes = _test.size();
     std::vector<ADReal> darcy_residuals(num_nodes, 0.0);
-    for (unsigned int n = 0; n < num_nodes; ++n)
-      for (unsigned int ph = 0; ph < _num_phases; ++ph)
+    for (const auto n : make_range(num_nodes))
+      for (const auto ph : make_range(_num_phases))
         darcy_residuals[n] += _proto_flux[ph][n];
 
     this->addJacobianWithoutConstraints(
@@ -266,8 +266,11 @@ PorousFlowDarcyBaseTempl<is_ad>::computeProtoFluxWithoutMobility()
   {
     _proto_flux[ph].assign(num_nodes, 0.0);
     for (_qp = 0; _qp < this->_qrule->n_points(); _qp++)
+    {
+      const Real jxw_coord = this->_JxW[_qp] * this->_coord[_qp];
       for (_i = 0; _i < num_nodes; ++_i)
-        _proto_flux[ph][_i] += this->_JxW[_qp] * this->_coord[_qp] * darcyQp(ph);
+        _proto_flux[ph][_i] += jxw_coord * darcyQp(ph);
+    }
   }
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
@@ -16,10 +16,11 @@
 
 #include "libmesh/quadrature.h"
 
+template <bool is_ad>
 InputParameters
-PorousFlowDarcyBase::validParams()
+PorousFlowDarcyBaseTempl<is_ad>::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
   params.addRequiredParam<RealVectorValue>("gravity",
                                            "Gravitational acceleration vector downwards (m/s^2)");
   params.addRequiredParam<UserObjectName>(
@@ -41,35 +42,54 @@ PorousFlowDarcyBase::validParams()
   return params;
 }
 
-PorousFlowDarcyBase::PorousFlowDarcyBase(const InputParameters & parameters)
-  : Kernel(parameters),
-    _permeability(getMaterialProperty<RealTensorValue>("PorousFlow_permeability_qp")),
-    _dpermeability_dvar(
-        getMaterialProperty<std::vector<RealTensorValue>>("dPorousFlow_permeability_qp_dvar")),
-    _dpermeability_dgradvar(getMaterialProperty<std::vector<std::vector<RealTensorValue>>>(
-        "dPorousFlow_permeability_qp_dgradvar")),
-    _fluid_density_node(
-        getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_density_nodal")),
-    _dfluid_density_node_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_fluid_phase_density_nodal_dvar")),
-    _fluid_density_qp(getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_density_qp")),
-    _dfluid_density_qp_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_fluid_phase_density_qp_dvar")),
-    _fluid_viscosity(getMaterialProperty<std::vector<Real>>("PorousFlow_viscosity_nodal")),
+template <bool is_ad>
+PorousFlowDarcyBaseTempl<is_ad>::PorousFlowDarcyBaseTempl(const InputParameters & parameters)
+  : GenericKernel<is_ad>(parameters),
+    _permeability(this->template getGenericMaterialProperty<RealTensorValue, is_ad>(
+        "PorousFlow_permeability_qp")),
+    _dpermeability_dvar(is_ad ? nullptr
+                              : &this->template getMaterialProperty<std::vector<RealTensorValue>>(
+                                    "dPorousFlow_permeability_qp_dvar")),
+    _dpermeability_dgradvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<RealTensorValue>>>(
+                    "dPorousFlow_permeability_qp_dgradvar")),
+    _fluid_density_node(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_fluid_phase_density_nodal")),
+    _dfluid_density_node_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                    "dPorousFlow_fluid_phase_density_nodal_dvar")),
+    _fluid_density_qp(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_fluid_phase_density_qp")),
+    _dfluid_density_qp_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                    "dPorousFlow_fluid_phase_density_qp_dvar")),
+    _fluid_viscosity(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_viscosity_nodal")),
     _dfluid_viscosity_dvar(
-        getMaterialProperty<std::vector<std::vector<Real>>>("dPorousFlow_viscosity_nodal_dvar")),
-    _pp(getMaterialProperty<std::vector<Real>>("PorousFlow_porepressure_nodal")),
-    _grad_p(getMaterialProperty<std::vector<RealGradient>>("PorousFlow_grad_porepressure_qp")),
-    _dgrad_p_dgrad_var(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_grad_porepressure_qp_dgradvar")),
-    _dgrad_p_dvar(getMaterialProperty<std::vector<std::vector<RealGradient>>>(
-        "dPorousFlow_grad_porepressure_qp_dvar")),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                    "dPorousFlow_viscosity_nodal_dvar")),
+    _pp(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_porepressure_nodal")),
+    _grad_p(this->template getGenericMaterialProperty<std::vector<RealGradient>, is_ad>(
+        "PorousFlow_grad_porepressure_qp")),
+    _dgrad_p_dgrad_var(is_ad ? nullptr
+                             : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                   "dPorousFlow_grad_porepressure_qp_dgradvar")),
+    _dgrad_p_dvar(is_ad
+                      ? nullptr
+                      : &this->template getMaterialProperty<std::vector<std::vector<RealGradient>>>(
+                            "dPorousFlow_grad_porepressure_qp_dvar")),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
     _num_phases(_dictator.numPhases()),
-    _gravity(getParam<RealVectorValue>("gravity")),
+    _gravity(this->template getParam<RealVectorValue>("gravity")),
     _perm_derivs(_dictator.usePermDerivs()),
-    _full_upwind_threshold(getParam<unsigned>("full_upwind_threshold")),
-    _fallback_scheme(getParam<MooseEnum>("fallback_scheme").getEnum<FallbackEnum>()),
+    _full_upwind_threshold(this->template getParam<unsigned>("full_upwind_threshold")),
+    _fallback_scheme(
+        this->template getParam<MooseEnum>("fallback_scheme").template getEnum<FallbackEnum>()),
     _proto_flux(_num_phases),
     _jacobian(_num_phases),
     _num_upwinds(),
@@ -82,106 +102,179 @@ PorousFlowDarcyBase::PorousFlowDarcyBase(const InputParameters & parameters)
 #endif
 }
 
+template <bool is_ad>
 void
-PorousFlowDarcyBase::timestepSetup()
+PorousFlowDarcyBaseTempl<is_ad>::timestepSetup()
 {
-  Kernel::timestepSetup();
+  GenericKernel<is_ad>::timestepSetup();
   _num_upwinds = std::unordered_map<unsigned, std::vector<std::vector<unsigned>>>();
   _num_downwinds = std::unordered_map<unsigned, std::vector<std::vector<unsigned>>>();
 }
 
-Real
-PorousFlowDarcyBase::darcyQp(unsigned int ph) const
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::jacobianSetup()
+{
+  GenericKernel<is_ad>::jacobianSetup();
+  _my_elem_darcy = nullptr;
+}
+
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowDarcyBaseTempl<is_ad>::darcyQp(unsigned int ph) const
 {
   return _grad_test[_i][_qp] *
          (_permeability[_qp] * (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity));
 }
 
+template <bool is_ad>
 Real
-PorousFlowDarcyBase::darcyQpJacobian(unsigned int jvar, unsigned int ph) const
+PorousFlowDarcyBaseTempl<is_ad>::darcyQpJacobian(unsigned int jvar, unsigned int ph) const
 {
-  if (_dictator.notPorousFlowVariable(jvar))
-    return 0.0;
-
-  const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
-
-  RealVectorValue deriv =
-      _permeability[_qp] * (_grad_phi[_j][_qp] * _dgrad_p_dgrad_var[_qp][ph][pvar] -
-                            _phi[_j][_qp] * _dfluid_density_qp_dvar[_qp][ph][pvar] * _gravity);
-
-  deriv += _permeability[_qp] * (_dgrad_p_dvar[_qp][ph][pvar] * _phi[_j][_qp]);
-
-  if (_perm_derivs)
+  if constexpr (!is_ad)
   {
-    deriv += _dpermeability_dvar[_qp][pvar] * _phi[_j][_qp] *
-             (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity);
-    for (const auto i : make_range(Moose::dim))
-      deriv += _dpermeability_dgradvar[_qp][i][pvar] * _grad_phi[_j][_qp](i) *
-               (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity);
-  }
+    if (_dictator.notPorousFlowVariable(jvar))
+      return 0.0;
 
-  return _grad_test[_i][_qp] * deriv;
+    const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
+
+    RealVectorValue deriv =
+        _permeability[_qp] * (_grad_phi[_j][_qp] * (*_dgrad_p_dgrad_var)[_qp][ph][pvar] -
+                              _phi[_j][_qp] * (*_dfluid_density_qp_dvar)[_qp][ph][pvar] * _gravity);
+
+    deriv += _permeability[_qp] * ((*_dgrad_p_dvar)[_qp][ph][pvar] * _phi[_j][_qp]);
+
+    if (_perm_derivs)
+    {
+      deriv += (*_dpermeability_dvar)[_qp][pvar] * _phi[_j][_qp] *
+               (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity);
+      for (const auto i : make_range(Moose::dim))
+        deriv += (*_dpermeability_dgradvar)[_qp][i][pvar] * _grad_phi[_j][_qp](i) *
+                 (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity);
+    }
+
+    return _grad_test[_i][_qp] * deriv;
+  }
+  else
+    libmesh_ignore(jvar, ph);
+  return 0.0;
 }
 
-Real
-PorousFlowDarcyBase::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowDarcyBaseTempl<is_ad>::computeQpResidual()
 {
   mooseError("PorousFlowDarcyBase: computeQpResidual called");
   return 0.0;
 }
 
+template <bool is_ad>
 void
-PorousFlowDarcyBase::computeResidual()
+PorousFlowDarcyBaseTempl<is_ad>::computeResidual()
 {
-  computeResidualAndJacobian(JacRes::CALCULATE_RESIDUAL, 0.0);
-}
-
-void
-PorousFlowDarcyBase::computeJacobian()
-{
-  computeResidualAndJacobian(JacRes::CALCULATE_JACOBIAN, _var.number());
-}
-
-void
-PorousFlowDarcyBase::computeOffDiagJacobian(const unsigned int jvar)
-{
-  computeResidualAndJacobian(JacRes::CALCULATE_JACOBIAN, jvar);
-}
-
-void
-PorousFlowDarcyBase::computeResidualAndJacobian(JacRes res_or_jac, unsigned int jvar)
-{
-  if ((res_or_jac == JacRes::CALCULATE_JACOBIAN) && _dictator.notPorousFlowVariable(jvar))
-    return;
-
-  // The PorousFlow variable index corresponding to the variable number jvar
-  const unsigned int pvar =
-      ((res_or_jac == JacRes::CALCULATE_JACOBIAN) ? _dictator.porousFlowVariableNum(jvar) : 0);
-
-  prepareMatrixTag(_assembly, _var.number(), jvar);
-  if ((_local_ke.n() == 0) && (res_or_jac == JacRes::CALCULATE_JACOBIAN)) // this removes a problem
-                                                                          // encountered in the
-                                                                          // initial timestep when
-                                                                          // use_displaced_mesh=true
-    return;
-
-  // The number of nodes in the element
-  const unsigned int num_nodes = _test.size();
-
-  // Compute the residual and jacobian without the mobility terms. Even if we are computing the
-  // Jacobian we still need this in order to see which nodes are upwind and which are downwind.
-  for (unsigned ph = 0; ph < _num_phases; ++ph)
+  if constexpr (!is_ad)
+    computeResidualAndJacobian(JacRes::CALCULATE_RESIDUAL, 0);
+  else
   {
-    _proto_flux[ph].assign(num_nodes, 0);
-    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    adComputeProtoFlux(false);
+    // Assemble the real-valued residual from the value parts of the ADReal proto fluxes
+    assembleProtoFluxResidual();
+  }
+}
+
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::assembleProtoFluxResidual()
+{
+  this->prepareVectorTag(this->_assembly, _var.number());
+  for (_i = 0; _i < _test.size(); _i++)
+    for (unsigned int ph = 0; ph < _num_phases; ++ph)
+      this->_local_re(_i) += MetaPhysicL::raw_value(_proto_flux[ph][_i]);
+  this->accumulateTaggedLocalResidual();
+
+  if (this->_has_save_in)
+    for (unsigned int i = 0; i < this->_save_in.size(); i++)
+      this->_save_in[i]->sys().solution().add_vector(this->_local_re,
+                                                     this->_save_in[i]->dofIndices());
+}
+
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::computeJacobian()
+{
+  if constexpr (!is_ad)
+    computeResidualAndJacobian(JacRes::CALCULATE_JACOBIAN, _var.number());
+  else
+    // Block-diagonal (e.g. PJFNK) assembly path: this is the only Jacobian call we get.
+    adComputeJacobian();
+}
+
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::adComputeJacobian()
+{
+  if constexpr (is_ad)
+  {
+    // Compute ADReal proto fluxes with upwind counting, then extract the Jacobian.
+    // Every block (diagonal and off-diagonal) is encoded in the ADReal derivatives, so a
+    // single call to addJacobianWithoutConstraints captures all variable sensitivities.
+    //
+    // See PorousFlowLumpedKernelBase.C::computeJacobian for the detailed rationale of why
+    // addJacobianWithoutConstraints (rather than the default ADKernel addJacobian) is required:
+    // each residual row's column set must be read from its own derivatives instead of being shared
+    // from row 0. There it is forced by mass-lumped nodal materials; here it is forced by the
+    // upwinding scheme, which makes each node's proto flux depend on a different set of nodal DOFs.
+    adComputeProtoFlux(true);
+
+    const unsigned int num_nodes = _test.size();
+    std::vector<ADReal> darcy_residuals(num_nodes, 0.0);
+    for (unsigned int n = 0; n < num_nodes; ++n)
+      for (unsigned int ph = 0; ph < _num_phases; ++ph)
+        darcy_residuals[n] += _proto_flux[ph][n];
+
+    this->addJacobianWithoutConstraints(
+        this->_assembly, darcy_residuals, this->dofIndices(), _var.scalingFactor());
+  }
+}
+
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::computeOffDiagJacobian(const unsigned int jvar)
+{
+  if constexpr (!is_ad)
+    computeResidualAndJacobian(JacRes::CALCULATE_JACOBIAN, jvar);
+  else
+  {
+    libmesh_ignore(jvar);
+    // Full (SMP) assembly calls this once per coupled variable; the first call performs the
+    // single AD pass that fills every block, and the guard makes the rest no-ops. This mirrors
+    // ADKernel::computeOffDiagJacobian and avoids the ADD-semantics double-counting.
+    if (_my_elem_darcy != this->_current_elem)
     {
-      for (_i = 0; _i < num_nodes; ++_i)
-        _proto_flux[ph][_i] += _JxW[_qp] * _coord[_qp] * darcyQp(ph);
+      adComputeJacobian();
+      _my_elem_darcy = this->_current_elem;
     }
   }
+}
 
-  // for this element, record whether each node is "upwind" or "downwind" (or neither)
-  const unsigned elem = _current_elem->id();
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::computeProtoFluxWithoutMobility()
+{
+  const unsigned int num_nodes = _test.size();
+  for (unsigned ph = 0; ph < _num_phases; ++ph)
+  {
+    _proto_flux[ph].assign(num_nodes, 0.0);
+    for (_qp = 0; _qp < this->_qrule->n_points(); _qp++)
+      for (_i = 0; _i < num_nodes; ++_i)
+        _proto_flux[ph][_i] += this->_JxW[_qp] * this->_coord[_qp] * darcyQp(ph);
+  }
+}
+
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::initializeUpwindTracking(unsigned elem, unsigned int num_nodes)
+{
   if (_num_upwinds.find(elem) == _num_upwinds.end())
   {
     _num_upwinds[elem] = std::vector<std::vector<unsigned>>(_num_phases);
@@ -192,51 +285,41 @@ PorousFlowDarcyBase::computeResidualAndJacobian(JacRes res_or_jac, unsigned int 
       _num_downwinds[elem][ph].assign(num_nodes, 0);
     }
   }
-  // record the information once per nonlinear iteration
-  if (res_or_jac == JacRes::CALCULATE_JACOBIAN && jvar == _var.number())
-  {
-    for (unsigned ph = 0; ph < _num_phases; ++ph)
-    {
-      for (unsigned nod = 0; nod < num_nodes; ++nod)
-      {
-        if (_proto_flux[ph][nod] > 0)
-          _num_upwinds[elem][ph][nod]++;
-        else if (_proto_flux[ph][nod] < 0)
-          _num_downwinds[elem][ph][nod]++;
-      }
-    }
-  }
+}
 
-  // based on _num_upwinds and _num_downwinds, calculate the maximum number
-  // of upwind-downwind swaps that have been encountered in this timestep
-  // for this element
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::updateUpwindCounts(unsigned elem, unsigned int num_nodes)
+{
+  for (unsigned ph = 0; ph < _num_phases; ++ph)
+    for (unsigned nod = 0; nod < num_nodes; ++nod)
+    {
+      if (_proto_flux[ph][nod] > 0)
+        _num_upwinds[elem][ph][nod]++;
+      else if (_proto_flux[ph][nod] < 0)
+        _num_downwinds[elem][ph][nod]++;
+    }
+}
+
+template <bool is_ad>
+std::vector<unsigned>
+PorousFlowDarcyBaseTempl<is_ad>::computeMaxSwaps(unsigned elem, unsigned int num_nodes) const
+{
   std::vector<unsigned> max_swaps(_num_phases, 0);
   for (unsigned ph = 0; ph < _num_phases; ++ph)
-  {
     for (unsigned nod = 0; nod < num_nodes; ++nod)
-      max_swaps[ph] = std::max(
-          max_swaps[ph], std::min(_num_upwinds[elem][ph][nod], _num_downwinds[elem][ph][nod]));
-  }
+      max_swaps[ph] =
+          std::max(max_swaps[ph],
+                   std::min(_num_upwinds.at(elem)[ph][nod], _num_downwinds.at(elem)[ph][nod]));
+  return max_swaps;
+}
 
-  // size the _jacobian correctly and calculate it for the case residual = _proto_flux
-  if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
-  {
-    for (unsigned ph = 0; ph < _num_phases; ++ph)
-    {
-      _jacobian[ph].resize(_local_ke.m());
-      for (_i = 0; _i < _test.size(); _i++)
-      {
-        _jacobian[ph][_i].assign(_local_ke.n(), 0.0);
-        for (_j = 0; _j < _phi.size(); _j++)
-          for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-            _jacobian[ph][_i][_j] += _JxW[_qp] * _coord[_qp] * darcyQpJacobian(jvar, ph);
-      }
-    }
-  }
-
-  // Loop over all the phases, computing the mass flux, which
-  // gets placed into _proto_flux, and the derivative of this
-  // which gets placed into _jacobian
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::applyUpwinding(const std::vector<unsigned> & max_swaps,
+                                                JacRes res_or_jac,
+                                                unsigned int pvar)
+{
   for (unsigned int ph = 0; ph < _num_phases; ++ph)
   {
     if (max_swaps[ph] < _full_upwind_threshold)
@@ -254,46 +337,124 @@ PorousFlowDarcyBase::computeResidualAndJacobian(JacRes res_or_jac, unsigned int 
       }
     }
   }
+}
+
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::adComputeProtoFlux(bool do_counting)
+{
+  const unsigned int num_nodes = _test.size();
+  computeProtoFluxWithoutMobility();
+
+  // Initialise upwind-tracking maps for this element on first encounter
+  const unsigned elem = this->_current_elem->id();
+  initializeUpwindTracking(elem, num_nodes);
+
+  if (do_counting)
+    updateUpwindCounts(elem, num_nodes);
+
+  // Determine how many upwind-downwind swaps have occurred this timestep
+  const std::vector<unsigned> max_swaps = computeMaxSwaps(elem, num_nodes);
+
+  // Apply mobility via the chosen upwinding scheme (always in residual mode for AD)
+  applyUpwinding(max_swaps, JacRes::CALCULATE_RESIDUAL, 0);
+}
+
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::computeResidualAndJacobian(JacRes res_or_jac, unsigned int jvar)
+{
+  if ((res_or_jac == JacRes::CALCULATE_JACOBIAN) && _dictator.notPorousFlowVariable(jvar))
+    return;
+
+  // The PorousFlow variable index corresponding to the variable number jvar
+  const unsigned int pvar =
+      ((res_or_jac == JacRes::CALCULATE_JACOBIAN) ? _dictator.porousFlowVariableNum(jvar) : 0);
+
+  this->prepareMatrixTag(this->_assembly, _var.number(), jvar);
+  if ((this->_local_ke.n() == 0) &&
+      (res_or_jac == JacRes::CALCULATE_JACOBIAN)) // this removes a problem
+                                                  // encountered in the
+                                                  // initial timestep when
+                                                  // use_displaced_mesh=true
+    return;
+
+  // The number of nodes in the element
+  const unsigned int num_nodes = _test.size();
+
+  // Compute the residual and jacobian without the mobility terms. Even if we are computing the
+  // Jacobian we still need this in order to see which nodes are upwind and which are downwind.
+  computeProtoFluxWithoutMobility();
+
+  // for this element, record whether each node is "upwind" or "downwind" (or neither)
+  const unsigned elem = this->_current_elem->id();
+  initializeUpwindTracking(elem, num_nodes);
+  // record the information once per nonlinear iteration
+  if (res_or_jac == JacRes::CALCULATE_JACOBIAN && jvar == _var.number())
+    updateUpwindCounts(elem, num_nodes);
+
+  // based on _num_upwinds and _num_downwinds, calculate the maximum number
+  // of upwind-downwind swaps that have been encountered in this timestep
+  // for this element
+  const std::vector<unsigned> max_swaps = computeMaxSwaps(elem, num_nodes);
+
+  // size the _jacobian correctly and calculate it for the case residual = _proto_flux
+  if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
+  {
+    for (unsigned ph = 0; ph < _num_phases; ++ph)
+    {
+      _jacobian[ph].resize(this->_local_ke.m());
+      for (_i = 0; _i < _test.size(); _i++)
+      {
+        _jacobian[ph][_i].assign(this->_local_ke.n(), 0.0);
+        for (_j = 0; _j < _phi.size(); _j++)
+          for (_qp = 0; _qp < this->_qrule->n_points(); _qp++)
+            _jacobian[ph][_i][_j] +=
+                this->_JxW[_qp] * this->_coord[_qp] * darcyQpJacobian(jvar, ph);
+      }
+    }
+  }
+
+  // Loop over all the phases, computing the mass flux, which
+  // gets placed into _proto_flux, and the derivative of this
+  // which gets placed into _jacobian
+  applyUpwinding(max_swaps, res_or_jac, pvar);
 
   // Add results to the Residual or Jacobian
   if (res_or_jac == JacRes::CALCULATE_RESIDUAL)
-  {
-    prepareVectorTag(_assembly, _var.number());
-    for (_i = 0; _i < _test.size(); _i++)
-      for (unsigned int ph = 0; ph < _num_phases; ++ph)
-        _local_re(_i) += _proto_flux[ph][_i];
-    accumulateTaggedLocalResidual();
-
-    if (_has_save_in)
-      for (unsigned int i = 0; i < _save_in.size(); i++)
-        _save_in[i]->sys().solution().add_vector(_local_re, _save_in[i]->dofIndices());
-  }
+    assembleProtoFluxResidual();
 
   if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
   {
     for (_i = 0; _i < _test.size(); _i++)
       for (_j = 0; _j < _phi.size(); _j++)
         for (unsigned int ph = 0; ph < _num_phases; ++ph)
-          _local_ke(_i, _j) += _jacobian[ph][_i][_j];
+          this->_local_ke(_i, _j) += _jacobian[ph][_i][_j];
 
-    accumulateTaggedLocalMatrix();
+    this->accumulateTaggedLocalMatrix();
 
-    if (_has_diag_save_in && jvar == _var.number())
+    if (this->_has_diag_save_in && jvar == _var.number())
     {
-      unsigned int rows = _local_ke.m();
+      unsigned int rows = this->_local_ke.m();
       DenseVector<Number> diag(rows);
       for (unsigned int i = 0; i < rows; i++)
-        diag(i) = _local_ke(i, i);
+        diag(i) = this->_local_ke(i, i);
 
-      for (unsigned int i = 0; i < _diag_save_in.size(); i++)
-        _diag_save_in[i]->sys().solution().add_vector(diag, _diag_save_in[i]->dofIndices());
+      for (unsigned int i = 0; i < this->_diag_save_in.size(); i++)
+        this->_diag_save_in[i]->sys().solution().add_vector(diag,
+                                                            this->_diag_save_in[i]->dofIndices());
     }
   }
 }
 
+template <bool is_ad>
 void
-PorousFlowDarcyBase::fullyUpwind(JacRes res_or_jac, unsigned int ph, unsigned int pvar)
+PorousFlowDarcyBaseTempl<is_ad>::fullyUpwind(JacRes res_or_jac, unsigned int ph, unsigned int pvar)
 {
+  // res_or_jac and pvar drive the hand-coded non-AD Jacobian only; the AD path ignores them
+  if constexpr (is_ad)
+    libmesh_ignore(res_or_jac, pvar);
+
   /**
    * Perform the full upwinding by multiplying the residuals at the upstream nodes by their
    * mobilities.
@@ -326,20 +487,20 @@ PorousFlowDarcyBase::fullyUpwind(JacRes res_or_jac, unsigned int ph, unsigned in
   // The number of nodes in the element
   const unsigned int num_nodes = _test.size();
 
-  Real mob;
-  Real dmob;
+  GenericReal<is_ad> mob;
   // Define variables used to ensure mass conservation
-  Real total_mass_out = 0.0;
-  Real total_in = 0.0;
+  GenericReal<is_ad> total_mass_out = 0.0;
+  GenericReal<is_ad> total_in = 0.0;
 
-  // The following holds derivatives of these
+  // The following holds derivatives of these (non-AD path only)
   std::vector<Real> dtotal_mass_out;
   std::vector<Real> dtotal_in;
-  if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
-  {
-    dtotal_mass_out.assign(num_nodes, 0.0);
-    dtotal_in.assign(num_nodes, 0.0);
-  }
+  if constexpr (!is_ad)
+    if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
+    {
+      dtotal_mass_out.assign(num_nodes, 0.0);
+      dtotal_in.assign(num_nodes, 0.0);
+    }
 
   // Perform the upwinding using the mobility
   std::vector<bool> upwind_node(num_nodes);
@@ -350,10 +511,86 @@ PorousFlowDarcyBase::fullyUpwind(JacRes res_or_jac, unsigned int ph, unsigned in
       upwind_node[n] = true;
       // The mobility at the upstream node
       mob = mobility(n, ph);
+      if constexpr (!is_ad)
+        if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
+        {
+          // The derivative of the mobility wrt the PorousFlow variable
+          const Real dmob = dmobility(n, ph, pvar);
+
+          for (_j = 0; _j < _phi.size(); _j++)
+            _jacobian[ph][n][_j] *= mob;
+
+          if (_test.size() == _phi.size())
+            /* mobility at node=n depends only on the variables at node=n, by construction.  For
+             * linear-lagrange variables, this means that Jacobian entries involving the derivative
+             * of mobility will only be nonzero for derivatives wrt variables at node=n.  Hence the
+             * [n][n] in the line below.  However, for other variable types (eg constant monomials)
+             * I cannot tell what variable number contributes to the derivative.  However, in all
+             * cases I can possibly imagine, the derivative is zero anyway, since in the full
+             * upwinding scheme, mobility shouldn't depend on these other sorts of variables.
+             */
+            _jacobian[ph][n][n] += dmob * MetaPhysicL::raw_value(_proto_flux[ph][n]);
+
+          for (_j = 0; _j < _phi.size(); _j++)
+            dtotal_mass_out[_j] += _jacobian[ph][n][_j];
+        }
+      _proto_flux[ph][n] *= mob;
+      total_mass_out += _proto_flux[ph][n];
+    }
+    else
+    {
+      upwind_node[n] = false;
+      total_in -= _proto_flux[ph][n]; /// note the -= means the result is positive
+      if constexpr (!is_ad)
+        if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
+          for (_j = 0; _j < _phi.size(); _j++)
+            dtotal_in[_j] -= _jacobian[ph][n][_j];
+    }
+  }
+
+  // Conserve mass over all phases by proportioning the total_mass_out mass to the inflow nodes,
+  // weighted by their proto_flux values
+  for (unsigned int n = 0; n < num_nodes; ++n)
+  {
+    if (!upwind_node[n]) // downstream node
+    {
+      if constexpr (!is_ad)
+        if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
+          for (_j = 0; _j < _phi.size(); _j++)
+          {
+            _jacobian[ph][n][_j] *= MetaPhysicL::raw_value(total_mass_out / total_in);
+            _jacobian[ph][n][_j] +=
+                MetaPhysicL::raw_value(_proto_flux[ph][n]) *
+                (dtotal_mass_out[_j] / MetaPhysicL::raw_value(total_in) -
+                 dtotal_in[_j] * MetaPhysicL::raw_value(total_mass_out) /
+                     MetaPhysicL::raw_value(total_in) / MetaPhysicL::raw_value(total_in));
+          }
+      _proto_flux[ph][n] *= total_mass_out / total_in;
+    }
+  }
+}
+
+template <bool is_ad>
+void
+PorousFlowDarcyBaseTempl<is_ad>::quickUpwind(JacRes res_or_jac, unsigned int ph, unsigned int pvar)
+{
+  // res_or_jac and pvar drive the hand-coded non-AD Jacobian only; the AD path ignores them
+  if constexpr (is_ad)
+    libmesh_ignore(res_or_jac, pvar);
+
+  // The number of nodes in the element
+  const unsigned int num_nodes = _test.size();
+
+  // Use the raw nodal mobility
+  for (unsigned int n = 0; n < num_nodes; ++n)
+  {
+    // The mobility at the node
+    const GenericReal<is_ad> mob = mobility(n, ph);
+    if constexpr (!is_ad)
       if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
       {
         // The derivative of the mobility wrt the PorousFlow variable
-        dmob = dmobility(n, ph, pvar);
+        const Real dmob = dmobility(n, ph, pvar);
 
         for (_j = 0; _j < _phi.size(); _j++)
           _jacobian[ph][n][_j] *= mob;
@@ -367,94 +604,31 @@ PorousFlowDarcyBase::fullyUpwind(JacRes res_or_jac, unsigned int ph, unsigned in
            * cases I can possibly imagine, the derivative is zero anyway, since in the full
            * upwinding scheme, mobility shouldn't depend on these other sorts of variables.
            */
-          _jacobian[ph][n][n] += dmob * _proto_flux[ph][n];
-
-        for (_j = 0; _j < _phi.size(); _j++)
-          dtotal_mass_out[_j] += _jacobian[ph][n][_j];
+          _jacobian[ph][n][n] += dmob * MetaPhysicL::raw_value(_proto_flux[ph][n]);
       }
-      _proto_flux[ph][n] *= mob;
-      total_mass_out += _proto_flux[ph][n];
-    }
-    else
-    {
-      upwind_node[n] = false;
-      total_in -= _proto_flux[ph][n]; /// note the -= means the result is positive
-      if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
-        for (_j = 0; _j < _phi.size(); _j++)
-          dtotal_in[_j] -= _jacobian[ph][n][_j];
-    }
-  }
-
-  // Conserve mass over all phases by proportioning the total_mass_out mass to the inflow nodes,
-  // weighted by their proto_flux values
-  for (unsigned int n = 0; n < num_nodes; ++n)
-  {
-    if (!upwind_node[n]) // downstream node
-    {
-      if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
-        for (_j = 0; _j < _phi.size(); _j++)
-        {
-          _jacobian[ph][n][_j] *= total_mass_out / total_in;
-          _jacobian[ph][n][_j] +=
-              _proto_flux[ph][n] * (dtotal_mass_out[_j] / total_in -
-                                    dtotal_in[_j] * total_mass_out / total_in / total_in);
-        }
-      _proto_flux[ph][n] *= total_mass_out / total_in;
-    }
-  }
-}
-
-void
-PorousFlowDarcyBase::quickUpwind(JacRes res_or_jac, unsigned int ph, unsigned int pvar)
-{
-  // The number of nodes in the element
-  const unsigned int num_nodes = _test.size();
-
-  Real mob;
-  Real dmob;
-
-  // Use the raw nodal mobility
-  for (unsigned int n = 0; n < num_nodes; ++n)
-  {
-    // The mobility at the node
-    mob = mobility(n, ph);
-    if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
-    {
-      // The derivative of the mobility wrt the PorousFlow variable
-      dmob = dmobility(n, ph, pvar);
-
-      for (_j = 0; _j < _phi.size(); _j++)
-        _jacobian[ph][n][_j] *= mob;
-
-      if (_test.size() == _phi.size())
-        /* mobility at node=n depends only on the variables at node=n, by construction.  For
-         * linear-lagrange variables, this means that Jacobian entries involving the derivative
-         * of mobility will only be nonzero for derivatives wrt variables at node=n.  Hence the
-         * [n][n] in the line below.  However, for other variable types (eg constant monomials)
-         * I cannot tell what variable number contributes to the derivative.  However, in all
-         * cases I can possibly imagine, the derivative is zero anyway, since in the full
-         * upwinding scheme, mobility shouldn't depend on these other sorts of variables.
-         */
-        _jacobian[ph][n][n] += dmob * _proto_flux[ph][n];
-    }
     _proto_flux[ph][n] *= mob;
   }
 }
 
+template <bool is_ad>
 void
-PorousFlowDarcyBase::harmonicMean(JacRes res_or_jac, unsigned int ph, unsigned int pvar)
+PorousFlowDarcyBaseTempl<is_ad>::harmonicMean(JacRes res_or_jac, unsigned int ph, unsigned int pvar)
 {
+  // res_or_jac and pvar drive the hand-coded non-AD Jacobian only; the AD path ignores them
+  if constexpr (is_ad)
+    libmesh_ignore(res_or_jac, pvar);
+
   // The number of nodes in the element
   const unsigned int num_nodes = _test.size();
 
-  std::vector<Real> mob(num_nodes);
+  std::vector<GenericReal<is_ad>> mob(num_nodes);
   unsigned num_zero = 0;
   unsigned zero_mobility_node = std::numeric_limits<unsigned>::max();
-  Real harmonic_mob = 0;
+  GenericReal<is_ad> harmonic_mob = 0;
   for (unsigned n = 0; n < num_nodes; ++n)
   {
     mob[n] = mobility(n, ph);
-    if (mob[n] == 0.0)
+    if (MetaPhysicL::raw_value(mob[n]) == 0.0)
     {
       zero_mobility_node = n;
       num_zero++;
@@ -467,45 +641,58 @@ PorousFlowDarcyBase::harmonicMean(JacRes res_or_jac, unsigned int ph, unsigned i
   else
     harmonic_mob = (1.0 * num_nodes) / harmonic_mob;
 
-  // d(harmonic_mob)/d(PorousFlow variable at node n)
+  // d(harmonic_mob)/d(PorousFlow variable at node n) -- non-AD path only
   std::vector<Real> dharmonic_mob(num_nodes, 0.0);
-  if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
-  {
-    const Real harm2 = std::pow(harmonic_mob, 2) / (1.0 * num_nodes);
-    if (num_zero == 0)
+  if constexpr (!is_ad)
+    if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
+    {
+      const Real harm2 = std::pow(MetaPhysicL::raw_value(harmonic_mob), 2) / (1.0 * num_nodes);
+      if (num_zero == 0)
+        for (unsigned n = 0; n < num_nodes; ++n)
+          dharmonic_mob[n] =
+              dmobility(n, ph, pvar) * harm2 / std::pow(MetaPhysicL::raw_value(mob[n]), 2);
+      else if (num_zero == 1)
+        dharmonic_mob[zero_mobility_node] =
+            num_nodes * dmobility(zero_mobility_node, ph, pvar); // other derivs are zero
+      // if num_zero > 1 then all dharmonic_mob = 0.0
+    }
+
+  if constexpr (!is_ad)
+    if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
       for (unsigned n = 0; n < num_nodes; ++n)
-        dharmonic_mob[n] = dmobility(n, ph, pvar) * harm2 / std::pow(mob[n], 2);
-    else if (num_zero == 1)
-      dharmonic_mob[zero_mobility_node] =
-          num_nodes * dmobility(zero_mobility_node, ph, pvar); // other derivs are zero
-    // if num_zero > 1 then all dharmonic_mob = 0.0
-  }
+        for (_j = 0; _j < _phi.size(); _j++)
+        {
+          _jacobian[ph][n][_j] *= MetaPhysicL::raw_value(harmonic_mob);
+          if (_test.size() == _phi.size())
+            _jacobian[ph][n][_j] += dharmonic_mob[_j] * MetaPhysicL::raw_value(_proto_flux[ph][n]);
+        }
 
-  if (res_or_jac == JacRes::CALCULATE_JACOBIAN)
-    for (unsigned n = 0; n < num_nodes; ++n)
-      for (_j = 0; _j < _phi.size(); _j++)
-      {
-        _jacobian[ph][n][_j] *= harmonic_mob;
-        if (_test.size() == _phi.size())
-          _jacobian[ph][n][_j] += dharmonic_mob[_j] * _proto_flux[ph][n];
-      }
-
-  if (res_or_jac == JacRes::CALCULATE_RESIDUAL)
-    for (unsigned n = 0; n < num_nodes; ++n)
-      _proto_flux[ph][n] *= harmonic_mob;
+  for (unsigned n = 0; n < num_nodes; ++n)
+    _proto_flux[ph][n] *= harmonic_mob;
 }
 
-Real
-PorousFlowDarcyBase::mobility(unsigned nodenum, unsigned phase) const
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowDarcyBaseTempl<is_ad>::mobility(unsigned nodenum, unsigned phase) const
 {
   return _fluid_density_node[nodenum][phase] / _fluid_viscosity[nodenum][phase];
 }
 
+template <bool is_ad>
 Real
-PorousFlowDarcyBase::dmobility(unsigned nodenum, unsigned phase, unsigned pvar) const
+PorousFlowDarcyBaseTempl<is_ad>::dmobility(unsigned nodenum, unsigned phase, unsigned pvar) const
 {
-  Real dm = _dfluid_density_node_dvar[nodenum][phase][pvar] / _fluid_viscosity[nodenum][phase];
-  dm -= _fluid_density_node[nodenum][phase] * _dfluid_viscosity_dvar[nodenum][phase][pvar] /
-        std::pow(_fluid_viscosity[nodenum][phase], 2);
-  return dm;
+  if constexpr (!is_ad)
+  {
+    Real dm = (*_dfluid_density_node_dvar)[nodenum][phase][pvar] / _fluid_viscosity[nodenum][phase];
+    dm -= _fluid_density_node[nodenum][phase] * (*_dfluid_viscosity_dvar)[nodenum][phase][pvar] /
+          std::pow(_fluid_viscosity[nodenum][phase], 2);
+    return dm;
+  }
+  else
+    libmesh_ignore(nodenum, phase, pvar);
+  return 0.0;
 }
+
+template class PorousFlowDarcyBaseTempl<false>;
+template class PorousFlowDarcyBaseTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowDesorpedMassTimeDerivative.C
+++ b/modules/porous_flow/src/kernels/PorousFlowDesorpedMassTimeDerivative.C
@@ -14,11 +14,15 @@
 #include "libmesh/quadrature.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowDesorpedMassTimeDerivative);
+registerMooseObject("PorousFlowApp", ADPorousFlowDesorpedMassTimeDerivative);
 
+template <bool is_ad>
 InputParameters
-PorousFlowDesorpedMassTimeDerivative::validParams()
+PorousFlowDesorpedMassTimeDerivativeTempl<is_ad>::validParams()
 {
-  InputParameters params = TimeKernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
+  params.set<MultiMooseEnum>("vector_tags") = "time";
+  params.set<MultiMooseEnum>("matrix_tags") = "system time";
   params.addRequiredParam<UserObjectName>(
       "PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names.");
   params.addRequiredCoupledVar(
@@ -27,55 +31,74 @@ PorousFlowDesorpedMassTimeDerivative::validParams()
   return params;
 }
 
-PorousFlowDesorpedMassTimeDerivative::PorousFlowDesorpedMassTimeDerivative(
+template <bool is_ad>
+PorousFlowDesorpedMassTimeDerivativeTempl<is_ad>::PorousFlowDesorpedMassTimeDerivativeTempl(
     const InputParameters & parameters)
-  : TimeKernel(parameters),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-    _conc_var_number(coupled("conc_var")),
-    _conc(coupledValue("conc_var")),
-    _conc_old(coupledValueOld("conc_var")),
-    _porosity(getMaterialProperty<Real>("PorousFlow_porosity_qp")),
-    _porosity_old(getMaterialPropertyOld<Real>("PorousFlow_porosity_qp")),
-    _dporosity_dvar(getMaterialProperty<std::vector<Real>>("dPorousFlow_porosity_qp_dvar")),
-    _dporosity_dgradvar(
-        getMaterialProperty<std::vector<RealGradient>>("dPorousFlow_porosity_qp_dgradvar"))
+  : GenericKernel<is_ad>(parameters),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _conc_var_number(this->coupled("conc_var")),
+    _conc(this->template coupledGenericValue<is_ad>("conc_var")),
+    _conc_old(this->coupledValueOld("conc_var")),
+    _porosity(this->template getGenericMaterialProperty<Real, is_ad>("PorousFlow_porosity_qp")),
+    _porosity_old(this->template getMaterialPropertyOld<Real>("PorousFlow_porosity_qp")),
+    _dporosity_dvar(is_ad ? nullptr
+                          : &this->template getMaterialProperty<std::vector<Real>>(
+                                "dPorousFlow_porosity_qp_dvar")),
+    _dporosity_dgradvar(is_ad ? nullptr
+                              : &this->template getMaterialProperty<std::vector<RealGradient>>(
+                                    "dPorousFlow_porosity_qp_dgradvar"))
 {
 }
 
-Real
-PorousFlowDesorpedMassTimeDerivative::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowDesorpedMassTimeDerivativeTempl<is_ad>::computeQpResidual()
 {
-  Real c = (1.0 - _porosity[_qp]) * _conc[_qp];
+  GenericReal<is_ad> c = (1.0 - _porosity[_qp]) * _conc[_qp];
   Real c_old = (1.0 - _porosity_old[_qp]) * _conc_old[_qp];
-  return _test[_i][_qp] * (c - c_old) / _dt;
+  return _test[_i][_qp] * (c - c_old) / this->_dt;
 }
 
+template <bool is_ad>
 Real
-PorousFlowDesorpedMassTimeDerivative::computeQpJacobian()
+PorousFlowDesorpedMassTimeDerivativeTempl<is_ad>::computeQpJacobian()
 {
   return computeQpJac(_var.number());
 }
 
+template <bool is_ad>
 Real
-PorousFlowDesorpedMassTimeDerivative::computeQpOffDiagJacobian(unsigned int jvar)
+PorousFlowDesorpedMassTimeDerivativeTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
 {
   return computeQpJac(jvar);
 }
 
+template <bool is_ad>
 Real
-PorousFlowDesorpedMassTimeDerivative::computeQpJac(unsigned int jvar) const
+PorousFlowDesorpedMassTimeDerivativeTempl<is_ad>::computeQpJac(unsigned int jvar)
 {
-  Real deriv = 0.0;
+  if constexpr (!is_ad)
+  {
+    Real deriv = 0.0;
 
-  if (jvar == _conc_var_number)
-    deriv = (1.0 - _porosity[_qp]) * _phi[_j][_qp];
+    if (jvar == _conc_var_number)
+      deriv = (1.0 - this->_porosity[this->_qp]) * this->_phi[this->_j][this->_qp];
 
-  if (_dictator.notPorousFlowVariable(jvar))
-    return _test[_i][_qp] * deriv / _dt;
-  const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
+    if (_dictator.notPorousFlowVariable(jvar))
+      return this->_test[this->_i][this->_qp] * deriv / this->_dt;
+    const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
 
-  deriv -= _dporosity_dgradvar[_qp][pvar] * _grad_phi[_j][_qp] * _conc[_qp];
-  deriv -= _dporosity_dvar[_qp][pvar] * _phi[_j][_qp] * _conc[_qp];
+    deriv -= (*_dporosity_dgradvar)[this->_qp][pvar] * this->_grad_phi[this->_j][this->_qp] *
+             this->_conc[this->_qp];
+    deriv -= (*_dporosity_dvar)[this->_qp][pvar] * this->_phi[this->_j][this->_qp] *
+             this->_conc[this->_qp];
 
-  return _test[_i][_qp] * deriv / _dt;
+    return this->_test[this->_i][this->_qp] * deriv / this->_dt;
+  }
+  else
+    libmesh_ignore(jvar);
+  return 0.0;
 }
+
+template class PorousFlowDesorpedMassTimeDerivativeTempl<false>;
+template class PorousFlowDesorpedMassTimeDerivativeTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowDispersiveFlux.C
+++ b/modules/porous_flow/src/kernels/PorousFlowDispersiveFlux.C
@@ -12,11 +12,13 @@
 #include "MooseVariable.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowDispersiveFlux);
+registerMooseObject("PorousFlowApp", ADPorousFlowDispersiveFlux);
 
+template <bool is_ad>
 InputParameters
-PorousFlowDispersiveFlux::validParams()
+PorousFlowDispersiveFluxTempl<is_ad>::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
   params.addParam<unsigned int>(
       "fluid_component", 0, "The index corresponding to the fluid component for this kernel");
   params.addRequiredParam<UserObjectName>(
@@ -32,53 +34,79 @@ PorousFlowDispersiveFlux::validParams()
   return params;
 }
 
-PorousFlowDispersiveFlux::PorousFlowDispersiveFlux(const InputParameters & parameters)
-  : Kernel(parameters),
-
-    _fluid_density_qp(getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_density_qp")),
-    _dfluid_density_qp_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_fluid_phase_density_qp_dvar")),
-    _grad_mass_frac(getMaterialProperty<std::vector<std::vector<RealGradient>>>(
-        "PorousFlow_grad_mass_frac_qp")),
-    _dmass_frac_dvar(getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
-        "dPorousFlow_mass_frac_qp_dvar")),
-    _porosity_qp(getMaterialProperty<Real>("PorousFlow_porosity_qp")),
-    _dporosity_qp_dvar(getMaterialProperty<std::vector<Real>>("dPorousFlow_porosity_qp_dvar")),
-    _tortuosity(getMaterialProperty<std::vector<Real>>("PorousFlow_tortuosity_qp")),
-    _dtortuosity_dvar(
-        getMaterialProperty<std::vector<std::vector<Real>>>("dPorousFlow_tortuosity_qp_dvar")),
-    _diffusion_coeff(
-        getMaterialProperty<std::vector<std::vector<Real>>>("PorousFlow_diffusion_coeff_qp")),
-    _ddiffusion_coeff_dvar(getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
-        "dPorousFlow_diffusion_coeff_qp_dvar")),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-    _fluid_component(getParam<unsigned int>("fluid_component")),
+template <bool is_ad>
+PorousFlowDispersiveFluxTempl<is_ad>::PorousFlowDispersiveFluxTempl(
+    const InputParameters & parameters)
+  : GenericKernel<is_ad>(parameters),
+    _fluid_density_qp(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_fluid_phase_density_qp")),
+    _dfluid_density_qp_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                    "dPorousFlow_fluid_phase_density_qp_dvar")),
+    _grad_mass_frac(
+        this->template getGenericMaterialProperty<std::vector<std::vector<RealGradient>>, is_ad>(
+            "PorousFlow_grad_mass_frac_qp")),
+    _dmass_frac_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
+                    "dPorousFlow_mass_frac_qp_dvar")),
+    _porosity_qp(this->template getGenericMaterialProperty<Real, is_ad>("PorousFlow_porosity_qp")),
+    _dporosity_qp_dvar(is_ad ? nullptr
+                             : &this->template getMaterialProperty<std::vector<Real>>(
+                                   "dPorousFlow_porosity_qp_dvar")),
+    _tortuosity(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_tortuosity_qp")),
+    _dtortuosity_dvar(is_ad ? nullptr
+                            : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                  "dPorousFlow_tortuosity_qp_dvar")),
+    _diffusion_coeff(this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+        "PorousFlow_diffusion_coeff_qp")),
+    _ddiffusion_coeff_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
+                    "dPorousFlow_diffusion_coeff_qp_dvar")),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _fluid_component(this->template getParam<unsigned int>("fluid_component")),
     _num_phases(_dictator.numPhases()),
-    _identity_tensor(RankTwoTensor::initIdentity),
-    _relative_permeability(
-        getMaterialProperty<std::vector<Real>>("PorousFlow_relative_permeability_qp")),
-    _drelative_permeability_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_relative_permeability_qp_dvar")),
-    _fluid_viscosity(getMaterialProperty<std::vector<Real>>("PorousFlow_viscosity_qp")),
+    _identity_tensor(GenericRankTwoTensor<is_ad>::initIdentity),
+    _relative_permeability(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_relative_permeability_qp")),
+    _drelative_permeability_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                    "dPorousFlow_relative_permeability_qp_dvar")),
+    _fluid_viscosity(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_viscosity_qp")),
     _dfluid_viscosity_dvar(
-        getMaterialProperty<std::vector<std::vector<Real>>>("dPorousFlow_viscosity_qp_dvar")),
-    _permeability(getMaterialProperty<RealTensorValue>("PorousFlow_permeability_qp")),
-    _dpermeability_dvar(
-        getMaterialProperty<std::vector<RealTensorValue>>("dPorousFlow_permeability_qp_dvar")),
-    _dpermeability_dgradvar(getMaterialProperty<std::vector<std::vector<RealTensorValue>>>(
-        "dPorousFlow_permeability_qp_dgradvar")),
-    _grad_p(getMaterialProperty<std::vector<RealGradient>>("PorousFlow_grad_porepressure_qp")),
-    _dgrad_p_dgrad_var(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_grad_porepressure_qp_dgradvar")),
-    _dgrad_p_dvar(getMaterialProperty<std::vector<std::vector<RealGradient>>>(
-        "dPorousFlow_grad_porepressure_qp_dvar")),
-    _gravity(getParam<RealVectorValue>("gravity")),
-    _disp_long(getParam<std::vector<Real>>("disp_long")),
-    _disp_trans(getParam<std::vector<Real>>("disp_trans")),
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                    "dPorousFlow_viscosity_qp_dvar")),
+    _permeability(this->template getGenericMaterialProperty<RealTensorValue, is_ad>(
+        "PorousFlow_permeability_qp")),
+    _dpermeability_dvar(is_ad ? nullptr
+                              : &this->template getMaterialProperty<std::vector<RealTensorValue>>(
+                                    "dPorousFlow_permeability_qp_dvar")),
+    _dpermeability_dgradvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<RealTensorValue>>>(
+                    "dPorousFlow_permeability_qp_dgradvar")),
+    _grad_p(this->template getGenericMaterialProperty<std::vector<RealGradient>, is_ad>(
+        "PorousFlow_grad_porepressure_qp")),
+    _dgrad_p_dgrad_var(is_ad ? nullptr
+                             : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                   "dPorousFlow_grad_porepressure_qp_dgradvar")),
+    _dgrad_p_dvar(is_ad
+                      ? nullptr
+                      : &this->template getMaterialProperty<std::vector<std::vector<RealGradient>>>(
+                            "dPorousFlow_grad_porepressure_qp_dvar")),
+    _gravity(this->template getParam<RealVectorValue>("gravity")),
+    _disp_long(this->template getParam<std::vector<Real>>("disp_long")),
+    _disp_trans(this->template getParam<std::vector<Real>>("disp_trans")),
     _perm_derivs(_dictator.usePermDerivs())
 {
   if (_fluid_component >= _dictator.numComponents())
-    paramError(
+    this->paramError(
         "fluid_component",
         "The Dictator proclaims that the maximum fluid component index in this simulation is ",
         _dictator.numComponents() - 1,
@@ -86,47 +114,43 @@ PorousFlowDispersiveFlux::PorousFlowDispersiveFlux(const InputParameters & param
         _fluid_component,
         ". Remember that indexing starts at 0. The Dictator does not take such mistakes lightly.");
 
-  // Check that sufficient values of the dispersion coefficients have been entered
   if (_disp_long.size() != _num_phases)
-    paramError(
+    this->paramError(
         "disp_long",
         "The number of longitudinal dispersion coefficients is not equal to the number of phases");
 
   if (_disp_trans.size() != _num_phases)
-    paramError("disp_trans",
-               "The number of transverse dispersion coefficients disp_trans is not equal to the "
-               "number of phases");
+    this->paramError("disp_trans",
+                     "The number of transverse dispersion coefficients disp_trans is not equal to "
+                     "the number of phases");
 }
 
-Real
-PorousFlowDispersiveFlux::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowDispersiveFluxTempl<is_ad>::computeQpResidual()
 {
-  RealVectorValue flux = 0.0;
-  RealVectorValue velocity;
-  Real velocity_abs;
-  RankTwoTensor v2;
-  RankTwoTensor dispersion;
+  GenericRealVectorValue<is_ad> flux;
+  GenericRealVectorValue<is_ad> velocity;
+  GenericReal<is_ad> velocity_abs;
+  GenericRankTwoTensor<is_ad> v2;
+  GenericRankTwoTensor<is_ad> dispersion;
   dispersion.zero();
-  Real diffusion;
+  GenericReal<is_ad> diffusion;
 
   for (unsigned int ph = 0; ph < _num_phases; ++ph)
   {
-    // Diffusive component
     diffusion =
         _porosity_qp[_qp] * _tortuosity[_qp][ph] * _diffusion_coeff[_qp][ph][_fluid_component];
 
-    // Calculate Darcy velocity
-    velocity = (_permeability[_qp] * (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity) *
-                _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph]);
-    velocity_abs = std::sqrt(velocity * velocity);
+    velocity = _permeability[_qp] * (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity) *
+               _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph];
+    velocity_abs = velocity.norm();
 
-    if (velocity_abs > 0.0)
+    if (MetaPhysicL::raw_value(velocity_abs) > 0.0)
     {
-      v2 = RankTwoTensor::selfOuterProduct(velocity);
-
-      // Add longitudinal dispersion to diffusive component
-      diffusion += _disp_trans[ph] * velocity_abs;
-      dispersion = (_disp_long[ph] - _disp_trans[ph]) * v2 / velocity_abs;
+      v2 = GenericRankTwoTensor<is_ad>::selfOuterProduct(velocity);
+      diffusion += GenericReal<is_ad>(_disp_trans[ph]) * velocity_abs;
+      dispersion = GenericReal<is_ad>(_disp_long[ph] - _disp_trans[ph]) * v2 / velocity_abs;
     }
 
     flux += _fluid_density_qp[_qp][ph] * (diffusion * _identity_tensor + dispersion) *
@@ -135,116 +159,124 @@ PorousFlowDispersiveFlux::computeQpResidual()
   return _grad_test[_i][_qp] * flux;
 }
 
+template <bool is_ad>
 Real
-PorousFlowDispersiveFlux::computeQpJacobian()
+PorousFlowDispersiveFluxTempl<is_ad>::computeQpJacobian()
 {
   return computeQpJac(_var.number());
 }
 
+template <bool is_ad>
 Real
-PorousFlowDispersiveFlux::computeQpOffDiagJacobian(unsigned int jvar)
+PorousFlowDispersiveFluxTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
 {
   return computeQpJac(jvar);
 }
 
+template <bool is_ad>
 Real
-PorousFlowDispersiveFlux::computeQpJac(unsigned int jvar) const
+PorousFlowDispersiveFluxTempl<is_ad>::computeQpJac(unsigned int jvar) const
 {
-  // If the variable is not a valid PorousFlow variable, set the Jacobian to 0
-  if (_dictator.notPorousFlowVariable(jvar))
-    return 0.0;
-
-  const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
-
-  RealVectorValue velocity;
-  Real velocity_abs;
-  RankTwoTensor v2;
-  RankTwoTensor dispersion;
-  dispersion.zero();
-  Real diffusion;
-  RealVectorValue dflux = 0.0;
-
-  for (unsigned int ph = 0; ph < _num_phases; ++ph)
+  if constexpr (!is_ad)
   {
-    // Diffusive component
-    diffusion =
-        _porosity_qp[_qp] * _tortuosity[_qp][ph] * _diffusion_coeff[_qp][ph][_fluid_component];
+    if (_dictator.notPorousFlowVariable(jvar))
+      return 0.0;
 
-    // Calculate Darcy velocity
-    velocity = (_permeability[_qp] * (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity) *
-                _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph]);
-    velocity_abs = std::sqrt(velocity * velocity);
+    const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
 
-    if (velocity_abs > 0.0)
+    RealVectorValue velocity;
+    Real velocity_abs;
+    RankTwoTensor v2;
+    RankTwoTensor dispersion;
+    dispersion.zero();
+    Real diffusion;
+    RealVectorValue dflux = 0.0;
+
+    for (unsigned int ph = 0; ph < _num_phases; ++ph)
     {
-      v2 = RankTwoTensor::selfOuterProduct(velocity);
+      diffusion =
+          _porosity_qp[_qp] * _tortuosity[_qp][ph] * _diffusion_coeff[_qp][ph][_fluid_component];
 
-      // Add longitudinal dispersion to diffusive component
-      diffusion += _disp_trans[ph] * velocity_abs;
-      dispersion = (_disp_long[ph] - _disp_trans[ph]) * v2 / velocity_abs;
-    }
+      velocity = _permeability[_qp] * (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity) *
+                 _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph];
+      velocity_abs = MetaPhysicL::raw_value(velocity).norm();
 
-    // Derivative of Darcy velocity
-    RealVectorValue dvelocity =
-        _permeability[_qp] * (_grad_phi[_j][_qp] * _dgrad_p_dgrad_var[_qp][ph][pvar] -
-                              _phi[_j][_qp] * _dfluid_density_qp_dvar[_qp][ph][pvar] * _gravity);
-    dvelocity += _permeability[_qp] * (_dgrad_p_dvar[_qp][ph][pvar] * _phi[_j][_qp]);
+      if (velocity_abs > 0.0)
+      {
+        v2 = RankTwoTensor::selfOuterProduct(velocity);
+        diffusion += _disp_trans[ph] * velocity_abs;
+        dispersion = (_disp_long[ph] - _disp_trans[ph]) * v2 / velocity_abs;
+      }
 
-    if (_perm_derivs)
-    {
-      dvelocity += _dpermeability_dvar[_qp][pvar] * _phi[_j][_qp] *
-                   (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity);
+      RealVectorValue dvelocity =
+          _permeability[_qp] *
+          (_grad_phi[_j][_qp] * (*_dgrad_p_dgrad_var)[_qp][ph][pvar] -
+           _phi[_j][_qp] * (*_dfluid_density_qp_dvar)[_qp][ph][pvar] * _gravity);
+      dvelocity += _permeability[_qp] * ((*_dgrad_p_dvar)[_qp][ph][pvar] * _phi[_j][_qp]);
 
-      for (const auto i : make_range(Moose::dim))
-        dvelocity += _dpermeability_dgradvar[_qp][i][pvar] * _grad_phi[_j][_qp](i) *
+      if (_perm_derivs)
+      {
+        dvelocity += (*_dpermeability_dvar)[_qp][pvar] * _phi[_j][_qp] *
                      (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity);
+
+        for (const auto i : make_range(Moose::dim))
+          dvelocity += (*_dpermeability_dgradvar)[_qp][i][pvar] * _grad_phi[_j][_qp](i) *
+                       (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity);
+      }
+
+      dvelocity =
+          dvelocity * _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph] +
+          (_permeability[_qp] * (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity)) *
+              ((*_drelative_permeability_dvar)[_qp][ph][pvar] / _fluid_viscosity[_qp][ph] -
+               _relative_permeability[_qp][ph] * (*_dfluid_viscosity_dvar)[_qp][ph][pvar] /
+                   std::pow(_fluid_viscosity[_qp][ph], 2)) *
+              _phi[_j][_qp];
+
+      Real dvelocity_abs = 0.0;
+      if (velocity_abs > 0.0)
+        dvelocity_abs = velocity * dvelocity / velocity_abs;
+
+      Real ddiffusion = _phi[_j][_qp] * (*_dporosity_qp_dvar)[_qp][pvar] * _tortuosity[_qp][ph] *
+                        _diffusion_coeff[_qp][ph][_fluid_component];
+      ddiffusion += _phi[_j][_qp] * _porosity_qp[_qp] * (*_dtortuosity_dvar)[_qp][ph][pvar] *
+                    _diffusion_coeff[_qp][ph][_fluid_component];
+      ddiffusion += _phi[_j][_qp] * _porosity_qp[_qp] * _tortuosity[_qp][ph] *
+                    (*_ddiffusion_coeff_dvar)[_qp][ph][_fluid_component][pvar];
+      ddiffusion += _disp_trans[ph] * dvelocity_abs;
+
+      RankTwoTensor ddispersion;
+      ddispersion.zero();
+      if (velocity_abs > 0.0)
+      {
+        RankTwoTensor dv2a, dv2b;
+        dv2a = RankTwoTensor::outerProduct(velocity, dvelocity);
+        dv2b = RankTwoTensor::outerProduct(dvelocity, velocity);
+        ddispersion = (_disp_long[ph] - _disp_trans[ph]) * (dv2a + dv2b) / velocity_abs;
+        ddispersion -=
+            (_disp_long[ph] - _disp_trans[ph]) * v2 * dvelocity_abs / velocity_abs / velocity_abs;
+      }
+
+      dflux += _phi[_j][_qp] * (*_dfluid_density_qp_dvar)[_qp][ph][pvar] *
+               (diffusion * RankTwoTensor(RankTwoTensor::initIdentity) + dispersion) *
+               _grad_mass_frac[_qp][ph][_fluid_component];
+      dflux += _fluid_density_qp[_qp][ph] *
+               (ddiffusion * RankTwoTensor(RankTwoTensor::initIdentity) + ddispersion) *
+               _grad_mass_frac[_qp][ph][_fluid_component];
+
+      // NOTE: Here we assume that d(grad_mass_frac)/d(var) = d(mass_frac)/d(var) * grad_phi
+      //       This is true for most PorousFlow scenarios, but not for chemical reactions
+      //       where mass_frac is a nonlinear function of the primary MOOSE Variables
+      dflux += _fluid_density_qp[_qp][ph] *
+               (diffusion * RankTwoTensor(RankTwoTensor::initIdentity) + dispersion) *
+               (*_dmass_frac_dvar)[_qp][ph][_fluid_component][pvar] * _grad_phi[_j][_qp];
     }
 
-    dvelocity = dvelocity * _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph] +
-                (_permeability[_qp] * (_grad_p[_qp][ph] - _fluid_density_qp[_qp][ph] * _gravity)) *
-                    (_drelative_permeability_dvar[_qp][ph][pvar] / _fluid_viscosity[_qp][ph] -
-                     _relative_permeability[_qp][ph] * _dfluid_viscosity_dvar[_qp][ph][pvar] /
-                         std::pow(_fluid_viscosity[_qp][ph], 2)) *
-                    _phi[_j][_qp];
-
-    Real dvelocity_abs = 0.0;
-    if (velocity_abs > 0.0)
-      dvelocity_abs = velocity * dvelocity / velocity_abs;
-
-    // Derivative of diffusion term (note: dispersivity is assumed constant)
-    Real ddiffusion = _phi[_j][_qp] * _dporosity_qp_dvar[_qp][pvar] * _tortuosity[_qp][ph] *
-                      _diffusion_coeff[_qp][ph][_fluid_component];
-    ddiffusion += _phi[_j][_qp] * _porosity_qp[_qp] * _dtortuosity_dvar[_qp][ph][pvar] *
-                  _diffusion_coeff[_qp][ph][_fluid_component];
-    ddiffusion += _phi[_j][_qp] * _porosity_qp[_qp] * _tortuosity[_qp][ph] *
-                  _ddiffusion_coeff_dvar[_qp][ph][_fluid_component][pvar];
-    ddiffusion += _disp_trans[ph] * dvelocity_abs;
-
-    // Derivative of dispersion term (note: dispersivity is assumed constant)
-    RankTwoTensor ddispersion;
-    ddispersion.zero();
-    if (velocity_abs > 0.0)
-    {
-      RankTwoTensor dv2a, dv2b;
-      dv2a = RankTwoTensor::outerProduct(velocity, dvelocity);
-      dv2b = RankTwoTensor::outerProduct(dvelocity, velocity);
-      ddispersion = (_disp_long[ph] - _disp_trans[ph]) * (dv2a + dv2b) / velocity_abs;
-      ddispersion -=
-          (_disp_long[ph] - _disp_trans[ph]) * v2 * dvelocity_abs / velocity_abs / velocity_abs;
-    }
-
-    dflux += _phi[_j][_qp] * _dfluid_density_qp_dvar[_qp][ph][pvar] *
-             (diffusion * _identity_tensor + dispersion) *
-             _grad_mass_frac[_qp][ph][_fluid_component];
-    dflux += _fluid_density_qp[_qp][ph] * (ddiffusion * _identity_tensor + ddispersion) *
-             _grad_mass_frac[_qp][ph][_fluid_component];
-
-    // NOTE: Here we assume that d(grad_mass_frac)/d(var) = d(mass_frac)/d(var) * grad_phi
-    //       This is true for most PorousFlow scenarios, but not for chemical reactions
-    //       where mass_frac is a nonlinear function of the primary MOOSE Variables
-    dflux += _fluid_density_qp[_qp][ph] * (diffusion * _identity_tensor + dispersion) *
-             _dmass_frac_dvar[_qp][ph][_fluid_component][pvar] * _grad_phi[_j][_qp];
+    return _grad_test[_i][_qp] * dflux;
   }
-
-  return _grad_test[_i][_qp] * dflux;
+  else
+    libmesh_ignore(jvar);
+  return 0.0;
 }
+
+template class PorousFlowDispersiveFluxTempl<false>;
+template class PorousFlowDispersiveFluxTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowDispersiveFlux.C
+++ b/modules/porous_flow/src/kernels/PorousFlowDispersiveFlux.C
@@ -257,17 +257,15 @@ PorousFlowDispersiveFluxTempl<is_ad>::computeQpJac(unsigned int jvar) const
       }
 
       dflux += _phi[_j][_qp] * (*_dfluid_density_qp_dvar)[_qp][ph][pvar] *
-               (diffusion * RankTwoTensor(RankTwoTensor::initIdentity) + dispersion) *
+               (diffusion * _identity_tensor + dispersion) *
                _grad_mass_frac[_qp][ph][_fluid_component];
-      dflux += _fluid_density_qp[_qp][ph] *
-               (ddiffusion * RankTwoTensor(RankTwoTensor::initIdentity) + ddispersion) *
+      dflux += _fluid_density_qp[_qp][ph] * (ddiffusion * _identity_tensor + ddispersion) *
                _grad_mass_frac[_qp][ph][_fluid_component];
 
       // NOTE: Here we assume that d(grad_mass_frac)/d(var) = d(mass_frac)/d(var) * grad_phi
       //       This is true for most PorousFlow scenarios, but not for chemical reactions
       //       where mass_frac is a nonlinear function of the primary MOOSE Variables
-      dflux += _fluid_density_qp[_qp][ph] *
-               (diffusion * RankTwoTensor(RankTwoTensor::initIdentity) + dispersion) *
+      dflux += _fluid_density_qp[_qp][ph] * (diffusion * _identity_tensor + dispersion) *
                (*_dmass_frac_dvar)[_qp][ph][_fluid_component][pvar] * _grad_phi[_j][_qp];
     }
 

--- a/modules/porous_flow/src/kernels/PorousFlowEffectiveStressCoupling.C
+++ b/modules/porous_flow/src/kernels/PorousFlowEffectiveStressCoupling.C
@@ -14,11 +14,13 @@
 #include "MooseVariable.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowEffectiveStressCoupling);
+registerMooseObject("PorousFlowApp", ADPorousFlowEffectiveStressCoupling);
 
+template <bool is_ad>
 InputParameters
-PorousFlowEffectiveStressCoupling::validParams()
+PorousFlowEffectiveStressCouplingTempl<is_ad>::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
   params.addClassDescription("Implements the weak form of the expression biot_coefficient * "
                              "grad(effective fluid pressure)");
   params.addRequiredParam<UserObjectName>(
@@ -30,49 +32,70 @@ PorousFlowEffectiveStressCoupling::validParams()
   return params;
 }
 
-PorousFlowEffectiveStressCoupling::PorousFlowEffectiveStressCoupling(
+template <bool is_ad>
+PorousFlowEffectiveStressCouplingTempl<is_ad>::PorousFlowEffectiveStressCouplingTempl(
     const InputParameters & parameters)
-  : Kernel(parameters),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-    _coefficient(getParam<Real>("biot_coefficient")),
-    _component(getParam<unsigned int>("component")),
-    _pf(getMaterialProperty<Real>("PorousFlow_effective_fluid_pressure_qp")),
-    _dpf_dvar(
-        getMaterialProperty<std::vector<Real>>("dPorousFlow_effective_fluid_pressure_qp_dvar")),
-    _rz(getBlockCoordSystem() == Moose::COORD_RZ)
+  : GenericKernel<is_ad>(parameters),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _coefficient(this->template getParam<Real>("biot_coefficient")),
+    _component(this->template getParam<unsigned int>("component")),
+    _pf(this->template getGenericMaterialProperty<Real, is_ad>(
+        "PorousFlow_effective_fluid_pressure_qp")),
+    _dpf_dvar(is_ad ? nullptr
+                    : &this->template getMaterialProperty<std::vector<Real>>(
+                          "dPorousFlow_effective_fluid_pressure_qp_dvar")),
+    _rz(this->getBlockCoordSystem() == Moose::COORD_RZ)
 {
-  if (_component >= _mesh.dimension())
-    paramError("component", "The component cannot be greater than the mesh dimension");
+  if (_component >= this->_mesh.dimension())
+    this->paramError("component", "The component cannot be greater than the mesh dimension");
 }
 
-Real
-PorousFlowEffectiveStressCoupling::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowEffectiveStressCouplingTempl<is_ad>::computeQpResidual()
 {
   if (_rz && _component == 0)
     return -_coefficient * _pf[_qp] * (_grad_test[_i][_qp](0) + _test[_i][_qp] / _q_point[_qp](0));
   return -_coefficient * _pf[_qp] * _grad_test[_i][_qp](_component);
 }
 
+template <bool is_ad>
 Real
-PorousFlowEffectiveStressCoupling::computeQpJacobian()
+PorousFlowEffectiveStressCouplingTempl<is_ad>::computeQpJacobian()
 {
-  if (_dictator.notPorousFlowVariable(_var.number()))
-    return 0.0;
-  const unsigned int pvar = _dictator.porousFlowVariableNum(_var.number());
-  if (_rz && _component == 0)
-    return -_coefficient * _phi[_j][_qp] * _dpf_dvar[_qp][pvar] *
-           (_grad_test[_i][_qp](0) + _test[_i][_qp] / _q_point[_qp](0));
-  return -_coefficient * _phi[_j][_qp] * _dpf_dvar[_qp][pvar] * _grad_test[_i][_qp](_component);
+  if constexpr (!is_ad)
+  {
+    if (_dictator.notPorousFlowVariable(_var.number()))
+      return 0.0;
+    const unsigned int pvar = _dictator.porousFlowVariableNum(_var.number());
+    if (_rz && _component == 0)
+      return -_coefficient * _phi[_j][_qp] * (*_dpf_dvar)[_qp][pvar] *
+             (_grad_test[_i][_qp](0) + _test[_i][_qp] / _q_point[_qp](0));
+    return -_coefficient * _phi[_j][_qp] * (*_dpf_dvar)[_qp][pvar] *
+           _grad_test[_i][_qp](_component);
+  }
+  return 0.0;
 }
 
+template <bool is_ad>
 Real
-PorousFlowEffectiveStressCoupling::computeQpOffDiagJacobian(unsigned int jvar)
+PorousFlowEffectiveStressCouplingTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  if (_dictator.notPorousFlowVariable(jvar))
-    return 0.0;
-  const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
-  if (_rz && _component == 0)
-    return -_coefficient * _phi[_j][_qp] * _dpf_dvar[_qp][pvar] *
-           (_grad_test[_i][_qp](0) + _test[_i][_qp] / _q_point[_qp](0));
-  return -_coefficient * _phi[_j][_qp] * _dpf_dvar[_qp][pvar] * _grad_test[_i][_qp](_component);
+  if constexpr (!is_ad)
+  {
+    if (_dictator.notPorousFlowVariable(jvar))
+      return 0.0;
+    const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
+    if (_rz && _component == 0)
+      return -_coefficient * _phi[_j][_qp] * (*_dpf_dvar)[_qp][pvar] *
+             (_grad_test[_i][_qp](0) + _test[_i][_qp] / _q_point[_qp](0));
+    return -_coefficient * _phi[_j][_qp] * (*_dpf_dvar)[_qp][pvar] *
+           _grad_test[_i][_qp](_component);
+  }
+  else
+    libmesh_ignore(jvar);
+  return 0.0;
 }
+
+template class PorousFlowEffectiveStressCouplingTempl<false>;
+template class PorousFlowEffectiveStressCouplingTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowEnergyTimeDerivative.C
+++ b/modules/porous_flow/src/kernels/PorousFlowEnergyTimeDerivative.C
@@ -12,11 +12,15 @@
 #include "MooseVariable.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowEnergyTimeDerivative);
+registerMooseObject("PorousFlowApp", ADPorousFlowEnergyTimeDerivative);
 
+template <bool is_ad>
 InputParameters
-PorousFlowEnergyTimeDerivative::validParams()
+PorousFlowEnergyTimeDerivativeTempl<is_ad>::validParams()
 {
-  InputParameters params = TimeKernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
+  params.set<MultiMooseEnum>("vector_tags") = "time";
+  params.set<MultiMooseEnum>("matrix_tags") = "system time";
   params.addParam<bool>("strain_at_nearest_qp",
                         false,
                         "When calculating nodal porosity that depends on strain, use the strain at "
@@ -40,66 +44,85 @@ PorousFlowEnergyTimeDerivative::validParams()
   return params;
 }
 
-PorousFlowEnergyTimeDerivative::PorousFlowEnergyTimeDerivative(const InputParameters & parameters)
-  : TimeKernel(parameters),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+template <bool is_ad>
+PorousFlowEnergyTimeDerivativeTempl<is_ad>::PorousFlowEnergyTimeDerivativeTempl(
+    const InputParameters & parameters)
+  : PorousFlowLumpedKernelBaseTempl<is_ad>(parameters),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
     _var_is_porflow_var(_dictator.isPorousFlowVariable(_var.number())),
     _num_phases(_dictator.numPhases()),
     _fluid_present(_num_phases > 0),
-    _strain_at_nearest_qp(getParam<bool>("strain_at_nearest_qp")),
-    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
-    _has_total_strain(hasMaterialProperty<RankTwoTensor>(_base_name + "total_strain")),
-    _total_strain_old(_has_total_strain
-                          ? &getMaterialPropertyOld<RankTwoTensor>(_base_name + "total_strain")
-                          : nullptr),
-    _porosity(getMaterialProperty<Real>("PorousFlow_porosity_nodal")),
-    _porosity_old(getMaterialPropertyOld<Real>("PorousFlow_porosity_nodal")),
-    _dporosity_dvar(getMaterialProperty<std::vector<Real>>("dPorousFlow_porosity_nodal_dvar")),
-    _dporosity_dgradvar(
-        getMaterialProperty<std::vector<RealGradient>>("dPorousFlow_porosity_nodal_dgradvar")),
-    _nearest_qp(_strain_at_nearest_qp
-                    ? &getMaterialProperty<unsigned int>("PorousFlow_nearestqp_nodal")
-                    : nullptr),
-    _rock_energy_nodal(getMaterialProperty<Real>("PorousFlow_matrix_internal_energy_nodal")),
-    _rock_energy_nodal_old(getMaterialPropertyOld<Real>("PorousFlow_matrix_internal_energy_nodal")),
-    _drock_energy_nodal_dvar(
-        getMaterialProperty<std::vector<Real>>("dPorousFlow_matrix_internal_energy_nodal_dvar")),
-    _fluid_density(_fluid_present ? &getMaterialProperty<std::vector<Real>>(
-                                        "PorousFlow_fluid_phase_density_nodal")
-                                  : nullptr),
-    _fluid_density_old(_fluid_present ? &getMaterialPropertyOld<std::vector<Real>>(
+    _strain_at_nearest_qp(this->template getParam<bool>("strain_at_nearest_qp")),
+    _base_name(this->isParamValid("base_name")
+                   ? this->template getParam<std::string>("base_name") + "_"
+                   : ""),
+    _has_total_strain(
+        this->template hasMaterialProperty<RankTwoTensor>(_base_name + "total_strain")),
+    _total_strain_old(_has_total_strain ? &this->template getMaterialPropertyOld<RankTwoTensor>(
+                                              _base_name + "total_strain")
+                                        : nullptr),
+    _porosity(this->template getGenericMaterialProperty<Real, is_ad>("PorousFlow_porosity_nodal")),
+    _porosity_old(this->template getMaterialPropertyOld<Real>("PorousFlow_porosity_nodal")),
+    _dporosity_dvar(is_ad ? nullptr
+                          : &this->template getMaterialProperty<std::vector<Real>>(
+                                "dPorousFlow_porosity_nodal_dvar")),
+    _dporosity_dgradvar(is_ad ? nullptr
+                              : &this->template getMaterialProperty<std::vector<RealGradient>>(
+                                    "dPorousFlow_porosity_nodal_dgradvar")),
+    _nearest_qp(_strain_at_nearest_qp ? &this->template getMaterialProperty<unsigned int>(
+                                            "PorousFlow_nearestqp_nodal")
+                                      : nullptr),
+    _rock_energy_nodal(this->template getGenericMaterialProperty<Real, is_ad>(
+        "PorousFlow_matrix_internal_energy_nodal")),
+    _rock_energy_nodal_old(
+        this->template getMaterialPropertyOld<Real>("PorousFlow_matrix_internal_energy_nodal")),
+    _drock_energy_nodal_dvar(is_ad ? nullptr
+                                   : &this->template getMaterialProperty<std::vector<Real>>(
+                                         "dPorousFlow_matrix_internal_energy_nodal_dvar")),
+    _fluid_density(_fluid_present
+                       ? &this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+                             "PorousFlow_fluid_phase_density_nodal")
+                       : nullptr),
+    _fluid_density_old(_fluid_present ? &this->template getMaterialPropertyOld<std::vector<Real>>(
                                             "PorousFlow_fluid_phase_density_nodal")
                                       : nullptr),
-    _dfluid_density_dvar(_fluid_present ? &getMaterialProperty<std::vector<std::vector<Real>>>(
-                                              "dPorousFlow_fluid_phase_density_nodal_dvar")
-                                        : nullptr),
+    _dfluid_density_dvar(_fluid_present && !is_ad
+                             ? &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                   "dPorousFlow_fluid_phase_density_nodal_dvar")
+                             : nullptr),
     _fluid_saturation_nodal(
-        _fluid_present ? &getMaterialProperty<std::vector<Real>>("PorousFlow_saturation_nodal")
+        _fluid_present ? &this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+                             "PorousFlow_saturation_nodal")
                        : nullptr),
-    _fluid_saturation_nodal_old(
-        _fluid_present ? &getMaterialPropertyOld<std::vector<Real>>("PorousFlow_saturation_nodal")
-                       : nullptr),
-    _dfluid_saturation_nodal_dvar(_fluid_present
-                                      ? &getMaterialProperty<std::vector<std::vector<Real>>>(
-                                            "dPorousFlow_saturation_nodal_dvar")
-                                      : nullptr),
-    _energy_nodal(_fluid_present ? &getMaterialProperty<std::vector<Real>>(
-                                       "PorousFlow_fluid_phase_internal_energy_nodal")
-                                 : nullptr),
-    _energy_nodal_old(_fluid_present ? &getMaterialPropertyOld<std::vector<Real>>(
+    _fluid_saturation_nodal_old(_fluid_present
+                                    ? &this->template getMaterialPropertyOld<std::vector<Real>>(
+                                          "PorousFlow_saturation_nodal")
+                                    : nullptr),
+    _dfluid_saturation_nodal_dvar(
+        _fluid_present && !is_ad
+            ? &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                  "dPorousFlow_saturation_nodal_dvar")
+            : nullptr),
+    _energy_nodal(_fluid_present
+                      ? &this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+                            "PorousFlow_fluid_phase_internal_energy_nodal")
+                      : nullptr),
+    _energy_nodal_old(_fluid_present ? &this->template getMaterialPropertyOld<std::vector<Real>>(
                                            "PorousFlow_fluid_phase_internal_energy_nodal")
                                      : nullptr),
-    _denergy_nodal_dvar(_fluid_present ? &getMaterialProperty<std::vector<std::vector<Real>>>(
-                                             "dPorousFlow_fluid_phase_internal_energy_nodal_dvar")
-                                       : nullptr)
+    _denergy_nodal_dvar(_fluid_present && !is_ad
+                            ? &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                  "dPorousFlow_fluid_phase_internal_energy_nodal_dvar")
+                            : nullptr)
 {
 }
 
-Real
-PorousFlowEnergyTimeDerivative::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowEnergyTimeDerivativeTempl<is_ad>::computeQpResidual()
 {
   /// Porous matrix heat energy
-  Real energy = (1.0 - _porosity[_i]) * _rock_energy_nodal[_i];
+  GenericReal<is_ad> energy = (1.0 - _porosity[_i]) * _rock_energy_nodal[_i];
   Real energy_old = (1.0 - _porosity_old[_i]) * _rock_energy_nodal_old[_i];
 
   /// Add the fluid heat energy
@@ -116,55 +139,74 @@ PorousFlowEnergyTimeDerivative::computeQpResidual()
   return _test[_i][_qp] * (1.0 + strain) * (energy - energy_old) / _dt;
 }
 
+template <bool is_ad>
 Real
-PorousFlowEnergyTimeDerivative::computeQpJacobian()
+PorousFlowEnergyTimeDerivativeTempl<is_ad>::computeQpJacobian()
 {
-  // If the variable is not a PorousFlow variable (very unusual), the diag Jacobian terms are 0
-  if (!_var_is_porflow_var)
-    return 0.0;
-  return computeQpJac(_dictator.porousFlowVariableNum(_var.number()));
-}
-
-Real
-PorousFlowEnergyTimeDerivative::computeQpOffDiagJacobian(unsigned int jvar)
-{
-  // If the variable is not a PorousFlow variable, the OffDiag Jacobian terms are 0
-  if (_dictator.notPorousFlowVariable(jvar))
-    return 0.0;
-  return computeQpJac(_dictator.porousFlowVariableNum(jvar));
-}
-
-Real
-PorousFlowEnergyTimeDerivative::computeQpJac(unsigned int pvar) const
-{
-  const unsigned nearest_qp = (_strain_at_nearest_qp ? (*_nearest_qp)[_i] : _i);
-
-  const Real strain = (_has_total_strain ? (*_total_strain_old)[_qp].trace() : 0.0);
-
-  // porosity is dependent on variables that are lumped to the nodes,
-  // but it can depend on the gradient
-  // of variables, which are NOT lumped to the nodes, hence:
-  Real denergy = -_dporosity_dgradvar[_i][pvar] * _grad_phi[_j][_i] * _rock_energy_nodal[_i];
-  for (unsigned ph = 0; ph < _num_phases; ++ph)
-    denergy += (*_fluid_density)[_i][ph] * (*_fluid_saturation_nodal)[_i][ph] *
-               (*_energy_nodal)[_i][ph] * _dporosity_dgradvar[_i][pvar] * _grad_phi[_j][nearest_qp];
-
-  if (_i != _j)
-    return _test[_i][_qp] * (1.0 + strain) * denergy / _dt;
-
-  // As the fluid energy is lumped to the nodes, only non-zero terms are for _i==_j
-  denergy += -_dporosity_dvar[_i][pvar] * _rock_energy_nodal[_i];
-  denergy += (1.0 - _porosity[_i]) * _drock_energy_nodal_dvar[_i][pvar];
-  for (unsigned ph = 0; ph < _num_phases; ++ph)
+  if constexpr (!is_ad)
   {
-    denergy += (*_dfluid_density_dvar)[_i][ph][pvar] * (*_fluid_saturation_nodal)[_i][ph] *
-               (*_energy_nodal)[_i][ph] * _porosity[_i];
-    denergy += (*_fluid_density)[_i][ph] * (*_dfluid_saturation_nodal_dvar)[_i][ph][pvar] *
-               (*_energy_nodal)[_i][ph] * _porosity[_i];
-    denergy += (*_fluid_density)[_i][ph] * (*_fluid_saturation_nodal)[_i][ph] *
-               (*_denergy_nodal_dvar)[_i][ph][pvar] * _porosity[_i];
-    denergy += (*_fluid_density)[_i][ph] * (*_fluid_saturation_nodal)[_i][ph] *
-               (*_energy_nodal)[_i][ph] * _dporosity_dvar[_i][pvar];
+    // If the variable is not a PorousFlow variable (very unusual), the diag Jacobian terms are 0
+    if (!_var_is_porflow_var)
+      return 0.0;
+    return computeQpJac(_dictator.porousFlowVariableNum(_var.number()));
   }
-  return _test[_i][_qp] * (1.0 + strain) * denergy / _dt;
+  return 0.0;
 }
+
+template <bool is_ad>
+Real
+PorousFlowEnergyTimeDerivativeTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  if constexpr (!is_ad)
+  {
+    // If the variable is not a PorousFlow variable, the OffDiag Jacobian terms are 0
+    if (_dictator.notPorousFlowVariable(jvar))
+      return 0.0;
+    return computeQpJac(_dictator.porousFlowVariableNum(jvar));
+  }
+  return 0.0;
+}
+
+template <bool is_ad>
+Real
+PorousFlowEnergyTimeDerivativeTempl<is_ad>::computeQpJac(unsigned int pvar) const
+{
+  if constexpr (!is_ad)
+  {
+    const unsigned nearest_qp = (_strain_at_nearest_qp ? (*_nearest_qp)[_i] : _i);
+
+    const Real strain = (_has_total_strain ? (*_total_strain_old)[_qp].trace() : 0.0);
+
+    // porosity is dependent on variables that are lumped to the nodes,
+    // but it can depend on the gradient
+    // of variables, which are NOT lumped to the nodes, hence:
+    Real denergy = -(*_dporosity_dgradvar)[_i][pvar] * _grad_phi[_j][_i] * _rock_energy_nodal[_i];
+    for (unsigned ph = 0; ph < _num_phases; ++ph)
+      denergy += (*_fluid_density)[_i][ph] * (*_fluid_saturation_nodal)[_i][ph] *
+                 (*_energy_nodal)[_i][ph] * (*_dporosity_dgradvar)[_i][pvar] *
+                 _grad_phi[_j][nearest_qp];
+
+    if (_i != _j)
+      return _test[_i][_qp] * (1.0 + strain) * denergy / _dt;
+
+    // As the fluid energy is lumped to the nodes, only non-zero terms are for _i==_j
+    denergy += -(*_dporosity_dvar)[_i][pvar] * _rock_energy_nodal[_i];
+    denergy += (1.0 - _porosity[_i]) * (*_drock_energy_nodal_dvar)[_i][pvar];
+    for (unsigned ph = 0; ph < _num_phases; ++ph)
+    {
+      denergy += (*_dfluid_density_dvar)[_i][ph][pvar] * (*_fluid_saturation_nodal)[_i][ph] *
+                 (*_energy_nodal)[_i][ph] * _porosity[_i];
+      denergy += (*_fluid_density)[_i][ph] * (*_dfluid_saturation_nodal_dvar)[_i][ph][pvar] *
+                 (*_energy_nodal)[_i][ph] * _porosity[_i];
+      denergy += (*_fluid_density)[_i][ph] * (*_fluid_saturation_nodal)[_i][ph] *
+                 (*_denergy_nodal_dvar)[_i][ph][pvar] * _porosity[_i];
+      denergy += (*_fluid_density)[_i][ph] * (*_fluid_saturation_nodal)[_i][ph] *
+                 (*_energy_nodal)[_i][ph] * (*_dporosity_dvar)[_i][pvar];
+    }
+    return _test[_i][_qp] * (1.0 + strain) * denergy / _dt;
+  }
+  return 0.0;
+}
+
+template class PorousFlowEnergyTimeDerivativeTempl<false>;
+template class PorousFlowEnergyTimeDerivativeTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowEnergyTimeDerivative.C
+++ b/modules/porous_flow/src/kernels/PorousFlowEnergyTimeDerivative.C
@@ -164,6 +164,8 @@ PorousFlowEnergyTimeDerivativeTempl<is_ad>::computeQpOffDiagJacobian(unsigned in
       return 0.0;
     return computeQpJac(_dictator.porousFlowVariableNum(jvar));
   }
+  else
+    libmesh_ignore(jvar);
   return 0.0;
 }
 
@@ -205,6 +207,8 @@ PorousFlowEnergyTimeDerivativeTempl<is_ad>::computeQpJac(unsigned int pvar) cons
     }
     return _test[_i][_qp] * (1.0 + strain) * denergy / _dt;
   }
+  else
+    libmesh_ignore(pvar);
   return 0.0;
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowExponentialDecay.C
+++ b/modules/porous_flow/src/kernels/PorousFlowExponentialDecay.C
@@ -30,8 +30,8 @@ template <bool is_ad>
 PorousFlowExponentialDecayTempl<is_ad>::PorousFlowExponentialDecayTempl(
     const InputParameters & parameters)
   : GenericKernel<is_ad>(parameters),
-    _rate(this->coupledValue("rate")),
-    _reference(this->coupledValue("reference"))
+    _rate(this->template coupledGenericValue<is_ad>("rate")),
+    _reference(this->template coupledGenericValue<is_ad>("reference"))
 {
 }
 
@@ -46,9 +46,9 @@ template <bool is_ad>
 Real
 PorousFlowExponentialDecayTempl<is_ad>::computeQpJacobian()
 {
-  // Never called for the AD instantiation, which assembles the Jacobian from the AD residual.
-  mooseAssert(!is_ad, "computeQpJacobian should not be called for the AD instantiation");
-  return _test[_i][_qp] * _rate[_qp] * _phi[_j][_qp];
+  if constexpr (!is_ad)
+    return _test[_i][_qp] * _rate[_qp] * _phi[_j][_qp];
+  return 0.0;
 }
 
 template class PorousFlowExponentialDecayTempl<false>;

--- a/modules/porous_flow/src/kernels/PorousFlowExponentialDecay.C
+++ b/modules/porous_flow/src/kernels/PorousFlowExponentialDecay.C
@@ -12,11 +12,13 @@
 #include "MooseVariable.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowExponentialDecay);
+registerMooseObject("PorousFlowApp", ADPorousFlowExponentialDecay);
 
+template <bool is_ad>
 InputParameters
-PorousFlowExponentialDecay::validParams()
+PorousFlowExponentialDecayTempl<is_ad>::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
   params.addCoupledVar("rate", 1.0, "Rate of exponential decay");
   params.addCoupledVar("reference", 0.0, "Reference value of the variable");
   params.addClassDescription("Residual = rate * (variable - reference).  Useful for modelling "
@@ -24,19 +26,30 @@ PorousFlowExponentialDecay::validParams()
   return params;
 }
 
-PorousFlowExponentialDecay::PorousFlowExponentialDecay(const InputParameters & parameters)
-  : Kernel(parameters), _rate(coupledValue("rate")), _reference(coupledValue("reference"))
+template <bool is_ad>
+PorousFlowExponentialDecayTempl<is_ad>::PorousFlowExponentialDecayTempl(
+    const InputParameters & parameters)
+  : GenericKernel<is_ad>(parameters),
+    _rate(this->coupledValue("rate")),
+    _reference(this->coupledValue("reference"))
 {
 }
 
-Real
-PorousFlowExponentialDecay::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowExponentialDecayTempl<is_ad>::computeQpResidual()
 {
   return _test[_i][_qp] * _rate[_qp] * (_u[_qp] - _reference[_qp]);
 }
 
+template <bool is_ad>
 Real
-PorousFlowExponentialDecay::computeQpJacobian()
+PorousFlowExponentialDecayTempl<is_ad>::computeQpJacobian()
 {
+  // Never called for the AD instantiation, which assembles the Jacobian from the AD residual.
+  mooseAssert(!is_ad, "computeQpJacobian should not be called for the AD instantiation");
   return _test[_i][_qp] * _rate[_qp] * _phi[_j][_qp];
 }
+
+template class PorousFlowExponentialDecayTempl<false>;
+template class PorousFlowExponentialDecayTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedAdvectiveFlux.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedAdvectiveFlux.C
@@ -10,11 +10,13 @@
 #include "PorousFlowFullySaturatedAdvectiveFlux.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowFullySaturatedAdvectiveFlux);
+registerMooseObject("PorousFlowApp", ADPorousFlowFullySaturatedAdvectiveFlux);
 
+template <bool is_ad>
 InputParameters
-PorousFlowFullySaturatedAdvectiveFlux::validParams()
+PorousFlowFullySaturatedAdvectiveFluxTempl<is_ad>::validParams()
 {
-  InputParameters params = PorousFlowDarcyBase::validParams();
+  InputParameters params = PorousFlowDarcyBaseTempl<is_ad>::validParams();
   params.addParam<unsigned int>(
       "fluid_component", 0, "The index corresponding to the fluid component for this kernel");
   params.addParam<bool>("multiply_by_density",
@@ -28,15 +30,19 @@ PorousFlowFullySaturatedAdvectiveFlux::validParams()
   return params;
 }
 
-PorousFlowFullySaturatedAdvectiveFlux::PorousFlowFullySaturatedAdvectiveFlux(
+template <bool is_ad>
+PorousFlowFullySaturatedAdvectiveFluxTempl<is_ad>::PorousFlowFullySaturatedAdvectiveFluxTempl(
     const InputParameters & parameters)
-  : PorousFlowDarcyBase(parameters),
+  : PorousFlowDarcyBaseTempl<is_ad>(parameters),
     _mass_fractions(
-        getMaterialProperty<std::vector<std::vector<Real>>>("PorousFlow_mass_frac_nodal")),
-    _dmass_fractions_dvar(getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
-        "dPorousFlow_mass_frac_nodal_dvar")),
-    _fluid_component(getParam<unsigned int>("fluid_component")),
-    _multiply_by_density(getParam<bool>("multiply_by_density"))
+        this->template getGenericMaterialProperty<std::vector<std::vector<Real>>, is_ad>(
+            "PorousFlow_mass_frac_nodal")),
+    _dmass_fractions_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
+                    "dPorousFlow_mass_frac_nodal_dvar")),
+    _fluid_component(this->template getParam<unsigned int>("fluid_component")),
+    _multiply_by_density(this->template getParam<bool>("multiply_by_density"))
 {
   if (_dictator.numPhases() != 1)
     mooseError(
@@ -44,8 +50,9 @@ PorousFlowFullySaturatedAdvectiveFlux::PorousFlowFullySaturatedAdvectiveFlux(
         "it does not include relative-permeability effects");
 }
 
-Real
-PorousFlowFullySaturatedAdvectiveFlux::mobility(unsigned nodenum, unsigned phase) const
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowFullySaturatedAdvectiveFluxTempl<is_ad>::mobility(unsigned nodenum, unsigned phase) const
 {
   if (_multiply_by_density == false)
     return _mass_fractions[nodenum][phase][_fluid_component] / _fluid_viscosity[nodenum][phase];
@@ -53,23 +60,33 @@ PorousFlowFullySaturatedAdvectiveFlux::mobility(unsigned nodenum, unsigned phase
          _fluid_viscosity[nodenum][phase];
 }
 
+template <bool is_ad>
 Real
-PorousFlowFullySaturatedAdvectiveFlux::dmobility(unsigned nodenum,
-                                                 unsigned phase,
-                                                 unsigned pvar) const
+PorousFlowFullySaturatedAdvectiveFluxTempl<is_ad>::dmobility(unsigned nodenum,
+                                                             unsigned phase,
+                                                             unsigned pvar) const
 {
-  if (_multiply_by_density == false)
-    return _dmass_fractions_dvar[nodenum][phase][_fluid_component][pvar] /
-               _fluid_viscosity[nodenum][phase] -
-           _mass_fractions[nodenum][phase][_fluid_component] *
-               _dfluid_viscosity_dvar[nodenum][phase][pvar] /
-               Utility::pow<2>(_fluid_viscosity[nodenum][phase]);
-  Real dm = _dmass_fractions_dvar[nodenum][phase][_fluid_component][pvar] *
-            _fluid_density_node[nodenum][phase] / _fluid_viscosity[nodenum][phase];
-  dm += _mass_fractions[nodenum][phase][_fluid_component] *
-        _dfluid_density_node_dvar[nodenum][phase][pvar] / _fluid_viscosity[nodenum][phase];
-  dm -= _mass_fractions[nodenum][phase][_fluid_component] * _fluid_density_node[nodenum][phase] *
-        _dfluid_viscosity_dvar[nodenum][phase][pvar] /
-        Utility::pow<2>(_fluid_viscosity[nodenum][phase]);
-  return dm;
+  if constexpr (!is_ad)
+  {
+    if (_multiply_by_density == false)
+      return (*_dmass_fractions_dvar)[nodenum][phase][_fluid_component][pvar] /
+                 _fluid_viscosity[nodenum][phase] -
+             _mass_fractions[nodenum][phase][_fluid_component] *
+                 (*_dfluid_viscosity_dvar)[nodenum][phase][pvar] /
+                 Utility::pow<2>(_fluid_viscosity[nodenum][phase]);
+    Real dm = (*_dmass_fractions_dvar)[nodenum][phase][_fluid_component][pvar] *
+              _fluid_density_node[nodenum][phase] / _fluid_viscosity[nodenum][phase];
+    dm += _mass_fractions[nodenum][phase][_fluid_component] *
+          (*_dfluid_density_node_dvar)[nodenum][phase][pvar] / _fluid_viscosity[nodenum][phase];
+    dm -= _mass_fractions[nodenum][phase][_fluid_component] * _fluid_density_node[nodenum][phase] *
+          (*_dfluid_viscosity_dvar)[nodenum][phase][pvar] /
+          Utility::pow<2>(_fluid_viscosity[nodenum][phase]);
+    return dm;
+  }
+  else
+    libmesh_ignore(nodenum, phase, pvar);
+  return 0.0;
 }
+
+template class PorousFlowFullySaturatedAdvectiveFluxTempl<false>;
+template class PorousFlowFullySaturatedAdvectiveFluxTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyBase.C
@@ -132,6 +132,8 @@ PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::computeQpOffDiagJacobian(unsigned
 
     return _grad_test[_i][_qp] * (dmob * flow + mob * dflow);
   }
+  else
+    libmesh_ignore(jvar);
   return 0.0;
 }
 
@@ -158,6 +160,8 @@ PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::dmobility(unsigned int pvar) cons
       dmob = _density[_qp][ph] * dmob + (*_ddensity_dvar)[_qp][ph][pvar] / _viscosity[_qp][ph];
     return dmob;
   }
+  else
+    libmesh_ignore(pvar);
   return 0.0;
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyBase.C
@@ -12,120 +12,154 @@
 #include "MooseVariable.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowFullySaturatedDarcyBase);
+registerMooseObject("PorousFlowApp", ADPorousFlowFullySaturatedDarcyBase);
 
+template <bool is_ad>
 InputParameters
-PorousFlowFullySaturatedDarcyBase::validParams()
+PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
   params.addRequiredParam<RealVectorValue>("gravity",
                                            "Gravitational acceleration vector downwards (m/s^2)");
   params.addParam<bool>("multiply_by_density",
                         true,
-                        "If true, then this Kernel is the fluid mass "
-                        "flux.  If false, then this Kernel is the "
-                        "fluid volume flux (which is common in "
-                        "poro-mechanics)");
+                        "If true, then this Kernel is the fluid mass flux.  If false, then this "
+                        "Kernel is the fluid volume flux (which is common in poro-mechanics)");
   params.addRequiredParam<UserObjectName>(
       "PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
-  params.addClassDescription("Darcy flux suitable for models involving a fully-saturated, single "
-                             "phase, single component fluid.  No upwinding is used");
+  params.addClassDescription(
+      "Darcy flux suitable for models involving a fully-saturated, single phase, single component "
+      "fluid.  No upwinding is used.  Templated on is_ad: the AD version requires no hand-coded "
+      "Jacobian.");
   return params;
 }
 
-PorousFlowFullySaturatedDarcyBase::PorousFlowFullySaturatedDarcyBase(
+template <bool is_ad>
+PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::PorousFlowFullySaturatedDarcyBaseTempl(
     const InputParameters & parameters)
-  : Kernel(parameters),
-    _multiply_by_density(getParam<bool>("multiply_by_density")),
-    _permeability(getMaterialProperty<RealTensorValue>("PorousFlow_permeability_qp")),
-    _dpermeability_dvar(
-        getMaterialProperty<std::vector<RealTensorValue>>("dPorousFlow_permeability_qp_dvar")),
-    _dpermeability_dgradvar(getMaterialProperty<std::vector<std::vector<RealTensorValue>>>(
-        "dPorousFlow_permeability_qp_dgradvar")),
-    _density(getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_density_qp")),
-    _ddensity_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_fluid_phase_density_qp_dvar")),
-    _viscosity(getMaterialProperty<std::vector<Real>>("PorousFlow_viscosity_qp")),
-    _dviscosity_dvar(
-        getMaterialProperty<std::vector<std::vector<Real>>>("dPorousFlow_viscosity_qp_dvar")),
-    _pp(getMaterialProperty<std::vector<Real>>("PorousFlow_porepressure_qp")),
-    _grad_p(getMaterialProperty<std::vector<RealGradient>>("PorousFlow_grad_porepressure_qp")),
-    _dgrad_p_dgrad_var(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_grad_porepressure_qp_dgradvar")),
-    _dgrad_p_dvar(getMaterialProperty<std::vector<std::vector<RealGradient>>>(
-        "dPorousFlow_grad_porepressure_qp_dvar")),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-    _gravity(getParam<RealVectorValue>("gravity")),
+  : GenericKernel<is_ad>(parameters),
+    _multiply_by_density(this->template getParam<bool>("multiply_by_density")),
+    _permeability(this->template getGenericMaterialProperty<RealTensorValue, is_ad>(
+        "PorousFlow_permeability_qp")),
+    _dpermeability_dvar(is_ad ? nullptr
+                              : &this->template getMaterialProperty<std::vector<RealTensorValue>>(
+                                    "dPorousFlow_permeability_qp_dvar")),
+    _dpermeability_dgradvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<RealTensorValue>>>(
+                    "dPorousFlow_permeability_qp_dgradvar")),
+    _density(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_fluid_phase_density_qp")),
+    _ddensity_dvar(is_ad ? nullptr
+                         : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                               "dPorousFlow_fluid_phase_density_qp_dvar")),
+    _viscosity(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_viscosity_qp")),
+    _dviscosity_dvar(is_ad ? nullptr
+                           : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                 "dPorousFlow_viscosity_qp_dvar")),
+    _pp(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_porepressure_qp")),
+    _grad_p(this->template getGenericMaterialProperty<std::vector<RealGradient>, is_ad>(
+        "PorousFlow_grad_porepressure_qp")),
+    _dgrad_p_dgrad_var(is_ad ? nullptr
+                             : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                   "dPorousFlow_grad_porepressure_qp_dgradvar")),
+    _dgrad_p_dvar(is_ad
+                      ? nullptr
+                      : &this->template getMaterialProperty<std::vector<std::vector<RealGradient>>>(
+                            "dPorousFlow_grad_porepressure_qp_dvar")),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _gravity(this->template getParam<RealVectorValue>("gravity")),
     _perm_derivs(_dictator.usePermDerivs())
 {
   if (_dictator.numPhases() != 1)
-    mooseError("PorousFlowFullySaturatedDarcyBase should not be used for multi-phase scenarios as "
-               "it does no upwinding and does not include relative-permeability effects");
+    mooseError(
+        "PorousFlowFullySaturatedDarcyBase should not be used for multi-phase scenarios as it "
+        "does no upwinding and does not include relative-permeability effects");
 }
 
-Real
-PorousFlowFullySaturatedDarcyBase::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::computeQpResidual()
 {
   const unsigned ph = 0;
-  const Real mob = mobility();
-  const RealVectorValue flow =
-      _permeability[_qp] * (_grad_p[_qp][ph] - _density[_qp][ph] * _gravity);
+  const auto mob = mobility();
+  const auto flow = _permeability[_qp] * (_grad_p[_qp][ph] - _density[_qp][ph] * _gravity);
   return _grad_test[_i][_qp] * mob * flow;
 }
 
+template <bool is_ad>
 Real
-PorousFlowFullySaturatedDarcyBase::computeQpJacobian()
+PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::computeQpJacobian()
 {
-  return computeQpOffDiagJacobian(_var.number());
+  if constexpr (!is_ad)
+    return computeQpOffDiagJacobian(_var.number());
+  return 0.0;
 }
 
+template <bool is_ad>
 Real
-PorousFlowFullySaturatedDarcyBase::computeQpOffDiagJacobian(unsigned int jvar)
+PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  if (_dictator.notPorousFlowVariable(jvar))
-    return 0.0;
-
-  const unsigned ph = 0;
-  const unsigned pvar = _dictator.porousFlowVariableNum(jvar);
-
-  const Real mob = mobility();
-  const Real dmob = dmobility(pvar) * _phi[_j][_qp];
-
-  const RealVectorValue flow =
-      _permeability[_qp] * (_grad_p[_qp][ph] - _density[_qp][ph] * _gravity);
-
-  RealVectorValue dflow =
-      _permeability[_qp] * (_grad_phi[_j][_qp] * _dgrad_p_dgrad_var[_qp][ph][pvar] -
-                            _phi[_j][_qp] * _ddensity_dvar[_qp][ph][pvar] * _gravity);
-  dflow += _permeability[_qp] * (_dgrad_p_dvar[_qp][ph][pvar] * _phi[_j][_qp]);
-
-  if (_perm_derivs)
+  if constexpr (!is_ad)
   {
-    dflow += _dpermeability_dvar[_qp][pvar] * _phi[_j][_qp] *
-             (_grad_p[_qp][ph] - _density[_qp][ph] * _gravity);
-    for (const auto i : make_range(Moose::dim))
-      dflow += _dpermeability_dgradvar[_qp][i][pvar] * _grad_phi[_j][_qp](i) *
-               (_grad_p[_qp][ph] - _density[_qp][ph] * _gravity);
-  }
+    if (_dictator.notPorousFlowVariable(jvar))
+      return 0.0;
 
-  return _grad_test[_i][_qp] * (dmob * flow + mob * dflow);
+    const unsigned ph = 0;
+    const unsigned pvar = _dictator.porousFlowVariableNum(jvar);
+
+    const Real mob = mobility();
+    const Real dmob = dmobility(pvar) * _phi[_j][_qp];
+
+    const RealVectorValue flow =
+        _permeability[_qp] * (_grad_p[_qp][ph] - _density[_qp][ph] * _gravity);
+
+    RealVectorValue dflow =
+        _permeability[_qp] * (_grad_phi[_j][_qp] * (*_dgrad_p_dgrad_var)[_qp][ph][pvar] -
+                              _phi[_j][_qp] * (*_ddensity_dvar)[_qp][ph][pvar] * _gravity);
+    dflow += _permeability[_qp] * ((*_dgrad_p_dvar)[_qp][ph][pvar] * _phi[_j][_qp]);
+
+    if (_perm_derivs)
+    {
+      dflow += (*_dpermeability_dvar)[_qp][pvar] * _phi[_j][_qp] *
+               (_grad_p[_qp][ph] - _density[_qp][ph] * _gravity);
+      for (const auto i : make_range(Moose::dim))
+        dflow += (*_dpermeability_dgradvar)[_qp][i][pvar] * _grad_phi[_j][_qp](i) *
+                 (_grad_p[_qp][ph] - _density[_qp][ph] * _gravity);
+    }
+
+    return _grad_test[_i][_qp] * (dmob * flow + mob * dflow);
+  }
+  return 0.0;
 }
 
-Real
-PorousFlowFullySaturatedDarcyBase::mobility() const
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::mobility() const
 {
   const unsigned ph = 0;
-  Real mob = 1.0 / _viscosity[_qp][ph];
+  GenericReal<is_ad> mob = 1.0 / _viscosity[_qp][ph];
   if (_multiply_by_density)
     mob *= _density[_qp][ph];
   return mob;
 }
 
+template <bool is_ad>
 Real
-PorousFlowFullySaturatedDarcyBase::dmobility(unsigned pvar) const
+PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::dmobility(unsigned int pvar) const
 {
-  const unsigned ph = 0;
-  Real dmob = -_dviscosity_dvar[_qp][ph][pvar] / std::pow(_viscosity[_qp][ph], 2);
-  if (_multiply_by_density)
-    dmob = _density[_qp][ph] * dmob + _ddensity_dvar[_qp][ph][pvar] / _viscosity[_qp][ph];
-  return dmob;
+  if constexpr (!is_ad)
+  {
+    const unsigned ph = 0;
+    Real dmob = -(*_dviscosity_dvar)[_qp][ph][pvar] / std::pow(_viscosity[_qp][ph], 2);
+    if (_multiply_by_density)
+      dmob = _density[_qp][ph] * dmob + (*_ddensity_dvar)[_qp][ph][pvar] / _viscosity[_qp][ph];
+    return dmob;
+  }
+  return 0.0;
 }
+
+template class PorousFlowFullySaturatedDarcyBaseTempl<false>;
+template class PorousFlowFullySaturatedDarcyBaseTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyFlow.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyFlow.C
@@ -10,28 +10,36 @@
 #include "PorousFlowFullySaturatedDarcyFlow.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowFullySaturatedDarcyFlow);
+registerMooseObject("PorousFlowApp", ADPorousFlowFullySaturatedDarcyFlow);
 
+template <bool is_ad>
 InputParameters
-PorousFlowFullySaturatedDarcyFlow::validParams()
+PorousFlowFullySaturatedDarcyFlowTempl<is_ad>::validParams()
 {
-  InputParameters params = PorousFlowFullySaturatedDarcyBase::validParams();
+  InputParameters params = PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::validParams();
   params.addParam<unsigned int>(
       "fluid_component", 0, "The index corresponding to the fluid component for this kernel");
-  params.addClassDescription("Darcy flux suitable for models involving a fully-saturated single "
-                             "phase, multi-component fluid.  No upwinding is used");
+  params.addClassDescription(
+      "Darcy flux suitable for models involving a fully-saturated single phase, multi-component "
+      "fluid.  No upwinding is used.  Templated on is_ad: the AD version requires no hand-coded "
+      "Jacobian.");
   return params;
 }
 
-PorousFlowFullySaturatedDarcyFlow::PorousFlowFullySaturatedDarcyFlow(
+template <bool is_ad>
+PorousFlowFullySaturatedDarcyFlowTempl<is_ad>::PorousFlowFullySaturatedDarcyFlowTempl(
     const InputParameters & parameters)
-  : PorousFlowFullySaturatedDarcyBase(parameters),
-    _mfrac(getMaterialProperty<std::vector<std::vector<Real>>>("PorousFlow_mass_frac_qp")),
-    _dmfrac_dvar(getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
-        "dPorousFlow_mass_frac_qp_dvar")),
-    _fluid_component(getParam<unsigned int>("fluid_component"))
+  : PorousFlowFullySaturatedDarcyBaseTempl<is_ad>(parameters),
+    _mfrac(this->template getGenericMaterialProperty<std::vector<std::vector<Real>>, is_ad>(
+        "PorousFlow_mass_frac_qp")),
+    _dmfrac_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
+                    "dPorousFlow_mass_frac_qp_dvar")),
+    _fluid_component(this->template getParam<unsigned int>("fluid_component"))
 {
   if (_fluid_component >= _dictator.numComponents())
-    paramError(
+    this->paramError(
         "fluid_component",
         "The Dictator proclaims that the maximum fluid component index in this simulation is ",
         _dictator.numComponents() - 1,
@@ -40,19 +48,29 @@ PorousFlowFullySaturatedDarcyFlow::PorousFlowFullySaturatedDarcyFlow(
         ". Remember that indexing starts at 0. Happiness equals perfection.");
 }
 
-Real
-PorousFlowFullySaturatedDarcyFlow::mobility() const
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowFullySaturatedDarcyFlowTempl<is_ad>::mobility() const
 {
   const unsigned ph = 0;
-  return _mfrac[_qp][ph][_fluid_component] * PorousFlowFullySaturatedDarcyBase::mobility();
+  return _mfrac[_qp][ph][_fluid_component] *
+         PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::mobility();
 }
 
+template <bool is_ad>
 Real
-PorousFlowFullySaturatedDarcyFlow::dmobility(unsigned pvar) const
+PorousFlowFullySaturatedDarcyFlowTempl<is_ad>::dmobility(unsigned int pvar) const
 {
-  const unsigned ph = 0;
-  const Real darcy_mob = PorousFlowFullySaturatedDarcyBase::mobility();
-  const Real ddarcy_mob = PorousFlowFullySaturatedDarcyBase::dmobility(pvar);
-  return _dmfrac_dvar[_qp][ph][_fluid_component][pvar] * darcy_mob +
-         _mfrac[_qp][ph][_fluid_component] * ddarcy_mob;
+  if constexpr (!is_ad)
+  {
+    const unsigned ph = 0;
+    const Real darcy_mob = PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::mobility();
+    const Real ddarcy_mob = PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::dmobility(pvar);
+    return (*_dmfrac_dvar)[_qp][ph][_fluid_component][pvar] * darcy_mob +
+           _mfrac[_qp][ph][_fluid_component] * ddarcy_mob;
+  }
+  return 0.0;
 }
+
+template class PorousFlowFullySaturatedDarcyFlowTempl<false>;
+template class PorousFlowFullySaturatedDarcyFlowTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyFlow.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyFlow.C
@@ -69,6 +69,8 @@ PorousFlowFullySaturatedDarcyFlowTempl<is_ad>::dmobility(unsigned int pvar) cons
     return (*_dmfrac_dvar)[_qp][ph][_fluid_component][pvar] * darcy_mob +
            _mfrac[_qp][ph][_fluid_component] * ddarcy_mob;
   }
+  else
+    libmesh_ignore(pvar);
   return 0.0;
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyFlow.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedDarcyFlow.C
@@ -21,8 +21,7 @@ PorousFlowFullySaturatedDarcyFlowTempl<is_ad>::validParams()
       "fluid_component", 0, "The index corresponding to the fluid component for this kernel");
   params.addClassDescription(
       "Darcy flux suitable for models involving a fully-saturated single phase, multi-component "
-      "fluid.  No upwinding is used.  Templated on is_ad: the AD version requires no hand-coded "
-      "Jacobian.");
+      "fluid.  No upwinding is used.");
   return params;
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedHeatAdvection.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedHeatAdvection.C
@@ -10,37 +10,51 @@
 #include "PorousFlowFullySaturatedHeatAdvection.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowFullySaturatedHeatAdvection);
+registerMooseObject("PorousFlowApp", ADPorousFlowFullySaturatedHeatAdvection);
 
+template <bool is_ad>
 InputParameters
-PorousFlowFullySaturatedHeatAdvection::validParams()
+PorousFlowFullySaturatedHeatAdvectionTempl<is_ad>::validParams()
 {
-  InputParameters params = PorousFlowFullySaturatedDarcyBase::validParams();
+  InputParameters params = PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::validParams();
   params.addClassDescription("Heat flux that arises from the advection of a fully-saturated single "
                              "phase fluid.  No upwinding is used");
   return params;
 }
 
-PorousFlowFullySaturatedHeatAdvection::PorousFlowFullySaturatedHeatAdvection(
+template <bool is_ad>
+PorousFlowFullySaturatedHeatAdvectionTempl<is_ad>::PorousFlowFullySaturatedHeatAdvectionTempl(
     const InputParameters & parameters)
-  : PorousFlowFullySaturatedDarcyBase(parameters),
-    _enthalpy(getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_enthalpy_qp")),
-    _denthalpy_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_fluid_phase_enthalpy_qp_dvar"))
+  : PorousFlowFullySaturatedDarcyBaseTempl<is_ad>(parameters),
+    _enthalpy(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_fluid_phase_enthalpy_qp")),
+    _denthalpy_dvar(is_ad ? nullptr
+                          : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                "dPorousFlow_fluid_phase_enthalpy_qp_dvar"))
 {
 }
 
-Real
-PorousFlowFullySaturatedHeatAdvection::mobility() const
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowFullySaturatedHeatAdvectionTempl<is_ad>::mobility() const
 {
   const unsigned ph = 0;
-  return _enthalpy[_qp][ph] * PorousFlowFullySaturatedDarcyBase::mobility();
+  return _enthalpy[_qp][ph] * PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::mobility();
 }
 
+template <bool is_ad>
 Real
-PorousFlowFullySaturatedHeatAdvection::dmobility(unsigned pvar) const
+PorousFlowFullySaturatedHeatAdvectionTempl<is_ad>::dmobility(unsigned pvar) const
 {
-  const unsigned ph = 0;
-  const Real darcy_mob = PorousFlowFullySaturatedDarcyBase::mobility();
-  const Real ddarcy_mob = PorousFlowFullySaturatedDarcyBase::dmobility(pvar);
-  return _denthalpy_dvar[_qp][ph][pvar] * darcy_mob + _enthalpy[_qp][ph] * ddarcy_mob;
+  if constexpr (!is_ad)
+  {
+    const unsigned ph = 0;
+    const Real darcy_mob = PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::mobility();
+    const Real ddarcy_mob = PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::dmobility(pvar);
+    return (*_denthalpy_dvar)[_qp][ph][pvar] * darcy_mob + _enthalpy[_qp][ph] * ddarcy_mob;
+  }
+  return 0.0;
 }
+
+template class PorousFlowFullySaturatedHeatAdvectionTempl<false>;
+template class PorousFlowFullySaturatedHeatAdvectionTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedHeatAdvection.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedHeatAdvection.C
@@ -53,6 +53,8 @@ PorousFlowFullySaturatedHeatAdvectionTempl<is_ad>::dmobility(unsigned pvar) cons
     const Real ddarcy_mob = PorousFlowFullySaturatedDarcyBaseTempl<is_ad>::dmobility(pvar);
     return (*_denthalpy_dvar)[_qp][ph][pvar] * darcy_mob + _enthalpy[_qp][ph] * ddarcy_mob;
   }
+  else
+    libmesh_ignore(pvar);
   return 0.0;
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedMassTimeDerivative.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedMassTimeDerivative.C
@@ -12,72 +12,87 @@
 #include "MooseVariable.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowFullySaturatedMassTimeDerivative);
+registerMooseObject("PorousFlowApp", ADPorousFlowFullySaturatedMassTimeDerivative);
 
+template <bool is_ad>
 InputParameters
-PorousFlowFullySaturatedMassTimeDerivative::validParams()
+PorousFlowFullySaturatedMassTimeDerivativeTempl<is_ad>::validParams()
 {
-  InputParameters params = TimeKernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
+  // Mark residual contributions as time terms (same as TimeKernel / ADTimeKernel)
+  params.set<MultiMooseEnum>("vector_tags") = "time";
+  params.set<MultiMooseEnum>("matrix_tags") = "system time";
   MooseEnum coupling_type("Hydro ThermoHydro HydroMechanical ThermoHydroMechanical", "Hydro");
-  params.addParam<MooseEnum>("coupling_type",
-                             coupling_type,
-                             "The type of simulation.  For simulations involving Mechanical "
-                             "deformations, you will need to supply the correct Biot coefficient.  "
-                             "For simulations involving Thermal flows, you will need an associated "
-                             "ConstantThermalExpansionCoefficient Material");
+  params.addParam<MooseEnum>(
+      "coupling_type",
+      coupling_type,
+      "The type of simulation.  For simulations involving Mechanical deformations, you will need "
+      "to supply the correct Biot coefficient.  For simulations involving Thermal flows, you will "
+      "need an associated ConstantThermalExpansionCoefficient Material");
   params.addRangeCheckedParam<Real>(
       "biot_coefficient", 1.0, "biot_coefficient>=0 & biot_coefficient<=1", "Biot coefficient");
   params.addParam<bool>("multiply_by_density",
                         true,
-                        "If true, then this Kernel is the time derivative of the fluid "
-                        "mass.  If false, then this Kernel is the derivative of the "
-                        "fluid volume (which is common in poro-mechanics)");
+                        "If true, then this Kernel is the time derivative of the fluid mass.  If "
+                        "false, then this Kernel is the derivative of the fluid volume (which is "
+                        "common in poro-mechanics)");
   params.addRequiredParam<UserObjectName>(
       "PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names.");
-  params.addClassDescription("Fully-saturated version of the single-component, single-phase fluid "
-                             "mass derivative wrt time");
+  params.addClassDescription(
+      "Fully-saturated version of the single-component, single-phase fluid mass derivative wrt "
+      "time.  Templated on is_ad: the AD version requires no hand-coded Jacobian.");
   return params;
 }
 
-PorousFlowFullySaturatedMassTimeDerivative::PorousFlowFullySaturatedMassTimeDerivative(
-    const InputParameters & parameters)
-  : TimeKernel(parameters),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+template <bool is_ad>
+PorousFlowFullySaturatedMassTimeDerivativeTempl<
+    is_ad>::PorousFlowFullySaturatedMassTimeDerivativeTempl(const InputParameters & parameters)
+  : GenericKernel<is_ad>(parameters),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
     _var_is_porflow_var(_dictator.isPorousFlowVariable(_var.number())),
-    _multiply_by_density(getParam<bool>("multiply_by_density")),
-    _coupling_type(getParam<MooseEnum>("coupling_type").getEnum<CouplingTypeEnum>()),
+    _multiply_by_density(this->template getParam<bool>("multiply_by_density")),
+    _coupling_type(
+        this->template getParam<MooseEnum>("coupling_type").template getEnum<CouplingTypeEnum>()),
     _includes_thermal(_coupling_type == CouplingTypeEnum::ThermoHydro ||
                       _coupling_type == CouplingTypeEnum::ThermoHydroMechanical),
     _includes_mechanical(_coupling_type == CouplingTypeEnum::HydroMechanical ||
                          _coupling_type == CouplingTypeEnum::ThermoHydroMechanical),
-    _biot_coefficient(getParam<Real>("biot_coefficient")),
-    _biot_modulus(getMaterialProperty<Real>("PorousFlow_constant_biot_modulus_qp")),
-    _thermal_coeff(_includes_thermal ? &getMaterialProperty<Real>(
+    _biot_coefficient(this->template getParam<Real>("biot_coefficient")),
+    _biot_modulus(this->template getMaterialProperty<Real>("PorousFlow_constant_biot_modulus_qp")),
+    _thermal_coeff(_includes_thermal ? &this->template getMaterialProperty<Real>(
                                            "PorousFlow_constant_thermal_expansion_coefficient_qp")
                                      : nullptr),
-    _fluid_density(_multiply_by_density ? &getMaterialProperty<std::vector<Real>>(
-                                              "PorousFlow_fluid_phase_density_qp")
-                                        : nullptr),
-    _dfluid_density_dvar(_multiply_by_density
-                             ? &getMaterialProperty<std::vector<std::vector<Real>>>(
+    _fluid_density(_multiply_by_density
+                       ? &this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+                             "PorousFlow_fluid_phase_density_qp")
+                       : nullptr),
+    _dfluid_density_dvar(_multiply_by_density && !is_ad
+                             ? &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
                                    "dPorousFlow_fluid_phase_density_qp_dvar")
                              : nullptr),
-    _pp(getMaterialProperty<std::vector<Real>>("PorousFlow_porepressure_qp")),
-    _pp_old(getMaterialPropertyOld<std::vector<Real>>("PorousFlow_porepressure_qp")),
-    _dpp_dvar(
-        getMaterialProperty<std::vector<std::vector<Real>>>("dPorousFlow_porepressure_qp_dvar")),
-    _temperature(_includes_thermal ? &getMaterialProperty<Real>("PorousFlow_temperature_qp")
+    _pp(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_porepressure_qp")),
+    _pp_old(this->template getMaterialPropertyOld<std::vector<Real>>("PorousFlow_porepressure_qp")),
+    _dpp_dvar(is_ad ? nullptr
+                    : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                          "dPorousFlow_porepressure_qp_dvar")),
+    _temperature(_includes_thermal ? &this->template getGenericMaterialProperty<Real, is_ad>(
+                                         "PorousFlow_temperature_qp")
                                    : nullptr),
-    _temperature_old(_includes_thermal ? &getMaterialPropertyOld<Real>("PorousFlow_temperature_qp")
-                                       : nullptr),
-    _dtemperature_dvar(_includes_thermal ? &getMaterialProperty<std::vector<Real>>(
-                                               "dPorousFlow_temperature_qp_dvar")
-                                         : nullptr),
-    _strain_rate(_includes_mechanical
-                     ? &getMaterialProperty<Real>("PorousFlow_volumetric_strain_rate_qp")
-                     : nullptr),
-    _dstrain_rate_dvar(_includes_mechanical ? &getMaterialProperty<std::vector<RealGradient>>(
-                                                  "dPorousFlow_volumetric_strain_rate_qp_dvar")
-                                            : nullptr)
+    _temperature_old(_includes_thermal
+                         ? &this->template getMaterialPropertyOld<Real>("PorousFlow_temperature_qp")
+                         : nullptr),
+    _dtemperature_dvar(_includes_thermal && !is_ad
+                           ? &this->template getMaterialProperty<std::vector<Real>>(
+                                 "dPorousFlow_temperature_qp_dvar")
+                           : nullptr),
+    _strain_rate(_includes_mechanical ? &this->template getMaterialProperty<Real>(
+                                            "PorousFlow_volumetric_strain_rate_qp")
+                                      : nullptr),
+    _dstrain_rate_dvar(_includes_mechanical && !is_ad
+                           ? &this->template getMaterialProperty<std::vector<RealGradient>>(
+                                 "dPorousFlow_volumetric_strain_rate_qp_dvar")
+                           : nullptr)
 {
   if (_dictator.numComponents() != 1 || _dictator.numPhases() != 1)
     mooseError("PorousFlowFullySaturatedMassTimeDerivative is only applicable to single-phase, "
@@ -86,11 +101,12 @@ PorousFlowFullySaturatedMassTimeDerivative::PorousFlowFullySaturatedMassTimeDeri
                "mistakes lightly");
 }
 
-Real
-PorousFlowFullySaturatedMassTimeDerivative::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowFullySaturatedMassTimeDerivativeTempl<is_ad>::computeQpResidual()
 {
   const unsigned phase = 0;
-  Real volume = (_pp[_qp][phase] - _pp_old[_qp][phase]) / _dt / _biot_modulus[_qp];
+  GenericReal<is_ad> volume = (_pp[_qp][phase] - _pp_old[_qp][phase]) / _dt / _biot_modulus[_qp];
   if (_includes_thermal)
     volume -= (*_thermal_coeff)[_qp] * ((*_temperature)[_qp] - (*_temperature_old)[_qp]) / _dt;
   if (_includes_mechanical)
@@ -100,42 +116,58 @@ PorousFlowFullySaturatedMassTimeDerivative::computeQpResidual()
   return _test[_i][_qp] * volume;
 }
 
+template <bool is_ad>
 Real
-PorousFlowFullySaturatedMassTimeDerivative::computeQpJacobian()
+PorousFlowFullySaturatedMassTimeDerivativeTempl<is_ad>::computeQpJacobian()
 {
-  // If the variable is not a PorousFlow variable (very unusual), the diag Jacobian terms are 0
-  if (!_var_is_porflow_var)
-    return 0.0;
-  return computeQpJac(_dictator.porousFlowVariableNum(_var.number()));
+  if constexpr (!is_ad)
+  {
+    if (!_var_is_porflow_var)
+      return 0.0;
+    return computeQpJac(_dictator.porousFlowVariableNum(_var.number()));
+  }
+  return 0.0;
 }
 
+template <bool is_ad>
 Real
-PorousFlowFullySaturatedMassTimeDerivative::computeQpOffDiagJacobian(unsigned int jvar)
+PorousFlowFullySaturatedMassTimeDerivativeTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  // If the variable is not a PorousFlow variable, the OffDiag Jacobian terms are 0
-  if (_dictator.notPorousFlowVariable(jvar))
-    return 0.0;
-  return computeQpJac(_dictator.porousFlowVariableNum(jvar));
+  if constexpr (!is_ad)
+  {
+    if (_dictator.notPorousFlowVariable(jvar))
+      return 0.0;
+    return computeQpJac(_dictator.porousFlowVariableNum(jvar));
+  }
+  return 0.0;
 }
 
+template <bool is_ad>
 Real
-PorousFlowFullySaturatedMassTimeDerivative::computeQpJac(unsigned int pvar)
+PorousFlowFullySaturatedMassTimeDerivativeTempl<is_ad>::computeQpJac(unsigned int pvar)
 {
-  const unsigned phase = 0;
-  Real volume = (_pp[_qp][phase] - _pp_old[_qp][phase]) / _dt / _biot_modulus[_qp];
-  Real dvolume = _dpp_dvar[_qp][phase][pvar] / _dt / _biot_modulus[_qp] * _phi[_j][_qp];
-  if (_includes_thermal)
+  if constexpr (!is_ad)
   {
-    volume -= (*_thermal_coeff)[_qp] * ((*_temperature)[_qp] - (*_temperature_old)[_qp]) / _dt;
-    dvolume -= (*_thermal_coeff)[_qp] * (*_dtemperature_dvar)[_qp][pvar] / _dt * _phi[_j][_qp];
+    const unsigned phase = 0;
+    Real volume = (_pp[_qp][phase] - _pp_old[_qp][phase]) / _dt / _biot_modulus[_qp];
+    Real dvolume = (*_dpp_dvar)[_qp][phase][pvar] / _dt / _biot_modulus[_qp] * _phi[_j][_qp];
+    if (_includes_thermal)
+    {
+      volume -= (*_thermal_coeff)[_qp] * ((*_temperature)[_qp] - (*_temperature_old)[_qp]) / _dt;
+      dvolume -= (*_thermal_coeff)[_qp] * (*_dtemperature_dvar)[_qp][pvar] / _dt * _phi[_j][_qp];
+    }
+    if (_includes_mechanical)
+    {
+      volume += _biot_coefficient * (*_strain_rate)[_qp];
+      dvolume += _biot_coefficient * (*_dstrain_rate_dvar)[_qp][pvar] * _grad_phi[_j][_qp];
+    }
+    if (_multiply_by_density)
+      return _test[_i][_qp] * ((*_fluid_density)[_qp][phase] * dvolume +
+                               (*_dfluid_density_dvar)[_qp][phase][pvar] * _phi[_j][_qp] * volume);
+    return _test[_i][_qp] * dvolume;
   }
-  if (_includes_mechanical)
-  {
-    volume += _biot_coefficient * (*_strain_rate)[_qp];
-    dvolume += _biot_coefficient * (*_dstrain_rate_dvar)[_qp][pvar] * _grad_phi[_j][_qp];
-  }
-  if (_multiply_by_density)
-    return _test[_i][_qp] * ((*_fluid_density)[_qp][phase] * dvolume +
-                             (*_dfluid_density_dvar)[_qp][phase][pvar] * _phi[_j][_qp] * volume);
-  return _test[_i][_qp] * dvolume;
+  return 0.0;
 }
+
+template class PorousFlowFullySaturatedMassTimeDerivativeTempl<false>;
+template class PorousFlowFullySaturatedMassTimeDerivativeTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedMassTimeDerivative.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedMassTimeDerivative.C
@@ -139,6 +139,8 @@ PorousFlowFullySaturatedMassTimeDerivativeTempl<is_ad>::computeQpOffDiagJacobian
       return 0.0;
     return computeQpJac(_dictator.porousFlowVariableNum(jvar));
   }
+  else
+    libmesh_ignore(jvar);
   return 0.0;
 }
 
@@ -166,6 +168,8 @@ PorousFlowFullySaturatedMassTimeDerivativeTempl<is_ad>::computeQpJac(unsigned in
                                (*_dfluid_density_dvar)[_qp][phase][pvar] * _phi[_j][_qp] * volume);
     return _test[_i][_qp] * dvolume;
   }
+  else
+    libmesh_ignore(pvar);
   return 0.0;
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedMassTimeDerivative.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedMassTimeDerivative.C
@@ -40,7 +40,7 @@ PorousFlowFullySaturatedMassTimeDerivativeTempl<is_ad>::validParams()
       "PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names.");
   params.addClassDescription(
       "Fully-saturated version of the single-component, single-phase fluid mass derivative wrt "
-      "time.  Templated on is_ad: the AD version requires no hand-coded Jacobian.");
+      "time.");
   return params;
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowFullySaturatedUpwindHeatAdvection.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFullySaturatedUpwindHeatAdvection.C
@@ -10,46 +10,63 @@
 #include "PorousFlowFullySaturatedUpwindHeatAdvection.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowFullySaturatedUpwindHeatAdvection);
+registerMooseObject("PorousFlowApp", ADPorousFlowFullySaturatedUpwindHeatAdvection);
 
+template <bool is_ad>
 InputParameters
-PorousFlowFullySaturatedUpwindHeatAdvection::validParams()
+PorousFlowFullySaturatedUpwindHeatAdvectionTempl<is_ad>::validParams()
 {
-  InputParameters params = PorousFlowDarcyBase::validParams();
+  InputParameters params = PorousFlowDarcyBaseTempl<is_ad>::validParams();
   params.addClassDescription("Heat advection by a fluid.  The fluid is assumed to have a single "
                              "phase, and the advection is fully upwinded");
   return params;
 }
 
-PorousFlowFullySaturatedUpwindHeatAdvection::PorousFlowFullySaturatedUpwindHeatAdvection(
-    const InputParameters & parameters)
-  : PorousFlowDarcyBase(parameters),
-    _enthalpy(getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_enthalpy_nodal")),
-    _denthalpy_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_fluid_phase_enthalpy_nodal_dvar"))
+template <bool is_ad>
+PorousFlowFullySaturatedUpwindHeatAdvectionTempl<
+    is_ad>::PorousFlowFullySaturatedUpwindHeatAdvectionTempl(const InputParameters & parameters)
+  : PorousFlowDarcyBaseTempl<is_ad>(parameters),
+    _enthalpy(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_fluid_phase_enthalpy_nodal")),
+    _denthalpy_dvar(is_ad ? nullptr
+                          : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                "dPorousFlow_fluid_phase_enthalpy_nodal_dvar"))
 {
   if (_dictator.numPhases() != 1)
     mooseError("PorousFlowFullySaturatedUpwindHeatAdvection should not be used for multi-phase "
                "scenarios as it does not include relative-permeability effects");
 }
 
-Real
-PorousFlowFullySaturatedUpwindHeatAdvection::mobility(unsigned nodenum, unsigned phase) const
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowFullySaturatedUpwindHeatAdvectionTempl<is_ad>::mobility(unsigned nodenum,
+                                                                  unsigned phase) const
 {
   return _enthalpy[nodenum][phase] * _fluid_density_node[nodenum][phase] /
          _fluid_viscosity[nodenum][phase];
 }
 
+template <bool is_ad>
 Real
-PorousFlowFullySaturatedUpwindHeatAdvection::dmobility(unsigned nodenum,
-                                                       unsigned phase,
-                                                       unsigned pvar) const
+PorousFlowFullySaturatedUpwindHeatAdvectionTempl<is_ad>::dmobility(unsigned nodenum,
+                                                                   unsigned phase,
+                                                                   unsigned pvar) const
 {
-  Real dm = _denthalpy_dvar[nodenum][phase][pvar] * _fluid_density_node[nodenum][phase] /
-            _fluid_viscosity[nodenum][phase];
-  dm += _enthalpy[nodenum][phase] * _dfluid_density_node_dvar[nodenum][phase][pvar] /
-        _fluid_viscosity[nodenum][phase];
-  dm -= _enthalpy[nodenum][phase] * _fluid_density_node[nodenum][phase] *
-        _dfluid_viscosity_dvar[nodenum][phase][pvar] /
-        Utility::pow<2>(_fluid_viscosity[nodenum][phase]);
-  return dm;
+  if constexpr (!is_ad)
+  {
+    Real dm = (*_denthalpy_dvar)[nodenum][phase][pvar] * _fluid_density_node[nodenum][phase] /
+              _fluid_viscosity[nodenum][phase];
+    dm += _enthalpy[nodenum][phase] * (*_dfluid_density_node_dvar)[nodenum][phase][pvar] /
+          _fluid_viscosity[nodenum][phase];
+    dm -= _enthalpy[nodenum][phase] * _fluid_density_node[nodenum][phase] *
+          (*_dfluid_viscosity_dvar)[nodenum][phase][pvar] /
+          Utility::pow<2>(_fluid_viscosity[nodenum][phase]);
+    return dm;
+  }
+  else
+    libmesh_ignore(nodenum, phase, pvar);
+  return 0.0;
 }
+
+template class PorousFlowFullySaturatedUpwindHeatAdvectionTempl<false>;
+template class PorousFlowFullySaturatedUpwindHeatAdvectionTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowHeatAdvection.C
+++ b/modules/porous_flow/src/kernels/PorousFlowHeatAdvection.C
@@ -10,45 +10,66 @@
 #include "PorousFlowHeatAdvection.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowHeatAdvection);
+registerMooseObject("PorousFlowApp", ADPorousFlowHeatAdvection);
 
+template <bool is_ad>
 InputParameters
-PorousFlowHeatAdvection::validParams()
+PorousFlowHeatAdvectionTempl<is_ad>::validParams()
 {
-  InputParameters params = PorousFlowDarcyBase::validParams();
+  InputParameters params = PorousFlowDarcyBaseTempl<is_ad>::validParams();
   params.addClassDescription("Fully-upwinded heat flux, advected by the fluid");
   return params;
 }
 
-PorousFlowHeatAdvection::PorousFlowHeatAdvection(const InputParameters & parameters)
-  : PorousFlowDarcyBase(parameters),
-    _enthalpy(getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_enthalpy_nodal")),
-    _denthalpy_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_fluid_phase_enthalpy_nodal_dvar")),
-    _relative_permeability(
-        getMaterialProperty<std::vector<Real>>("PorousFlow_relative_permeability_nodal")),
-    _drelative_permeability_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_relative_permeability_nodal_dvar"))
+template <bool is_ad>
+PorousFlowHeatAdvectionTempl<is_ad>::PorousFlowHeatAdvectionTempl(
+    const InputParameters & parameters)
+  : PorousFlowDarcyBaseTempl<is_ad>(parameters),
+    _enthalpy(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_fluid_phase_enthalpy_nodal")),
+    _denthalpy_dvar(is_ad ? nullptr
+                          : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                "dPorousFlow_fluid_phase_enthalpy_nodal_dvar")),
+    _relative_permeability(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_relative_permeability_nodal")),
+    _drelative_permeability_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                    "dPorousFlow_relative_permeability_nodal_dvar"))
 {
 }
 
-Real
-PorousFlowHeatAdvection::mobility(unsigned nodenum, unsigned phase) const
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowHeatAdvectionTempl<is_ad>::mobility(unsigned nodenum, unsigned phase) const
 {
   return _enthalpy[nodenum][phase] * _fluid_density_node[nodenum][phase] *
          _relative_permeability[nodenum][phase] / _fluid_viscosity[nodenum][phase];
 }
 
+template <bool is_ad>
 Real
-PorousFlowHeatAdvection::dmobility(unsigned nodenum, unsigned phase, unsigned pvar) const
+PorousFlowHeatAdvectionTempl<is_ad>::dmobility(unsigned nodenum,
+                                               unsigned phase,
+                                               unsigned pvar) const
 {
-  Real dm = _denthalpy_dvar[nodenum][phase][pvar] * _fluid_density_node[nodenum][phase] *
-            _relative_permeability[nodenum][phase] / _fluid_viscosity[nodenum][phase];
-  dm += _enthalpy[nodenum][phase] * _dfluid_density_node_dvar[nodenum][phase][pvar] *
-        _relative_permeability[nodenum][phase] / _fluid_viscosity[nodenum][phase];
-  dm += _enthalpy[nodenum][phase] * _fluid_density_node[nodenum][phase] *
-        _drelative_permeability_dvar[nodenum][phase][pvar] / _fluid_viscosity[nodenum][phase];
-  dm -= _enthalpy[nodenum][phase] * _fluid_density_node[nodenum][phase] *
-        _relative_permeability[nodenum][phase] * _dfluid_viscosity_dvar[nodenum][phase][pvar] /
-        std::pow(_fluid_viscosity[nodenum][phase], 2);
-  return dm;
+  if constexpr (!is_ad)
+  {
+    Real dm = (*_denthalpy_dvar)[nodenum][phase][pvar] * _fluid_density_node[nodenum][phase] *
+              _relative_permeability[nodenum][phase] / _fluid_viscosity[nodenum][phase];
+    dm += _enthalpy[nodenum][phase] * (*_dfluid_density_node_dvar)[nodenum][phase][pvar] *
+          _relative_permeability[nodenum][phase] / _fluid_viscosity[nodenum][phase];
+    dm += _enthalpy[nodenum][phase] * _fluid_density_node[nodenum][phase] *
+          (*_drelative_permeability_dvar)[nodenum][phase][pvar] / _fluid_viscosity[nodenum][phase];
+    dm -= _enthalpy[nodenum][phase] * _fluid_density_node[nodenum][phase] *
+          _relative_permeability[nodenum][phase] * (*_dfluid_viscosity_dvar)[nodenum][phase][pvar] /
+          std::pow(_fluid_viscosity[nodenum][phase], 2);
+    return dm;
+  }
+  else
+    libmesh_ignore(nodenum, phase, pvar);
+  return 0.0;
 }
+
+template class PorousFlowHeatAdvectionTempl<false>;
+template class PorousFlowHeatAdvectionTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowHeatConduction.C
+++ b/modules/porous_flow/src/kernels/PorousFlowHeatConduction.C
@@ -12,54 +12,74 @@
 #include "MooseVariable.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowHeatConduction);
+registerMooseObject("PorousFlowApp", ADPorousFlowHeatConduction);
 
+template <bool is_ad>
 InputParameters
-PorousFlowHeatConduction::validParams()
+PorousFlowHeatConductionTempl<is_ad>::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
   params.addRequiredParam<UserObjectName>(
       "PorousFlowDictator", "The UserObject that holds the list of PorousFlow variable names");
   params.addClassDescription("Heat conduction in the Porous Flow module");
   return params;
 }
 
-PorousFlowHeatConduction::PorousFlowHeatConduction(const InputParameters & parameters)
-  : Kernel(parameters),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
-    _la(getMaterialProperty<RealTensorValue>("PorousFlow_thermal_conductivity_qp")),
-    _dla_dvar(getMaterialProperty<std::vector<RealTensorValue>>(
-        "dPorousFlow_thermal_conductivity_qp_dvar")),
-    _grad_t(getMaterialProperty<RealGradient>("PorousFlow_grad_temperature_qp")),
-    _dgrad_t_dvar(
-        getMaterialProperty<std::vector<RealGradient>>("dPorousFlow_grad_temperature_qp_dvar")),
-    _dgrad_t_dgradvar(
-        getMaterialProperty<std::vector<Real>>("dPorousFlow_grad_temperature_qp_dgradvar"))
+template <bool is_ad>
+PorousFlowHeatConductionTempl<is_ad>::PorousFlowHeatConductionTempl(
+    const InputParameters & parameters)
+  : GenericKernel<is_ad>(parameters),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+    _la(this->template getGenericMaterialProperty<RealTensorValue, is_ad>(
+        "PorousFlow_thermal_conductivity_qp")),
+    _dla_dvar(is_ad ? nullptr
+                    : &this->template getMaterialProperty<std::vector<RealTensorValue>>(
+                          "dPorousFlow_thermal_conductivity_qp_dvar")),
+    _grad_t(this->template getGenericMaterialProperty<RealGradient, is_ad>(
+        "PorousFlow_grad_temperature_qp")),
+    _dgrad_t_dvar(is_ad ? nullptr
+                        : &this->template getMaterialProperty<std::vector<RealGradient>>(
+                              "dPorousFlow_grad_temperature_qp_dvar")),
+    _dgrad_t_dgradvar(is_ad ? nullptr
+                            : &this->template getMaterialProperty<std::vector<Real>>(
+                                  "dPorousFlow_grad_temperature_qp_dgradvar"))
 {
 }
 
-Real
-PorousFlowHeatConduction::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowHeatConductionTempl<is_ad>::computeQpResidual()
 {
   return _grad_test[_i][_qp] * (_la[_qp] * _grad_t[_qp]);
 }
 
+template <bool is_ad>
 Real
-PorousFlowHeatConduction::computeQpJacobian()
+PorousFlowHeatConductionTempl<is_ad>::computeQpJacobian()
 {
-  return computeQpOffDiagJacobian(_var.number());
+  if constexpr (!is_ad)
+    return computeQpOffDiagJacobian(_var.number());
+  return 0.0;
 }
 
+template <bool is_ad>
 Real
-PorousFlowHeatConduction::computeQpOffDiagJacobian(unsigned int jvar)
+PorousFlowHeatConductionTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
 {
-  if (_dictator.notPorousFlowVariable(jvar))
-    return 0.0;
-
-  // The PorousFlow variable index corresponding to the variable number jvar
-  const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
-
-  return _grad_test[_i][_qp] *
-         ((_dla_dvar[_qp][pvar] * _grad_t[_qp] + _la[_qp] * _dgrad_t_dvar[_qp][pvar]) *
-              _phi[_j][_qp] +
-          _la[_qp] * _dgrad_t_dgradvar[_qp][pvar] * _grad_phi[_j][_qp]);
+  if constexpr (!is_ad)
+  {
+    if (_dictator.notPorousFlowVariable(jvar))
+      return 0.0;
+    const unsigned int pvar = _dictator.porousFlowVariableNum(jvar);
+    return _grad_test[_i][_qp] *
+           (((*_dla_dvar)[_qp][pvar] * _grad_t[_qp] + _la[_qp] * (*_dgrad_t_dvar)[_qp][pvar]) *
+                _phi[_j][_qp] +
+            _la[_qp] * (*_dgrad_t_dgradvar)[_qp][pvar] * _grad_phi[_j][_qp]);
+  }
+  else
+    libmesh_ignore(jvar);
+  return 0.0;
 }
+
+template class PorousFlowHeatConductionTempl<false>;
+template class PorousFlowHeatConductionTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowHeatMassTransfer.C
+++ b/modules/porous_flow/src/kernels/PorousFlowHeatMassTransfer.C
@@ -12,11 +12,13 @@
 #include "MooseVariable.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowHeatMassTransfer);
+registerMooseObject("PorousFlowApp", ADPorousFlowHeatMassTransfer);
 
+template <bool is_ad>
 InputParameters
-PorousFlowHeatMassTransfer::validParams()
+PorousFlowHeatMassTransferTempl<is_ad>::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
 
   params.addClassDescription(
       "Calculate heat or mass transfer from a coupled variable v to the variable u. "
@@ -30,38 +32,49 @@ PorousFlowHeatMassTransfer::validParams()
   return params;
 }
 
-PorousFlowHeatMassTransfer::PorousFlowHeatMassTransfer(const InputParameters & parameters)
-  : Kernel(parameters),
+template <bool is_ad>
+PorousFlowHeatMassTransferTempl<is_ad>::PorousFlowHeatMassTransferTempl(
+    const InputParameters & parameters)
+  : GenericKernel<is_ad>(parameters),
     _v_var(coupled("v")),
-    _v(coupledValue("v")),
-    _coef_var(coupledValue("transfer_coefficient"))
+    _v(this->template coupledGenericValue<is_ad>("v")),
+    _coef_var(this->coupledValue("transfer_coefficient"))
 {
 }
 
-Real
-PorousFlowHeatMassTransfer::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowHeatMassTransferTempl<is_ad>::computeQpResidual()
 {
   return _coef_var[_qp] * (_u[_qp] - _v[_qp]) * _test[_i][_qp];
 }
 
+template <bool is_ad>
 Real
-PorousFlowHeatMassTransfer::computeQpJacobian()
+PorousFlowHeatMassTransferTempl<is_ad>::computeQpJacobian()
 {
   return jac(_var.number());
 }
 
+template <bool is_ad>
 Real
-PorousFlowHeatMassTransfer::computeQpOffDiagJacobian(unsigned int jvar)
+PorousFlowHeatMassTransferTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
 {
   return jac(jvar);
 }
 
+template <bool is_ad>
 Real
-PorousFlowHeatMassTransfer::jac(unsigned int jvar) const
+PorousFlowHeatMassTransferTempl<is_ad>::jac(unsigned int jvar) const
 {
+  // Never called for the AD instantiation, which assembles the Jacobian from the AD residual.
+  mooseAssert(!is_ad, "jac should not be called for the AD instantiation");
   if (jvar == _var.number())
     return _coef_var[_qp] * _phi[_j][_qp] * _test[_i][_qp];
   else if (jvar == _v_var)
     return -_coef_var[_qp] * _phi[_j][_qp] * _test[_i][_qp];
   return 0.0;
 }
+
+template class PorousFlowHeatMassTransferTempl<false>;
+template class PorousFlowHeatMassTransferTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowHeatMassTransfer.C
+++ b/modules/porous_flow/src/kernels/PorousFlowHeatMassTransfer.C
@@ -38,7 +38,7 @@ PorousFlowHeatMassTransferTempl<is_ad>::PorousFlowHeatMassTransferTempl(
   : GenericKernel<is_ad>(parameters),
     _v_var(coupled("v")),
     _v(this->template coupledGenericValue<is_ad>("v")),
-    _coef_var(this->coupledValue("transfer_coefficient"))
+    _coef_var(this->template coupledGenericValue<is_ad>("transfer_coefficient"))
 {
 }
 
@@ -67,12 +67,16 @@ template <bool is_ad>
 Real
 PorousFlowHeatMassTransferTempl<is_ad>::jac(unsigned int jvar) const
 {
-  // Never called for the AD instantiation, which assembles the Jacobian from the AD residual.
-  mooseAssert(!is_ad, "jac should not be called for the AD instantiation");
-  if (jvar == _var.number())
-    return _coef_var[_qp] * _phi[_j][_qp] * _test[_i][_qp];
-  else if (jvar == _v_var)
-    return -_coef_var[_qp] * _phi[_j][_qp] * _test[_i][_qp];
+  if constexpr (!is_ad)
+  {
+    if (jvar == _var.number())
+      return _coef_var[_qp] * _phi[_j][_qp] * _test[_i][_qp];
+    else if (jvar == _v_var)
+      return -_coef_var[_qp] * _phi[_j][_qp] * _test[_i][_qp];
+    return 0.0;
+  }
+  else
+    libmesh_ignore(jvar);
   return 0.0;
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowLumpedKernelBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowLumpedKernelBase.C
@@ -1,0 +1,92 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "PorousFlowLumpedKernelBase.h"
+
+template <bool is_ad>
+InputParameters
+PorousFlowLumpedKernelBaseTempl<is_ad>::validParams()
+{
+  return GenericKernel<is_ad>::validParams();
+}
+
+template <bool is_ad>
+PorousFlowLumpedKernelBaseTempl<is_ad>::PorousFlowLumpedKernelBaseTempl(
+    const InputParameters & parameters)
+  : GenericKernel<is_ad>(parameters)
+{
+}
+
+template <bool is_ad>
+void
+PorousFlowLumpedKernelBaseTempl<is_ad>::jacobianSetup()
+{
+  GenericKernel<is_ad>::jacobianSetup();
+  _my_elem_lma = nullptr;
+}
+
+// AD-path Jacobian assembly for kernels that use mass-lumped (nodal) material properties.
+//
+// The default ADKernel path (ADKernel::computeADJacobian -> addJacobian) routes through
+// Assembly::cacheJacobian, which takes the sparse column set from residuals[0] and reuses it for
+// every row.  That assumes every test function's residual depends on the same set of DOFs, which
+// holds for ordinary qp-based weak forms because the solution at any QP is sum_j u_j*phi_j(qp)
+// and therefore involves every element DOF.
+//
+// With mass lumping each residual row _i depends only on the nodal material properties at node _i
+// (i.e. on the DOFs at node _i alone), so the column set from residuals[0] is only valid for row 0;
+// the off-node rows are assembled against the wrong columns and come out zero.
+//
+// addJacobianWithoutConstraints reads each row's own column indices from
+// residuals[_i].derivatives().nude_indices(), giving the correct per-node block structure.
+//
+// This is consistent with how the framework handles analogous cases:
+//   - ADNodalKernel::computeJacobian passes a size-1 residual array; Assembly::cacheJacobian's
+//     residuals.size()==1 branch falls straight through to cacheJacobianWithoutConstraints.
+//   - MassLumpedTimeDerivative::computeJacobian (non-AD) overrides assembly to fill only the
+//     node-diagonal entries, for the same structural reason.
+//
+// constrain_element_matrix is therefore skipped.  It cannot be applied to a node-diagonal block
+// structure: the constraint machinery assumes a fully-coupled local matrix where all rows share a
+// column space.  Neither the non-AD lumped path nor the framework AD nodal path applies it either.
+template <bool is_ad>
+void
+PorousFlowLumpedKernelBaseTempl<is_ad>::computeJacobian()
+{
+  if constexpr (!is_ad)
+    GenericKernel<is_ad>::computeJacobian();
+  else
+  {
+    this->computeResidualsForJacobian();
+    this->addJacobianWithoutConstraints(
+        this->_assembly, this->_residuals, this->dofIndices(), this->_var.scalingFactor());
+  }
+}
+
+// A single AD residual evaluation carries derivatives wrt every coupled variable, so the
+// off-diagonal blocks are assembled by the same addJacobianWithoutConstraints call as the diagonal.
+// _my_elem_lma caches the element so computation happens once per element rather than once per
+// coupled jvar, mirroring ADKernel's own _my_elem guard in ADKernel::computeOffDiagJacobian.
+template <bool is_ad>
+void
+PorousFlowLumpedKernelBaseTempl<is_ad>::computeOffDiagJacobian(unsigned int jvar)
+{
+  if constexpr (!is_ad)
+    GenericKernel<is_ad>::computeOffDiagJacobian(jvar);
+  else if (_my_elem_lma != this->_current_elem)
+  {
+    this->computeResidualsForJacobian();
+    this->addJacobianWithoutConstraints(
+        this->_assembly, this->_residuals, this->dofIndices(), this->_var.scalingFactor());
+    _my_elem_lma = this->_current_elem;
+  }
+}
+
+template class PorousFlowLumpedKernelBaseTempl<false>;
+template class PorousFlowLumpedKernelBaseTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowLumpedKernelBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowLumpedKernelBase.C
@@ -79,12 +79,16 @@ PorousFlowLumpedKernelBaseTempl<is_ad>::computeOffDiagJacobian(unsigned int jvar
 {
   if constexpr (!is_ad)
     GenericKernel<is_ad>::computeOffDiagJacobian(jvar);
-  else if (_my_elem_lma != this->_current_elem)
+  else
   {
-    this->computeResidualsForJacobian();
-    this->addJacobianWithoutConstraints(
-        this->_assembly, this->_residuals, this->dofIndices(), this->_var.scalingFactor());
-    _my_elem_lma = this->_current_elem;
+    libmesh_ignore(jvar);
+    if (_my_elem_lma != this->_current_elem)
+    {
+      this->computeResidualsForJacobian();
+      this->addJacobianWithoutConstraints(
+          this->_assembly, this->_residuals, this->dofIndices(), this->_var.scalingFactor());
+      _my_elem_lma = this->_current_elem;
+    }
   }
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowLumpedKernelBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowLumpedKernelBase.C
@@ -14,6 +14,15 @@ PorousFlowLumpedKernelBaseTempl<is_ad>::PorousFlowLumpedKernelBaseTempl(
     const InputParameters & parameters)
   : GenericKernel<is_ad>(parameters)
 {
+  // Mass lumping evaluates each residual row using the nodal material property at that node, which
+  // identifies each element test function with a mesh node.  This is only valid for nodal
+  // (Lagrange) variables.
+  if (!_var.isNodal())
+    mooseError("The variable '",
+               _var.name(),
+               "' is not a nodal (Lagrange) variable.  This kernel uses mass lumping, which "
+               "requires a nodal variable.  For non-nodal variables use the non-lumped "
+               "PorousFlowFullySaturated* kernels instead.");
 }
 
 template <bool is_ad>

--- a/modules/porous_flow/src/kernels/PorousFlowLumpedKernelBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowLumpedKernelBase.C
@@ -10,13 +10,6 @@
 #include "PorousFlowLumpedKernelBase.h"
 
 template <bool is_ad>
-InputParameters
-PorousFlowLumpedKernelBaseTempl<is_ad>::validParams()
-{
-  return GenericKernel<is_ad>::validParams();
-}
-
-template <bool is_ad>
 PorousFlowLumpedKernelBaseTempl<is_ad>::PorousFlowLumpedKernelBaseTempl(
     const InputParameters & parameters)
   : GenericKernel<is_ad>(parameters)
@@ -63,9 +56,13 @@ PorousFlowLumpedKernelBaseTempl<is_ad>::computeJacobian()
     GenericKernel<is_ad>::computeJacobian();
   else
   {
-    this->computeResidualsForJacobian();
-    this->addJacobianWithoutConstraints(
-        this->_assembly, this->_residuals, this->dofIndices(), this->_var.scalingFactor());
+    if (_my_elem_lma != this->_current_elem)
+    {
+      this->computeResidualsForJacobian();
+      this->addJacobianWithoutConstraints(
+          this->_assembly, this->_residuals, this->dofIndices(), this->_var.scalingFactor());
+      _my_elem_lma = this->_current_elem;
+    }
   }
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowMassRadioactiveDecay.C
+++ b/modules/porous_flow/src/kernels/PorousFlowMassRadioactiveDecay.C
@@ -16,11 +16,15 @@
 #include <limits>
 
 registerMooseObject("PorousFlowApp", PorousFlowMassRadioactiveDecay);
+registerMooseObject("PorousFlowApp", ADPorousFlowMassRadioactiveDecay);
 
+template <bool is_ad>
 InputParameters
-PorousFlowMassRadioactiveDecay::validParams()
+PorousFlowMassRadioactiveDecayTempl<is_ad>::validParams()
 {
-  InputParameters params = TimeKernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
+  params.set<MultiMooseEnum>("vector_tags") = "time";
+  params.set<MultiMooseEnum>("matrix_tags") = "system time";
   params.addParam<bool>("strain_at_nearest_qp",
                         false,
                         "When calculating nodal porosity that depends on strain, use the strain at "
@@ -38,33 +42,47 @@ PorousFlowMassRadioactiveDecay::validParams()
   return params;
 }
 
-PorousFlowMassRadioactiveDecay::PorousFlowMassRadioactiveDecay(const InputParameters & parameters)
-  : TimeKernel(parameters),
-    _decay_rate(getParam<Real>("decay_rate")),
-    _fluid_component(getParam<unsigned int>("fluid_component")),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+template <bool is_ad>
+PorousFlowMassRadioactiveDecayTempl<is_ad>::PorousFlowMassRadioactiveDecayTempl(
+    const InputParameters & parameters)
+  : PorousFlowLumpedKernelBaseTempl<is_ad>(parameters),
+    _decay_rate(this->template getParam<Real>("decay_rate")),
+    _fluid_component(this->template getParam<unsigned int>("fluid_component")),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
     _var_is_porflow_var(_dictator.isPorousFlowVariable(_var.number())),
     _num_phases(_dictator.numPhases()),
-    _strain_at_nearest_qp(getParam<bool>("strain_at_nearest_qp")),
-    _porosity(getMaterialProperty<Real>("PorousFlow_porosity_nodal")),
-    _dporosity_dvar(getMaterialProperty<std::vector<Real>>("dPorousFlow_porosity_nodal_dvar")),
-    _dporosity_dgradvar(
-        getMaterialProperty<std::vector<RealGradient>>("dPorousFlow_porosity_nodal_dgradvar")),
-    _nearest_qp(_strain_at_nearest_qp
-                    ? &getMaterialProperty<unsigned int>("PorousFlow_nearestqp_nodal")
-                    : nullptr),
-    _fluid_density(getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_density_nodal")),
-    _dfluid_density_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_fluid_phase_density_nodal_dvar")),
-    _fluid_saturation_nodal(getMaterialProperty<std::vector<Real>>("PorousFlow_saturation_nodal")),
+    _strain_at_nearest_qp(this->template getParam<bool>("strain_at_nearest_qp")),
+    _porosity(this->template getGenericMaterialProperty<Real, is_ad>("PorousFlow_porosity_nodal")),
+    _dporosity_dvar(is_ad ? nullptr
+                          : &this->template getMaterialProperty<std::vector<Real>>(
+                                "dPorousFlow_porosity_nodal_dvar")),
+    _dporosity_dgradvar(is_ad ? nullptr
+                              : &this->template getMaterialProperty<std::vector<RealGradient>>(
+                                    "dPorousFlow_porosity_nodal_dgradvar")),
+    _nearest_qp(_strain_at_nearest_qp ? &this->template getMaterialProperty<unsigned int>(
+                                            "PorousFlow_nearestqp_nodal")
+                                      : nullptr),
+    _fluid_density(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_fluid_phase_density_nodal")),
+    _dfluid_density_dvar(is_ad
+                             ? nullptr
+                             : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                   "dPorousFlow_fluid_phase_density_nodal_dvar")),
+    _fluid_saturation_nodal(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_saturation_nodal")),
     _dfluid_saturation_nodal_dvar(
-        getMaterialProperty<std::vector<std::vector<Real>>>("dPorousFlow_saturation_nodal_dvar")),
-    _mass_frac(getMaterialProperty<std::vector<std::vector<Real>>>("PorousFlow_mass_frac_nodal")),
-    _dmass_frac_dvar(getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
-        "dPorousFlow_mass_frac_nodal_dvar"))
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                    "dPorousFlow_saturation_nodal_dvar")),
+    _mass_frac(this->template getGenericMaterialProperty<std::vector<std::vector<Real>>, is_ad>(
+        "PorousFlow_mass_frac_nodal")),
+    _dmass_frac_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
+                    "dPorousFlow_mass_frac_nodal_dvar"))
 {
   if (_fluid_component >= _dictator.numComponents())
-    paramError(
+    this->paramError(
         "fluid_component",
         "The Dictator proclaims that the maximum fluid component index in this simulation is ",
         _dictator.numComponents() - 1,
@@ -73,10 +91,11 @@ PorousFlowMassRadioactiveDecay::PorousFlowMassRadioactiveDecay(const InputParame
         ". Remember that indexing starts at 0. The Dictator does not take such mistakes lightly.");
 }
 
-Real
-PorousFlowMassRadioactiveDecay::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowMassRadioactiveDecayTempl<is_ad>::computeQpResidual()
 {
-  Real mass = 0.0;
+  GenericReal<is_ad> mass = 0.0;
   for (unsigned ph = 0; ph < _num_phases; ++ph)
     mass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] *
             _mass_frac[_i][ph][_fluid_component];
@@ -84,52 +103,67 @@ PorousFlowMassRadioactiveDecay::computeQpResidual()
   return _test[_i][_qp] * _decay_rate * _porosity[_i] * mass;
 }
 
+template <bool is_ad>
 Real
-PorousFlowMassRadioactiveDecay::computeQpJacobian()
+PorousFlowMassRadioactiveDecayTempl<is_ad>::computeQpJacobian()
 {
-  // If the variable is not a PorousFlow variable (very unusual), the diag Jacobian terms are 0
-  if (!_var_is_porflow_var)
-    return 0.0;
-  return computeQpJac(_dictator.porousFlowVariableNum(_var.number()));
-}
-
-Real
-PorousFlowMassRadioactiveDecay::computeQpOffDiagJacobian(unsigned int jvar)
-{
-  // If the variable is not a PorousFlow variable, the OffDiag Jacobian terms are 0
-  if (_dictator.notPorousFlowVariable(jvar))
-    return 0.0;
-  return computeQpJac(_dictator.porousFlowVariableNum(jvar));
-}
-
-Real
-PorousFlowMassRadioactiveDecay::computeQpJac(unsigned int pvar)
-{
-  const unsigned nearest_qp = (_strain_at_nearest_qp ? (*_nearest_qp)[_i] : _i);
-
-  // porosity is dependent on variables that are lumped to the nodes,
-  // but it can depend on the gradient
-  // of variables, which are NOT lumped to the nodes, hence:
-  Real dmass = 0.0;
-  for (unsigned ph = 0; ph < _num_phases; ++ph)
-    dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] *
-             _mass_frac[_i][ph][_fluid_component] * _dporosity_dgradvar[_i][pvar] *
-             _grad_phi[_j][nearest_qp];
-
-  if (_i != _j)
-    return _test[_i][_qp] * _decay_rate * dmass;
-
-  // As the fluid mass is lumped to the nodes, only non-zero terms are for _i==_j
-  for (unsigned ph = 0; ph < _num_phases; ++ph)
+  if constexpr (!is_ad)
   {
-    dmass += _dfluid_density_dvar[_i][ph][pvar] * _fluid_saturation_nodal[_i][ph] *
-             _mass_frac[_i][ph][_fluid_component] * _porosity[_i];
-    dmass += _fluid_density[_i][ph] * _dfluid_saturation_nodal_dvar[_i][ph][pvar] *
-             _mass_frac[_i][ph][_fluid_component] * _porosity[_i];
-    dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] *
-             _dmass_frac_dvar[_i][ph][_fluid_component][pvar] * _porosity[_i];
-    dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] *
-             _mass_frac[_i][ph][_fluid_component] * _dporosity_dvar[_i][pvar];
+    if (!_var_is_porflow_var)
+      return 0.0;
+    return computeQpJac(_dictator.porousFlowVariableNum(_var.number()));
   }
-  return _test[_i][_qp] * _decay_rate * dmass;
+  return 0.0;
 }
+
+template <bool is_ad>
+Real
+PorousFlowMassRadioactiveDecayTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  if constexpr (!is_ad)
+  {
+    if (_dictator.notPorousFlowVariable(jvar))
+      return 0.0;
+    return computeQpJac(_dictator.porousFlowVariableNum(jvar));
+  }
+  return 0.0;
+}
+
+template <bool is_ad>
+Real
+PorousFlowMassRadioactiveDecayTempl<is_ad>::computeQpJac(unsigned int pvar)
+{
+  if constexpr (!is_ad)
+  {
+    const unsigned nearest_qp = (_strain_at_nearest_qp ? (*_nearest_qp)[_i] : _i);
+
+    // porosity can depend on grad(variables) evaluated at qps, so the grad-term is nonzero even
+    // for off-node DOFs
+    Real dmass = 0.0;
+    for (unsigned ph = 0; ph < _num_phases; ++ph)
+      dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] *
+               _mass_frac[_i][ph][_fluid_component] * (*_dporosity_dgradvar)[_i][pvar] *
+               _grad_phi[_j][nearest_qp];
+
+    if (_i != _j)
+      return _test[_i][_qp] * _decay_rate * dmass;
+
+    // As the fluid mass is lumped to the nodes, only non-zero terms are for _i==_j
+    for (unsigned ph = 0; ph < _num_phases; ++ph)
+    {
+      dmass += (*_dfluid_density_dvar)[_i][ph][pvar] * _fluid_saturation_nodal[_i][ph] *
+               _mass_frac[_i][ph][_fluid_component] * _porosity[_i];
+      dmass += _fluid_density[_i][ph] * (*_dfluid_saturation_nodal_dvar)[_i][ph][pvar] *
+               _mass_frac[_i][ph][_fluid_component] * _porosity[_i];
+      dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] *
+               (*_dmass_frac_dvar)[_i][ph][_fluid_component][pvar] * _porosity[_i];
+      dmass += _fluid_density[_i][ph] * _fluid_saturation_nodal[_i][ph] *
+               _mass_frac[_i][ph][_fluid_component] * (*_dporosity_dvar)[_i][pvar];
+    }
+    return _test[_i][_qp] * _decay_rate * dmass;
+  }
+  return 0.0;
+}
+
+template class PorousFlowMassRadioactiveDecayTempl<false>;
+template class PorousFlowMassRadioactiveDecayTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowMassRadioactiveDecay.C
+++ b/modules/porous_flow/src/kernels/PorousFlowMassRadioactiveDecay.C
@@ -126,6 +126,8 @@ PorousFlowMassRadioactiveDecayTempl<is_ad>::computeQpOffDiagJacobian(unsigned in
       return 0.0;
     return computeQpJac(_dictator.porousFlowVariableNum(jvar));
   }
+  else
+    libmesh_ignore(jvar);
   return 0.0;
 }
 
@@ -162,6 +164,8 @@ PorousFlowMassRadioactiveDecayTempl<is_ad>::computeQpJac(unsigned int pvar)
     }
     return _test[_i][_qp] * _decay_rate * dmass;
   }
+  else
+    libmesh_ignore(pvar);
   return 0.0;
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowMassTimeDerivative.C
+++ b/modules/porous_flow/src/kernels/PorousFlowMassTimeDerivative.C
@@ -169,6 +169,8 @@ PorousFlowMassTimeDerivativeTempl<is_ad>::computeQpOffDiagJacobian(unsigned int 
       return 0.0;
     return computeQpJac(_dictator.porousFlowVariableNum(jvar));
   }
+  else
+    libmesh_ignore(jvar);
   return 0.0;
 }
 
@@ -208,6 +210,8 @@ PorousFlowMassTimeDerivativeTempl<is_ad>::computeQpJac(unsigned int pvar)
     }
     return _test[_i][_qp] * (1.0 + strain) * dmass / _dt;
   }
+  else
+    libmesh_ignore(pvar);
   return 0.0;
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowMassTimeDerivative.C
+++ b/modules/porous_flow/src/kernels/PorousFlowMassTimeDerivative.C
@@ -16,11 +16,15 @@
 #include <limits>
 
 registerMooseObject("PorousFlowApp", PorousFlowMassTimeDerivative);
+registerMooseObject("PorousFlowApp", ADPorousFlowMassTimeDerivative);
 
+template <bool is_ad>
 InputParameters
-PorousFlowMassTimeDerivative::validParams()
+PorousFlowMassTimeDerivativeTempl<is_ad>::validParams()
 {
-  InputParameters params = TimeKernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
+  params.set<MultiMooseEnum>("vector_tags") = "time";
+  params.set<MultiMooseEnum>("matrix_tags") = "system time";
   params.addParam<bool>("strain_at_nearest_qp",
                         false,
                         "When calculating nodal porosity that depends on strain, use the strain at "
@@ -53,50 +57,66 @@ PorousFlowMassTimeDerivative::validParams()
   return params;
 }
 
-PorousFlowMassTimeDerivative::PorousFlowMassTimeDerivative(const InputParameters & parameters)
-  : TimeKernel(parameters),
-    _fluid_component(getParam<unsigned int>("fluid_component")),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+template <bool is_ad>
+PorousFlowMassTimeDerivativeTempl<is_ad>::PorousFlowMassTimeDerivativeTempl(
+    const InputParameters & parameters)
+  : PorousFlowLumpedKernelBaseTempl<is_ad>(parameters),
+    _fluid_component(this->template getParam<unsigned int>("fluid_component")),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
     _var_is_porflow_var(_dictator.isPorousFlowVariable(_var.number())),
     _num_phases(_dictator.numPhases()),
-    _strain_at_nearest_qp(getParam<bool>("strain_at_nearest_qp")),
-    _multiply_by_density(getParam<bool>("multiply_by_density")),
-    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
-    _has_total_strain(hasMaterialProperty<RankTwoTensor>(_base_name + "total_strain")),
-    _total_strain_old(_has_total_strain
-                          ? &getMaterialPropertyOld<RankTwoTensor>(_base_name + "total_strain")
-                          : nullptr),
-    _porosity(getMaterialProperty<Real>("PorousFlow_porosity_nodal")),
-    _porosity_old(getMaterialPropertyOld<Real>("PorousFlow_porosity_nodal")),
-    _dporosity_dvar(getMaterialProperty<std::vector<Real>>("dPorousFlow_porosity_nodal_dvar")),
-    _dporosity_dgradvar(
-        getMaterialProperty<std::vector<RealGradient>>("dPorousFlow_porosity_nodal_dgradvar")),
-    _nearest_qp(_strain_at_nearest_qp
-                    ? &getMaterialProperty<unsigned int>("PorousFlow_nearestqp_nodal")
-                    : nullptr),
-    _fluid_density(_multiply_by_density ? &getMaterialProperty<std::vector<Real>>(
-                                              "PorousFlow_fluid_phase_density_nodal")
+    _strain_at_nearest_qp(this->template getParam<bool>("strain_at_nearest_qp")),
+    _multiply_by_density(this->template getParam<bool>("multiply_by_density")),
+    _base_name(this->isParamValid("base_name")
+                   ? this->template getParam<std::string>("base_name") + "_"
+                   : ""),
+    _has_total_strain(
+        this->template hasMaterialProperty<RankTwoTensor>(_base_name + "total_strain")),
+    _total_strain_old(_has_total_strain ? &this->template getMaterialPropertyOld<RankTwoTensor>(
+                                              _base_name + "total_strain")
                                         : nullptr),
-    _fluid_density_old(_multiply_by_density ? &getMaterialPropertyOld<std::vector<Real>>(
-                                                  "PorousFlow_fluid_phase_density_nodal")
-                                            : nullptr),
-    _dfluid_density_dvar(_multiply_by_density
-                             ? &getMaterialProperty<std::vector<std::vector<Real>>>(
+    _porosity(this->template getGenericMaterialProperty<Real, is_ad>("PorousFlow_porosity_nodal")),
+    _porosity_old(this->template getMaterialPropertyOld<Real>("PorousFlow_porosity_nodal")),
+    _dporosity_dvar(is_ad ? nullptr
+                          : &this->template getMaterialProperty<std::vector<Real>>(
+                                "dPorousFlow_porosity_nodal_dvar")),
+    _dporosity_dgradvar(is_ad ? nullptr
+                              : &this->template getMaterialProperty<std::vector<RealGradient>>(
+                                    "dPorousFlow_porosity_nodal_dgradvar")),
+    _nearest_qp(_strain_at_nearest_qp ? &this->template getMaterialProperty<unsigned int>(
+                                            "PorousFlow_nearestqp_nodal")
+                                      : nullptr),
+    _fluid_density(_multiply_by_density
+                       ? &this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+                             "PorousFlow_fluid_phase_density_nodal")
+                       : nullptr),
+    _fluid_density_old(_multiply_by_density
+                           ? &this->template getMaterialPropertyOld<std::vector<Real>>(
+                                 "PorousFlow_fluid_phase_density_nodal")
+                           : nullptr),
+    _dfluid_density_dvar(_multiply_by_density && !is_ad
+                             ? &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
                                    "dPorousFlow_fluid_phase_density_nodal_dvar")
                              : nullptr),
-    _fluid_saturation_nodal(getMaterialProperty<std::vector<Real>>("PorousFlow_saturation_nodal")),
+    _fluid_saturation_nodal(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_saturation_nodal")),
     _fluid_saturation_nodal_old(
-        getMaterialPropertyOld<std::vector<Real>>("PorousFlow_saturation_nodal")),
+        this->template getMaterialPropertyOld<std::vector<Real>>("PorousFlow_saturation_nodal")),
     _dfluid_saturation_nodal_dvar(
-        getMaterialProperty<std::vector<std::vector<Real>>>("dPorousFlow_saturation_nodal_dvar")),
-    _mass_frac(getMaterialProperty<std::vector<std::vector<Real>>>("PorousFlow_mass_frac_nodal")),
-    _mass_frac_old(
-        getMaterialPropertyOld<std::vector<std::vector<Real>>>("PorousFlow_mass_frac_nodal")),
-    _dmass_frac_dvar(getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
-        "dPorousFlow_mass_frac_nodal_dvar"))
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                    "dPorousFlow_saturation_nodal_dvar")),
+    _mass_frac(this->template getGenericMaterialProperty<std::vector<std::vector<Real>>, is_ad>(
+        "PorousFlow_mass_frac_nodal")),
+    _mass_frac_old(this->template getMaterialPropertyOld<std::vector<std::vector<Real>>>(
+        "PorousFlow_mass_frac_nodal")),
+    _dmass_frac_dvar(
+        is_ad ? nullptr
+              : &this->template getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
+                    "dPorousFlow_mass_frac_nodal_dvar"))
 {
   if (_fluid_component >= _dictator.numComponents())
-    paramError(
+    this->paramError(
         "fluid_component",
         "The Dictator proclaims that the maximum fluid component index in this simulation is ",
         _dictator.numComponents() - 1,
@@ -105,14 +125,16 @@ PorousFlowMassTimeDerivative::PorousFlowMassTimeDerivative(const InputParameters
         ". Remember that indexing starts at 0. The Dictator does not take such mistakes lightly.");
 }
 
-Real
-PorousFlowMassTimeDerivative::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowMassTimeDerivativeTempl<is_ad>::computeQpResidual()
 {
-  Real mass = 0.0;
+  GenericReal<is_ad> mass = 0.0;
   Real mass_old = 0.0;
   for (unsigned ph = 0; ph < _num_phases; ++ph)
   {
-    const Real dens = (_multiply_by_density ? (*_fluid_density)[_i][ph] : 1.0);
+    const GenericReal<is_ad> dens =
+        (_multiply_by_density ? (*_fluid_density)[_i][ph] : GenericReal<is_ad>(1.0));
     mass += dens * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_fluid_component];
     const Real dens_old = (_multiply_by_density ? (*_fluid_density_old)[_i][ph] : 1.0);
     mass_old +=
@@ -124,58 +146,70 @@ PorousFlowMassTimeDerivative::computeQpResidual()
          _dt;
 }
 
+template <bool is_ad>
 Real
-PorousFlowMassTimeDerivative::computeQpJacobian()
+PorousFlowMassTimeDerivativeTempl<is_ad>::computeQpJacobian()
 {
-  // If the variable is not a PorousFlow variable (very unusual), the diag Jacobian terms are 0
-  if (!_var_is_porflow_var)
-    return 0.0;
-  return computeQpJac(_dictator.porousFlowVariableNum(_var.number()));
-}
-
-Real
-PorousFlowMassTimeDerivative::computeQpOffDiagJacobian(unsigned int jvar)
-{
-  // If the variable is not a PorousFlow variable, the OffDiag Jacobian terms are 0
-  if (_dictator.notPorousFlowVariable(jvar))
-    return 0.0;
-  return computeQpJac(_dictator.porousFlowVariableNum(jvar));
-}
-
-Real
-PorousFlowMassTimeDerivative::computeQpJac(unsigned int pvar)
-{
-  const unsigned nearest_qp = (_strain_at_nearest_qp ? (*_nearest_qp)[_i] : _i);
-
-  const Real strain = (_has_total_strain ? (*_total_strain_old)[_qp].trace() : 0.0);
-
-  // porosity is dependent on variables that are lumped to the nodes,
-  // but it can depend on the gradient
-  // of variables, which are NOT lumped to the nodes, hence:
-  Real dmass = 0.0;
-  for (unsigned ph = 0; ph < _num_phases; ++ph)
+  if constexpr (!is_ad)
   {
-    const Real dens = (_multiply_by_density ? (*_fluid_density)[_i][ph] : 1.0);
-    dmass += dens * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_fluid_component] *
-             _dporosity_dgradvar[_i][pvar] * _grad_phi[_j][nearest_qp];
+    if (!_var_is_porflow_var)
+      return 0.0;
+    return computeQpJac(_dictator.porousFlowVariableNum(_var.number()));
   }
+  return 0.0;
+}
 
-  if (_i != _j)
-    return _test[_i][_qp] * (1.0 + strain) * dmass / _dt;
-
-  // As the fluid mass is lumped to the nodes, only non-zero terms are for _i==_j
-  for (unsigned ph = 0; ph < _num_phases; ++ph)
+template <bool is_ad>
+Real
+PorousFlowMassTimeDerivativeTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  if constexpr (!is_ad)
   {
-    if (_multiply_by_density)
-      dmass += (*_dfluid_density_dvar)[_i][ph][pvar] * _fluid_saturation_nodal[_i][ph] *
+    if (_dictator.notPorousFlowVariable(jvar))
+      return 0.0;
+    return computeQpJac(_dictator.porousFlowVariableNum(jvar));
+  }
+  return 0.0;
+}
+
+template <bool is_ad>
+Real
+PorousFlowMassTimeDerivativeTempl<is_ad>::computeQpJac(unsigned int pvar)
+{
+  if constexpr (!is_ad)
+  {
+    const unsigned nearest_qp = (_strain_at_nearest_qp ? (*_nearest_qp)[_i] : _i);
+
+    const Real strain = (_has_total_strain ? (*_total_strain_old)[_qp].trace() : 0.0);
+
+    Real dmass = 0.0;
+    for (unsigned ph = 0; ph < _num_phases; ++ph)
+    {
+      const Real dens = (_multiply_by_density ? (*_fluid_density)[_i][ph] : 1.0);
+      dmass += dens * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_fluid_component] *
+               (*_dporosity_dgradvar)[_i][pvar] * _grad_phi[_j][nearest_qp];
+    }
+
+    if (_i != _j)
+      return _test[_i][_qp] * (1.0 + strain) * dmass / _dt;
+
+    for (unsigned ph = 0; ph < _num_phases; ++ph)
+    {
+      if (_multiply_by_density)
+        dmass += (*_dfluid_density_dvar)[_i][ph][pvar] * _fluid_saturation_nodal[_i][ph] *
+                 _mass_frac[_i][ph][_fluid_component] * _porosity[_i];
+      const Real dens = (_multiply_by_density ? (*_fluid_density)[_i][ph] : 1.0);
+      dmass += dens * (*_dfluid_saturation_nodal_dvar)[_i][ph][pvar] *
                _mass_frac[_i][ph][_fluid_component] * _porosity[_i];
-    const Real dens = (_multiply_by_density ? (*_fluid_density)[_i][ph] : 1.0);
-    dmass += dens * _dfluid_saturation_nodal_dvar[_i][ph][pvar] *
-             _mass_frac[_i][ph][_fluid_component] * _porosity[_i];
-    dmass += dens * _fluid_saturation_nodal[_i][ph] *
-             _dmass_frac_dvar[_i][ph][_fluid_component][pvar] * _porosity[_i];
-    dmass += dens * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_fluid_component] *
-             _dporosity_dvar[_i][pvar];
+      dmass += dens * _fluid_saturation_nodal[_i][ph] *
+               (*_dmass_frac_dvar)[_i][ph][_fluid_component][pvar] * _porosity[_i];
+      dmass += dens * _fluid_saturation_nodal[_i][ph] * _mass_frac[_i][ph][_fluid_component] *
+               (*_dporosity_dvar)[_i][pvar];
+    }
+    return _test[_i][_qp] * (1.0 + strain) * dmass / _dt;
   }
-  return _test[_i][_qp] * (1.0 + strain) * dmass / _dt;
+  return 0.0;
 }
+
+template class PorousFlowMassTimeDerivativeTempl<false>;
+template class PorousFlowMassTimeDerivativeTempl<true>;

--- a/modules/porous_flow/src/kernels/PorousFlowPreDis.C
+++ b/modules/porous_flow/src/kernels/PorousFlowPreDis.C
@@ -126,6 +126,8 @@ PorousFlowPreDisTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
       return 0.0;
     return computeQpJac(_dictator.porousFlowVariableNum(jvar));
   }
+  else
+    libmesh_ignore(jvar);
   return 0.0;
 }
 
@@ -150,6 +152,8 @@ PorousFlowPreDisTempl<is_ad>::computeQpJac(unsigned int pvar)
            (dres * _saturation[_i][_aq_ph] + res * (*_dsaturation_dvar)[_i][_aq_ph][pvar]) *
            _porosity_old[_i];
   }
+  else
+    libmesh_ignore(pvar);
   return 0.0;
 }
 

--- a/modules/porous_flow/src/kernels/PorousFlowPreDis.C
+++ b/modules/porous_flow/src/kernels/PorousFlowPreDis.C
@@ -10,11 +10,15 @@
 #include "PorousFlowPreDis.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowPreDis);
+registerMooseObject("PorousFlowApp", ADPorousFlowPreDis);
 
+template <bool is_ad>
 InputParameters
-PorousFlowPreDis::validParams()
+PorousFlowPreDisTempl<is_ad>::validParams()
 {
-  InputParameters params = TimeKernel::validParams();
+  InputParameters params = GenericKernel<is_ad>::validParams();
+  params.set<MultiMooseEnum>("vector_tags") = "time";
+  params.set<MultiMooseEnum>("matrix_tags") = "system time";
   params.addRequiredParam<std::vector<Real>>(
       "mineral_density",
       "Density (kg(precipitate)/m^3(precipitate)) of each secondary species in the "
@@ -30,20 +34,25 @@ PorousFlowPreDis::validParams()
   return params;
 }
 
-PorousFlowPreDis::PorousFlowPreDis(const InputParameters & parameters)
-  : TimeKernel(parameters),
-    _mineral_density(getParam<std::vector<Real>>("mineral_density")),
-    _dictator(getUserObject<PorousFlowDictator>("PorousFlowDictator")),
+template <bool is_ad>
+PorousFlowPreDisTempl<is_ad>::PorousFlowPreDisTempl(const InputParameters & parameters)
+  : PorousFlowLumpedKernelBaseTempl<is_ad>(parameters),
+    _mineral_density(this->template getParam<std::vector<Real>>("mineral_density")),
+    _dictator(this->template getUserObject<PorousFlowDictator>("PorousFlowDictator")),
     _aq_ph(_dictator.aqueousPhaseNumber()),
-    _porosity_old(getMaterialPropertyOld<Real>("PorousFlow_porosity_nodal")),
-    _saturation(getMaterialProperty<std::vector<Real>>("PorousFlow_saturation_nodal")),
-    _dsaturation_dvar(
-        getMaterialProperty<std::vector<std::vector<Real>>>("dPorousFlow_saturation_nodal_dvar")),
-    _reaction_rate(
-        getMaterialProperty<std::vector<Real>>("PorousFlow_mineral_reaction_rate_nodal")),
-    _dreaction_rate_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_mineral_reaction_rate_nodal_dvar")),
-    _stoichiometry(getParam<std::vector<Real>>("stoichiometry"))
+    _porosity_old(this->template getMaterialPropertyOld<Real>("PorousFlow_porosity_nodal")),
+    _saturation(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_saturation_nodal")),
+    _dsaturation_dvar(is_ad ? nullptr
+                            : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                  "dPorousFlow_saturation_nodal_dvar")),
+    _reaction_rate(this->template getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_mineral_reaction_rate_nodal")),
+    _dreaction_rate_dvar(is_ad
+                             ? nullptr
+                             : &this->template getMaterialProperty<std::vector<std::vector<Real>>>(
+                                   "dPorousFlow_mineral_reaction_rate_nodal_dvar")),
+    _stoichiometry(this->template getParam<std::vector<Real>>("stoichiometry"))
 {
   /* Not needed due to PorousFlow_mineral_reaction_rate already checking this condition
   if (_dictator.numPhases() < 1)
@@ -51,26 +60,29 @@ PorousFlowPreDis::PorousFlowPreDis(const InputParameters & parameters)
   */
 
   if (_mineral_density.size() != _dictator.numAqueousKinetic())
-    paramError("mineral_density",
-               "The Dictator proclaims that the number of precipitation-dissolution secondary "
-               "species in this simulation is ",
-               _dictator.numAqueousKinetic(),
-               " whereas you have provided ",
-               _mineral_density.size(),
-               ". The Dictator does not take such mistakes lightly");
+    this->paramError(
+        "mineral_density",
+        "The Dictator proclaims that the number of precipitation-dissolution secondary "
+        "species in this simulation is ",
+        _dictator.numAqueousKinetic(),
+        " whereas you have provided ",
+        _mineral_density.size(),
+        ". The Dictator does not take such mistakes lightly");
 
   if (_stoichiometry.size() != _dictator.numAqueousKinetic())
-    paramError("stoichiometry",
-               "The Dictator proclaims that the number of precipitation-dissolution secondary "
-               "species in this simulation is ",
-               _dictator.numAqueousKinetic(),
-               " whereas you have provided ",
-               _stoichiometry.size(),
-               ". The Dictator does not take such mistakes lightly");
+    this->paramError(
+        "stoichiometry",
+        "The Dictator proclaims that the number of precipitation-dissolution secondary "
+        "species in this simulation is ",
+        _dictator.numAqueousKinetic(),
+        " whereas you have provided ",
+        _stoichiometry.size(),
+        ". The Dictator does not take such mistakes lightly");
 }
 
-Real
-PorousFlowPreDis::computeQpResidual()
+template <bool is_ad>
+GenericReal<is_ad>
+PorousFlowPreDisTempl<is_ad>::computeQpResidual()
 {
   /*
    *
@@ -83,45 +95,63 @@ PorousFlowPreDis::computeQpResidual()
    * Material: PorousFlowAqueousPreDisMineral
    *
    */
-  Real res = 0.0;
+  GenericReal<is_ad> res = 0.0;
   for (unsigned r = 0; r < _dictator.numAqueousKinetic(); ++r)
     res += _stoichiometry[r] * _mineral_density[r] * _reaction_rate[_i][r];
   return _test[_i][_qp] * res * _porosity_old[_i] * _saturation[_i][_aq_ph];
 }
 
+template <bool is_ad>
 Real
-PorousFlowPreDis::computeQpJacobian()
+PorousFlowPreDisTempl<is_ad>::computeQpJacobian()
 {
-  /// If the variable is not a PorousFlow variable (very unusual), the diag Jacobian terms are 0
-  if (_dictator.notPorousFlowVariable(_var.number()))
-    return 0.0;
-  return computeQpJac(_dictator.porousFlowVariableNum(_var.number()));
-}
-
-Real
-PorousFlowPreDis::computeQpOffDiagJacobian(unsigned int jvar)
-{
-  /// If the variable is not a PorousFlow variable, the OffDiag Jacobian terms are 0
-  if (_dictator.notPorousFlowVariable(jvar))
-    return 0.0;
-  return computeQpJac(_dictator.porousFlowVariableNum(jvar));
-}
-
-Real
-PorousFlowPreDis::computeQpJac(unsigned int pvar)
-{
-  if (_i != _j)
-    return 0.0;
-
-  Real res = 0.0;
-  Real dres = 0.0;
-  for (unsigned r = 0; r < _dictator.numAqueousKinetic(); ++r)
+  if constexpr (!is_ad)
   {
-    dres += _stoichiometry[r] * _mineral_density[r] * _dreaction_rate_dvar[_i][r][pvar];
-    res += _stoichiometry[r] * _mineral_density[r] * _reaction_rate[_i][r];
+    /// If the variable is not a PorousFlow variable (very unusual), the diag Jacobian terms are 0
+    if (_dictator.notPorousFlowVariable(_var.number()))
+      return 0.0;
+    return computeQpJac(_dictator.porousFlowVariableNum(_var.number()));
   }
-
-  return _test[_i][_qp] *
-         (dres * _saturation[_i][_aq_ph] + res * _dsaturation_dvar[_i][_aq_ph][pvar]) *
-         _porosity_old[_i];
+  return 0.0;
 }
+
+template <bool is_ad>
+Real
+PorousFlowPreDisTempl<is_ad>::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  if constexpr (!is_ad)
+  {
+    /// If the variable is not a PorousFlow variable, the OffDiag Jacobian terms are 0
+    if (_dictator.notPorousFlowVariable(jvar))
+      return 0.0;
+    return computeQpJac(_dictator.porousFlowVariableNum(jvar));
+  }
+  return 0.0;
+}
+
+template <bool is_ad>
+Real
+PorousFlowPreDisTempl<is_ad>::computeQpJac(unsigned int pvar)
+{
+  if constexpr (!is_ad)
+  {
+    if (_i != _j)
+      return 0.0;
+
+    Real res = 0.0;
+    Real dres = 0.0;
+    for (unsigned r = 0; r < _dictator.numAqueousKinetic(); ++r)
+    {
+      dres += _stoichiometry[r] * _mineral_density[r] * (*_dreaction_rate_dvar)[_i][r][pvar];
+      res += _stoichiometry[r] * _mineral_density[r] * _reaction_rate[_i][r];
+    }
+
+    return _test[_i][_qp] *
+           (dres * _saturation[_i][_aq_ph] + res * (*_dsaturation_dvar)[_i][_aq_ph][pvar]) *
+           _porosity_old[_i];
+  }
+  return 0.0;
+}
+
+template class PorousFlowPreDisTempl<false>;
+template class PorousFlowPreDisTempl<true>;

--- a/modules/porous_flow/src/materials/PorousFlowDarcyVelocityMaterial.C
+++ b/modules/porous_flow/src/materials/PorousFlowDarcyVelocityMaterial.C
@@ -10,9 +10,11 @@
 #include "PorousFlowDarcyVelocityMaterial.h"
 
 registerMooseObject("PorousFlowApp", PorousFlowDarcyVelocityMaterial);
+registerMooseObject("PorousFlowApp", ADPorousFlowDarcyVelocityMaterial);
 
+template <bool is_ad>
 InputParameters
-PorousFlowDarcyVelocityMaterial::validParams()
+PorousFlowDarcyVelocityMaterialTempl<is_ad>::validParams()
 {
   InputParameters params = PorousFlowMaterial::validParams();
   params.addRequiredParam<RealVectorValue>("gravity",
@@ -23,44 +25,60 @@ PorousFlowDarcyVelocityMaterial::validParams()
   return params;
 }
 
-PorousFlowDarcyVelocityMaterial::PorousFlowDarcyVelocityMaterial(const InputParameters & parameters)
+template <bool is_ad>
+PorousFlowDarcyVelocityMaterialTempl<is_ad>::PorousFlowDarcyVelocityMaterialTempl(
+    const InputParameters & parameters)
   : PorousFlowMaterial(parameters),
     _num_phases(_dictator.numPhases()),
     _num_var(_dictator.numVariables()),
-    _permeability(getMaterialProperty<RealTensorValue>("PorousFlow_permeability_qp")),
-    _dpermeability_dvar(
-        getMaterialProperty<std::vector<RealTensorValue>>("dPorousFlow_permeability_qp_dvar")),
-    _dpermeability_dgradvar(getMaterialProperty<std::vector<std::vector<RealTensorValue>>>(
-        "dPorousFlow_permeability_qp_dgradvar")),
-    _fluid_density(getMaterialProperty<std::vector<Real>>("PorousFlow_fluid_phase_density_qp")),
-    _dfluid_density_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_fluid_phase_density_qp_dvar")),
-    _fluid_viscosity(getMaterialProperty<std::vector<Real>>("PorousFlow_viscosity_qp")),
-    _dfluid_viscosity_dvar(
-        getMaterialProperty<std::vector<std::vector<Real>>>("dPorousFlow_viscosity_qp_dvar")),
-    _relative_permeability(
-        getMaterialProperty<std::vector<Real>>("PorousFlow_relative_permeability_qp")),
-    _drelative_permeability_dvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_relative_permeability_qp_dvar")),
-    _grad_p(getMaterialProperty<std::vector<RealGradient>>("PorousFlow_grad_porepressure_qp")),
-    _dgrad_p_dgradvar(getMaterialProperty<std::vector<std::vector<Real>>>(
-        "dPorousFlow_grad_porepressure_qp_dgradvar")),
-    _dgrad_p_dvar(getMaterialProperty<std::vector<std::vector<RealGradient>>>(
-        "dPorousFlow_grad_porepressure_qp_dvar")),
+    _permeability(getGenericMaterialProperty<RealTensorValue, is_ad>("PorousFlow_permeability_qp")),
+    _dpermeability_dvar(is_ad ? nullptr
+                              : &getMaterialProperty<std::vector<RealTensorValue>>(
+                                    "dPorousFlow_permeability_qp_dvar")),
+    _dpermeability_dgradvar(is_ad ? nullptr
+                                  : &getMaterialProperty<std::vector<std::vector<RealTensorValue>>>(
+                                        "dPorousFlow_permeability_qp_dgradvar")),
+    _fluid_density(
+        getGenericMaterialProperty<std::vector<Real>, is_ad>("PorousFlow_fluid_phase_density_qp")),
+    _dfluid_density_dvar(is_ad ? nullptr
+                               : &getMaterialProperty<std::vector<std::vector<Real>>>(
+                                     "dPorousFlow_fluid_phase_density_qp_dvar")),
+    _fluid_viscosity(
+        getGenericMaterialProperty<std::vector<Real>, is_ad>("PorousFlow_viscosity_qp")),
+    _dfluid_viscosity_dvar(is_ad ? nullptr
+                                 : &getMaterialProperty<std::vector<std::vector<Real>>>(
+                                       "dPorousFlow_viscosity_qp_dvar")),
+    _relative_permeability(getGenericMaterialProperty<std::vector<Real>, is_ad>(
+        "PorousFlow_relative_permeability_qp")),
+    _drelative_permeability_dvar(is_ad ? nullptr
+                                       : &getMaterialProperty<std::vector<std::vector<Real>>>(
+                                             "dPorousFlow_relative_permeability_qp_dvar")),
+    _grad_p(getGenericMaterialProperty<std::vector<RealGradient>, is_ad>(
+        "PorousFlow_grad_porepressure_qp")),
+    _dgrad_p_dgradvar(is_ad ? nullptr
+                            : &getMaterialProperty<std::vector<std::vector<Real>>>(
+                                  "dPorousFlow_grad_porepressure_qp_dgradvar")),
+    _dgrad_p_dvar(is_ad ? nullptr
+                        : &getMaterialProperty<std::vector<std::vector<RealGradient>>>(
+                              "dPorousFlow_grad_porepressure_qp_dvar")),
     _gravity(getParam<RealVectorValue>("gravity")),
-    _darcy_velocity(declareProperty<std::vector<RealVectorValue>>("PorousFlow_darcy_velocity_qp")),
-    _ddarcy_velocity_dvar(declareProperty<std::vector<std::vector<RealVectorValue>>>(
-        "dPorousFlow_darcy_velocity_qp_dvar")),
+    _darcy_velocity(declareGenericProperty<std::vector<RealVectorValue>, is_ad>(
+        "PorousFlow_darcy_velocity_qp")),
+    _ddarcy_velocity_dvar(is_ad ? nullptr
+                                : &declareProperty<std::vector<std::vector<RealVectorValue>>>(
+                                      "dPorousFlow_darcy_velocity_qp_dvar")),
     _ddarcy_velocity_dgradvar(
-        declareProperty<std::vector<std::vector<std::vector<RealVectorValue>>>>(
-            "dPorousFlow_darcy_velocity_qp_dgradvar"))
+        is_ad ? nullptr
+              : &declareProperty<std::vector<std::vector<std::vector<RealVectorValue>>>>(
+                    "dPorousFlow_darcy_velocity_qp_dgradvar"))
 {
   if (_nodal_material == true)
     mooseError("PorousFlowDarcyVelocityMaterial is only defined for at_nodes = false");
 }
 
+template <bool is_ad>
 void
-PorousFlowDarcyVelocityMaterial::computeQpProperties()
+PorousFlowDarcyVelocityMaterialTempl<is_ad>::computeQpProperties()
 {
   _darcy_velocity[_qp].resize(_num_phases);
 
@@ -69,46 +87,53 @@ PorousFlowDarcyVelocityMaterial::computeQpProperties()
         -(_permeability[_qp] * (_grad_p[_qp][ph] - _fluid_density[_qp][ph] * _gravity) *
           _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph]);
 
-  _ddarcy_velocity_dvar[_qp].resize(_num_phases);
-  for (unsigned ph = 0; ph < _num_phases; ++ph)
-    _ddarcy_velocity_dvar[_qp][ph].resize(_num_var);
-
-  for (unsigned ph = 0; ph < _num_phases; ++ph)
-    for (unsigned v = 0; v < _num_var; ++v)
-    {
-      _ddarcy_velocity_dvar[_qp][ph][v] =
-          -_dpermeability_dvar[_qp][v] * (_grad_p[_qp][ph] - _fluid_density[_qp][ph] * _gravity) *
-          _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph];
-      _ddarcy_velocity_dvar[_qp][ph][v] -=
-          _permeability[_qp] *
-          (_dgrad_p_dvar[_qp][ph][v] - _dfluid_density_dvar[_qp][ph][v] * _gravity) *
-          _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph];
-      _ddarcy_velocity_dvar[_qp][ph][v] -=
-          _permeability[_qp] * (_grad_p[_qp][ph] - _fluid_density[_qp][ph] * _gravity) *
-          (_drelative_permeability_dvar[_qp][ph][v] / _fluid_viscosity[_qp][ph] -
-           _relative_permeability[_qp][ph] * _dfluid_viscosity_dvar[_qp][ph][v] /
-               std::pow(_fluid_viscosity[_qp][ph], 2));
-    }
-
-  _ddarcy_velocity_dgradvar[_qp].resize(_num_phases);
-  for (unsigned ph = 0; ph < _num_phases; ++ph)
+  if constexpr (!is_ad)
   {
-    _ddarcy_velocity_dgradvar[_qp][ph].resize(LIBMESH_DIM);
-    for (unsigned i = 0; i < LIBMESH_DIM; ++i)
-      _ddarcy_velocity_dgradvar[_qp][ph][i].resize(_num_var);
-  }
+    (*_ddarcy_velocity_dvar)[_qp].resize(_num_phases);
+    for (unsigned ph = 0; ph < _num_phases; ++ph)
+      (*_ddarcy_velocity_dvar)[_qp][ph].resize(_num_var);
 
-  for (unsigned ph = 0; ph < _num_phases; ++ph)
-    for (unsigned i = 0; i < LIBMESH_DIM; ++i)
+    for (unsigned ph = 0; ph < _num_phases; ++ph)
       for (unsigned v = 0; v < _num_var; ++v)
       {
-        _ddarcy_velocity_dgradvar[_qp][ph][i][v] =
-            -_dpermeability_dgradvar[_qp][i][v] *
-            (_grad_p[_qp][ph] - _fluid_density[_qp][ph] * _gravity);
-        for (unsigned j = 0; j < LIBMESH_DIM; ++j)
-          _ddarcy_velocity_dgradvar[_qp][ph][i][v](j) -=
-              _permeability[_qp](j, i) * _dgrad_p_dgradvar[_qp][ph][v];
-        _ddarcy_velocity_dgradvar[_qp][ph][i][v] *=
+        (*_ddarcy_velocity_dvar)[_qp][ph][v] =
+            -(*_dpermeability_dvar)[_qp][v] *
+            (_grad_p[_qp][ph] - _fluid_density[_qp][ph] * _gravity) *
             _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph];
+        (*_ddarcy_velocity_dvar)[_qp][ph][v] -=
+            _permeability[_qp] *
+            ((*_dgrad_p_dvar)[_qp][ph][v] - (*_dfluid_density_dvar)[_qp][ph][v] * _gravity) *
+            _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph];
+        (*_ddarcy_velocity_dvar)[_qp][ph][v] -=
+            _permeability[_qp] * (_grad_p[_qp][ph] - _fluid_density[_qp][ph] * _gravity) *
+            ((*_drelative_permeability_dvar)[_qp][ph][v] / _fluid_viscosity[_qp][ph] -
+             _relative_permeability[_qp][ph] * (*_dfluid_viscosity_dvar)[_qp][ph][v] /
+                 std::pow(_fluid_viscosity[_qp][ph], 2));
       }
+
+    (*_ddarcy_velocity_dgradvar)[_qp].resize(_num_phases);
+    for (unsigned ph = 0; ph < _num_phases; ++ph)
+    {
+      (*_ddarcy_velocity_dgradvar)[_qp][ph].resize(LIBMESH_DIM);
+      for (unsigned i = 0; i < LIBMESH_DIM; ++i)
+        (*_ddarcy_velocity_dgradvar)[_qp][ph][i].resize(_num_var);
+    }
+
+    for (unsigned ph = 0; ph < _num_phases; ++ph)
+      for (unsigned i = 0; i < LIBMESH_DIM; ++i)
+        for (unsigned v = 0; v < _num_var; ++v)
+        {
+          (*_ddarcy_velocity_dgradvar)[_qp][ph][i][v] =
+              -(*_dpermeability_dgradvar)[_qp][i][v] *
+              (_grad_p[_qp][ph] - _fluid_density[_qp][ph] * _gravity);
+          for (unsigned j = 0; j < LIBMESH_DIM; ++j)
+            (*_ddarcy_velocity_dgradvar)[_qp][ph][i][v](j) -=
+                _permeability[_qp](j, i) * (*_dgrad_p_dgradvar)[_qp][ph][v];
+          (*_ddarcy_velocity_dgradvar)[_qp][ph][i][v] *=
+              _relative_permeability[_qp][ph] / _fluid_viscosity[_qp][ph];
+        }
+  }
 }
+
+template class PorousFlowDarcyVelocityMaterialTempl<false>;
+template class PorousFlowDarcyVelocityMaterialTempl<true>;

--- a/modules/porous_flow/src/materials/PorousFlowMatrixInternalEnergy.C
+++ b/modules/porous_flow/src/materials/PorousFlowMatrixInternalEnergy.C
@@ -36,7 +36,7 @@ PorousFlowMatrixInternalEnergyTempl<is_ad>::PorousFlowMatrixInternalEnergyTempl(
     _density(getParam<Real>("density")),
     _heat_cap(_cp * _density),
     _temperature(getGenericMaterialProperty<Real, is_ad>(
-        _nodal_material ? "PorousFlow_temperature_nodal" : "PorousFlow_temperature_qp")),
+        _dictator.isFV() ? "PorousFlow_temperature_qp" : "PorousFlow_temperature_nodal")),
     _dtemperature_dvar(
         is_ad ? nullptr
               : &getMaterialProperty<std::vector<Real>>("dPorousFlow_temperature_nodal_dvar")),
@@ -45,7 +45,7 @@ PorousFlowMatrixInternalEnergyTempl<is_ad>::PorousFlowMatrixInternalEnergyTempl(
                         : &declareProperty<std::vector<Real>>(
                               "dPorousFlow_matrix_internal_energy_nodal_dvar"))
 {
-  if (!is_ad && _nodal_material != true)
+  if (!_dictator.isFV() && !_nodal_material)
     mooseError("PorousFlowMatrixInternalEnergy classes are only defined for at_nodes = true");
 }
 

--- a/modules/porous_flow/src/materials/PorousFlowMatrixInternalEnergy.C
+++ b/modules/porous_flow/src/materials/PorousFlowMatrixInternalEnergy.C
@@ -20,7 +20,6 @@ PorousFlowMatrixInternalEnergyTempl<is_ad>::validParams()
   params.addRequiredParam<Real>("specific_heat_capacity",
                                 "Specific heat capacity of the rock grains (J/kg/K).");
   params.addRequiredParam<Real>("density", "Density of the rock grains");
-  params.set<bool>("at_nodes") = is_ad ? false : true;
   params.addPrivateParam<std::string>("pf_material_type", "matrix_internal_energy");
   params.addClassDescription("This Material calculates the internal energy of solid rock grains, "
                              "which is specific_heat_capacity * density * temperature.  Kernels "
@@ -36,8 +35,8 @@ PorousFlowMatrixInternalEnergyTempl<is_ad>::PorousFlowMatrixInternalEnergyTempl(
     _cp(getParam<Real>("specific_heat_capacity")),
     _density(getParam<Real>("density")),
     _heat_cap(_cp * _density),
-    _temperature(is_ad ? getGenericMaterialProperty<Real, is_ad>("PorousFlow_temperature_qp")
-                       : getGenericMaterialProperty<Real, is_ad>("PorousFlow_temperature_nodal")),
+    _temperature(getGenericMaterialProperty<Real, is_ad>(
+        _nodal_material ? "PorousFlow_temperature_nodal" : "PorousFlow_temperature_qp")),
     _dtemperature_dvar(
         is_ad ? nullptr
               : &getMaterialProperty<std::vector<Real>>("dPorousFlow_temperature_nodal_dvar")),

--- a/modules/porous_flow/src/materials/PorousFlowMatrixInternalEnergy.C
+++ b/modules/porous_flow/src/materials/PorousFlowMatrixInternalEnergy.C
@@ -45,8 +45,6 @@ PorousFlowMatrixInternalEnergyTempl<is_ad>::PorousFlowMatrixInternalEnergyTempl(
                         : &declareProperty<std::vector<Real>>(
                               "dPorousFlow_matrix_internal_energy_nodal_dvar"))
 {
-  if (!_dictator.isFV() && !_nodal_material)
-    mooseError("PorousFlowMatrixInternalEnergy classes are only defined for at_nodes = true");
 }
 
 template <bool is_ad>

--- a/modules/porous_flow/src/userobjects/PorousFlowDictator.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowDictator.C
@@ -57,7 +57,8 @@ PorousFlowDictator::PorousFlowDictator(const InputParameters & parameters)
     _num_aqueous_kinetic(getParam<unsigned int>("number_aqueous_kinetic")),
     _aqueous_phase_number(getParam<unsigned int>("aqueous_phase_number")),
     _consistent_fe_type(false),
-    _fe_type(0)
+    _fe_type(0),
+    _is_fv(false)
 {
   _moose_var_num.resize(_num_variables);
   for (unsigned int i = 0; i < _num_variables; ++i)
@@ -66,6 +67,7 @@ PorousFlowDictator::PorousFlowDictator(const InputParameters & parameters)
   if (_num_variables > 0)
   {
     _consistent_fe_type = true;
+    _is_fv = getFieldVar("porous_flow_vars", 0)->isFV();
     _fe_type = FEType(getFieldVar("porous_flow_vars", 0)->feType());
     for (unsigned int i = 1; i < _num_variables; ++i)
       if (getFieldVar("porous_flow_vars", i)->feType() != _fe_type)
@@ -175,4 +177,10 @@ FEType
 PorousFlowDictator::feType() const
 {
   return _fe_type;
+}
+
+bool
+PorousFlowDictator::isFV() const
+{
+  return _is_fv;
 }

--- a/modules/porous_flow/src/utils/PorousFlowDependencies.C
+++ b/modules/porous_flow/src/utils/PorousFlowDependencies.C
@@ -139,6 +139,8 @@ PorousFlowDependencies::PorousFlowDependencies()
   _deps.insertDependency("PorousFlowEnergyTimeDerivative", "internal_energy_nodal");
   _deps.insertDependency("PorousFlowEnergyTimeDerivative", "pressure_saturation_nodal");
 
+  _deps.insertDependency("ADPorousFlowEnergyTimeDerivative", "PorousFlowEnergyTimeDerivative");
+
   _deps.insertDependency("PorousFlowFullySaturatedDarcyBase", "permeability_qp");
   _deps.insertDependency("PorousFlowFullySaturatedDarcyBase", "density_qp");
   _deps.insertDependency("PorousFlowFullySaturatedDarcyBase", "viscosity_qp");
@@ -182,6 +184,8 @@ PorousFlowDependencies::PorousFlowDependencies()
   _deps.insertDependency("PorousFlowMassRadioactiveDecay", "pressure_saturation_nodal");
   _deps.insertDependency("PorousFlowMassRadioactiveDecay", "mass_fraction_nodal");
 
+  _deps.insertDependency("ADPorousFlowMassRadioactiveDecay", "PorousFlowMassRadioactiveDecay");
+
   _deps.insertDependency("PorousFlowMassTimeDerivative", "porosity_nodal");
   _deps.insertDependency("PorousFlowMassTimeDerivative", "nearest_qp_nodal");
   _deps.insertDependency("PorousFlowMassTimeDerivative", "density_nodal");
@@ -205,6 +209,8 @@ PorousFlowDependencies::PorousFlowDependencies()
   _deps.insertDependency("PorousFlowPreDis", "porosity_nodal");
   _deps.insertDependency("PorousFlowPreDis", "chemistry_nodal");
   _deps.insertDependency("PorousFlowPreDis", "mineral_nodal");
+
+  _deps.insertDependency("ADPorousFlowPreDis", "PorousFlowPreDis");
 
   // Material dependencies
   _deps.insertDependency("density_qp", "fluid_properties_qp");

--- a/modules/porous_flow/src/utils/PorousFlowDependencies.C
+++ b/modules/porous_flow/src/utils/PorousFlowDependencies.C
@@ -103,11 +103,15 @@ PorousFlowDependencies::PorousFlowDependencies()
   _deps.insertDependency("PorousFlowAdvectiveFlux", "PorousFlowDarcyBase");
   _deps.insertDependency("PorousFlowAdvectiveFlux", "mass_fraction_nodal");
   _deps.insertDependency("PorousFlowAdvectiveFlux", "relative_permeability_nodal");
+  _deps.insertDependency("ADPorousFlowAdvectiveFlux", "PorousFlowAdvectiveFlux");
 
   _deps.insertDependency("PorousFlowFullySaturatedAdvectiveFlux", "PorousFlowDarcyBase");
   _deps.insertDependency("PorousFlowFullySaturatedAdvectiveFlux", "mass_fraction_nodal");
+  _deps.insertDependency("ADPorousFlowFullySaturatedAdvectiveFlux",
+                         "PorousFlowFullySaturatedAdvectiveFlux");
 
   _deps.insertDependency("PorousFlowBasicAdvection", "darcy_velocity_qp");
+  _deps.insertDependency("ADPorousFlowBasicAdvection", "PorousFlowBasicAdvection");
 
   _deps.insertDependency("PorousFlowDarcyBase", "permeability_qp");
   _deps.insertDependency("PorousFlowDarcyBase", "density_qp");
@@ -116,6 +120,8 @@ PorousFlowDependencies::PorousFlowDependencies()
   _deps.insertDependency("PorousFlowDarcyBase", "pressure_saturation_qp");
 
   _deps.insertDependency("PorousFlowDesorpedMassTimeDerivative", "porosity_qp");
+  _deps.insertDependency("ADPorousFlowDesorpedMassTimeDerivative",
+                         "PorousFlowDesorpedMassTimeDerivative");
 
   _deps.insertDependency("PorousFlowDesorpedMassVolumetricExpansion", "porosity_qp");
   _deps.insertDependency("PorousFlowDesorpedMassVolumetricExpansion", "volumetric_strain_qp");
@@ -128,8 +134,11 @@ PorousFlowDependencies::PorousFlowDependencies()
   _deps.insertDependency("PorousFlowDispersiveFlux", "relative_permeability_qp");
   _deps.insertDependency("PorousFlowDispersiveFlux", "permeability_qp");
   _deps.insertDependency("PorousFlowDispersiveFlux", "pressure_saturation_qp");
+  _deps.insertDependency("ADPorousFlowDispersiveFlux", "PorousFlowDispersiveFlux");
 
   _deps.insertDependency("PorousFlowEffectiveStressCoupling", "effective_pressure_qp");
+  _deps.insertDependency("ADPorousFlowEffectiveStressCoupling",
+                         "PorousFlowEffectiveStressCoupling");
 
   _deps.insertDependency("PorousFlowEnergyTimeDerivative", "porosity_nodal");
   _deps.insertDependency("PorousFlowEnergyTimeDerivative", "nearest_qp_nodal");
@@ -157,6 +166,8 @@ PorousFlowDependencies::PorousFlowDependencies()
 
   _deps.insertDependency("PorousFlowFullySaturatedUpwindHeatAdvection", "PorousFlowDarcyBase");
   _deps.insertDependency("PorousFlowFullySaturatedUpwindHeatAdvection", "enthalpy_nodal");
+  _deps.insertDependency("ADPorousFlowFullySaturatedUpwindHeatAdvection",
+                         "PorousFlowFullySaturatedUpwindHeatAdvection");
 
   _deps.insertDependency("PorousFlowFullySaturatedMassTimeDerivative", "biot_modulus_qp");
   _deps.insertDependency("PorousFlowFullySaturatedMassTimeDerivative", "thermal_expansion_qp");
@@ -168,9 +179,11 @@ PorousFlowDependencies::PorousFlowDependencies()
   _deps.insertDependency("PorousFlowHeatAdvection", "PorousFlowDarcyBase");
   _deps.insertDependency("PorousFlowHeatAdvection", "enthalpy_nodal");
   _deps.insertDependency("PorousFlowHeatAdvection", "relative_permeability_nodal");
+  _deps.insertDependency("ADPorousFlowHeatAdvection", "PorousFlowHeatAdvection");
 
   _deps.insertDependency("PorousFlowHeatConduction", "thermal_conductivity_qp");
   _deps.insertDependency("PorousFlowHeatConduction", "temperature_qp");
+  _deps.insertDependency("ADPorousFlowHeatConduction", "PorousFlowHeatConduction");
 
   _deps.insertDependency("PorousFlowHeatVolumetricExpansion", "porosity_nodal");
   _deps.insertDependency("PorousFlowHeatVolumetricExpansion", "nearest_qp_nodal");

--- a/modules/porous_flow/src/utils/PorousFlowDependencies.C
+++ b/modules/porous_flow/src/utils/PorousFlowDependencies.C
@@ -152,6 +152,8 @@ PorousFlowDependencies::PorousFlowDependencies()
   _deps.insertDependency("PorousFlowFullySaturatedHeatAdvection",
                          "PorousFlowFullySaturatedDarcyBase");
   _deps.insertDependency("PorousFlowFullySaturatedHeatAdvection", "enthalpy_qp");
+  _deps.insertDependency("ADPorousFlowFullySaturatedHeatAdvection",
+                         "PorousFlowFullySaturatedHeatAdvection");
 
   _deps.insertDependency("PorousFlowFullySaturatedUpwindHeatAdvection", "PorousFlowDarcyBase");
   _deps.insertDependency("PorousFlowFullySaturatedUpwindHeatAdvection", "enthalpy_nodal");

--- a/modules/porous_flow/src/utils/PorousFlowDependencies.C
+++ b/modules/porous_flow/src/utils/PorousFlowDependencies.C
@@ -188,6 +188,8 @@ PorousFlowDependencies::PorousFlowDependencies()
   _deps.insertDependency("PorousFlowMassTimeDerivative", "pressure_saturation_nodal");
   _deps.insertDependency("PorousFlowMassTimeDerivative", "mass_fraction_nodal");
 
+  _deps.insertDependency("ADPorousFlowMassTimeDerivative", "PorousFlowMassTimeDerivative");
+
   _deps.insertDependency("PorousFlowMassVolumetricExpansion", "porosity_nodal");
   _deps.insertDependency("PorousFlowMassVolumetricExpansion", "nearest_qp_nodal");
   _deps.insertDependency("PorousFlowMassVolumetricExpansion", "density_nodal");

--- a/modules/porous_flow/test/tests/fluidstate/water_vapor_tab.i
+++ b/modules/porous_flow/test/tests/fluidstate/water_vapor_tab.i
@@ -208,6 +208,7 @@
   []
   [internal_energy]
     type = PorousFlowMatrixInternalEnergy
+    at_nodes = true # Needed as there are no kernels
     density = 2500
     specific_heat_capacity = 1200
   []

--- a/modules/porous_flow/test/tests/jacobian/basic_advection_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/basic_advection_AD.i
@@ -1,0 +1,113 @@
+# Basic advection with 1 porepressure as a PorousFlow variable
+# Fully saturated, constant permeability, constant viscosity
+# AD path: Jacobian verified against finite differences via PetscJacobianTester
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [u]
+  []
+  [P]
+  []
+[]
+
+[ICs]
+  [P]
+    type = RandomIC
+    variable = P
+  []
+  [u]
+    type = RandomIC
+    variable = u
+  []
+[]
+
+[Kernels]
+  [dummy_P]
+    type = NullKernel
+    variable = P
+  []
+  [u_advection]
+    type = ADPorousFlowBasicAdvection
+    variable = u
+    phase = 0
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = P
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+  [pc]
+    type = PorousFlowCapillaryPressureVG
+    alpha = 1
+    m = 0.6
+    sat_lr = 0.1
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 3
+    density0 = 4
+    thermal_expansion = 0
+    viscosity = 150.0
+  []
+[]
+
+[Materials]
+  [temperature_qp]
+    type = ADPorousFlowTemperature
+  []
+  [ppss_qp]
+    type = ADPorousFlow1PhaseP
+    porepressure = P
+    capillary_pressure = pc
+  []
+  [simple_fluid_qp]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+  [permeability]
+    type = ADPorousFlowPermeabilityConst
+    permeability = '5 0 0 0 5 0 0 0 5'
+  []
+  [relperm_qp]
+    type = ADPorousFlowRelativePermeabilityCorey
+    n = 2
+    phase = 0
+    s_res = 0.1
+    sum_s_res = 0.1
+  []
+  [darcy_velocity_qp]
+    type = ADPorousFlowDarcyVelocityMaterial
+    gravity = '0.25 0 0'
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-snes_type'
+    petsc_options_value = ' test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  end_time = 1
+[]

--- a/modules/porous_flow/test/tests/jacobian/denergy01_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/denergy01_AD.i
@@ -1,0 +1,83 @@
+# Jacobian test for ADPorousFlowEnergyTimeDerivative
+# 0 phases (rock heat only), constant porosity
+# AD path: Jacobian verified against finite differences via PetscJacobianTester
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  xmin = 0
+  xmax = 1
+  ny = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [temp]
+  []
+[]
+
+[ICs]
+  [temp]
+    type = RandomIC
+    variable = temp
+    max = 1.0
+    min = 0.0
+  []
+[]
+
+[Kernels]
+  [energy_dot]
+    type = ADPorousFlowEnergyTimeDerivative
+    variable = temp
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'temp'
+    number_fluid_phases = 0
+    number_fluid_components = 0
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+    temperature = temp
+  []
+  [porosity]
+    type = ADPorousFlowPorosityConst
+    porosity = 0.1
+  []
+  [rock_heat]
+    type = ADPorousFlowMatrixInternalEnergy
+    specific_heat_capacity = 1.1
+    density = 0.5
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/denergy02_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/denergy02_AD.i
@@ -1,0 +1,117 @@
+# Jacobian test for ADPorousFlowEnergyTimeDerivative
+# 1 phase, 1 component, fully saturated, constant porosity
+# AD path: Jacobian verified against finite differences via PetscJacobianTester
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  xmin = 0
+  xmax = 1
+  ny = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [pp]
+  []
+  [temp]
+  []
+[]
+
+[ICs]
+  [pp]
+    type = RandomIC
+    variable = pp
+    min = 0
+    max = 1
+  []
+  [temp]
+    type = RandomIC
+    variable = temp
+    min = 0.5
+    max = 1.5
+  []
+[]
+
+[Kernels]
+  [dummy_pp]
+    type = Diffusion
+    variable = pp
+  []
+  [energy_dot]
+    type = ADPorousFlowEnergyTimeDerivative
+    variable = temp
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp temp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 1.5
+    density0 = 1
+    thermal_expansion = 0
+    cv = 1.3
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+    temperature = temp
+  []
+  [ppss]
+    type = ADPorousFlow1PhaseFullySaturated
+    porepressure = pp
+  []
+  [massfrac]
+    type = ADPorousFlowMassFraction
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+  [porosity]
+    type = ADPorousFlowPorosityConst
+    porosity = 0.1
+  []
+  [rock_heat]
+    type = ADPorousFlowMatrixInternalEnergy
+    specific_heat_capacity = 1.1
+    density = 0.5
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/desorped_mass01_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/desorped_mass01_AD.i
@@ -1,0 +1,113 @@
+# 1phase, constant porosity, desorped mass time derivative, AD
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  xmin = -1
+  xmax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [pp]
+  []
+  [conc]
+    family = MONOMIAL
+    order = CONSTANT
+  []
+[]
+
+[ICs]
+  [pp]
+    type = RandomIC
+    variable = pp
+    min = -1
+    max = 1
+  []
+  [conc]
+    type = RandomIC
+    variable = conc
+    min = 0
+    max = 1
+  []
+[]
+
+[Kernels]
+  [mass0]
+    type = TimeDerivative
+    variable = pp
+  []
+  [conc]
+    type = ADPorousFlowDesorpedMassTimeDerivative
+    conc_var = conc
+    variable = conc
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+  [pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 1.5
+    density0 = 1
+    thermal_expansion = 0
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+  []
+  [ppss]
+    type = ADPorousFlow1PhaseP
+    porepressure = pp
+    capillary_pressure = pc
+  []
+  [massfrac]
+    type = ADPorousFlowMassFraction
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+  [porosity]
+    type = ADPorousFlowPorosityConst
+    porosity = 0.1
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/disp01_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/disp01_AD.i
@@ -1,0 +1,131 @@
+# Dispersive flux: 1 phase, 2 components, fully saturated, AD
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 3
+  xmin = 0
+  xmax = 1
+  ny = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [pp]
+  []
+  [massfrac0]
+  []
+[]
+
+[ICs]
+  [pp]
+    type = RandomIC
+    variable = pp
+    max = 2e1
+    min = 1e1
+  []
+  [massfrac0]
+    type = RandomIC
+    variable = massfrac0
+    min = 0
+    max = 1
+  []
+[]
+
+[Kernels]
+  [diff0]
+    type = ADPorousFlowDispersiveFlux
+    fluid_component = 0
+    variable = pp
+    gravity = '1 0 0'
+    disp_long = 0.1
+    disp_trans = 0.1
+  []
+  [diff1]
+    type = ADPorousFlowDispersiveFlux
+    fluid_component = 1
+    variable = massfrac0
+    gravity = '1 0 0'
+    disp_long = 0.1
+    disp_trans = 0.1
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp massfrac0'
+    number_fluid_phases = 1
+    number_fluid_components = 2
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 1e7
+    density0 = 10
+    thermal_expansion = 0
+    viscosity = 1
+  []
+[]
+
+[Materials]
+  [temp]
+    type = ADPorousFlowTemperature
+  []
+  [ppss]
+    type = ADPorousFlow1PhaseFullySaturated
+    porepressure = pp
+  []
+  [massfrac]
+    type = ADPorousFlowMassFraction
+    mass_fraction_vars = 'massfrac0'
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+  [poro]
+    type = ADPorousFlowPorosityConst
+    porosity = 0.1
+  []
+  [diff]
+    type = ADPorousFlowDiffusivityConst
+    diffusion_coeff = '1e-2 1e-1'
+    tortuosity = 1
+  []
+  [permeability]
+    type = ADPorousFlowPermeabilityConst
+    permeability = '1 0 0 0 2 0 0 0 3'
+  []
+  [relperm]
+    type = ADPorousFlowRelativePermeabilityConst
+    phase = 0
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/eff_stress01_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/eff_stress01_AD.i
@@ -1,0 +1,113 @@
+# 2phase (PP), effective stress coupling, AD
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 1
+  ny = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [ppwater]
+  []
+  [ppgas]
+  []
+[]
+
+[AuxVariables]
+  [massfrac_ph0_sp0]
+  []
+  [massfrac_ph1_sp0]
+  []
+[]
+
+[ICs]
+  [ppwater]
+    type = RandomIC
+    variable = ppwater
+    min = -1
+    max = 0
+  []
+  [ppgas]
+    type = RandomIC
+    variable = ppgas
+    min = 0
+    max = 1
+  []
+  [massfrac_ph0_sp0]
+    type = RandomIC
+    variable = massfrac_ph0_sp0
+    min = 0
+    max = 1
+  []
+  [massfrac_ph1_sp0]
+    type = RandomIC
+    variable = massfrac_ph1_sp0
+    min = 0
+    max = 1
+  []
+[]
+
+[Kernels]
+  [grad0]
+    type = ADPorousFlowEffectiveStressCoupling
+    biot_coefficient = 0.3
+    component = 0
+    variable = ppwater
+  []
+  [grad1]
+    type = ADPorousFlowEffectiveStressCoupling
+    biot_coefficient = 0.3
+    component = 1
+    variable = ppgas
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'ppwater ppgas'
+    number_fluid_phases = 2
+    number_fluid_components = 2
+  []
+  [pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1
+  []
+[]
+
+[Materials]
+  [ppss]
+    type = ADPorousFlow2PhasePP
+    phase0_porepressure = ppwater
+    phase1_porepressure = ppgas
+    capillary_pressure = pc
+  []
+  [p_eff]
+    type = ADPorousFlowEffectiveFluidPressure
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/exponential_decay_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/exponential_decay_AD.i
@@ -1,0 +1,64 @@
+# ADExponentialDecay
+# AD path: Jacobian verified against finite differences via PetscJacobianTester
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 1
+  ny = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [exp_decay]
+    type = ADPorousFlowExponentialDecay
+    variable = u
+    rate = rate
+    reference = reference
+  []
+[]
+
+[AuxVariables]
+  [rate]
+  []
+  [reference]
+  []
+[]
+
+[ICs]
+  [rate]
+    type = RandomIC
+    variable = rate
+    min = -1
+    max = 1
+  []
+  [reference]
+    type = RandomIC
+    variable = reference
+    min = 1
+    max = 2
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/fflux01_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux01_AD.i
@@ -1,0 +1,112 @@
+# Using ADPorousFlowAdvectiveFlux
+# 1phase, 1component, constant viscosity, constant insitu permeability
+# density with constant bulk, Corey relative perm, nonzero gravity, unsaturated with vanGenuchten
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  xmin = 0
+  xmax = 1
+  ny = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [pp]
+  []
+[]
+
+[ICs]
+  [pp]
+    type = FunctionIC
+    variable = pp
+    function = -0.7+x+y
+  []
+[]
+
+[Kernels]
+  [flux0]
+    type = ADPorousFlowAdvectiveFlux
+    fluid_component = 0
+    variable = pp
+    gravity = '-1 -0.1 0'
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+  [pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 1.5
+    density0 = 1
+    thermal_expansion = 0
+    viscosity = 1
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+  []
+  [ppss]
+    type = ADPorousFlow1PhaseP
+    porepressure = pp
+    capillary_pressure = pc
+  []
+  [massfrac]
+    type = ADPorousFlowMassFraction
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+  [permeability]
+    type = ADPorousFlowPermeabilityConst
+    permeability = '1 0 0 0 2 0 0 0 3'
+  []
+  [relperm]
+    type = ADPorousFlowRelativePermeabilityCorey
+    n = 2
+    phase = 0
+  []
+[]
+
+[Preconditioning]
+  active = check
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/fflux01_fully_saturated_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux01_fully_saturated_AD.i
@@ -1,0 +1,129 @@
+# Jacobian test for ADPorousFlowFullySaturatedDarcyFlow (3 components).
+# The PetscJacobianTester verifies that the AD-computed Jacobian matches
+# the finite-difference approximation to machine precision.
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  xmin = 0
+  xmax = 1
+  ny = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [pp]
+  []
+  [massfrac0]
+  []
+  [massfrac1]
+  []
+[]
+
+[ICs]
+  [pp]
+    type = FunctionIC
+    variable = pp
+    function = -0.7+x+y
+  []
+  [massfrac0]
+    type = RandomIC
+    variable = massfrac0
+    min = 0
+    max = 0.3
+  []
+  [massfrac1]
+    type = RandomIC
+    variable = massfrac1
+    min = 0
+    max = 0.4
+  []
+[]
+
+[Kernels]
+  [flux0]
+    type = ADPorousFlowFullySaturatedDarcyFlow
+    fluid_component = 0
+    variable = pp
+    gravity = '-1 -0.1 0'
+  []
+  [flux1]
+    type = ADPorousFlowFullySaturatedDarcyFlow
+    fluid_component = 1
+    variable = massfrac0
+    gravity = '-1 -0.1 0'
+  []
+  [flux2]
+    type = ADPorousFlowFullySaturatedDarcyFlow
+    fluid_component = 2
+    variable = massfrac1
+    gravity = '-1 -0.1 0'
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp massfrac0 massfrac1'
+    number_fluid_phases = 1
+    number_fluid_components = 3
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 1.5
+    density0 = 1
+    thermal_expansion = 0
+    viscosity = 1
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+  []
+  [ppss]
+    type = ADPorousFlow1PhaseFullySaturated
+    porepressure = pp
+  []
+  [massfrac]
+    type = ADPorousFlowMassFraction
+    mass_fraction_vars = 'massfrac0 massfrac1'
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+  [permeability]
+    type = ADPorousFlowPermeabilityConst
+    permeability = '1 0 0 0 2 0 0 0 3'
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/fflux02_fully_saturated_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux02_fully_saturated_AD.i
@@ -1,0 +1,142 @@
+# Using ADPorousFlowFullySaturatedAdvectiveFlux
+# 1phase, 3components, constant insitu permeability
+# density with constant bulk, constant viscosity, nonzero gravity
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [pp]
+  []
+  [massfrac0]
+  []
+  [massfrac1]
+  []
+[]
+
+[ICs]
+  [pp]
+    type = FunctionIC
+    variable = pp
+    function = -0.7+x+y
+  []
+  [massfrac0]
+    type = RandomIC
+    variable = massfrac0
+    min = 0
+    max = 0.3
+  []
+  [massfrac1]
+    type = RandomIC
+    variable = massfrac1
+    min = 0
+    max = 0.4
+  []
+[]
+
+[Kernels]
+  [flux0]
+    type = ADPorousFlowFullySaturatedAdvectiveFlux
+    fluid_component = 0
+    variable = pp
+    gravity = '-1 -0.1 0'
+  []
+  [flux1]
+    type = ADPorousFlowFullySaturatedAdvectiveFlux
+    fluid_component = 1
+    variable = massfrac0
+    gravity = '-1 -0.1 0'
+  []
+  [flux2]
+    type = ADPorousFlowFullySaturatedAdvectiveFlux
+    fluid_component = 2
+    variable = massfrac1
+    gravity = '-1 -0.1 0'
+  []
+  [flux0_nodensity]
+    type = ADPorousFlowFullySaturatedAdvectiveFlux
+    fluid_component = 0
+    variable = pp
+    gravity = '-1 -0.1 0'
+    multiply_by_density = false
+  []
+  [flux1_nodensity]
+    type = ADPorousFlowFullySaturatedAdvectiveFlux
+    fluid_component = 1
+    variable = massfrac0
+    gravity = '-1 -0.1 0'
+    multiply_by_density = false
+  []
+  [flux2_nodensity]
+    type = ADPorousFlowFullySaturatedAdvectiveFlux
+    fluid_component = 2
+    variable = massfrac1
+    gravity = '-1 -0.1 0'
+    multiply_by_density = false
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp massfrac0 massfrac1'
+    number_fluid_phases = 1
+    number_fluid_components = 3
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 1.5
+    density0 = 1
+    thermal_expansion = 0
+    viscosity = 1
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+  []
+  [ppss]
+    type = ADPorousFlow1PhaseFullySaturated
+    porepressure = pp
+  []
+  [massfrac]
+    type = ADPorousFlowMassFraction
+    mass_fraction_vars = 'massfrac0 massfrac1'
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+  [permeability]
+    type = ADPorousFlowPermeabilityConst
+    permeability = '2 0 0 0 2 0 0 0 3'
+  []
+[]
+
+[Preconditioning]
+  active = check
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-snes_type'
+    petsc_options_value = 'test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  num_steps = 1
+[]

--- a/modules/porous_flow/test/tests/jacobian/hcond01_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/hcond01_AD.i
@@ -1,0 +1,76 @@
+# 0phase heat conduction, AD
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  xmin = 0
+  xmax = 1
+  ny = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [temp]
+  []
+[]
+
+[ICs]
+  [temp]
+    type = RandomIC
+    variable = temp
+    max = 1.0
+    min = 0.0
+  []
+[]
+
+[Kernels]
+  [heat_conduction]
+    type = ADPorousFlowHeatConduction
+    variable = temp
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'temp'
+    number_fluid_phases = 0
+    number_fluid_components = 0
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+    temperature = temp
+  []
+  [thermal_conductivity]
+    type = ADPorousFlowThermalConductivityIdeal
+    dry_thermal_conductivity = '1.1 0.1 0.3 0.1 2.2 0 0.3 0 3.3'
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/heat_advection01_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/heat_advection01_AD.i
@@ -1,0 +1,122 @@
+# Using ADPorousFlowHeatAdvection
+# 1phase, unsaturated, heat advection
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  xmin = 0
+  xmax = 1
+  ny = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [temp]
+  []
+  [pp]
+  []
+[]
+
+[ICs]
+  [temp]
+    type = RandomIC
+    variable = temp
+    max = 1.0
+    min = 0.0
+  []
+  [pp]
+    type = RandomIC
+    variable = pp
+    max = 0.0
+    min = -1.0
+  []
+[]
+
+[Kernels]
+  [pp]
+    type = TimeDerivative
+    variable = pp
+  []
+  [heat_advection]
+    type = ADPorousFlowHeatAdvection
+    variable = temp
+    gravity = '1 2 3'
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'temp pp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+  [pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.6
+    alpha = 1.3
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 0.5
+    density0 = 1.1
+    thermal_expansion = 0
+    viscosity = 1
+    cv = 1.1
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+    temperature = temp
+  []
+  [permeability]
+    type = ADPorousFlowPermeabilityConst
+    permeability = '1 0 0 0 2 0 0 0 3'
+  []
+  [relperm]
+    type = ADPorousFlowRelativePermeabilityCorey
+    n = 2
+    phase = 0
+  []
+  [PS]
+    type = ADPorousFlow1PhaseP
+    porepressure = pp
+    capillary_pressure = pc
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+[]
+
+[Preconditioning]
+  active = check
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/heat_advection01_fullsat_upwind_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/heat_advection01_fullsat_upwind_AD.i
@@ -1,0 +1,111 @@
+# Using ADPorousFlowFullySaturatedUpwindHeatAdvection
+# 1phase, using fully-saturated, fully-upwinded version, heat advection
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  xmin = 0
+  xmax = 1
+  ny = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [temp]
+  []
+  [pp]
+  []
+[]
+
+[ICs]
+  [temp]
+    type = RandomIC
+    variable = temp
+    max = 1.0
+    min = 0.0
+  []
+  [pp]
+    type = RandomIC
+    variable = pp
+    max = 0.0
+    min = -1.0
+  []
+[]
+
+[Kernels]
+  [pp]
+    type = TimeDerivative
+    variable = pp
+  []
+  [heat_advection]
+    type = ADPorousFlowFullySaturatedUpwindHeatAdvection
+    variable = temp
+    gravity = '1 2 3'
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'temp pp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 0.5
+    density0 = 1.1
+    thermal_expansion = 1
+    viscosity = 1
+    cv = 1.1
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+    temperature = temp
+  []
+  [permeability]
+    type = ADPorousFlowPermeabilityConst
+    permeability = '1 0 0 0 2 0 0 0 3'
+  []
+  [PS]
+    type = ADPorousFlow1PhaseFullySaturated
+    porepressure = pp
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+[]
+
+[Preconditioning]
+  active = check
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-snes_type'
+    petsc_options_value = 'test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/heat_advection01_fully_saturated_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/heat_advection01_fully_saturated_AD.i
@@ -1,0 +1,109 @@
+# 1phase, using fully-saturated version, heat advection, AD
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  xmin = 0
+  xmax = 1
+  ny = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [temp]
+  []
+  [pp]
+  []
+[]
+
+[ICs]
+  [temp]
+    type = RandomIC
+    variable = temp
+    max = 1.0
+    min = 0.0
+  []
+  [pp]
+    type = RandomIC
+    variable = pp
+    max = 0.0
+    min = -1.0
+  []
+[]
+
+[Kernels]
+  [pp]
+    type = TimeDerivative
+    variable = pp
+  []
+  [heat_advection]
+    type = ADPorousFlowFullySaturatedHeatAdvection
+    variable = temp
+    gravity = '1 2 3'
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'temp pp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 0.5
+    density0 = 1.1
+    thermal_expansion = 0
+    viscosity = 1
+    cv = 1.1
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+    temperature = temp
+  []
+  [permeability]
+    type = ADPorousFlowPermeabilityConst
+    permeability = '1 0 0 0 2 0 0 0 3'
+  []
+  [PS]
+    type = ADPorousFlow1PhaseFullySaturated
+    porepressure = pp
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/heat_mass_transfer_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/heat_mass_transfer_AD.i
@@ -1,0 +1,80 @@
+# ADHeatMassTransfer
+# Transfer between two coupled variables u and v, exercising the diagonal (wrt u)
+# and off-diagonal (wrt v) Jacobian entries.
+# AD path: Jacobian verified against finite differences via PetscJacobianTester
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 1
+  ny = 1
+[]
+
+[Variables]
+  [u]
+  []
+  [v]
+  []
+[]
+
+[ICs]
+  [u]
+    type = RandomIC
+    variable = u
+    min = 1
+    max = 2
+  []
+  [v]
+    type = RandomIC
+    variable = v
+    min = 1
+    max = 2
+  []
+  [c]
+    type = RandomIC
+    variable = c
+    min = 0.1
+    max = 1
+  []
+[]
+
+[Kernels]
+  [u_dot]
+    type = TimeDerivative
+    variable = u
+  []
+  [v_dot]
+    type = TimeDerivative
+    variable = v
+  []
+  [transfer]
+    type = ADPorousFlowHeatMassTransfer
+    variable = u
+    v = v
+    transfer_coefficient = c
+  []
+[]
+
+[AuxVariables]
+  [c]
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/mass01_fully_saturated_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/mass01_fully_saturated_AD.i
@@ -1,0 +1,99 @@
+# Jacobian test for ADPorousFlowFullySaturatedMassTimeDerivative.
+# The PetscJacobianTester verifies that the AD-computed Jacobian matches
+# the finite-difference approximation to machine precision.
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 1
+  ny = 1
+  nz = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[FluidProperties]
+  [the_simple_fluid]
+    type = SimpleFluidProperties
+    thermal_expansion = 0.5
+    bulk_modulus = 1.5
+    density0 = 1.0
+  []
+[]
+
+[Variables]
+  [pp]
+  []
+[]
+
+[ICs]
+  [pp]
+    type = RandomIC
+    variable = pp
+    min = 0
+    max = 1
+  []
+[]
+
+[Kernels]
+  [mass0]
+    type = ADPorousFlowFullySaturatedMassTimeDerivative
+    variable = pp
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+  []
+  [ppss]
+    type = ADPorousFlow1PhaseFullySaturated
+    porepressure = pp
+  []
+  [massfrac]
+    type = ADPorousFlowMassFraction
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = the_simple_fluid
+    phase = 0
+  []
+  [porosity]
+    type = PorousFlowPorosityConst
+    porosity = 0.1
+  []
+  [biot_modulus]
+    type = PorousFlowConstantBiotModulus
+    fluid_bulk_modulus = 1.5
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 2
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/mass03_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/mass03_AD.i
@@ -1,0 +1,130 @@
+# Jacobian test for ADPorousFlowMassTimeDerivative
+# 1phase, vanGenuchten, constant-bulk density, constant porosity, 3components, unsaturated
+# AD path: Jacobian verified against finite differences via PetscJacobianTester
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 1
+  ny = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [pp]
+  []
+  [mass_frac_comp0]
+  []
+  [mass_frac_comp1]
+  []
+[]
+
+[ICs]
+  [pp]
+    type = RandomIC
+    variable = pp
+    min = -1
+    max = 0
+  []
+  [mass_frac_comp0]
+    type = RandomIC
+    variable = mass_frac_comp0
+    min = 0
+    max = 0.3
+  []
+  [mass_frac_comp1]
+    type = RandomIC
+    variable = mass_frac_comp1
+    min = 0
+    max = 0.3
+  []
+[]
+
+[Kernels]
+  [mass_comp0]
+    type = ADPorousFlowMassTimeDerivative
+    fluid_component = 0
+    variable = pp
+  []
+  [masscomp1]
+    type = ADPorousFlowMassTimeDerivative
+    fluid_component = 1
+    variable = mass_frac_comp0
+  []
+  [masscomp2]
+    type = ADPorousFlowMassTimeDerivative
+    fluid_component = 2
+    variable = mass_frac_comp1
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp mass_frac_comp0 mass_frac_comp1'
+    number_fluid_phases = 1
+    number_fluid_components = 3
+  []
+  [pc]
+    type = PorousFlowCapillaryPressureVG
+    m = 0.5
+    alpha = 1
+    s_scale = 0.9
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 1.5
+    density0 = 1
+    thermal_expansion = 0
+    viscosity = 1
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+  []
+  [ppss]
+    type = ADPorousFlow1PhaseP
+    porepressure = pp
+    capillary_pressure = pc
+  []
+  [massfrac]
+    type = ADPorousFlowMassFraction
+    mass_fraction_vars = 'mass_frac_comp0 mass_frac_comp1'
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+  [porosity]
+    type = ADPorousFlowPorosityConst
+    porosity = 0.1
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 2
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/radioactive_decay01_AD.i
+++ b/modules/porous_flow/test/tests/jacobian/radioactive_decay01_AD.i
@@ -1,0 +1,100 @@
+# Jacobian test for ADPorousFlowMassRadioactiveDecay
+# 1 phase, 1 component, fully saturated, constant porosity
+# AD path: Jacobian verified against finite differences via PetscJacobianTester
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  xmin = 0
+  xmax = 1
+  ny = 1
+  ymin = 0
+  ymax = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [pp]
+  []
+[]
+
+[ICs]
+  [pp]
+    type = RandomIC
+    variable = pp
+    min = 0
+    max = 1
+  []
+[]
+
+[Kernels]
+  [decay]
+    type = ADPorousFlowMassRadioactiveDecay
+    fluid_component = 0
+    variable = pp
+    decay_rate = 2.0
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 1.5
+    density0 = 1
+    thermal_expansion = 0
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = ADPorousFlowTemperature
+  []
+  [ppss]
+    type = ADPorousFlow1PhaseFullySaturated
+    porepressure = pp
+  []
+  [massfrac]
+    type = ADPorousFlowMassFraction
+  []
+  [simple_fluid]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+  [porosity]
+    type = ADPorousFlowPorosityConst
+    porosity = 0.1
+  []
+[]
+
+[Preconditioning]
+  [check]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it -snes_type'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-10 10000 test'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1
+  end_time = 1
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/modules/porous_flow/test/tests/jacobian/tests
+++ b/modules/porous_flow/test/tests/jacobian/tests
@@ -139,6 +139,16 @@
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
+  [mass01_fully_saturated_AD]
+    type = 'PetscJacobianTester'
+    input = 'mass01_fully_saturated_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    requirement = 'The porous flow module shall compute an exact Jacobian via AD for the fully-saturated mass time derivative kernel.'
+    issues = '#6845'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
 
   [fflux01]
     type = 'PetscJacobianTester'
@@ -297,6 +307,16 @@
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
     requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-components, constant viscosity, constant permeability, constant fluid-bulk modulus, fully-saturated formulation.'
+    issues = '#6845'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
+  [fflux01_fully_saturated_AD]
+    type = 'PetscJacobianTester'
+    input = 'fflux01_fully_saturated_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    requirement = 'The porous flow module shall compute an exact Jacobian via AD for the fully-saturated Darcy flow kernel with multiple components.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []

--- a/modules/porous_flow/test/tests/jacobian/tests
+++ b/modules/porous_flow/test/tests/jacobian/tests
@@ -7,7 +7,7 @@
     cli_args = 'Executioner/num_steps=1'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 1phase, constant-bulk density, constant porosity, 1-component, fully saturated.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 1phase, constant-bulk density, constant porosity, 1-component, fully saturated.'
   []
   [mass01_nodens]
     type = 'PetscJacobianTester'
@@ -15,7 +15,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 1phase, constant-bulk density, constant porosity, 1-component, fully saturated, in a volume approach.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 1phase, constant-bulk density, constant porosity, 1-component, fully saturated, in a volume approach.'
     issues = '#16841'
     design = 'PorousFlowMassTimeDerivative.md porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -25,7 +25,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 1phase, constant-bulk density, constant porosity, 1-component, unsaturated.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 1phase, constant-bulk density, constant porosity, 1-component, unsaturated.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -35,7 +35,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 1phase, constant-bulk density, constant porosity, multi-component, unsaturated.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 1phase, constant-bulk density, constant porosity, multi-component, unsaturated.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -46,8 +46,8 @@
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
     prereq = mass03
-    requirement = 'The porous flow module shall compute all Jacobian entries via AD for the mass time derivative of 1phase, constant-bulk density, constant porosity, multi-component, unsaturated.'
-    issues = '#6845'
+    requirement = 'The system shall compute all Jacobian entries via AD for the mass time derivative of 1phase, constant-bulk density, constant porosity, multi-component, unsaturated.'
+    issues = '#6845 #33122'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
   [mass04]
@@ -56,7 +56,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 2-phase, constant-bulk density, constant porosity, 2-component.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 2-phase, constant-bulk density, constant porosity, 2-component.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -66,7 +66,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 2-phase, constant-bulk density, constant porosity, multi-component.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 2-phase, constant-bulk density, constant porosity, multi-component.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -76,7 +76,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 2-phase, constant-bulk density, constant porosity, multi-component, in a volume formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 2-phase, constant-bulk density, constant porosity, multi-component, in a volume formulation.'
     issues = '#16841'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -86,7 +86,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, constant-bulk density, constant porosity, 1-component, in a log(mass-density) formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, constant-bulk density, constant porosity, 1-component, in a log(mass-density) formulation.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -96,7 +96,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, constant-bulk density, constant porosity, 1-component, in a log(mass-density), volumetric formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, constant-bulk density, constant porosity, 1-component, in a log(mass-density), volumetric formulation.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -106,7 +106,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, constant-bulk density, HMporosity, 1-component, unsaturated.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, constant-bulk density, HMporosity, 1-component, unsaturated.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -116,7 +116,7 @@
     ratio_tol = 5E-6 # lots of chain rules here
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 2-phase, constant-bulk density, 2-component, PS-formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 2-phase, constant-bulk density, 2-component, PS-formulation.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -126,7 +126,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, constant-bulk density, HM-porosity, 1-component, unsaturated.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, constant-bulk density, HM-porosity, 1-component, unsaturated.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -136,7 +136,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, constant-bulk density, HM-porosity, 1-component, unsaturated, with a volumetric formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, constant-bulk density, HM-porosity, 1-component, unsaturated, with a volumetric formulation.'
     issues = '#16841'
     design = 'PorousFlowMassTimeDerivative.md porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -146,7 +146,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, with a fully-saturated formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass time derivative of 1-phase, with a fully-saturated formulation.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -156,8 +156,8 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute an exact Jacobian via AD for the fully-saturated mass time derivative kernel.'
-    issues = '#6845'
+    requirement = 'The system shall compute an exact Jacobian via AD for the fully-saturated mass time derivative kernel.'
+    issues = '#6845 #33122'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
 
@@ -167,7 +167,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 1-component, unsaturated, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 1-component, unsaturated, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -177,7 +177,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-component, unsaturated, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-component, unsaturated, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -187,7 +187,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 2-phase, 2-component, PS formulation, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 2-phase, 2-component, PS formulation, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -197,7 +197,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 2-phase, 3-component, PP formulation, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 2-phase, 3-component, PP formulation, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -207,7 +207,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, log-mass-density formulation, fully-saturated, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, log-mass-density formulation, fully-saturated, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -217,7 +217,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, log-mass-density formulation, unsaturated, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, log-mass-density formulation, unsaturated, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -227,7 +227,7 @@
     ratio_tol = 5E-6 # lots of chain rules here
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 2-phase, 2-component with components in both phases, PS formulation, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 2-phase, 2-component with components in both phases, PS formulation, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -237,7 +237,7 @@
     ratio_tol = 1E-7 # lots of chain rules here
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 1-component, constant viscosity, Kozeny-Carman permeability, constant fluid-bulk modulus, Corey-relative permeability.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 1-component, constant viscosity, Kozeny-Carman permeability, constant fluid-bulk modulus, Corey-relative permeability.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -247,7 +247,7 @@
     ratio_tol = 1E-7 # lots of chain rules here
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 2-phase, 3-component, PP formulation, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability, with RSC capilarity.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 2-phase, 3-component, PP formulation, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability, with RSC capilarity.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -257,7 +257,7 @@
     ratio_tol = 1E-7 # lots of chain rules here
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-component, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability, with BW capilarity.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-component, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability, with BW capilarity.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -267,7 +267,7 @@
     ratio_tol = 1E-7 # lots of chain rules here
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-component, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability, with VG capilarity with a cubic extension.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-component, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability, with VG capilarity with a cubic extension.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -277,7 +277,7 @@
     ratio_tol = 1E-7 # lots of chain rules here
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-component, constant viscosity, constant permeability, constant fluid-bulk modulus, FLAC-relative permeability.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-component, constant viscosity, constant permeability, constant fluid-bulk modulus, FLAC-relative permeability.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -287,7 +287,7 @@
     ratio_tol = 1E-6 # lots of chain rules here
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 2-phase, 3-component, PP-formulation, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability, with a harmonic-mean mobility.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 2-phase, 3-component, PP-formulation, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability, with a harmonic-mean mobility.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -297,7 +297,7 @@
     ratio_tol = 1E-6 # lots of chain rules here
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1 -mat_fd_type ds'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 2-component multicomponent fluid (brine).'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 2-component multicomponent fluid (brine).'
     issues = '#6845 #23609'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -307,7 +307,7 @@
     ratio_tol = 1E-6 # lots of chain rules here
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1 -mat_fd_type ds'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 2-component multicomponent fluid (brine) with tracer.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 2-component multicomponent fluid (brine) with tracer.'
     issues = '#6845 #23609 #30662'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -317,7 +317,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-components, constant viscosity, constant permeability, constant fluid-bulk modulus, fully-saturated formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-components, constant viscosity, constant permeability, constant fluid-bulk modulus, fully-saturated formulation.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -327,8 +327,8 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute an exact Jacobian via AD for the fully-saturated Darcy flow kernel with multiple components.'
-    issues = '#6845'
+    requirement = 'The system shall compute an exact Jacobian via AD for the fully-saturated Darcy flow kernel with multiple components.'
+    issues = '#6845 #33122'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
   [fflux02_fully_saturated]
@@ -336,7 +336,7 @@
     input = 'fflux02_fully_saturated.i'
     ratio_tol = 1E-7
     difference_tol = 1E10
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-components, constant viscosity, constant permeability, constant fluid-bulk modulus, fully-saturated formulation with strong advection.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the fluid flux, with 1-phase, 3-components, constant viscosity, constant permeability, constant fluid-bulk modulus, fully-saturated formulation with strong advection.'
     issues = '#16841'
     design = 'PorousFlowFullySaturated.md PorousFlowFullySaturatedAdvectiveFlux.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -346,7 +346,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the effective stress, with 2-phase, 2-component, PP formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the effective stress, with 2-phase, 2-component, PP formulation.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -356,7 +356,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the effective stress, with 2-phase, 2-component, PS formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the effective stress, with 2-phase, 2-component, PS formulation.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -366,7 +366,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the effective stress, with 2-phase, 2-component, PP formulation, in RZ coordinates.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the effective stress, with 2-phase, 2-component, PP formulation, in RZ coordinates.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -376,7 +376,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the effective stress, with 2-phase, 2-component, PS formulation, in RZ coordinates.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the effective stress, with 2-phase, 2-component, PS formulation, in RZ coordinates.'
     issues = '#6845 #12506'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -386,7 +386,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass volumetric expansion, with constant bulk modulus, constant porosity and VG capilarity.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass volumetric expansion, with constant bulk modulus, constant porosity and VG capilarity.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -396,7 +396,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass volumetric expansion, with constant bulk modulus, HM porosity and VG capilarity.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass volumetric expansion, with constant bulk modulus, HM porosity and VG capilarity.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -406,7 +406,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass volumetric expansion, with constant bulk modulus, HM porosity and VG capilarity, in a volumetric formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass volumetric expansion, with constant bulk modulus, HM porosity and VG capilarity, in a volumetric formulation.'
     issues = '#16841'
     design = 'PorousFlowMassVolumetricExpansion.md porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -417,7 +417,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the piecewise linear sink, with 1-phase and 1-component.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the piecewise linear sink, with 1-phase and 1-component.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -427,7 +427,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the piecewise linear sink, with 2-phase and 2-components.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the piecewise linear sink, with 2-phase and 2-components.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -437,7 +437,7 @@
     ratio_tol = 1E-6
     cli_args = 'Executioner/num_steps=1'
     difference_tol = 1E10
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the piecewise linear sink, with 2-phase and 3-components.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the piecewise linear sink, with 2-phase and 3-components.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -447,7 +447,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the piecewise linear sink, with 2-phase and 3-components, with enthalpy, internal energy and thermal conductivity.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the piecewise linear sink, with 2-phase and 3-components, with enthalpy, internal energy and thermal conductivity.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -457,7 +457,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the half-gaussian sink.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the half-gaussian sink.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -467,7 +467,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the half-cubic sink of fluid.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the half-cubic sink of fluid.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -477,7 +477,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the half-cubic sink of heat.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the half-cubic sink of heat.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -488,7 +488,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the heat conduction, with 0 phases.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the heat conduction, with 0 phases.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -498,7 +498,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the heat conduction, with 2 phases.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the heat conduction, with 2 phases.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -509,7 +509,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the energy-density time derivative, with 0 phases.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the energy-density time derivative, with 0 phases.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -519,7 +519,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the energy-density time derivative, with 2-phase, 1-component, with solid displacements.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the energy-density time derivative, with 2-phase, 1-component, with solid displacements.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -529,7 +529,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the energy-density time derivative, with 2-phase, 1-component, with solid displacements, and TM porosity.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the energy-density time derivative, with 2-phase, 1-component, with solid displacements, and TM porosity.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -539,7 +539,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the energy-density time derivative, with 2-phase, 1-component, with solid displacements, and THM porosity.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the energy-density time derivative, with 2-phase, 1-component, with solid displacements, and THM porosity.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -549,7 +549,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the energy-density time derivative, with 2-phase, 1-component, with solid displacements, and THM porosity, compressive strains and ensuring porosity remains positivie.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the energy-density time derivative, with 2-phase, 1-component, with solid displacements, and THM porosity, compressive strains and ensuring porosity remains positivie.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -560,8 +560,8 @@
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
     prereq = denergy01
-    requirement = 'The porous flow module shall compute all Jacobian entries via AD for the energy-density time derivative, with 0 phases.'
-    issues = '#6845'
+    requirement = 'The system shall compute all Jacobian entries via AD for the energy-density time derivative, with 0 phases.'
+    issues = '#6845 #33122'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
   [denergy02_AD]
@@ -571,8 +571,8 @@
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
     prereq = denergy01_AD
-    requirement = 'The porous flow module shall compute all Jacobian entries via AD for the energy-density time derivative, with 1 phase, 1 component, fully saturated.'
-    issues = '#6845'
+    requirement = 'The system shall compute all Jacobian entries via AD for the energy-density time derivative, with 1 phase, 1 component, fully saturated.'
+    issues = '#6845 #33122'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
 
@@ -582,7 +582,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the heat advection, with 1 phase, unsaturated.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the heat advection, with 1 phase, unsaturated.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -592,7 +592,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the heat advection, with 2 phase, unsaturated.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the heat advection, with 2 phase, unsaturated.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -602,8 +602,19 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the heat advection, with 1 phase, fully-saturated formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the heat advection, with 1 phase, fully-saturated formulation.'
     issues = '#6845'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
+  [heat_advection01_fully_saturated_AD]
+    type = 'PetscJacobianTester'
+    input = 'heat_advection01_fully_saturated_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = heat_advection01_fully_saturated
+    requirement = 'The system shall compute all Jacobian entries via AD for the heat advection, with 1 phase, fully-saturated formulation.'
+    issues = '#6845 #33122'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
   [heat_advection01_fullsat_upwind]
@@ -612,7 +623,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the heat advection, with 1 phase, fully-saturated, fully-upwinded formulation.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the heat advection, with 1 phase, fully-saturated, fully-upwinded formulation.'
     issues = '#16841'
     design = 'PorousFlowFullySaturatedUpwindHeatAdvection.md porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -623,7 +634,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the diffusion.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the diffusion.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -633,7 +644,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the diffusion with constant tortuousity and diffusivity.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the diffusion with constant tortuousity and diffusivity.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -643,7 +654,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the diffusion  with 2-phases, with saturation-dependent tortuousity and MQ diffusion coefficients.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the diffusion  with 2-phases, with saturation-dependent tortuousity and MQ diffusion coefficients.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -653,7 +664,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the transverse dispersion.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the transverse dispersion.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -663,7 +674,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the transverse dispersion and diffusion.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the transverse dispersion and diffusion.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -673,7 +684,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the transverse and longitudinal dispersion.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the transverse and longitudinal dispersion.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -683,7 +694,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the transverse and longitudinal dispersion and diffusion.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the transverse and longitudinal dispersion and diffusion.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -694,7 +705,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the heat volumetric expansion, 1phase with constant bulk modulus, VG capilarity and THM porosity.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the heat volumetric expansion, 1phase with constant bulk modulus, VG capilarity and THM porosity.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -705,7 +716,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the plastic heat energy.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the plastic heat energy.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -716,7 +727,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the a peaceman line sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the a peaceman line sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -726,7 +737,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the a poly-line sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the a poly-line sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -736,7 +747,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the a peaceman sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity, and with many points within each element.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the a peaceman sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity, and with many points within each element.'
     issues = '#6845 #10471 #16255'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -746,7 +757,7 @@
     cli_args = 'DiracKernels/dirac4/point_file=five_points.bh DiracKernels/dirac5/point_file=five_points.bh DiracKernels/dirac6/point_file=five_points.bh Executioner/num_steps=1'
     ratio_tol = 1E-7
     difference_tol = 1E10
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the a peaceman sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity, and with 5 points within each element.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the a peaceman sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity, and with 5 points within each element.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -756,7 +767,7 @@
     cli_args = 'DiracKernels/dirac4/point_file=five_points.bh DiracKernels/dirac5/point_file=five_points.bh DiracKernels/dirac6/point_file=five_points.bh Executioner/num_steps=1'
     ratio_tol = 1E-7
     difference_tol = 1E10
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the a poly-line sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity, and with 5 points within each element.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the a poly-line sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity, and with 5 points within each element.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -766,7 +777,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the a poly-line sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity, and with 1 point within each element.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the a poly-line sink, with 2-phase, 3-components, with enthalpy, internal energy and thermal conductivity, and with 1 point within each element.'
     issues = '#6845 #10471'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -777,7 +788,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the desorbed mass.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the desorbed mass.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -787,7 +798,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the volumetric expansion of desorbed mass.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the volumetric expansion of desorbed mass.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -798,7 +809,7 @@
     ratio_tol = 1e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
     cli_args = '-mat_fd_type ds Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the non-condensible gas version of water, 2 phase.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the non-condensible gas version of water, 2 phase.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -808,7 +819,7 @@
     ratio_tol = 1e-6
     difference_tol = 1e10
     cli_args = '-mat_fd_type ds Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the non-condensible gas version of water, 1 liquid phase.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the non-condensible gas version of water, 1 liquid phase.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -818,7 +829,7 @@
     ratio_tol = 1e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
     cli_args = '-mat_fd_type ds Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the non-condensible gas version of water, 1 gas phase.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the non-condensible gas version of water, 1 gas phase.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -831,7 +842,7 @@
     # test will fail to converge despite the Jacobian test successfully passing. Aborting on solve fail
     # allows this test to pass.
     cli_args = '-mat_fd_type ds Executioner/num_steps=1 Executioner/abort_on_solve_fail=true'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the non-condensible gas version of water, 2 phase, nonisothermal.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the non-condensible gas version of water, 2 phase, nonisothermal.'
     issues = '#6845 #10167'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -841,7 +852,7 @@
     ratio_tol = 1e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
     cli_args = '-mat_fd_type ds Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the brine equation of state, 2 phase.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the brine equation of state, 2 phase.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -851,7 +862,7 @@
     ratio_tol = 1e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
     cli_args = '-mat_fd_type ds Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the brine equation of state, 1 liquid phase.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the brine equation of state, 1 liquid phase.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -861,7 +872,7 @@
     ratio_tol = 1e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
     cli_args = '-mat_fd_type ds Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the brine equation of state, 1 gas phase.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the brine equation of state, 1 gas phase.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -871,7 +882,7 @@
     ratio_tol = 5e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
     cli_args = '-mat_fd_type ds Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the brine equation of state, 2 phase, nonisothermal.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the brine equation of state, 2 phase, nonisothermal.'
     issues = '#6845 #10167'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -881,7 +892,7 @@
     ratio_tol = 1e-6 # Lots of chain rule derivatives
     difference_tol = 1e10
     cli_args = '-mat_fd_type ds Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the brine equation of state, 1 phase with salt fraction as a variable.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the brine equation of state, 1 phase with salt fraction as a variable.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -892,7 +903,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the exponential decay.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the exponential decay.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -902,8 +913,8 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries via AD for the radioactive decay of a fluid component, with 1 phase, 1 component, fully saturated.'
-    issues = '#6845'
+    requirement = 'The system shall compute all Jacobian entries via AD for the radioactive decay of a fluid component, with 1 phase, 1 component, fully saturated.'
+    issues = '#6845 #33122'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
 
@@ -913,7 +924,7 @@
     ratio_tol = 1E-3 # lots of crazy chain rules
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical dissoluation not depending on temperature.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical dissoluation not depending on temperature.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -923,7 +934,7 @@
     ratio_tol = 1E-5 # lots of crazy chain rules
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical precipitation not depending on temperature.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical precipitation not depending on temperature.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -933,7 +944,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -943,7 +954,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical precipitation not depending on temperature.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical precipitation not depending on temperature.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -953,7 +964,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical dissolution not depending on temperature where one concentration is initialized to zero, and the stoichiometry is > 1.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical dissolution not depending on temperature where one concentration is initialized to zero, and the stoichiometry is > 1.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -963,7 +974,7 @@
     ratio_tol = 1E-4
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical dissolution not depending on temperature where one concentration is initialized to zero, and the stoichiometry is = 1.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical dissolution not depending on temperature where one concentration is initialized to zero, and the stoichiometry is = 1.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -973,7 +984,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical dissolution not depending on temperature where the concentrations are initialized to zero.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical dissolution not depending on temperature where the concentrations are initialized to zero.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -983,7 +994,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature where one concentration is initialized to zero, and the stoichiometry is > 1.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature where one concentration is initialized to zero, and the stoichiometry is > 1.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -993,7 +1004,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature where one concentration is initialized to zero, and the stoichiometry is = 1.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature where one concentration is initialized to zero, and the stoichiometry is = 1.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1003,7 +1014,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature where concentrations are initialized to zero.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature where concentrations are initialized to zero.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1013,7 +1024,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature with 3 primary variables and 4 reactions.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature with 3 primary variables and 4 reactions.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1023,7 +1034,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature with 3 primary variables and 4 reactions, with negative initial concentrations.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature with 3 primary variables and 4 reactions, with negative initial concentrations.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1033,7 +1044,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature with 3 primary variables and 4 reactions, with some zero initial concentrations.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the chemical dissolution depending on temperature with 3 primary variables and 4 reactions, with some zero initial concentrations.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1043,7 +1054,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the porosity depending on chemical concentrations.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the porosity depending on chemical concentrations.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1053,7 +1064,7 @@
     ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the mass-fractions that depend on chemical concentrations.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the mass-fractions that depend on chemical concentrations.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1064,7 +1075,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the basic advection with a pre-defined velocity vector, in the 0-phase, no temperature case.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the basic advection with a pre-defined velocity vector, in the 0-phase, no temperature case.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1074,7 +1085,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the basic advection with a Darcy velocity vector in the fully-saturated, constant permeability, constant viscosity case.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the basic advection with a Darcy velocity vector in the fully-saturated, constant permeability, constant viscosity case.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1084,7 +1095,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the basic advection with a Darcy velocity vector in the unsaturated, constant permeability, constant viscosity case.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the basic advection with a Darcy velocity vector in the unsaturated, constant permeability, constant viscosity case.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1094,7 +1105,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the basic advection with a Darcy velocity vector in the unsaturated, non-isothermal, constant permeability, constant viscosity case.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the basic advection with a Darcy velocity vector in the unsaturated, non-isothermal, constant permeability, constant viscosity case.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1104,7 +1115,7 @@
     ratio_tol = 1E-7
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the basic advection with a Darcy velocity vector in the unsaturated case.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the basic advection with a Darcy velocity vector in the unsaturated case.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1114,7 +1125,7 @@
     ratio_tol = 1E-5
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the basic advection with a Darcy velocity vector in the 2-phase PP case.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the basic advection with a Darcy velocity vector in the 2-phase PP case.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
@@ -1123,7 +1134,7 @@
     input = 'esbc01.i'
     ratio_tol = 1E-8
     difference_tol = 1E10
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the enthalpy sink, where porepressure is specified.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the enthalpy sink, where porepressure is specified.'
     issues = '#15742'
     design = 'PorousFlowEnthalpySink.md'
   []
@@ -1132,7 +1143,7 @@
     input = 'esbc02.i'
     ratio_tol = 1E-9
     difference_tol = 1E10
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the enthalpy sink, where external pressure is specified.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the enthalpy sink, where external pressure is specified.'
     issues = '#15742'
     design = 'PorousFlowEnthalpySink.md'
   []
@@ -1141,7 +1152,7 @@
     input = 'hfrompps.i'
     ratio_tol = 1E-5
     difference_tol = 1E10
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the enthalpy source.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the enthalpy source.'
     issues = '#15742'
     design = 'PorousFlowPointEnthalpySourceFromPostprocessor.md'
   []
@@ -1150,7 +1161,7 @@
     input = 'outflowbc01.i'
     ratio_tol = 1E-6
     difference_tol = 1E10
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the outflow boundary condition, 1-phase, 1-component.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the outflow boundary condition, 1-phase, 1-component.'
     issues = '#18037'
     design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md PorousFlowOutflowBC.md'
   []
@@ -1159,7 +1170,7 @@
     input = 'outflowbc02.i'
     ratio_tol = 1E-6
     difference_tol = 1E10
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the outflow heat boundary condition, 1-phase, 1-component.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the outflow heat boundary condition, 1-phase, 1-component.'
     issues = '#18037'
     design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md PorousFlowOutflowBC.md'
   []
@@ -1168,7 +1179,7 @@
     input = 'outflowbc03.i'
     ratio_tol = 1E-6
     difference_tol = 1E10
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the outflow fluid and heat boundary conditions, 1-phase, multi-component.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the outflow fluid and heat boundary conditions, 1-phase, multi-component.'
     issues = '#18037'
     design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md PorousFlowOutflowBC.md'
   []
@@ -1177,7 +1188,7 @@
     input = 'outflowbc04.i'
     ratio_tol = 1E-6
     difference_tol = 1E10
-    requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the outflow fluid boundary conditions, multi-phase, multi-component.'
+    requirement = 'The system shall compute all Jacobian entries of physics kernels for the outflow fluid boundary conditions, multi-phase, multi-component.'
     issues = '#18037'
     design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md PorousFlowOutflowBC.md'
   []
@@ -1191,7 +1202,7 @@
     # test will fail to converge despite the Jacobian test successfully passing. Aborting on solve fail
     # allows this test to pass.
     cli_args = 'Executioner/abort_on_solve_fail=true'
-    requirement = 'The porous flow module shall be able to calculate the analytic Jacobian of systems that include a porosity that is a linear function of effective porepressure, temperature and volumetric strain.'
+    requirement = 'The system shall be able to calculate the analytic Jacobian of systems that include a porosity that is a linear function of effective porepressure, temperature and volumetric strain.'
     issues = '#18079'
     design = 'porous_flow/porosity.md PorousFlowPorosityLinear.md'
   []
@@ -1201,7 +1212,7 @@
     input = 'fv_mass_flux.i'
     ratio_tol = 1e-7
     cli_args = '-mat_fd_type ds Executioner/num_steps=1'
-    requirement = 'The porous flow module shall compute all Jacobian entries of FV physics kernels for flux and mass conservation.'
+    requirement = 'The system shall compute all Jacobian entries of FV physics kernels for flux and mass conservation.'
     issues = '#21275'
     design = 'FVPorousFlowMassTimeDerivative.md FVPorousFlowAdvectiveFlux.md'
   []

--- a/modules/porous_flow/test/tests/jacobian/tests
+++ b/modules/porous_flow/test/tests/jacobian/tests
@@ -553,6 +553,28 @@
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
+  [denergy01_AD]
+    type = 'PetscJacobianTester'
+    input = 'denergy01_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = denergy01
+    requirement = 'The porous flow module shall compute all Jacobian entries via AD for the energy-density time derivative, with 0 phases.'
+    issues = '#6845'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
+  [denergy02_AD]
+    type = 'PetscJacobianTester'
+    input = 'denergy02_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = denergy01_AD
+    requirement = 'The porous flow module shall compute all Jacobian entries via AD for the energy-density time derivative, with 1 phase, 1 component, fully saturated.'
+    issues = '#6845'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
 
   [heat_advection01]
     type = 'PetscJacobianTester'
@@ -871,6 +893,16 @@
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
     requirement = 'The porous flow module shall compute all Jacobian entries of physics kernels for the exponential decay.'
+    issues = '#6845'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
+  [radioactive_decay01_AD]
+    type = 'PetscJacobianTester'
+    input = 'radioactive_decay01_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    requirement = 'The porous flow module shall compute all Jacobian entries via AD for the radioactive decay of a fluid component, with 1 phase, 1 component, fully saturated.'
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []

--- a/modules/porous_flow/test/tests/jacobian/tests
+++ b/modules/porous_flow/test/tests/jacobian/tests
@@ -171,6 +171,17 @@
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
+  [fflux01_AD]
+    type = 'PetscJacobianTester'
+    input = 'fflux01_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = fflux01
+    requirement = 'The system shall compute all Jacobian entries via AD for the fluid flux, with 1-phase, 1-component, unsaturated, constant viscosity, constant permeability, constant fluid-bulk modulus, Corey-relative permeability.'
+    issues = '#6845 #33122'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
   [fflux02]
     type = 'PetscJacobianTester'
     input = 'fflux02.i'
@@ -340,6 +351,17 @@
     issues = '#16841'
     design = 'PorousFlowFullySaturated.md PorousFlowFullySaturatedAdvectiveFlux.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
+  [fflux02_fully_saturated_AD]
+    type = 'PetscJacobianTester'
+    input = 'fflux02_fully_saturated_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = fflux02_fully_saturated
+    requirement = 'The system shall compute all Jacobian entries via AD for the fluid flux, with 1-phase, 3-components, constant viscosity, constant permeability, constant fluid-bulk modulus, fully-saturated formulation with strong advection.'
+    issues = '#16841 #33122'
+    design = 'PorousFlowFullySaturated.md PorousFlowFullySaturatedAdvectiveFlux.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
   [eff_stress01]
     type = 'PetscJacobianTester'
     input = 'eff_stress01.i'
@@ -348,6 +370,17 @@
     cli_args = 'Executioner/num_steps=1'
     requirement = 'The system shall compute all Jacobian entries of physics kernels for the effective stress, with 2-phase, 2-component, PP formulation.'
     issues = '#6845'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
+  [eff_stress01_AD]
+    type = 'PetscJacobianTester'
+    input = 'eff_stress01_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = eff_stress01
+    requirement = 'The system shall compute all Jacobian entries via AD for the effective stress, with 2-phase, 2-component, PP formulation.'
+    issues = '#6845 #33122'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
   [eff_stress02]
@@ -492,6 +525,17 @@
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
+  [hcond01_AD]
+    type = 'PetscJacobianTester'
+    input = 'hcond01_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = hcond01
+    requirement = 'The system shall compute all Jacobian entries via AD for the heat conduction, with 0 phases.'
+    issues = '#6845 #33122'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
   [hcond02]
     type = 'PetscJacobianTester'
     input = 'hcond02.i'
@@ -586,6 +630,17 @@
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
+  [heat_advection01_AD]
+    type = 'PetscJacobianTester'
+    input = 'heat_advection01_AD.i'
+    ratio_tol = 1E-6
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = heat_advection01
+    requirement = 'The system shall compute all Jacobian entries via AD for the heat advection, with 1 phase, unsaturated.'
+    issues = '#6845 #33122'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
   [heat_advection02]
     type = 'PetscJacobianTester'
     input = 'heat_advection02.i'
@@ -627,6 +682,17 @@
     issues = '#16841'
     design = 'PorousFlowFullySaturatedUpwindHeatAdvection.md porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
+  [heat_advection01_fullsat_upwind_AD]
+    type = 'PetscJacobianTester'
+    input = 'heat_advection01_fullsat_upwind_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = heat_advection01_fullsat_upwind
+    requirement = 'The system shall compute all Jacobian entries via AD for the heat advection, with 1 phase, fully-saturated, fully-upwinded formulation.'
+    issues = '#16841 #33122'
+    design = 'PorousFlowFullySaturatedUpwindHeatAdvection.md porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
 
   [diff01]
     type = 'PetscJacobianTester'
@@ -666,6 +732,17 @@
     cli_args = 'Executioner/num_steps=1'
     requirement = 'The system shall compute all Jacobian entries of physics kernels for the transverse dispersion.'
     issues = '#6845'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
+  [disp01_AD]
+    type = 'PetscJacobianTester'
+    input = 'disp01_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = disp01
+    requirement = 'The system shall compute all Jacobian entries via AD for the dispersive flux, with 1 phase, 2 components, fully saturated.'
+    issues = '#6845 #33122'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
   [disp02]
@@ -792,6 +869,17 @@
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
+  [desorped_mass01_AD]
+    type = 'PetscJacobianTester'
+    input = 'desorped_mass01_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = desorped_mass01
+    requirement = 'The system shall compute all Jacobian entries via AD for the desorbed mass time derivative, with 1 phase, constant porosity.'
+    issues = '#6845 #33122'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
   [desorped_mass_vol_exp01]
     type = 'PetscJacobianTester'
     input = 'desorped_mass_vol_exp01.i'
@@ -905,6 +993,27 @@
     cli_args = 'Executioner/num_steps=1'
     requirement = 'The system shall compute all Jacobian entries of physics kernels for the exponential decay.'
     issues = '#6845'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
+  [exponential_decay_AD]
+    type = 'PetscJacobianTester'
+    input = 'exponential_decay_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = exponential_decay
+    requirement = 'The system shall compute all Jacobian entries via AD for the exponential decay.'
+    issues = '#6845 #33122'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
+  [heat_mass_transfer_AD]
+    type = 'PetscJacobianTester'
+    input = 'heat_mass_transfer_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    requirement = 'The system shall compute all Jacobian entries via AD for the heat or mass transfer between two coupled variables.'
+    issues = '#6845 #33122'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
   [radioactive_decay01_AD]
@@ -1127,6 +1236,17 @@
     cli_args = 'Executioner/num_steps=1'
     requirement = 'The system shall compute all Jacobian entries of physics kernels for the basic advection with a Darcy velocity vector in the 2-phase PP case.'
     issues = '#6845'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
+  [basic_advection_AD]
+    type = 'PetscJacobianTester'
+    input = 'basic_advection_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = basic_advection2
+    requirement = 'The system shall compute all Jacobian entries via AD for the basic advection with a Darcy velocity vector in the fully-saturated, constant permeability, constant viscosity case.'
+    issues = '#6845 #33122'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
   [esbc01]

--- a/modules/porous_flow/test/tests/jacobian/tests
+++ b/modules/porous_flow/test/tests/jacobian/tests
@@ -39,6 +39,17 @@
     issues = '#6845'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   []
+  [mass03_AD]
+    type = 'PetscJacobianTester'
+    input = 'mass03_AD.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = 'Executioner/num_steps=1'
+    prereq = mass03
+    requirement = 'The porous flow module shall compute all Jacobian entries via AD for the mass time derivative of 1phase, constant-bulk density, constant porosity, multi-component, unsaturated.'
+    issues = '#6845'
+    design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
+  []
   [mass04]
     type = 'PetscJacobianTester'
     input = 'mass04.i'

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_fully_saturated_2_AD.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_fully_saturated_2_AD.i
@@ -1,0 +1,177 @@
+# Pressure pulse in 1D with 1 phase - transient
+# Using the ADPorousFlowFullySaturatedDarcyBase and
+# ADPorousFlowFullySaturatedMassTimeDerivative kernels.
+# Results should be identical to pressure_pulse_1d_fully_saturated_2.i;
+# this test verifies that the AD-templated kernels converge to the same solution.
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 20
+  xmin = 0
+  xmax = 100
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Variables]
+  [pp]
+    initial_condition = 2E6
+  []
+[]
+
+[Kernels]
+  [mass0]
+    type = ADPorousFlowFullySaturatedMassTimeDerivative
+    variable = pp
+  []
+  [flux]
+    type = ADPorousFlowFullySaturatedDarcyBase
+    variable = pp
+    gravity = '0 0 0'
+  []
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+[]
+
+[FluidProperties]
+  [simple_fluid]
+    type = SimpleFluidProperties
+    bulk_modulus = 2e9
+    density0 = 1000
+    thermal_expansion = 0
+    viscosity = 1e-3
+  []
+[]
+
+[Materials]
+  [temperature_qp]
+    type = ADPorousFlowTemperature
+  []
+  [ppss_qp]
+    type = ADPorousFlow1PhaseFullySaturated
+    porepressure = pp
+  []
+  [massfrac]
+    type = ADPorousFlowMassFraction
+  []
+  [simple_fluid_qp]
+    type = ADPorousFlowSingleComponentFluid
+    fp = simple_fluid
+    phase = 0
+  []
+  [porosity]
+    type = PorousFlowPorosityConst
+    porosity = 0.1
+  []
+  [biot_modulus]
+    type = PorousFlowConstantBiotModulus
+    fluid_bulk_modulus = 2E9
+  []
+  [permeability]
+    type = ADPorousFlowPermeabilityConst
+    permeability = '1E-15 0 0 0 1E-15 0 0 0 1E-15'
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    boundary = left
+    value = 3E6
+    variable = pp
+  []
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+    petsc_options_iname = '-ksp_type -pc_type -snes_atol -snes_rtol -snes_max_it'
+    petsc_options_value = 'bcgs bjacobi 1E-15 1E-20 10000'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  dt = 1E3
+  end_time = 1E4
+[]
+
+[Postprocessors]
+  [p005]
+    type = PointValue
+    variable = pp
+    point = '5 0 0'
+    execute_on = 'initial timestep_end'
+  []
+  [p015]
+    type = PointValue
+    variable = pp
+    point = '15 0 0'
+    execute_on = 'initial timestep_end'
+  []
+  [p025]
+    type = PointValue
+    variable = pp
+    point = '25 0 0'
+    execute_on = 'initial timestep_end'
+  []
+  [p035]
+    type = PointValue
+    variable = pp
+    point = '35 0 0'
+    execute_on = 'initial timestep_end'
+  []
+  [p045]
+    type = PointValue
+    variable = pp
+    point = '45 0 0'
+    execute_on = 'initial timestep_end'
+  []
+  [p055]
+    type = PointValue
+    variable = pp
+    point = '55 0 0'
+    execute_on = 'initial timestep_end'
+  []
+  [p065]
+    type = PointValue
+    variable = pp
+    point = '65 0 0'
+    execute_on = 'initial timestep_end'
+  []
+  [p075]
+    type = PointValue
+    variable = pp
+    point = '75 0 0'
+    execute_on = 'initial timestep_end'
+  []
+  [p085]
+    type = PointValue
+    variable = pp
+    point = '85 0 0'
+    execute_on = 'initial timestep_end'
+  []
+  [p095]
+    type = PointValue
+    variable = pp
+    point = '95 0 0'
+    execute_on = 'initial timestep_end'
+  []
+[]
+
+[Outputs]
+  file_base = pressure_pulse_1d_fully_saturated_2
+  print_linear_residuals = false
+  csv = true
+[]

--- a/modules/porous_flow/test/tests/pressure_pulse/tests
+++ b/modules/porous_flow/test/tests/pressure_pulse/tests
@@ -165,6 +165,16 @@
     design = 'porous_flow/tests/pressure_pulse/pressure_pulse_tests.md'
     requirement = 'The system shall correctly simulate the transient evolution of a pressure pulse in 1D when using 1 fluid phase and employing the fully-saturated version of Darcy flow along with the fully-saturated version of the fluid-mass time derivative.'
   []
+  [pressure_pulse_1d_fully_saturated_2_AD]
+    type = 'CSVDiff'
+    input = 'pressure_pulse_1d_fully_saturated_2_AD.i'
+    csvdiff = 'pressure_pulse_1d_fully_saturated_2.csv'
+    prereq = pressure_pulse_1d_fully_saturated_2
+    rel_err = 1.0E-5
+    issues = '#6845'
+    design = 'porous_flow/tests/pressure_pulse/pressure_pulse_tests.md'
+    requirement = 'The system shall correctly simulate the transient evolution of a pressure pulse in 1D when using 1 fluid phase and employing the AD-templated fully-saturated Darcy and mass time derivative kernels, producing an identical solution to the non-AD formulation.'
+  []
   [pressure_pulse_1d_adapt]
     type = 'CSVDiff'
     input = 'pressure_pulse_1d_adaptivity.i'

--- a/modules/porous_flow/test/tests/pressure_pulse/tests
+++ b/modules/porous_flow/test/tests/pressure_pulse/tests
@@ -8,6 +8,24 @@
     design = 'porous_flow/tests/pressure_pulse/pressure_pulse_tests.md'
     requirement = 'The system shall correctly simulate the transient evolution of a pressure pulse in 1D using 1 phase physics.'
   []
+  [pressure_pulse_1d_lumped_not_nodal]
+    type = 'RunException'
+    input = 'pressure_pulse_1d.i'
+    cli_args = "Kernels/active=mass0 Variables/pp/family=MONOMIAL Variables/pp/order=CONSTANT BCs/active=''"
+    expect_err = "The variable 'pp' is not a nodal .Lagrange. variable"
+    issues = '#33122 #33370'
+    design = 'porous_flow/mass_lumping.md PorousFlowDictator.md'
+    requirement = 'The system shall produce an error if a mass-lumped PorousFlow kernel is applied to a non-nodal variable.'
+  []
+  [pressure_pulse_1d_upwind_not_nodal]
+    type = 'RunException'
+    input = 'pressure_pulse_1d.i'
+    cli_args = "Kernels/active=flux Variables/pp/family=MONOMIAL Variables/pp/order=CONSTANT BCs/active=''"
+    expect_err = "The variable 'pp' is not a nodal .Lagrange. variable"
+    issues = '#33122 #33370'
+    design = 'porous_flow/upwinding.md PorousFlowDictator.md'
+    requirement = 'The system shall produce an error if a fully-upwinded PorousFlow flux kernel is applied to a non-nodal variable.'
+  []
   [pressure_pulse_1d_action]
     type = 'CSVDiff'
     input = 'pressure_pulse_1d_action.i'


### PR DESCRIPTION
Refs #33122 

I've been working on this for a while...


Looks like a lot, but most of the new lines are Jacobian tests of each kernel, and most of the code is templating on GenericKernel
```
template <bool is_ad>
class PorousFlowBasicAdvectionTempl : public GenericKernel<is_ad>
{
...
}
```

and making derivative materials null pointers when `is_ad` is true
```
   _dmass_fractions_dvar(
        is_ad ? nullptr
              : &this->template getMaterialProperty<std::vector<std::vector<std::vector<Real>>>>(
                    "dPorousFlow_mass_frac_nodal_dvar")),
```

There's heaps of this stuff in there. 

The main thing that I would like a second opinion on is the new base class `PorousFlowLumpedKernelBase`, in particular I had to copy a design from `NodalKernels` to make the Jacobian evaluate correctly
```
template <bool is_ad>
void
PorousFlowLumpedKernelBaseTempl<is_ad>::computeJacobian()
{
  if constexpr (!is_ad)
    GenericKernel<is_ad>::computeJacobian();
  else
  {
    this->computeResidualsForJacobian();
    this->addJacobianWithoutConstraints(
        this->_assembly, this->_residuals, this->dofIndices(), this->_var.scalingFactor());
  }
}
```

I had to get Claude to get this bit working properly (I was hitting a compiler error that I couldn't fix).

I also got Claude to generate all of the tests as they were basically identical to the existing tests but with lots of objects swapped to AD versions.

Not sure if it's best to do this in one PR or multiple, but most of it is so similar in design