### PR TITLE
Fix DiracKernel using residual_and_jacobian_together

### DIFF
--- a/framework/doc/content/source/systems/NonlinearSystem.md
+++ b/framework/doc/content/source/systems/NonlinearSystem.md
@@ -427,6 +427,11 @@ cost of an additional Jacobian evaluation during the final residual evaluation
 is amortized. Also, simulations in which material property calculations are very
 expensive may be good candidates for computing the residual and Jacobian together.
 
+Not all residual objects are supported when computing the residual and Jacobian
+together. Simulations containing `ScalarKernels`, `NodalKernels`, or nodal
+constraints will error, since their contributions are not yet computed in the
+combined evaluation path.
+
 ## Reusing preconditioners id=reuse_preconditioners
 
 The simple version of GMRES and other iterative methods converge only very

--- a/framework/include/dirackernels/DiracKernel.h
+++ b/framework/include/dirackernels/DiracKernel.h
@@ -47,6 +47,11 @@ public:
   virtual void computeJacobian() override;
 
   /**
+   * Computes the residual and Jacobian together for the current element.
+   */
+  virtual void computeResidualAndJacobian() override;
+
+  /**
    * This gets called by computeOffDiagJacobian() at each quadrature point.
    */
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);

--- a/framework/include/loops/ComputeDiracThread.h
+++ b/framework/include/loops/ComputeDiracThread.h
@@ -11,6 +11,7 @@
 
 // Moose Includes
 #include "ThreadedElementLoop.h"
+#include "MooseTypes.h"
 
 #include "libmesh/stored_range.h"
 
@@ -27,7 +28,10 @@ typedef StoredRange<std::set<const Elem *>::const_iterator, const Elem *> DistEl
 class ComputeDiracThread : public ThreadedElementLoop<DistElemRange>
 {
 public:
-  ComputeDiracThread(FEProblemBase & feproblem, const std::set<TagID> & tags, bool _is_jacobian);
+  ComputeDiracThread(FEProblemBase & feproblem,
+                     const std::set<TagID> & vector_tags,
+                     const std::set<TagID> & matrix_tags,
+                     Moose::ComputeType compute_type);
 
   // Splitting Constructor
   ComputeDiracThread(ComputeDiracThread & x, Threads::split);
@@ -49,10 +53,11 @@ protected:
   /// Output the order of execution of objects within the current subdomain
   void printBlockExecutionInformation() const override;
 
-  bool _is_jacobian;
+  Moose::ComputeType _compute_type;
   NonlinearSystemBase & _nl;
 
-  const std::set<TagID> & _tags;
+  const std::set<TagID> & _vector_tags;
+  const std::set<TagID> & _matrix_tags;
 
   /// Storage for DiracKernel objects
   MooseObjectTagWarehouse<DiracKernelBase> & _dirac_kernels;

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -830,7 +830,9 @@ protected:
   void computeKokkosJacobian(const std::set<TagID> & tags);
 #endif
 
-  void computeDiracContributions(const std::set<TagID> & tags, bool is_jacobian);
+  void computeDiracContributions(const std::set<TagID> & vector_tags,
+                                 const std::set<TagID> & matrix_tags,
+                                 Moose::ComputeType compute_type);
 
   void computeScalarKernelsJacobians(const std::set<TagID> & tags);
 

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -15,6 +15,7 @@
 #include "SystemBase.h"
 #include "Problem.h"
 #include "MooseMesh.h"
+#include "FEProblemBase.h"
 
 #include "libmesh/libmesh_common.h"
 #include "libmesh/quadrature.h"
@@ -143,6 +144,28 @@ DiracKernelTempl<T>::computeOffDiagJacobian(const unsigned int jvar_num)
     }
 
     accumulateTaggedLocalMatrix();
+  }
+}
+
+template <typename T>
+void
+DiracKernelTempl<T>::computeResidualAndJacobian()
+{
+  computeResidual();
+
+  const auto subdomain = _current_elem->subdomain_id();
+
+  for (const auto & [ivariable, jvariable] : _fe_problem.couplingEntries(_tid, _sys.number()))
+  {
+    const unsigned int ivar = ivariable->number();
+    const unsigned int jvar = jvariable->number();
+
+    if (ivar != _var.number() || !ivariable->activeOnSubdomain(subdomain) ||
+        !jvariable->activeOnSubdomain(subdomain) || jvariable->numberOfDofs() == 0)
+      continue;
+
+    prepareShapes(jvar);
+    computeOffDiagJacobian(jvar);
   }
 }
 

--- a/framework/src/loops/ComputeDiracThread.C
+++ b/framework/src/loops/ComputeDiracThread.C
@@ -21,12 +21,14 @@
 #include "libmesh/threads.h"
 
 ComputeDiracThread::ComputeDiracThread(FEProblemBase & feproblem,
-                                       const std::set<TagID> & tags,
-                                       bool is_jacobian)
+                                       const std::set<TagID> & vector_tags,
+                                       const std::set<TagID> & matrix_tags,
+                                       Moose::ComputeType compute_type)
   : ThreadedElementLoop<DistElemRange>(feproblem),
-    _is_jacobian(is_jacobian),
+    _compute_type(compute_type),
     _nl(feproblem.currentNonlinearSystem()),
-    _tags(tags),
+    _vector_tags(vector_tags),
+    _matrix_tags(matrix_tags),
     _dirac_kernels(_nl.getDiracKernelWarehouse())
 {
 }
@@ -34,9 +36,10 @@ ComputeDiracThread::ComputeDiracThread(FEProblemBase & feproblem,
 // Splitting Constructor
 ComputeDiracThread::ComputeDiracThread(ComputeDiracThread & x, Threads::split split)
   : ThreadedElementLoop<DistElemRange>(x, split),
-    _is_jacobian(x._is_jacobian),
+    _compute_type(x._compute_type),
     _nl(x._nl),
-    _tags(x._tags),
+    _vector_tags(x._vector_tags),
+    _matrix_tags(x._matrix_tags),
     _dirac_kernels(x._dirac_kernels)
 {
 }
@@ -66,19 +69,30 @@ ComputeDiracThread::subdomainChanged()
   _fe_problem.setActiveElementalMooseVariables(needed_moose_vars, _tid);
   _fe_problem.setActiveMaterialProperties(needed_mat_props, _tid);
 
+  // The combined path always operates on the full suite of residual and Jacobian tags, so there's
+  // no need for (and no single tag set to do) tag-based warehouse selection
+  if (_compute_type == Moose::ComputeType::ResidualAndJacobian)
+  {
+    _dirac_warehouse = &_dirac_kernels;
+    return;
+  }
+
+  const bool is_jacobian = _compute_type == Moose::ComputeType::Jacobian;
+  const std::set<TagID> & tags = is_jacobian ? _matrix_tags : _vector_tags;
+
   // If users pass a empty vector or a full size of vector,
   // we take all kernels
-  if (!_tags.size() || _tags.size() == _fe_problem.numMatrixTags())
+  if (!tags.size() || tags.size() == _fe_problem.numMatrixTags())
     _dirac_warehouse = &_dirac_kernels;
   // If we have one tag only,  We call tag based storage
-  else if (_tags.size() == 1)
-    _dirac_warehouse = _is_jacobian
-                           ? &(_dirac_kernels.getMatrixTagObjectWarehouse(*(_tags.begin()), _tid))
-                           : &(_dirac_kernels.getVectorTagObjectWarehouse(*(_tags.begin()), _tid));
+  else if (tags.size() == 1)
+    _dirac_warehouse = is_jacobian
+                           ? &(_dirac_kernels.getMatrixTagObjectWarehouse(*(tags.begin()), _tid))
+                           : &(_dirac_kernels.getVectorTagObjectWarehouse(*(tags.begin()), _tid));
   // This one may be expensive, and hopefully we do not use it so often
   else
-    _dirac_warehouse = _is_jacobian ? &(_dirac_kernels.getMatrixTagsObjectWarehouse(_tags, _tid))
-                                    : &(_dirac_kernels.getVectorTagsObjectWarehouse(_tags, _tid));
+    _dirac_warehouse = is_jacobian ? &(_dirac_kernels.getMatrixTagsObjectWarehouse(tags, _tid))
+                                   : &(_dirac_kernels.getVectorTagsObjectWarehouse(tags, _tid));
 }
 
 void
@@ -109,9 +123,15 @@ ComputeDiracThread::onElement(const Elem * elem)
   {
     if (!dirac_kernel->hasPointsOnElem(elem))
       continue;
-    else if (!_is_jacobian)
+
+    if (_compute_type == Moose::ComputeType::Residual)
     {
       dirac_kernel->computeResidual();
+      continue;
+    }
+    else if (_compute_type == Moose::ComputeType::ResidualAndJacobian)
+    {
+      dirac_kernel->computeResidualAndJacobian();
       continue;
     }
 
@@ -148,9 +168,9 @@ ComputeDiracThread::onElement(const Elem * elem)
 void
 ComputeDiracThread::postElement(const Elem * /*elem*/)
 {
-  if (!_is_jacobian)
+  if (_compute_type != Moose::ComputeType::Jacobian)
     _fe_problem.addResidual(_tid);
-  else
+  if (_compute_type != Moose::ComputeType::Residual)
     _fe_problem.addJacobian(_tid);
 }
 

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -1954,7 +1954,7 @@ NonlinearSystemBase::computeResidualInternal(const std::set<TagID> & tags)
     _residual_ghosted->close();
   }
 
-  PARALLEL_TRY { computeDiracContributions(tags, false); }
+  PARALLEL_TRY { computeDiracContributions(tags, {}, Moose::ComputeType::Residual); }
   PARALLEL_CATCH;
 
   if (_fe_problem._has_constraints)
@@ -1994,6 +1994,21 @@ NonlinearSystemBase::computeResidualAndJacobianInternal(const std::set<TagID> & 
                                                         const std::set<TagID> & matrix_tags)
 {
   TIME_SECTION("computeResidualAndJacobianInternal", 3);
+
+  // These residual objects are only computed in the separate residual/Jacobian paths. Erroring
+  // here prevents them from being silently dropped, which would produce wrong answers
+  if (_scalar_kernels.hasActiveObjects())
+    mooseError("residual_and_jacobian_together does not yet support ScalarKernels. Their "
+               "contributions would be silently dropped. Please use "
+               "residual_and_jacobian_together = false");
+  if (_nodal_kernels.hasActiveBlockObjects() || _nodal_kernels.hasActiveBoundaryObjects())
+    mooseError("residual_and_jacobian_together does not yet support NodalKernels. Their "
+               "contributions would be silently dropped. Please use "
+               "residual_and_jacobian_together = false");
+  if (_constraints.hasActiveNodalConstraints())
+    mooseError("residual_and_jacobian_together does not yet support nodal constraints. Their "
+               "contributions would be silently dropped. Please use "
+               "residual_and_jacobian_together = false");
 
   // Make matrix ready to use
   activateAllMatrixTags();
@@ -2085,6 +2100,13 @@ NonlinearSystemBase::computeResidualAndJacobianInternal(const std::set<TagID> & 
       _fe_problem.addCachedResidual(i);
       _fe_problem.addCachedJacobian(i);
     }
+  }
+  PARALLEL_CATCH;
+
+  // residual and Jacobian contributions from DiracKernels, computed together in a single pass
+  PARALLEL_TRY
+  {
+    computeDiracContributions(vector_tags, matrix_tags, Moose::ComputeType::ResidualAndJacobian);
   }
   PARALLEL_CATCH;
 }
@@ -3168,7 +3190,7 @@ NonlinearSystemBase::computeJacobianInternal(const std::set<TagID> & tags)
       break;
     }
 
-    computeDiracContributions(tags, true);
+    computeDiracContributions({}, tags, Moose::ComputeType::Jacobian);
 
     static bool first = true;
 
@@ -3509,7 +3531,9 @@ NonlinearSystemBase::computeDamping(const NumericVector<Number> & solution,
 }
 
 void
-NonlinearSystemBase::computeDiracContributions(const std::set<TagID> & tags, bool is_jacobian)
+NonlinearSystemBase::computeDiracContributions(const std::set<TagID> & vector_tags,
+                                               const std::set<TagID> & matrix_tags,
+                                               const Moose::ComputeType compute_type)
 {
   _fe_problem.clearDiracInfo();
 
@@ -3530,7 +3554,7 @@ NonlinearSystemBase::computeDiracContributions(const std::set<TagID> & tags, boo
       }
     }
 
-    ComputeDiracThread cd(_fe_problem, tags, is_jacobian);
+    ComputeDiracThread cd(_fe_problem, vector_tags, matrix_tags, compute_type);
 
     _fe_problem.getDiracElements(dirac_elements);
 
@@ -3540,7 +3564,13 @@ NonlinearSystemBase::computeDiracContributions(const std::set<TagID> & tags, boo
 
     cd(range);
 
-    if (is_jacobian)
+    // AD DiracKernels computing the residual and Jacobian together cache their residual
+    // contributions (via addResidualsAndJacobian), so those must be flushed too
+    if (compute_type != Moose::ComputeType::Jacobian)
+      for (const auto tid : make_range(libMesh::n_threads()))
+        _fe_problem.addCachedResidual(tid);
+
+    if (compute_type != Moose::ComputeType::Residual)
       for (const auto tid : make_range(libMesh::n_threads()))
         _fe_problem.addCachedJacobian(tid);
   }

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -1925,7 +1925,7 @@ NonlinearSystemBase::computeResidualInternal(const std::set<TagID> & tags)
     _residual_ghosted->close();
   }
 
-  PARALLEL_TRY { computeDiracContributions(tags, false); }
+  PARALLEL_TRY { computeDiracContributions(tags, {}, Moose::ComputeType::Residual); }
   PARALLEL_CATCH;
 
   if (_fe_problem._has_constraints)
@@ -1965,6 +1965,21 @@ NonlinearSystemBase::computeResidualAndJacobianInternal(const std::set<TagID> & 
                                                         const std::set<TagID> & matrix_tags)
 {
   TIME_SECTION("computeResidualAndJacobianInternal", 3);
+
+  // These residual objects are only computed in the separate residual/Jacobian paths. Erroring
+  // here prevents them from being silently dropped, which would produce wrong answers
+  if (_scalar_kernels.hasActiveObjects())
+    mooseError("residual_and_jacobian_together does not yet support ScalarKernels. Their "
+               "contributions would be silently dropped. Please use "
+               "residual_and_jacobian_together = false");
+  if (_nodal_kernels.hasActiveBlockObjects() || _nodal_kernels.hasActiveBoundaryObjects())
+    mooseError("residual_and_jacobian_together does not yet support NodalKernels. Their "
+               "contributions would be silently dropped. Please use "
+               "residual_and_jacobian_together = false");
+  if (_constraints.hasActiveNodalConstraints())
+    mooseError("residual_and_jacobian_together does not yet support nodal constraints. Their "
+               "contributions would be silently dropped. Please use "
+               "residual_and_jacobian_together = false");
 
   // Make matrix ready to use
   activateAllMatrixTags();
@@ -2056,6 +2071,13 @@ NonlinearSystemBase::computeResidualAndJacobianInternal(const std::set<TagID> & 
       _fe_problem.addCachedResidual(i);
       _fe_problem.addCachedJacobian(i);
     }
+  }
+  PARALLEL_CATCH;
+
+  // residual and Jacobian contributions from DiracKernels, computed together in a single pass
+  PARALLEL_TRY
+  {
+    computeDiracContributions(vector_tags, matrix_tags, Moose::ComputeType::ResidualAndJacobian);
   }
   PARALLEL_CATCH;
 }
@@ -3154,7 +3176,7 @@ NonlinearSystemBase::computeJacobianInternal(const std::set<TagID> & tags)
       break;
     }
 
-    computeDiracContributions(tags, true);
+    computeDiracContributions({}, tags, Moose::ComputeType::Jacobian);
 
     static bool first = true;
 
@@ -3495,7 +3517,9 @@ NonlinearSystemBase::computeDamping(const NumericVector<Number> & solution,
 }
 
 void
-NonlinearSystemBase::computeDiracContributions(const std::set<TagID> & tags, bool is_jacobian)
+NonlinearSystemBase::computeDiracContributions(const std::set<TagID> & vector_tags,
+                                               const std::set<TagID> & matrix_tags,
+                                               const Moose::ComputeType compute_type)
 {
   _fe_problem.clearDiracInfo();
 
@@ -3516,7 +3540,7 @@ NonlinearSystemBase::computeDiracContributions(const std::set<TagID> & tags, boo
       }
     }
 
-    ComputeDiracThread cd(_fe_problem, tags, is_jacobian);
+    ComputeDiracThread cd(_fe_problem, vector_tags, matrix_tags, compute_type);
 
     _fe_problem.getDiracElements(dirac_elements);
 
@@ -3526,7 +3550,13 @@ NonlinearSystemBase::computeDiracContributions(const std::set<TagID> & tags, boo
 
     cd(range);
 
-    if (is_jacobian)
+    // AD DiracKernels computing the residual and Jacobian together cache their residual
+    // contributions (via addResidualsAndJacobian), so those must be flushed too
+    if (compute_type != Moose::ComputeType::Jacobian)
+      for (const auto tid : make_range(libMesh::n_threads()))
+        _fe_problem.addCachedResidual(tid);
+
+    if (compute_type != Moose::ComputeType::Residual)
       for (const auto tid : make_range(libMesh::n_threads()))
         _fe_problem.addCachedJacobian(tid);
   }

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -1969,17 +1969,24 @@ NonlinearSystemBase::computeResidualAndJacobianInternal(const std::set<TagID> & 
   // These residual objects are only computed in the separate residual/Jacobian paths. Erroring
   // here prevents them from being silently dropped, which would produce wrong answers
   if (_scalar_kernels.hasActiveObjects())
-    mooseError("residual_and_jacobian_together does not yet support ScalarKernels. Their "
-               "contributions would be silently dropped. Please use "
-               "residual_and_jacobian_together = false");
+    mooseDocumentedError("moose",
+                         33531,
+                         "residual_and_jacobian_together does not yet support ScalarKernels. Their "
+                         "contributions would be silently dropped. Please use "
+                         "residual_and_jacobian_together = false");
   if (_nodal_kernels.hasActiveBlockObjects() || _nodal_kernels.hasActiveBoundaryObjects())
-    mooseError("residual_and_jacobian_together does not yet support NodalKernels. Their "
-               "contributions would be silently dropped. Please use "
-               "residual_and_jacobian_together = false");
+    mooseDocumentedError("moose",
+                         33531,
+                         "residual_and_jacobian_together does not yet support NodalKernels. Their "
+                         "contributions would be silently dropped. Please use "
+                         "residual_and_jacobian_together = false");
   if (_constraints.hasActiveNodalConstraints())
-    mooseError("residual_and_jacobian_together does not yet support nodal constraints. Their "
-               "contributions would be silently dropped. Please use "
-               "residual_and_jacobian_together = false");
+    mooseDocumentedError(
+        "moose",
+        33531,
+        "residual_and_jacobian_together does not yet support nodal constraints. Their "
+        "contributions would be silently dropped. Please use "
+        "residual_and_jacobian_together = false");
 
   // Make matrix ready to use
   activateAllMatrixTags();

--- a/test/tests/constraints/nodal_constraint/residual_and_jacobian_together/nodal_constraint_test.i
+++ b/test/tests/constraints/nodal_constraint/residual_and_jacobian_together/nodal_constraint_test.i
@@ -1,0 +1,1 @@
+../nodal_constraint_test.i

--- a/test/tests/constraints/nodal_constraint/residual_and_jacobian_together/tests
+++ b/test/tests/constraints/nodal_constraint/residual_and_jacobian_together/tests
@@ -1,0 +1,12 @@
+[Tests]
+  design = 'Constraints/index.md NonlinearSystem.md'
+  issues = '#33531'
+
+  [error]
+    type = 'RunException'
+    input = 'nodal_constraint_test.i'
+    cli_args = 'Executioner/residual_and_jacobian_together=true Mesh/file=../2-lines.e'
+    requirement = "The system shall return an error if attempting to compute residual and jacobian together with nodal constraints that currently do not support this functionality."
+    expect_err = "residual_and_jacobian_together does not yet support nodal constraints"
+  []
+[]

--- a/test/tests/dirackernels/constant_point_source/tests
+++ b/test/tests/dirackernels/constant_point_source/tests
@@ -47,5 +47,14 @@
       exodiff = 'vector_3d_out.e'
       detail = 'with vector variables in 3D'
     []
+    [2D_resid_and_jac_together]
+      type = 'Exodiff'
+      input = '2d_point_source.i'
+      exodiff = '2d_out.e'
+      cli_args = 'Executioner/solve_type=NEWTON Executioner/residual_and_jacobian_together=true'
+      prereq = 'dim/2D'
+      issues = '#26938'
+      detail = 'in 2D when computing the residual and Jacobian together'
+    []
   []
 []

--- a/test/tests/dirackernels/constant_point_source/tests
+++ b/test/tests/dirackernels/constant_point_source/tests
@@ -1,5 +1,5 @@
 [Tests]
-  issues = '#1695 #1696 #16033 #23442'
+  issues = '#1695 #1696 #16033 #23442 #26938'
   design = 'syntax/DiracKernels/index.md'
 
   [dim]
@@ -53,7 +53,6 @@
       exodiff = '2d_out.e'
       cli_args = 'Executioner/solve_type=NEWTON Executioner/residual_and_jacobian_together=true'
       prereq = 'dim/2D'
-      issues = '#26938'
       detail = 'in 2D when computing the residual and Jacobian together'
     []
   []

--- a/test/tests/dirackernels/functor_dirac_kernel/tests
+++ b/test/tests/dirackernels/functor_dirac_kernel/tests
@@ -15,4 +15,14 @@
     requirement = "The system shall compute the correct Jacobian for the functor dirac kernel."
     capabilities = 'method=opt'
   []
+  [resid_and_jac_together]
+    type = CSVDiff
+    input = 'functor_dirac_kernel.i'
+    csvdiff = 'functor_dirac_kernel_out.csv'
+    cli_args = 'Executioner/residual_and_jacobian_together=true'
+    prereq = 'test'
+    issues = '#26938'
+    requirement = "The system shall produce the same result for a dirac kernel specified using a "
+                  "functor when computing the residual and Jacobian together."
+  []
 []

--- a/test/tests/dirackernels/nonlinear_source/tests
+++ b/test/tests/dirackernels/nonlinear_source/tests
@@ -7,4 +7,13 @@
     exodiff = 'nonlinear_source_out.e'
     requirement = "The system shall support the computation of off diagonal Jacobian terms for residual terms defined with a Dirac delta function."
   [../]
+  [./resid_and_jac_together]
+    type = 'Exodiff'
+    input = 'nonlinear_source.i'
+    exodiff = 'nonlinear_source_out.e'
+    cli_args = 'Executioner/residual_and_jacobian_together=true'
+    prereq = 'nonlinear_source'
+    issues = '#26938'
+    requirement = "The system shall produce the same result for the off diagonal Jacobian terms of a Dirac delta function residual when computing the residual and Jacobian together."
+  [../]
 []

--- a/test/tests/nodalkernels/residual_and_jacobian_together/constant_rate.i
+++ b/test/tests/nodalkernels/residual_and_jacobian_together/constant_rate.i
@@ -1,0 +1,1 @@
+../constant_rate/constant_rate.i

--- a/test/tests/nodalkernels/residual_and_jacobian_together/tests
+++ b/test/tests/nodalkernels/residual_and_jacobian_together/tests
@@ -1,0 +1,12 @@
+[Tests]
+  design = 'NodalKernels/index.md NonlinearSystem.md'
+  issues = '#33531'
+
+  [error]
+    type = 'RunException'
+    input = 'constant_rate.i'
+    cli_args = 'Executioner/residual_and_jacobian_together=true'
+    requirement = "The system shall return an error if attempting to compute residual and jacobian together with nodal kernels that currently do not support this functionality."
+    expect_err = "residual_and_jacobian_together does not yet support NodalKernels"
+  []
+[]

--- a/test/tests/scalar_kernels/residual_and_jacobian_together/ad_scalar_kernel.i
+++ b/test/tests/scalar_kernels/residual_and_jacobian_together/ad_scalar_kernel.i
@@ -1,0 +1,1 @@
+../ad_scalar_kernel/ad_scalar_kernel.i

--- a/test/tests/scalar_kernels/residual_and_jacobian_together/tests
+++ b/test/tests/scalar_kernels/residual_and_jacobian_together/tests
@@ -1,0 +1,14 @@
+[Tests]
+  design = 'ScalarKernels/index.md NonlinearSystem.md'
+  issues = '#33531'
+
+  [error]
+    type = 'RunException'
+    input = 'ad_scalar_kernel.i'
+    cli_args = 'Executioner/residual_and_jacobian_together=true'
+    # uses a test object that cannot be used in parallel
+    max_parallel = 1
+    requirement = "The system shall return an error if attempting to compute residual and jacobian together with scalar kernels that currently do not support this functionality."
+    expect_err = "residual_and_jacobian_together does not yet support ScalarKernels"
+  []
+[]


### PR DESCRIPTION
Previously, using a DiracKernel with `residual_and_jacobian_together = true` silently dropped its residual contribution, so nothing happened. Now, the DiracKernel actually adds to the residual and Jacobian when this flag is set true.

Turns out ADDiracKernel also didn't work in this case despite having a combined `addResidaulAndJacobian` method. The contribution was routed through `addCachedResidual` which `ComputeDiracThread` never calls - again the Dirac contribution was silently dropped.

I had claude check this, and it suggested that scalar kernels, nodal kernels and nodal constraints are all silently dropped when `residual_and_jacobian_together = true` so I throw an error saying not to use it in these cases.

Fixes #26938 