### PR TITLE
Kokkos SYCL build

### DIFF
--- a/framework/include/base/Registry.h
+++ b/framework/include/base/Registry.h
@@ -32,18 +32,21 @@
 /// when your app/module code may be compiled with other apps without your objects being
 /// registered.  Calling this multiple times with the same argument is safe.
 #define registerKnownLabel(X)                                                                      \
-  static char combineNames(dummy_var_for_known_label, __COUNTER__) = Registry::addKnownLabel(X)
+  [[maybe_unused]] static char combineNames(dummy_var_for_known_label, __COUNTER__) =              \
+      Registry::addKnownLabel(X)
 
 /// add an Action to the registry with the given app name/label as being associated with the given
 /// task (quoted string).  classname is the (unquoted) c++ class.
 #define registerMooseAction(app, classname, task)                                                  \
-  static char combineNames(dummyvar_for_registering_action_##classname, __COUNTER__) =             \
+  [[maybe_unused]] static char combineNames(dummyvar_for_registering_action_##classname,           \
+                                            __COUNTER__) =                                         \
       Registry::addAction<classname>({app, #classname, "", task, __FILE__, __LINE__, "", ""})
 
 /// Add a MooseObject to the registry with the given app name/label.  classname is the (unquoted)
 /// c++ class.  Each object/class should only be registered once.
 #define registerMooseObject(app, classname)                                                        \
-  static char combineNames(dummyvar_for_registering_obj_##classname, __COUNTER__) =                \
+  [[maybe_unused]] static char combineNames(dummyvar_for_registering_obj_##classname,              \
+                                            __COUNTER__) =                                         \
       Registry::add<classname>({app, #classname, "", "", __FILE__, __LINE__, "", ""})
 
 #define registerADMooseObject(app, classname) registerMooseObject(app, classname)
@@ -51,13 +54,15 @@
 /// Add a MooseObject to the registry with the given app name/label under an alternate alias/name
 /// (quoted string) instead of the classname.
 #define registerMooseObjectAliased(app, classname, alias)                                          \
-  static char combineNames(dummyvar_for_registering_obj_##classname, __COUNTER__) =                \
+  [[maybe_unused]] static char combineNames(dummyvar_for_registering_obj_##classname,              \
+                                            __COUNTER__) =                                         \
       Registry::add<classname>({app, #classname, alias, "", __FILE__, __LINE__, "", ""})
 
 /// Add a deprecated MooseObject to the registry with the given app name/label. time is the time
 /// the object became/becomes deprecated in "mm/dd/yyyy HH:MM" format.
 #define registerMooseObjectDeprecated(app, classname, time)                                        \
-  static char combineNames(dummyvar_for_registering_obj_##classname, __COUNTER__) =                \
+  [[maybe_unused]] static char combineNames(dummyvar_for_registering_obj_##classname,              \
+                                            __COUNTER__) =                                         \
       Registry::add<classname>({app, #classname, "", "", __FILE__, __LINE__, time, ""})
 
 #define registerADMooseObjectDeprecated(app, classname, time)                                      \
@@ -66,7 +71,8 @@
 /// add a deprecated MooseObject to the registry that has been replaced by another
 /// object. time is the time the object became/becomes deprecated in "mm/dd/yyyy hh:mm" format.
 #define registerMooseObjectReplaced(app, classname, time, replacement)                             \
-  static char combineNames(dummyvar_for_registering_obj_##classname, __COUNTER__) =                \
+  [[maybe_unused]] static char combineNames(dummyvar_for_registering_obj_##classname,              \
+                                            __COUNTER__) =                                         \
       Registry::add<classname>({app, #classname, "", "", __FILE__, __LINE__, time, #replacement})
 
 /// add a deprecated MooseObject orig_class to the registry that has been replaced by another
@@ -74,7 +80,8 @@
 /// "mm/dd/yyyy hh:mm" format.
 /// A call to registerMooseObject is still required for the new class
 #define registerMooseObjectRenamed(app, orig_class, time, new_class)                               \
-  static char combineNames(dummyvar_for_registering_obj_##orig_class, __COUNTER__) =               \
+  [[maybe_unused]] static char combineNames(dummyvar_for_registering_obj_##orig_class,             \
+                                            __COUNTER__) =                                         \
       Registry::add<new_class>(                                                                    \
           {app, #new_class, #orig_class, #orig_class, __FILE__, __LINE__, time, #new_class})
 

--- a/framework/include/kokkos/base/KokkosDispatcher.h
+++ b/framework/include/kokkos/base/KokkosDispatcher.h
@@ -383,7 +383,8 @@ private:
     return 0;                                                                                      \
   }                                                                                                \
                                                                                                    \
-  static char combineNames(kokkos_dispatcher_residual_object_##classname, __COUNTER__) =           \
+  [[maybe_unused]] static char combineNames(kokkos_dispatcher_residual_object_##classname,         \
+                                            __COUNTER__) =                                         \
       registerKokkosResidualObject##classname()
 
 #define registerKokkosResidualObject(app, classname)                                               \
@@ -406,7 +407,8 @@ private:
     return 0;                                                                                      \
   }                                                                                                \
                                                                                                    \
-  static char combineNames(kokkos_dispatcher_ad_residual_object_##classname, __COUNTER__) =        \
+  [[maybe_unused]] static char combineNames(kokkos_dispatcher_ad_residual_object_##classname,      \
+                                            __COUNTER__) =                                         \
       registerKokkosADResidualObject##classname()
 
 #define registerKokkosADResidualObject(app, classname)                                             \
@@ -446,7 +448,7 @@ private:
     return 0;                                                                                      \
   }                                                                                                \
                                                                                                    \
-  static char combineNames(kokkos_dispatcher_material_##classname, __COUNTER__) =                  \
+  [[maybe_unused]] static char combineNames(kokkos_dispatcher_material_##classname, __COUNTER__) = \
       registerKokkosMaterial##classname()
 
 #define registerKokkosMaterial(app, classname)                                                     \
@@ -470,8 +472,8 @@ private:
     return 0;                                                                                      \
   }                                                                                                \
                                                                                                    \
-  static char combineNames(kokkos_dispatcher_auxkernel_##classname, __COUNTER__) =                 \
-      registerKokkosAuxKernel##classname()
+  [[maybe_unused]] static char combineNames(kokkos_dispatcher_auxkernel_##classname,               \
+                                            __COUNTER__) = registerKokkosAuxKernel##classname()
 
 #define registerKokkosAuxKernel(app, classname)                                                    \
   registerMooseObject(app, classname);                                                             \
@@ -498,8 +500,8 @@ private:
     return 0;                                                                                      \
   }                                                                                                \
                                                                                                    \
-  static char combineNames(kokkos_dispatcher_userobject_##classname, __COUNTER__) =                \
-      registerKokkosUserObject##classname()
+  [[maybe_unused]] static char combineNames(kokkos_dispatcher_userobject_##classname,              \
+                                            __COUNTER__) = registerKokkosUserObject##classname()
 
 #define registerKokkosUserObject(app, classname)                                                   \
   registerMooseObject(app, classname);                                                             \
@@ -521,5 +523,5 @@ private:
     return 0;                                                                                      \
   }                                                                                                \
                                                                                                    \
-  static char combineNames(kokkos_##classname##_##operation, __COUNTER__) =                        \
+  [[maybe_unused]] static char combineNames(kokkos_##classname##_##operation, __COUNTER__) =       \
       registerKokkos##classname##operation()

--- a/framework/include/kokkos/base/KokkosFunctorWrapper.h
+++ b/framework/include/kokkos/base/KokkosFunctorWrapper.h
@@ -30,7 +30,7 @@ public:
   /**
    * Virtual destructor
    */
-  KOKKOS_FUNCTION virtual ~FunctorWrapperDeviceBase() {}
+  KOKKOS_VIRTUAL_FUNCTION ~FunctorWrapperDeviceBase() {}
 };
 
 /**

--- a/framework/include/kokkos/base/KokkosHeader.h
+++ b/framework/include/kokkos/base/KokkosHeader.h
@@ -35,14 +35,19 @@
 #ifdef KOKKOS_ENABLE_CUDA
 #define MemSpace ::Kokkos::CudaSpace
 #define ExecSpace ::Kokkos::Cuda
+#define KOKKOS_VIRTUAL_FUNCTION KOKKOS_FUNCTION virtual
 #endif
 #ifdef KOKKOS_ENABLE_HIP
 #define MemSpace ::Kokkos::HIPSpace
 #define ExecSpace ::Kokkos::HIP
+#define KOKKOS_VIRTUAL_FUNCTION KOKKOS_FUNCTION virtual
 #endif
 #ifdef KOKKOS_ENABLE_SYCL
 #define MemSpace ::Kokkos::SYCLDeviceUSMSpace
 #define ExecSpace ::Kokkos::SYCL
+#define KOKKOS_VIRTUAL_FUNCTION                                                                    \
+  KOKKOS_FUNCTION SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(                                               \
+      sycl::ext::oneapi::experimental::indirectly_callable) virtual
 #endif
 #else
 #define MemSpace ::Kokkos::HostSpace
@@ -51,6 +56,7 @@
 #define KOKKOS_FUNCTION
 #undef KOKKOS_INLINE_FUNCTION
 #define KOKKOS_INLINE_FUNCTION inline
+#define KOKKOS_VIRTUAL_FUNCTION KOKKOS_FUNCTION virtual
 #undef KOKKOS_IF_ON_HOST
 #define KOKKOS_IF_ON_HOST(code)                                                                    \
   if (!omp_get_level())                                                                            \

--- a/framework/include/kokkos/functions/KokkosFunctionWrapper.h
+++ b/framework/include/kokkos/functions/KokkosFunctionWrapper.h
@@ -30,21 +30,21 @@ public:
   /**
    * Virtual destructor
    */
-  KOKKOS_FUNCTION virtual ~FunctionWrapperDeviceBase() {}
+  KOKKOS_VIRTUAL_FUNCTION ~FunctionWrapperDeviceBase() {}
 
   /**
    * Virtual shims that calls the corresponding methods of the actual stored function
    */
   ///@{
-  KOKKOS_FUNCTION virtual Real value(Real t, Real3 p) const = 0;
-  KOKKOS_FUNCTION virtual Real3 vectorValue(Real t, Real3 p) const = 0;
-  KOKKOS_FUNCTION virtual Real3 gradient(Real t, Real3 p) const = 0;
-  KOKKOS_FUNCTION virtual Real3 curl(Real t, Real3 p) const = 0;
-  KOKKOS_FUNCTION virtual Real div(Real t, Real3 p) const = 0;
-  KOKKOS_FUNCTION virtual Real timeDerivative(Real t, Real3 p) const = 0;
-  KOKKOS_FUNCTION virtual Real timeIntegral(Real t1, Real t2, Real3 p) const = 0;
-  KOKKOS_FUNCTION virtual Real integral() const = 0;
-  KOKKOS_FUNCTION virtual Real average() const = 0;
+  KOKKOS_VIRTUAL_FUNCTION Real value(Real t, Real3 p) const = 0;
+  KOKKOS_VIRTUAL_FUNCTION Real3 vectorValue(Real t, Real3 p) const = 0;
+  KOKKOS_VIRTUAL_FUNCTION Real3 gradient(Real t, Real3 p) const = 0;
+  KOKKOS_VIRTUAL_FUNCTION Real3 curl(Real t, Real3 p) const = 0;
+  KOKKOS_VIRTUAL_FUNCTION Real div(Real t, Real3 p) const = 0;
+  KOKKOS_VIRTUAL_FUNCTION Real timeDerivative(Real t, Real3 p) const = 0;
+  KOKKOS_VIRTUAL_FUNCTION Real timeIntegral(Real t1, Real t2, Real3 p) const = 0;
+  KOKKOS_VIRTUAL_FUNCTION Real integral() const = 0;
+  KOKKOS_VIRTUAL_FUNCTION Real average() const = 0;
   ///@}
 };
 

--- a/framework/kokkos.mk
+++ b/framework/kokkos.mk
@@ -18,6 +18,16 @@ KOKKOS_CUDA_ARCH_90  := Hopper CC 9.0
 KOKKOS_CUDA_ARCH_100 := Blackwell CC 10.0
 KOKKOS_CUDA_ARCH_120 := Blackwell CC 12.0
 
+# SYCL architecture strings
+KOKKOS_SYCL_ARCH_        := SPIR-V
+KOKKOS_SYCL_ARCH_gen9-   := Gen9+
+KOKKOS_SYCL_ARCH_gen9    := Gen9
+KOKKOS_SYCL_ARCH_gen11   := Gen11
+KOKKOS_SYCL_ARCH_gen12lp := Gen12LP
+KOKKOS_SYCL_ARCH_dg1     := DG1
+KOKKOS_SYCL_ARCH_12.50.4 := Xe-HP
+KOKKOS_SYCL_ARCH_12.60.7 := Xe-HPC
+
 CUDA_COMPILER ?= nvcc
 HIP_COMPILER  ?= hipcc
 SYCL_COMPILER ?= icpx
@@ -47,6 +57,7 @@ ifeq ($(PETSC_HAVE_KOKKOS),1)
     endif
   endif
   ifeq ($(PETSC_HAVE_SYCL),1)
+    SYCL_ARCH := $(shell sed -n 's/\#define PETSC_SYCL_DEVICE //p' $(PETSC_CONF))
   endif
 else
   $(error PETSc was not configured with Kokkos support)
@@ -86,14 +97,17 @@ else ifneq ($(PETSC_HAVE_HIP),) # To be determined for HIP
   KOKKOS_CXXFLAGS    =
   KOKKOS_CPPFLAGS    =
   KOKKOS_LDFLAGS     =
-else ifneq ($(PETSC_HAVE_SYCL),) # To be determined for SYCL
+else ifneq ($(PETSC_HAVE_SYCL),)
   KOKKOS_DEVICE     := SYCL
-  KOKKOS_ARCH       :=
-  KOKKOS_COMPILER   := DPCPP
+  KOKKOS_ARCH       := $(KOKKOS_SYCL_ARCH_$(SYCL_ARCH))
+  KOKKOS_COMPILER   := ICPX
   KOKKOS_CXX         = $(SYCL_COMPILER)
-  KOKKOS_CXXFLAGS    = -fsycl
-  KOKKOS_CPPFLAGS    =
-  KOKKOS_LDFLAGS     =
+  KOKKOS_CXXFLAGS    = -fsycl -fsycl-targets=spir64_gen -x c++ $(CXXFLAGS) $(libmesh_CXXFLAGS)
+  KOKKOS_CPPFLAGS    = $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS}
+  KOKKOS_LDFLAGS     = -fsycl
+  ifneq ($(SYCL_ARCH),)
+    KOKKOS_LDFLAGS  += -Xsycl-target-backend "-device $(SYCL_ARCH)"
+  endif
 else
   KOKKOS_COMPILER   := CPU
   KOKKOS_CXX         = $(libmesh_CXX)

--- a/framework/src/kokkos/base/KokkosArray.K
+++ b/framework/src/kokkos/base/KokkosArray.K
@@ -137,8 +137,6 @@ Array<T, 1, index_type, LayoutType::LEFT>::nrm2()
   return KokkosBlas::nrm2(self);
 }
 
-template class Array<Real, 1, uint8_t, LayoutType::LEFT>;
-template class Array<Real, 1, uint16_t, LayoutType::LEFT>;
 template class Array<Real, 1, uint32_t, LayoutType::LEFT>;
 template class Array<Real, 1, uint64_t, LayoutType::LEFT>;
 


### PR DESCRIPTION
SYCL build only supports Intel OneAPI toolchain (uses Intel MPI as well) and requires Kokkos 5+ (tested with OneAPI 2026.0.0 + Kokkos 5.1, does not build with the current Kokkos 4.7).

Currently, PETSc does not support configuring libCEED with SYCL, but I'm not sure whether it is even necessary as MFEM doesn't seem to utilize SYCL. SLATE is not used for PTSCOTCH, so it is not necessary either.

Supporting virtual functions requires a Kokkos update: https://github.com/kokkos/kokkos/pull/8070. A MetaPhysicL patch is also required to supply missing `Kokkos::nearbyint()` overload for SYCL: https://github.com/libMesh/MetaPhysicL/pull/74.