### PR TITLE
Fix index for liquid phase

### DIFF
--- a/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
@@ -311,7 +311,7 @@ PorousFlowBrineCO2::saturation(const ADReal & pressure,
                                std::vector<FluidStateProperties> & fsp) const
 {
   auto & gas = fsp[_gas_phase_number];
-  auto & liquid = fsp[_aqueous_fluid_component];
+  auto & liquid = fsp[_aqueous_phase_number];
 
   // Approximate liquid density as saturation isn't known yet, by using the gas
   // pressure rather than the liquid pressure. This does result in a small error

--- a/modules/porous_flow/src/userobjects/PorousFlowWaterNCG.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowWaterNCG.C
@@ -310,7 +310,7 @@ PorousFlowWaterNCG::saturation(const ADReal & pressure,
                                std::vector<FluidStateProperties> & fsp) const
 {
   auto & gas = fsp[_gas_phase_number];
-  auto & liquid = fsp[_aqueous_fluid_component];
+  auto & liquid = fsp[_aqueous_phase_number];
 
   // Approximate liquid density as saturation isn't known yet, by using the gas
   // pressure rather than the liquid pressure. This does result in a small error


### PR DESCRIPTION
PorousFlowBrineCO2::saturation and PorousFlowWaterNCG::saturation incorrectly used _aqueous_fluid_component instead of _aqueous_phase_number.

Fixes #33350
