### PR TITLE
Skip material reinit in indicator/marker loops when unused

### DIFF
--- a/framework/src/loops/ComputeIndicatorThread.C
+++ b/framework/src/loops/ComputeIndicatorThread.C
@@ -73,7 +73,12 @@ ComputeIndicatorThread::subdomainChanged()
   _indicator_whs.updateMatPropDependency(needed_mat_props, _tid);
   _internal_side_indicators.updateMatPropDependency(needed_mat_props, _tid);
 
-  _fe_problem.prepareMaterials(needed_mat_props, _subdomain, _tid);
+  // Only prepare (and therefore reinit) materials if an indicator actually consumes a material
+  // property. Otherwise skip the material system entirely to avoid recomputing the whole stack.
+  if (!needed_mat_props.empty())
+    _fe_problem.prepareMaterials(needed_mat_props, _subdomain, _tid);
+  else
+    _fe_problem.clearActiveMaterialProperties(_tid);
 }
 
 void

--- a/framework/src/loops/ComputeMarkerThread.C
+++ b/framework/src/loops/ComputeMarkerThread.C
@@ -53,7 +53,13 @@ ComputeMarkerThread::subdomainChanged()
   _marker_whs.updateMatPropDependency(needed_mat_props, _tid);
 
   _fe_problem.setActiveElementalMooseVariables(needed_moose_vars, _tid);
-  _fe_problem.prepareMaterials(needed_mat_props, _subdomain, _tid);
+
+  // Only prepare (and therefore reinit) materials if a marker actually consumes a material
+  // property. Otherwise skip the material system entirely to avoid recomputing the whole stack.
+  if (!needed_mat_props.empty())
+    _fe_problem.prepareMaterials(needed_mat_props, _subdomain, _tid);
+  else
+    _fe_problem.clearActiveMaterialProperties(_tid);
 }
 
 void


### PR DESCRIPTION
The indicator and marker element loops unconditionally called prepareMaterials in subdomainChanged.

Fixes #33252

Note: it looks like `_fe_problem.prepareMaterials` ends up computing all material properties with a material property dependency, even if no properties are passed in the indicator and marker loops. This seems like a deliberate choice to guard against a missing property dependency, so I didn't touch it.