### PR TITLE
cache_elem_data() if needed in surface remesher

### DIFF
--- a/framework/src/meshgenerators/SurfaceSubdomainsDelaunayRemesher.C
+++ b/framework/src/meshgenerators/SurfaceSubdomainsDelaunayRemesher.C
@@ -448,6 +448,13 @@ SurfaceSubdomainsDelaunayRemesher::General2DDelaunay(
       }
     }
   }
+
+  // get_mesh_subdomains() pulls from a cache, and can scream at us
+  // if the Mesh thinks the element caches have been invalidated by
+  // Modification.
+  if (!mesh_2d.preparation().has_cached_elem_data)
+    mesh_2d.cache_elem_data();
+
   // Give the old subdomain to all elements
   const auto common_id = mesh_2d.get_mesh_subdomains().begin();
   for (auto & elem : mesh->active_element_ptr_range())


### PR DESCRIPTION
The existing code here isn't actually going to output wrong results (those Modification calls are invalidating cached spatial dimension but only querying cached subdomains), but it's interfering with my attempts to fix a couple libMesh preparation bugs in
https://github.com/libMesh/libmesh/pull/4435

Refs #32398

## Reason
We're keeping track of "cached element data" preparation in one bool, for forwards compatibility and to keep the updates inside a single element loop, but that means we can't go perfectly fine-grained with preparation aspects, so for safety we have to rebuild all element data caches whenever one of them gets invalidated.  I'm trying to make sure MeshTools::Modification marks caches invalid whenever they might be, and to assert that we only query caches if they're marked valid, but the extra safety requires an extra rebuild here.

## Design
Rebuild cached data (including subdomain sets) if needed.

## Impact
No API changes.

No effect at all before https://github.com/libMesh/libmesh/pull/4435 gets merged.  After that merge there'll be a tiny slowdown, one extra element loop in this mesh generator.