### PR TITLE
[WIP] Enabling Kokkos RDC

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -396,19 +396,26 @@ $(app_KOKKOS_LIB): curr_objs := $(app_KOKKOS_OBJECTS)
 $(app_KOKKOS_LIB): $(app_KOKKOS_OBJECTS)
 	@echo "Linking Kokkos Library "$@"..."
 	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-		$(KOKKOS_CXX) -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) -rpath $(curr_dir)/lib ${SILENCE_SOME_WARNINGS}'
+		$(KOKKOS_CXX) -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS) -rpath $(curr_dir)/lib ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $@ $(curr_dir)/lib
 
-else
-
-# libtool ignores nvcc and just uses mpicxx to link, so cannot be used
+else ifeq ($(KOKKOS_COMPILER),NVCC)
 
 $(app_KOKKOS_LIB): curr_dir  := $(APPLICATION_DIR)
 $(app_KOKKOS_LIB): curr_objs := $(app_KOKKOS_OBJECTS)
 $(app_KOKKOS_LIB): $(app_KOKKOS_OBJECTS)
 	@mkdir -p $(curr_dir)/lib
 	@echo "Linking Kokkos Library "$@"..."
-	@$(KOKKOS_CXX) --shared -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS)
+	@ar rcs $@ $(curr_objs)
+
+else
+
+$(app_KOKKOS_LIB): curr_dir  := $(APPLICATION_DIR)
+$(app_KOKKOS_LIB): curr_objs := $(app_KOKKOS_OBJECTS)
+$(app_KOKKOS_LIB): $(app_KOKKOS_OBJECTS)
+	@mkdir -p $(curr_dir)/lib
+	@echo "Linking Kokkos Library "$@"..."
+	@$(KOKKOS_CXX) --shared -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS)
 
 endif
 
@@ -452,19 +459,26 @@ $(app_KOKKOS_TEST_LIB): curr_objs := $(app_KOKKOS_TEST_OBJECTS)
 $(app_KOKKOS_TEST_LIB): $(app_KOKKOS_TEST_OBJECTS)
 	@echo "Linking Kokkos Test Library "$@"..."
 	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-		$(KOKKOS_CXX) -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) -rpath $(curr_dir)/lib ${SILENCE_SOME_WARNINGS}'
+		$(KOKKOS_CXX) -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS) -rpath $(curr_dir)/lib ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $@ $(curr_dir)/lib
 
-else
-
-# libtool ignores nvcc and just uses mpicxx to link, so cannot be used
+else ifeq ($(KOKKOS_COMPILER),NVCC)
 
 $(app_KOKKOS_TEST_LIB): curr_dir  := $(APPLICATION_DIR)/test
 $(app_KOKKOS_TEST_LIB): curr_objs := $(app_KOKKOS_TEST_OBJECTS)
 $(app_KOKKOS_TEST_LIB): $(app_KOKKOS_TEST_OBJECTS)
 	@mkdir -p $(curr_dir)/lib
 	@echo "Linking Kokkos Test Library "$@"..."
-	@$(KOKKOS_CXX) --shared -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS)
+	@ar rcs $@ $(curr_objs)
+
+else
+
+$(app_KOKKOS_TEST_LIB): curr_dir  := $(APPLICATION_DIR)/test
+$(app_KOKKOS_TEST_LIB): curr_objs := $(app_KOKKOS_TEST_OBJECTS)
+$(app_KOKKOS_TEST_LIB): $(app_KOKKOS_TEST_OBJECTS)
+	@mkdir -p $(curr_dir)/lib
+	@echo "Linking Kokkos Test Library "$@"..."
+	@$(KOKKOS_CXX) --shared -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS)
 
 endif
 
@@ -480,7 +494,7 @@ $(KOKKOS_DEVICE_LINK_OBJECT): curr_dir := $(APPLICATION_DIR)
 $(KOKKOS_DEVICE_LINK_OBJECT): $(KOKKOS_OBJECTS)
 	@mkdir -p $(curr_dir)/lib
 	@echo "Device Linking Kokkos Objects..."
-	@$(KOKKOS_CXX) -dlink -o $@ $(KOKKOS_LDFLAGS) $(KOKKOS_OBJECTS) $(KOKKOS_LIBS)
+	@$(KOKKOS_CXX) -dlink -o $@ $(KOKKOS_LDFLAGS) $(KOKKOS_OBJECTS) $(KOKKOS_LIBS) $(libmesh_LIBS)
 
 endif
 
@@ -583,7 +597,7 @@ endif
 $(app_EXEC): $(app_LIBS) $(MOOSE_KOKKOS_LIB) $(app_KOKKOS_LIBS) $(app_KOKKOS_TEST_LIB) $(KOKKOS_DEVICE_LINK_OBJECT) $(mesh_library) $(main_object) $(app_test_LIB) $(depend_test_libs) $(ADDITIONAL_EXEC_OBJECTS)
 	@echo "Linking Executable "$@"..."
 	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(main_object) $(if $(filter yes,$(HAVE_NO_AS_NEEDED)),$(NO_AS_NEEDED_FLAG)) $(depend_test_libs_flags) $(applibs) $(KOKKOS_DEVICE_LINK_OBJECT) $(ADDITIONAL_LIBS) $(ADDITIONAL_EXEC_OBJECTS) $(LDFLAGS) $(libmesh_LDFLAGS) $(libmesh_LIBS) $(EXTERNAL_FLAGS) ${SILENCE_SOME_WARNINGS}'
+	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(main_object) $(if $(filter yes,$(HAVE_NO_AS_NEEDED)),$(NO_AS_NEEDED_FLAG)) $(depend_test_libs_flags) $(applibs) $(KOKKOS_DEVICE_LINK_OBJECT) $(ADDITIONAL_LIBS) $(ADDITIONAL_EXEC_OBJECTS) $(LDFLAGS) $(libmesh_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS) $(EXTERNAL_FLAGS) ${SILENCE_SOME_WARNINGS}'
 	@$(codesign)
 
 ###### install stuff #############

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -399,17 +399,9 @@ $(app_KOKKOS_LIB): $(app_KOKKOS_OBJECTS)
 		$(KOKKOS_CXX) -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(libmesh_LIBS) -rpath $(curr_dir)/lib ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $@ $(curr_dir)/lib
 
-else ifeq ($(KOKKOS_COMPILER),NVCC)
-
-$(app_KOKKOS_LIB): curr_dir  := $(APPLICATION_DIR)
-$(app_KOKKOS_LIB): curr_objs := $(app_KOKKOS_OBJECTS)
-$(app_KOKKOS_LIB): $(app_KOKKOS_OBJECTS)
-	@mkdir -p $(curr_dir)/lib
-	@echo "Linking Kokkos Library "$@"..."
-	@ar rcs $@ $(curr_objs)
-
 else
 
+# libtool ignores nvcc and just uses mpicxx to link, so cannot be used
 $(app_KOKKOS_LIB): curr_dir  := $(APPLICATION_DIR)
 $(app_KOKKOS_LIB): curr_objs := $(app_KOKKOS_OBJECTS)
 $(app_KOKKOS_LIB): $(app_KOKKOS_OBJECTS)
@@ -462,17 +454,9 @@ $(app_KOKKOS_TEST_LIB): $(app_KOKKOS_TEST_OBJECTS)
 		$(KOKKOS_CXX) -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(libmesh_LIBS) -rpath $(curr_dir)/lib ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $@ $(curr_dir)/lib
 
-else ifeq ($(KOKKOS_COMPILER),NVCC)
-
-$(app_KOKKOS_TEST_LIB): curr_dir  := $(APPLICATION_DIR)/test
-$(app_KOKKOS_TEST_LIB): curr_objs := $(app_KOKKOS_TEST_OBJECTS)
-$(app_KOKKOS_TEST_LIB): $(app_KOKKOS_TEST_OBJECTS)
-	@mkdir -p $(curr_dir)/lib
-	@echo "Linking Kokkos Test Library "$@"..."
-	@ar rcs $@ $(curr_objs)
-
 else
 
+# libtool ignores nvcc and just uses mpicxx to link, so cannot be used
 $(app_KOKKOS_TEST_LIB): curr_dir  := $(APPLICATION_DIR)/test
 $(app_KOKKOS_TEST_LIB): curr_objs := $(app_KOKKOS_TEST_OBJECTS)
 $(app_KOKKOS_TEST_LIB): $(app_KOKKOS_TEST_OBJECTS)

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -396,7 +396,7 @@ $(app_KOKKOS_LIB): curr_objs := $(app_KOKKOS_OBJECTS)
 $(app_KOKKOS_LIB): $(app_KOKKOS_OBJECTS)
 	@echo "Linking Kokkos Library "$@"..."
 	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-		$(KOKKOS_CXX) -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS) -rpath $(curr_dir)/lib ${SILENCE_SOME_WARNINGS}'
+		$(KOKKOS_CXX) -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(libmesh_LIBS) -rpath $(curr_dir)/lib ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $@ $(curr_dir)/lib
 
 else ifeq ($(KOKKOS_COMPILER),NVCC)
@@ -415,7 +415,7 @@ $(app_KOKKOS_LIB): curr_objs := $(app_KOKKOS_OBJECTS)
 $(app_KOKKOS_LIB): $(app_KOKKOS_OBJECTS)
 	@mkdir -p $(curr_dir)/lib
 	@echo "Linking Kokkos Library "$@"..."
-	@$(KOKKOS_CXX) --shared -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS)
+	@$(KOKKOS_CXX) --shared -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(libmesh_LIBS)
 
 endif
 
@@ -459,7 +459,7 @@ $(app_KOKKOS_TEST_LIB): curr_objs := $(app_KOKKOS_TEST_OBJECTS)
 $(app_KOKKOS_TEST_LIB): $(app_KOKKOS_TEST_OBJECTS)
 	@echo "Linking Kokkos Test Library "$@"..."
 	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-		$(KOKKOS_CXX) -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS) -rpath $(curr_dir)/lib ${SILENCE_SOME_WARNINGS}'
+		$(KOKKOS_CXX) -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(libmesh_LIBS) -rpath $(curr_dir)/lib ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $@ $(curr_dir)/lib
 
 else ifeq ($(KOKKOS_COMPILER),NVCC)
@@ -478,7 +478,7 @@ $(app_KOKKOS_TEST_LIB): curr_objs := $(app_KOKKOS_TEST_OBJECTS)
 $(app_KOKKOS_TEST_LIB): $(app_KOKKOS_TEST_OBJECTS)
 	@mkdir -p $(curr_dir)/lib
 	@echo "Linking Kokkos Test Library "$@"..."
-	@$(KOKKOS_CXX) --shared -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS)
+	@$(KOKKOS_CXX) --shared -o $@ $(curr_objs) $(KOKKOS_LDFLAGS) $(libmesh_LIBS)
 
 endif
 
@@ -494,7 +494,7 @@ $(KOKKOS_DEVICE_LINK_OBJECT): curr_dir := $(APPLICATION_DIR)
 $(KOKKOS_DEVICE_LINK_OBJECT): $(KOKKOS_OBJECTS)
 	@mkdir -p $(curr_dir)/lib
 	@echo "Device Linking Kokkos Objects..."
-	@$(KOKKOS_CXX) -dlink -o $@ $(KOKKOS_LDFLAGS) $(KOKKOS_OBJECTS) $(KOKKOS_LIBS) $(libmesh_LIBS)
+	@$(KOKKOS_CXX) -dlink -o $@ $(KOKKOS_LDFLAGS) $(KOKKOS_OBJECTS) $(libmesh_LIBS)
 
 endif
 
@@ -597,7 +597,7 @@ endif
 $(app_EXEC): $(app_LIBS) $(MOOSE_KOKKOS_LIB) $(app_KOKKOS_LIBS) $(app_KOKKOS_TEST_LIB) $(KOKKOS_DEVICE_LINK_OBJECT) $(mesh_library) $(main_object) $(app_test_LIB) $(depend_test_libs) $(ADDITIONAL_EXEC_OBJECTS)
 	@echo "Linking Executable "$@"..."
 	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(main_object) $(if $(filter yes,$(HAVE_NO_AS_NEEDED)),$(NO_AS_NEEDED_FLAG)) $(depend_test_libs_flags) $(applibs) $(KOKKOS_DEVICE_LINK_OBJECT) $(ADDITIONAL_LIBS) $(ADDITIONAL_EXEC_OBJECTS) $(LDFLAGS) $(libmesh_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS) $(EXTERNAL_FLAGS) ${SILENCE_SOME_WARNINGS}'
+	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(main_object) $(if $(filter yes,$(HAVE_NO_AS_NEEDED)),$(NO_AS_NEEDED_FLAG)) $(depend_test_libs_flags) $(applibs) $(KOKKOS_DEVICE_LINK_OBJECT) $(ADDITIONAL_LIBS) $(ADDITIONAL_EXEC_OBJECTS) $(LDFLAGS) $(libmesh_LDFLAGS) $(libmesh_LIBS) $(EXTERNAL_FLAGS) ${SILENCE_SOME_WARNINGS}'
 	@$(codesign)
 
 ###### install stuff #############

--- a/framework/kokkos.mk
+++ b/framework/kokkos.mk
@@ -69,42 +69,43 @@ ifeq ($(PETSC_HAVE_SYCL),1)
 endif
 
 ifneq ($(PETSC_HAVE_CUDA),)
-  KOKKOS_DEVICE             := CUDA
-  KOKKOS_ARCH               := $(KOKKOS_CUDA_ARCH_$(CUDA_ARCH))
-  KOKKOS_COMPILER           := NVCC
-  KOKKOS_CXX                 = $(CUDA_COMPILER)
-  KOKKOS_CXXFLAGS            = -arch=sm_$(CUDA_ARCH) --extended-lambda --relocatable-device-code=true --dlink-time-opt
-  KOKKOS_CXXFLAGS           += --forward-unknown-to-host-compiler --disable-warnings -x cu -ccbin $(word 1, $(libmesh_CXX))
-  KOKKOS_CXXFLAGS           += $(filter-out -Werror=return-type,$(CXXFLAGS) $(libmesh_CXXFLAGS)) # Incompatible with NVCC
-  KOKKOS_CPPFLAGS            = $(subst -Werror,-Werror=all-warnings,$(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS})
-  KOKKOS_LDFLAGS             = --forward-unknown-to-host-compiler --relocatable-device-code=true --dlink-time-opt -arch=sm_$(CUDA_ARCH)
-  KOKKOS_LIBS                = -lpetsckokkos
-  libmesh_PETSC_KOKKOS_LIBS := $(filter %petsckokkos %petsckokkosdlink,$(libmesh_LIBS))
-  libmesh_LIBS              := $(filter-out %petsckokkos %petsckokkosdlink,$(libmesh_LIBS))
+# CUDA link-time optimization (LTO) can improve the performance of relocatable device code (RDC).
+# Some testing showed that LTO can achieve almost equivalent performance with fully inlined code
+# even when linking across translation units through RDC. But it was causing some weird device
+# stack corruptions and crashes with CUDA 12.9 for a couple of tests. When it is resolved, turn
+# on --dlink-time-opt.
+  KOKKOS_DEVICE     := CUDA
+  KOKKOS_ARCH       := $(KOKKOS_CUDA_ARCH_$(CUDA_ARCH))
+  KOKKOS_COMPILER   := NVCC
+  KOKKOS_CXX         = $(CUDA_COMPILER)
+  KOKKOS_CXXFLAGS    = -arch=sm_$(CUDA_ARCH) --extended-lambda --relocatable-device-code=true
+  KOKKOS_CXXFLAGS   += --forward-unknown-to-host-compiler --disable-warnings -x cu -ccbin $(word 1, $(libmesh_CXX))
+  KOKKOS_CXXFLAGS   += $(filter-out -Werror=return-type,$(CXXFLAGS) $(libmesh_CXXFLAGS)) # Incompatible with NVCC
+  KOKKOS_CPPFLAGS    = $(subst -Werror,-Werror=all-warnings,$(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS})
+  KOKKOS_LDFLAGS     = --forward-unknown-to-host-compiler --relocatable-device-code=true -arch=sm_$(CUDA_ARCH)
 else ifneq ($(PETSC_HAVE_HIP),) # To be determined for HIP
-  KOKKOS_DEVICE             := HIP
-  KOKKOS_ARCH               :=
-  KOKKOS_COMPILER           := HIPCC
-  KOKKOS_CXX                 = $(HIP_COMPILER)
-  KOKKOS_CXXFLAGS            =
-  KOKKOS_CPPFLAGS            =
-  KOKKOS_LDFLAGS             =
+  KOKKOS_DEVICE     := HIP
+  KOKKOS_ARCH       :=
+  KOKKOS_COMPILER   := HIPCC
+  KOKKOS_CXX         = $(HIP_COMPILER)
+  KOKKOS_CXXFLAGS    =
+  KOKKOS_CPPFLAGS    =
+  KOKKOS_LDFLAGS     =
 else ifneq ($(PETSC_HAVE_SYCL),) # To be determined for SYCL
-  KOKKOS_DEVICE             := SYCL
-  KOKKOS_ARCH               :=
-  KOKKOS_COMPILER           := DPCPP
-  KOKKOS_CXX                 = $(SYCL_COMPILER)
-  KOKKOS_CXXFLAGS            = -fsycl
-  KOKKOS_CPPFLAGS            =
-  KOKKOS_LDFLAGS             =
+  KOKKOS_DEVICE     := SYCL
+  KOKKOS_ARCH       :=
+  KOKKOS_COMPILER   := DPCPP
+  KOKKOS_CXX         = $(SYCL_COMPILER)
+  KOKKOS_CXXFLAGS    = -fsycl
+  KOKKOS_CPPFLAGS    =
+  KOKKOS_LDFLAGS     =
 else
-  KOKKOS_COMPILER           := CPU
-  KOKKOS_CXX                 = $(libmesh_CXX)
-  KOKKOS_CXXFLAGS            = $(CXXFLAGS) $(libmesh_CXXFLAGS) -x c++
-  KOKKOS_CPPFLAGS            = $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS}
-  KOKKOS_LDFLAGS             =
-  KOKKOS_LIBS                =
-  ENABLE_KOKKOS_GPU         := false
+  KOKKOS_COMPILER   := CPU
+  KOKKOS_CXX         = $(libmesh_CXX)
+  KOKKOS_CXXFLAGS    = $(CXXFLAGS) $(libmesh_CXXFLAGS) -x c++
+  KOKKOS_CPPFLAGS    = $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS}
+  KOKKOS_LDFLAGS     =
+  ENABLE_KOKKOS_GPU := false
 endif
 
 ifeq ($(ENABLE_KOKKOS_GPU),false)
@@ -116,7 +117,6 @@ endif
 
 KOKKOS_CXXFLAGS += -DMOOSE_KOKKOS_SCOPE=1 -DMETAPHYSICL_KOKKOS_COMPILATION=1 -fPIC
 KOKKOS_LDFLAGS  += $(libmesh_LDFLAGS)
-KOKKOS_INCLUDE   = $(libmesh_INCLUDE)
 
 ifeq ($(METHOD),opt)
   KOKKOS_CXXFLAGS += -DNDEBUG
@@ -137,7 +137,7 @@ KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).lo
 %.$(KOKKOS_OBJ_SUFFIX) : %.K
 	@echo "Compiling Kokkos C++ (in "$(METHOD)" mode, $(KOKKOS_DEVICE), $(KOKKOS_ARCH)) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
-	  $(KOKKOS_CXX) $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_INCLUDE) $(app_INCLUDES) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
+	  $(KOKKOS_CXX) $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(libmesh_INCLUDE) $(app_INCLUDES) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 else
 
@@ -145,6 +145,6 @@ KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).o
 
 %.$(KOKKOS_OBJ_SUFFIX) : %.K
 	@echo "Compiling Kokkos C++ (in "$(METHOD)" mode, $(KOKKOS_DEVICE), $(KOKKOS_ARCH)) "$<"..."
-	@$(KOKKOS_CXX) $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_INCLUDE) $(app_INCLUDES) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
+	@$(KOKKOS_CXX) $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(libmesh_INCLUDE) $(app_INCLUDES) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 endif

--- a/framework/kokkos.mk
+++ b/framework/kokkos.mk
@@ -69,38 +69,42 @@ ifeq ($(PETSC_HAVE_SYCL),1)
 endif
 
 ifneq ($(PETSC_HAVE_CUDA),)
-  KOKKOS_DEVICE     := CUDA
-  KOKKOS_ARCH       := $(KOKKOS_CUDA_ARCH_$(CUDA_ARCH))
-  KOKKOS_COMPILER   := NVCC
-  KOKKOS_CXX         = $(CUDA_COMPILER)
-  KOKKOS_CXXFLAGS    = -arch=sm_$(CUDA_ARCH) --extended-lambda
-  KOKKOS_CXXFLAGS   += --forward-unknown-to-host-compiler --disable-warnings -x cu -ccbin $(word 1, $(libmesh_CXX))
-  KOKKOS_CXXFLAGS   += $(filter-out -Werror=return-type,$(CXXFLAGS) $(libmesh_CXXFLAGS)) # Incompatible with NVCC
-  KOKKOS_CPPFLAGS    = $(subst -Werror,-Werror=all-warnings,$(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS})
-  KOKKOS_LDFLAGS     = --forward-unknown-to-host-compiler -arch=sm_$(CUDA_ARCH)
+  KOKKOS_DEVICE             := CUDA
+  KOKKOS_ARCH               := $(KOKKOS_CUDA_ARCH_$(CUDA_ARCH))
+  KOKKOS_COMPILER           := NVCC
+  KOKKOS_CXX                 = $(CUDA_COMPILER)
+  KOKKOS_CXXFLAGS            = -arch=sm_$(CUDA_ARCH) --extended-lambda --relocatable-device-code=true --dlink-time-opt
+  KOKKOS_CXXFLAGS           += --forward-unknown-to-host-compiler --disable-warnings -x cu -ccbin $(word 1, $(libmesh_CXX))
+  KOKKOS_CXXFLAGS           += $(filter-out -Werror=return-type,$(CXXFLAGS) $(libmesh_CXXFLAGS)) # Incompatible with NVCC
+  KOKKOS_CPPFLAGS            = $(subst -Werror,-Werror=all-warnings,$(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS})
+  KOKKOS_LDFLAGS             = --forward-unknown-to-host-compiler --relocatable-device-code=true --dlink-time-opt -arch=sm_$(CUDA_ARCH)
+  KOKKOS_LIBS                = -lpetsckokkos
+  libmesh_PETSC_KOKKOS_LIBS := $(filter %petsckokkos %petsckokkosdlink,$(libmesh_LIBS))
+  libmesh_LIBS              := $(filter-out %petsckokkos %petsckokkosdlink,$(libmesh_LIBS))
 else ifneq ($(PETSC_HAVE_HIP),) # To be determined for HIP
-  KOKKOS_DEVICE     := HIP
-  KOKKOS_ARCH       :=
-  KOKKOS_COMPILER   := HIPCC
-  KOKKOS_CXX         = $(HIP_COMPILER)
-  KOKKOS_CXXFLAGS    =
-  KOKKOS_CPPFLAGS    =
-  KOKKOS_LDFLAGS     =
+  KOKKOS_DEVICE             := HIP
+  KOKKOS_ARCH               :=
+  KOKKOS_COMPILER           := HIPCC
+  KOKKOS_CXX                 = $(HIP_COMPILER)
+  KOKKOS_CXXFLAGS            =
+  KOKKOS_CPPFLAGS            =
+  KOKKOS_LDFLAGS             =
 else ifneq ($(PETSC_HAVE_SYCL),) # To be determined for SYCL
-  KOKKOS_DEVICE     := SYCL
-  KOKKOS_ARCH       :=
-  KOKKOS_COMPILER   := DPCPP
-  KOKKOS_CXX         = $(SYCL_COMPILER)
-  KOKKOS_CXXFLAGS    = -fsycl
-  KOKKOS_CPPFLAGS    =
-  KOKKOS_LDFLAGS     =
+  KOKKOS_DEVICE             := SYCL
+  KOKKOS_ARCH               :=
+  KOKKOS_COMPILER           := DPCPP
+  KOKKOS_CXX                 = $(SYCL_COMPILER)
+  KOKKOS_CXXFLAGS            = -fsycl
+  KOKKOS_CPPFLAGS            =
+  KOKKOS_LDFLAGS             =
 else
-  KOKKOS_COMPILER   := CPU
-  KOKKOS_CXX         = $(libmesh_CXX)
-  KOKKOS_CXXFLAGS    = $(CXXFLAGS) $(libmesh_CXXFLAGS) -x c++
-  KOKKOS_CPPFLAGS    = $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS}
-  KOKKOS_LDFLAGS     =
-  ENABLE_KOKKOS_GPU := false
+  KOKKOS_COMPILER           := CPU
+  KOKKOS_CXX                 = $(libmesh_CXX)
+  KOKKOS_CXXFLAGS            = $(CXXFLAGS) $(libmesh_CXXFLAGS) -x c++
+  KOKKOS_CPPFLAGS            = $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS}
+  KOKKOS_LDFLAGS             =
+  KOKKOS_LIBS                =
+  ENABLE_KOKKOS_GPU         := false
 endif
 
 ifeq ($(ENABLE_KOKKOS_GPU),false)
@@ -113,15 +117,21 @@ endif
 KOKKOS_CXXFLAGS += -DMOOSE_KOKKOS_SCOPE=1 -DMETAPHYSICL_KOKKOS_COMPILATION=1 -fPIC
 KOKKOS_LDFLAGS  += $(libmesh_LDFLAGS)
 KOKKOS_INCLUDE   = $(libmesh_INCLUDE)
-KOKKOS_LIBS      = $(libmesh_LIBS)
 
 ifeq ($(METHOD),opt)
   KOKKOS_CXXFLAGS += -DNDEBUG
 endif
 
 ifeq ($(KOKKOS_COMPILER),CPU)
+  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).la
+else ifeq ($(KOKKOS_COMPILER),NVCC)
+  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).a
+else
+  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).so
+endif
 
-KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).la
+ifeq ($(KOKKOS_COMPILER),CPU)
+
 KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).lo
 
 %.$(KOKKOS_OBJ_SUFFIX) : %.K
@@ -131,7 +141,6 @@ KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).lo
 
 else
 
-KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).so
 KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).o
 
 %.$(KOKKOS_OBJ_SUFFIX) : %.K

--- a/framework/kokkos.mk
+++ b/framework/kokkos.mk
@@ -123,15 +123,8 @@ ifeq ($(METHOD),opt)
 endif
 
 ifeq ($(KOKKOS_COMPILER),CPU)
-  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).la
-else ifeq ($(KOKKOS_COMPILER),NVCC)
-  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).a
-else
-  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).so
-endif
 
-ifeq ($(KOKKOS_COMPILER),CPU)
-
+KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).la
 KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).lo
 
 %.$(KOKKOS_OBJ_SUFFIX) : %.K
@@ -141,6 +134,7 @@ KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).lo
 
 else
 
+KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).so
 KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).o
 
 %.$(KOKKOS_OBJ_SUFFIX) : %.K

--- a/framework/kokkos.mk
+++ b/framework/kokkos.mk
@@ -147,15 +147,8 @@ ifeq ($(METHOD),opt)
 endif
 
 ifeq ($(KOKKOS_COMPILER),CPU)
-  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).la
-else ifeq ($(KOKKOS_COMPILER),NVCC)
-  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).a
-else
-  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).so
-endif
 
-ifeq ($(KOKKOS_COMPILER),CPU)
-
+KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).la
 KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).lo
 
 %.$(KOKKOS_OBJ_SUFFIX) : %.K
@@ -165,6 +158,7 @@ KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).lo
 
 else
 
+KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).so
 KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).o
 
 %.$(KOKKOS_OBJ_SUFFIX) : %.K

--- a/framework/kokkos.mk
+++ b/framework/kokkos.mk
@@ -88,15 +88,18 @@ ifeq ($(PETSC_HAVE_SYCL),1)
 endif
 
 ifneq ($(PETSC_HAVE_CUDA),)
-  KOKKOS_DEVICE     := CUDA
-  KOKKOS_ARCH       := $(KOKKOS_CUDA_ARCH_$(CUDA_ARCH))
-  KOKKOS_COMPILER   := NVCC
-  KOKKOS_CXX         = $(CUDA_COMPILER)
-  KOKKOS_CXXFLAGS    = -arch=sm_$(CUDA_ARCH) --extended-lambda
-  KOKKOS_CXXFLAGS   += --forward-unknown-to-host-compiler --disable-warnings -x cu -ccbin $(word 1, $(libmesh_CXX))
-  KOKKOS_CXXFLAGS   += $(filter-out -Werror=return-type,$(CXXFLAGS) $(libmesh_CXXFLAGS)) # Incompatible with NVCC
-  KOKKOS_CPPFLAGS    = $(subst -Werror,-Werror=all-warnings,$(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS})
-  KOKKOS_LDFLAGS     = --forward-unknown-to-host-compiler -arch=sm_$(CUDA_ARCH)
+  KOKKOS_DEVICE             := CUDA
+  KOKKOS_ARCH               := $(KOKKOS_CUDA_ARCH_$(CUDA_ARCH))
+  KOKKOS_COMPILER           := NVCC
+  KOKKOS_CXX                 = $(CUDA_COMPILER)
+  KOKKOS_CXXFLAGS            = -arch=sm_$(CUDA_ARCH) --extended-lambda --relocatable-device-code=true --dlink-time-opt
+  KOKKOS_CXXFLAGS           += --forward-unknown-to-host-compiler --disable-warnings -x cu -ccbin $(word 1, $(libmesh_CXX))
+  KOKKOS_CXXFLAGS           += $(filter-out -Werror=return-type,$(CXXFLAGS) $(libmesh_CXXFLAGS)) # Incompatible with NVCC
+  KOKKOS_CPPFLAGS            = $(subst -Werror,-Werror=all-warnings,$(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS})
+  KOKKOS_LDFLAGS             = --forward-unknown-to-host-compiler --relocatable-device-code=true --dlink-time-opt -arch=sm_$(CUDA_ARCH)
+  KOKKOS_LIBS                = -lpetsckokkos
+  libmesh_PETSC_KOKKOS_LIBS := $(filter %petsckokkos %petsckokkosdlink,$(libmesh_LIBS))
+  libmesh_LIBS              := $(filter-out %petsckokkos %petsckokkosdlink,$(libmesh_LIBS))
 else ifneq ($(PETSC_HAVE_HIP),)
   KOKKOS_DEVICE     := HIP
   KOKKOS_ARCH       := $(KOKKOS_HIP_ARCH_$(HIP_ARCH))
@@ -137,15 +140,21 @@ endif
 KOKKOS_CXXFLAGS += -DMOOSE_KOKKOS_SCOPE=1 -DMETAPHYSICL_KOKKOS_COMPILATION=1 -fPIC
 KOKKOS_LDFLAGS  += $(libmesh_LDFLAGS)
 KOKKOS_INCLUDE   = $(libmesh_INCLUDE)
-KOKKOS_LIBS      = $(libmesh_LIBS)
 
 ifeq ($(METHOD),opt)
   KOKKOS_CXXFLAGS += -DNDEBUG
 endif
 
 ifeq ($(KOKKOS_COMPILER),CPU)
+  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).la
+else ifeq ($(KOKKOS_COMPILER),NVCC)
+  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).a
+else
+  KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).so
+endif
 
-KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).la
+ifeq ($(KOKKOS_COMPILER),CPU)
+
 KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).lo
 
 %.$(KOKKOS_OBJ_SUFFIX) : %.K
@@ -155,7 +164,6 @@ KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).lo
 
 else
 
-KOKKOS_LIB_SUFFIX := _kokkos-$(METHOD).so
 KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).o
 
 %.$(KOKKOS_OBJ_SUFFIX) : %.K

--- a/framework/kokkos.mk
+++ b/framework/kokkos.mk
@@ -88,18 +88,20 @@ ifeq ($(PETSC_HAVE_SYCL),1)
 endif
 
 ifneq ($(PETSC_HAVE_CUDA),)
-  KOKKOS_DEVICE             := CUDA
-  KOKKOS_ARCH               := $(KOKKOS_CUDA_ARCH_$(CUDA_ARCH))
-  KOKKOS_COMPILER           := NVCC
-  KOKKOS_CXX                 = $(CUDA_COMPILER)
-  KOKKOS_CXXFLAGS            = -arch=sm_$(CUDA_ARCH) --extended-lambda --relocatable-device-code=true --dlink-time-opt
-  KOKKOS_CXXFLAGS           += --forward-unknown-to-host-compiler --disable-warnings -x cu -ccbin $(word 1, $(libmesh_CXX))
-  KOKKOS_CXXFLAGS           += $(filter-out -Werror=return-type,$(CXXFLAGS) $(libmesh_CXXFLAGS)) # Incompatible with NVCC
-  KOKKOS_CPPFLAGS            = $(subst -Werror,-Werror=all-warnings,$(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS})
-  KOKKOS_LDFLAGS             = --forward-unknown-to-host-compiler --relocatable-device-code=true --dlink-time-opt -arch=sm_$(CUDA_ARCH)
-  KOKKOS_LIBS                = -lpetsckokkos
-  libmesh_PETSC_KOKKOS_LIBS := $(filter %petsckokkos %petsckokkosdlink,$(libmesh_LIBS))
-  libmesh_LIBS              := $(filter-out %petsckokkos %petsckokkosdlink,$(libmesh_LIBS))
+# CUDA link-time optimization (LTO) can improve the performance of relocatable device code (RDC).
+# Some testing showed that LTO can achieve almost equivalent performance with fully inlined code
+# even when linking across translation units through RDC. But it was causing some weird device
+# stack corruptions and crashes with CUDA 12.9 for a couple of tests. When it is resolved, turn
+# on --dlink-time-opt.
+  KOKKOS_DEVICE     := CUDA
+  KOKKOS_ARCH       := $(KOKKOS_CUDA_ARCH_$(CUDA_ARCH))
+  KOKKOS_COMPILER   := NVCC
+  KOKKOS_CXX         = $(CUDA_COMPILER)
+  KOKKOS_CXXFLAGS    = -arch=sm_$(CUDA_ARCH) --extended-lambda --relocatable-device-code=true
+  KOKKOS_CXXFLAGS   += --forward-unknown-to-host-compiler --disable-warnings -x cu -ccbin $(word 1, $(libmesh_CXX))
+  KOKKOS_CXXFLAGS   += $(filter-out -Werror=return-type,$(CXXFLAGS) $(libmesh_CXXFLAGS)) # Incompatible with NVCC
+  KOKKOS_CPPFLAGS    = $(subst -Werror,-Werror=all-warnings,$(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS})
+  KOKKOS_LDFLAGS     = --forward-unknown-to-host-compiler --relocatable-device-code=true -arch=sm_$(CUDA_ARCH)
 else ifneq ($(PETSC_HAVE_HIP),)
   KOKKOS_DEVICE     := HIP
   KOKKOS_ARCH       := $(KOKKOS_HIP_ARCH_$(HIP_ARCH))
@@ -139,7 +141,6 @@ endif
 
 KOKKOS_CXXFLAGS += -DMOOSE_KOKKOS_SCOPE=1 -DMETAPHYSICL_KOKKOS_COMPILATION=1 -fPIC
 KOKKOS_LDFLAGS  += $(libmesh_LDFLAGS)
-KOKKOS_INCLUDE   = $(libmesh_INCLUDE)
 
 ifeq ($(METHOD),opt)
   KOKKOS_CXXFLAGS += -DNDEBUG
@@ -160,7 +161,7 @@ KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).lo
 %.$(KOKKOS_OBJ_SUFFIX) : %.K
 	@echo "Compiling Kokkos C++ (in "$(METHOD)" mode, $(KOKKOS_DEVICE), $(KOKKOS_ARCH)) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
-	  $(KOKKOS_CXX) $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_INCLUDE) $(app_INCLUDES) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
+	  $(KOKKOS_CXX) $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(libmesh_INCLUDE) $(app_INCLUDES) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 else
 
@@ -168,6 +169,6 @@ KOKKOS_OBJ_SUFFIX := $(libmesh_HOST).$(METHOD).o
 
 %.$(KOKKOS_OBJ_SUFFIX) : %.K
 	@echo "Compiling Kokkos C++ (in "$(METHOD)" mode, $(KOKKOS_DEVICE), $(KOKKOS_ARCH)) "$<"..."
-	@$(KOKKOS_CXX) $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_INCLUDE) $(app_INCLUDES) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
+	@$(KOKKOS_CXX) $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(libmesh_INCLUDE) $(app_INCLUDES) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 endif

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -520,7 +520,7 @@ ifeq ($(KOKKOS_COMPILER),CPU)
 $(MOOSE_KOKKOS_LIB): $(MOOSE_KOKKOS_OBJECTS)
 	@echo "Linking Kokkos Library "$@"..."
 	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-		$(KOKKOS_CXX) -o $@ $(MOOSE_KOKKOS_OBJECTS) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS) -rpath $(FRAMEWORK_DIR) ${SILENCE_SOME_WARNINGS}'
+		$(KOKKOS_CXX) -o $@ $(MOOSE_KOKKOS_OBJECTS) $(KOKKOS_LDFLAGS) $(libmesh_LIBS) -rpath $(FRAMEWORK_DIR) ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $(MOOSE_KOKKOS_LIB) $(FRAMEWORK_DIR)
 
 else ifeq ($(KOKKOS_COMPILER),NVCC)
@@ -533,7 +533,7 @@ else
 
 $(MOOSE_KOKKOS_LIB): $(MOOSE_KOKKOS_OBJECTS)
 	@echo "Linking Kokkos Library "$@"..."
-	@$(KOKKOS_CXX) --shared -o $@ $(MOOSE_KOKKOS_OBJECTS) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS)
+	@$(KOKKOS_CXX) --shared -o $@ $(MOOSE_KOKKOS_OBJECTS) $(KOKKOS_LDFLAGS) $(libmesh_LIBS)
 
 endif
 
@@ -631,17 +631,6 @@ exodiff_objects  := $(patsubst %.C, %.$(obj-suffix), $(exodiff_srcfiles))
 exodiff_includes := -I$(exodiff_DIR) $(libmesh_INCLUDE)
 # dependency files
 exodiff_deps := $(patsubst %.C, %.$(obj-suffix).d, $(exodiff_srcfiles))
-# Kokkos CUDA strips out -lpetsckokkos and -lpetsckokkosdlink from libmesh_LIBS, because
-# those static archives contain CUDA registration/device images and need to be linked
-# exactly once per program (namely, intermediate shared libraries should not link them,
-# and only the final executable should link them). Since exodiff is an independent program,
-# those flags should be added back for proper linking.
-exodiff_link_group_end := -Wl,--end-group
-exodiff_LIBS = $(if $(libmesh_PETSC_KOKKOS_LIBS), \
-  $(if $(findstring $(exodiff_link_group_end),$(libmesh_LIBS)), \
-    $(subst $(exodiff_link_group_end),$(libmesh_PETSC_KOKKOS_LIBS) $(exodiff_link_group_end),$(libmesh_LIBS)), \
-    $(libmesh_LIBS) $(libmesh_PETSC_KOKKOS_LIBS)), \
-  $(libmesh_LIBS))
 
 all: exodiff
 
@@ -653,7 +642,7 @@ $(exodiff_objects): | prebuild
 $(exodiff_APP): $(exodiff_objects)
 	@echo "Linking Executable "$@"..."
 	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-	  $(libmesh_CXX) $(libmesh_CPPFLAGS) $(libmesh_CXXFLAGS) $(libmesh_INCLUDE) $(exodiff_objects) -o $@ $(LDFLAGS) $(libmesh_LDFLAGS) $(exodiff_LIBS) $(EXTERNAL_FLAGS) ${SILENCE_SOME_WARNINGS}'
+	  $(libmesh_CXX) $(libmesh_CPPFLAGS) $(libmesh_CXXFLAGS) $(libmesh_INCLUDE) $(exodiff_objects) -o $@ $(LDFLAGS) $(libmesh_LDFLAGS) $(libmesh_LIBS) $(EXTERNAL_FLAGS) ${SILENCE_SOME_WARNINGS}'
 
 -include $(wildcard $(exodiff_DIR)/*.d)
 
@@ -822,7 +811,7 @@ ifeq ($(ENABLE_KOKKOS),true)
 # Kokkos sources
 	$(file >> .compile_commands.json,$(CURDIR))
 	$(file >> .compile_commands.json,$(KOKKOS_CXX))
-	$(file >> .compile_commands.json,$(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_INCLUDE) $(app_INCLUDES))
+	$(file >> .compile_commands.json,$(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(libmesh_INCLUDE) $(app_INCLUDES))
 	$(file >> .compile_commands.json,$(compile_commands_all_kokkos_srcfiles))
 endif
 else
@@ -835,7 +824,7 @@ ifeq ($(ENABLE_KOKKOS),true)
 # Kokkos sources
 	@echo $(CURDIR) >> .compile_commands.json
 	@echo $(KOKKOS_CXX) >> .compile_commands.json
-	@echo $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_INCLUDE) $(app_INCLUDES) >> .compile_commands.json
+	@echo $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS) $(libmesh_INCLUDE) $(app_INCLUDES) >> .compile_commands.json
 	@echo $(compile_commands_all_kokkos_srcfiles) >> .compile_commands.json
 endif
 endif

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -523,14 +523,9 @@ $(MOOSE_KOKKOS_LIB): $(MOOSE_KOKKOS_OBJECTS)
 		$(KOKKOS_CXX) -o $@ $(MOOSE_KOKKOS_OBJECTS) $(KOKKOS_LDFLAGS) $(libmesh_LIBS) -rpath $(FRAMEWORK_DIR) ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $(MOOSE_KOKKOS_LIB) $(FRAMEWORK_DIR)
 
-else ifeq ($(KOKKOS_COMPILER),NVCC)
-
-$(MOOSE_KOKKOS_LIB): $(MOOSE_KOKKOS_OBJECTS)
-	@echo "Linking Kokkos Library "$@"..."
-	@ar rcs $@ $(MOOSE_KOKKOS_OBJECTS)
-
 else
 
+# libtool ignores nvcc and just uses mpicxx to link, so cannot be used
 $(MOOSE_KOKKOS_LIB): $(MOOSE_KOKKOS_OBJECTS)
 	@echo "Linking Kokkos Library "$@"..."
 	@$(KOKKOS_CXX) --shared -o $@ $(MOOSE_KOKKOS_OBJECTS) $(KOKKOS_LDFLAGS) $(libmesh_LIBS)

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -520,15 +520,20 @@ ifeq ($(KOKKOS_COMPILER),CPU)
 $(MOOSE_KOKKOS_LIB): $(MOOSE_KOKKOS_OBJECTS)
 	@echo "Linking Kokkos Library "$@"..."
 	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-		$(KOKKOS_CXX) -o $@ $(MOOSE_KOKKOS_OBJECTS) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) -rpath $(FRAMEWORK_DIR) ${SILENCE_SOME_WARNINGS}'
+		$(KOKKOS_CXX) -o $@ $(MOOSE_KOKKOS_OBJECTS) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS) -rpath $(FRAMEWORK_DIR) ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $(MOOSE_KOKKOS_LIB) $(FRAMEWORK_DIR)
+
+else ifeq ($(KOKKOS_COMPILER),NVCC)
+
+$(MOOSE_KOKKOS_LIB): $(MOOSE_KOKKOS_OBJECTS)
+	@echo "Linking Kokkos Library "$@"..."
+	@ar rcs $@ $(MOOSE_KOKKOS_OBJECTS)
 
 else
 
-# libtool ignores nvcc and just uses mpicxx to link, so cannot be used
 $(MOOSE_KOKKOS_LIB): $(MOOSE_KOKKOS_OBJECTS)
 	@echo "Linking Kokkos Library "$@"..."
-	@$(KOKKOS_CXX) --shared -o $@ $(MOOSE_KOKKOS_OBJECTS) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS)
+	@$(KOKKOS_CXX) --shared -o $@ $(MOOSE_KOKKOS_OBJECTS) $(KOKKOS_LDFLAGS) $(KOKKOS_LIBS) $(libmesh_LIBS)
 
 endif
 
@@ -626,6 +631,17 @@ exodiff_objects  := $(patsubst %.C, %.$(obj-suffix), $(exodiff_srcfiles))
 exodiff_includes := -I$(exodiff_DIR) $(libmesh_INCLUDE)
 # dependency files
 exodiff_deps := $(patsubst %.C, %.$(obj-suffix).d, $(exodiff_srcfiles))
+# Kokkos CUDA strips out -lpetsckokkos and -lpetsckokkosdlink from libmesh_LIBS, because
+# those static archives contain CUDA registration/device images and need to be linked
+# exactly once per program (namely, intermediate shared libraries should not link them,
+# and only the final executable should link them). Since exodiff is an independent program,
+# those flags should be added back for proper linking.
+exodiff_link_group_end := -Wl,--end-group
+exodiff_LIBS = $(if $(libmesh_PETSC_KOKKOS_LIBS), \
+  $(if $(findstring $(exodiff_link_group_end),$(libmesh_LIBS)), \
+    $(subst $(exodiff_link_group_end),$(libmesh_PETSC_KOKKOS_LIBS) $(exodiff_link_group_end),$(libmesh_LIBS)), \
+    $(libmesh_LIBS) $(libmesh_PETSC_KOKKOS_LIBS)), \
+  $(libmesh_LIBS))
 
 all: exodiff
 
@@ -637,7 +653,7 @@ $(exodiff_objects): | prebuild
 $(exodiff_APP): $(exodiff_objects)
 	@echo "Linking Executable "$@"..."
 	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-	  $(libmesh_CXX) $(libmesh_CPPFLAGS) $(libmesh_CXXFLAGS) $(libmesh_INCLUDE) $(exodiff_objects) -o $@ $(LDFLAGS) $(libmesh_LDFLAGS) $(libmesh_LIBS) $(EXTERNAL_FLAGS) ${SILENCE_SOME_WARNINGS}'
+	  $(libmesh_CXX) $(libmesh_CPPFLAGS) $(libmesh_CXXFLAGS) $(libmesh_INCLUDE) $(exodiff_objects) -o $@ $(LDFLAGS) $(libmesh_LDFLAGS) $(exodiff_LIBS) $(EXTERNAL_FLAGS) ${SILENCE_SOME_WARNINGS}'
 
 -include $(wildcard $(exodiff_DIR)/*.d)
 

--- a/framework/src/kokkos/base/KokkosMooseInit.K
+++ b/framework/src/kokkos/base/KokkosMooseInit.K
@@ -35,7 +35,6 @@ MooseInit::initKokkos()
     settings.set_disable_warnings(true);
 
 #ifdef MOOSE_ENABLE_KOKKOS_GPU
-
   unsigned int num_kokkos_gpus = Kokkos::num_devices();
 
   comm().min(num_kokkos_gpus);
@@ -53,7 +52,6 @@ MooseInit::initKokkos()
     // Override the default GPU ID
     settings.set_device_id(kokkos_gpu_id);
   }
-
 #endif
 
   // Set this environment variable if not set already to silence Kokkos warning

--- a/framework/src/kokkos/problems/KokkosFEProblemBase.K
+++ b/framework/src/kokkos/problems/KokkosFEProblemBase.K
@@ -197,10 +197,6 @@ FEProblemBase::hasKokkosFunction(const std::string & name) const
 Moose::Kokkos::Function
 FEProblemBase::getKokkosFunction(const std::string & name)
 {
-#ifdef MOOSE_ENABLE_KOKKOS_GPU
-  mooseError("Retrieving a Kokkos function as abstract type is currently not supported for GPU.");
-#endif
-
   const auto & function = getKokkosFunction<Moose::FunctionBase>(name);
 
   std::shared_ptr<Moose::Kokkos::FunctionWrapperHostBase> wrapper =

--- a/framework/src/kokkos/problems/KokkosFEProblemBase.K
+++ b/framework/src/kokkos/problems/KokkosFEProblemBase.K
@@ -136,10 +136,6 @@ FEProblemBase::hasKokkosFunction(const std::string & name) const
 Moose::Kokkos::Function
 FEProblemBase::getKokkosFunction(const std::string & name)
 {
-#ifdef MOOSE_ENABLE_KOKKOS_GPU
-  mooseError("Retrieving a Kokkos function as abstract type is currently not supported for GPU.");
-#endif
-
   const auto & function = getKokkosFunction<Moose::FunctionBase>(name);
 
   std::shared_ptr<Moose::Kokkos::FunctionWrapperHostBase> wrapper =

--- a/test/tests/kokkos/functions/constant_function/tests
+++ b/test/tests/kokkos/functions/constant_function/tests
@@ -6,7 +6,7 @@
     input = 'kokkos_constant_function.i'
     exodiff = 'kokkos_constant_function_out.e'
     requirement = 'The Kokkos function system shall include a constant function and the ability to retrieve it as an abstract type.'
-    capabilities = 'kokkos & !cuda'
-    compute_devices = 'cpu'
+    capabilities = 'kokkos'
+    compute_devices = 'cpu cuda'
   []
 []

--- a/test/tests/kokkos/functions/default_function/tests
+++ b/test/tests/kokkos/functions/default_function/tests
@@ -6,7 +6,7 @@
     input = 'kokkos_default_function.i'
     exodiff = 'kokkos_default_function_out.e'
     requirement = 'The Kokkos function system shall include the ability to set default values for input parameters expecting a function name.'
-    capabilities = 'kokkos & !cuda'
-    compute_devices = 'cpu'
+    capabilities = 'kokkos'
+    compute_devices = 'cpu cuda'
   []
 []

--- a/test/tests/kokkos/functions/piecewise_constant/tests
+++ b/test/tests/kokkos/functions/piecewise_constant/tests
@@ -7,8 +7,8 @@
       type = 'Exodiff'
       input = 'kokkos_piecewise_constant.i'
       exodiff = 'kokkos_piecewise_constant_out.e'
-      capabilities = 'kokkos & !cuda'
-      compute_devices = 'cpu'
+      capabilities = 'kokkos'
+      compute_devices = 'cpu cuda'
       detail = 'provided separately as two vectors in the input,'
     []
     [xy_data]
@@ -16,8 +16,8 @@
       input = 'kokkos_piecewise_constant.i'
       cli_args = 'Kernels/diff/coef=func_xy_data AuxKernels/coef_aux/function=func_xy_data'
       exodiff = 'kokkos_piecewise_constant_out.e'
-      capabilities = 'kokkos & !cuda'
-      compute_devices = 'cpu'
+      capabilities = 'kokkos'
+      compute_devices = 'cpu cuda'
       detail = 'provided as a table in the input,'
     []
     [csv]
@@ -25,8 +25,8 @@
       input = 'kokkos_piecewise_constant.i'
       cli_args = 'Kernels/diff/coef=func_csv AuxKernels/coef_aux/function=func_csv'
       exodiff = 'kokkos_piecewise_constant_out.e'
-      capabilities = 'kokkos & !cuda'
-      compute_devices = 'cpu'
+      capabilities = 'kokkos'
+      compute_devices = 'cpu cuda'
       detail = 'provided as a CSV file,'
     []
     [json]
@@ -34,8 +34,8 @@
       input = 'kokkos_piecewise_constant.i'
       cli_args = 'Kernels/diff/coef=func_json AuxKernels/coef_aux/function=func_json'
       exodiff = 'kokkos_piecewise_constant_out.e'
-      capabilities = 'kokkos & !cuda'
-      compute_devices = 'cpu'
+      capabilities = 'kokkos'
+      compute_devices = 'cpu cuda'
       detail = 'provided as a JSON file.'
     []
   []

--- a/test/tests/kokkos/materials/parsed/tests
+++ b/test/tests/kokkos/materials/parsed/tests
@@ -8,6 +8,6 @@
     exodiff = 'kokkos_parsed_material_out.e'
     requirement = 'The Kokkos system shall support parsed material property calculations.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu'
+    compute_devices = 'cpu cuda'
   []
 []


### PR DESCRIPTION
I have a working local PETSc and libMesh branch that can build with Kokkos CUDA RDC enabled, but the build system is pretty complicated and expected to get a lot of resistance. Also see:

https://github.com/libMesh/libmesh/pull/4488
https://gitlab.com/petsc/petsc/-/merge_requests/9376

Alternatively, the following Kokkos patches can make things a lot easier:

https://github.com/kokkos/kokkos/pull/9346
https://github.com/kokkos/kokkos/pull/9352