### PR TITLE
Add optional `!include?` tag to MooseDocs configuration

### DIFF
--- a/python/MooseDocs/common/load_config.py
+++ b/python/MooseDocs/common/load_config.py
@@ -14,7 +14,7 @@ import importlib
 import logging
 import collections
 from mooseutils import recursive_update
-from mooseutils.yaml_load import yaml_load
+from mooseutils.yaml_load import yaml_load, prune_missing_includes
 
 import MooseDocs
 from ..tree import pages
@@ -73,6 +73,10 @@ def load_config(filename, **kwargs):
     Read the config.yml file and create the Translator object.
     """
     config = yaml_load(filename, root=MooseDocs.ROOT_DIR)
+
+    # Drop any configuration that referenced an optional include ('!include?') whose file was
+    # missing (e.g. an optional dependency submodule that is not checked out).
+    prune_missing_includes(config)
 
     # Replace 'default' and 'disable' key in Extensions to allow for recursive_update to accept command line
     for key in config.get("Extensions", dict()).keys():

--- a/python/doc/content/python/MooseDocs/config.md
+++ b/python/doc/content/python/MooseDocs/config.md
@@ -80,11 +80,11 @@ doc/content/index.md -> ${HOME}/.local/share/moose/site/index.html
 ${MOOSE_DIR}/framework/doc/content/utilities/index.md -> ${HOME}/.local/share/moose/site/utilties/index.md
 ```
 
-In the advanced mode the root location can be specified for each location, in this case the
+In the advanced mode, the root location can be specified for each content entry. In this case, the
 content configuration section contains a dictionary of dictionaries as shown below. The top-level key
 is an arbitrary name, the second level has three keys available: "root_dir", "content", and
-"external". The root_dir is the directory to include and "content" is a list of folders and/or files
-within the root_dir to consider. The "external" key is described in
+"external". The "root_dir" is the directory to include and "content" is a list of folders and/or files
+within the "root_dir" to consider. The "external" key is described in
 [#optional-dependencies].
 
 

--- a/python/doc/content/python/MooseDocs/config.md
+++ b/python/doc/content/python/MooseDocs/config.md
@@ -66,7 +66,7 @@ If you find yourself creating autolinks across pages from different configuratio
 concerned about them failing when only building one of those configurations, consider using the
 `alternative` setting (see the [MooseDocs/extensions/autolink.md] page for more information).
 
-### Advanced Content
+### Advanced Content id=advanced-content
 
 There is also a more advanced interface for the content, but it is required to explain how these
 directories are used. When building content all relevant files (e.g., markdown) are extracted from
@@ -82,9 +82,10 @@ ${MOOSE_DIR}/framework/doc/content/utilities/index.md -> ${HOME}/.local/share/mo
 
 In the advanced mode the root location can be specified for each location, in this case the
 content configuration section contains a dictionary of dictionaries as shown below. The top-level key
-is an arbitrary name, the second level has two keys available: "root_dir" and "content". The
-root_dir is the directory to include and "content" is a list of folders and/or files within the
-root_dir to consider.
+is an arbitrary name, the second level has three keys available: "root_dir", "content", and
+"external". The root_dir is the directory to include and "content" is a list of folders and/or files
+within the root_dir to consider. The "external" key is described in
+[#optional-dependencies].
 
 
 ```yaml
@@ -105,7 +106,52 @@ doc/content/index.md -> ${HOME}/.local/share/moose/site/index.html
 ${MOOSE_DIR}/framework/doc/content/utilities/MooseDocs/setup.md -> ${HOME}/.local/share/moose/site/MooseDocs/setup.md
 ```
 
-## Extensions
+## Optional Dependencies id=optional-dependencies
+
+An application may pull documentation from dependencies that are not always present, such as
+submodules that are only checked out for some builds. By default a missing content directory or a
+missing `!include` file is an error, which prevents the documentation from building at all. The two
+mechanisms below allow such content to be skipped gracefully (with a warning) when the dependency is
+absent.
+
+### Optional Content
+
+Adding `external: true` to a [#advanced-content] entry marks that content source as optional. When
+the entry's `root_dir` does not exist, the content is skipped with a warning rather than causing an
+error, and any pages that are found are tagged as "external" (which, for example, allows the
+[appsyntax.md] extension to render a notice for syntax that belongs to an unavailable application).
+
+```yaml
+Content:
+    app:
+        root_dir: doc/content
+    optional_dep:
+        root_dir: ${OPTIONAL_DEP_DIR}/doc/content
+        external: true
+```
+
+### Optional Includes
+
+The `!include` YAML tag embeds the contents of another YAML file, and is used throughout the
+configuration (for example in the [#extensions] section). Its optional counterpart, `!include?`,
+behaves identically when the referenced file exists, but resolves to nothing---dropping the
+key (or list item) that used it---when the file is missing, instead of raising an error.
+
+```yaml
+Extensions:
+    MooseDocs.extensions.acronym:
+        acronyms:
+            framework: !include ${MOOSE_DIR}/framework/doc/acronyms.yml
+            optional_dep: !include? ${OPTIONAL_DEP_DIR}/doc/acronyms.yml
+```
+
+!alert note title=Use both for a fully optional dependency
+A single optional dependency is usually referenced from more than one place: its content directory
+*and* one or more `!include` files (e.g. acronyms or SQA categories). Use `external: true` for the
+content entry and `!include?` for each include so that the documentation builds whether or not the
+dependency is present.
+
+## Extensions id=extensions
 
 The Extensions section is used to enable non-default or custom extensions as well as change the
 configuration for existing extensions. The list of default extensions is shown in

--- a/python/mooseutils/tests/foo_optional.yml
+++ b/python/mooseutils/tests/foo_optional.yml
@@ -1,0 +1,6 @@
+a: 1
+b: !include? bar.yml
+c: !include? unknown.yml
+d: # list with a missing optional include and a kept item
+    - !include? unknown.yml
+    - keep

--- a/python/mooseutils/tests/test_yaml_load.py
+++ b/python/mooseutils/tests/test_yaml_load.py
@@ -10,7 +10,13 @@
 import os
 import unittest
 import tempfile
-from mooseutils.yaml_load import yaml_load, yaml_write, IncludeYamlFile
+from mooseutils.yaml_load import (
+    yaml_load,
+    yaml_write,
+    IncludeYamlFile,
+    is_missing_include,
+    prune_missing_includes,
+)
 
 
 class TestYamlLoad(unittest.TestCase):
@@ -52,6 +58,33 @@ class TestYamlLoad(unittest.TestCase):
         self.assertEqual(data["e"], ["Edward", "Bonnie"])
         self.assertEqual(data["f"], [1906])
 
+    def testIncludeOptional(self):
+        data = yaml_load("foo_optional.yml")
+
+        # A present optional include resolves like a normal '!include'
+        self.assertEqual(data["b"][0], 3.6)
+        self.assertEqual(data["b"][1], [1, 2, 3])
+
+        # A missing optional include resolves to the sentinel instead of raising
+        self.assertTrue(is_missing_include(data["c"]))
+        self.assertTrue(is_missing_include(data["d"][0]))
+
+        # Surrounding data is untouched
+        self.assertEqual(data["a"], 1)
+        self.assertEqual(data["d"][1], "keep")
+
+    def testPruneMissingIncludes(self):
+        data = yaml_load("foo_optional.yml")
+        self.assertEqual(prune_missing_includes(data), data)  # returns the pruned node
+
+        # The missing optional includes are removed (mapping key and list item)
+        self.assertNotIn("c", data)
+        self.assertEqual(data["d"], ["keep"])
+
+        # The present include and surrounding data remain
+        self.assertEqual(data["a"], 1)
+        self.assertEqual(data["b"][0], 3.6)
+
 
 class TestYamlWrite(unittest.TestCase):
     def setUp(self):
@@ -91,6 +124,30 @@ class TestYamlWrite(unittest.TestCase):
         with open(self._tmp, "r") as fid:
             out_data = fid.read()
         self.assertEqual(in_data, out_data)
+
+    def testWriteOptional(self):
+
+        # Load without processing includes; a missing optional include becomes the sentinel while a
+        # present one is retained as an IncludeYamlFile flagged optional.
+        data = yaml_load("foo_optional.yml", include=False)
+        self.assertIsInstance(data["b"], IncludeYamlFile)
+        self.assertTrue(data["b"].optional)
+        self.assertTrue(is_missing_include(data["c"]))
+
+        # Prune the missing optional includes, then the remainder round-trips
+        prune_missing_includes(data)
+        yaml_write(self._tmp, data)
+
+        # The present optional include is written back using the '!include?' tag (unquoted)
+        with open(self._tmp, "r") as fid:
+            out_data = fid.read()
+        self.assertIn("!include? bar.yml", out_data)
+
+        # Reloading resolves the present include and the missing ones stay gone
+        data = yaml_load(self._tmp)
+        self.assertEqual(data["b"][0], 3.6)
+        self.assertNotIn("c", data)
+        self.assertEqual(data["d"], ["keep"])
 
 
 if __name__ == "__main__":

--- a/python/mooseutils/yaml_load.py
+++ b/python/mooseutils/yaml_load.py
@@ -132,7 +132,12 @@ class Loader(yaml.Loader):
         items = self.construct_scalar(node).split()
         try:
             obj = IncludeYamlFile(
-                items, self._root, self._filename, node.line, self._include, optional=True
+                items,
+                self._root,
+                self._filename,
+                node.line,
+                self._include,
+                optional=True,
             )
         except IOError:
             LOG.warning(

--- a/python/mooseutils/yaml_load.py
+++ b/python/mooseutils/yaml_load.py
@@ -11,10 +11,53 @@
 
 import os
 import collections
+import logging
 import yaml
 import re
 
 from .eval_path import eval_path
+
+LOG = logging.getLogger(__name__)
+
+
+class _MissingInclude(object):
+    """
+    Sentinel returned by the optional include tag '!include?' when the target file does not exist.
+
+    Consumers (e.g. MooseDocs.common.load_config) prune mapping keys and list items whose value is
+    this sentinel so that optional dependencies (missing submodules) silently drop out of the
+    configuration rather than raising an error.
+    """
+
+
+# Single shared instance used for identity comparisons (value is MISSING_INCLUDE)
+MISSING_INCLUDE = _MissingInclude()
+
+
+def is_missing_include(value):
+    """Return True if the supplied value is the missing optional include sentinel."""
+    return value is MISSING_INCLUDE
+
+
+def prune_missing_includes(node):
+    """
+    Recursively remove any mapping keys or list items whose value is the MISSING_INCLUDE sentinel.
+
+    Returns the pruned node. Operates in-place for dict/list containers.
+    """
+    if isinstance(node, dict):
+        # identify sentinel-valued keys, then delete them
+        for key in [k for k, v in node.items() if is_missing_include(v)]:
+            del node[key]
+        for value in node.values():
+            prune_missing_includes(value)
+    elif isinstance(node, list):
+        # identify sentinel entries, then remove them
+        for value in [v for v in node if is_missing_include(v)]:
+            node.remove(value)
+        for value in node:
+            prune_missing_includes(value)
+    return node
 
 
 class IncludeYamlFile(object):
@@ -22,7 +65,9 @@ class IncludeYamlFile(object):
     Object for handling including and reproducing output without include.
     """
 
-    def __init__(self, items, root, parent, line="?", include=True):
+    def __init__(self, items, root, parent, line="?", include=True, optional=False):
+
+        self.optional = optional
 
         filename = eval_path(items[0])
         if not os.path.isabs(filename) and isinstance(root, str):
@@ -46,7 +91,8 @@ class IncludeYamlFile(object):
         """NOTE: I tried to get this to output without adding quotes to the items, but I can't figure
         out how to get that working. So, I just process the output in yaml_write.
         """
-        return dumper.represent_scalar("!include", " ".join(data.items))
+        tag = "!include?" if data.optional else "!include"
+        return dumper.represent_scalar(tag, " ".join(data.items))
 
 
 class Loader(yaml.Loader):
@@ -62,6 +108,7 @@ class Loader(yaml.Loader):
         self._include = include
         self._root = root or os.path.dirname(self._filename)
         self.add_constructor("!include", Loader.include)
+        self.add_constructor("!include?", Loader.include_optional)
         super(Loader, self).__init__(stream)
 
     def include(self, node):
@@ -72,6 +119,29 @@ class Loader(yaml.Loader):
         obj = IncludeYamlFile(
             items, self._root, self._filename, node.line, self._include
         )
+        return obj.content if self._include else obj
+
+    def include_optional(self, node):
+        """
+        Allow for the embedding of yaml files that may not exist.
+
+        If the referenced file is missing (e.g. an optional submodule that has not been checked
+        out), the MISSING_INCLUDE sentinel is returned instead of raising. Callers are expected to
+        prune sentinel values from the resulting data (see prune_missing_includes).
+        """
+        items = self.construct_scalar(node).split()
+        try:
+            obj = IncludeYamlFile(
+                items, self._root, self._filename, node.line, self._include, optional=True
+            )
+        except IOError:
+            LOG.warning(
+                "Optional include '%s' on line %s of %s was not found and is being skipped.",
+                " ".join(items),
+                node.line,
+                self._filename,
+            )
+            return MISSING_INCLUDE
         return obj.content if self._include else obj
 
     def compose_node(self, parent, index):
@@ -142,7 +212,7 @@ def yaml_write(filename, content, indent=4):
         content, None, lambda *args, **kwargs: make_dumper(*args, **kwargs)
     )
     document = re.sub(
-        r"(?P<tag>!include\s+)'(?P<string>.*?)'", r"\g<tag>\g<string>", document
+        r"(?P<tag>!include\??\s+)'(?P<string>.*?)'", r"\g<tag>\g<string>", document
     )
 
     with open(filename, "w") as fid:


### PR DESCRIPTION
Closes #33135 

Adds optional include tag to MooseDocs config ingestion, to complement `external` parameter in MooseDocs content. This way, optional `.yml` files can be freely included in the config. When the included file is not present, MooseDocs removes the entry from the tree entirely, such that there are no broken parts of the tree (or broken links in navigation, etc.). A warning is thrown to let the documentation-builder know that it is being skipped.