### PR TITLE
Fix libhit link and premake package-manager lookup

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -584,14 +584,14 @@ ifeq ($(MOOSE_UNITY),true)
 $(moose_LIB): $(moose_objects) $(pcre_LIB) $(gtest_LIB) $(hit_LIB) $(pyhit_LIB) $(moose_revision_header)
 	@echo "Linking Library "$@"..."
 	@bash -c '$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(moose_objects) $(pcre_LIB) $(png_LIB) $(LDFLAGS) $(libmesh_LDFLAGS) $(libmesh_LIBS) $(EXTERNAL_FLAGS) -rpath $(FRAMEWORK_DIR) ${SILENCE_SOME_WARNINGS}'
+	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(moose_objects) $(pcre_LIB) $(hit_LIB) $(png_LIB) $(LDFLAGS) $(libmesh_LDFLAGS) $(libmesh_LIBS) $(EXTERNAL_FLAGS) -rpath $(FRAMEWORK_DIR) ${SILENCE_SOME_WARNINGS}'
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $(moose_LIB) $(FRAMEWORK_DIR)
 else
 # We avoid bash -c outside unity build mode because there would be too many arguments and it triggers an error
 $(moose_LIB): $(moose_objects) $(pcre_LIB) $(gtest_LIB) $(hit_LIB) $(pyhit_LIB) $(moose_revision_header)
 	@echo "Linking Library "$@"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \
-	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(moose_objects) $(pcre_LIB) $(png_LIB) $(LDFLAGS) $(libmesh_LDFLAGS) $(libmesh_LIBS) $(EXTERNAL_FLAGS) -rpath $(FRAMEWORK_DIR)
+	  $(libmesh_CXX) $(libmesh_CXXFLAGS) -o $@ $(moose_objects) $(pcre_LIB) $(hit_LIB) $(png_LIB) $(LDFLAGS) $(libmesh_LDFLAGS) $(libmesh_LIBS) $(EXTERNAL_FLAGS) -rpath $(FRAMEWORK_DIR)
 	@$(libmesh_LIBTOOL) --mode=install --quiet install -c $(moose_LIB) $(FRAMEWORK_DIR)
 endif
 

--- a/modules/porous_flow/doc/content/bib/porous_flow.bib
+++ b/modules/porous_flow/doc/content/bib/porous_flow.bib
@@ -564,7 +564,6 @@ volume = {94},
 year = {2018}
 }
 
-<<<<<<< HEAD
 @article{REHBINDER1995453,
 title = {Analytical solutions of stationary coupled thermo-hydro-mechanical problems},
 journal = {International Journal of Rock Mechanics and Mining Sciences & Geomechanics Abstracts},

--- a/scripts/premake.py
+++ b/scripts/premake.py
@@ -8,7 +8,7 @@
 # Licensed under LGPL 2.1, please see LICENSE for details
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
-import subprocess, os, platform, re, sys, traceback
+import subprocess, os, platform, re, shutil, sys, traceback
 from datetime import date
 
 
@@ -52,7 +52,7 @@ class PreMake:
         Separated out on purpose so that we can mock it in unit tests,
         running tests even when conda doesn't exist.
         """
-        cmd = ["conda", "list", "--json"]
+        cmd = PreMake.condaListCommand()
         process = subprocess.run(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8"
         )
@@ -69,6 +69,33 @@ class PreMake:
         return json.loads(process.stdout)
 
     @staticmethod
+    def condaListCommand():
+        """
+        Gets the available conda-compatible package-list command.
+
+        MOOSE environments may be managed by conda, mamba, or micromamba. Prefer
+        explicit environment variables when available, then search PATH.
+        """
+        candidates = []
+        for env_var in ("CONDA_EXE", "MAMBA_EXE"):
+            exe = os.environ.get(env_var)
+            if exe:
+                candidates.append(exe)
+        candidates.extend(["conda", "mamba", "micromamba"])
+
+        for exe in candidates:
+            if os.path.isabs(exe) and os.access(exe, os.X_OK):
+                return [exe, "list", "--json"]
+
+            found = shutil.which(exe)
+            if found:
+                return [found, "list", "--json"]
+
+        raise FileNotFoundError(
+            "Failed to find conda, mamba, or micromamba for package version checks"
+        )
+
+    @staticmethod
     def getCondaEnv():
         """
         Gets the conda package environment in the form of a dict of
@@ -82,7 +109,11 @@ class PreMake:
         conda_env = None
 
         if os.environ.get("CONDA_PREFIX") is not None:
-            conda_list = PreMake.condaList()
+            try:
+                conda_list = PreMake.condaList()
+            except FileNotFoundError as e:
+                PreMake.warn(str(e))
+                return None
 
             conda_env = {}
             for entry in conda_list:

--- a/scripts/tests/test_premake.py
+++ b/scripts/tests/test_premake.py
@@ -14,7 +14,11 @@ import sys
 import mooseutils
 import subprocess
 import copy
-from mock import patch
+
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
 
 MOOSE_DIR = mooseutils.git_root_dir()
 sys.path.insert(0, os.path.join(MOOSE_DIR, "scripts"))
@@ -126,10 +130,14 @@ class Test(unittest.TestCase):
     def testCondaList(self):
         # Can only test this if we actually have conda
         if os.environ.get("CONDA_PREFIX") is not None:
+            try:
+                cmd = PreMake.condaListCommand()[:-1]
+            except FileNotFoundError as e:
+                self.skipTest(str(e))
+
             conda_list = PreMake.condaList()
 
-            # Run our own conda list to make sure it all looks right
-            cmd = ["conda", "list"]
+            # Run our own package list to make sure it all looks right
             out = subprocess.check_output(cmd)
             result = out.decode("utf-8").splitlines()
             for line in result:
@@ -151,6 +159,38 @@ class Test(unittest.TestCase):
                         self.assertEqual(version, gold_entry.get("version"))
                         self.assertEqual(build_string, gold_entry.get("build_string"))
                 self.assertTrue(found)
+
+    def testCondaListCommandUsesCondaExe(self):
+        conda_exe = "/bin/sh"
+        with patch.dict(os.environ, {"CONDA_EXE": conda_exe}, clear=True):
+            self.assertEqual(PreMake.condaListCommand(), [conda_exe, "list", "--json"])
+
+    @patch("premake.shutil.which")
+    def testCondaListCommandUsesMicromambaFallback(self, mock_which):
+        def which(exe):
+            if exe == "micromamba":
+                return "/usr/bin/micromamba"
+            return None
+
+        mock_which.side_effect = which
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(
+                PreMake.condaListCommand(),
+                ["/usr/bin/micromamba", "list", "--json"],
+            )
+
+    @patch.object(PreMake, "condaList")
+    def testGetCondaEnvWithoutPackageManager(self, mock_conda_list):
+        mock_conda_list.side_effect = FileNotFoundError("missing package manager")
+        CONDA_PREFIX = os.environ.get("CONDA_PREFIX")
+        os.environ["CONDA_PREFIX"] = "foo"
+
+        self.assertEqual(PreMake.getCondaEnv(), None)
+
+        if CONDA_PREFIX is not None:
+            os.environ["CONDA_PREFIX"] = CONDA_PREFIX
+        else:
+            del os.environ["CONDA_PREFIX"]
 
     @patch.object(PreMake, "condaList")
     def testGetCondaEnv(self, mock_conda_list):


### PR DESCRIPTION
## Summary

Refs #33313.

This fixes three issues found while building and checking MOOSE locally:

- link `$(hit_LIB)` into `libmoose` in both unity and non-unity link commands, matching the existing dependency and avoiding missing `hit::Error` symbols at runtime on macOS
- make `scripts/premake.py` resolve a conda-compatible package manager from `CONDA_EXE`, `MAMBA_EXE`, `conda`, `mamba`, or `micromamba` instead of hard-coding `conda`
- remove a stray merge-conflict marker from `modules/porous_flow/doc/content/bib/porous_flow.bib`

## Testing

- `python3 -m py_compile scripts/premake.py scripts/tests/test_premake.py`
- `PYTHONPATH=python:scripts python3 -m unittest scripts.tests.test_premake`
- `git diff --check`
- verified no conflict markers remain in `modules/porous_flow/doc/content/bib/porous_flow.bib`
