### PR TITLE
Add normal NCP options for mortar contact

### DIFF
--- a/modules/contact/doc/content/source/constraints/ComputeDynamicWeightedGapLMMechanicalContact.md
+++ b/modules/contact/doc/content/source/constraints/ComputeDynamicWeightedGapLMMechanicalContact.md
@@ -16,6 +16,13 @@ where $\,\dot{}\,$ denotes the first time derivative, $\Delta t$ is the time ste
 
 The `capture_tolerance` is an optional contact parameter used in dynamic contact constraints to determine when to impose the persistency condition for normal contact.
 
+The normal complementarity equation is enforced with the same
+[!param](/Constraints/ComputeDynamicWeightedGapLMMechanicalContact/normal_ncp_function)
+and
+[!param](/Constraints/ComputeDynamicWeightedGapLMMechanicalContact/normal_ncp_smoothing_width)
+options described for
+[ComputeWeightedGapLMMechanicalContact](/ComputeWeightedGapLMMechanicalContact.md).
+
 For relevant, general equations, see [!citep](tal2018dynamic). Also, for discussion on the relevance of normal contact constraint stabilization for energy conservation and contact force accuracy, in the context of mortar constraints, see [!citep](recuero2022practical).
 
 !syntax parameters /Constraints/ComputeDynamicWeightedGapLMMechanicalContact

--- a/modules/contact/doc/content/source/constraints/ComputeWeightedGapLMMechanicalContact.md
+++ b/modules/contact/doc/content/source/constraints/ComputeWeightedGapLMMechanicalContact.md
@@ -35,14 +35,42 @@ j'th lagrange multiplier test function, and $g_{n,h}$ is the discretized version
 of the gap function.
 
 The `ComputeWeightedGapLMMechanicalContact` object computes the weighted gap and
-applies the KKT conditions. The KKT conditions
-are enforced using a nonlinear complementarity problem (NCP) function, in this case the most
-simple such function, $min(c(\tilde{g}_n)_j, (\lambda_n)_j)$, where $c$ (implemented with the input
-parameter `c`) is used to balance the size of the gap
-and the normal contact pressure. If the contact pressure is of order 10000, and the
-gap is of order .01, then `c` should be set to 1e6 in order to bring
-components of the NCP function onto the same level and achieve optimal
-convergence in the non-linear solve.
+applies the KKT conditions. The KKT conditions are enforced using a nonlinear
+complementarity problem (NCP) function. By default this is the simple min
+function, $\min(c(\tilde{g}_n)_j, (\lambda_n)_j)$, where $c$ (implemented with the
+input parameter [!param](/Constraints/ComputeWeightedGapLMMechanicalContact/c)) is
+used to balance the size of the gap and the normal contact pressure. If the
+contact pressure is of order 10000, and the gap is of order .01, then
+[!param](/Constraints/ComputeWeightedGapLMMechanicalContact/c) should be set to
+1e6 in order to bring components of the NCP function onto the same level and
+achieve optimal convergence in the non-linear solve.
+
+The [!param](/Constraints/ComputeWeightedGapLMMechanicalContact/normal_ncp_function)
+parameter selects the NCP function used for this normal constraint. The default
+`MIN` option preserves the historical residual. `SMOOTH_MIN` replaces the corner
+of the min function with a differentiable approximation, while
+`FISCHER_BURMEISTER` and `SMOOTH_FISCHER_BURMEISTER` use the corresponding
+Fischer-Burmeister NCP functions. The exact Fischer-Burmeister option remains
+nonsmooth at the origin, where the implementation uses a finite generalized
+derivative. The smooth options require a positive
+[!param](/Constraints/ComputeWeightedGapLMMechanicalContact/normal_ncp_smoothing_width),
+whose value is measured on the same scale as $(\lambda_n)_j$ and
+$c_\mathrm{eff}(\tilde{g}_n)_j$, where $c_\mathrm{eff}$ is the effective value of
+[!param](/Constraints/ComputeWeightedGapLMMechanicalContact/c) after any
+[!param](/Constraints/ComputeWeightedGapLMMechanicalContact/normalize_c)
+normalization.
+
+The smoothing width is not normalized internally. After choosing
+[!param](/Constraints/ComputeWeightedGapLMMechanicalContact/c), choose a
+dimensioned width from one of the two arguments of the normal NCP function, for
+example $\epsilon = \alpha |(\lambda_n)_j|$ using a representative active-contact
+normal Lagrange multiplier, or
+$\epsilon = \alpha |c_\mathrm{eff}(\tilde{g}_n)_j|$ using a representative
+effective scaled weighted gap. Typical trial factors are roughly
+$\alpha = 10^{-8}$ to $10^{-4}$. Smaller values approach the exact nonsmooth
+complementarity function more closely; larger values create a wider
+differentiable transition but can also round the active-set transition enough to
+perturb the contact pressure and gap response.
 
 !syntax description /Constraints/ComputeWeightedGapLMMechanicalContact
 

--- a/modules/contact/include/constraints/ComputeDynamicWeightedGapLMMechanicalContact.h
+++ b/modules/contact/include/constraints/ComputeDynamicWeightedGapLMMechanicalContact.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "ADMortarConstraint.h"
+#include "MortarContactUtils.h"
 
 #include <unordered_map>
 
@@ -87,6 +88,12 @@ protected:
 
   /// Whether to normalize weighted gap by weighting function norm
   bool _normalize_c;
+
+  /// Function used for the normal complementarity residual
+  const Moose::Mortar::Contact::NormalNCPFunction _normal_ncp_function;
+
+  /// Smoothing width for smooth normal NCP functions
+  const Real _normal_ncp_smoothing_width;
 
   /// Whether the dof objects are nodal; if they're not, then they're elemental
   const bool _nodal;

--- a/modules/contact/include/constraints/ComputeWeightedGapLMMechanicalContact.h
+++ b/modules/contact/include/constraints/ComputeWeightedGapLMMechanicalContact.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "ADMortarConstraint.h"
+#include "MortarContactUtils.h"
 
 #include <unordered_map>
 
@@ -90,6 +91,12 @@ protected:
 
   /// Whether to normalize weighted gap by weighting function norm
   const bool _normalize_c;
+
+  /// Function used for the normal complementarity residual
+  const Moose::Mortar::Contact::NormalNCPFunction _normal_ncp_function;
+
+  /// Smoothing width for smooth normal NCP functions
+  const Real _normal_ncp_smoothing_width;
 
   /// Whether the dof objects are nodal; if they're not, then they're elemental
   const bool _nodal;

--- a/modules/contact/include/utils/MortarContactUtils.h
+++ b/modules/contact/include/utils/MortarContactUtils.h
@@ -13,6 +13,7 @@
 #include "ADReal.h"
 #include "RankTwoTensor.h"
 #include "MooseMesh.h"
+#include "MooseEnum.h"
 
 #include "libmesh/dof_object.h"
 
@@ -27,6 +28,8 @@
 
 #include <utility>
 #include <array>
+#include <algorithm>
+#include <cmath>
 #include <unordered_map>
 #include <vector>
 
@@ -56,6 +59,73 @@ namespace Mortar
 {
 namespace Contact
 {
+
+CreateMooseEnumClass(
+    NormalNCPFunction, MIN, SMOOTH_MIN, FISCHER_BURMEISTER, SMOOTH_FISCHER_BURMEISTER);
+
+inline MooseEnum
+normalNCPFunctionOptions()
+{
+  MooseEnum options(getNormalNCPFunctionOptions(), "MIN");
+  options.addDocumentation("MIN",
+                           "Use the exact min function for the normal complementarity residual.");
+  options.addDocumentation(
+      "SMOOTH_MIN",
+      "Use a differentiable smooth-min approximation for the normal complementarity residual.");
+  options.addDocumentation("FISCHER_BURMEISTER",
+                           "Use the exact Fischer-Burmeister NCP function for the normal "
+                           "complementarity residual.");
+  options.addDocumentation("SMOOTH_FISCHER_BURMEISTER",
+                           "Use the smoothed Fischer-Burmeister NCP function for the normal "
+                           "complementarity residual.");
+  return options;
+}
+
+inline bool
+normalNCPSmoothingRequired(const NormalNCPFunction normal_ncp_function)
+{
+  return normal_ncp_function == NormalNCPFunction::SMOOTH_MIN ||
+         normal_ncp_function == NormalNCPFunction::SMOOTH_FISCHER_BURMEISTER;
+}
+
+template <typename T>
+inline T
+normalNCPResidual(const T & normal_lm,
+                  const T & scaled_gap,
+                  const NormalNCPFunction normal_ncp_function,
+                  const Real smoothing_width)
+{
+  using std::min;
+  using std::sqrt;
+
+  switch (normal_ncp_function)
+  {
+    case NormalNCPFunction::MIN:
+      return min(normal_lm, scaled_gap);
+    case NormalNCPFunction::SMOOTH_MIN:
+      mooseAssert(smoothing_width > 0, "The smooth normal NCP width must be positive.");
+      return 0.5 * (normal_lm + scaled_gap -
+                    sqrt((normal_lm - scaled_gap) * (normal_lm - scaled_gap) +
+                         smoothing_width * smoothing_width));
+    case NormalNCPFunction::FISCHER_BURMEISTER:
+    {
+      const auto norm_sq = normal_lm * normal_lm + scaled_gap * scaled_gap;
+      // The exact FB function is nonsmooth at the origin. Pick a finite generalized derivative
+      // there instead of differentiating sqrt(0), which produces invalid AD derivatives.
+      if (MetaPhysicL::raw_value(norm_sq) == 0)
+        return 0.5 * (normal_lm + scaled_gap);
+      return normal_lm + scaled_gap - sqrt(norm_sq);
+    }
+    case NormalNCPFunction::SMOOTH_FISCHER_BURMEISTER:
+      mooseAssert(smoothing_width > 0, "The smooth normal NCP width must be positive.");
+      return normal_lm + scaled_gap -
+             sqrt(normal_lm * normal_lm + scaled_gap * scaled_gap +
+                  smoothing_width * smoothing_width);
+  }
+
+  mooseError("Unhandled normal NCP function type.");
+  return normal_lm;
+}
 
 /**
  * This function is used to communicate velocities across processes

--- a/modules/contact/src/actions/ContactAction.C
+++ b/modules/contact/src/actions/ContactAction.C
@@ -18,6 +18,7 @@
 #include "NonlinearSystemBase.h"
 #include "Parser.h"
 #include "AugmentedLagrangianContactProblem.h"
+#include "MortarContactUtils.h"
 
 #include "NanoflannMeshAdaptor.h"
 #include "PointListAdaptor.h"
@@ -203,6 +204,19 @@ ContactAction::validParams()
       "parameter affects convergence behavior and, in general, should be larger for stiffer "
       "materials. It is recommended that the user tries out various orders of magnitude for this "
       "parameter if the default value generates poor contact convergence.");
+  params.addParam<MooseEnum>(
+      "normal_ncp_function",
+      Moose::Mortar::Contact::normalNCPFunctionOptions(),
+      "The nonlinear complementarity problem function used to enforce the normal weighted-gap "
+      "constraint for mortar contact.");
+  params.addRangeCheckedParam<Real>(
+      "normal_ncp_smoothing_width",
+      0.0,
+      "normal_ncp_smoothing_width >= 0",
+      "Width of the smooth transition for smooth normal NCP functions, in the same scale as the "
+      "normal Lagrange multiplier and the effective scaled weighted gap argument. This value is "
+      "not normalized internally; choose it as a small factor, typically 1e-8 to 1e-4, times a "
+      "representative normal Lagrange multiplier or representative effective scaled weighted gap.");
   params.addParam<Real>(
       "c_tangential", 1, "Numerical parameter for nonlinear mortar frictional constraints");
   params.addParam<bool>("ping_pong_protection",
@@ -323,8 +337,8 @@ ContactAction::validParams()
   params.addParamNamesToGroup("friction_coefficient tension_release", "Friction");
   // Mortar-specific parameters
   params.addParamNamesToGroup("c_normal c_tangential normal_lm_scaling tangential_lm_scaling "
-                              "lm_space "
-                              "use_dual correct_edge_dropping normalize_c use_petrov_galerkin "
+                              "lm_space normal_ncp_function normal_ncp_smoothing_width use_dual "
+                              "correct_edge_dropping normalize_c use_petrov_galerkin "
                               "generate_mortar_mesh segment_quadrature wear_depth debug_mesh",
                               "Mortar");
   // Mortar dynamics (Newmark-beta)
@@ -467,6 +481,14 @@ ContactAction::ContactAction(const InputParameters & params)
     else if (params.isParamSetByUser("c_normal"))
       paramError("c_normal",
                  "The 'c_normal' option can only be used with the 'mortar' formulation");
+    else if (params.isParamSetByUser("normal_ncp_function"))
+      paramError("normal_ncp_function",
+                 "The 'normal_ncp_function' option can only be used with the 'mortar' "
+                 "formulation");
+    else if (params.isParamSetByUser("normal_ncp_smoothing_width"))
+      paramError("normal_ncp_smoothing_width",
+                 "The 'normal_ncp_smoothing_width' option can only be used with the 'mortar' "
+                 "formulation");
     else if (params.isParamSetByUser("c_tangential"))
       paramError("c_tangential",
                  "The 'c_tangential' option can only be used with the 'mortar' formulation");
@@ -1210,6 +1232,8 @@ ContactAction::addMortarContact()
                                       "triangulation",
                                       "triangulate_triangles",
                                       "normalize_c",
+                                      "normal_ncp_function",
+                                      "normal_ncp_smoothing_width",
                                       "extra_vector_tags",
                                       "absolute_value_vector_tags",
                                       "debug_mesh"});
@@ -1270,6 +1294,8 @@ ContactAction::addMortarContact()
       params.applySpecificParameters(parameters(),
                                      {"triangulation",
                                       "triangulate_triangles",
+                                      "normal_ncp_function",
+                                      "normal_ncp_smoothing_width",
                                       "extra_vector_tags",
                                       "absolute_value_vector_tags",
                                       "debug_mesh"});

--- a/modules/contact/src/constraints/ComputeDynamicWeightedGapLMMechanicalContact.C
+++ b/modules/contact/src/constraints/ComputeDynamicWeightedGapLMMechanicalContact.C
@@ -75,6 +75,19 @@ ComputeDynamicWeightedGapLMMechanicalContact::validParams()
       "the value of c effectively depends on element size since in the constraint we compare nodal "
       "Lagrange Multiplier values to integrated gap values (LM nodal value is independent of "
       "element size, where integrated values are dependent on element size).");
+  params.addParam<MooseEnum>(
+      "normal_ncp_function",
+      Moose::Mortar::Contact::normalNCPFunctionOptions(),
+      "The nonlinear complementarity problem function used to enforce the normal weighted-gap "
+      "constraint.");
+  params.addRangeCheckedParam<Real>(
+      "normal_ncp_smoothing_width",
+      0.0,
+      "normal_ncp_smoothing_width >= 0",
+      "Width of the smooth transition for smooth normal NCP functions, in the same scale as the "
+      "normal Lagrange multiplier and the effective scaled weighted gap argument. This value is "
+      "not normalized internally; choose it as a small factor, typically 1e-8 to 1e-4, times a "
+      "representative normal Lagrange multiplier or representative effective scaled weighted gap.");
   params.set<bool>("use_displaced_mesh") = true;
   params.set<bool>("interpolate_normals") = false;
   return params;
@@ -92,6 +105,9 @@ ComputeDynamicWeightedGapLMMechanicalContact::ComputeDynamicWeightedGapLMMechani
     _primary_disp_z(_has_disp_z ? &adCoupledNeighborValue("disp_z") : nullptr),
     _c(getParam<Real>("c")),
     _normalize_c(getParam<bool>("normalize_c")),
+    _normal_ncp_function(getParam<MooseEnum>("normal_ncp_function")
+                             .getEnum<Moose::Mortar::Contact::NormalNCPFunction>()),
+    _normal_ncp_smoothing_width(getParam<Real>("normal_ncp_smoothing_width")),
     _nodal(getVar("disp_x", 0)->feType().family == LAGRANGE),
     _disp_x_var(getVar("disp_x", 0)),
     _disp_y_var(getVar("disp_y", 0)),
@@ -111,6 +127,12 @@ ComputeDynamicWeightedGapLMMechanicalContact::ComputeDynamicWeightedGapLMMechani
   if (!useDual())
     mooseError("Dynamic mortar contact constraints requires the use of Lagrange multipliers dual "
                "interpolation");
+
+  if (Moose::Mortar::Contact::normalNCPSmoothingRequired(_normal_ncp_function) &&
+      _normal_ncp_smoothing_width <= 0)
+    paramError("normal_ncp_smoothing_width",
+               "A positive normal_ncp_smoothing_width is required when normal_ncp_function is a "
+               "smooth NCP function.");
 }
 
 void
@@ -388,7 +410,8 @@ ComputeDynamicWeightedGapLMMechanicalContact::enforceConstraintOnDof(const DofOb
   ADReal lm_value = (*_sys.currentSolution())(dof_index);
   Moose::derivInsert(lm_value.derivatives(), dof_index, 1.);
 
-  const ADReal dof_residual = std::min(lm_value, weighted_gap * c);
+  const ADReal dof_residual = Moose::Mortar::Contact::normalNCPResidual(
+      lm_value, weighted_gap * c, _normal_ncp_function, _normal_ncp_smoothing_width);
 
   addResidualsAndJacobian(_assembly,
                           std::array<ADReal, 1>{{dof_residual}},

--- a/modules/contact/src/constraints/ComputeWeightedGapLMMechanicalContact.C
+++ b/modules/contact/src/constraints/ComputeWeightedGapLMMechanicalContact.C
@@ -63,6 +63,19 @@ ComputeWeightedGapLMMechanicalContact::validParams()
       "the value of c effectively depends on element size since in the constraint we compare nodal "
       "Lagrange Multiplier values to integrated gap values (LM nodal value is independent of "
       "element size, where integrated values are dependent on element size).");
+  params.addParam<MooseEnum>(
+      "normal_ncp_function",
+      Moose::Mortar::Contact::normalNCPFunctionOptions(),
+      "The nonlinear complementarity problem function used to enforce the normal weighted-gap "
+      "constraint.");
+  params.addRangeCheckedParam<Real>(
+      "normal_ncp_smoothing_width",
+      0.0,
+      "normal_ncp_smoothing_width >= 0",
+      "Width of the smooth transition for smooth normal NCP functions, in the same scale as the "
+      "normal Lagrange multiplier and the effective scaled weighted gap argument. This value is "
+      "not normalized internally; choose it as a small factor, typically 1e-8 to 1e-4, times a "
+      "representative normal Lagrange multiplier or representative effective scaled weighted gap.");
   params.set<bool>("use_displaced_mesh") = true;
   params.set<bool>("interpolate_normals") = false;
   params.addRequiredParam<UserObjectName>("weighted_gap_uo", "The weighted gap user object");
@@ -81,6 +94,9 @@ ComputeWeightedGapLMMechanicalContact::ComputeWeightedGapLMMechanicalContact(
     _primary_disp_z(_has_disp_z ? &adCoupledNeighborValue("disp_z") : nullptr),
     _c(getParam<Real>("c")),
     _normalize_c(getParam<bool>("normalize_c")),
+    _normal_ncp_function(getParam<MooseEnum>("normal_ncp_function")
+                             .getEnum<Moose::Mortar::Contact::NormalNCPFunction>()),
+    _normal_ncp_smoothing_width(getParam<Real>("normal_ncp_smoothing_width")),
     _nodal(getVar("disp_x", 0)->feType().family == LAGRANGE),
     _disp_x_var(getVar("disp_x", 0)),
     _disp_y_var(getVar("disp_y", 0)),
@@ -95,6 +111,12 @@ ComputeWeightedGapLMMechanicalContact::ComputeWeightedGapLMMechanicalContact(
   if (!_var->isNodal())
     if (_var->feType().order != static_cast<Order>(0))
       mooseError("Normal contact constraints only support elemental variables of CONSTANT order");
+
+  if (Moose::Mortar::Contact::normalNCPSmoothingRequired(_normal_ncp_function) &&
+      _normal_ncp_smoothing_width <= 0)
+    paramError("normal_ncp_smoothing_width",
+               "A positive normal_ncp_smoothing_width is required when normal_ncp_function is a "
+               "smooth NCP function.");
 }
 
 ADReal
@@ -191,7 +213,8 @@ ComputeWeightedGapLMMechanicalContact::enforceConstraintOnDof(const DofObject * 
   ADReal lm_value = (*_sys.currentSolution())(dof_index);
   Moose::derivInsert(lm_value.derivatives(), dof_index, 1.);
 
-  const ADReal dof_residual = std::min(lm_value, weighted_gap * c);
+  const ADReal dof_residual = Moose::Mortar::Contact::normalNCPResidual(
+      lm_value, weighted_gap * c, _normal_ncp_function, _normal_ncp_smoothing_width);
 
   addResidualsAndJacobian(_assembly,
                           std::array<ADReal, 1>{{dof_residual}},

--- a/modules/contact/test/tests/bouncing-block-contact/tests
+++ b/modules/contact/test/tests/bouncing-block-contact/tests
@@ -96,12 +96,13 @@
   [weighted_gap]
     requirement = 'The system shall support a variationally consistent weighted gap implementation '
                   'of the zero-penetration contact constraint'
-    issues = '#16961'
+    issues = '#16961 #33322'
     [equal_order]
       type = 'Exodiff'
       input = frictionless-weighted-gap.i
       exodiff = 'frictionless-weighted-gap_out.e'
       detail = 'using equal, first order bases for displacements and the lagrange multiplier'
+      recover = false # Recover can restart from an early checkpoint and output extra adaptive steps
       cli_args = "Mesh/file=long-bottom-block-1elem-blocks-coarse.e Executioner/end_time=50 "
                  "Postprocessors/active=''"
     []
@@ -115,6 +116,26 @@
                  "Postprocessors/active=''"
       capabilities = 'ad_size>=73'
       restep = false # Issue #31054
+    []
+    [fischer_burmeister_exact_touch_normal_ncp]
+      type = 'RunApp'
+      input = frictionless-weighted-gap.i
+      detail = 'using the Fischer-Burmeister normal complementarity function at exact initial '
+               'contact'
+      cli_args = "starting_point=0 offset=0 Mesh/file=long-bottom-block-1elem-blocks-coarse.e "
+                 "Executioner/end_time=0.1 Executioner/dt=0.1 "
+                 "Constraints/weighted_gap_lm/normal_ncp_function=FISCHER_BURMEISTER "
+                 "Postprocessors/active='' Outputs/exodus=false"
+    []
+    [smooth_normal_ncp_requires_width]
+      type = 'RunException'
+      input = frictionless-weighted-gap.i
+      expect_err = 'A positive normal_ncp_smoothing_width is required when normal_ncp_function is '
+                   'a smooth NCP function.'
+      detail = 'and report an error if a smooth normal complementarity function is selected '
+               'without a positive smoothing width'
+      cli_args = "Mesh/file=long-bottom-block-1elem-blocks-coarse.e "
+                 "Constraints/weighted_gap_lm/normal_ncp_function=SMOOTH_MIN Outputs/exodus=false"
     []
     [equal_order_edge_dropping]
       type = 'Exodiff'
@@ -207,7 +228,7 @@
   [weighted_vel_pdass]
     requirement = 'The system shall support a variationally consistent mortar frictional constraints '
                   'with dual bases'
-    issues = '#17495'
+    issues = '#17495 #33322'
 
     [verbose]
       type = 'Exodiff'
@@ -224,6 +245,16 @@
       detail = 'using the contact action'
       cli_args = "Postprocessors/active=''"
       custom_cmp = 'frictional-nodal-min-normal-lm-mortar-pdass-tangential-lm-mortar-action.cmp'
+    []
+    [action_smooth_fischer_burmeister_normal_ncp]
+      type = 'RunApp'
+      input = frictional-nodal-min-normal-lm-mortar-pdass-tangential-lm-mortar-action.i
+      detail = 'using the contact action with a smooth Fischer-Burmeister normal '
+               'complementarity function'
+      cli_args = "Executioner/end_time=5 "
+                 "Contact/frictional/normal_ncp_function=SMOOTH_FISCHER_BURMEISTER "
+                 "Contact/frictional/normal_ncp_smoothing_width=1e-8 Postprocessors/active='' "
+                 "Outputs/exodus=false"
     []
   []
   [split_secondary]

--- a/modules/contact/test/tests/mortar_dynamics/tests
+++ b/modules/contact/test/tests/mortar_dynamics/tests
@@ -41,6 +41,20 @@
     # ComputeDynamicWeightedGapLMMechanicalContact does not support recover
     recover = false
   []
+  [block-dynamics-action-smooth-min-normal-ncp]
+    type = 'RunApp'
+    input = 'block-dynamics-action.i'
+    issues = '#33322'
+    cli_args = 'Contact/mechanical/mortar_dynamics=true Contact/mechanical/newmark_beta=0.25 '
+               'Contact/mechanical/newmark_gamma=0.5 '
+               'Contact/mechanical/normal_ncp_function=SMOOTH_MIN '
+               'Contact/mechanical/normal_ncp_smoothing_width=1e-8 Executioner/dt=0.05 '
+               'Executioner/end_time=0.05 Outputs/exodus=false'
+    requirement = 'The system shall solve dynamic mortar frictionless contact with a smooth min '
+                  'normal complementarity function via the contact mechanics action.'
+    # ComputeDynamicWeightedGapLMMechanicalContact does not support recover
+    recover = false
+  []
   [block-dynamics-action-beta-error]
     type = RunException
     input = 'block-dynamics-action.i'


### PR DESCRIPTION
closes #33322

## Reason

LM mortar normal contact currently exposes only the min-function NCP residual for the normal weighted-gap constraint. That preserves exact complementarity, but it gives users no input-level way to try smooth-min or Fischer-Burmeister forms when active-set transitions make nonlinear solves difficult.

## Design

- Add `normal_ncp_function = MIN | SMOOTH_MIN | FISCHER_BURMEISTER | SMOOTH_FISCHER_BURMEISTER`.
- Add `normal_ncp_smoothing_width` for the smooth normal NCP functions.
- Apply the selected residual in the static and dynamic LM mortar weighted-gap constraints, including the frictional subclasses that inherit the normal constraint.
- Thread the parameters through `ContactAction` for `formulation = mortar` and reject them for non-mortar contact formulations.
- Use a finite generalized derivative for exact Fischer-Burmeister at the origin so exact-touch states do not produce invalid AD derivatives.
- Document the smoothing-width scale and add focused regression coverage for direct constraint use and action-based contact use.

## Impact

Existing inputs and results are unchanged because `MIN` remains the default. Users gain optional smooth-min and Fischer-Burmeister normal NCP residuals for LM mortar contact. Penalty mortar and node-face contact are unchanged.
