### PR TITLE
Added execution order dependency check

### DIFF
--- a/framework/doc/content/syntax/UserObjects/index.md
+++ b/framework/doc/content/syntax/UserObjects/index.md
@@ -94,6 +94,14 @@ is 0 (zero). Negative values can be specified to force user object execution *be
 positive values can be uses to create execution groups that run *after* the default group. Execution
 order groups apply to all `execute_on` flags specified for a given object.
 
+Developers may enforce some `execution_order_group` dependency in a user object `uo` using the
+`declareExecutionOrderGroupDependency(other_uo)` method; an error is reported:
+
+- If the type of `other_uo` executes before the type of `uo` in the sequence above,
+  then `execution_order_group` of `uo` must be greater than or equal to that of `other_uo`.
+- If the type of `other_uo` executes at the same step or after the type of `uo` in the sequence above,
+  then `execution_order_group` of `uo` must be greater than that of `other_uo`.
+
 ## Restartable Data
 
 Since UserObjects often create and store large data structures, the developer of a UserObject

--- a/framework/include/kokkos/userobjects/KokkosElementUserObject.h
+++ b/framework/include/kokkos/userobjects/KokkosElementUserObject.h
@@ -41,7 +41,7 @@ public:
   ElementUserObject(const ElementUserObject & object);
 
   virtual void compute() override;
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 5; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
 
   /**
    * The parallel computation entry function called by Kokkos

--- a/framework/include/kokkos/userobjects/KokkosElementUserObject.h
+++ b/framework/include/kokkos/userobjects/KokkosElementUserObject.h
@@ -41,6 +41,7 @@ public:
   ElementUserObject(const ElementUserObject & object);
 
   virtual void compute() override;
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 5; }
 
   /**
    * The parallel computation entry function called by Kokkos

--- a/framework/include/kokkos/userobjects/KokkosGeneralUserObject.h
+++ b/framework/include/kokkos/userobjects/KokkosGeneralUserObject.h
@@ -34,6 +34,8 @@ public:
    */
   GeneralUserObject(const GeneralUserObject & object);
 
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 5; }
+
 private:
   // General user objects are not dispatched
   virtual void computeUserObject() override final {}

--- a/framework/include/kokkos/userobjects/KokkosGeneralUserObject.h
+++ b/framework/include/kokkos/userobjects/KokkosGeneralUserObject.h
@@ -34,7 +34,7 @@ public:
    */
   GeneralUserObject(const GeneralUserObject & object);
 
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 5; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
 
 private:
   // General user objects are not dispatched

--- a/framework/include/kokkos/userobjects/KokkosNodalUserObject.h
+++ b/framework/include/kokkos/userobjects/KokkosNodalUserObject.h
@@ -37,7 +37,7 @@ public:
   NodalUserObject(const NodalUserObject & object);
 
   virtual void compute() override;
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 5; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
 
   /**
    * The parallel computation entry function called by Kokkos

--- a/framework/include/kokkos/userobjects/KokkosNodalUserObject.h
+++ b/framework/include/kokkos/userobjects/KokkosNodalUserObject.h
@@ -37,6 +37,7 @@ public:
   NodalUserObject(const NodalUserObject & object);
 
   virtual void compute() override;
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 5; }
 
   /**
    * The parallel computation entry function called by Kokkos

--- a/framework/include/kokkos/userobjects/KokkosSideUserObject.h
+++ b/framework/include/kokkos/userobjects/KokkosSideUserObject.h
@@ -40,7 +40,7 @@ public:
   SideUserObject(const SideUserObject & object);
 
   virtual void compute() override;
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 5; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
 
   /**
    * The parallel computation entry function called by Kokkos

--- a/framework/include/kokkos/userobjects/KokkosSideUserObject.h
+++ b/framework/include/kokkos/userobjects/KokkosSideUserObject.h
@@ -40,6 +40,7 @@ public:
   SideUserObject(const SideUserObject & object);
 
   virtual void compute() override;
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 5; }
 
   /**
    * The parallel computation entry function called by Kokkos

--- a/framework/include/userobjects/DomainUserObject.h
+++ b/framework/include/userobjects/DomainUserObject.h
@@ -106,6 +106,8 @@ public:
 
   void checkVariable(const MooseVariableFieldBase & variable) const override;
 
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
+
 protected:
   const MooseArray<Point> & qPoints() const { return *_current_q_point; }
   const QBase & qRule() const { return *_current_q_rule; }

--- a/framework/include/userobjects/DomainUserObject.h
+++ b/framework/include/userobjects/DomainUserObject.h
@@ -106,7 +106,7 @@ public:
 
   void checkVariable(const MooseVariableFieldBase & variable) const override;
 
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 1; }
 
 protected:
   const MooseArray<Point> & qPoints() const { return *_current_q_point; }

--- a/framework/include/userobjects/ElementUserObject.h
+++ b/framework/include/userobjects/ElementUserObject.h
@@ -37,7 +37,7 @@ public:
 
   ElementUserObject(const InputParameters & parameters);
 
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 1; }
 
 protected:
   MooseMesh & _mesh;

--- a/framework/include/userobjects/ElementUserObject.h
+++ b/framework/include/userobjects/ElementUserObject.h
@@ -37,6 +37,8 @@ public:
 
   ElementUserObject(const InputParameters & parameters);
 
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
+
 protected:
   MooseMesh & _mesh;
 

--- a/framework/include/userobjects/GeneralUserObject.h
+++ b/framework/include/userobjects/GeneralUserObject.h
@@ -37,5 +37,5 @@ public:
   virtual void subdomainSetup() override;
   ///@}
 
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override { return 4; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override { return 5; }
 };

--- a/framework/include/userobjects/GeneralUserObject.h
+++ b/framework/include/userobjects/GeneralUserObject.h
@@ -36,4 +36,6 @@ public:
   virtual void threadJoin(const UserObject &) override;
   virtual void subdomainSetup() override;
   ///@}
+
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override { return 4; }
 };

--- a/framework/include/userobjects/InterfaceUserObject.h
+++ b/framework/include/userobjects/InterfaceUserObject.h
@@ -23,6 +23,8 @@ public:
 
   InterfaceUserObject(const InputParameters & parameters);
 
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
+
 protected:
   /**
    * Execute method.

--- a/framework/include/userobjects/InterfaceUserObject.h
+++ b/framework/include/userobjects/InterfaceUserObject.h
@@ -23,7 +23,7 @@ public:
 
   InterfaceUserObject(const InputParameters & parameters);
 
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 1; }
 
 protected:
   /**

--- a/framework/include/userobjects/InternalSideUserObject.h
+++ b/framework/include/userobjects/InternalSideUserObject.h
@@ -33,7 +33,7 @@ public:
 
   InternalSideUserObject(const InputParameters & parameters);
 
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 1; }
 
 protected:
   MooseMesh & _mesh;

--- a/framework/include/userobjects/InternalSideUserObject.h
+++ b/framework/include/userobjects/InternalSideUserObject.h
@@ -33,6 +33,8 @@ public:
 
   InternalSideUserObject(const InputParameters & parameters);
 
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
+
 protected:
   MooseMesh & _mesh;
 

--- a/framework/include/userobjects/MortarUserObject.h
+++ b/framework/include/userobjects/MortarUserObject.h
@@ -35,5 +35,5 @@ public:
   virtual void reinit() = 0;
   virtual void threadJoin(const UserObject &) override final {}
 
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 2; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 3; }
 };

--- a/framework/include/userobjects/MortarUserObject.h
+++ b/framework/include/userobjects/MortarUserObject.h
@@ -34,4 +34,6 @@ public:
    */
   virtual void reinit() = 0;
   virtual void threadJoin(const UserObject &) override final {}
+
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 2; }
 };

--- a/framework/include/userobjects/NodalUserObject.h
+++ b/framework/include/userobjects/NodalUserObject.h
@@ -35,7 +35,7 @@ public:
 
   virtual void subdomainSetup() override /*final*/;
 
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 1; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 2; }
 
   bool isUniqueNodeExecute() { return _unique_node_execute; }
 

--- a/framework/include/userobjects/NodalUserObject.h
+++ b/framework/include/userobjects/NodalUserObject.h
@@ -35,6 +35,8 @@ public:
 
   virtual void subdomainSetup() override /*final*/;
 
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 1; }
+
   bool isUniqueNodeExecute() { return _unique_node_execute; }
 
 protected:

--- a/framework/include/userobjects/SideUserObject.h
+++ b/framework/include/userobjects/SideUserObject.h
@@ -34,7 +34,7 @@ public:
 
   SideUserObject(const InputParameters & parameters);
 
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 1; }
 
 protected:
   MooseMesh & _mesh;

--- a/framework/include/userobjects/SideUserObject.h
+++ b/framework/include/userobjects/SideUserObject.h
@@ -34,6 +34,8 @@ public:
 
   SideUserObject(const InputParameters & parameters);
 
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 0; }
+
 protected:
   MooseMesh & _mesh;
 

--- a/framework/include/userobjects/ThreadedGeneralUserObject.h
+++ b/framework/include/userobjects/ThreadedGeneralUserObject.h
@@ -23,4 +23,6 @@ public:
   virtual void subdomainSetup() override{};
 
   bool needThreadedCopy() const override final { return true; }
+
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 3; }
 };

--- a/framework/include/userobjects/ThreadedGeneralUserObject.h
+++ b/framework/include/userobjects/ThreadedGeneralUserObject.h
@@ -24,5 +24,5 @@ public:
 
   bool needThreadedCopy() const override final { return true; }
 
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 3; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 4; }
 };

--- a/framework/include/userobjects/UserObjectBase.h
+++ b/framework/include/userobjects/UserObjectBase.h
@@ -167,12 +167,13 @@ public:
    * Gets the order of types of user objects within an execution order group
    *
    * As of June 2026, the ordering is:
-   * 0: side, element, internal side, domain, interface (in no particular order)
-   * 1: nodal
-   * 2: mortar
-   * 3: threaded general
-   * 4: general
-   * 5: others that do not get executed
+   * 0: Kokkos user object (all types)
+   * 1: side, element, internal side, domain, interface (in no particular order)
+   * 2: nodal
+   * 3: mortar
+   * 4: threaded general
+   * 5: general
+   * 6: others that do not get executed
    */
   virtual unsigned int getUOExecutionOrderWithinGroup() const = 0;
 

--- a/framework/include/userobjects/UserObjectBase.h
+++ b/framework/include/userobjects/UserObjectBase.h
@@ -163,12 +163,32 @@ public:
    */
   virtual bool needThreadedCopy() const { return false; }
 
+  /**
+   * Gets the order of types of user objects within an execution order group
+   *
+   * As of June 2026, the ordering is:
+   * 0: side, element, internal side, domain, interface (in no particular order)
+   * 1: nodal
+   * 2: mortar
+   * 3: threaded general
+   * 4: general
+   * 5: others that do not get executed
+   */
+  virtual unsigned int getUOExecutionOrderWithinGroup() const = 0;
+
 protected:
   virtual void addPostprocessorDependencyHelper(const PostprocessorName & name) const override;
   virtual void
   addVectorPostprocessorDependencyHelper(const VectorPostprocessorName & name) const override;
   virtual void addUserObjectDependencyHelper(const UserObjectBase & uo) const override;
   void addReporterDependencyHelper(const ReporterName & reporter_name) override;
+
+  /**
+   * Throws error if the execution order group of this UO is <= the provided UO's group
+   *
+   * @param[in] other_uo  User object that this user object depends upon
+   */
+  void declareExecutionOrderGroupDependency(const UserObjectBase & other_uo);
 
   /// Thread ID of this postprocessor
   const THREAD_ID _tid;

--- a/framework/include/utils/ExecFlagEnum.h
+++ b/framework/include/utils/ExecFlagEnum.h
@@ -65,11 +65,6 @@ public:
    */
   std::string getDocString() const;
 
-  /**
-   * Reference the all the available items.
-   */
-  const std::set<ExecFlagType> & items() const { return _items; }
-
 protected:
   /**
    *  Append the list of current flags.

--- a/framework/include/utils/MultiMooseEnum.h
+++ b/framework/include/utils/MultiMooseEnum.h
@@ -254,6 +254,9 @@ public:
   void addValidName(const std::initializer_list<std::string> & names);
   void addValidName(const MultiMooseEnum & names);
 
+  /// Return the set of the currently selected values
+  std::set<MooseEnumItem> selectedItems() const;
+
 protected:
   /// Check whether any of the current values are deprecated when called
   virtual void checkDeprecated() const override;

--- a/framework/src/userobjects/UserObjectBase.C
+++ b/framework/src/userobjects/UserObjectBase.C
@@ -169,3 +169,54 @@ UserObjectBase::addReporterDependencyHelper(const ReporterName & reporter_name)
 {
   _depend_uo.insert(reporter_name.getObjectName());
 }
+
+void
+UserObjectBase::declareExecutionOrderGroupDependency(const UserObjectBase & other_uo)
+{
+  // dependency checking only applies if the two UOs share an execute_on flag
+  const auto this_execute_on_flags = getParam<ExecFlagEnum>("execute_on").selectedItems();
+  const auto other_execute_on_flags = other_uo.getParam<ExecFlagEnum>("execute_on").selectedItems();
+  std::set<ExecFlagType> shared_execute_on_flags;
+  std::set_intersection(this_execute_on_flags.begin(),
+                        this_execute_on_flags.end(),
+                        other_execute_on_flags.begin(),
+                        other_execute_on_flags.end(),
+                        std::inserter(shared_execute_on_flags, shared_execute_on_flags.begin()));
+  if (shared_execute_on_flags.size() == 0)
+    return;
+
+  const int this_group = getParam<int>("execution_order_group");
+  const int other_group = other_uo.getParam<int>("execution_order_group");
+
+  const auto this_uo_order = getUOExecutionOrderWithinGroup();
+  const auto other_uo_order = other_uo.getUOExecutionOrderWithinGroup();
+
+  // if the other type of UO executes before this one's type in a given execution order group,
+  // then they can be in the same execution order group.
+  if (other_uo_order < this_uo_order)
+  {
+    if (this_group < other_group)
+      mooseError("The 'execution_order_group' of this object (",
+                 this_group,
+                 ") must be greater than or equal to that of the user object '",
+                 other_uo.name(),
+                 "' (",
+                 other_group,
+                 ") due to a declared dependency of this object on '",
+                 other_uo.name(),
+                 "'.");
+  }
+  else
+  {
+    if (this_group <= other_group)
+      mooseError("The 'execution_order_group' of this object (",
+                 this_group,
+                 ") must be greater than that of the user object '",
+                 other_uo.name(),
+                 "' (",
+                 other_group,
+                 ") due to a declared dependency of this object on '",
+                 other_uo.name(),
+                 "'.");
+  }
+}

--- a/framework/src/userobjects/UserObjectBase.C
+++ b/framework/src/userobjects/UserObjectBase.C
@@ -196,27 +196,27 @@ UserObjectBase::declareExecutionOrderGroupDependency(const UserObjectBase & othe
   if (other_uo_order < this_uo_order)
   {
     if (this_group < other_group)
-      mooseError("The 'execution_order_group' of this object (",
-                 this_group,
-                 ") must be greater than or equal to that of the user object '",
-                 other_uo.name(),
-                 "' (",
-                 other_group,
-                 ") due to a declared dependency of this object on '",
-                 other_uo.name(),
-                 "'.");
+      mooseWarning("The 'execution_order_group' of this object (",
+                   this_group,
+                   ") must be greater than or equal to that of the user object '",
+                   other_uo.name(),
+                   "' (",
+                   other_group,
+                   ") due to a declared dependency of this object on '",
+                   other_uo.name(),
+                   "'.");
   }
   else
   {
     if (this_group <= other_group)
-      mooseError("The 'execution_order_group' of this object (",
-                 this_group,
-                 ") must be greater than that of the user object '",
-                 other_uo.name(),
-                 "' (",
-                 other_group,
-                 ") due to a declared dependency of this object on '",
-                 other_uo.name(),
-                 "'.");
+      mooseWarning("The 'execution_order_group' of this object (",
+                   this_group,
+                   ") must be greater than that of the user object '",
+                   other_uo.name(),
+                   "' (",
+                   other_group,
+                   ") due to a declared dependency of this object on '",
+                   other_uo.name(),
+                   "'.");
   }
 }

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -371,3 +371,10 @@ MultiMooseEnum::addValidName(const MultiMooseEnum & names)
   for (const auto & item : names._items)
     addEnumerationItem(MooseEnumItem(item.name(), getNextValidID()));
 }
+
+std::set<MooseEnumItem>
+MultiMooseEnum::selectedItems() const
+{
+  std::set<MooseEnumItem> selected_items(_current_values.begin(), _current_values.end());
+  return selected_items;
+}

--- a/modules/heat_transfer/include/userobjects/GapFluxModelBase.h
+++ b/modules/heat_transfer/include/userobjects/GapFluxModelBase.h
@@ -37,6 +37,8 @@ public:
   virtual void finalize() final{};
   virtual void threadJoin(const UserObject &) final{};
 
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 5; }
+
 protected:
   mutable unsigned int _qp;
   mutable ADReal _gap_width;

--- a/modules/heat_transfer/include/userobjects/GapFluxModelBase.h
+++ b/modules/heat_transfer/include/userobjects/GapFluxModelBase.h
@@ -37,7 +37,7 @@ public:
   virtual void finalize() final{};
   virtual void threadJoin(const UserObject &) final{};
 
-  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 5; }
+  virtual unsigned int getUOExecutionOrderWithinGroup() const override final { return 6; }
 
 protected:
   mutable unsigned int _qp;

--- a/modules/heat_transfer/include/userobjects/ViewFactorObjectSurfaceRadiation.h
+++ b/modules/heat_transfer/include/userobjects/ViewFactorObjectSurfaceRadiation.h
@@ -25,6 +25,11 @@ public:
 
   ViewFactorObjectSurfaceRadiation(const InputParameters & parameters);
 
+  virtual void initialSetup() override;
+
 protected:
   virtual std::vector<std::vector<Real>> setViewFactors() override;
+
+  /// View factor object
+  const ViewFactorBase * _view_factor_uo;
 };

--- a/modules/heat_transfer/src/postprocessors/GrayLambertSurfaceRadiationPP.C
+++ b/modules/heat_transfer/src/postprocessors/GrayLambertSurfaceRadiationPP.C
@@ -33,6 +33,7 @@ GrayLambertSurfaceRadiationPP::GrayLambertSurfaceRadiationPP(const InputParamete
     _return_type(getParam<MooseEnum>("return_type")),
     _bnd_id(_fe_problem.mesh().getBoundaryID(getParam<BoundaryName>("boundary")))
 {
+  declareExecutionOrderGroupDependency(_glsr_uo);
 }
 
 PostprocessorValue

--- a/modules/heat_transfer/src/userobjects/ViewFactorObjectSurfaceRadiation.C
+++ b/modules/heat_transfer/src/userobjects/ViewFactorObjectSurfaceRadiation.C
@@ -36,6 +36,8 @@ ViewFactorObjectSurfaceRadiation::initialSetup()
   // After resolving https://github.com/idaholab/moose/issues/7879, this can made into
   // a reference and all of this can be done in the constructor
   _view_factor_uo = &getUserObject<ViewFactorBase>("view_factor_object_name");
+
+  declareExecutionOrderGroupDependency(*_view_factor_uo);
 }
 
 std::vector<std::vector<Real>>

--- a/modules/heat_transfer/src/userobjects/ViewFactorObjectSurfaceRadiation.C
+++ b/modules/heat_transfer/src/userobjects/ViewFactorObjectSurfaceRadiation.C
@@ -30,10 +30,17 @@ ViewFactorObjectSurfaceRadiation::ViewFactorObjectSurfaceRadiation(
 {
 }
 
+void
+ViewFactorObjectSurfaceRadiation::initialSetup()
+{
+  // After resolving https://github.com/idaholab/moose/issues/7879, this can made into
+  // a reference and all of this can be done in the constructor
+  _view_factor_uo = &getUserObject<ViewFactorBase>("view_factor_object_name");
+}
+
 std::vector<std::vector<Real>>
 ViewFactorObjectSurfaceRadiation::setViewFactors()
 {
-  const ViewFactorBase & view_factor_uo = getUserObject<ViewFactorBase>("view_factor_object_name");
   std::vector<BoundaryName> boundary_names = getParam<std::vector<BoundaryName>>("boundary");
   std::vector<std::vector<Real>> vf(_n_sides);
 
@@ -42,7 +49,7 @@ ViewFactorObjectSurfaceRadiation::setViewFactors()
     vf[i].resize(_n_sides);
 
     for (unsigned int j = 0; j < _n_sides; ++j)
-      vf[i][j] = view_factor_uo.getViewFactor(boundary_names[i], boundary_names[j]);
+      vf[i][j] = _view_factor_uo->getViewFactor(boundary_names[i], boundary_names[j]);
   }
   return vf;
 }

--- a/modules/heat_transfer/src/vectorpostprocessors/SurfaceRadiationVectorPostprocessor.C
+++ b/modules/heat_transfer/src/vectorpostprocessors/SurfaceRadiationVectorPostprocessor.C
@@ -42,6 +42,8 @@ SurfaceRadiationVectorPostprocessor::SurfaceRadiationVectorPostprocessor(
 {
   for (unsigned int j = 0; j < _n_data; ++j)
     _data[j] = &declareVector(_information_types[j]);
+
+  declareExecutionOrderGroupDependency(_glsr_uo);
 }
 
 void

--- a/modules/heat_transfer/src/vectorpostprocessors/ViewFactorVectorPostprocessor.C
+++ b/modules/heat_transfer/src/vectorpostprocessors/ViewFactorVectorPostprocessor.C
@@ -47,6 +47,11 @@ ViewFactorVectorPostprocessor::ViewFactorVectorPostprocessor(const InputParamete
   if (isParamValid("surface_radiation_object_name") && isParamValid("view_factor_object_name"))
     mooseError("The parameters 'surface_radiation_object_name' and 'view_factor_object_name' "
                "cannot both be provided. Please delete 'surface_radiation_object_name'.");
+
+  if (_view_factor_uo)
+    declareExecutionOrderGroupDependency(*_view_factor_uo);
+  if (_glsr_uo)
+    declareExecutionOrderGroupDependency(*_glsr_uo);
 }
 
 void

--- a/modules/heat_transfer/test/tests/gray_lambert_radiator/gray_lambert_cavity.i
+++ b/modules/heat_transfer/test/tests/gray_lambert_radiator/gray_lambert_cavity.i
@@ -30,11 +30,6 @@
     normalize_view_factor = true
     normalization_method = inverse_row_sum
     view_factor_tol = 0.05
-    # Without changing from 'TIMESTEP_END' to 'INITIAL' here, this test would
-    # diff, since GrayLambertSurfaceRadiationBase objects currently set their
-    # view factors in initial() (and finalize() of this view factor object has
-    # not yet executed). See https://github.com/idaholab/moose/issues/32611.
-    # Alternatively we can keep 'TIMESTEP_END' and do 'execution_order_group = -1'.
     execute_on = 'INITIAL'
   []
   [./gray_lambert]

--- a/unit/include/DeclareExecutionOrderGroupDependencyTest.h
+++ b/unit/include/DeclareExecutionOrderGroupDependencyTest.h
@@ -1,0 +1,39 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseObjectUnitTest.h"
+
+class DeclareExecutionOrderGroupDependencyTest : public MooseObjectUnitTest
+{
+public:
+  DeclareExecutionOrderGroupDependencyTest() : MooseObjectUnitTest("MooseUnitApp") {}
+
+  void addDependentUserObject(std::string uo_name,
+                              bool is_general_uo,
+                              std::string depends_on_uo_name,
+                              bool depends_on_is_general_uo,
+                              int execution_order_group);
+  void addIndependentUserObject(std::string uo_name, bool is_general_uo, int execution_order_group);
+};
+
+template <typename BaseType>
+class ExecutionOrderGroupDependencyUserObject : public BaseType
+{
+public:
+  static InputParameters validParams();
+
+  ExecutionOrderGroupDependencyUserObject(const InputParameters & params);
+
+  virtual void initialize() override {};
+  virtual void execute() override {};
+  virtual void finalize() override {};
+  virtual void threadJoin(const UserObject &) override {};
+};

--- a/unit/src/DeclareExecutionOrderGroupDependencyTest.C
+++ b/unit/src/DeclareExecutionOrderGroupDependencyTest.C
@@ -1,0 +1,128 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "DeclareExecutionOrderGroupDependencyTest.h"
+#include "GeneralUserObject.h"
+#include "SideUserObject.h"
+
+TEST_F(DeclareExecutionOrderGroupDependencyTest, Side0Side0)
+{
+  addIndependentUserObject("objA", false, 0);
+  ASSERT_THROW(addDependentUserObject("objB", false, "objA", false, 0), std::runtime_error);
+}
+
+TEST_F(DeclareExecutionOrderGroupDependencyTest, Side0Side1)
+{
+  addIndependentUserObject("objA", false, 0);
+  ASSERT_NO_THROW(addDependentUserObject("objB", false, "objA", false, 1));
+}
+
+TEST_F(DeclareExecutionOrderGroupDependencyTest, Side0General0)
+{
+  addIndependentUserObject("objA", false, 0);
+  ASSERT_NO_THROW(addDependentUserObject("objB", true, "objA", false, 0));
+}
+
+TEST_F(DeclareExecutionOrderGroupDependencyTest, Side1General0)
+{
+  addIndependentUserObject("objA", false, 1);
+  ASSERT_THROW(addDependentUserObject("objB", true, "objA", false, 0), std::runtime_error);
+}
+
+TEST_F(DeclareExecutionOrderGroupDependencyTest, General0Side0)
+{
+  addIndependentUserObject("objA", true, 0);
+  ASSERT_THROW(addDependentUserObject("objB", false, "objA", true, 0), std::runtime_error);
+}
+
+TEST_F(DeclareExecutionOrderGroupDependencyTest, General0Side1)
+{
+  addIndependentUserObject("objA", true, 0);
+  ASSERT_NO_THROW(addDependentUserObject("objB", false, "objA", true, 1));
+}
+
+void
+DeclareExecutionOrderGroupDependencyTest::addDependentUserObject(std::string uo_name,
+                                                                 bool is_general_uo,
+                                                                 std::string depends_on_uo_name,
+                                                                 bool depends_on_is_general_uo,
+                                                                 int execution_order_group)
+{
+  std::string class_name;
+  if (is_general_uo)
+    class_name = "ExecutionOrderGroupDependencyGeneralUserObject";
+  else
+    class_name = "ExecutionOrderGroupDependencySideUserObject";
+  InputParameters params = _factory.getValidParams(class_name);
+  if (!is_general_uo)
+    params.set<std::vector<BoundaryName>>("boundary") = {};
+  params.set<int>("execution_order_group") = execution_order_group;
+  params.set<UserObjectName>("depends_on") = depends_on_uo_name;
+  params.set<bool>("depends_on_is_general_uo") = depends_on_is_general_uo;
+  _fe_problem->addUserObject(class_name, uo_name, params);
+}
+
+void
+DeclareExecutionOrderGroupDependencyTest::addIndependentUserObject(std::string uo_name,
+                                                                   bool is_general_uo,
+                                                                   int execution_order_group)
+{
+  std::string class_name;
+  if (is_general_uo)
+    class_name = "ExecutionOrderGroupDependencyGeneralUserObject";
+  else
+    class_name = "ExecutionOrderGroupDependencySideUserObject";
+  InputParameters params = _factory.getValidParams(class_name);
+  if (!is_general_uo)
+    params.set<std::vector<BoundaryName>>("boundary") = {};
+  params.set<int>("execution_order_group") = execution_order_group;
+  _fe_problem->addUserObject(class_name, uo_name, params);
+}
+
+typedef ExecutionOrderGroupDependencyUserObject<GeneralUserObject>
+    ExecutionOrderGroupDependencyGeneralUserObject;
+typedef ExecutionOrderGroupDependencyUserObject<SideUserObject>
+    ExecutionOrderGroupDependencySideUserObject;
+
+registerMooseObject("MooseUnitApp", ExecutionOrderGroupDependencyGeneralUserObject);
+registerMooseObject("MooseUnitApp", ExecutionOrderGroupDependencySideUserObject);
+
+template <typename BaseType>
+InputParameters
+ExecutionOrderGroupDependencyUserObject<BaseType>::validParams()
+{
+  InputParameters params = BaseType::validParams();
+  params.addParam<UserObjectName>("depends_on", "User object that this one depends on");
+  params.addParam<bool>("depends_on_is_general_uo",
+                        "Is the type of 'depends_on' a general UO? Else, side UO");
+  return params;
+}
+
+template <typename BaseType>
+ExecutionOrderGroupDependencyUserObject<BaseType>::ExecutionOrderGroupDependencyUserObject(
+    const InputParameters & params)
+  : BaseType(params)
+{
+  if (BaseType::isParamValid("depends_on"))
+  {
+    if (this->template getParam<bool>("depends_on_is_general_uo"))
+    {
+      const auto & depends_on =
+          this->template getUserObject<ExecutionOrderGroupDependencyGeneralUserObject>(
+              "depends_on");
+      BaseType::declareExecutionOrderGroupDependency(depends_on);
+    }
+    else
+    {
+      const auto & depends_on =
+          this->template getUserObject<ExecutionOrderGroupDependencySideUserObject>("depends_on");
+      BaseType::declareExecutionOrderGroupDependency(depends_on);
+    }
+  }
+}


### PR DESCRIPTION
- Added `MultiMooseEnum::selectedItems()`
- Added `UserObjectBase::declareExecutionOrderGroupDependency()`. User objects can now explicitly declare dependency in terms of execution order group (see #33195 for motivation). To avoid requiring unnecessary execution order groups, we define and refer to the "user object base class index", which denotes the order of execution of base classes within `FEProblemBase::computeUserObjectsInternal()`. See #33195 for potential follow-on to this concept.
- Used new dependency method in some radiative heat transfer UOs. Note that input files were unaffected because this issue had been discovered the hard way and avoided using appropriate `execute_on` values.

Refs #33195
Closes #32611

TODO:
- [x] add tests for `declareExecutionOrderGroupDependency()`
- [x] add doc for `declareExecutionOrderGroupDependency()`