### PR TITLE
C++20 warning fixes

### DIFF
--- a/framework/contrib/gtest/gtest/gtest-printers.h
+++ b/framework/contrib/gtest/gtest/gtest-printers.h
@@ -521,11 +521,11 @@ GTEST_API_ void PrintTo(wchar_t wc, ::std::ostream* os);
 
 GTEST_API_ void PrintTo(char32_t c, ::std::ostream* os);
 inline void PrintTo(char16_t c, ::std::ostream* os) {
-  PrintTo(ImplicitCast_<char32_t>(c), os);
+  PrintTo(static_cast<char32_t>(c), os);
 }
 #ifdef __cpp_lib_char8_t
 inline void PrintTo(char8_t c, ::std::ostream* os) {
-  PrintTo(ImplicitCast_<char32_t>(c), os);
+  PrintTo(static_cast<char32_t>(c), os);
 }
 #endif
 

--- a/framework/contrib/hit/src/hit/lex.cc
+++ b/framework/contrib/hit/src/hit/lex.cc
@@ -13,7 +13,6 @@ const std::string digits = "0123456789";
 const std::string alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const std::string space = " \t";
 const std::string allspace = " \t\n\r";
-const std::string newline = "\n\r";
 const std::string alphanumeric = digits + alpha;
 const std::string identchars = alphanumeric + "_./:<>-+*!";
 


### PR DESCRIPTION
This fixes #33015 for me. (at least in `dbg` mode, but surely we have no real `opt` mode code paths that aren't in `dbg` mode too; that'd be a different and more serious problem)

I had no idea there were only going to be two fixes here, or I would have just fixed them in May instead of turning off -Werror and letting my eyes glaze over warnings.