### PR TITLE
Sanitize semantics of MooseUtils::tokenize() w/ MooseUtils::stringSplit() 

### DIFF
--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -347,7 +347,7 @@ CommandLine::setCommandLineParam(std::list<CommandLine::Entry>::iterator entry_i
       if constexpr (std::is_same_v<T, std::vector<std::string>>)
       {
         std::vector<std::string> split_values;
-        MooseUtils::tokenize(*entry.value, split_values, 1, " ");
+        MooseUtils::stringSplit(*entry.value, split_values);
         value.resize(split_values.size());
         for (const auto i : index_range(split_values))
           set_value(split_values[i], value[i]);

--- a/framework/include/parser/ParameterRegistration.h
+++ b/framework/include/parser/ParameterRegistration.h
@@ -211,7 +211,7 @@ setTripleVectorValue(std::vector<std::vector<std::vector<T>>> & value, const hit
 
   // split vector at delim | to get a series of 2D subvectors
   std::vector<std::string> outer_tokens;
-  MooseUtils::tokenize(buffer, outer_tokens, 1, "|");
+  MooseUtils::stringSplit(buffer, outer_tokens, 1, "|");
   value.resize(outer_tokens.size());
   for (const auto i : index_range(outer_tokens))
   {
@@ -228,7 +228,7 @@ setTripleVectorValue(std::vector<std::vector<std::vector<T>>> & value, const hit
     // split each 2D subvector at delim ; to get 1D sub-subvectors
     // NOTE: the 1D sub-subvectors are _not_ of type T yet
     std::vector<std::string> inner_tokenized;
-    MooseUtils::tokenize(inner_token, inner_tokenized, 1, ";");
+    MooseUtils::stringSplit(inner_token, inner_tokenized, 1, ";");
     inner_value.resize(inner_tokenized.size());
     for (const auto j : index_range(inner_tokenized))
     {

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -1886,7 +1886,7 @@ InputParameters::addCommandLineParamHelper(const std::string & name,
 
   // Split up the syntax by whitespace
   std::vector<std::string> syntax_split;
-  MooseUtils::tokenize(syntax, syntax_split, 1, " \t\n\v\f\r");
+  MooseUtils::stringSplit(syntax, syntax_split);
 
   // Set the single syntax string as the combined syntax with removed whitespace
   cl_data->syntax = MooseUtils::stringJoin(syntax_split);

--- a/framework/include/utils/MooseEnum.h
+++ b/framework/include/utils/MooseEnum.h
@@ -25,7 +25,7 @@
     std::string s = #__VA_ARGS__;                                                                  \
     /* 2) normalize to the format MooseEnum expects: "A B C=3 D ..."                  */           \
     std::vector<std::string> elements;                                                             \
-    MooseUtils::tokenize(s, elements, 1, ",");                                                     \
+    MooseUtils::stringSplit(s, elements, 1, ",");                                                  \
     for (auto & elem : elements)                                                                   \
       elem.erase(std::remove_if(elem.begin(), elem.end(), isspace), elem.end());                   \
     return MooseUtils::join(elements, " ");                                                        \

--- a/framework/include/utils/MooseStringUtils.h
+++ b/framework/include/utils/MooseStringUtils.h
@@ -207,4 +207,30 @@ stringJoin(const std::vector<std::string> & values, const std::string & separato
     combined = combined.substr(0, combined.size() - separator.size());
   return combined;
 }
+
+/**
+ * This function will split the passed in string on a set of delimiters appending the substrings to
+ * the passed in vector, which is cleared beforehand. The delimiters default to whitespace, but may
+ * be supplied as well. In addition, if min_len is provided, all tokens whose length is below
+ * min_len will be discarded. T should be std::string or a MOOSE derived string class.
+ */
+template <typename T>
+void
+stringSplit(const std::string & str,
+            std::vector<T> & elements,
+            unsigned int min_len = 1,
+            const std::string & delims = " \t\n\v\f\r")
+{
+  elements.clear();
+
+  std::string::size_type last_pos = 0, curr_pos = 0;
+
+  do
+  {
+    curr_pos = str.find_first_of(delims, last_pos);
+    if (auto token = str.substr(last_pos, curr_pos - last_pos); token.length() >= min_len)
+      elements.push_back(std::move(token));
+    last_pos = curr_pos + 1;
+  } while (curr_pos != std::string::npos);
+}
 }

--- a/framework/include/utils/MooseStringUtils.h
+++ b/framework/include/utils/MooseStringUtils.h
@@ -45,10 +45,11 @@ trim(const std::string & str, const std::string & white_space = " \t\n\v\f\r")
 }
 
 /**
- * This function will split the passed in string on a set of delimiters appending the substrings
- * to the passed in vector.  The delimiters default to "/" but may be supplied as well.  In
- * addition if min_len is supplied, the minimum token length will be >= than the supplied
- * value. T should be std::string or a MOOSE derived string class.
+ * This function will split the passed in string on a set of delimiters appending the substrings to
+ * the passed in vector, which is cleared beforehand. The delimiters default to "/", but may be
+ * supplied as well. In addition, if min_len is provided, the minimum token length will be >= than
+ * the supplied value *even if the token includes delimiters*. You should probably be using the much
+ * more sane stringSplit alternative below. T should be std::string or a MOOSE derived string class.
  */
 template <typename T>
 void

--- a/framework/src/actions/AddAuxKernelAction.C
+++ b/framework/src/actions/AddAuxKernelAction.C
@@ -35,7 +35,7 @@ void
 AddAuxKernelAction::act()
 {
   std::vector<std::string> elements;
-  MooseUtils::tokenize<std::string>(_pars.blockFullpath(), elements);
+  MooseUtils::stringSplit(_pars.blockFullpath(), elements, 1, "/");
 
   // The variable name will be the second to last element in the path name
   std::string & var_name = elements[elements.size() - 2];

--- a/framework/src/actions/AddFVICAction.C
+++ b/framework/src/actions/AddFVICAction.C
@@ -35,7 +35,7 @@ void
 AddFVICAction::act()
 {
   std::vector<std::string> elements;
-  MooseUtils::tokenize<std::string>(_pars.blockFullpath(), elements);
+  MooseUtils::stringSplit(_pars.blockFullpath(), elements, 1, "/");
 
   // The variable name will be the second to last element in the path name
   std::string & var_name = elements[elements.size() - 2];

--- a/framework/src/actions/AddICAction.C
+++ b/framework/src/actions/AddICAction.C
@@ -35,7 +35,7 @@ void
 AddICAction::act()
 {
   std::vector<std::string> elements;
-  MooseUtils::tokenize<std::string>(_pars.blockFullpath(), elements);
+  MooseUtils::stringSplit(_pars.blockFullpath(), elements, 1, "/");
 
   // The variable name will be the second to last element in the path name
   std::string & var_name = elements[elements.size() - 2];

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -2185,7 +2185,7 @@ MooseApp::showInputs() const
     {
       mooseAssert(!show_inputs_syntax.empty(), "show_inputs sytnax should not be empty");
 
-      MooseUtils::tokenize(installable_inputs, dirs, 1, " ");
+      MooseUtils::stringSplit(installable_inputs, dirs);
       Moose::out << "The following directories are installable into a user-writeable directory:\n\n"
                  << installable_inputs << '\n'
                  << "\nTo install one or more directories of inputs, execute the binary with the \""
@@ -2844,7 +2844,7 @@ MooseApp::getLibrarySearchPaths(const std::string & library_path) const
   if (!library_path.empty())
   {
     std::vector<std::string> tmp_paths;
-    MooseUtils::tokenize(library_path, tmp_paths, 1, ":");
+    MooseUtils::stringSplit(library_path, tmp_paths, 1, ":");
 
     paths.insert(tmp_paths.begin(), tmp_paths.end());
   }
@@ -2854,7 +2854,7 @@ MooseApp::getLibrarySearchPaths(const std::string & library_path) const
   {
     std::string moose_lib_path(moose_lib_path_env);
     std::vector<std::string> tmp_paths;
-    MooseUtils::tokenize(moose_lib_path, tmp_paths, 1, ":");
+    MooseUtils::stringSplit(moose_lib_path, tmp_paths, 1, ":");
 
     paths.insert(tmp_paths.begin(), tmp_paths.end());
   }

--- a/framework/src/meshgenerators/TransfiniteMeshGenerator.C
+++ b/framework/src/meshgenerators/TransfiniteMeshGenerator.C
@@ -303,7 +303,7 @@ TransfiniteMeshGenerator::getParsedEdge(const std::string & parameter,
   Real x_coord, y_coord;
 
   std::vector<std::string> param_coords;
-  MooseUtils::tokenize(parameter, param_coords, 1, ";");
+  MooseUtils::stringSplit(parameter, param_coords, 1, ";");
 
   auto it = 0;
   for (auto rx : param_vec)
@@ -324,7 +324,7 @@ TransfiniteMeshGenerator::getDiscreteEdge(const unsigned int np, const std::stri
 {
   std::vector<Point> edge(np);
   std::vector<std::string> string_points;
-  MooseUtils::tokenize(parameter, string_points, 1, "\n");
+  MooseUtils::stringSplit(parameter, string_points, 1, "\n");
   if (string_points.size() != np)
     mooseError("DISCRETE: the number of discrete points does not match the number of points on the"
                "opposite edge.");

--- a/framework/src/mfem/actions/AddMFEMComplexBCComponentAction.C
+++ b/framework/src/mfem/actions/AddMFEMComplexBCComponentAction.C
@@ -32,7 +32,7 @@ void
 AddMFEMComplexBCComponentAction::act()
 {
   std::vector<std::string> elements;
-  MooseUtils::tokenize<std::string>(_pars.blockFullpath(), elements);
+  MooseUtils::stringSplit(_pars.blockFullpath(), elements, 1, "/");
 
   if (_problem->feBackend() == Moose::FEBackend::MFEM && _name == "RealComponent")
     static_cast<MFEMProblem &>(*_problem).addRealComponentToBC(

--- a/framework/src/mfem/actions/AddMFEMComplexKernelComponentAction.C
+++ b/framework/src/mfem/actions/AddMFEMComplexKernelComponentAction.C
@@ -34,7 +34,7 @@ void
 AddMFEMComplexKernelComponentAction::act()
 {
   std::vector<std::string> elements;
-  MooseUtils::tokenize<std::string>(_pars.blockFullpath(), elements);
+  MooseUtils::stringSplit(_pars.blockFullpath(), elements, 1, "/");
 
   if (_problem->feBackend() == Moose::FEBackend::MFEM && _name == "RealComponent")
     static_cast<MFEMProblem &>(*_problem).addRealComponentToKernel(

--- a/framework/src/parser/ParameterRegistration.C
+++ b/framework/src/parser/ParameterRegistration.C
@@ -200,7 +200,7 @@ static auto realeigenmatrix = registry.add<RealEigenMatrix>(
     {
       value.resize(0, 0);
       std::vector<std::string> tokens;
-      MooseUtils::tokenize(field.param<std::string>(), tokens, 1, ";");
+      MooseUtils::stringSplit(field.param<std::string>(), tokens, 1, ";");
 
       for (const auto i : index_range(tokens))
       {
@@ -314,7 +314,7 @@ static auto vector_multimooseenum = registry.add<std::vector<MultiMooseEnum>>(
       for (const auto i : index_range(tokens))
       {
         std::vector<std::string> strvals;
-        MooseUtils::tokenize<std::string>(tokens[i], strvals, 1, " ");
+        MooseUtils::stringSplit(tokens[i], strvals);
         value[i] = strvals;
       }
     });
@@ -380,7 +380,7 @@ const auto set_double_vector_component_value = [](auto & value, const hit::Field
 
   // Split vector at delim ";" (substrings are not of type T yet)
   std::vector<std::string> tokens;
-  MooseUtils::tokenize(strval, tokens, 1, ";");
+  MooseUtils::stringSplit(strval, tokens, 1, ";");
   value.resize(tokens.size());
 
   // Split each token at spaces

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -69,12 +69,12 @@ void
 Syntax::addDependencySets(const std::string & action_sets)
 {
   std::vector<std::string> sets, prev_names, tasks;
-  MooseUtils::tokenize(action_sets, sets, 1, "()");
+  MooseUtils::stringSplit(action_sets, sets, 1, "()");
 
   for (unsigned int i = 0; i < sets.size(); ++i)
   {
     tasks.clear();
-    MooseUtils::tokenize(sets[i], tasks, 0, ", ");
+    MooseUtils::stringSplit(sets[i], tasks, 1, ", ");
     for (unsigned int j = 0; j < tasks.size(); ++j)
     {
       // Each line should depend on each item in the previous line
@@ -278,7 +278,7 @@ Syntax::isAssociated(const std::string & real_id,
   std::vector<std::string> real_elements, reg_elements;
   std::string return_value;
 
-  MooseUtils::tokenize(real_id, real_elements);
+  MooseUtils::stringSplit(real_id, real_elements, 1, "/");
 
   *is_parent = false;
   for (auto it = syntax_to_traverse.rbegin(); it != syntax_to_traverse.rend(); ++it)
@@ -290,7 +290,7 @@ Syntax::isAssociated(const std::string & real_id,
       return reg_id;
     }
     reg_elements.clear();
-    MooseUtils::tokenize(reg_id, reg_elements);
+    MooseUtils::stringSplit(reg_id, reg_elements, 1, "/");
     if (real_elements.size() <= reg_elements.size())
     {
       bool keep_going = true;

--- a/framework/src/preconditioners/SingleMatrixPreconditioner.C
+++ b/framework/src/preconditioners/SingleMatrixPreconditioner.C
@@ -69,7 +69,7 @@ SingleMatrixPreconditioner::SingleMatrixPreconditioner(const InputParameters & p
     for (const auto & group : getParam<std::vector<NonlinearVariableName>>("coupled_groups"))
     {
       std::vector<VariableName> vars;
-      MooseUtils::tokenize(group, vars, 1, ",");
+      MooseUtils::stringSplit(group, vars, 1, ",");
       try
       {
         MooseUtils::expandAllMatches(all_vars, vars);

--- a/framework/src/preconditioners/VariableCondensationPreconditioner.C
+++ b/framework/src/preconditioners/VariableCondensationPreconditioner.C
@@ -167,7 +167,7 @@ VariableCondensationPreconditioner::VariableCondensationPreconditioner(
          getParam<std::vector<NonlinearVariableName>>("coupled_groups"))
     {
       std::vector<NonlinearVariableName> vars;
-      MooseUtils::tokenize<NonlinearVariableName>(coupled_group, vars, 1, ",");
+      MooseUtils::stringSplit<NonlinearVariableName>(coupled_group, vars, 1, ",");
       for (unsigned int j : index_range(vars))
         for (unsigned int k = j + 1; k < vars.size(); ++k)
         {

--- a/framework/src/utils/DelimitedFileReader.C
+++ b/framework/src/utils/DelimitedFileReader.C
@@ -240,7 +240,7 @@ DelimitedFileReaderTempl<T>::readColumnData(std::ifstream & stream_data, std::ve
     // Read header, if the header exists and the column names do not exist.
     if (_names.empty() && header(line))
     {
-      MooseUtils::tokenize(line, _names, 1, delimiter(line));
+      MooseUtils::stringSplit(line, _names, 1, delimiter(line));
       for (std::string & str : _names)
         str = MooseUtils::trim(str);
       continue;

--- a/framework/src/utils/FunctionMaterialPropertyDescriptor.C
+++ b/framework/src/utils/FunctionMaterialPropertyDescriptor.C
@@ -157,7 +157,7 @@ FunctionMaterialPropertyDescriptor<is_ad>::parseDerivative(const std::string & e
       {
         // rest of argument list 0 is the function and 1,.. are the variable to take the derivative
         // w.r.t.
-        MooseUtils::tokenize(arguments, _derivative_symbols, 0, ",");
+        MooseUtils::stringSplit(arguments, _derivative_symbols, 0, ",");
 
         // check for empty [] brackets
         if (_derivative_symbols.size() > 0)
@@ -175,7 +175,7 @@ FunctionMaterialPropertyDescriptor<is_ad>::parseDerivative(const std::string & e
       else
       {
         parseDependentSymbols(arguments.substr(0, close2 + 1));
-        MooseUtils::tokenize(arguments.substr(close2 + 2), _derivative_symbols, 0, ",");
+        MooseUtils::stringSplit(arguments.substr(close2 + 2), _derivative_symbols, 0, ",");
         updatePropertyName();
         return;
       }
@@ -203,7 +203,8 @@ FunctionMaterialPropertyDescriptor<is_ad>::parseDependentSymbols(const std::stri
     _base_name = expression.substr(0, open);
 
     // parse argument list
-    MooseUtils::tokenize(expression.substr(open + 1, close - open - 1), _dependent_symbols, 0, ",");
+    MooseUtils::stringSplit(
+        expression.substr(open + 1, close - open - 1), _dependent_symbols, 0, ",");
 
     // remove duplicates from dependent variable list
     std::sort(_dependent_symbols.begin(), _dependent_symbols.end());

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -457,7 +457,7 @@ InputParameters::declareControllable(const std::string & input_names,
                                      std::set<ExecFlagType> execute_flags)
 {
   std::vector<std::string> names;
-  MooseUtils::tokenize<std::string>(input_names, names, 1, " ");
+  MooseUtils::stringSplit(input_names, names);
   for (auto & name_in : names)
   {
     const auto name = checkForRename(name_in);
@@ -530,7 +530,7 @@ void
 InputParameters::registerBuildableTypes(const std::string & names)
 {
   _buildable_types.clear();
-  MooseUtils::tokenize(names, _buildable_types, 1, " \t\n\v\f\r"); // tokenize on whitespace
+  MooseUtils::stringSplit(names, _buildable_types); // split on whitespace
 }
 
 void
@@ -1028,7 +1028,7 @@ InputParameters::addParamNamesToGroup(const std::string & space_delim_names,
                                       const std::string group_name)
 {
   std::vector<std::string> elements;
-  MooseUtils::tokenize(space_delim_names, elements, 1, " \t\n\v\f\r"); // tokenize on whitespace
+  MooseUtils::stringSplit(space_delim_names, elements); // split on whitespace
 
   // Since we don't require types (templates) for this method, we need
   // to get a raw list of parameter names to compare against.

--- a/framework/src/utils/MooseEnumBase.C
+++ b/framework/src/utils/MooseEnumBase.C
@@ -64,7 +64,7 @@ void
 MooseEnumBase::addEnumerationNames(const std::string & names)
 {
   std::vector<std::string> elements;
-  MooseUtils::tokenize(names, elements, 1, " ");
+  MooseUtils::stringSplit(names, elements);
   for (const std::string & raw_name : elements)
     addEnumerationName(raw_name);
 }
@@ -78,7 +78,7 @@ MooseEnumBase::addEnumerationName(const std::string & raw_name)
 
   // Split on equals sign
   std::vector<std::string> name_value;
-  MooseUtils::tokenize(MooseUtils::trim(raw_name), name_value, 1, "=");
+  MooseUtils::stringSplit(MooseUtils::trim(raw_name), name_value, 1, "=");
 
   // There should be one or two items in the name_value
   if (name_value.size() < 1 || name_value.size() > 2)

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -450,7 +450,7 @@ makedirs(const std::string & dir_name, bool throw_on_failure)
 {
   // split path into directories with delimiter '/'
   std::vector<std::string> split_dir_names;
-  MooseUtils::tokenize(dir_name, split_dir_names);
+  MooseUtils::stringSplit(dir_name, split_dir_names, 1, "/");
 
   auto n = split_dir_names.size();
 
@@ -506,7 +506,7 @@ removedirs(const std::string & dir_name, bool throw_on_failure)
 {
   // split path into directories with delimiter '/'
   std::vector<std::string> split_dir_names;
-  MooseUtils::tokenize(dir_name, split_dir_names);
+  MooseUtils::stringSplit(dir_name, split_dir_names, 1, "/");
 
   auto n = split_dir_names.size();
 
@@ -904,7 +904,7 @@ wildCardMatch(std::string name, std::string search_string)
 
   // wildcard
   std::vector<std::string> tokens;
-  MooseUtils::tokenize(search_string, tokens, 1, "*");
+  MooseUtils::stringSplit(search_string, tokens, 1, "*");
 
   size_t pos = 0;
   for (unsigned int i = 0; i < tokens.size() && pos != std::string::npos; ++i)

--- a/framework/src/utils/MultiMooseEnum.C
+++ b/framework/src/utils/MultiMooseEnum.C
@@ -121,7 +121,7 @@ MultiMooseEnum &
 MultiMooseEnum::operator=(const std::string & names)
 {
   std::vector<std::string> names_vector;
-  MooseUtils::tokenize(names, names_vector, 1, " ");
+  MooseUtils::stringSplit(names, names_vector);
   return assignValues(names_vector.begin(), names_vector.end(), false);
 }
 
@@ -141,7 +141,7 @@ void
 MultiMooseEnum::eraseSetValue(const std::string & names)
 {
   std::vector<std::string> names_vector;
-  MooseUtils::tokenize(names, names_vector, 1, " ");
+  MooseUtils::stringSplit(names, names_vector);
   removeSetValues(names_vector.begin(), names_vector.end());
 }
 
@@ -182,7 +182,7 @@ void
 MultiMooseEnum::setAdditionalValue(const std::string & names)
 {
   std::vector<std::string> names_vector;
-  MooseUtils::tokenize(names, names_vector, 1, " ");
+  MooseUtils::stringSplit(names, names_vector);
   assignValues(names_vector.begin(), names_vector.end(), true);
 }
 

--- a/modules/chemical_reactions/src/actions/ChemicalCompositionAction.C
+++ b/modules/chemical_reactions/src/actions/ChemicalCompositionAction.C
@@ -257,7 +257,7 @@ ChemicalCompositionAction::ChemicalCompositionAction(const InputParameters & par
       {
         _tokenized_species.resize(species.size());
         std::vector<std::string> tokens;
-        MooseUtils::tokenize(species[i], tokens, 1, ":");
+        MooseUtils::stringSplit(species[i], tokens, 1, ":");
         if (tokens.size() == 1)
           paramError("output_species", "No ':' separator found in variable '", species[i], "'");
 
@@ -297,7 +297,7 @@ ChemicalCompositionAction::ChemicalCompositionAction(const InputParameters & par
       for (const auto i : index_range(element_potentials))
       {
         std::vector<std::string> tokens;
-        MooseUtils::tokenize(element_potentials[i], tokens, 1, ":");
+        MooseUtils::stringSplit(element_potentials[i], tokens, 1, ":");
         if (tokens.size() == 1)
           paramError("output_element_potentials",
                      "No ':' separator found in variable '",
@@ -340,7 +340,7 @@ ChemicalCompositionAction::ChemicalCompositionAction(const InputParameters & par
       for (const auto i : index_range(vapor_pressures))
       {
         std::vector<std::string> tokens;
-        MooseUtils::tokenize(vapor_pressures[i], tokens, 1, ":");
+        MooseUtils::stringSplit(vapor_pressures[i], tokens, 1, ":");
         if (tokens.size() == 1)
           paramError("output_vapor_pressures",
                      "No ':' separator found in variable '",
@@ -389,7 +389,7 @@ ChemicalCompositionAction::ChemicalCompositionAction(const InputParameters & par
       for (const auto i : index_range(element_phases))
       {
         std::vector<std::string> tokens;
-        MooseUtils::tokenize(element_phases[i], tokens, 1, ":");
+        MooseUtils::stringSplit(element_phases[i], tokens, 1, ":");
         if (tokens.size() == 1)
           paramError("output_element_phases",
                      "No ':' separator found in variable '",
@@ -579,7 +579,7 @@ ChemicalCompositionAction::readCSV()
   std::getline(file, line);
   while (std::getline(file, line))
   {
-    MooseUtils::tokenize(line, items, 1, ",");
+    MooseUtils::stringSplit(line, items, 1, ",");
     if (items.empty())
       continue;
     if (items.size() != 2)

--- a/modules/thermal_hydraulics/src/actions/AddComponentAction.C
+++ b/modules/thermal_hydraulics/src/actions/AddComponentAction.C
@@ -44,7 +44,7 @@ AddComponentAction::act()
       _moose_object_pars.set<THMProblem *>("_thm_problem") = thm_problem;
 
       std::vector<std::string> parts;
-      MooseUtils::tokenize<std::string>(_moose_object_pars.blockFullpath(), parts);
+      MooseUtils::stringSplit(_moose_object_pars.blockFullpath(), parts, 1, "/");
 
       std::stringstream res;
       std::copy(++parts.begin(), parts.end(), std::ostream_iterator<std::string>(res, "/"));

--- a/unit/src/CommandLineTest.C
+++ b/unit/src/CommandLineTest.C
@@ -761,7 +761,7 @@ TEST(CommandLineTest, mergeArgsForParam)
       cl.populateCommandLineParams(params);
 
       std::vector<std::string> split_argument;
-      MooseUtils::tokenize(argument, split_argument, 1, " \t\n\v\f\r");
+      MooseUtils::stringSplit(argument, split_argument);
       ASSERT_EQ(params.get<std::vector<std::string>>("value"), split_argument);
     }
 


### PR DESCRIPTION
## Reason
I find the semantics of `MooseUtils::tokenize()` a bit odd, so I wrote `MooseUtils::stringSplit()` for general use.
Given string `";nuno;;logan;"` and delimiter `;`, here's what I suggest (https://godbolt.org/z/PW69K5f3d):

| `min_len` | `tokenize()` | `stringSplit()` |
| ---------  | ---| ----|
| 0 | `'nuno','logan'` | `'','nuno','','logan',''` |
| 1 | `'nuno','logan'` | `'nuno','logan'` |
| 5 | `'nuno;','logan'` | `'logan'` |

## Design
Simpler, reduces number of find-like calls to one per iteration. `{Json}InputFileFormatter` will keep using `MooseUtils::tokenize()` as those are the only two genuine use-cases of the peculiar semantics (i.e. tokens may never start with a delimiter, but may contain it at any other character position).

## Impact
The new semantics is more obvious, avoids losing information, avoids including the delimiter in the output and mimics Python (when the delimiter is specified) and C# when `min_len = 0`. Java is a bit odd, in that, by default (with an option to change behaviour), it drops trailing empty entries, but keeps those in the middle.
