### PR TITLE
Add pre-commit hooks for formatting and linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,71 @@
+# Pre-commit hooks for MOOSE. See https://pre-commit.com.
+#
+# Install once per clone:
+#     pip install pre-commit   # (already pinned in requirements.txt)
+#     pre-commit install
+#
+# The tool versions below mirror the pins in requirements.txt so that humans,
+# coding agents, and CIVET share a single source of truth for formatting/linting.
+
+# Global exclude: vendored / submodule / generated trees.
+exclude: |
+  (?x)^(
+    libmesh/|
+    petsc/|
+    large_media/|
+    framework/contrib/|
+    python/contrib/|
+    framework/doc/content/contrib/|
+    modules/[^/]+/contrib/
+  )
+
+repos:
+  # ---- Generic hygiene ----
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+        exclude: (?x)(^|/)gold/
+      - id: end-of-file-fixer
+        exclude: (?x)(^|/)gold/
+      - id: check-merge-conflict
+      - id: check-yaml
+        # --unsafe: syntax-only check that tolerates MOOSE's custom !include/!template
+        # YAML tags. conda recipes are jinja-templated and are not valid YAML.
+        args: [--unsafe]
+        exclude: ^conda/
+
+  # ---- C++ (MOOSE uses the .C extension for sources) ----
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v19.1.7  # mirrors clang-format in requirements.txt
+    hooks:
+      - id: clang-format
+        # types_or: [text] ensures .C files are included regardless of how the
+        # identify library tags that ambiguous extension.
+        files: \.(C|h)$
+        types_or: [text]
+
+  # ---- Python: Ruff (lint, autofix) then Black (format) ----
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.15  # mirrors ruff in requirements.txt
+    hooks:
+      - id: ruff
+        # Honors the restricted [tool.ruff] include/exclude list in pyproject.toml.
+        args: [--fix]
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.5.1  # mirrors black in requirements.txt
+    hooks:
+      - id: black
+        # Honors [tool.black] extend-exclude in pyproject.toml.
+
+  # ---- Copyright headers (reuse the existing MOOSE script) ----
+  - repo: local
+    hooks:
+      - id: check-copyright
+        name: check/insert MOOSE copyright headers
+        entry: framework/scripts/fixup_headers.py -u
+        language: script
+        files: \.(C|h|py)$
+        exclude: ^test/tests/test_harness/validation_badpython\.py$
+        pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       - id: clang-format
         # types_or: [text] ensures .C files are included regardless of how the
         # identify library tags that ambiguous extension.
-        files: \.(C|h)$
+        files: \.(C|K|h)$
         types_or: [text]
 
   # ---- Python: Ruff (lint, autofix) then Black (format) ----
@@ -66,6 +66,6 @@ repos:
         name: check/insert MOOSE copyright headers
         entry: framework/scripts/fixup_headers.py -u
         language: script
-        files: \.(C|h|py)$
+        files: \.(C|K|h|py)$
         exclude: ^test/tests/test_harness/validation_badpython\.py$
         pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,12 +36,14 @@ repos:
         args: [--unsafe]
         exclude: ^conda/
 
-  # ---- C++ (MOOSE uses the .C extension for sources) ----
+  # ---- C++ sources ----
+  # .C files use the standard host compiler; .K files contain Kokkos code and
+  # use the device compiler when Kokkos is enabled.
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.7  # mirrors clang-format in requirements.txt
     hooks:
       - id: clang-format
-        # types_or: [text] ensures .C files are included regardless of how the
+        # types_or: [text] ensures .C and .K files are included regardless of how the
         # identify library tags that ambiguous extension.
         files: \.(C|K|h)$
         types_or: [text]

--- a/framework/doc/content/framework/contributing.md
+++ b/framework/doc/content/framework/contributing.md
@@ -63,6 +63,15 @@ Create a branch for your work:
 git checkout -b branch_name upstream/devel
 ```
 
+We recommend installing the [pre-commit](https://pre-commit.com) hooks once per clone. They automatically format and check your changes before each commit, running the same clang-format, black, ruff, whitespace, and copyright-header checks that are enforced when your code is contributed:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The hook configuration lives in [`.pre-commit-config.yaml`](https://github.com/idaholab/moose/blob/devel/.pre-commit-config.yaml), and the tool versions mirror those pinned in `requirements.txt`. When a hook reformats a file, the commit is aborted; simply `git add` the modified files and commit again.
+
 Make your modifications and commit them to a branch (be sure to reference an issue number in your commit messages).
 
 ```bash

--- a/framework/doc/content/sqa/framework_scs.md
+++ b/framework/doc/content/sqa/framework_scs.md
@@ -15,7 +15,8 @@ git clang-format [<branch>]
 ```
 
 The automated testing that occurs on all Pull Requests will produce a "diff" of changes needed to
-conform with the standard.
+conform with the standard. Alternatively, installing the [pre-commit](https://pre-commit.com) hooks
+(see [framework/contributing.md]) applies this formatting to staged files automatically at commit time.
 
 General style guidelines include:
 
@@ -38,6 +39,9 @@ from the root of the [!ac](MOOSE) repository:
 ```
 black .
 ```
+
+Alternatively, installing the [pre-commit](https://pre-commit.com) hooks (see
+[framework/contributing.md]) formats staged Python files automatically at commit time.
 
 ## File Layout
 

--- a/framework/scripts/fixup_headers.py
+++ b/framework/scripts/fixup_headers.py
@@ -180,4 +180,14 @@ if __name__ == "__main__":
     parser.add_option("-f", "--force", action="store_true", dest="force", default=False)
 
     global_options, args = parser.parse_args()
-    fixupHeader()
+    if args:
+        # Process only the files passed on the command line (e.g. from a
+        # pre-commit hook); otherwise fall back to walking the tree.
+        for filename in args:
+            ext = os.path.splitext(filename)[1]
+            if ext in (".C", ".h") and not global_options.python_only:
+                checkAndUpdateCPlusPlus(os.path.abspath(filename))
+            elif ext == ".py" and not global_options.cxx_only:
+                checkAndUpdatePython(os.path.abspath(filename))
+    else:
+        fixupHeader()

--- a/framework/scripts/fixup_headers.py
+++ b/framework/scripts/fixup_headers.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
         # pre-commit hook); otherwise fall back to walking the tree.
         for filename in args:
             ext = os.path.splitext(filename)[1]
-            if ext in (".C", ".h") and not global_options.python_only:
+            if ext in (".C", ".K", ".h") and not global_options.python_only:
                 checkAndUpdateCPlusPlus(os.path.abspath(filename))
             elif ext == ".py" and not global_options.cxx_only:
                 checkAndUpdatePython(os.path.abspath(filename))


### PR DESCRIPTION
## Summary

Adds a `.pre-commit-config.yaml` so humans, coding agents, and CIVET can share a single
source of truth for formatting/linting. Contributors (and AI assistants) catch and fix
issues locally at commit time instead of after a CIVET pre-check fails.

Hooks:

- **Hygiene** (`pre-commit-hooks`): `trailing-whitespace`, `end-of-file-fixer`,
  `check-merge-conflict`, `check-yaml` (`--unsafe` to tolerate MOOSE's custom
  `!include`/`!template` YAML tags; jinja-templated conda recipes excluded).
- **C++**: `clang-format` on `.C`/`.h` (`mirrors-clang-format`, pinned to 19.1.7).
- **Python**: `ruff` (lint, autofix) + `black` (format), scoped by the existing
  `pyproject.toml`.
- **Copyright headers**: a local hook reusing `framework/scripts/fixup_headers.py`, which
  is extended to accept filenames (whole-tree behavior unchanged otherwise).

Hook tool versions mirror the pins in `requirements.txt` (`clang-format==19.1.7`,
`ruff==0.15.15`, `black==26.5.1`) so there is one source of truth for versions.

Docs: the contributing guide gains a short "install pre-commit" step, and the C++/Python
code-standards sections point at it.

## Setup

```bash
pip install pre-commit
pre-commit install
```

## Not included / future work

- **HIT input-file (`.i`) formatting is intentionally omitted.** `hit format` is a
  compiled binary (needs a built MOOSE) and `hit`/`wasp` are vendored from the upstream
  wasp/hit repo; the appropriate home for a `.i` hook is an upstream pre-commit hook
  published there. Tracked in #33318.
- No repo-wide `pre-commit run --all-files` baseline reformat — the config targets
  incremental (staged-file) use; a baseline run is a separate maintainer decision.
- `versioner.py --verify` stays a CIVET check (needs a base ref; not pre-commit friendly).

## Testing

Verified locally with pre-commit:

- `clang-format` runs on `.C` files (MOOSE's C++ extension; ensured via `types_or: [text]`).
- `ruff`/`black` run and pass on tracked Python.
- The copyright hook inserts a header preserving the shebang and is idempotent on
  already-headered files.
- `check-yaml --unsafe` passes on docs with custom `!include` tags; conda jinja recipes
  are excluded.

refs #33318
