### PR TITLE
Protect against receiving signal during MPI communication

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -14,6 +14,7 @@
 #include "libmesh/libmesh_common.h"
 #include "XTermConstants.h"
 
+#include <csignal>
 #include <limits>
 #include <memory>
 #include <set>
@@ -170,7 +171,7 @@ inline constexpr std::size_t invalid_size_t = std::numeric_limits<std::size_t>::
  * Used by the signal handler to determine if we should write a checkpoint file out at any point
  * during operation.
  */
-extern int interrupt_signal_number;
+extern volatile std::sig_atomic_t interrupt_signal_number;
 
 /**
  * Set to false (the default) to display an error message only once for each error call code

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -905,7 +905,7 @@ bool _warnings_are_errors = false;
 bool _deprecated_is_error = false;
 bool _throw_on_error = false;
 bool _throw_on_warning = false;
-int interrupt_signal_number = 0;
+volatile std::sig_atomic_t interrupt_signal_number = 0;
 bool show_multiple = false;
 
 } // namespace Moose

--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -239,9 +239,13 @@ Output::outputStep(const ExecFlagType & type)
   // Return if the current output is not on the desired interval and there is
   // no signal to process
   const bool on_interval_or_exec_final = (onInterval() || (type == EXEC_FINAL));
-  // Sync across processes and only output one time per signal received.
-  comm().max(Moose::interrupt_signal_number);
-  const bool signal_received = Moose::interrupt_signal_number;
+  // Reduce a copy so MPI cannot overwrite a signal received during the collective.
+  int signal_number = Moose::interrupt_signal_number;
+  comm().max(signal_number);
+  // Do not write back zero because the handler may have set the latch after the copy.
+  if (signal_number)
+    Moose::interrupt_signal_number = signal_number;
+  const bool signal_received = signal_number;
   if (!(on_interval_or_exec_final || signal_received))
     return;
 

--- a/test/src/userobjects/WaitForSignal.C
+++ b/test/src/userobjects/WaitForSignal.C
@@ -55,14 +55,18 @@ WaitForSignal::execute()
   {
     // Sync the latched signal across processes, matching Output::outputStep so
     // that the checkpoint sees a consistent value at the end of the step.
-    comm().max(Moose::interrupt_signal_number);
+    int signal_number = Moose::interrupt_signal_number;
+    comm().max(signal_number);
+    // Do not write back zero because the handler may have set the latch after the copy.
+    if (signal_number)
+      Moose::interrupt_signal_number = signal_number;
 
     const std::chrono::duration<Real> elapsed = std::chrono::steady_clock::now() - start;
     timed_out = elapsed.count() >= _timeout;
 
     // Decide collectively whether to release, so all ranks break on the same
     // iteration and none is left in a collective call by itself.
-    int done = (Moose::interrupt_signal_number != 0 || timed_out) ? 1 : 0;
+    int done = (signal_number != 0 || timed_out) ? 1 : 0;
     comm().max(done);
     if (done)
       break;


### PR DESCRIPTION
This PR does two things:
- Make the global atomic so there are never any torn read-writes
- Do MPI communications with a local variable so we don't miss a signal that comes in while we're in the process of communicating

Refs #24252