### PR TITLE
Check for stitch failure in StitchMeshGenerator

### DIFF
--- a/framework/include/meshgenerators/StitchMeshGenerator.h
+++ b/framework/include/meshgenerators/StitchMeshGenerator.h
@@ -25,6 +25,20 @@ public:
   std::unique_ptr<MeshBase> generate() override;
 
 protected:
+  /**
+   * Checks whether the given boundary ID has neighbors after a stitch.
+   *
+   * @param[in] mesh  Mesh
+   * @param[in] boundary_id  Boundary ID corresponding to the stitch surface
+   * @param[in] active_side_list  List of BC tuples (elem,side,boundary ID)
+   * @param[in] mg_name  Mesh generator name of secondary mesh in a stitch step
+   */
+  void
+  checkFullBoundaryHasNeighbor(const MeshBase & mesh,
+                               const BoundaryID boundary_id,
+                               const std::vector<libMesh::BoundaryInfo::BCTuple> & active_side_list,
+                               const MeshGeneratorName & mg_name) const;
+
   // Holds pointers to the pointers to the meshes.
   std::vector<std::unique_ptr<MeshBase> *> _mesh_ptrs;
 
@@ -37,4 +51,7 @@ protected:
 
   /// Whether to merge boundaries if they have the same name but different boundary IDs
   const bool _merge_boundaries_with_same_name;
+
+  /// Whether the boundaries in each pair must stitch along the whole of each boundary
+  const bool _require_boundaries_fully_stitch;
 };

--- a/framework/include/utils/MooseMeshUtils.h
+++ b/framework/include/utils/MooseMeshUtils.h
@@ -603,4 +603,50 @@ void buildPolyLineMesh(MeshBase & mesh,
  * shell)
  */
 void addExternalBoundary(MeshBase & mesh, const BoundaryID extern_bid, bool & has_external_bid);
+
+/**
+ * Sets flags stating whether the provided boundary is fully internal or fully external
+ *
+ * A face is external if its element has no neighbor across that side. A boundary is considered
+ * "fully external" if NONE of its faces have neighbors. Similary, a boundary is considered "fully
+ * internal" if ALL of its faces have neighbors. Note that is possible for a boundary to be neither
+ * fully internal nor fully external.
+ *
+ * Note that \c active_side_list may differ from the one produced by \c build_active_side_list()
+ * with the provided mesh. This allows for checking on a pre-stitch set of sides.
+ *
+ * @param[in] mesh  Mesh
+ * @param[in] boundary_id  Boundary ID of boundary to check
+ * @param[in] active_side_list  List of BC tuples (elem,side,boundary ID)
+ * @param[out] fully_internal  True if boundary is fully internal
+ * @param[out] fully_external  True if boundary is fully external
+ */
+void getBoundaryFullyInternalExternal(
+    const MeshBase & mesh,
+    const BoundaryID boundary_id,
+    const std::vector<libMesh::BoundaryInfo::BCTuple> & active_side_list,
+    bool & fully_internal,
+    bool & fully_external);
+
+/**
+ * Returns true if a boundary is fully internal; see \c getBoundaryFullyInternalExternal
+ *
+ * @param[in] mesh  Mesh
+ * @param[in] boundary_id  Boundary ID of boundary to check
+ * @param[in] active_side_list  List of BC tuples (elem,side,boundary ID)
+ */
+bool boundaryIsFullyInternal(const MeshBase & mesh,
+                             const BoundaryID boundary_id,
+                             const std::vector<libMesh::BoundaryInfo::BCTuple> & active_side_list);
+
+/**
+ * Returns true if a boundary is fully external; see \c getBoundaryFullyInternalExternal
+ *
+ * @param[in] mesh  Mesh
+ * @param[in] boundary_id  Boundary ID of boundary to check
+ * @param[in] active_side_list  List of BC tuples (elem,side,boundary ID)
+ */
+bool boundaryIsFullyExternal(const MeshBase & mesh,
+                             const BoundaryID boundary_id,
+                             const std::vector<libMesh::BoundaryInfo::BCTuple> & active_side_list);
 }

--- a/framework/src/meshgenerators/StitchMeshGenerator.C
+++ b/framework/src/meshgenerators/StitchMeshGenerator.C
@@ -43,10 +43,13 @@ StitchMeshGenerator::validParams()
   params.addParam<bool>(
       "enforce_all_nodes_match_on_boundaries",
       false,
-      "Whether to have the stitcher be very picky about the nodes being stitched.");
+      "If true, an error occurs if not all nodes on the specified boundaries have matching "
+      "positions, and this overrides the value of 'merge_boundary_nodes_all_or_nothing'.");
   params.addParam<bool>("merge_boundary_nodes_all_or_nothing",
                         false,
-                        "Whether the stitcher is set to merge all nodes or none.");
+                        "If true, and 'enforce_all_nodes_match_on_boundaries' is false, then when "
+                        "not all nodes on the specified boundaries have matching positions, no "
+                        "nodes get merged, and no error occurs.");
   params.addClassDescription(
       "Allows multiple mesh files to be stitched together to form a single mesh.");
 
@@ -127,6 +130,8 @@ StitchMeshGenerator::generate()
         if (base_mesh_bids.count(bid))
           overlap_found = true;
 
+      // If there is any overlap, renumber all of the boundary IDs of the secondary mesh starting
+      // at an index past the max of either mesh
       if (overlap_found)
       {
         const auto max_boundary_id =

--- a/framework/src/meshgenerators/StitchMeshGenerator.C
+++ b/framework/src/meshgenerators/StitchMeshGenerator.C
@@ -41,6 +41,12 @@ StitchMeshGenerator::validParams()
   params.addParam<bool>(
       "verbose_stitching", false, "Whether mesh stitching should have verbose output.");
   params.addParam<bool>(
+      "require_boundaries_fully_stitch",
+      true,
+      "If true, an error if occurs if after the stitch operation, any element "
+      "does not have a neighbor across the stitch boundary. This should be disabled if you know "
+      "that part of a boundary in a stitch boundary pair will not be stitched in that step.");
+  params.addParam<bool>(
       "enforce_all_nodes_match_on_boundaries",
       false,
       "If true, an error occurs if not all nodes on the specified boundaries have matching "
@@ -63,7 +69,8 @@ StitchMeshGenerator::StitchMeshGenerator(const InputParameters & parameters)
     _mesh_ptrs(getMeshes("inputs")),
     _input_names(getParam<std::vector<MeshGeneratorName>>("inputs")),
     _prevent_boundary_ids_overlap(getParam<bool>("prevent_boundary_ids_overlap")),
-    _merge_boundaries_with_same_name(getParam<bool>("merge_boundaries_with_same_name"))
+    _merge_boundaries_with_same_name(getParam<bool>("merge_boundaries_with_same_name")),
+    _require_boundaries_fully_stitch(getParam<bool>("require_boundaries_fully_stitch"))
 {
   // Check inputs
   if (_input_names.size() - 1 != _stitch_boundaries_pairs.size() && getParam<bool>("_check_inputs"))
@@ -186,6 +193,10 @@ StitchMeshGenerator::generate()
       }
     }
 
+    // Save BCTuples for possibly checking stitch success
+    const auto & boundary_info = mesh->get_boundary_info();
+    const auto prestitch_active_side_list = boundary_info.build_active_side_list();
+
     mesh->stitch_meshes(*meshes[i],
                         first,
                         second,
@@ -193,11 +204,13 @@ StitchMeshGenerator::generate()
                         _clear_stitched_boundary_ids,
                         getParam<bool>("verbose_stitching"),
                         use_binary_search,
-                        /*enforce_all_nodes_match_on_boundaries=*/
                         getParam<bool>("enforce_all_nodes_match_on_boundaries"),
-                        /*merge_boundary_nodes_all_or_nothing=*/
                         getParam<bool>("merge_boundary_nodes_all_or_nothing"),
                         getParam<bool>("subdomain_remapping"));
+
+    // Check that stitching was successful: each face on the first boundary must have a neighbor
+    if (_require_boundaries_fully_stitch)
+      checkFullBoundaryHasNeighbor(*mesh, first, prestitch_active_side_list, _input_names[i + 1]);
 
     if (_merge_boundaries_with_same_name)
       MooseMeshUtils::mergeBoundaryIDsWithSameName(*mesh);
@@ -205,4 +218,31 @@ StitchMeshGenerator::generate()
 
   mesh->unset_is_prepared();
   return dynamic_pointer_cast<MeshBase>(mesh);
+}
+
+void
+StitchMeshGenerator::checkFullBoundaryHasNeighbor(
+    const MeshBase & mesh,
+    const BoundaryID boundary_id,
+    const std::vector<libMesh::BoundaryInfo::BCTuple> & active_side_list,
+    const MeshGeneratorName & mg_name) const
+{
+  if (!MooseMeshUtils::boundaryIsFullyInternal(mesh, boundary_id, active_side_list))
+  {
+    const auto & boundary_info = mesh.get_boundary_info();
+    const auto & boundary_name = boundary_info.get_sideset_name(boundary_id);
+
+    std::stringstream ss;
+    ss << "After stitching mesh '" << mg_name << "', boundary '" << boundary_name
+       << "' (id = " << boundary_id
+       << ") is not fully internal: one or more elements on this boundary does not have a "
+          "neighbor, which means that either (A) part of one or both of the boundaries in the "
+          "provided boundary pair were not intended to be stitched, or (B) a stitch failure has "
+          "occurred. If (A), set 'require_boundaries_fully_stitch' to false. If (B), reasons for "
+          "stitch failure may include: (1) nodes along the stitch boundary do not "
+          "have matching positions, (2) faces to be stitched together do not match. To determine "
+          "which is the reason, try setting 'enforce_all_nodes_match_on_boundaries' to true. If "
+          "the associated error is triggered, then (1) is the reason; else (2) is the reason.";
+    mooseError(ss.str());
+  }
 }

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -1557,4 +1557,58 @@ addExternalBoundary(MeshBase & mesh, const BoundaryID extern_bid, bool & has_ext
         binfo.add_side(elem, i_side, extern_bid);
       }
 }
+
+void
+getBoundaryFullyInternalExternal(
+    const MeshBase & mesh,
+    const BoundaryID boundary_id,
+    const std::vector<libMesh::BoundaryInfo::BCTuple> & active_side_list,
+    bool & fully_internal,
+    bool & fully_external)
+{
+  fully_internal = true;
+  fully_external = true;
+
+  for (std::size_t i = 0; i < active_side_list.size(); ++i)
+  {
+    const auto elem_id = std::get<0>(active_side_list[i]);
+    const auto side_id = std::get<1>(active_side_list[i]);
+    const auto bid = std::get<2>(active_side_list[i]);
+
+    if (bid != boundary_id)
+      continue;
+
+    const Elem * elem = mesh.elem_ptr(elem_id);
+
+    if (elem->neighbor_ptr(side_id))
+      fully_external = false;
+    else
+      fully_internal = false;
+  }
+
+  mesh.comm().min(fully_internal);
+  mesh.comm().min(fully_external);
+}
+
+bool
+boundaryIsFullyInternal(const MeshBase & mesh,
+                        const BoundaryID boundary_id,
+                        const std::vector<libMesh::BoundaryInfo::BCTuple> & active_side_list)
+{
+  bool fully_internal, fully_external;
+  getBoundaryFullyInternalExternal(
+      mesh, boundary_id, active_side_list, fully_internal, fully_external);
+  return fully_internal;
+}
+
+bool
+boundaryIsFullyExternal(const MeshBase & mesh,
+                        const BoundaryID boundary_id,
+                        const std::vector<libMesh::BoundaryInfo::BCTuple> & active_side_list)
+{
+  bool fully_internal, fully_external;
+  getBoundaryFullyInternalExternal(
+      mesh, boundary_id, active_side_list, fully_internal, fully_external);
+  return fully_external;
+}
 }

--- a/modules/reactor/test/tests/meshgenerators/peripheral_ring_mesh_generator/err_mix_type.i
+++ b/modules/reactor/test/tests/meshgenerators/peripheral_ring_mesh_generator/err_mix_type.i
@@ -42,6 +42,7 @@
     stitch_boundaries_pairs = '10 10'
     parallel_type = 'replicated'
     prevent_boundary_ids_overlap = false
+    require_boundaries_fully_stitch = false # testing for other error
   []
   [pr]
     type = PeripheralRingMeshGenerator

--- a/modules/solid_mechanics/test/tests/crystal_plasticity/stress_update_material_based/bicrystal_test.i
+++ b/modules/solid_mechanics/test/tests/crystal_plasticity/stress_update_material_based/bicrystal_test.i
@@ -25,11 +25,10 @@
     input = brass
     subdomain_id = 1
   []
-  [sticher]
+  [stitcher]
     type = StitchedMeshGenerator
     inputs = 'copper_id brass_id'
     stitch_boundaries_pairs = 'front back'
-    prevent_boundary_ids_overlap = false
   []
 []
 

--- a/test/tests/mesh/preparedness/test.i
+++ b/test/tests/mesh/preparedness/test.i
@@ -1,5 +1,6 @@
 [GlobalParams]
   prevent_boundary_ids_overlap = false
+  require_boundaries_fully_stitch = false # partial stitching used
 []
 
 [Mesh]

--- a/test/tests/meshgenerators/boundary_2d_delaunay_generator/cylinder.i
+++ b/test/tests/meshgenerators/boundary_2d_delaunay_generator/cylinder.i
@@ -91,6 +91,7 @@
     stitch_boundaries_pairs = '0 0;0 0;0 0;0 0;0 0'
     merge_boundaries_with_same_name = true
     prevent_boundary_ids_overlap = false
+    require_boundaries_fully_stitch = false # stitch occurs only along one side in each step
   []
   [xyzd]
     type = XYZDelaunayGenerator

--- a/test/tests/meshgenerators/boundary_2d_delaunay_generator/tests
+++ b/test/tests/meshgenerators/boundary_2d_delaunay_generator/tests
@@ -20,7 +20,7 @@
       recover = false
       cli_args = 'Outputs/csv/file_base=cube_rf
                   Mesh/b2dd/use_auto_area_func=true'
-      
+
       detail = 'from a flat 2D boundary in a given 3D mesh with refinement'
       mesh_mode = replicated # block to mesh conversion only supports replicated meshes
     []
@@ -34,7 +34,7 @@
       recover = false
       cli_args = 'Outputs/csv/file_base=curved_surf
                   Mesh/final_generator=bd_1'
-      
+
       detail = 'from a curved 2D boundary in a given 3D mesh without a reference level set'
       mesh_mode = replicated # block to mesh conversion only supports replicated meshes
     []
@@ -49,7 +49,7 @@
       cli_args = 'Outputs/csv/file_base=curved_surf_ls
                   Mesh/final_generator=bd_1
                   Mesh/bd_1/level_set="x^2+y^2-1"'
-      
+
       detail = 'from a curved 2D boundary in a given 3D mesh with a reference level set'
       mesh_mode = replicated # block to mesh conversion only supports replicated meshes
     []
@@ -62,7 +62,7 @@
       override_abs_zero = '1.0e-10'
       recover = false
       cli_args = 'Outputs/csv/file_base=sphere_surf'
-      
+
       detail = 'from a curved 2D boundary in a given 3D mesh with a hole boundary in the same mesh'
       mesh_mode = replicated # block to mesh conversion only supports replicated meshes
     []
@@ -80,7 +80,7 @@
                   Mesh/bd_3/level_set="x^2+y^2-1"
                   Mesh/bd_4/level_set="x^2+y^2-1"'
 
-      detail = 'from an arbitrary 2D boundary in a given 3D mesh. And the output put meshes '
+      detail = 'from an arbitrary 2D boundary in a given 3D mesh. And the output meshes '
                'can be combined to be used as input for 3D Delaunay mesh generation'
       mesh_mode = replicated # block to mesh conversion only supports replicated meshes
       valgrind = none # see #31360

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/detect_amr_tri.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/detect_amr_tri.i
@@ -26,6 +26,7 @@
     type = StitchedMeshGenerator
     inputs = 'big_one cut_one'
     stitch_boundaries_pairs = 'left right'
+    require_boundaries_fully_stitch = false # nodes do not match on boundary
   []
   [diag]
     type = MeshDiagnosticsGenerator

--- a/test/tests/meshgenerators/mesh_diagnostics_generator/intersecting_edge_test.i
+++ b/test/tests/meshgenerators/mesh_diagnostics_generator/intersecting_edge_test.i
@@ -55,6 +55,7 @@
     type = StitchedMeshGenerator
     inputs = 'convert1 rotate'
     stitch_boundaries_pairs = 'front back'
+    require_boundaries_fully_stitch = false # faces do not match on boundary
   []
   [diag]
     type = MeshDiagnosticsGenerator

--- a/test/tests/meshgenerators/sidesets_from_points_generator/sidesets_ambiguity.i
+++ b/test/tests/meshgenerators/sidesets_from_points_generator/sidesets_ambiguity.i
@@ -1,5 +1,6 @@
 [GlobalParams]
   prevent_boundary_ids_overlap = false
+  require_boundaries_fully_stitch = false # testing for other error
 []
 
 [Mesh]

--- a/test/tests/meshgenerators/stitch_mesh_generator/failed_stitch.i
+++ b/test/tests/meshgenerators/stitch_mesh_generator/failed_stitch.i
@@ -1,0 +1,117 @@
+# This mesh uses XYZDelaunayGenerator to mesh a cavity between a shield and
+# reactor core. A stitch occurs, where the nodes match, but the faces do not,
+# resulting in a stitch failure.
+
+[Mesh]
+  [cartesian_mg]
+    type = CartesianMeshGenerator
+    dim = 3
+    dx = '1 5 1'
+    ix = '2 5 2'
+    dy = '1 5 1'
+    iy = '2 5 2'
+    dz = '1 5 1'
+    iz = '2 5 2'
+  []
+  [renumber_cartesian_mg]
+    type = RenameBlockGenerator
+    input = cartesian_mg
+    old_block = 0
+    new_block = 100
+  []
+  [shield_mg]
+    type = RenameBlockGenerator
+    input = renumber_cartesian_mg
+    old_block = 100
+    new_block = shield
+  []
+  [cavity_mg]
+    type = ParsedSubdomainMeshGenerator
+    input = shield_mg
+    combinatorial_geometry = 'x > 1 & x < 6 & y > 1 & y < 6 & z > 1 & z < 6'
+    block_id = 101
+    block_name = 'cavity'
+  []
+  [remove_cavity_mg]
+    type = BlockDeletionGenerator
+    input = cavity_mg
+    block = cavity
+    new_boundary = shield_inner
+  []
+
+  [core_mg]
+    type = CartesianMeshGenerator
+    dim = 3
+    dx = '2'
+    ix = '4'
+    dy = '2'
+    iy = '4'
+    dz = '2'
+    iz = '4'
+  []
+  [translate_core_mg]
+    type = TransformGenerator
+    input = core_mg
+    transform = TRANSLATE
+    vector_value = '2.5 2.5 2.5'
+  []
+  [renumber_core_mg]
+    type = RenameBlockGenerator
+    input = translate_core_mg
+    old_block = 0
+    new_block = 200
+  []
+  [name_core_mg]
+    type = RenameBlockGenerator
+    input = renumber_core_mg
+    old_block = 200
+    new_block = core
+  []
+
+  # generate cavity mesh; 3 steps:
+  #   1. create lower-D block of the shield inner surface
+  #   2. extract that into its own mesh
+  #   3. provide that and the core mesh to XYZDelaunayGenerator to generate cavity mesh
+  [shield_inner_block_mg]
+    type = LowerDBlockFromSidesetGenerator
+    input = remove_cavity_mg
+    sidesets = 'shield_inner'
+    new_block_id = 300
+    new_block_name = shield_inner_block
+  []
+  [extract_shield_inner_block_mg]
+    type = BlockToMeshConverterGenerator
+    input = shield_inner_block_mg
+    target_blocks = 'shield_inner_block'
+  []
+  [cavity_xyz_mg]
+    type = XYZDelaunayGenerator
+    boundary = 'extract_shield_inner_block_mg'
+    holes = 'name_core_mg'
+    output_subdomain_name = 'cavity'
+    output_boundary = 'cavity_outer'
+    desired_volume = 1.0
+    stitch_holes = true
+    convert_holes_for_stitching = true
+    conversion_method = SURFACE
+  []
+  [rename_core_surface_blocks_mg]
+    type = RenameBlockGenerator
+    input = cavity_xyz_mg
+    old_block = '401 602'
+    new_block = 'core_tet core_pyr'
+  []
+  [stitch_mg]
+    type = StitchMeshGenerator
+    inputs = 'remove_cavity_mg rename_core_surface_blocks_mg'
+    stitch_boundaries_pairs = 'shield_inner cavity_outer'
+    enforce_all_nodes_match_on_boundaries = true
+  []
+  [core_outer_mg]
+    type = SideSetsBetweenSubdomainsGenerator
+    input = stitch_mg
+    primary_block = core_tet
+    paired_block = cavity
+    new_boundary = core_outer
+  []
+[]

--- a/test/tests/meshgenerators/stitch_mesh_generator/tests
+++ b/test/tests/meshgenerators/stitch_mesh_generator/tests
@@ -70,4 +70,12 @@
     expect_err = "Boundary ID 1 corresponds to different boundary names on the input meshes! On the first mesh it corresponds to `right` while on the second mesh it corresponds to `bazinga`."
     input = 'stitched_mesh_generator_sameid.i'
   []
+  [failed_stitch]
+    type = RunException
+    design = 'meshgenerators/StitchMeshGenerator.md'
+    issues = '#27758'
+    requirement = "The system shall throw an error if the mesh is not stitched along the full stitch boundary."
+    expect_err = "not fully internal: one or more elements on this boundary does not have a neighbor"
+    input = 'failed_stitch.i'
+  []
 []


### PR DESCRIPTION
This adds a parameter `error_on_stitch_failure` to `StitchMeshGenerator`. For the initial attempt, the default will be `true`, but this likely results in downstream failures.

The check is performed after each stitch: if there are no neighbors across a stitch boundary, an error results.

There are plenty of other places in MOOSE that perform mesh stitching, so this could be considered for other places too.

Refs #27758
