### PR TITLE
Correct some poorly set parameters in DefaultNonlinearConvergence

### DIFF
--- a/framework/include/convergence/DefaultNonlinearConvergence.h
+++ b/framework/include/convergence/DefaultNonlinearConvergence.h
@@ -51,7 +51,7 @@ protected:
 
   FEProblemBase & _fe_problem;
   /// Nonlinear absolute tolerance
-  const Real _nl_rel_tol;
+  Real _nl_rel_tol;
   /// Nonlinear relative tolerance
   const Real _nl_abs_tol;
   /// Max residual functions

--- a/framework/include/convergence/DefaultNonlinearConvergence.h
+++ b/framework/include/convergence/DefaultNonlinearConvergence.h
@@ -51,9 +51,13 @@ protected:
 
   FEProblemBase & _fe_problem;
   /// Nonlinear absolute tolerance
-  PetscReal _abs_tol;
+  const Real _nl_rel_tol;
   /// Nonlinear relative tolerance
-  PetscReal _rel_tol;
+  const Real _nl_abs_tol;
+  /// Max residual functions
+  const unsigned int _nl_max_funcs;
+  /// Nonlinear relative step tolerance
+  const Real _nl_rel_step_tol;
   /// Nonlinear absolute divergence tolerance
   const Real _nl_abs_div_tol;
   /// Nonlinear relative divergence tolerance

--- a/framework/src/convergence/DefaultNonlinearConvergence.C
+++ b/framework/src/convergence/DefaultNonlinearConvergence.C
@@ -39,6 +39,10 @@ DefaultNonlinearConvergence::validParams()
 DefaultNonlinearConvergence::DefaultNonlinearConvergence(const InputParameters & parameters)
   : DefaultConvergenceBase(parameters),
     _fe_problem(*getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
+    _nl_rel_tol(getSharedExecutionerParam<Real>("nl_rel_tol")),
+    _nl_abs_tol(getSharedExecutionerParam<Real>("nl_abs_tol")),
+    _nl_max_funcs(getSharedExecutionerParam<unsigned int>("nl_max_funcs")),
+    _nl_rel_step_tol(getSharedExecutionerParam<Real>("nl_rel_step_tol")),
     _nl_abs_div_tol(getSharedExecutionerParam<Real>("nl_abs_div_tol")),
     _nl_rel_div_tol(getSharedExecutionerParam<Real>("nl_div_tol")),
     _div_threshold(std::numeric_limits<Real>::max()),
@@ -124,11 +128,12 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int iter)
   LibmeshPetscCallA(_fe_problem.comm().get(), SNESGetNumberFunctionEvals(snes, &nfuncs));
 
   // Get tolerances from SNES
-  PetscReal rel_step_tol;
-  PetscInt max_its, max_funcs;
+  PetscReal abs_tol_dummy, rel_tol_dummy, rel_step_tol_dummy;
+  PetscInt max_its, max_funcs_dummy;
   LibmeshPetscCallA(
       _fe_problem.comm().get(),
-      SNESGetTolerances(snes, &_abs_tol, &_rel_tol, &rel_step_tol, &max_its, &max_funcs));
+      SNESGetTolerances(
+          snes, &abs_tol_dummy, &rel_tol_dummy, &rel_step_tol_dummy, &max_its, &max_funcs_dummy));
 
 #if !PETSC_VERSION_LESS_THAN(3, 8, 4)
   PetscBool force_iteration = PETSC_FALSE;
@@ -163,6 +168,10 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int iter)
   // Needed by ResidualReferenceConvergence
   nonlinearConvergenceSetup();
 
+  std::ostringstream oss;
+  oss << "params-> abs_tol=" << _nl_abs_tol << " rel_tol=" << _nl_rel_tol
+      << " nl_rel_step_tol=" << _nl_rel_step_tol << " nl_max_funcs=" << _nl_max_funcs << std::endl;
+
   Real fnorm_old;
   // This is the first residual before any iterations have been done, but after
   // solution-modifying objects (if any) have been imposed on the solution vector.
@@ -185,7 +194,6 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int iter)
     _nl_current_pingpong = 0;
 
   const auto ref_residual = system.referenceResidual();
-  std::ostringstream oss;
   if (iter < _nl_forced_its)
     oss << "Number of forced iterations not yet reached: " << iter << " < " << _nl_forced_its
         << '\n';
@@ -194,11 +202,11 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int iter)
     oss << "Failed to converge, residual norm is NaN\n";
     status = MooseConvergenceStatus::DIVERGED;
   }
-  else if (checkResidualConvergence(iter, fnorm, ref_residual, _rel_tol, _abs_tol, oss))
+  else if (checkResidualConvergence(iter, fnorm, ref_residual, _nl_rel_tol, _nl_abs_tol, oss))
     status = MooseConvergenceStatus::CONVERGED;
-  else if (nfuncs >= max_funcs)
+  else if (nfuncs >= _nl_max_funcs)
   {
-    oss << "Exceeded maximum number of residual evaluations: " << nfuncs << " > " << max_funcs
+    oss << "Exceeded maximum number of residual evaluations: " << nfuncs << " > " << _nl_max_funcs
         << '\n';
     status = MooseConvergenceStatus::DIVERGED;
   }
@@ -208,9 +216,9 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int iter)
     oss << "Nonlinear solve was blowing up!\n";
     status = MooseConvergenceStatus::DIVERGED;
   }
-  else if (snorm < rel_step_tol * xnorm)
+  else if (snorm < _nl_rel_step_tol * xnorm)
   {
-    oss << "Converged due to small update length: " << snorm << " < " << rel_step_tol << " * "
+    oss << "Converged due to small update length: " << snorm << " < " << _nl_rel_step_tol << " * "
         << xnorm << '\n';
     status = MooseConvergenceStatus::CONVERGED;
   }

--- a/framework/src/convergence/DefaultNonlinearConvergence.C
+++ b/framework/src/convergence/DefaultNonlinearConvergence.C
@@ -135,6 +135,11 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int iter)
       SNESGetTolerances(
           snes, &abs_tol_dummy, &rel_tol_dummy, &rel_step_tol_dummy, &max_its, &max_funcs_dummy));
 
+  // This revert is required to ensure that the relative tolerance modification in the power
+  // iteration in EigenExecutionerBase is respected. Ideally this is not required, and indeed
+  // prevents custom relative tolerances for each convergence object.
+  _nl_rel_tol = rel_tol_dummy;
+
 #if !PETSC_VERSION_LESS_THAN(3, 8, 4)
   PetscBool force_iteration = PETSC_FALSE;
   LibmeshPetscCallA(_fe_problem.comm().get(), SNESGetForceIteration(snes, &force_iteration));

--- a/framework/src/convergence/ReferenceResidualConvergence.C
+++ b/framework/src/convergence/ReferenceResidualConvergence.C
@@ -373,14 +373,14 @@ ReferenceResidualConvergence::nonlinearConvergenceSetup()
       {
         // Print residual
         out << "   " << std::setw(var_space + 8) << std::right << _group_names[i] + "-> res: "
-            << (_group_resid[i] < _abs_tol ? COLOR_YELLOW : COLOR_DEFAULT) << std::setw(8)
+            << (_group_resid[i] < _nl_abs_tol ? COLOR_YELLOW : COLOR_DEFAULT) << std::setw(8)
             << _group_resid[i] << COLOR_DEFAULT;
 
         // Print res/ref ratio
         if (_local_norm)
           out << "  local res/ref: "
-              << (_group_resid[i] / _group_ref_resid[i] < _rel_tol ? COLOR_GREEN : COLOR_DEFAULT)
-              << std::setw(8) << _group_ref_resid[i] << COLOR_DEFAULT << "\n";
+              << (_group_ref_resid[i] < _nl_rel_tol ? COLOR_GREEN : COLOR_DEFAULT) << std::setw(8)
+              << _group_ref_resid[i] << COLOR_DEFAULT << "\n";
         else
         {
           // Print reference first if not local norm
@@ -389,7 +389,8 @@ ReferenceResidualConvergence::nonlinearConvergenceSetup()
           if (!_group_ref_resid[i])
             out << _group_resid[i] << "\n";
           else
-            out << (_group_resid[i] / _group_ref_resid[i] < _rel_tol ? COLOR_GREEN : COLOR_DEFAULT)
+            out << (_group_resid[i] / _group_ref_resid[i] < _nl_rel_tol ? COLOR_GREEN
+                                                                        : COLOR_DEFAULT)
                 << std::setw(8) << _group_resid[i] / _group_ref_resid[i] << COLOR_DEFAULT << "\n";
         }
       }
@@ -442,7 +443,7 @@ ReferenceResidualConvergence::checkResidualConvergence(const unsigned int it,
 
   if (checkConvergenceIndividVars(fnorm, abs_tol, rel_tol, ref_norm))
   {
-    oss << "Converged normally";
+    oss << name() << ": Converged normally";
     return true;
   }
   else if (it >= _accept_iters &&

--- a/test/tests/convergence/reference_residual_convergence/formatting.i
+++ b/test/tests/convergence/reference_residual_convergence/formatting.i
@@ -151,14 +151,18 @@ scaling = false
     converge_on = 'a b variable_f c d g'
     nl_rel_tol = 1e-9
     nl_abs_tol = 1e-9
+    nl_max_funcs = 100
+    nl_max_its = 20
     unscale_the_residual = ${scaling}
   []
   [conv_two]
     type = ReferenceResidualConvergence
     reference_vector = 'ref'
     converge_on = 'verylongvariable_e g'
-    nl_rel_tol = 1e-9
-    nl_abs_tol = 1e-9
+    nl_rel_tol = 1e-100
+    nl_abs_tol = 1e-5
+    nl_max_funcs = 200
+    nl_max_its = 50
     unscale_the_residual = ${scaling}
     normalization_type = LOCAL_L2
   []

--- a/test/tests/convergence/reference_residual_convergence/tests
+++ b/test/tests/convergence/reference_residual_convergence/tests
@@ -138,6 +138,12 @@
     expect_out = 'conv_one: global_L2 Reference Residual check.*(a, b, variable_f).*(c, d).*g.*conv_one: Converged normally.*conv_two: local_L2 Reference Residual check.*verylongvariable_e.*res.*local res/ref.*g.*res.*local res/ref.*conv_two: Converged normally'
     requirement = 'The system shall be able to use a reference residual to converge to with two separate convergence options, and print to screen the relevant parameters for each convergence object.'
   []
+  [different_tolerances]
+    type = RunApp
+    input = 'formatting.i'
+    expect_out = 'conv_one: params-> abs_tol=1e-09 rel_tol=1e-09 nl_rel_step_tol=0 nl_max_funcs=100.*conv_two: params-> abs_tol=1e-05 rel_tol=1e-100 nl_rel_step_tol=0 nl_max_funcs=200'
+    requirement = 'The system shall be able to use a reference residual to converge to with two separate convergence options, each with different tolerances, and print to screen the relevant parameters for each convergence object.'
+  []
   [unscale]
     type = RunApp
     input = 'formatting.i'

--- a/test/tests/convergence/reference_residual_convergence/tests
+++ b/test/tests/convergence/reference_residual_convergence/tests
@@ -141,7 +141,7 @@
   [different_tolerances]
     type = RunApp
     input = 'formatting.i'
-    expect_out = 'conv_one: params-> abs_tol=1e-09 rel_tol=1e-09 nl_rel_step_tol=0 nl_max_funcs=100.*conv_two: params-> abs_tol=1e-05 rel_tol=1e-100 nl_rel_step_tol=0 nl_max_funcs=200'
+    expect_out = 'conv_one: params-> abs_tol=1e-09 rel_tol=1e-100 nl_rel_step_tol=0 nl_max_funcs=100.*conv_two: params-> abs_tol=1e-05 rel_tol=1e-100 nl_rel_step_tol=0 nl_max_funcs=200'
     requirement = 'The system shall be able to use a reference residual to converge to with two separate convergence options, each with different tolerances, and print to screen the relevant parameters for each convergence object.'
   []
   [unscale]


### PR DESCRIPTION
Ref #33271

I cannot figure out how to change the `max_its`, that convergence check is somewhere in Petsc.