### PR TITLE
Diagnose side user object use of interface material properties

### DIFF
--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -2681,6 +2681,15 @@ public:
   bool fvBCsIntegrityCheck() const { return _fv_bcs_integrity_check; }
 
   /**
+   * @return whether to perform an integrity check for side user objects consuming interface
+   * material properties
+   */
+  bool sideUOInterfaceMatPropIntegrityCheck() const
+  {
+    return _side_uo_interface_mat_prop_integrity_check;
+  }
+
+  /**
    * @param fv_bcs_integrity_check Whether to perform a boundary condition integrity check for
    * finite volume
    */
@@ -3335,6 +3344,9 @@ protected:
   /// whether to perform checking of boundary restricted elemental object variable dependencies,
   /// e.g. whether the variable dependencies are defined on the selected boundaries
   const bool _boundary_restricted_elem_integrity_check;
+
+  /// Whether to check that side user objects do not consume interface material properties
+  const bool _side_uo_interface_mat_prop_integrity_check;
 
   /// Determines whether and which subdomains are to be checked to ensure that they have an active material
   CoverageCheckMode _material_coverage_check;

--- a/framework/include/userobjects/SideUserObject.h
+++ b/framework/include/userobjects/SideUserObject.h
@@ -34,6 +34,8 @@ public:
 
   SideUserObject(const InputParameters & parameters);
 
+  virtual void initialSetup() override;
+
 protected:
   MooseMesh & _mesh;
 
@@ -63,4 +65,7 @@ protected:
    * sideset. Sidesets are oriented!
    */
   void getFaceInfos();
+
+private:
+  void checkNoInterfaceMaterialPropertyDependencies() const;
 };

--- a/framework/src/postprocessors/SideIntegralMaterialProperty.C
+++ b/framework/src/postprocessors/SideIntegralMaterialProperty.C
@@ -35,6 +35,8 @@ template <bool is_ad>
 void
 SideIntegralMaterialPropertyTempl<is_ad>::initialSetup()
 {
+  SideIntegralPostprocessor::initialSetup();
+
   // check if the material property type and number of supplied components match
   _prop.check();
 }

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -245,6 +245,11 @@ FEProblemBase::validParams()
                         "Set to false to disable checking of boundary restricted elemental object "
                         "variable dependencies, e.g. are the variable dependencies defined on the "
                         "selected boundaries?");
+  params.addParam<bool>(
+      "side_uo_interface_mat_prop_integrity_check",
+      true,
+      "Set to false to disable checking that side user objects do not consume material "
+      "properties declared by interface materials on the same boundary.");
   MooseEnum material_coverage_check_modes("FALSE TRUE OFF ON SKIP_LIST ONLY_LIST", "TRUE");
   params.addParam<MooseEnum>(
       "material_coverage_check",
@@ -373,7 +378,8 @@ FEProblemBase::validParams()
   params.addParamNamesToGroup(
       "skip_nl_system_check kernel_coverage_check kernel_coverage_block_list "
       "boundary_restricted_node_integrity_check "
-      "boundary_restricted_elem_integrity_check material_coverage_check "
+      "boundary_restricted_elem_integrity_check "
+      "side_uo_interface_mat_prop_integrity_check material_coverage_check "
       "material_coverage_block_list fv_bcs_integrity_check "
       "material_dependency_check check_uo_aux_state error_on_jacobian_nonzero_reallocation",
       "Simulation checks");
@@ -489,6 +495,8 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
         getParam<bool>("boundary_restricted_node_integrity_check")),
     _boundary_restricted_elem_integrity_check(
         getParam<bool>("boundary_restricted_elem_integrity_check")),
+    _side_uo_interface_mat_prop_integrity_check(
+        getParam<bool>("side_uo_interface_mat_prop_integrity_check")),
     _material_coverage_check(
         getParam<MooseEnum>("material_coverage_check").getEnum<CoverageCheckMode>()),
     _material_coverage_blocks(getParam<std::vector<SubdomainName>>("material_coverage_block_list")),

--- a/framework/src/userobjects/SideUserObject.C
+++ b/framework/src/userobjects/SideUserObject.C
@@ -11,6 +11,9 @@
 #include "SubProblem.h"
 #include "MooseTypes.h"
 #include "Assembly.h"
+#include "FEProblemBase.h"
+#include "MaterialBase.h"
+#include "MaterialWarehouse.h"
 
 InputParameters
 SideUserObject::validParams()
@@ -43,6 +46,43 @@ SideUserObject::SideUserObject(const InputParameters & parameters)
     _current_side_volume(_assembly.sideElemVolume()),
     _current_boundary_id(_assembly.currentBoundaryID())
 {
+}
+
+void
+SideUserObject::initialSetup()
+{
+  UserObject::initialSetup();
+  checkNoInterfaceMaterialPropertyDependencies();
+}
+
+void
+SideUserObject::checkNoInterfaceMaterialPropertyDependencies() const
+{
+  const auto & consumed_props = getMatPropDependencies();
+  if (consumed_props.empty())
+    return;
+
+  const auto & interface_materials = _fe_problem.getInterfaceMaterialsWarehouse();
+  const auto & registry = _fe_problem.getMaterialPropertyRegistry();
+
+  for (const auto bnd_id : boundaryIDs())
+  {
+    if (!interface_materials.hasActiveBoundaryObjects(bnd_id, _tid))
+      continue;
+
+    for (const auto & material : interface_materials.getActiveBoundaryObjects(bnd_id, _tid))
+      for (const auto supplied_prop : material->getSuppliedPropIDs())
+        if (consumed_props.count(supplied_prop))
+          paramError("boundary",
+                     "Side user object '",
+                     name(),
+                     "' consumes material property '",
+                     registry.getName(supplied_prop),
+                     "', which is declared by interface material '",
+                     material->name(),
+                     "'. Side user objects do not execute in an interface material context; use an "
+                     "InterfaceUserObject or InterfacePostprocessor for interface quantities.");
+  }
 }
 
 void

--- a/framework/src/userobjects/SideUserObject.C
+++ b/framework/src/userobjects/SideUserObject.C
@@ -11,6 +11,9 @@
 #include "SubProblem.h"
 #include "MooseTypes.h"
 #include "Assembly.h"
+#include "FEProblemBase.h"
+#include "MaterialBase.h"
+#include "MaterialWarehouse.h"
 
 InputParameters
 SideUserObject::validParams()
@@ -43,6 +46,47 @@ SideUserObject::SideUserObject(const InputParameters & parameters)
     _current_side_volume(_assembly.sideElemVolume()),
     _current_boundary_id(_assembly.currentBoundaryID())
 {
+}
+
+void
+SideUserObject::initialSetup()
+{
+  UserObject::initialSetup();
+
+  if (_fe_problem.sideUOInterfaceMatPropIntegrityCheck())
+    checkNoInterfaceMaterialPropertyDependencies();
+}
+
+void
+SideUserObject::checkNoInterfaceMaterialPropertyDependencies() const
+{
+  const auto & consumed_props = getMatPropDependencies();
+  if (consumed_props.empty())
+    return;
+
+  const auto & interface_materials = _fe_problem.getInterfaceMaterialsWarehouse();
+  const auto & registry = _fe_problem.getMaterialPropertyRegistry();
+
+  for (const auto bnd_id : boundaryIDs())
+  {
+    if (!interface_materials.hasActiveBoundaryObjects(bnd_id, _tid))
+      continue;
+
+    for (const auto & material : interface_materials.getActiveBoundaryObjects(bnd_id, _tid))
+      for (const auto supplied_prop : material->getSuppliedPropIDs())
+        if (consumed_props.count(supplied_prop))
+          paramError("boundary",
+                     "Side user object '",
+                     name(),
+                     "' consumes material property '",
+                     registry.getName(supplied_prop),
+                     "', which is declared by interface material '",
+                     material->name(),
+                     "'. Side user objects do not execute in an interface material context; use a "
+                     "class derived from InterfaceUserObject or InterfacePostprocessor for "
+                     "interface quantities. Please refer to "
+                     "https://github.com/idaholab/moose/pull/33168 for further context.");
+  }
 }
 
 void

--- a/test/tests/postprocessors/interface_material_side_integral/interface_material_side_integral.i
+++ b/test/tests/postprocessors/interface_material_side_integral/interface_material_side_integral.i
@@ -1,0 +1,103 @@
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 2
+    xmax = 2
+    ny = 2
+    ymax = 2
+  []
+  [subdomain1]
+    type = SubdomainBoundingBoxGenerator
+    bottom_left = '0 0 0'
+    top_right = '1 1 0'
+    block_id = 1
+    input = gen
+  []
+  [interface]
+    type = SideSetsBetweenSubdomainsGenerator
+    input = subdomain1
+    primary_block = '0'
+    paired_block = '1'
+    new_boundary = 'primary0_interface'
+  []
+  [break_boundary]
+    input = interface
+    type = BreakBoundaryOnSubdomainGenerator
+  []
+[]
+
+[Variables]
+  [u]
+    order = FIRST
+    family = LAGRANGE
+    block = 0
+  []
+  [v]
+    order = FIRST
+    family = LAGRANGE
+    block = 1
+  []
+[]
+
+[Kernels]
+  [diff_u]
+    type = CoeffParamDiffusion
+    variable = u
+    D = 4
+    block = 0
+  []
+  [diff_v]
+    type = CoeffParamDiffusion
+    variable = v
+    D = 2
+    block = 1
+  []
+  [source_u]
+    type = BodyForce
+    variable = u
+    value = 1
+  []
+[]
+
+[Materials]
+  [jump]
+    type = JumpInterfaceMaterial
+    var = u
+    neighbor_var = v
+    boundary = primary0_interface
+  []
+[]
+
+[BCs]
+  [u]
+    type = VacuumBC
+    variable = u
+    boundary = 'left_to_0 bottom_to_0 right top'
+  []
+  [v]
+    type = VacuumBC
+    variable = v
+    boundary = 'left_to_1 bottom_to_1'
+  []
+[]
+
+[Postprocessors]
+  [bad_side_integral]
+    type = SideIntegralMaterialProperty
+    boundary = primary0_interface
+    property = jump
+  []
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+[]

--- a/test/tests/postprocessors/interface_material_side_integral/tests
+++ b/test/tests/postprocessors/interface_material_side_integral/tests
@@ -1,0 +1,10 @@
+[Tests]
+  [side_user_object_interface_material_property]
+    design = 'source/postprocessors/SideIntegralMaterialProperty.md'
+    type = RunException
+    input = interface_material_side_integral.i
+    expect_err = "Side user object 'bad_side_integral' consumes material property 'jump', which is declared by interface material 'jump'"
+    requirement = 'The system shall report an error when a side user object consumes a material property declared by an interface material.'
+    issues = '#30156'
+  []
+[]

--- a/test/tests/postprocessors/interface_material_side_integral/tests
+++ b/test/tests/postprocessors/interface_material_side_integral/tests
@@ -1,0 +1,19 @@
+[Tests]
+  [side_user_object_interface_material_property]
+    design = 'source/postprocessors/SideIntegralMaterialProperty.md'
+    type = RunException
+    input = interface_material_side_integral.i
+    expect_err = "Side user object 'bad_side_integral' consumes material property 'jump', which is declared by interface material 'jump'"
+    requirement = 'The system shall report an error when a side user object consumes a material property declared by an interface material.'
+    issues = '#30156'
+  []
+
+  [disabled_side_user_object_interface_material_property_check]
+    design = 'source/postprocessors/SideIntegralMaterialProperty.md'
+    type = RunApp
+    input = interface_material_side_integral.i
+    cli_args = 'Problem/side_uo_interface_mat_prop_integrity_check=false'
+    requirement = 'The system shall allow users to disable the side user object interface material property integrity check.'
+    issues = '#30156'
+  []
+[]


### PR DESCRIPTION
This PR adds a setup-time diagnostic for side user objects consuming material properties declared by interface materials.

Side user objects do not execute in an interface material context, so consuming properties supplied by InterfaceMaterials can use stale or invalid data. The diagnostic compares each side user object's consumed material-property IDs against the property IDs supplied by active interface materials on the same boundary and errors before execution if there is an overlap.

The regression test uses `JumpInterfaceMaterial` to declare `jump` and verifies that `SideIntegralMaterialProperty` errors when attempting to consume it.

Refs #30156