### PR TITLE
Rename PorousFlowDarcyBase::computeResidualAndJacobian to computeResi…

### DIFF
--- a/modules/porous_flow/include/kernels/PorousFlowDarcyBase.h
+++ b/modules/porous_flow/include/kernels/PorousFlowDarcyBase.h
@@ -67,10 +67,8 @@ protected:
     CALCULATE_JACOBIAN = 1
   };
 
-  using ResidualObject::computeResidualAndJacobian;
-
   /**
-   * Computation of the residual and Jacobian (non-AD path only).
+   * Computation of the residual or the Jacobian, depending on res_or_jac (non-AD path only).
    *
    * If res_or_jac=CALCULATE_JACOBIAN then the residual
    * gets calculated anyway (becuase we have to know which
@@ -84,7 +82,7 @@ protected:
    * @param res_or_jac Whether to calculate the residual or the jacobian.
    * @param jvar PorousFlow variable to take derivatives wrt to
    */
-  void computeResidualAndJacobian(JacRes res_or_jac, unsigned int jvar);
+  void computeResidualOrJacobian(JacRes res_or_jac, unsigned int jvar);
 
   /// Permeability of porous material
   const GenericMaterialProperty<RealTensorValue, is_ad> & _permeability;

--- a/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
@@ -182,7 +182,7 @@ void
 PorousFlowDarcyBaseTempl<is_ad>::computeResidual()
 {
   if constexpr (!is_ad)
-    computeResidualAndJacobian(JacRes::CALCULATE_RESIDUAL, 0);
+    computeResidualOrJacobian(JacRes::CALCULATE_RESIDUAL, 0);
   else
   {
     adComputeProtoFlux(false);
@@ -212,7 +212,7 @@ void
 PorousFlowDarcyBaseTempl<is_ad>::computeJacobian()
 {
   if constexpr (!is_ad)
-    computeResidualAndJacobian(JacRes::CALCULATE_JACOBIAN, _var.number());
+    computeResidualOrJacobian(JacRes::CALCULATE_JACOBIAN, _var.number());
   else
     // Block-diagonal (e.g. PJFNK) assembly path: this is the only Jacobian call we get.
     adComputeJacobian();
@@ -251,7 +251,7 @@ void
 PorousFlowDarcyBaseTempl<is_ad>::computeOffDiagJacobian(const unsigned int jvar)
 {
   if constexpr (!is_ad)
-    computeResidualAndJacobian(JacRes::CALCULATE_JACOBIAN, jvar);
+    computeResidualOrJacobian(JacRes::CALCULATE_JACOBIAN, jvar);
   else
   {
     libmesh_ignore(jvar);
@@ -374,7 +374,7 @@ PorousFlowDarcyBaseTempl<is_ad>::adComputeProtoFlux(bool do_counting)
 
 template <bool is_ad>
 void
-PorousFlowDarcyBaseTempl<is_ad>::computeResidualAndJacobian(JacRes res_or_jac, unsigned int jvar)
+PorousFlowDarcyBaseTempl<is_ad>::computeResidualOrJacobian(JacRes res_or_jac, unsigned int jvar)
 {
   if ((res_or_jac == JacRes::CALCULATE_JACOBIAN) && _dictator.notPorousFlowVariable(jvar))
     return;


### PR DESCRIPTION
…dualOrJacobian

The method computes either the residual or Jacobian, so the old name was a misnomer which collided with the framework computeResidualAndJacobian() (the residual_and_jacobian_together mechanism).

Fixes #33308