### PR TITLE
Respected nonlinear convergence parameters in multi-system case

### DIFF
--- a/framework/include/convergence/Convergence.h
+++ b/framework/include/convergence/Convergence.h
@@ -55,7 +55,7 @@ public:
   /**
    * Method that gets called in each iteration before the solve
    */
-  virtual void preExecute() {}
+  virtual void preSolve() {}
 
   /**
    * Returns convergence status.

--- a/framework/include/convergence/DefaultMultiAppFixedPointConvergence.h
+++ b/framework/include/convergence/DefaultMultiAppFixedPointConvergence.h
@@ -26,7 +26,7 @@ public:
 
   virtual void checkIterationType(IterationType it_type) const override;
   virtual void initialize() override;
-  virtual void preExecute() override;
+  virtual void preSolve() override;
 
   virtual MooseConvergenceStatus checkConvergence(unsigned int n_iter) override;
 

--- a/framework/include/convergence/DefaultNonlinearConvergence.h
+++ b/framework/include/convergence/DefaultNonlinearConvergence.h
@@ -31,6 +31,13 @@ public:
   virtual void preSolve() override;
   virtual MooseConvergenceStatus checkConvergence(unsigned int n_iter) override;
 
+  /// Modifies the maximum nonlinear iterations
+  void modifyMaximumIterations(const unsigned int max_iter);
+  /// Modifies the absolute nonlinear tolerance
+  void modifyAbsoluteTolerance(const Real abs_tol);
+  /// Modifies the relative nonlinear tolerance
+  void modifyRelativeTolerance(const Real rel_tol);
+
 protected:
   /// Sets the nonlinear system parameters, such as tolerances
   void setNonlinearSystemParameters();
@@ -61,9 +68,9 @@ protected:
   virtual void nonlinearConvergenceSetup() {}
 
   FEProblemBase & _fe_problem;
-  /// Nonlinear absolute tolerance
+  /// Nonlinear absolute tolerance retrieved from SNES
   PetscReal _abs_tol;
-  /// Nonlinear relative tolerance
+  /// Nonlinear relative tolerance retrieved from SNES
   PetscReal _rel_tol;
   /// Nonlinear absolute divergence tolerance
   const Real _nl_abs_div_tol;
@@ -77,4 +84,12 @@ protected:
   const unsigned int _nl_max_pingpong;
   /// Current number of nonlinear ping-pong iterations for the current solve
   unsigned int _nl_current_pingpong;
+
+private:
+  /// Nonlinear maximum nonlinear iterations (modifiable by modifyMaximumIterations)
+  unsigned int _nl_max_its;
+  /// Nonlinear absolute tolerance (modifiable by modifyAbsoluteTolerance)
+  Real _nl_abs_tol;
+  /// Nonlinear relative tolerance (modifiable by modifyRelativeTolerance)
+  Real _nl_rel_tol;
 };

--- a/framework/include/convergence/DefaultNonlinearConvergence.h
+++ b/framework/include/convergence/DefaultNonlinearConvergence.h
@@ -68,10 +68,6 @@ protected:
   virtual void nonlinearConvergenceSetup() {}
 
   FEProblemBase & _fe_problem;
-  /// Nonlinear absolute tolerance retrieved from SNES
-  PetscReal _abs_tol;
-  /// Nonlinear relative tolerance retrieved from SNES
-  PetscReal _rel_tol;
   /// Nonlinear absolute divergence tolerance
   const Real _nl_abs_div_tol;
   /// Nonlinear relative divergence tolerance

--- a/framework/include/convergence/DefaultNonlinearConvergence.h
+++ b/framework/include/convergence/DefaultNonlinearConvergence.h
@@ -31,12 +31,12 @@ public:
   virtual void preSolve() override;
   virtual MooseConvergenceStatus checkConvergence(unsigned int n_iter) override;
 
-  /// Modifies the maximum nonlinear iterations
-  void modifyMaximumIterations(const unsigned int max_iter);
-  /// Modifies the absolute nonlinear tolerance
-  void modifyAbsoluteTolerance(const Real abs_tol);
-  /// Modifies the relative nonlinear tolerance
-  void modifyRelativeTolerance(const Real rel_tol);
+  /// Sets the maximum nonlinear iterations
+  void setMaximumIterations(const unsigned int max_iter);
+  /// Sets the absolute nonlinear tolerance
+  void setAbsoluteTolerance(const Real abs_tol);
+  /// Sets the relative nonlinear tolerance
+  void setRelativeTolerance(const Real rel_tol);
 
 protected:
   /// Sets the nonlinear system parameters, such as tolerances
@@ -82,10 +82,10 @@ protected:
   unsigned int _nl_current_pingpong;
 
 private:
-  /// Nonlinear maximum nonlinear iterations (modifiable by modifyMaximumIterations)
+  /// Nonlinear maximum nonlinear iterations (modifiable by setMaximumIterations)
   unsigned int _nl_max_its;
-  /// Nonlinear absolute tolerance (modifiable by modifyAbsoluteTolerance)
+  /// Nonlinear absolute tolerance (modifiable by setAbsoluteTolerance)
   Real _nl_abs_tol;
-  /// Nonlinear relative tolerance (modifiable by modifyRelativeTolerance)
+  /// Nonlinear relative tolerance (modifiable by setRelativeTolerance)
   Real _nl_rel_tol;
 };

--- a/framework/include/convergence/DefaultNonlinearConvergence.h
+++ b/framework/include/convergence/DefaultNonlinearConvergence.h
@@ -26,11 +26,15 @@ public:
 
   DefaultNonlinearConvergence(const InputParameters & parameters);
 
+  virtual void initialSetup() override;
   virtual void checkIterationType(IterationType it_type) const override;
-
+  virtual void preSolve() override;
   virtual MooseConvergenceStatus checkConvergence(unsigned int n_iter) override;
 
 protected:
+  /// Sets the nonlinear system parameters, such as tolerances
+  void setNonlinearSystemParameters();
+
   /**
    * Nonlinear system whose convergence state should be checked.
    */

--- a/framework/include/executioners/EigenExecutionerBase.h
+++ b/framework/include/executioners/EigenExecutionerBase.h
@@ -13,6 +13,7 @@
 
 class MooseEigenSystem;
 class FEProblemBase;
+class DefaultNonlinearConvergence;
 
 /**
  * This class provides reusable routines for eigenvalue executioners.
@@ -122,9 +123,15 @@ protected:
    */
   virtual void printEigenvalue();
 
+  /// Gets the Convergence object for \c _eigen_sys and checks it's the right type
+  DefaultNonlinearConvergence * getEigenSystemConvergence();
+
   // the fe problem
   FEProblemBase & _problem;
   MooseEigenSystem & _eigen_sys;
+
+  /// Convergence object corresponding to \c _eigen_sys
+  DefaultNonlinearConvergence * _eigen_sys_conv;
 
   /// dummy solve object for properly setting PETSc options
   FEProblemSolve _feproblem_solve;

--- a/framework/include/executioners/EigenExecutionerBase.h
+++ b/framework/include/executioners/EigenExecutionerBase.h
@@ -130,9 +130,6 @@ protected:
   FEProblemBase & _problem;
   MooseEigenSystem & _eigen_sys;
 
-  /// Convergence object corresponding to \c _eigen_sys
-  DefaultNonlinearConvergence * _eigen_sys_conv;
-
   /// dummy solve object for properly setting PETSc options
   FEProblemSolve _feproblem_solve;
 
@@ -170,4 +167,8 @@ protected:
   void chebyshev(Chebyshev_Parameters & params,
                  unsigned int iter,
                  const PostprocessorValue * solution_diff);
+
+private:
+  /// Convergence object corresponding to \c _eigen_sys
+  DefaultNonlinearConvergence * _eigen_sys_conv;
 };

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -47,6 +47,7 @@ class BoundaryCondition;
 class ResidualObject;
 class PenetrationInfo;
 class FieldSplitPreconditionerBase;
+class Convergence;
 
 // libMesh forward declarations
 namespace libMesh
@@ -773,6 +774,15 @@ public:
    */
   void destroyColoring();
 
+  /// Sets the name of the associated Convergence object
+  void setConvergenceName(const ConvergenceName & convergence_name)
+  {
+    _convergence_name = convergence_name;
+  }
+
+  /// Retrieves the associated Convergence object
+  Convergence & convergence();
+
 protected:
   /**
    * Compute the residual for a given tag
@@ -1110,4 +1120,7 @@ private:
 
   /// The number of scaling groups
   std::size_t _num_scaling_groups;
+
+  /// Associated convergence object name
+  ConvergenceName _convergence_name;
 };

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -47,6 +47,7 @@ class BoundaryCondition;
 class ResidualObject;
 class PenetrationInfo;
 class FieldSplitPreconditionerBase;
+class Convergence;
 
 // libMesh forward declarations
 namespace libMesh
@@ -773,6 +774,15 @@ public:
    */
   void destroyColoring();
 
+  /// Sets the name of the associated Convergence object
+  void setConvergenceName(const ConvergenceName & convergence_name)
+  {
+    _convergence_name = convergence_name;
+  }
+
+  /// Retrieves the associated Convergence object
+  Convergence & convergence();
+
 protected:
   /**
    * Compute the residual for a given tag
@@ -1118,4 +1128,7 @@ private:
 
   /// The number of scaling groups
   std::size_t _num_scaling_groups;
+
+  /// Associated convergence object name
+  ConvergenceName _convergence_name;
 };

--- a/framework/src/convergence/DefaultMultiAppFixedPointConvergence.C
+++ b/framework/src/convergence/DefaultMultiAppFixedPointConvergence.C
@@ -109,9 +109,9 @@ DefaultMultiAppFixedPointConvergence::initialize()
 }
 
 void
-DefaultMultiAppFixedPointConvergence::preExecute()
+DefaultMultiAppFixedPointConvergence::preSolve()
 {
-  DefaultConvergenceBase::preExecute();
+  DefaultConvergenceBase::preSolve();
 
   // compute TIMESTEP_BEGIN residual norm; this should be executed after TIMESTEP_BEGIN
   // but before the solve

--- a/framework/src/convergence/DefaultNonlinearConvergence.C
+++ b/framework/src/convergence/DefaultNonlinearConvergence.C
@@ -157,11 +157,11 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int n_iter)
   LibmeshPetscCallA(_fe_problem.comm().get(), SNESGetNumberFunctionEvals(snes, &nfuncs));
 
   // Get tolerances from SNES
-  PetscReal rel_step_tol;
+  PetscReal abs_tol, rel_tol, rel_step_tol;
   PetscInt max_its, max_funcs;
   LibmeshPetscCallA(
       _fe_problem.comm().get(),
-      SNESGetTolerances(snes, &_abs_tol, &_rel_tol, &rel_step_tol, &max_its, &max_funcs));
+      SNESGetTolerances(snes, &abs_tol, &rel_tol, &rel_step_tol, &max_its, &max_funcs));
 
 #if !PETSC_VERSION_LESS_THAN(3, 8, 4)
   PetscBool force_iteration = PETSC_FALSE;
@@ -227,7 +227,7 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int n_iter)
     oss << "Failed to converge, residual norm is NaN\n";
     status = MooseConvergenceStatus::DIVERGED;
   }
-  else if (checkResidualConvergence(n_iter, fnorm, ref_residual, _rel_tol, _abs_tol, oss))
+  else if (checkResidualConvergence(n_iter, fnorm, ref_residual, rel_tol, abs_tol, oss))
     status = MooseConvergenceStatus::CONVERGED;
   else if (nfuncs >= max_funcs)
   {

--- a/framework/src/convergence/DefaultNonlinearConvergence.C
+++ b/framework/src/convergence/DefaultNonlinearConvergence.C
@@ -14,7 +14,7 @@
 #include "NonlinearSystemBase.h"
 #include "ConvergenceIterationTypes.h"
 
-#include "libmesh/equation_systems.h"
+#include "libmesh/system.h"
 
 // PETSc includes
 #include <petsc.h>
@@ -46,22 +46,19 @@ DefaultNonlinearConvergence::DefaultNonlinearConvergence(const InputParameters &
     _nl_max_pingpong(getSharedExecutionerParam<unsigned int>("n_max_nonlinear_pingpong")),
     _nl_current_pingpong(0)
 {
-  EquationSystems & es = _fe_problem.es();
+}
 
-  es.parameters.set<unsigned int>("nonlinear solver maximum iterations") =
-      getSharedExecutionerParam<unsigned int>("nl_max_its");
-  es.parameters.set<unsigned int>("nonlinear solver maximum function evaluations") =
-      getSharedExecutionerParam<unsigned int>("nl_max_funcs");
-  es.parameters.set<Real>("nonlinear solver absolute residual tolerance") =
-      getSharedExecutionerParam<Real>("nl_abs_tol");
-  es.parameters.set<Real>("nonlinear solver relative residual tolerance") =
-      getSharedExecutionerParam<Real>("nl_rel_tol");
-  es.parameters.set<Real>("nonlinear solver divergence tolerance") =
-      getSharedExecutionerParam<Real>("nl_div_tol");
-  es.parameters.set<Real>("nonlinear solver absolute step tolerance") =
-      getSharedExecutionerParam<Real>("nl_abs_step_tol");
-  es.parameters.set<Real>("nonlinear solver relative step tolerance") =
-      getSharedExecutionerParam<Real>("nl_rel_step_tol");
+void
+DefaultNonlinearConvergence::initialSetup()
+{
+  DefaultConvergenceBase::initialSetup();
+
+  // This method is also called in preSolve(), which will overwrite the parameters set here.
+  // It needs to be called here to collect the names of any duplicate parameters for the
+  // checkDuplicateSetSharedExecutionerParams() check. It needs to be called in preSolve()
+  // because it needs to know the current nonlinear system; Convergence objects do not know
+  // their "associated" nonlinear system (and they could in fact have multiple).
+  setNonlinearSystemParameters();
 }
 
 void
@@ -71,6 +68,36 @@ DefaultNonlinearConvergence::checkIterationType(IterationType it_type) const
 
   if (it_type != ConvergenceIterationTypes::NONLINEAR)
     mooseError("DefaultNonlinearConvergence can only be used with nonlinear solves.");
+}
+
+void
+DefaultNonlinearConvergence::preSolve()
+{
+  DefaultConvergenceBase::preSolve();
+
+  setNonlinearSystemParameters();
+}
+
+void
+DefaultNonlinearConvergence::setNonlinearSystemParameters()
+{
+  NonlinearSystemBase & nl_sys = _fe_problem.currentNonlinearSystem();
+
+  auto & params = nl_sys.system().parameters;
+  params.set<unsigned int>("nonlinear solver maximum iterations") =
+      getSharedExecutionerParam<unsigned int>("nl_max_its");
+  params.set<unsigned int>("nonlinear solver maximum function evaluations") =
+      getSharedExecutionerParam<unsigned int>("nl_max_funcs");
+  params.set<Real>("nonlinear solver absolute residual tolerance") =
+      getSharedExecutionerParam<Real>("nl_abs_tol");
+  params.set<Real>("nonlinear solver relative residual tolerance") =
+      getSharedExecutionerParam<Real>("nl_rel_tol");
+  params.set<Real>("nonlinear solver divergence tolerance") =
+      getSharedExecutionerParam<Real>("nl_div_tol");
+  params.set<Real>("nonlinear solver absolute step tolerance") =
+      getSharedExecutionerParam<Real>("nl_abs_step_tol");
+  params.set<Real>("nonlinear solver relative step tolerance") =
+      getSharedExecutionerParam<Real>("nl_rel_step_tol");
 }
 
 NonlinearSystemBase &

--- a/framework/src/convergence/DefaultNonlinearConvergence.C
+++ b/framework/src/convergence/DefaultNonlinearConvergence.C
@@ -285,19 +285,19 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int n_iter)
 }
 
 void
-DefaultNonlinearConvergence::modifyMaximumIterations(const unsigned int max_iter)
+DefaultNonlinearConvergence::setMaximumIterations(const unsigned int max_iter)
 {
   _nl_max_its = max_iter;
 }
 
 void
-DefaultNonlinearConvergence::modifyAbsoluteTolerance(const Real abs_tol)
+DefaultNonlinearConvergence::setAbsoluteTolerance(const Real abs_tol)
 {
   _nl_abs_tol = abs_tol;
 }
 
 void
-DefaultNonlinearConvergence::modifyRelativeTolerance(const Real rel_tol)
+DefaultNonlinearConvergence::setRelativeTolerance(const Real rel_tol)
 {
   _nl_rel_tol = rel_tol;
 }

--- a/framework/src/convergence/DefaultNonlinearConvergence.C
+++ b/framework/src/convergence/DefaultNonlinearConvergence.C
@@ -44,7 +44,10 @@ DefaultNonlinearConvergence::DefaultNonlinearConvergence(const InputParameters &
     _div_threshold(std::numeric_limits<Real>::max()),
     _nl_forced_its(getSharedExecutionerParam<unsigned int>("nl_forced_its")),
     _nl_max_pingpong(getSharedExecutionerParam<unsigned int>("n_max_nonlinear_pingpong")),
-    _nl_current_pingpong(0)
+    _nl_current_pingpong(0),
+    _nl_max_its(getSharedExecutionerParam<unsigned int>("nl_max_its")),
+    _nl_abs_tol(getSharedExecutionerParam<Real>("nl_abs_tol")),
+    _nl_rel_tol(getSharedExecutionerParam<Real>("nl_rel_tol"))
 {
 }
 
@@ -84,14 +87,11 @@ DefaultNonlinearConvergence::setNonlinearSystemParameters()
   NonlinearSystemBase & nl_sys = _fe_problem.currentNonlinearSystem();
 
   auto & params = nl_sys.system().parameters;
-  params.set<unsigned int>("nonlinear solver maximum iterations") =
-      getSharedExecutionerParam<unsigned int>("nl_max_its");
+  params.set<unsigned int>("nonlinear solver maximum iterations") = _nl_max_its;
   params.set<unsigned int>("nonlinear solver maximum function evaluations") =
       getSharedExecutionerParam<unsigned int>("nl_max_funcs");
-  params.set<Real>("nonlinear solver absolute residual tolerance") =
-      getSharedExecutionerParam<Real>("nl_abs_tol");
-  params.set<Real>("nonlinear solver relative residual tolerance") =
-      getSharedExecutionerParam<Real>("nl_rel_tol");
+  params.set<Real>("nonlinear solver absolute residual tolerance") = _nl_abs_tol;
+  params.set<Real>("nonlinear solver relative residual tolerance") = _nl_rel_tol;
   params.set<Real>("nonlinear solver divergence tolerance") =
       getSharedExecutionerParam<Real>("nl_div_tol");
   params.set<Real>("nonlinear solver absolute step tolerance") =
@@ -282,4 +282,22 @@ DefaultNonlinearConvergence::checkConvergence(unsigned int n_iter)
   verboseOutput(oss);
 
   return status;
+}
+
+void
+DefaultNonlinearConvergence::modifyMaximumIterations(const unsigned int max_iter)
+{
+  _nl_max_its = max_iter;
+}
+
+void
+DefaultNonlinearConvergence::modifyAbsoluteTolerance(const Real abs_tol)
+{
+  _nl_abs_tol = abs_tol;
+}
+
+void
+DefaultNonlinearConvergence::modifyRelativeTolerance(const Real rel_tol)
+{
+  _nl_rel_tol = rel_tol;
 }

--- a/framework/src/convergence/ReferenceResidualConvergence.C
+++ b/framework/src/convergence/ReferenceResidualConvergence.C
@@ -377,19 +377,28 @@ ReferenceResidualConvergence::nonlinearConvergenceSetup()
       if (_group_names[i].size() > var_space)
         var_space = _group_names[i].size();
 
+    // Get tolerances from SNES
+    NonlinearSystemBase & system = nonlinearSystem();
+    SNES snes = system.getSNES();
+    PetscReal abs_tol, rel_tol, rel_step_tol;
+    PetscInt max_its, max_funcs;
+    LibmeshPetscCallA(
+        _fe_problem.comm().get(),
+        SNESGetTolerances(snes, &abs_tol, &rel_tol, &rel_step_tol, &max_its, &max_funcs));
+
     for (const auto i : index_range(_group_names))
     {
       if (_converge_on_group[i])
       {
         // Print residual
         out << "   " << std::setw(var_space + 8) << std::right << _group_names[i] + "-> res: "
-            << (_group_resid[i] < _abs_tol ? COLOR_YELLOW : COLOR_DEFAULT) << std::setw(8)
+            << (_group_resid[i] < abs_tol ? COLOR_YELLOW : COLOR_DEFAULT) << std::setw(8)
             << _group_resid[i] << COLOR_DEFAULT;
 
         // Print res/ref ratio
         if (_local_norm)
           out << "  local res/ref: "
-              << (_group_resid[i] / _group_ref_resid[i] < _rel_tol ? COLOR_GREEN : COLOR_DEFAULT)
+              << (_group_resid[i] / _group_ref_resid[i] < rel_tol ? COLOR_GREEN : COLOR_DEFAULT)
               << std::setw(8) << _group_ref_resid[i] << COLOR_DEFAULT << "\n";
         else
         {
@@ -399,7 +408,7 @@ ReferenceResidualConvergence::nonlinearConvergenceSetup()
           if (!_group_ref_resid[i])
             out << _group_resid[i] << "\n";
           else
-            out << (_group_resid[i] / _group_ref_resid[i] < _rel_tol ? COLOR_GREEN : COLOR_DEFAULT)
+            out << (_group_resid[i] / _group_ref_resid[i] < rel_tol ? COLOR_GREEN : COLOR_DEFAULT)
                 << std::setw(8) << _group_resid[i] / _group_ref_resid[i] << COLOR_DEFAULT << "\n";
         }
       }

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -16,6 +16,7 @@
 #include "MooseApp.h"
 #include "MooseEigenSystem.h"
 #include "UserObject.h"
+#include "DefaultNonlinearConvergence.h"
 
 InputParameters
 EigenExecutionerBase::validParams()
@@ -127,6 +128,8 @@ EigenExecutionerBase::init()
 
   /* a time step check point */
   _problem.onTimestepEnd();
+
+  _eigen_sys_conv = getEigenSystemConvergence();
 }
 
 void
@@ -203,16 +206,19 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
     _problem.getDisplacedProblem()->saveOldSolutions();
 
   // save solver control parameters to be modified by the power iteration
-  Real tol1 = _problem.es().parameters.get<Real>("linear solver tolerance");
-  unsigned int num1 =
-      _problem.es().parameters.get<unsigned int>("nonlinear solver maximum iterations");
-  Real tol2 = _problem.es().parameters.get<Real>("nonlinear solver relative residual tolerance");
+  auto & es_params = _problem.es().parameters;
+  auto & eigen_sys_params = _eigen_sys.system().parameters;
+  const Real l_tol_bak = es_params.get<Real>("linear solver tolerance");
+  const auto nl_max_its_bak =
+      eigen_sys_params.get<unsigned int>("nonlinear solver maximum iterations");
+  const auto nl_rel_tol_bak =
+      eigen_sys_params.get<Real>("nonlinear solver relative residual tolerance");
 
-  // every power iteration is a linear solve, so set nonlinear iteration number to one
-  _problem.es().parameters.set<Real>("linear solver tolerance") = l_rtol;
-  // disable nonlinear convergence check
-  _problem.es().parameters.set<unsigned int>("nonlinear solver maximum iterations") = 1;
-  _problem.es().parameters.set<Real>("nonlinear solver relative residual tolerance") = 1 - 1e-8;
+  // every power iteration is a linear solve, so set max nonlinear iterations to 1 and
+  // give a very loose nonlinear tolerance so that it always converges
+  es_params.set<Real>("linear solver tolerance") = l_rtol;
+  _eigen_sys_conv->modifyMaximumIterations(1);
+  _eigen_sys_conv->modifyRelativeTolerance(1.0 - 1e-8);
 
   if (echo)
   {
@@ -356,9 +362,9 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
   }
 
   // restore parameters changed by the executioner
-  _problem.es().parameters.set<Real>("linear solver tolerance") = tol1;
-  _problem.es().parameters.set<unsigned int>("nonlinear solver maximum iterations") = num1;
-  _problem.es().parameters.set<Real>("nonlinear solver relative residual tolerance") = tol2;
+  es_params.set<Real>("linear solver tolerance") = l_tol_bak;
+  _eigen_sys_conv->modifyMaximumIterations(nl_max_its_bak);
+  _eigen_sys_conv->modifyRelativeTolerance(nl_rel_tol_bak);
 
   // FIXME: currently power iteration use old and older solutions, so restore them
   _problem.restoreOldSolutions();
@@ -574,14 +580,18 @@ EigenExecutionerBase::nonlinearSolve(Real nl_rtol, Real nl_atol, Real l_rtol, Re
   // turn on nonlinear flag so that eigen kernels opterate on the current solutions
   _eigen_sys.eigenKernelOnCurrent();
 
-  // set nonlinear solver controls
-  Real tol1 = _problem.es().parameters.get<Real>("nonlinear solver absolute residual tolerance");
-  Real tol2 = _problem.es().parameters.get<Real>("linear solver tolerance");
-  Real tol3 = _problem.es().parameters.get<Real>("nonlinear solver relative residual tolerance");
+  // save nonlinear solve parameters for restoration after solve
+  auto & es_params = _problem.es().parameters;
+  auto & eigen_sys_params = _eigen_sys.system().parameters;
+  const Real l_tol_bak = es_params.get<Real>("linear solver tolerance");
+  const Real nl_abs_tol_bak =
+      eigen_sys_params.get<Real>("nonlinear solver absolute residual tolerance");
+  const Real nl_rel_tol_bak =
+      eigen_sys_params.get<Real>("nonlinear solver relative residual tolerance");
 
-  _problem.es().parameters.set<Real>("nonlinear solver absolute residual tolerance") = nl_atol;
-  _problem.es().parameters.set<Real>("nonlinear solver relative residual tolerance") = nl_rtol;
-  _problem.es().parameters.set<Real>("linear solver tolerance") = l_rtol;
+  es_params.set<Real>("linear solver tolerance") = l_rtol;
+  _eigen_sys_conv->modifyAbsoluteTolerance(nl_atol);
+  _eigen_sys_conv->modifyRelativeTolerance(nl_rtol);
 
   // call nonlinear solve
   _problem.solve(_eigen_sys.number());
@@ -589,9 +599,22 @@ EigenExecutionerBase::nonlinearSolve(Real nl_rtol, Real nl_atol, Real l_rtol, Re
   k = _source_integral;
   _eigenvalue = k;
 
-  _problem.es().parameters.set<Real>("nonlinear solver absolute residual tolerance") = tol1;
-  _problem.es().parameters.set<Real>("linear solver tolerance") = tol2;
-  _problem.es().parameters.set<Real>("nonlinear solver relative residual tolerance") = tol3;
+  // restore nonlinear solve parameters
+  es_params.set<Real>("linear solver tolerance") = l_tol_bak;
+  _eigen_sys_conv->modifyAbsoluteTolerance(nl_abs_tol_bak);
+  _eigen_sys_conv->modifyRelativeTolerance(nl_rel_tol_bak);
 
   return _problem.converged(_eigen_sys.number());
+}
+
+DefaultNonlinearConvergence *
+EigenExecutionerBase::getEigenSystemConvergence()
+{
+  auto & convergence = _eigen_sys.convergence();
+  auto * const nl_convergence = dynamic_cast<DefaultNonlinearConvergence *>(&convergence);
+  if (nl_convergence)
+    return nl_convergence;
+  else
+    mooseError("EigenExecutionerBase requires 'nonlinear_convergence' to be of type "
+               "DefaultNonlinearConvergence.");
 }

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -217,8 +217,8 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
   // every power iteration is a linear solve, so set max nonlinear iterations to 1 and
   // give a very loose nonlinear tolerance so that it always converges
   es_params.set<Real>("linear solver tolerance") = l_rtol;
-  _eigen_sys_conv->modifyMaximumIterations(1);
-  _eigen_sys_conv->modifyRelativeTolerance(1.0 - 1e-8);
+  _eigen_sys_conv->setMaximumIterations(1);
+  _eigen_sys_conv->setRelativeTolerance(1.0 - 1e-8);
 
   if (echo)
   {
@@ -363,8 +363,8 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
 
   // restore parameters changed by the executioner
   es_params.set<Real>("linear solver tolerance") = l_tol_bak;
-  _eigen_sys_conv->modifyMaximumIterations(nl_max_its_bak);
-  _eigen_sys_conv->modifyRelativeTolerance(nl_rel_tol_bak);
+  _eigen_sys_conv->setMaximumIterations(nl_max_its_bak);
+  _eigen_sys_conv->setRelativeTolerance(nl_rel_tol_bak);
 
   // FIXME: currently power iteration use old and older solutions, so restore them
   _problem.restoreOldSolutions();
@@ -590,8 +590,8 @@ EigenExecutionerBase::nonlinearSolve(Real nl_rtol, Real nl_atol, Real l_rtol, Re
       eigen_sys_params.get<Real>("nonlinear solver relative residual tolerance");
 
   es_params.set<Real>("linear solver tolerance") = l_rtol;
-  _eigen_sys_conv->modifyAbsoluteTolerance(nl_atol);
-  _eigen_sys_conv->modifyRelativeTolerance(nl_rtol);
+  _eigen_sys_conv->setAbsoluteTolerance(nl_atol);
+  _eigen_sys_conv->setRelativeTolerance(nl_rtol);
 
   // call nonlinear solve
   _problem.solve(_eigen_sys.number());
@@ -601,8 +601,8 @@ EigenExecutionerBase::nonlinearSolve(Real nl_rtol, Real nl_atol, Real l_rtol, Re
 
   // restore nonlinear solve parameters
   es_params.set<Real>("linear solver tolerance") = l_tol_bak;
-  _eigen_sys_conv->modifyAbsoluteTolerance(nl_abs_tol_bak);
-  _eigen_sys_conv->modifyRelativeTolerance(nl_rel_tol_bak);
+  _eigen_sys_conv->setAbsoluteTolerance(nl_abs_tol_bak);
+  _eigen_sys_conv->setRelativeTolerance(nl_rel_tol_bak);
 
   return _problem.converged(_eigen_sys.number());
 }

--- a/framework/src/executioners/FixedPointSolve.C
+++ b/framework/src/executioners/FixedPointSolve.C
@@ -455,7 +455,7 @@ FixedPointSolve::solveStep(const std::set<dof_id_type> & transformed_dofs)
   if (_has_fixed_point_its)
   {
     auto & convergence = _problem.getConvergence(_problem.getMultiAppFixedPointConvergenceName());
-    convergence.preExecute();
+    convergence.preSolve();
   }
 
   // Keep track of the solution warnings from the TIMESTEP_BEGIN phase before:

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -9732,7 +9732,11 @@ FEProblemBase::setNonlinearConvergenceNames(const std::vector<ConvergenceName> &
   if (convergence_names.size() != numNonlinearSystems())
     paramError("nonlinear_convergence",
                "There must be one convergence object per nonlinear system");
+
   _nonlinear_convergence_names = convergence_names;
+
+  for (const auto i : make_range(numNonlinearSystems()))
+    _nl[i]->setConvergenceName(convergence_names[i]);
 }
 
 void

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -9751,7 +9751,11 @@ FEProblemBase::setNonlinearConvergenceNames(const std::vector<ConvergenceName> &
   if (convergence_names.size() != numNonlinearSystems())
     paramError("nonlinear_convergence",
                "There must be one convergence object per nonlinear system");
+
   _nonlinear_convergence_names = convergence_names;
+
+  for (const auto i : make_range(numNonlinearSystems()))
+    _nl[i]->setConvergenceName(convergence_names[i]);
 }
 
 void

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -80,6 +80,7 @@
 #include "OffDiagonalScalingMatrix.h"
 #include "HDGKernel.h"
 #include "AutomaticMortarGeneration.h"
+#include "Convergence.h"
 
 // libMesh
 #include "libmesh/nonlinear_solver.h"
@@ -4280,6 +4281,8 @@ NonlinearSystemBase::preSolve()
   // We do not know a priori what variable a global degree of freedom corresponds to, so we need a
   // map from global dof to scaling factor. We just use a ghosted NumericVector for that mapping
   assembleScalingVector();
+
+  convergence().preSolve();
 
   return true;
 }

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -4299,3 +4299,9 @@ NonlinearSystemBase::getFieldSplitPreconditioner()
 
   return *_fsp;
 }
+
+Convergence &
+NonlinearSystemBase::convergence()
+{
+  return _fe_problem.getConvergence(_convergence_name);
+}

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -82,6 +82,7 @@
 #include "OffDiagonalScalingMatrix.h"
 #include "HDGKernel.h"
 #include "AutomaticMortarGeneration.h"
+#include "Convergence.h"
 
 // libMesh
 #include "libmesh/nonlinear_solver.h"
@@ -4267,6 +4268,8 @@ NonlinearSystemBase::preSolve()
   // We do not know a priori what variable a global degree of freedom corresponds to, so we need a
   // map from global dof to scaling factor. We just use a ghosted NumericVector for that mapping
   assembleScalingVector();
+
+  convergence().preSolve();
 
   return true;
 }

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -4286,3 +4286,9 @@ NonlinearSystemBase::getFieldSplitPreconditioner()
 
   return *_fsp;
 }
+
+Convergence &
+NonlinearSystemBase::convergence()
+{
+  return _fe_problem.getConvergence(_convergence_name);
+}

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -436,8 +436,7 @@ petscNonlinearConverged(SNES /*snes*/,
   }
   else
   {
-    auto & convergence = problem.getConvergence(
-        problem.getNonlinearConvergenceNames()[problem.currentNonlinearSystem().number()]);
+    auto & convergence = problem.currentNonlinearSystem().convergence();
     status = convergence.checkConvergence(it);
   }
 

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -455,8 +455,7 @@ petscNonlinearConverged(SNES /*snes*/,
   }
   else
   {
-    auto & convergence = problem.getConvergence(
-        problem.getNonlinearConvergenceNames()[problem.currentNonlinearSystem().number()]);
+    auto & convergence = problem.currentNonlinearSystem().convergence();
     status = convergence.checkConvergence(it);
   }
 

--- a/test/tests/convergence/default_nonlinear_convergence/multi_system.i
+++ b/test/tests/convergence/default_nonlinear_convergence/multi_system.i
@@ -1,0 +1,23 @@
+!include ../../multisystem/picard/nonlinearfe_nonlinearfe/multi_system.i
+
+[Convergence]
+  [u_conv]
+    nl_abs_tol := 0
+    nl_rel_tol := 1e-8
+    verbose = true
+  []
+  [v_conv]
+    nl_abs_tol := 1e-9
+    nl_rel_tol := 0
+    verbose = true
+  []
+  [fp_conv_1iteration]
+    type = IterationCountConvergence
+    max_iterations = 1
+    converge_at_max_iterations = true
+  []
+[]
+
+[Executioner]
+  multi_system_fixed_point_convergence := fp_conv_1iteration
+[]

--- a/test/tests/convergence/default_nonlinear_convergence/tests
+++ b/test/tests/convergence/default_nonlinear_convergence/tests
@@ -2,12 +2,19 @@
   design = 'DefaultNonlinearConvergence.md'
   issues = '#25931'
 
-  [test]
+  [single_system]
     type = CSVDiff
     input = 'default_nonlinear_convergence.i'
     csvdiff = 'default_nonlinear_convergence_out.csv'
     expect_out = 'Converged due to absolute residual'
     requirement = 'The system shall be able to determine convergence of the nonlinear solve using default criteria through an object.'
+  []
+  [multi_system]
+    type = RunApp
+    input = 'multi_system.i'
+    expect_out = 'u_conv: Converged due to.*relative tolerance \(1e-08\).*v_conv: Converged due to.*absolute tolerance \(1e-09\)'
+    requirement = 'The system shall be able to determine convergence of each nonlinear solve when there are multiple nonlinear systems in the same application.'
+    issues = '#33271'
   []
   [error_reporting]
     requirement = 'The system shall report an error for the default nonlinear convergence class'


### PR DESCRIPTION
1. Renamed `Convergence::preExecute()` to `preSolve()` to better reflect its intention
2. Added `NonlinearSystemBase::convergence()` to retrieve the associated Convergence object
3. Called `Convergence::preSolve()` in `NonlinearSystemBase::preSolve()`
4. Set the nonlinear system parameters (like tolerances) in `Convergence::preSolve()` instead of setting `EquationSystem` parameters in `DefaultNonlinearConvergence` constructor.
5. Added test

Closes #33271
