### PR TITLE
Fix SchemaDiff for comparisons involving negative vals

### DIFF
--- a/python/TestHarness/testers/SchemaDiff.py
+++ b/python/TestHarness/testers/SchemaDiff.py
@@ -151,12 +151,12 @@ class SchemaDiff(RunApp):
                         x = float(level.t1)
                         y = float(level.t2)
 
-                        if x < self.abs_zero and y < self.abs_zero:
+                        if abs(x) < self.abs_zero and abs(y) < self.abs_zero:
                             return True
                         if self.rel_err == 0 or y == 0:
                             if abs(x - y) > self.rel_err:
                                 return False
-                        elif abs(x - y) / y > self.rel_err:
+                        elif abs(x - y) / abs(y) > self.rel_err:
                             return False
                     return True  # if the two items are the same, you can stop evaluating them.
 

--- a/test/tests/mfem/kernels/tests
+++ b/test/tests/mfem/kernels/tests
@@ -69,6 +69,7 @@
     cli_args = 'Solvers/main/type=MFEMCGSolver Solvers/main/preconditioner=jacobi '
                'Executioner/assembly_level=partial'
     requirement = 'The system shall have the ability to solve a diffusion problem with partial assembly using MFEM.'
+    abs_zero = 2e-10
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
@@ -84,6 +85,7 @@
                'Executioner/assembly_level=none'
     compute_devices = 'ceed-cpu'
     requirement = 'The system shall have the ability to solve a diffusion problem with matrix-free assembly using MFEM.'
+    abs_zero = 2e-10
     capabilities = 'mfem'
     max_parallel = 1
     recover = false


### PR DESCRIPTION
## Reason
Correct SchemaDiff comparisons.

## Design
Added a few `abs()` applications as needed.

## Impact
~Brace! Brace!~ To my surprise, only two tests needed some love and no apps required changes, I count myself lucky. 
