### PR TITLE
Check DebugResidualAux block restriction

### DIFF
--- a/framework/src/auxkernels/DebugResidualAux.C
+++ b/framework/src/auxkernels/DebugResidualAux.C
@@ -19,9 +19,9 @@ DebugResidualAux::validParams()
 {
   InputParameters params = AuxKernel::validParams();
   params.addClassDescription(
-      "Populate an auxiliary variable with the residual contribution of a variable.");
-  params.addRequiredParam<NonlinearVariableName>("debug_variable",
-                                                 "The variable that is being debugged.");
+      "Populate an auxiliary variable with the residual contribution of a variable's equation.");
+  params.addRequiredParam<NonlinearVariableName>(
+      "debug_variable", "The variable whose equation residual is being output.");
   return params;
 }
 
@@ -30,6 +30,25 @@ DebugResidualAux::DebugResidualAux(const InputParameters & parameters)
     _debug_var(_nl_sys.getVariable(_tid, getParam<NonlinearVariableName>("debug_variable"))),
     _residual_copy(_nl_sys.residualGhosted())
 {
+  // Note we don't use Coupleable API checks to avoid computing the variable values
+  for (const auto block_id : blockIDs())
+    if (!_debug_var.hasBlocks(block_id))
+    {
+      const auto block_name = _mesh.getSubdomainName(block_id);
+      const auto block_description =
+          block_name.empty() ? Moose::stringify(block_id)
+                             : "'" + block_name + "' (" + Moose::stringify(block_id) + ")";
+
+      paramError("debug_variable",
+                 "The variable '",
+                 _debug_var.name(),
+                 "', whose equation we want to output the residual of, is not defined on block ",
+                 block_description,
+                 ", where DebugResidualAux '",
+                 name(),
+                 "' is active.");
+    }
+
   // Check that variable order/family match aux_variable order/family
   auto var_order = Utility::string_to_enum<Order>(_var.getParam<MooseEnum>("order"));
   auto debug_order = Utility::string_to_enum<Order>(_debug_var.getParam<MooseEnum>("order"));

--- a/test/tests/auxkernels/debug_residual_aux/block_restriction_mismatch.i
+++ b/test/tests/auxkernels/debug_residual_aux/block_restriction_mismatch.i
@@ -1,0 +1,52 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 2
+    ny = 1
+  []
+  [right_block]
+    type = SubdomainBoundingBoxGenerator
+    input = gmg
+    bottom_left = '0.5 0 0'
+    top_right = '1 1 0'
+    block_id = 1
+  []
+[]
+
+[Variables]
+  [u]
+    order = FIRST
+    family = LAGRANGE
+    block = 0
+  []
+[]
+
+[AuxVariables]
+  [u_residual]
+    order = FIRST
+    family = LAGRANGE
+    block = 1
+  []
+[]
+
+[Kernels]
+  [diff_u]
+    type = Diffusion
+    variable = u
+    block = 0
+  []
+[]
+
+[AuxKernels]
+  [debug_aux]
+    type = DebugResidualAux
+    debug_variable = u
+    variable = u_residual
+    block = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/auxkernels/debug_residual_aux/tests
+++ b/test/tests/auxkernels/debug_residual_aux/tests
@@ -1,10 +1,16 @@
 [Tests]
   design = 'source/auxkernels/DebugResidualAux.md'
-  issues = '#27633'
+  issues = '#27633 #32047'
   [errors]
     type = RunException
     input = mismatch_residual_test.i
     expect_err = "A mismatch was found between family and order parameters for u_residual and u"
     requirement = "The system shall have the ability to create an auxiliary variable that keeps track of the residual for a nonlinear system variable's equation and check that family and order parameters must be the same for the residual output variable and the equation variable."
+  []
+  [block_restriction_mismatch]
+    type = RunException
+    input = block_restriction_mismatch.i
+    expect_err = "The variable 'u', whose equation we want to output the residual of, is not defined on block"
+    requirement = "The system shall report an error when a residual debugging auxiliary kernel is active on a block where the variable whose equation residual is being output is not defined."
   []
 []


### PR DESCRIPTION
Adds a setup-time check in DebugResidualAux to verify that the debugged nonlinear variable is defined on every block where the AuxKernel is active. This prevents later invalid DOF access and reports a parameter-specific error instead.

A regression test covers the case where DebugResidualAux is active on a block where debug_variable is not defined.

Refs #32047