### PR TITLE
Do not print the multi-system fixed point iteration index if not iterating

### DIFF
--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -481,9 +481,10 @@ FEProblemSolve::solve()
     converged = false;
     while (!converged)
     {
-      _console << COLOR_MAGENTA << "Multi-system fixed point iteration " << num_fp_multisys_iters
-               << ":" << COLOR_DEFAULT << "\n"
-               << std::endl;
+      if (_using_multi_sys_fp_iterations)
+        _console << COLOR_MAGENTA << "Multi-system fixed point iteration " << num_fp_multisys_iters
+                 << ":" << COLOR_DEFAULT << "\n"
+                 << std::endl;
 
       // Loop over each system
       for (const auto sys_i : index_range(_systems))


### PR DESCRIPTION
The multi-system iteration index print was added in https://github.com/idaholab/moose/pull/33274, but it should have only done this when doing more than one iteration. This fix avoids the printing of "Multi-system fixed point iteration 0:" at the beginning of almost every simulation.

Refs #33273
