### PR TITLE
Keep unsupported MooseDocs LaTeX commands blank

### DIFF
--- a/python/MooseDocs/extensions/content.py
+++ b/python/MooseDocs/extensions/content.py
@@ -525,8 +525,8 @@ class RenderContentOutline(components.RenderComponent):
                     previous = current
 
     def createLatex(self, parent, token, page):
-        msg = "Warning: The Content Extension's 'outline' command is not supported for LaTex documents."
-        latex.String(parent, content=msg)
+        msg = "The Content Extension's 'outline' command is not supported for LaTeX documents."
+        LOG.warning(msg)
 
 
 class RenderPagination(components.RenderComponent):
@@ -572,5 +572,5 @@ class RenderPagination(components.RenderComponent):
         )
 
     def createLatex(self, parent, token, page):
-        msg = "Warning: The Content Extension's 'pagination' command is not supported for LaTeX documents."
-        latex.String(parent, content=msg)
+        msg = "The Content Extension's 'pagination' command is not supported for LaTeX documents."
+        LOG.warning(msg)

--- a/python/MooseDocs/test/extensions/test_content.py
+++ b/python/MooseDocs/test/extensions/test_content.py
@@ -772,7 +772,9 @@ class TestUnsupportedLatexContentCommands(MooseDocsTestCase):
     ]
 
     def testOutline(self):
-        with self.assertLogs("MooseDocs.extensions.content", level=logging.WARNING) as cm:
+        with self.assertLogs(
+            "MooseDocs.extensions.content", level=logging.WARNING
+        ) as cm:
             _, res = self.execute(
                 "!content outline location=extensions", renderer=base.LatexRenderer()
             )
@@ -784,7 +786,9 @@ class TestUnsupportedLatexContentCommands(MooseDocsTestCase):
 
     def testPagination(self):
         text = "!content pagination previous=previous.md next=next.md"
-        with self.assertLogs("MooseDocs.extensions.content", level=logging.WARNING) as cm:
+        with self.assertLogs(
+            "MooseDocs.extensions.content", level=logging.WARNING
+        ) as cm:
             _, res = self.execute(text, renderer=base.LatexRenderer())
         self.assertSize(res, 0)
         self.assertIn(

--- a/python/MooseDocs/test/extensions/test_content.py
+++ b/python/MooseDocs/test/extensions/test_content.py
@@ -763,6 +763,36 @@ class testContentPagination(MooseDocsTestCase):
         self.assertHTMLString(res(1)(1)(1)(0), content="arrow_forward")
 
 
+class TestUnsupportedLatexContentCommands(MooseDocsTestCase):
+    EXTENSIONS = [
+        extensions.core,
+        extensions.command,
+        extensions.heading,
+        extensions.content,
+    ]
+
+    def testOutline(self):
+        with self.assertLogs("MooseDocs.extensions.content", level=logging.WARNING) as cm:
+            _, res = self.execute(
+                "!content outline location=extensions", renderer=base.LatexRenderer()
+            )
+        self.assertSize(res, 0)
+        self.assertIn(
+            "The Content Extension's 'outline' command is not supported for LaTeX documents.",
+            cm.output[0],
+        )
+
+    def testPagination(self):
+        text = "!content pagination previous=previous.md next=next.md"
+        with self.assertLogs("MooseDocs.extensions.content", level=logging.WARNING) as cm:
+            _, res = self.execute(text, renderer=base.LatexRenderer())
+        self.assertSize(res, 0)
+        self.assertIn(
+            "The Content Extension's 'pagination' command is not supported for LaTeX documents.",
+            cm.output[0],
+        )
+
+
 class TestMissingExternalContentList(MooseDocsTestCase):
     EXTENSIONS = [
         extensions.core,


### PR DESCRIPTION
This PR resolves issue #32549 .
