### PR TITLE
adjust thermal conductivity and speed of sound for kelvin scale

### DIFF
--- a/modules/fluid_properties/doc/content/source/fluidproperties/LeadLithiumFluidProperties.md
+++ b/modules/fluid_properties/doc/content/source/fluidproperties/LeadLithiumFluidProperties.md
@@ -10,10 +10,10 @@ These properties are based on experiments and compilations reported in the liter
 | Melting point, $T_{mo}$ `[K]`          | $508$ | [!cite](Martelli2009,MasdeLesValls2008) |
 | Density, $\rho$ `[kg/m^3]`             | $\displaystyle 10520.35 - 1.19051\,T$ | [!cite](MasdeLesValls2008) |
 | Viscosity, $\mu$ `[Pa s]`              | $\displaystyle 1.87 \times 10^{-4}\,\exp\!\left(\frac{11640}{8.314\,T}\right)$ | [!cite](Schulz1991) |
-| Specific enthalpy, $h$ `[J/kg]`        | $\displaystyle 195\,(T-T_{mo}) - 0.5\times9.116\times10^{-3}\,(T^2-T_{mo}^2)$ | [!cite](Zinkle1998) |
+| Specific enthalpy, $h$ `[J/kg]`        | $\displaystyle 195\,(T-T_{mo}) - 0.5\times9.116\times10^{-3}\,(T^2-T_{mo}^2)$ | [!cite](Schulz1991) |
 | Thermal Conductivity, $k$ `[W/(m-K)]`       | $\displaystyle 14.51 + 0.019631\,T$ | [!cite](Mogahed1995) |
 | Isobaric Specific Heat, $c_p$ `[J/(kg-K)]`  | $\displaystyle 195 - 9.116\times10^{-3}\,T$ | [!cite](Schulz1991) |
-| Isochoric Specific Heat, $c_v$ `[J/(kg-K)]` | $\displaystyle \frac{c_p}{1+\left(\frac{1.19051}{10520.35-1.19051 \, T}\right)^2 \frac{B_S \, T}{\rho \, c_p}}$ | [!cite](Zinkle1998) |
+| Isochoric Specific Heat, $c_v$ `[J/(kg-K)]` | $\displaystyle \frac{c_p}{1+\left(\frac{1.19051}{10520.35-1.19051 \, T}\right)^2 \frac{B_S \, T}{\rho \, c_p}}$ | [!cite](Schulz1991) |
 | Isentropic Bulk Modulus, $B_S$ `[Pa]`       | $\dfrac{c^2}{\rho} | [!cite](Martelli2009)|
 | Speed of Sound, $c$ `[m/s]`                 | $\displaystyle 1876 - 0.306\,T$ | [!cite](Ueki2009) |
 

--- a/modules/fluid_properties/src/fluidproperties/LeadLithiumFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/LeadLithiumFluidProperties.C
@@ -118,7 +118,7 @@ ADReal
 LeadLithiumFluidProperties::c_from_v_e(const ADReal & v, const ADReal & e) const
 {
   ADReal T = SinglePhaseFluidProperties::T_from_v_e(v, e);
-  return 1876 - 0.306 * T;
+  return 1876 - 0.306 * (T - 273.15);
 }
 
 Real
@@ -231,7 +231,7 @@ LeadLithiumFluidProperties::k_from_v_e(Real v, Real e) const
   Real T = T_from_v_e(v, e);
   if (T < _T_mo || T > 873)
     flagInvalidSolution("Temperature out of bounds for the PbLi dynamic viscosity computation");
-  return 14.51 + 1.9631e-2 * T;
+  return 14.51 + 1.9631e-2 * (T - 273.15);
 }
 
 void

--- a/modules/fluid_properties/src/fluidproperties/LeadLithiumFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/LeadLithiumFluidProperties.C
@@ -104,14 +104,14 @@ LeadLithiumFluidProperties::bulk_modulus_from_p_T(Real /*p*/, Real T) const
 Real
 LeadLithiumFluidProperties::c_from_p_T(Real /*p*/, Real T) const
 {
-  return 1876 - 0.306 * T;
+  return 1876 - 0.306 * (T - 273.15);
 }
 
 Real
 LeadLithiumFluidProperties::c_from_v_e(Real v, Real e) const
 {
   Real T = T_from_v_e(v, e);
-  return 1876 - 0.306 * T;
+  return 1876 - 0.306 * (T - 273.15);
 }
 
 ADReal
@@ -394,7 +394,7 @@ LeadLithiumFluidProperties::k_from_p_T(Real /*p*/, Real T) const
 {
   if (T < _T_mo || T > 873)
     flagInvalidSolution("Temperature out of bounds for the PbLi dynamic viscosity computation");
-  return 14.51 + 1.9631e-2 * T;
+  return 14.51 + 1.9631e-2 * (T - 273.15);
 }
 
 void

--- a/modules/fluid_properties/unit/src/LeadLithiumFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/LeadLithiumFluidPropertiesTest.C
@@ -32,9 +32,9 @@ TEST_F(LeadLithiumFluidPropertiesTest, molarMass)
  *   rho(T) = 10520.35 - 1.19051*T
  *   h(T)   = 195*(T - 508) - 0.5*9.116e-3*(T^2 - 508^2)    (T_mo = 508 K)
  *   e      = h - p/rho
- *   k(T)   = 9.144 + 0.019631*T
+ *   k(T)   = 14.51 + 0.019631 * (T - 273.15);
  *   E(T)   = (44.73077 - 0.02634615*T + 5.76923e-6*T^2)*1e9
- *   c(T)   = 1959.63 - 0.306*T
+ *   c(T)   = 1876. - 0.306 * (T - 273.15);
  *   cp(T)  = 195 - 9.116e-3*T
  *   cv(T)  = cp/(1 + alpha^2*E*T/(rho*cp)),  alpha  = 1.19051/(10520.35 - 1.19051*T)
  *   mu(T)  = 1.87e-4 * exp(11640/(R*T))
@@ -62,9 +62,9 @@ TEST_F(LeadLithiumFluidPropertiesTest, properties)
       // Compute reference internal energy:
       const Real e_ref = h_ref - p / rho_ref;
       // Compute thermal conductivity:
-      const Real k_ref = 14.51 + 0.019631 * T;
+      const Real k_ref = 14.51 + 0.019631 * (T - 273.15);
       // Compute speed of sound:
-      const Real c_ref = 1876. - 0.306 * T;
+      const Real c_ref = 1876. - 0.306 * (T - 273.15);
       // Compute bulk modulus:
       const Real E_ref = c_ref * c_ref * rho_ref;
       // Compute isobaric specific heat:


### PR DESCRIPTION
remove references to zinkle from documentation and adjust thermal conductivity and speed of sound for kelvin scale. closes #33216 

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
