### PR TITLE
Gravity QF test hotfix

### DIFF
--- a/test/tests/mfem/kernels/gravity_qf.i
+++ b/test/tests/mfem/kernels/gravity_qf.i
@@ -104,7 +104,7 @@
     type = MFEMHyprePCG
     preconditioner = boomeramg
     l_max_its = 100
-    l_tol = 1e-4
+    l_tol = 1e-10
     l_abs_tol = 0.0
     print_level = 2
   []


### PR DESCRIPTION
Closes #33364

(Fixes the [p=5 and p=6 Gravity QF runs](https://github.com/idaholab/moose/pull/33292#issuecomment-4998891857))