### PR TITLE
Increase slots for memory heavy test

### DIFF
--- a/test/tests/linearfvkernels/diffusion/tests
+++ b/test/tests/linearfvkernels/diffusion/tests
@@ -7,6 +7,7 @@
     test_case = TestDiffusion1D
     requirement = 'The system shall display second-order convergence for diffusion problems with a central differencing scheme solved using a linear finite volume system on a one-dimensional domain.'
     max_threads = 1 # see libmesh issue #3808
+    min_slots = 2 # memory heavy
   []
   [mms-diffusion-1d-cd_neumann]
     type = MMSTest


### PR DESCRIPTION
## Reason
This test goes over memory quite often and it's not a good idea to increase the total memory requirement for this one test.

## Design
Require test to take two slots.

## Impact
Will reduce test parllelism but will help enforce a lower memory limit.
