### PR TITLE
Renamed hasBoundaryName to hasBoundaryNameOrID

### DIFF
--- a/framework/include/utils/MooseMeshUtils.h
+++ b/framework/include/utils/MooseMeshUtils.h
@@ -323,11 +323,24 @@ bool hasSubdomainName(const MeshBase & input_mesh, const SubdomainName & name);
 bool hasBoundaryID(const MeshBase & input_mesh, const BoundaryID id);
 
 /**
- * Whether a particular boundary name exists in the mesh
- * @param input mesh over which to determine boundary names
- * @param boundary name
+ * Whether a particular boundary name exists in the mesh.
+ *
+ * This returns true if \c name is non-empty and is a name (not ID) that exists.
+ *
+ * @param mesh mesh over which to determine boundary names
+ * @param name boundary name
  */
-bool hasBoundaryName(const MeshBase & input_mesh, const BoundaryName & name);
+bool hasBoundaryName(const MeshBase & mesh, const BoundaryName & name);
+
+/**
+ * Whether a particular boundary name or ID exists in the mesh.
+ *
+ * This returns true if \c name_or_id is non-empty and either a name or ID that exists.
+ *
+ * @param mesh mesh over which to determine boundary names
+ * @param name_or_id boundary name or ID
+ */
+bool hasBoundaryNameOrID(const MeshBase & mesh, const BoundaryName & name_or_id);
 
 /**
  * Convert a list of sides in the form of a vector of pairs of node ids into a list of ordered nodes

--- a/framework/src/meshgenerators/BreakBoundaryOnSubdomainGenerator.C
+++ b/framework/src/meshgenerators/BreakBoundaryOnSubdomainGenerator.C
@@ -53,7 +53,7 @@ BreakBoundaryOnSubdomainGenerator::generate()
     for (auto & boundary_name : boundary_names)
     {
       // check that the boundary exists in the mesh
-      if (!MooseMeshUtils::hasBoundaryName(*mesh, boundary_name))
+      if (!MooseMeshUtils::hasBoundaryNameOrID(*mesh, boundary_name))
         paramError("boundaries", "The boundary '", boundary_name, "' was not found in the mesh");
 
       breaking_boundary_ids.insert(boundary_info.get_id_by_name(boundary_name));

--- a/framework/src/meshgenerators/CircularBoundaryCorrectionGenerator.C
+++ b/framework/src/meshgenerators/CircularBoundaryCorrectionGenerator.C
@@ -91,7 +91,7 @@ CircularBoundaryCorrectionGenerator::generate()
   // Check if the input mesh has the given boundaries
   for (const auto & bd : _input_mesh_circular_boundaries)
   {
-    if (!MooseMeshUtils::hasBoundaryName(*input_mesh, bd))
+    if (!MooseMeshUtils::hasBoundaryNameOrID(*input_mesh, bd))
       paramError("input_mesh_circular_boundaries",
                  "the boundary '" + bd + "' does not exist in the input mesh.");
   }

--- a/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
+++ b/framework/src/meshgenerators/CutMeshByLevelSetGeneratorBase.C
@@ -98,7 +98,7 @@ CutMeshByLevelSetGeneratorBase::generate()
 
   if (!_cut_face_name.empty())
   {
-    if (MooseMeshUtils::hasBoundaryName(mesh, _cut_face_name))
+    if (MooseMeshUtils::hasBoundaryNameOrID(mesh, _cut_face_name))
     {
       const boundary_id_type exist_cut_face_id =
           MooseMeshUtils::getBoundaryID(_cut_face_name, mesh);

--- a/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
+++ b/framework/src/meshgenerators/MeshDiagnosticsGenerator.C
@@ -153,7 +153,7 @@ MeshDiagnosticsGenerator::generate()
   // check that specified boundary is valid, convert BoundaryNames to BoundaryIDs, and sort
   for (const auto & boundary_name : _watertight_boundary_names)
   {
-    if (!MooseMeshUtils::hasBoundaryName(*mesh, boundary_name))
+    if (!MooseMeshUtils::hasBoundaryNameOrID(*mesh, boundary_name))
       mooseError("User specified boundary_to_check \'", boundary_name, "\' does not exist");
   }
   _watertight_boundaries = MooseMeshUtils::getBoundaryIDs(*mesh, _watertight_boundary_names, false);

--- a/framework/src/transfers/MultiAppGeneralFieldTransfer.C
+++ b/framework/src/transfers/MultiAppGeneralFieldTransfer.C
@@ -273,7 +273,7 @@ MultiAppGeneralFieldTransfer::initialSetup()
     {
       const auto & boundary_names = getParam<std::vector<BoundaryName>>("from_boundaries");
       for (const auto & bn : boundary_names)
-        if (!MooseMeshUtils::hasBoundaryName(from_moose_mesh.getMesh(), bn))
+        if (!MooseMeshUtils::hasBoundaryNameOrID(from_moose_mesh.getMesh(), bn))
           paramError("from_boundaries", "The boundary '", bn, "' was not found in the mesh");
 
       if (!boundary_names.empty())
@@ -352,7 +352,7 @@ MultiAppGeneralFieldTransfer::initialSetup()
     {
       const auto & boundary_names = getParam<std::vector<BoundaryName>>("to_boundaries");
       for (const auto & bn : boundary_names)
-        if (!MooseMeshUtils::hasBoundaryName(to_moose_mesh.getMesh(), bn))
+        if (!MooseMeshUtils::hasBoundaryNameOrID(to_moose_mesh.getMesh(), bn))
           paramError("to_boundaries", "The boundary '", bn, "' was not found in the mesh");
 
       if (!boundary_names.empty())

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -92,7 +92,7 @@ MultiAppNearestNodeTransfer::execute()
     if (_from_meshes.size())
     {
       const auto & sb = getParam<BoundaryName>("source_boundary");
-      if (!MooseMeshUtils::hasBoundaryName(_from_meshes[0]->getMesh(), sb))
+      if (!MooseMeshUtils::hasBoundaryNameOrID(_from_meshes[0]->getMesh(), sb))
         paramError("source_boundary", "The boundary '", sb, "' was not found in the mesh");
 
       bboxes = getFromBoundingBoxes(_from_meshes[0]->getBoundaryID(sb));
@@ -726,7 +726,7 @@ MultiAppNearestNodeTransfer::getLocalEntitiesAndComponents(
   {
     const auto & sb = getParam<BoundaryName>("source_boundary");
     BoundaryID src_bnd_id = mesh->getBoundaryID(sb);
-    if (!MooseMeshUtils::hasBoundaryName(mesh_base, sb))
+    if (!MooseMeshUtils::hasBoundaryNameOrID(mesh_base, sb))
       paramError("source_boundary", "The boundary '", sb, "' was not found in the mesh");
 
     if (is_nodal)
@@ -820,7 +820,7 @@ MultiAppNearestNodeTransfer::getTargetLocalNodes(const unsigned int to_problem_i
     const std::vector<BoundaryName> & target_boundaries =
         getParam<std::vector<BoundaryName>>("target_boundary");
     for (const auto & b : target_boundaries)
-      if (!MooseMeshUtils::hasBoundaryName(to_mesh, b))
+      if (!MooseMeshUtils::hasBoundaryNameOrID(to_mesh, b))
         paramError("target_boundary", "The boundary '", b, "' was not found in the mesh");
 
     ConstBndNodeRange & bnd_nodes = *(_to_meshes[to_problem_id])->getBoundaryNodeRange();

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -177,7 +177,7 @@ MultiAppUserObjectTransfer::execute()
             const std::vector<BoundaryName> & boundary_names =
                 getParam<std::vector<BoundaryName>>("boundary");
             for (const auto & b : boundary_names)
-              if (!MooseMeshUtils::hasBoundaryName(*mesh, b))
+              if (!MooseMeshUtils::hasBoundaryNameOrID(*mesh, b))
                 paramError("boundary", "The boundary '", b, "' was not found in the mesh");
 
             std::vector<BoundaryID> ids = mesh->getBoundaryIDs(boundary_names, true);
@@ -327,7 +327,7 @@ MultiAppUserObjectTransfer::execute()
         const std::vector<BoundaryName> & boundary_names =
             getParam<std::vector<BoundaryName>>("boundary");
         for (const auto & b : boundary_names)
-          if (!MooseMeshUtils::hasBoundaryName(*to_mesh, b))
+          if (!MooseMeshUtils::hasBoundaryNameOrID(*to_mesh, b))
             paramError("boundary", "The boundary '", b, "' was not found in the mesh");
 
         std::vector<BoundaryID> ids = to_mesh->getBoundaryIDs(boundary_names, true);

--- a/framework/src/utils/MooseMeshElementConversionUtils.C
+++ b/framework/src/utils/MooseMeshElementConversionUtils.C
@@ -1100,7 +1100,7 @@ transitionLayerGenerator(MeshBase & mesh,
   std::vector<boundary_id_type> boundary_ids;
   for (const auto & sideset : boundary_names)
   {
-    if (!MooseMeshUtils::hasBoundaryName(mesh, sideset))
+    if (!MooseMeshUtils::hasBoundaryNameOrID(mesh, sideset))
       throw MooseException("The provided boundary '", sideset, "' was not found within the mesh");
     boundary_ids.push_back(MooseMeshUtils::getBoundaryID(sideset, mesh));
     MooseMeshUtils::changeBoundaryId(mesh, boundary_ids.back(), uniform_tmp_bid, false);

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -563,10 +563,18 @@ hasBoundaryID(const MeshBase & input_mesh, const BoundaryID id)
 }
 
 bool
-hasBoundaryName(const MeshBase & input_mesh, const BoundaryName & name)
+hasBoundaryName(const MeshBase & mesh, const BoundaryName & name)
 {
-  const auto id = getBoundaryID(name, input_mesh);
-  return hasBoundaryID(input_mesh, id);
+  const BoundaryInfo & boundary_info = mesh.get_boundary_info();
+  const BoundaryID id = boundary_info.get_id_by_name(name);
+  return id != Moose::INVALID_BOUNDARY_ID;
+}
+
+bool
+hasBoundaryNameOrID(const MeshBase & mesh, const BoundaryName & name_or_id)
+{
+  const auto id = getBoundaryID(name_or_id, mesh);
+  return hasBoundaryID(mesh, id);
 }
 
 void
@@ -1037,7 +1045,7 @@ createSubdomainFromSidesets(MeshBase & mesh,
 
   // Check that the sidesets are present in the mesh
   for (const auto & sideset : boundary_names)
-    if (!MooseMeshUtils::hasBoundaryName(mesh, sideset))
+    if (!MooseMeshUtils::hasBoundaryNameOrID(mesh, sideset))
       mooseException("The sideset '", sideset, "' was not found within the mesh");
 
   auto sideset_ids = MooseMeshUtils::getBoundaryIDs(mesh, boundary_names, true);

--- a/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
@@ -164,7 +164,7 @@ PeripheralRingMeshGenerator::generate()
 
   _input_mesh_external_bid =
       MooseMeshUtils::getBoundaryID(_input_mesh_external_boundary, *input_mesh);
-  if (!MooseMeshUtils::hasBoundaryName(*input_mesh, _input_mesh_external_boundary))
+  if (!MooseMeshUtils::hasBoundaryNameOrID(*input_mesh, _input_mesh_external_boundary))
     paramError("input_mesh_external_boundary",
                "External boundary does not exist in the input mesh");
   // We check the element types of input mesh's external boundary here.


### PR DESCRIPTION
Renamed `MooseMeshUtils::hasBoundaryName()` to `hasBoundaryNameOrID()` to better reflect the check. This is being done because I plan to add a `hasBoundaryName()` that is different from the current implementation in that it only returns true if the provided string corresponds to an existing boundary name, not an ID.

Plan:
1. See which apps are currently using `hasBoundaryName()` - these will need rename fixes. ✅ Griffin, and the super apps that use it (BlueCrab, Direwolf, Sabertooth)
2. Change this PR to have the original `hasBoundaryName()` coexist with the new name `hasBoundaryNameOrID()`. Merge it.
3. Fix apps to use new name.
4. Remove old `hasBoundaryName()` or just change it to new implementation

Refs #32724