### PR TITLE
Add --suppress-info option (#31883)

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -203,6 +203,11 @@ extern bool _warnings_are_errors;
 extern bool _deprecated_is_error;
 
 /**
+ * Variable to suppress informational messages.
+ */
+extern bool _suppress_info;
+
+/**
  * Variable to turn on exceptions during mooseError(), should only be used within MOOSE unit tests
  * or when about to perform threaded operations because exception throwing in threaded regions is
  * safe while aborting is inherently not when singletons are involved (e.g. what thread is

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -212,6 +212,11 @@ public:
   virtual void setupOptions();
 
   /**
+   * Whether informational messages are suppressed for this app.
+   */
+  bool suppressInfo() const;
+
+  /**
    * Return a writable reference to the ActionWarehouse associated with this app
    */
   ActionWarehouse & actionWarehouse() { return _action_warehouse; }

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -231,6 +231,9 @@ template <typename S, typename... Args>
 void
 mooseInfoStreamRepeated(S & oss, Args &&... args)
 {
+  if (Moose::_suppress_info)
+    return;
+
   std::ostringstream ss;
   mooseStreamAll(ss, args...);
   std::string msg = mooseMsgFmt(ss.str(), "*** Info ***", COLOR_CYAN);
@@ -244,6 +247,9 @@ template <typename S, typename... Args>
 void
 mooseInfoStream(S & oss, Args &&... args)
 {
+  if (Moose::_suppress_info)
+    return;
+
   mooseDoOnce(mooseInfoStreamRepeated(oss, args...););
 }
 

--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -397,6 +397,7 @@ protected:
 
   private:
     const bool _original_suppress_info;
+    const bool _changed_suppress_info;
   };
 
   /// function that provides cli_args to subapps

--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -386,6 +386,19 @@ public:
   void setAppOutputFileBase();
 
 protected:
+  /**
+   * Temporarily use a sub-app's informational message suppression setting.
+   */
+  class ScopedAppInfoSuppression
+  {
+  public:
+    ScopedAppInfoSuppression(const MooseApp & app);
+    ~ScopedAppInfoSuppression();
+
+  private:
+    const bool _original_suppress_info;
+  };
+
   /// function that provides cli_args to subapps
   virtual std::vector<std::string> cliArgs() const;
 

--- a/framework/src/base/AppFactory.C
+++ b/framework/src/base/AppFactory.C
@@ -10,6 +10,7 @@
 #include "AppFactory.h"
 #include "CommandLine.h"
 #include "InputParameters.h"
+#include "Moose.h"
 #include "MooseApp.h"
 #include "Parser.h"
 #include "MooseMain.h"
@@ -71,6 +72,7 @@ AppFactory::create(const std::string & app_type,
   auto command_line = std::make_unique<CommandLine>(std::vector<std::string>{"unused"});
   command_line->addArguments(cli_args);
   command_line->parse();
+  Moose::_suppress_info = command_line->hasArgument("--suppress-info");
 
   return AppFactory::create(std::move(parser), std::move(command_line));
 }
@@ -116,6 +118,7 @@ AppFactory::createAppShared(const std::string & default_app_type,
 
   auto command_line = std::make_unique<CommandLine>(argc, argv);
   command_line->parse();
+  Moose::_suppress_info = command_line->hasArgument("--suppress-info");
 
   auto parser = std::make_unique<Parser>(input_filenames);
   parser->setCommandLineParams(command_line->buildHitParams());

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -914,6 +914,7 @@ hitMessagePrefix(const hit::Node & node)
 
 bool _warnings_are_errors = false;
 bool _deprecated_is_error = false;
+bool _suppress_info = false;
 bool _throw_on_error = false;
 bool _throw_on_warning = false;
 volatile std::sig_atomic_t interrupt_signal_number = 0;

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -460,6 +460,9 @@ MooseApp::validParams()
                                    false,
                                    "Disables the output of the application header.");
   params.setGlobalCommandLineParam("suppress_header");
+  params.addCommandLineParam<bool>(
+      "suppress_info", "--suppress-info", false, "Disables informational messages.");
+  params.setGlobalCommandLineParam("suppress_info");
 
   params.addCommandLineParam<bool>(
       "test_checkpoint_half_transient",
@@ -1052,6 +1055,9 @@ MooseApp::setupOptions()
 
   // Deprecated messages can be toggled to errors independently from everything else.
   Moose::_deprecated_is_error = getParam<bool>("error_deprecated");
+
+  // Informational messages can be suppressed independently from warnings and errors.
+  Moose::_suppress_info = getParam<bool>("suppress_info");
 
   if (isUltimateMaster()) // makes sure coloring isn't reset incorrectly in multi-app settings
   {

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1519,6 +1519,12 @@ MooseApp::setupOptions()
   Moose::out << std::flush;
 }
 
+bool
+MooseApp::suppressInfo() const
+{
+  return getParam<bool>("suppress_info");
+}
+
 const std::vector<std::string> &
 MooseApp::getInputFileNames() const
 {

--- a/framework/src/base/MooseMain.C
+++ b/framework/src/base/MooseMain.C
@@ -13,6 +13,7 @@
 #include "AppFactory.h"
 #include "CommandLine.h"
 #include "InputParameters.h"
+#include "Moose.h"
 #include "MooseApp.h"
 
 #ifdef LIBMESH_HAVE_OPENMP
@@ -52,6 +53,7 @@ createMooseApp(const std::string & default_app_type, int argc, char * argv[])
   // command line arguments for the Parser
   auto command_line = std::make_unique<CommandLine>(argc, argv);
   command_line->parse();
+  Moose::_suppress_info = command_line->hasArgument("--suppress-info");
 
   // Setup the parser with the input and the HIT parameters from the command line. The parse
   // will also look for "Application/type=" in input to specify the application type

--- a/framework/src/multiapps/FullSolveMultiApp.C
+++ b/framework/src/multiapps/FullSolveMultiApp.C
@@ -107,7 +107,10 @@ FullSolveMultiApp::initialSetup()
                      "avoid an error if Transient solve fails.");
       }
 
-      ex->init();
+      {
+        ScopedAppInfoSuppression scoped_info(*app);
+        ex->init();
+      }
 
       if (_keep_solution_during_restore && _update_old_state_when_keeping_solution_during_restore &&
           (appProblemBase(_first_local_app + i).getMaterialPropertyStorage().hasStatefulProperties()
@@ -173,7 +176,10 @@ FullSolveMultiApp::solveStep(Real /*dt*/, Real /*target_time*/, bool auto_advanc
       appProblemBase(_first_local_app + i).skipNextForwardSolutionCopyToOld();
 
     Executioner * ex = _executioners[i];
-    ex->execute();
+    {
+      ScopedAppInfoSuppression scoped_info(*_apps[i]);
+      ex->execute();
+    }
 
     last_solve_converged = last_solve_converged && ex->lastSolveConverged();
 

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -16,6 +16,7 @@
 #include "Console.h"
 #include "Executioner.h"
 #include "FEProblem.h"
+#include "MooseApp.h"
 #include "MooseMesh.h"
 #include "MooseUtils.h"
 #include "OutputWarehouse.h"
@@ -46,6 +47,17 @@
 #ifdef LIBMESH_HAVE_SYS_UTSNAME_H
 #include <sys/utsname.h>
 #endif
+
+MultiApp::ScopedAppInfoSuppression::ScopedAppInfoSuppression(const MooseApp & app)
+  : _original_suppress_info(Moose::_suppress_info)
+{
+  Moose::_suppress_info = app.suppressInfo();
+}
+
+MultiApp::ScopedAppInfoSuppression::~ScopedAppInfoSuppression()
+{
+  Moose::_suppress_info = _original_suppress_info;
+}
 
 InputParameters
 MultiApp::validParams()
@@ -1252,8 +1264,11 @@ MultiApp::createApp(unsigned int i, Real start_time)
     paramError("run_in_position",
                "Sub-apps are already displaced, so they are already output in position");
 
-  // Update the MultiApp level for the app that was just created
-  app->setupOptions();
+  {
+    ScopedAppInfoSuppression scoped_info(*app);
+    // Update the MultiApp level for the app that was just created
+    app->setupOptions();
+  }
   // if multiapp does not have file base in Outputs input block, output file base will
   // be empty here since setupOptions() does not set the default file base with the multiapp
   // input file name. Parent app will create the default file base for multiapp by taking the
@@ -1278,7 +1293,10 @@ MultiApp::createApp(unsigned int i, Real start_time)
   _apps[i]->fixedPointConfig().sub_transformed_pps =
       getParam<std::vector<PostprocessorName>>("transformed_postprocessors");
 
-  app->runInputFile();
+  {
+    ScopedAppInfoSuppression scoped_info(*app);
+    app->runInputFile();
+  }
   auto fixed_point_solve = &(_apps[i]->getExecutioner()->fixedPointSolve());
   if (fixed_point_solve)
     fixed_point_solve->allocateStorage(false);

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -35,6 +35,7 @@
 
 #include "libmesh/mesh_tools.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/threads.h"
 
 // C++ includes
 #include <algorithm>
@@ -49,14 +50,25 @@
 #endif
 
 MultiApp::ScopedAppInfoSuppression::ScopedAppInfoSuppression(const MooseApp & app)
-  : _original_suppress_info(Moose::_suppress_info)
+  : _original_suppress_info(Moose::_suppress_info),
+    _changed_suppress_info(Moose::_suppress_info != app.suppressInfo())
 {
-  Moose::_suppress_info = app.suppressInfo();
+  if (_changed_suppress_info)
+  {
+    mooseAssert(!libMesh::Threads::in_threads,
+                "Cannot modify informational message suppression in threads");
+    Moose::_suppress_info = app.suppressInfo();
+  }
 }
 
 MultiApp::ScopedAppInfoSuppression::~ScopedAppInfoSuppression()
 {
-  Moose::_suppress_info = _original_suppress_info;
+  if (_changed_suppress_info)
+  {
+    mooseAssert(!libMesh::Threads::in_threads,
+                "Cannot modify informational message suppression in threads");
+    Moose::_suppress_info = _original_suppress_info;
+  }
 }
 
 InputParameters

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -64,11 +64,7 @@ MultiApp::ScopedAppInfoSuppression::ScopedAppInfoSuppression(const MooseApp & ap
 MultiApp::ScopedAppInfoSuppression::~ScopedAppInfoSuppression()
 {
   if (_changed_suppress_info)
-  {
-    mooseAssert(!libMesh::Threads::in_threads,
-                "Cannot modify informational message suppression in threads");
     Moose::_suppress_info = _original_suppress_info;
-  }
 }
 
 InputParameters

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -232,6 +232,8 @@ TransientMultiApp::solveStep(Real dt, Real target_time, bool auto_advance)
               "This message will only print once for all apps and all time steps."));
       }
 
+      ScopedAppInfoSuppression scoped_info(*_apps[i]);
+
       if (_sub_cycling)
       {
         Real time_old = ex->getTime() + app_time_offset;
@@ -560,7 +562,10 @@ TransientMultiApp::incrementTStep(Real target_time)
       // Only increment the step if we are after (target_time) the
       // start_time (added to app_time_offset) of this sub_app.
       if (_apps[i]->getStartTime() + app_time_offset < target_time)
+      {
+        ScopedAppInfoSuppression scoped_info(*_apps[i]);
         ex->incrementStepOrReject();
+      }
     }
   }
 }
@@ -573,6 +578,7 @@ TransientMultiApp::finishStep(bool recurse_through_multiapp_levels)
     for (unsigned int i = 0; i < _my_num_apps; i++)
     {
       TransientBase * ex = _transient_executioners[i];
+      ScopedAppInfoSuppression scoped_info(*_apps[i]);
       ex->endStep();
       ex->postStep();
       if (recurse_through_multiapp_levels)
@@ -601,6 +607,7 @@ TransientMultiApp::computeDT()
     for (unsigned int i = 0; i < _my_num_apps; i++)
     {
       TransientBase * ex = _transient_executioners[i];
+      ScopedAppInfoSuppression scoped_info(*_apps[i]);
       ex->computeDT();
       Real dt = ex->getDT();
 
@@ -648,6 +655,7 @@ void
 TransientMultiApp::setupApp(unsigned int i, Real /*time*/) // FIXME: Should we be passing time?
 {
   auto & app = _apps[i];
+  ScopedAppInfoSuppression scoped_info(*app);
   TransientBase * ex = dynamic_cast<TransientBase *>(app->getExecutioner());
   if (!ex)
     mooseError("MultiApp ", name(), " is not using a Transient Executioner!");

--- a/modules/doc/content/application_usage/command_line_usage.md
+++ b/modules/doc/content/application_usage/command_line_usage.md
@@ -74,6 +74,7 @@ Global Options:
   --show-controls                     Shows the Control logic available and executed
   --show-input                        Shows the parsed input file before running the simulation
   --show-outputs                      Shows the output execution time information
+  --suppress-info                     Disables informational messages
   --test-checkpoint-half-transient    Run half of a transient with checkpoints enabled; used by the TestHarness
   -t --timing                         Enable all performance logging for timing; disables screen output of performance logs for all Console objects
   --timpi-sync <type=nbx>             Changes the sync type used in spare parallel communitations within TIMPI

--- a/modules/doc/content/framework_development/error_warning_messaging.md
+++ b/modules/doc/content/framework_development/error_warning_messaging.md
@@ -20,6 +20,9 @@ messages:
 - `mooseInfoRepeated(args)`: The same as `mooseInfo(args)` but only prints a message
   once, even if called multiple times.
 
+Informational messages emitted with `mooseInfo(args)` or `mooseInfoRepeated(args)` can
+be suppressed with the command-line flag `--suppress-info`.
+
 !alert note title=Warnings in repeating sections
 For warnings in sections of the code that are often executed, it is recommended to leverage
 the [SolutionInvalidInterface.md], which will only output the warning once but keep track of

--- a/test/tests/userobjects/Terminator/terminator_info_multiapp.i
+++ b/test/tests/userobjects/Terminator/terminator_info_multiapp.i
@@ -1,0 +1,83 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+  elem_type = QUAD4
+[]
+
+[Variables]
+  [c]
+    order = FIRST
+    family = LAGRANGE
+    initial_condition = 1
+  []
+[]
+
+[Postprocessors]
+  [dt]
+    type = TimestepSize
+  []
+[]
+
+[UserObjects]
+  [arnold]
+    type = Terminator
+    expression = 'dt > 0'
+    fail_mode = NONE
+    error_level = INFO
+    message = 'Parent info test'
+    execute_on = TIMESTEP_END
+  []
+[]
+
+[Kernels]
+  [cres]
+    type = Diffusion
+    variable = c
+  []
+
+  [time]
+    type = TimeDerivative
+    variable = c
+  []
+[]
+
+[BCs]
+  [c]
+    type = DirichletBC
+    variable = c
+    boundary = left
+    value = 0
+  []
+[]
+
+[MultiApps]
+  [sub]
+    type = TransientMultiApp
+    execute_on = TIMESTEP_BEGIN
+    input_files = terminator_soft.i
+    cli_args = "--suppress-info
+                Executioner/num_steps=1
+                UserObjects/arnold/fail_mode=NONE
+                UserObjects/arnold/error_level=INFO
+                UserObjects/arnold/message='Subapp info test'
+                Outputs/csv=false"
+  []
+[]
+
+[Executioner]
+  type = Transient
+  dt = 1
+  num_steps = 1
+  nl_abs_step_tol = 1e-10
+[]
+
+[Outputs]
+  csv = false
+  print_linear_residuals = false
+[]

--- a/test/tests/userobjects/Terminator/terminator_info_multiapp.i
+++ b/test/tests/userobjects/Terminator/terminator_info_multiapp.i
@@ -61,12 +61,7 @@
     type = TransientMultiApp
     execute_on = TIMESTEP_BEGIN
     input_files = terminator_soft.i
-    cli_args = "--suppress-info
-                Executioner/num_steps=1
-                UserObjects/arnold/fail_mode=NONE
-                UserObjects/arnold/error_level=INFO
-                UserObjects/arnold/message='Subapp info test'
-                Outputs/csv=false"
+    cli_args = "--suppress-info;Executioner/num_steps=1;UserObjects/arnold/fail_mode=NONE;UserObjects/arnold/error_level=INFO;UserObjects/arnold/message='Subapp info test';Outputs/csv=false"
   []
 []
 

--- a/test/tests/userobjects/Terminator/tests
+++ b/test/tests/userobjects/Terminator/tests
@@ -73,6 +73,29 @@
                   "with the regular simulation when that criterion is not met."
     recover = false # changes the time steps
   []
+  [terminator_info]
+    type = 'RunApp'
+    input = 'terminator_soft.i'
+    expect_out = '\*\*\* Info \*\*\*\s+Suppress info test'
+    issues = '#31883'
+    cli_args = "UserObjects/arnold/fail_mode=NONE
+                UserObjects/arnold/error_level=INFO
+                UserObjects/arnold/message='Suppress info test'
+                Outputs/csv=false"
+    requirement = "The system shall output informational messages by default."
+  []
+  [suppress_info]
+    type = 'RunApp'
+    input = 'terminator_soft.i'
+    absent_out = '\*\*\* Info \*\*\*\s+Suppress info test'
+    issues = '#31883'
+    cli_args = "--suppress-info
+                UserObjects/arnold/fail_mode=NONE
+                UserObjects/arnold/error_level=INFO
+                UserObjects/arnold/message='Suppress info test'
+                Outputs/csv=false"
+    requirement = "The system shall suppress informational messages when requested by command-line."
+  []
 
   [check_execution]
     type = RunException

--- a/test/tests/userobjects/Terminator/tests
+++ b/test/tests/userobjects/Terminator/tests
@@ -96,6 +96,14 @@
                 Outputs/csv=false"
     requirement = "The system shall suppress informational messages when requested by command-line."
   []
+  [suppress_info_multiapp_scope]
+    type = 'RunApp'
+    input = 'terminator_info_multiapp.i'
+    expect_out = '\*\*\* Info \*\*\*\s+Parent info test'
+    issues = '#31883'
+    requirement = "The system shall keep informational message suppression scoped to the "
+                  "sub-application that requested it."
+  []
 
   [check_execution]
     type = RunException


### PR DESCRIPTION
## Summary

  Fixes #31883 by adding a new global command-line option:

  ```bash
  --suppress-info

  This suppresses MOOSE informational messages emitted through mooseInfo() and mooseInfoRepeated().

  ## Motivation

  Info messages are useful when running an input for the first time, but they can become noisy when repeatedly running variations of the same
  input, especially for large problems.

  ## Behavior

  ### Before

  ./moose_test-opt -i input.i

  Could emit informational messages like:

  *** Info ***
  Suppress info test

  There was no command-line option to suppress only these messages.

  ### After

  Default behavior is unchanged:

  ./moose_test-opt -i input.i

  Still emits info messages.

  With the new flag:

  ./moose_test-opt -i input.i --suppress-info

  mooseInfo() / mooseInfoRepeated() messages are omitted.

  ## Scope

  This intentionally only suppresses informational messages. It does not suppress:

  - mooseWarning()
  - mooseDeprecated()
  - mooseError()
  - application headers
  - --help, --version, syntax dumps
  - normal Moose::out / console output
  - simulation output

  ## Testing

  Added regression coverage using Terminator INFO output:

  - default run expects the info message
  - --suppress-info run expects the info message to be absent
