### PR TITLE
Forward material property variable dependencies to coupling matrix

### DIFF
--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -20,6 +20,7 @@
 #include "MathUtils.h"
 #include "MooseObjectName.h"
 #include "InputParameters.h"
+#include <set>
 
 #include <unordered_map>
 
@@ -31,6 +32,8 @@
 class MooseObject;
 class FEProblemBase;
 class SubProblem;
+class MooseVariableDependencyInterface;
+class MooseVariableFieldBase;
 
 /**
  * Helper class for deferred getting of material properties after the construction
@@ -379,6 +382,17 @@ public:
   /// get a map of MaterialBase pointers for all material objects that this object depends on for each block
   std::unordered_map<SubdomainID, std::vector<MaterialBase *>>
   buildRequiredMaterials(bool allow_stateful = true);
+
+  /**
+   * Add the variable dependencies from materials required by this material-property consumer.
+   *
+   * This is used when an object consumes a material property whose providing material depends on
+   * coupled variables that the consumer does not explicitly couple. The returned set contains only
+   * the variable dependencies introduced through the required materials, so callers can distinguish
+   * those dependencies from the consumer's direct variable dependencies.
+   */
+  std::set<MooseVariableFieldBase *>
+  addRequiredMaterialMooseVariableDependencies(MooseVariableDependencyInterface & consumer);
 
   ///@{
   /**

--- a/framework/src/materials/MaterialPropertyInterface.C
+++ b/framework/src/materials/MaterialPropertyInterface.C
@@ -12,6 +12,8 @@
 #include "MooseApp.h"
 #include "MaterialBase.h"
 #include "FEProblemBase.h"
+#include "MooseVariableDependencyInterface.h"
+#include "MooseVariableFieldBase.h"
 
 const std::string MaterialPropertyInterface::_interpolated_old = "_interpolated_old";
 const std::string MaterialPropertyInterface::_interpolated_older = "_interpolated_older";
@@ -254,6 +256,28 @@ MaterialPropertyInterface::buildRequiredMaterials(bool allow_stateful)
         required_mats[id].begin(), block_required.begin(), block_required.end());
   }
   return required_mats;
+}
+
+std::set<MooseVariableFieldBase *>
+MaterialPropertyInterface::addRequiredMaterialMooseVariableDependencies(
+    MooseVariableDependencyInterface & consumer)
+{
+  std::set<MooseVariableFieldBase *> required_mat_vars;
+
+  if (!getMaterialPropertyCalled())
+    return required_mat_vars;
+
+  const auto required_mats = buildRequiredMaterials();
+
+  for (const auto & block_mats : required_mats)
+    for (const auto * const mat : block_mats.second)
+      for (auto * const var : mat->getMooseVariableDependencies())
+      {
+        consumer.addMooseVariableDependency(var);
+        required_mat_vars.insert(var);
+      }
+
+  return required_mat_vars;
 }
 
 void

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -125,6 +125,8 @@
 #include "Checkpoint.h"
 #include "MortarInterfaceWarehouse.h"
 #include "AutomaticMortarGeneration.h"
+#include "MaterialPropertyInterface.h"
+#include "MooseVariableDependencyInterface.h"
 
 #include "libmesh/exodusII_io.h"
 #include "libmesh/quadrature.h"
@@ -6753,8 +6755,31 @@ FEProblemBase::init()
           break;
 
         case Moose::COUPLING_CUSTOM:
-          // do nothing, _cm was already set through couplingMatrix() call
+        {
+          // The custom coupling matrix was already supplied by the preconditioner. This adds variable
+          // dependencies introduced by materials required by kernels consuming material properties;
+          // these dependencies are not available when preconditioners such as SMP construct the
+          // initial custom coupling matrix.
+          const auto & kernels = nl->getKernelWarehouse().getObjects();
+
+          for (const auto & kernel : kernels)
+          {
+            if (auto mpi = dynamic_cast<MaterialPropertyInterface *>(kernel.get()))
+              if (auto mvdi = dynamic_cast<MooseVariableDependencyInterface *>(kernel.get()))
+              {
+                const auto required_mat_vars =
+                    mpi->addRequiredMaterialMooseVariableDependencies(*mvdi);
+
+                const auto row = kernel->variable().number();
+
+                for (const auto * const coupled_var : required_mat_vars)
+                  if (nl->hasVariable(coupled_var->name()))
+                    (*cm)(row, coupled_var->number()) = 1;
+              }
+          }
+
           break;
+        }
       }
     }
 

--- a/test/include/kernels/MaterialPropertyDependencyKernel.h
+++ b/test/include/kernels/MaterialPropertyDependencyKernel.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Kernel.h"
+
+class MaterialPropertyDependencyKernel : public Kernel
+{
+public:
+  static InputParameters validParams();
+
+  MaterialPropertyDependencyKernel(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+
+  const MaterialProperty<Real> & _prop;
+  const Real _dprop_dvar;
+};

--- a/test/src/kernels/MaterialPropertyDependencyKernel.C
+++ b/test/src/kernels/MaterialPropertyDependencyKernel.C
@@ -1,0 +1,47 @@
+#include "MaterialPropertyDependencyKernel.h"
+
+registerMooseObject("MooseTestApp", MaterialPropertyDependencyKernel);
+
+InputParameters
+MaterialPropertyDependencyKernel::validParams()
+{
+  InputParameters params = Kernel::validParams();
+  params.addRequiredParam<MaterialPropertyName>("prop_name", "The material property to consume.");
+  params.addParam<Real>(
+      "dprop_dvar",
+      1.0,
+      "Derivative of the consumed material property with respect to the hidden coupled variable.");
+  params.addClassDescription(
+      "Test kernel for material-property variable dependency forwarding. The kernel consumes a "
+      "material property but does not directly couple the variable used by the material.");
+  return params;
+}
+
+MaterialPropertyDependencyKernel::MaterialPropertyDependencyKernel(
+    const InputParameters & parameters)
+  : Kernel(parameters),
+    _prop(getMaterialProperty<Real>("prop_name")),
+    _dprop_dvar(getParam<Real>("dprop_dvar"))
+{
+}
+
+Real
+MaterialPropertyDependencyKernel::computeQpResidual()
+{
+  return _prop[_qp] * _test[_i][_qp];
+}
+
+Real
+MaterialPropertyDependencyKernel::computeQpJacobian()
+{
+  // The residual does not depend directly on this kernel's variable.
+  return 0.0;
+}
+
+Real
+MaterialPropertyDependencyKernel::computeQpOffDiagJacobian(unsigned int /* jvar */)
+{
+  // For the regression input, the only off-diagonal dependency should be the hidden material
+  // dependency on v. If the framework does not forward that dependency, this method is never called.
+  return _dprop_dvar * _phi[_j][_qp] * _test[_i][_qp];
+}

--- a/test/tests/kernels/material_property_dependency/material_property_dependency.i
+++ b/test/tests/kernels/material_property_dependency/material_property_dependency.i
@@ -1,0 +1,65 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 2
+[]
+
+[Variables]
+  [u]
+  []
+  [v]
+  []
+[]
+
+[ICs]
+  [u_ic]
+    type = ConstantIC
+    variable = u
+    value = 0.5
+  []
+  [v_ic]
+    type = ConstantIC
+    variable = v
+    value = 2.0
+  []
+[]
+
+[Kernels]
+  [u_hidden_mat_dep]
+    type = MaterialPropertyDependencyKernel
+    variable = u
+    prop_name = hidden_prop
+    dprop_dvar = 1
+  []
+  [v_reaction]
+    type = Reaction
+    variable = v
+  []
+[]
+
+[Materials]
+  [hidden_dependency]
+    type = VarCouplingMaterial
+    var = v
+    use_tag = false
+    base = 0
+    coef = 1
+    coupled_prop_name = hidden_prop
+  []
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = false
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/test/tests/kernels/material_property_dependency/tests
+++ b/test/tests/kernels/material_property_dependency/tests
@@ -1,0 +1,8 @@
+[Tests]
+  [material_property_variable_dependency]
+    type = PetscJacobianTester
+    input = material_property_dependency.i
+    requirement = 'The system shall include off-diagonal Jacobian contributions caused by variables coupled through consumed material properties.'
+    issues = '#25800'
+  []
+[]


### PR DESCRIPTION
Summary

A kernel may consume a material property whose providing material depends on a coupled variable that the kernel does not explicitly couple. With custom coupling matrices such as SMP full=false, that hidden dependency was not represented in the coupling matrix, so the off-diagonal Jacobian path could be skipped.

This adds a MaterialPropertyInterface helper to collect variable dependencies from required materials and uses it while initializing custom coupling matrices. A new PetscJacobianTester regression covers the non-AD kernel/material dependency case.

This initial fix is intentionally limited to Kernels. Other residual objects such as disc Galerkin kernels, IntegratedBCs, InterfaceKernels, and constraints may need analogous handling if similar material-property-induced coupling gaps are identified there.

Refs #25800

Testing

METHOD=opt python ./run_tests --spec-file tests/kernels/material_property_dependency/tests -p 1
METHOD=opt python ./run_tests --spec-file tests/preconditioners/smp/tests -p 1
METHOD=opt python ./run_tests --spec-file tests/preconditioners/auto_smp/tests -p 1