### PR TITLE
Sync subdomain name map due to up-front element subdomain modifier ids/names

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -768,13 +768,17 @@ public:
   /**
    * This method sets the name for \p subdomain_id to \p name
    */
-  void setSubdomainName(SubdomainID subdomain_id, const SubdomainName & name);
+  void setSubdomainName(SubdomainID subdomain_id,
+                        const SubdomainName & name,
+                        const bool synchronous = false);
 
   /**
    * This method sets the name for \p subdomain_id on the provided \p mesh to \p name
    */
-  static void
-  setSubdomainName(MeshBase & mesh, SubdomainID subdomain_id, const SubdomainName & name);
+  static void setSubdomainName(MeshBase & mesh,
+                               SubdomainID subdomain_id,
+                               const SubdomainName & name,
+                               const bool synchronous = false);
 
   /**
    * Return the name of a block given an id.

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -768,17 +768,13 @@ public:
   /**
    * This method sets the name for \p subdomain_id to \p name
    */
-  void setSubdomainName(SubdomainID subdomain_id,
-                        const SubdomainName & name,
-                        const bool synchronous = false);
+  void setSubdomainName(SubdomainID subdomain_id, const SubdomainName & name);
 
   /**
    * This method sets the name for \p subdomain_id on the provided \p mesh to \p name
    */
-  static void setSubdomainName(MeshBase & mesh,
-                               SubdomainID subdomain_id,
-                               const SubdomainName & name,
-                               const bool synchronous = false);
+  static void
+  setSubdomainName(MeshBase & mesh, SubdomainID subdomain_id, const SubdomainName & name);
 
   /**
    * Return the name of a block given an id.

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -386,6 +386,8 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
 {
   TIME_SECTION("prepare", 2, "Preparing Mesh", true);
 
+  parallel_object_only();
+
   bool libmesh_mesh_prepared = false;
 
   mooseAssert(_mesh, "The MeshBase has not been constructed");

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -432,7 +432,7 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
       // add subdomain id
       _mesh_subdomains.insert(sub_id);
       // set name of the subdomain just added
-      setSubdomainName(sub_id, sub_name);
+      setSubdomainName(sub_id, sub_name, true);
     }
   }
   else if (isParamValid("add_subdomain_names"))
@@ -455,7 +455,7 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
       // add subdomain id
       _mesh_subdomains.insert(sub_id);
       // set name of the subdomain just added
-      setSubdomainName(sub_id, sub_name);
+      setSubdomainName(sub_id, sub_name, true);
     }
   }
 
@@ -1734,17 +1734,21 @@ MooseMesh::getSubdomainIDs(const std::set<SubdomainName> & subdomain_name) const
 }
 
 void
-MooseMesh::setSubdomainName(SubdomainID subdomain_id, const SubdomainName & name)
+MooseMesh::setSubdomainName(const SubdomainID subdomain_id,
+                            const SubdomainName & name,
+                            const bool synchronous)
 {
-  mooseAssert(name != "ANY_BLOCK_ID", "Cannot set subdomain name to 'ANY_BLOCK_ID'");
-  getMesh().subdomain_name(subdomain_id) = name;
+  setSubdomainName(getMesh(), subdomain_id, name, synchronous);
 }
 
 void
-MooseMesh::setSubdomainName(MeshBase & mesh, SubdomainID subdomain_id, const SubdomainName & name)
+MooseMesh::setSubdomainName(MeshBase & mesh,
+                            SubdomainID subdomain_id,
+                            const SubdomainName & name,
+                            const bool synchronous)
 {
   mooseAssert(name != "ANY_BLOCK_ID", "Cannot set subdomain name to 'ANY_BLOCK_ID'");
-  mesh.subdomain_name(subdomain_id) = name;
+  mesh.set_subdomain_name(subdomain_id, name, synchronous);
 }
 
 const std::string &

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -418,6 +418,7 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
   for (const auto & elem : getMesh().element_ptr_range())
     _mesh_subdomains.insert(elem->subdomain_id());
 
+  bool need_subdomain_name_map_sync = false;
   // add explicitly requested subdomains
   if (isParamValid("add_subdomain_ids") && !isParamValid("add_subdomain_names"))
   {
@@ -434,8 +435,9 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
       // add subdomain id
       _mesh_subdomains.insert(sub_id);
       // set name of the subdomain just added
-      setSubdomainName(sub_id, sub_name, true);
+      setSubdomainName(sub_id, sub_name);
     }
+    need_subdomain_name_map_sync = true;
   }
   else if (isParamValid("add_subdomain_names"))
   {
@@ -457,9 +459,12 @@ MooseMesh::prepare(const MeshBase * const mesh_to_clone)
       // add subdomain id
       _mesh_subdomains.insert(sub_id);
       // set name of the subdomain just added
-      setSubdomainName(sub_id, sub_name, true);
+      setSubdomainName(sub_id, sub_name);
     }
+    need_subdomain_name_map_sync = true;
   }
+  if (need_subdomain_name_map_sync)
+    _mesh->sync_subdomain_name_map();
 
   // Make sure nodesets have been generated
   buildNodeListFromSideList();
@@ -1736,21 +1741,17 @@ MooseMesh::getSubdomainIDs(const std::set<SubdomainName> & subdomain_name) const
 }
 
 void
-MooseMesh::setSubdomainName(const SubdomainID subdomain_id,
-                            const SubdomainName & name,
-                            const bool synchronous)
+MooseMesh::setSubdomainName(SubdomainID subdomain_id, const SubdomainName & name)
 {
-  setSubdomainName(getMesh(), subdomain_id, name, synchronous);
+  mooseAssert(name != "ANY_BLOCK_ID", "Cannot set subdomain name to 'ANY_BLOCK_ID'");
+  getMesh().subdomain_name(subdomain_id) = name;
 }
 
 void
-MooseMesh::setSubdomainName(MeshBase & mesh,
-                            SubdomainID subdomain_id,
-                            const SubdomainName & name,
-                            const bool synchronous)
+MooseMesh::setSubdomainName(MeshBase & mesh, SubdomainID subdomain_id, const SubdomainName & name)
 {
   mooseAssert(name != "ANY_BLOCK_ID", "Cannot set subdomain name to 'ANY_BLOCK_ID'");
-  mesh.set_subdomain_name(subdomain_id, name, synchronous);
+  mesh.subdomain_name(subdomain_id) = name;
 }
 
 const std::string &


### PR DESCRIPTION
This currently invokes an additional communication that is necessary to help https://github.com/libMesh/libmesh/pull/4485 pass. However, once libmesh/libmesh#4492 makes its way into MOOSE then https://github.com/idaholab/moose/pull/33276/commits/08c953ad9225a68e0fe1c7ba0ccbf74d1156df1f can be reverted and the additional communication can be removed