### PR TITLE
Allow explicit outputs to omit object name in file base 

### DIFF
--- a/framework/src/outputs/FileOutput.C
+++ b/framework/src/outputs/FileOutput.C
@@ -34,6 +34,10 @@ FileOutput::validParams()
       "name for a subapp input to set it.");
   params.addParam<std::string>("file_base_suffix", "Suffix to add to the file base");
   params.addParam<bool>(
+      "append_object_name",
+      true,
+      "Append the output object name to the default file base when using full output syntax.");
+  params.addParam<bool>(
       "append_date", false, "When true the date and time are appended to the output filename.");
   params.addParam<std::string>("append_date_format",
                                "The format of the date/time to append, if not given UTC format "
@@ -48,7 +52,7 @@ FileOutput::validParams()
                                             "strings.  This is helpful in outputting only a subset "
                                             "of outputs when using MultiApps.");
   params.addParamNamesToGroup(
-      "file_base append_date append_date_format padding output_if_base_contains",
+      "file_base append_object_name append_date append_date_format padding output_if_base_contains",
       "File name customization");
 
   return params;

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -421,8 +421,10 @@ OutputWarehouse::resetFileBase()
         else
           file_base = _app.getOutputFileBase();
       }
-      else
+      else if (obj->getParam<bool>("append_object_name"))
         file_base = _app.getOutputFileBase(true) + "_" + obj->name();
+      else
+        file_base = _app.getOutputFileBase();
 
       file_output->setFileBase(file_base);
       addOutputFilename(obj->name(), file_output->filename());

--- a/test/tests/outputs/subapp_file_base/parent.i
+++ b/test/tests/outputs/subapp_file_base/parent.i
@@ -1,0 +1,48 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[MultiApps]
+  [sub]
+    type = FullSolveMultiApp
+    execute_on = initial
+    positions = '0 0 0'
+    input_files = sub_shortcut.i
+  []
+[]
+
+[Outputs]
+  console = false
+[]

--- a/test/tests/outputs/subapp_file_base/sub_explicit_default.i
+++ b/test/tests/outputs/subapp_file_base/sub_explicit_default.i
@@ -1,0 +1,42 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  console = false
+  [out]
+    type = Exodus
+  []
+[]

--- a/test/tests/outputs/subapp_file_base/sub_explicit_no_append.i
+++ b/test/tests/outputs/subapp_file_base/sub_explicit_no_append.i
@@ -1,0 +1,43 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  console = false
+  [out]
+    type = Exodus
+    append_object_name = false
+  []
+[]

--- a/test/tests/outputs/subapp_file_base/sub_shortcut.i
+++ b/test/tests/outputs/subapp_file_base/sub_shortcut.i
@@ -1,0 +1,40 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  console = false
+  exodus = true
+[]

--- a/test/tests/outputs/subapp_file_base/tests
+++ b/test/tests/outputs/subapp_file_base/tests
@@ -1,0 +1,34 @@
+[Tests]
+  issues = '#32928'
+  design = 'syntax/Outputs/index.md'
+
+  [shortcut]
+    type = CheckFiles
+    input = parent.i
+    check_files = 'parent_out_sub0.e'
+    recover = false
+
+    requirement = "The system shall name shortcut syntax sub-application file output from the parent and sub-application names."
+  []
+
+  [explicit_default]
+    type = CheckFiles
+    input = parent.i
+    cli_args = 'MultiApps/sub/input_files=sub_explicit_default.i'
+    check_files = 'parent_out_sub0_out.e'
+    recover = false
+
+    requirement = "The system shall append the output object name to explicit syntax sub-application file output by default."
+  []
+
+  [explicit_no_append]
+    type = CheckFiles
+    input = parent.i
+    cli_args = 'MultiApps/sub/input_files=sub_explicit_no_append.i'
+    check_files = 'parent_out_sub0.e'
+    check_not_exists = 'parent_out_sub0_out.e'
+    recover = false
+
+    requirement = "The system shall allow explicit syntax sub-application file output to match shortcut syntax file naming."
+  []
+[]


### PR DESCRIPTION
This PR resolves issue #32928 .

  The issue was that subapp output filenames differed between shortcut and explicit output syntax.

  Shortcut syntax:

  ```ini
  [Outputs]
    exodus = true
  []

  produces:

  parent_out_sub0.e

  But equivalent explicit syntax:

  [Outputs]
    [out]
      type = Exodus
    []
  []

  previously produced:

  parent_out_sub0_out.e

  The extra _out came from the explicit output object name, which meant users could not expand shortcut syntax into full syntax while preserving
  the same default filename unless they manually set file_base.

  The fix adds a new FileOutput option:

  append_object_name = false

  Default behavior is unchanged, so existing explicit output filenames still append the object name. Users can now opt out:

  [Outputs]
    [out]
      type = Exodus
      append_object_name = false
    []
  []

  which produces:

  parent_out_sub0.e

  matching the shortcut syntax behavior.
