### PR TITLE
Adding error message for unsupported MFEM transient time integration scheme

### DIFF
--- a/framework/src/mfem/executioners/MFEMTransient.C
+++ b/framework/src/mfem/executioners/MFEMTransient.C
@@ -47,6 +47,12 @@ MFEMTransient::init()
 {
   TransientBase::init();
 
+  // verify that the requested time integration scheme is actually supported by MFEM transient
+  if (getTimeScheme() != Moose::TimeIntegratorType::TI_IMPLICIT_EULER)
+    paramError("scheme",
+               "Time Integration scheme \"" + stringify(getTimeScheme()) +
+                   "\" is not supported by MFEMTransient Executioner.");
+
   if (_mfem_problem_data.nonlinear_solver)
     _mfem_problem_data.eqn_system->SetSolverRequiresGradient(
         _mfem_problem_data.nonlinear_solver->RequiresGradient());

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -346,6 +346,31 @@ stringify(const RelationshipManagerType & t)
   mooseError("Unknown RelationshipManagerType");
 }
 
+// Definition in MooseTypes.h
+std::string
+stringify(const TimeIntegratorType & t)
+{
+  switch (t)
+  {
+    case TimeIntegratorType::TI_IMPLICIT_EULER:
+      return "IMPLICIT_EULER";
+    case TimeIntegratorType::TI_EXPLICIT_EULER:
+      return "EXPLICIT_EULER";
+    case TimeIntegratorType::TI_CRANK_NICOLSON:
+      return "CRANK_NICOLSON";
+    case TimeIntegratorType::TI_BDF2:
+      return "BDF2";
+    case TimeIntegratorType::TI_EXPLICIT_MIDPOINT:
+      return "EXPLICIT_MIDPOINT";
+    case TimeIntegratorType::TI_LSTABLE_DIRK2:
+      return "LSTABLE_DIRK2";
+    case TimeIntegratorType::TI_EXPLICIT_TVD_RK_2:
+      return "EXPLICIT_TVDRK2";
+    default:
+      mooseError("Unknown TimeIntegratorType");
+  }
+}
+
 std::string
 stringify(libMesh::FEFamily f)
 {

--- a/test/tests/mfem/kernels/tests
+++ b/test/tests/mfem/kernels/tests
@@ -201,6 +201,15 @@
     recover = false
     restep = false
   []
+  [MFEMTransientScheme]
+    type = RunException
+    input = heattransfer.i
+    cli_args = 'Executioner/scheme=bdf2'
+    expect_err = 'Time Integration scheme "BDF2" is not supported by MFEMTransient Executioner.'
+    requirement = 'The system shall report an error if the user specifies an unsupported time integration scheme.'
+    capabilities = 'mfem'
+    compute_devices = 'cpu cuda'
+  []
   [MFEMMixedHeatTransfer]
     type = XMLDiff
     input = mixed_heattransfer.i

--- a/unit/src/ConversionTest.C
+++ b/unit/src/ConversionTest.C
@@ -83,6 +83,17 @@ TEST(Conversion, ExecFlagType)
   EXPECT_EQ(Moose::stringify(EXEC_NONE), "NONE");
 }
 
+TEST(Conversion, TimeIntegratorType)
+{
+  EXPECT_EQ(Moose::stringify(Moose::TimeIntegratorType::TI_IMPLICIT_EULER), "IMPLICIT_EULER");
+  EXPECT_EQ(Moose::stringify(Moose::TimeIntegratorType::TI_EXPLICIT_EULER), "EXPLICIT_EULER");
+  EXPECT_EQ(Moose::stringify(Moose::TimeIntegratorType::TI_CRANK_NICOLSON), "CRANK_NICOLSON");
+  EXPECT_EQ(Moose::stringify(Moose::TimeIntegratorType::TI_BDF2), "BDF2");
+  EXPECT_EQ(Moose::stringify(Moose::TimeIntegratorType::TI_EXPLICIT_MIDPOINT), "EXPLICIT_MIDPOINT");
+  EXPECT_EQ(Moose::stringify(Moose::TimeIntegratorType::TI_LSTABLE_DIRK2), "LSTABLE_DIRK2");
+  EXPECT_EQ(Moose::stringify(Moose::TimeIntegratorType::TI_EXPLICIT_TVD_RK_2), "EXPLICIT_TVDRK2");
+}
+
 TEST(Conversion, stringifyExact)
 {
   EXPECT_EQ(Moose::stringifyExact(libMesh::pi), "3.1415926535897931");


### PR DESCRIPTION
Refs #33296

## Reason
Add an error message if the user has requested a time integration scheme unsupported by MFEM. Right now, the code keeps running but ignores the user input and just uses implicit-Euler.

## Design
Added an error message in `MFEMTransient::init()` to stop for unsupported time integration schemes. I also had to actually define `stringify(const TimeIntegratorType & t)` since it was declared in `include/utils/MooseTypes.h` but never defined. I chose to define the function in `src/utils/Conversion.C` to mirror the similar function for `RelationshipManagerType`.

## Impact
Will raise an error message if the user has specified an unacceptable time integration scheme for use with MFEM.
