### PR TITLE
Reject pc_type with JFNK solve type

### DIFF
--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -199,7 +199,8 @@ void addPetscPairsToPetscOptions(
     const unsigned int mesh_dimension,
     std::string prefix,
     const ParallelParamObject & param_object,
-    PetscOptions & petsc_options);
+    PetscOptions & petsc_options,
+    const FEProblemBase * problem = nullptr);
 
 /**
  * Returns the valid petsc line search options as a set of strings

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -193,6 +193,8 @@ void addPetscFlagsToPetscOptions(const MultiMooseEnum & petsc_flags,
  * work. This is the reason we pass \p prefix by value
  * @param param_object The \p ParallelParamObject adding the PETSc options
  * @param petsc_options Data structure which handles petsc options within moose
+ * @param problem Optional problem context used to reject PETSc options that are incompatible with
+ * JFNK solve types
  */
 void addPetscPairsToPetscOptions(
     const std::vector<std::pair<MooseEnumItem, std::string>> & petsc_pair_options,

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -21,6 +21,9 @@
 
 #include <petscksp.h>
 
+#include <optional>
+#include <string>
+
 // Forward declarations
 class FEProblemBase;
 class NonlinearSystemBase;
@@ -193,16 +196,13 @@ void addPetscFlagsToPetscOptions(const MultiMooseEnum & petsc_flags,
  * work. This is the reason we pass \p prefix by value
  * @param param_object The \p ParallelParamObject adding the PETSc options
  * @param petsc_options Data structure which handles petsc options within moose
- * @param problem Optional problem context used to reject PETSc options that are incompatible with
- * JFNK solve types
  */
 void addPetscPairsToPetscOptions(
     const std::vector<std::pair<MooseEnumItem, std::string>> & petsc_pair_options,
     const unsigned int mesh_dimension,
     std::string prefix,
     const ParallelParamObject & param_object,
-    PetscOptions & petsc_options,
-    const FEProblemBase * problem = nullptr);
+    PetscOptions & petsc_options);
 
 /**
  * Returns the valid petsc line search options as a set of strings
@@ -273,6 +273,13 @@ void registerPetscCitation(const std::string & bibtex);
  * bookkeeping for command-line '-vec_type' and '*mat_type' options.
  */
 void addPetscOptionsFromCommandline(FEProblemBase * const problem = nullptr);
+
+/**
+ * Returns the command-line value for PETSc option \p option with solver prefix \p prefix if it was
+ * supplied.
+ */
+std::optional<std::string> commandLinePetscOptionValue(const std::string & prefix,
+                                                       const std::string & option);
 
 /**
  * Setup which side we want to apply preconditioner

--- a/framework/src/physics/PhysicsBase.C
+++ b/framework/src/physics/PhysicsBase.C
@@ -603,7 +603,7 @@ PhysicsBase::addPetscPairsToPetscOptions(
         _problem->getSolverSystem(solver_sys_num).prefix(),
         *this,
         po,
-        _problem);
+        _problem.get());
 }
 
 bool

--- a/framework/src/physics/PhysicsBase.C
+++ b/framework/src/physics/PhysicsBase.C
@@ -602,7 +602,8 @@ PhysicsBase::addPetscPairsToPetscOptions(
         _problem->mesh().dimension(),
         _problem->getSolverSystem(solver_sys_num).prefix(),
         *this,
-        po);
+        po,
+        _problem);
 }
 
 bool

--- a/framework/src/physics/PhysicsBase.C
+++ b/framework/src/physics/PhysicsBase.C
@@ -602,8 +602,7 @@ PhysicsBase::addPetscPairsToPetscOptions(
         _problem->mesh().dimension(),
         _problem->getSolverSystem(solver_sys_num).prefix(),
         *this,
-        po,
-        _problem.get());
+        po);
 }
 
 bool

--- a/framework/src/preconditioners/PhysicsBasedPreconditioner.C
+++ b/framework/src/preconditioners/PhysicsBasedPreconditioner.C
@@ -13,10 +13,8 @@
 #include "ComputeJacobianBlocksThread.h"
 #include "FEProblem.h"
 #include "MooseEnum.h"
-#include "MooseUtils.h"
 #include "MooseVariableFE.h"
 #include "NonlinearSystem.h"
-#include "PetscSupport.h"
 
 #include "libmesh/libmesh_common.h"
 #include "libmesh/equation_systems.h"
@@ -136,13 +134,7 @@ PhysicsBasedPreconditioner::PhysicsBasedPreconditioner(const InputParameters & p
 
   _nl.attachPreconditioner(this);
 
-  const auto solve_type = _fe_problem.solverParams(_nl.number())._type;
-  const auto command_line_pc_type =
-      Moose::PetscSupport::commandLinePetscOptionValue(_nl.prefix(), "-pc_type");
-  const auto command_line_pc_type_displaces_pbp =
-      command_line_pc_type && MooseUtils::toLower(*command_line_pc_type) != "shell";
-  if (solve_type != Moose::ST_JFNK &&
-      !(solve_type == Moose::ST_PJFNK && command_line_pc_type_displaces_pbp))
+  if (_fe_problem.solverParams(_nl.number())._type != Moose::ST_JFNK)
     mooseError("PBP must be used with JFNK solve type");
 }
 

--- a/framework/src/preconditioners/PhysicsBasedPreconditioner.C
+++ b/framework/src/preconditioners/PhysicsBasedPreconditioner.C
@@ -13,6 +13,7 @@
 #include "ComputeJacobianBlocksThread.h"
 #include "FEProblem.h"
 #include "MooseEnum.h"
+#include "MooseUtils.h"
 #include "MooseVariableFE.h"
 #include "NonlinearSystem.h"
 #include "PetscSupport.h"
@@ -135,7 +136,13 @@ PhysicsBasedPreconditioner::PhysicsBasedPreconditioner(const InputParameters & p
 
   _nl.attachPreconditioner(this);
 
-  if (_fe_problem.solverParams(_nl.number())._type != Moose::ST_JFNK)
+  const auto solve_type = _fe_problem.solverParams(_nl.number())._type;
+  const auto command_line_pc_type =
+      Moose::PetscSupport::commandLinePetscOptionValue(_nl.prefix(), "-pc_type");
+  const auto command_line_pc_type_displaces_pbp =
+      command_line_pc_type && MooseUtils::toLower(*command_line_pc_type) != "shell";
+  if (solve_type != Moose::ST_JFNK &&
+      !(solve_type == Moose::ST_PJFNK && command_line_pc_type_displaces_pbp))
     mooseError("PBP must be used with JFNK solve type");
 }
 

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -18,6 +18,7 @@
 #include "ComputeFDResidualFunctor.h"
 #include "MooseVariableScalar.h"
 #include "MooseTypes.h"
+#include "MooseUtils.h"
 #include "AuxiliarySystem.h"
 #include "Console.h"
 
@@ -353,6 +354,11 @@ NonlinearSystem::converged()
 void
 NonlinearSystem::attachPreconditioner(Preconditioner<Number> * preconditioner)
 {
+  const auto command_line_pc_type =
+      Moose::PetscSupport::commandLinePetscOptionValue(prefix(), "-pc_type");
+  if (command_line_pc_type && MooseUtils::toLower(*command_line_pc_type) != "shell")
+    return;
+
   nonlinearSolver()->attach_preconditioner(preconditioner);
 }
 

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -147,22 +147,9 @@ petscOptionsHasName(::PetscOptions options,
   mooseAssert(MooseUtils::isAllLowercase(prefix), "PETSc prefixes should be all lower-case")
 
 bool
-hasJFNKSolveType(const FEProblemBase & problem)
-{
-  for (const auto sys_index : make_range(problem.numSolverSystems()))
-    if (problem.solverParams(sys_index)._type == Moose::ST_JFNK)
-      return true;
-
-  return false;
-}
-
-bool
 prefixTargetsJFNKSolver(const FEProblemBase & problem, const std::string & prefix)
 {
   checkPrefix(prefix);
-
-  if (prefix == "-")
-    return hasJFNKSolveType(problem);
 
   const auto solver_prefix = prefix.substr(1);
   for (const auto sys_index : make_range(problem.numSolverSystems()))
@@ -213,8 +200,8 @@ errorOnJFNKPCTypeOption(::PetscOptions options, FEProblemBase & problem)
       continue;
 
     const auto & solver_system = problem.getSolverSystem(sys_index);
-    const std::string solver_prefix = solver_system.name() + "_";
-    if (petscOptionsHasName(options, "-pc_type", solver_prefix))
+    const auto solver_prefix = solver_system.prefix();
+    if (!solver_prefix.empty() && petscOptionsHasName(options, "-pc_type", solver_prefix))
       errorOnJFNKPCTypeOption(problem, "-" + solver_prefix);
   }
 }

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -139,6 +139,86 @@ petscOptionsHasName(::PetscOptions options,
   return found;
 }
 
+#define checkPrefix(prefix)                                                                        \
+  mooseAssert(prefix[0] == '-',                                                                    \
+              "Leading prefix character must be a '-'. Current prefix is '" << prefix << "'");     \
+  mooseAssert((prefix.size() == 1) || (prefix.back() == '_'),                                      \
+              "Terminating prefix character must be a '_'. Current prefix is '" << prefix << "'"); \
+  mooseAssert(MooseUtils::isAllLowercase(prefix), "PETSc prefixes should be all lower-case")
+
+bool
+hasJFNKSolveType(const FEProblemBase & problem)
+{
+  for (const auto sys_index : make_range(problem.numSolverSystems()))
+    if (problem.solverParams(sys_index)._type == Moose::ST_JFNK)
+      return true;
+
+  return false;
+}
+
+bool
+prefixTargetsJFNKSolver(const FEProblemBase & problem, const std::string & prefix)
+{
+  checkPrefix(prefix);
+
+  if (prefix == "-")
+    return hasJFNKSolveType(problem);
+
+  const auto solver_prefix = prefix.substr(1);
+  for (const auto sys_index : make_range(problem.numSolverSystems()))
+    if (problem.solverParams(sys_index)._type == Moose::ST_JFNK)
+    {
+      const auto & solver_system = problem.getSolverSystem(sys_index);
+      if (solver_system.prefix() == solver_prefix || solver_system.name() + "_" == solver_prefix)
+        return true;
+    }
+
+  return false;
+}
+
+std::string
+prefixedPCTypeOption(const std::string & prefix)
+{
+  checkPrefix(prefix);
+  return prefix == "-" ? "-pc_type" : prefix + "pc_type";
+}
+
+void
+errorOnJFNKPCTypeOption(const FEProblemBase & problem,
+                        const std::string & prefix,
+                        const ParallelParamObject * const param_object = nullptr)
+{
+  if (!prefixTargetsJFNKSolver(problem, prefix))
+    return;
+
+  const auto option = prefixedPCTypeOption(prefix);
+  const std::string message =
+      "Setting PETSc option '" + option + "' is incompatible with a JFNK 'solve_type'";
+
+  if (param_object)
+    param_object->mooseError(message);
+  else
+    mooseError(message);
+}
+
+void
+errorOnJFNKPCTypeOption(::PetscOptions options, FEProblemBase & problem)
+{
+  if (petscOptionsHasName(options, "-pc_type"))
+    errorOnJFNKPCTypeOption(problem, "-");
+
+  for (const auto sys_index : make_range(problem.numSolverSystems()))
+  {
+    if (problem.solverParams(sys_index)._type != Moose::ST_JFNK)
+      continue;
+
+    const auto & solver_system = problem.getSolverSystem(sys_index);
+    const std::string solver_prefix = solver_system.name() + "_";
+    if (petscOptionsHasName(options, "-pc_type", solver_prefix))
+      errorOnJFNKPCTypeOption(problem, "-" + solver_prefix);
+  }
+}
+
 bool
 hasMatrixFreeSolveType(const FEProblemBase & problem)
 {
@@ -330,6 +410,7 @@ addPetscOptionsFromCommandline(FEProblemBase * const problem)
     return;
   }
 
+  errorOnJFNKPCTypeOption(command_line_options, *problem);
   errorOnUnprefixedMatTypeOption(command_line_options, *problem);
 
   // Some vector/matrix-type options may have been consumed before the PETSc database rebuild.
@@ -666,13 +747,6 @@ processSingletonMooseWrappedOptions(FEProblemBase & fe_problem, const InputParam
   setMFFDTypeFromParams(fe_problem, params);
 }
 
-#define checkPrefix(prefix)                                                                        \
-  mooseAssert(prefix[0] == '-',                                                                    \
-              "Leading prefix character must be a '-'. Current prefix is '" << prefix << "'");     \
-  mooseAssert((prefix.size() == 1) || (prefix.back() == '_'),                                      \
-              "Terminating prefix character must be a '_'. Current prefix is '" << prefix << "'"); \
-  mooseAssert(MooseUtils::isAllLowercase(prefix), "PETSc prefixes should be all lower-case")
-
 void
 storePetscOptions(FEProblemBase & fe_problem,
                   const std::string & prefix,
@@ -695,7 +769,7 @@ storePetscOptions(FEProblemBase & fe_problem,
 
   // Then process the option-value pairs
   addPetscPairsToPetscOptions(
-      petsc_pair_options, fe_problem.mesh().dimension(), prefix, param_object, po);
+      petsc_pair_options, fe_problem.mesh().dimension(), prefix, param_object, po, &fe_problem);
 }
 
 void
@@ -833,7 +907,8 @@ addPetscPairsToPetscOptions(
     const unsigned int mesh_dimension,
     std::string prefix,
     const ParallelParamObject & param_object,
-    PetscOptions & po)
+    PetscOptions & po,
+    const FEProblemBase * const problem)
 {
   prefix.insert(prefix.begin(), '-');
   checkPrefix(prefix);
@@ -858,6 +933,8 @@ addPetscPairsToPetscOptions(
   for (const auto & [option_name, option_value] : petsc_pair_options)
   {
     checkUserProvidedPetscOption(option_name, param_object);
+    if (problem && option_name == "-pc_type")
+      errorOnJFNKPCTypeOption(*problem, prefix, &param_object);
 
     new_options.clear();
     const std::string prefixed_option_name =

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -139,12 +139,44 @@ petscOptionsHasName(::PetscOptions options,
   return found;
 }
 
+void
+insertCommandLinePetscOptions(::PetscOptions options)
+{
+  int argc;
+  char ** args;
+
+  LibmeshPetscCallA(PETSC_COMM_WORLD, PetscGetArgs(&argc, &args));
+  std::vector<const char *> cl_args(args + 1, args + argc);
+  const auto cl_argc = libMesh::cast_int<int>(cl_args.size());
+
+  LibmeshPetscCallA(PETSC_COMM_WORLD, PetscOptionsInsertArgs(options, cl_argc, cl_args.data()));
+}
+
+::PetscOptions
+commandLinePetscOptions()
+{
+  ::PetscOptions command_line_options;
+  LibmeshPetscCallA(PETSC_COMM_WORLD, PetscOptionsCreate(&command_line_options));
+  insertCommandLinePetscOptions(command_line_options);
+  return command_line_options;
+}
+
 #define checkPrefix(prefix)                                                                        \
   mooseAssert(prefix[0] == '-',                                                                    \
               "Leading prefix character must be a '-'. Current prefix is '" << prefix << "'");     \
   mooseAssert((prefix.size() == 1) || (prefix.back() == '_'),                                      \
               "Terminating prefix character must be a '_'. Current prefix is '" << prefix << "'"); \
   mooseAssert(MooseUtils::isAllLowercase(prefix), "PETSc prefixes should be all lower-case")
+
+bool
+prefixHasCommandLineOption(::PetscOptions command_line_options,
+                           const std::string & prefix,
+                           const std::string & option)
+{
+  checkPrefix(prefix);
+  return prefix == "-" ? petscOptionsHasName(command_line_options, option)
+                       : petscOptionsHasName(command_line_options, option, prefix.substr(1));
+}
 
 bool
 prefixTargetsJFNKSolver(const FEProblemBase & problem, const std::string & prefix)
@@ -156,7 +188,7 @@ prefixTargetsJFNKSolver(const FEProblemBase & problem, const std::string & prefi
     if (problem.solverParams(sys_index)._type == Moose::ST_JFNK)
     {
       const auto & solver_system = problem.getSolverSystem(sys_index);
-      if (solver_system.prefix() == solver_prefix || solver_system.name() + "_" == solver_prefix)
+      if (solver_system.prefix() == solver_prefix)
         return true;
     }
 
@@ -167,7 +199,7 @@ std::string
 prefixedPCTypeOption(const std::string & prefix)
 {
   checkPrefix(prefix);
-  return prefix == "-" ? "-pc_type" : prefix + "pc_type";
+  return prefix + "pc_type";
 }
 
 void
@@ -377,19 +409,8 @@ addPetscOptionsFromCommandline(FEProblemBase * const problem)
 {
   // commandline options always win
   // the options from a user commandline will overwrite the existing ones if any conflicts
-  int argc;
-  char ** args;
-
-  LibmeshPetscCallA(PETSC_COMM_WORLD, PetscGetArgs(&argc, &args));
-  std::vector<const char *> cl_args(args + 1, args + argc);
-  const auto cl_argc = libMesh::cast_int<int>(cl_args.size());
-
-  ::PetscOptions command_line_options;
-  LibmeshPetscCallA(PETSC_COMM_WORLD, PetscOptionsCreate(&command_line_options));
-  LibmeshPetscCallA(PETSC_COMM_WORLD,
-                    PetscOptionsInsertArgs(command_line_options, cl_argc, cl_args.data()));
-  LibmeshPetscCallA(PETSC_COMM_WORLD,
-                    PetscOptionsInsertArgs(LIBMESH_PETSC_NULLPTR, cl_argc, cl_args.data()));
+  auto command_line_options = commandLinePetscOptions();
+  insertCommandLinePetscOptions(LIBMESH_PETSC_NULLPTR);
 
   if (!problem)
   {
@@ -726,10 +747,13 @@ petscSetDefaults(FEProblemBase & problem)
   }
 }
 
+void setSolveTypeFromCommandLine(FEProblemBase & fe_problem);
+
 void
 processSingletonMooseWrappedOptions(FEProblemBase & fe_problem, const InputParameters & params)
 {
   setSolveTypeFromParams(fe_problem, params);
+  setSolveTypeFromCommandLine(fe_problem);
   setLineSearchFromParams(fe_problem, params);
   setMFFDTypeFromParams(fe_problem, params);
 }
@@ -770,6 +794,23 @@ setSolveTypeFromParams(FEProblemBase & fe_problem, const InputParameters & param
     for (const auto i : make_range(fe_problem.numNonlinearSystems()))
       fe_problem.solverParams(i)._type = Moose::stringToEnum<Moose::SolveType>(solve_type);
   }
+}
+
+void
+setSolveTypeFromCommandLine(FEProblemBase & fe_problem)
+{
+  auto command_line_options = commandLinePetscOptions();
+
+  for (const auto i : make_range(fe_problem.numNonlinearSystems()))
+  {
+    const auto prefix = '-' + fe_problem.getSolverSystem(i).prefix();
+    if (prefixHasCommandLineOption(command_line_options, prefix, "-snes_mf_operator"))
+      fe_problem.solverParams(i)._type = Moose::ST_PJFNK;
+    else if (prefixHasCommandLineOption(command_line_options, prefix, "-snes_mf"))
+      fe_problem.solverParams(i)._type = Moose::ST_JFNK;
+  }
+
+  LibmeshPetscCallA(PETSC_COMM_WORLD, PetscOptionsDestroy(&command_line_options));
 }
 
 void

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -211,8 +211,12 @@ errorOnJFNKPCTypeOption(const FEProblemBase & problem,
     return;
 
   const auto option = prefixedPCTypeOption(prefix);
-  const std::string message =
-      "Setting PETSc option '" + option + "' is incompatible with a JFNK 'solve_type'";
+  const std::string message = "PETSc option '" + option +
+                              "' requires an assembled preconditioning matrix, but "
+                              "solve_type = JFNK uses a matrix-free Jacobian without an assembled "
+                              "preconditioning matrix. Use solve_type = PJFNK or "
+                              "-snes_mf_operator if you want matrix-free Jacobian actions with an "
+                              "assembled preconditioner.";
 
   if (param_object)
     param_object->mooseError(message);

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -178,68 +178,38 @@ prefixHasCommandLineOption(::PetscOptions command_line_options,
                        : petscOptionsHasName(command_line_options, option, prefix.substr(1));
 }
 
+std::optional<std::string>
+prefixCommandLineOptionValue(::PetscOptions command_line_options,
+                             const std::string & prefix,
+                             const std::string & option)
+{
+  checkPrefix(prefix);
+
+  char value[PETSC_MAX_PATH_LEN];
+  PetscBool set = PETSC_FALSE;
+  const auto petsc_prefix = prefix == "-" ? std::string() : prefix.substr(1);
+  const char * const prefix_ptr = petsc_prefix.empty() ? nullptr : petsc_prefix.c_str();
+  LibmeshPetscCallA(
+      PETSC_COMM_WORLD,
+      PetscOptionsGetString(
+          command_line_options, prefix_ptr, option.c_str(), value, sizeof(value), &set));
+
+  if (set)
+    return value;
+
+  return std::nullopt;
+}
+
 bool
-prefixTargetsJFNKSolver(const FEProblemBase & problem, const std::string & prefix)
+commandLinePCTypeImpliesPreconditioningMatrix(::PetscOptions command_line_options,
+                                              const std::string & prefix)
 {
-  checkPrefix(prefix);
+  const auto pc_type = prefixCommandLineOptionValue(command_line_options, prefix, "-pc_type");
+  if (!pc_type)
+    return false;
 
-  const auto solver_prefix = prefix.substr(1);
-  for (const auto sys_index : make_range(problem.numSolverSystems()))
-    if (problem.solverParams(sys_index)._type == Moose::ST_JFNK)
-    {
-      const auto & solver_system = problem.getSolverSystem(sys_index);
-      if (solver_system.prefix() == solver_prefix)
-        return true;
-    }
-
-  return false;
-}
-
-std::string
-prefixedPCTypeOption(const std::string & prefix)
-{
-  checkPrefix(prefix);
-  return prefix + "pc_type";
-}
-
-void
-errorOnJFNKPCTypeOption(const FEProblemBase & problem,
-                        const std::string & prefix,
-                        const ParallelParamObject * const param_object = nullptr)
-{
-  if (!prefixTargetsJFNKSolver(problem, prefix))
-    return;
-
-  const auto option = prefixedPCTypeOption(prefix);
-  const std::string message = "PETSc option '" + option +
-                              "' requires an assembled preconditioning matrix, but "
-                              "solve_type = JFNK uses a matrix-free Jacobian without an assembled "
-                              "preconditioning matrix. Use solve_type = PJFNK or "
-                              "-snes_mf_operator if you want matrix-free Jacobian actions with an "
-                              "assembled preconditioner.";
-
-  if (param_object)
-    param_object->mooseError(message);
-  else
-    mooseError(message);
-}
-
-void
-errorOnJFNKPCTypeOption(::PetscOptions options, FEProblemBase & problem)
-{
-  if (petscOptionsHasName(options, "-pc_type"))
-    errorOnJFNKPCTypeOption(problem, "-");
-
-  for (const auto sys_index : make_range(problem.numSolverSystems()))
-  {
-    if (problem.solverParams(sys_index)._type != Moose::ST_JFNK)
-      continue;
-
-    const auto & solver_system = problem.getSolverSystem(sys_index);
-    const auto solver_prefix = solver_system.prefix();
-    if (!solver_prefix.empty() && petscOptionsHasName(options, "-pc_type", solver_prefix))
-      errorOnJFNKPCTypeOption(problem, "-" + solver_prefix);
-  }
+  const auto lower_pc_type = MooseUtils::toLower(*pc_type);
+  return lower_pc_type != "none" && lower_pc_type != "shell";
 }
 
 bool
@@ -362,6 +332,17 @@ stringify(const MffdType & t)
   return "";
 }
 
+std::optional<std::string>
+commandLinePetscOptionValue(const std::string & prefix, const std::string & option)
+{
+  auto command_line_options = commandLinePetscOptions();
+
+  const auto result = prefixCommandLineOptionValue(command_line_options, '-' + prefix, option);
+
+  LibmeshPetscCallA(PETSC_COMM_WORLD, PetscOptionsDestroy(&command_line_options));
+  return result;
+}
+
 void
 setSolverOptions(const SolverParams & solver_params, const MultiMooseEnum & dont_add_these_options)
 {
@@ -422,7 +403,6 @@ addPetscOptionsFromCommandline(FEProblemBase * const problem)
     return;
   }
 
-  errorOnJFNKPCTypeOption(command_line_options, *problem);
   errorOnUnprefixedMatTypeOption(command_line_options, *problem);
 
   // Some vector/matrix-type options may have been consumed before the PETSc database rebuild.
@@ -784,7 +764,7 @@ storePetscOptions(FEProblemBase & fe_problem,
 
   // Then process the option-value pairs
   addPetscPairsToPetscOptions(
-      petsc_pair_options, fe_problem.mesh().dimension(), prefix, param_object, po, &fe_problem);
+      petsc_pair_options, fe_problem.mesh().dimension(), prefix, param_object, po);
 }
 
 void
@@ -812,6 +792,9 @@ setSolveTypeFromCommandLine(FEProblemBase & fe_problem)
       fe_problem.solverParams(i)._type = Moose::ST_PJFNK;
     else if (prefixHasCommandLineOption(command_line_options, prefix, "-snes_mf"))
       fe_problem.solverParams(i)._type = Moose::ST_JFNK;
+    else if (fe_problem.solverParams(i)._type == Moose::ST_JFNK &&
+             commandLinePCTypeImpliesPreconditioningMatrix(command_line_options, prefix))
+      fe_problem.solverParams(i)._type = Moose::ST_PJFNK;
   }
 
   LibmeshPetscCallA(PETSC_COMM_WORLD, PetscOptionsDestroy(&command_line_options));
@@ -939,8 +922,7 @@ addPetscPairsToPetscOptions(
     const unsigned int mesh_dimension,
     std::string prefix,
     const ParallelParamObject & param_object,
-    PetscOptions & po,
-    const FEProblemBase * const problem)
+    PetscOptions & po)
 {
   prefix.insert(prefix.begin(), '-');
   checkPrefix(prefix);
@@ -965,8 +947,6 @@ addPetscPairsToPetscOptions(
   for (const auto & [option_name, option_value] : petsc_pair_options)
   {
     checkUserProvidedPetscOption(option_name, param_object);
-    if (problem && option_name == "-pc_type")
-      errorOnJFNKPCTypeOption(*problem, prefix, &param_object);
 
     new_options.clear();
     const std::string prefixed_option_name =

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -201,18 +201,6 @@ prefixCommandLineOptionValue(::PetscOptions command_line_options,
 }
 
 bool
-commandLinePCTypeImpliesPreconditioningMatrix(::PetscOptions command_line_options,
-                                              const std::string & prefix)
-{
-  const auto pc_type = prefixCommandLineOptionValue(command_line_options, prefix, "-pc_type");
-  if (!pc_type)
-    return false;
-
-  const auto lower_pc_type = MooseUtils::toLower(*pc_type);
-  return lower_pc_type != "none" && lower_pc_type != "shell";
-}
-
-bool
 hasMatrixFreeSolveType(const FEProblemBase & problem)
 {
   for (const auto sys_index : make_range(problem.numSolverSystems()))
@@ -792,9 +780,6 @@ setSolveTypeFromCommandLine(FEProblemBase & fe_problem)
       fe_problem.solverParams(i)._type = Moose::ST_PJFNK;
     else if (prefixHasCommandLineOption(command_line_options, prefix, "-snes_mf"))
       fe_problem.solverParams(i)._type = Moose::ST_JFNK;
-    else if (fe_problem.solverParams(i)._type == Moose::ST_JFNK &&
-             commandLinePCTypeImpliesPreconditioningMatrix(command_line_options, prefix))
-      fe_problem.solverParams(i)._type = Moose::ST_PJFNK;
   }
 
   LibmeshPetscCallA(PETSC_COMM_WORLD, PetscOptionsDestroy(&command_line_options));

--- a/test/tests/physics/multi_system/tests
+++ b/test/tests/physics/multi_system/tests
@@ -15,7 +15,7 @@
                 Physics/Diffusion/ContinuousGalerkin/diff_2/preconditioning=defer
                 Outputs/csv=false
                 -pc_type lu"
-    absent_out = "Setting PETSc option '-pc_type' is incompatible with a JFNK 'solve_type'"
+    absent_out = "PETSc option '-pc_type' requires an assembled preconditioning matrix"
     requirement = "The system shall not reject an unprefixed PETSc preconditioner type option for a "
                   "JFNK solve using prefixed solver systems."
   []
@@ -49,7 +49,7 @@
       type = RunException
       input = 'diffusion_multisys.i'
       cli_args = "Executioner/solve_type=JFNK Outputs/csv=false"
-      expect_err = "Setting PETSc option '-sys1_pc_type' is incompatible with a JFNK 'solve_type'"
+      expect_err = "PETSc option '-sys1_pc_type' requires an assembled preconditioning matrix"
       detail = 'if a Physics adds PETSc preconditioner type options to a JFNK solve.'
     []
   []

--- a/test/tests/physics/multi_system/tests
+++ b/test/tests/physics/multi_system/tests
@@ -19,6 +19,16 @@
     requirement = "The system shall not reject an unprefixed PETSc preconditioner type option for a "
                   "JFNK solve using prefixed solver systems."
   []
+  [prefixed_pc_type_command_line_override]
+    type = RunApp
+    input = 'diffusion_multisys.i'
+    cli_args = "Executioner/solve_type=JFNK
+                Outputs/csv=false
+                -sys1_snes_mf_operator
+                -sys2_snes_mf_operator"
+    requirement = "The system shall allow Physics-added PETSc preconditioner type options when "
+                  "command-line PETSc options override JFNK solves to PJFNK."
+  []
   [errors]
     requirement = 'The system shall return an error'
     [wrong_systems]

--- a/test/tests/physics/multi_system/tests
+++ b/test/tests/physics/multi_system/tests
@@ -1,11 +1,23 @@
 [Tests]
   design = 'Physics/index.md'
-  issues = '#29019'
+  issues = '#29019 #16517'
   [cg]
     type = CSVDiff
     input = 'diffusion_multisys.i'
     csvdiff = 'diffusion_multisys_out_sample_0010.csv'
     requirement = 'The system shall be able to set up multi-system problems using a Physics syntax.'
+  []
+  [unprefixed_pc_type_prefixed_jfnk]
+    type = RunApp
+    input = 'diffusion_multisys.i'
+    cli_args = "Executioner/solve_type=JFNK
+                Physics/Diffusion/ContinuousGalerkin/diff_1/preconditioning=defer
+                Physics/Diffusion/ContinuousGalerkin/diff_2/preconditioning=defer
+                Outputs/csv=false
+                -pc_type lu"
+    absent_out = "Setting PETSc option '-pc_type' is incompatible with a JFNK 'solve_type'"
+    requirement = "The system shall not reject an unprefixed PETSc preconditioner type option for a "
+                  "JFNK solve using prefixed solver systems."
   []
   [errors]
     requirement = 'The system shall return an error'
@@ -22,6 +34,13 @@
       cli_args = "Physics/Diffusion/ContinuousGalerkin/diff_1/system_names='sys1 sys2'"
       expect_err = "There should be one system name per solver variable \(potentially repeated\), or a single system name for all variables"
       detail = 'if more systems than needed are specified to a Physics action.'
+    []
+    [jfnk_physics_pc_type]
+      type = RunException
+      input = 'diffusion_multisys.i'
+      cli_args = "Executioner/solve_type=JFNK Outputs/csv=false"
+      expect_err = "Setting PETSc option '-sys1_pc_type' is incompatible with a JFNK 'solve_type'"
+      detail = 'if a Physics adds PETSc preconditioner type options to a JFNK solve.'
     []
   []
 []

--- a/test/tests/physics/multi_system/tests
+++ b/test/tests/physics/multi_system/tests
@@ -19,20 +19,6 @@
     requirement = "The system shall not reject an unprefixed PETSc preconditioner type option for a "
                   "JFNK solve using prefixed solver systems."
   []
-  [prefixed_pc_type_command_line_override]
-    type = RunApp
-    input = 'diffusion_multisys.i'
-    cli_args = "Executioner/solve_type=JFNK
-                Executioner/num_steps=1
-                Outputs/csv=false
-                -sys1_pc_type lu
-                -sys2_pc_type lu
-                -sys1_ksp_view
-                -sys2_ksp_view"
-    expect_out = 'PC Object: \(sys1_\).*?type: lu.*?PC Object: \(sys2_\).*?type: lu'
-    requirement = "The system shall allow command-line PETSc preconditioner type options to "
-                  "override Physics-added PETSc preconditioner type options for JFNK solves."
-  []
   [jfnk_physics_pc_type]
     type = RunApp
     input = 'diffusion_multisys.i'

--- a/test/tests/physics/multi_system/tests
+++ b/test/tests/physics/multi_system/tests
@@ -23,11 +23,23 @@
     type = RunApp
     input = 'diffusion_multisys.i'
     cli_args = "Executioner/solve_type=JFNK
+                Executioner/num_steps=1
                 Outputs/csv=false
-                -sys1_snes_mf_operator
-                -sys2_snes_mf_operator"
-    requirement = "The system shall allow Physics-added PETSc preconditioner type options when "
-                  "command-line PETSc options override JFNK solves to PJFNK."
+                -sys1_pc_type lu
+                -sys2_pc_type lu
+                -sys1_ksp_view
+                -sys2_ksp_view"
+    expect_out = 'PC Object: \(sys1_\).*?type: lu.*?PC Object: \(sys2_\).*?type: lu'
+    requirement = "The system shall allow command-line PETSc preconditioner type options to "
+                  "override Physics-added PETSc preconditioner type options for JFNK solves."
+  []
+  [jfnk_physics_pc_type]
+    type = RunApp
+    input = 'diffusion_multisys.i'
+    cli_args = "Executioner/solve_type=JFNK Executioner/num_steps=1 Outputs/csv=false"
+    absent_out = "PETSc option '-sys1_pc_type' requires an assembled preconditioning matrix"
+    requirement = "The system shall allow Physics-added PETSc preconditioner type options for a "
+                  "JFNK solve."
   []
   [errors]
     requirement = 'The system shall return an error'
@@ -44,13 +56,6 @@
       cli_args = "Physics/Diffusion/ContinuousGalerkin/diff_1/system_names='sys1 sys2'"
       expect_err = "There should be one system name per solver variable \(potentially repeated\), or a single system name for all variables"
       detail = 'if more systems than needed are specified to a Physics action.'
-    []
-    [jfnk_physics_pc_type]
-      type = RunException
-      input = 'diffusion_multisys.i'
-      cli_args = "Executioner/solve_type=JFNK Outputs/csv=false"
-      expect_err = "PETSc option '-sys1_pc_type' requires an assembled preconditioning matrix"
-      detail = 'if a Physics adds PETSc preconditioner type options to a JFNK solve.'
     []
   []
 []

--- a/test/tests/preconditioners/pbp/tests
+++ b/test/tests/preconditioners/pbp/tests
@@ -28,7 +28,7 @@
     type = 'RunException'
     input = 'pbp_test.i'
     cli_args = '-pc_type lu Outputs/exodus=false'
-    expect_err = "Setting PETSc option '-pc_type' is incompatible with a JFNK 'solve_type'"
+    expect_err = "PETSc option '-pc_type' requires an assembled preconditioning matrix"
     requirement = "The system shall report an error when a JFNK solve uses an incompatible "
                   "PETSc preconditioner type option."
   []

--- a/test/tests/preconditioners/pbp/tests
+++ b/test/tests/preconditioners/pbp/tests
@@ -1,6 +1,6 @@
 [Tests]
   design = PhysicsBasedPreconditioner.md
-  issues = '#1048 #18777'
+  issues = '#1048 #18777 #16517'
 
   [pbp]
     requirement = "The system shall support the use of a physics based preconditioner"
@@ -22,6 +22,15 @@
 
       detail = "with mesh adaptivity."
     []
+  []
+
+  [jfnk_pc_type_error]
+    type = 'RunException'
+    input = 'pbp_test.i'
+    cli_args = '-pc_type lu Outputs/exodus=false'
+    expect_err = "Setting PETSc option '-pc_type' is incompatible with a JFNK 'solve_type'"
+    requirement = "The system shall report an error when a JFNK solve uses an incompatible "
+                  "PETSc preconditioner type option."
   []
 
   [check_petsc_options_test]

--- a/test/tests/preconditioners/pbp/tests
+++ b/test/tests/preconditioners/pbp/tests
@@ -27,10 +27,11 @@
   [jfnk_command_line_pc_type]
     type = 'RunApp'
     input = 'pbp_test.i'
-    cli_args = '-pc_type lu Outputs/exodus=false -ksp_view'
-    expect_out = 'PC Object:.*?type: lu'
+    cli_args = '-pc_type lu Outputs/exodus=false -snes_view'
+    expect_out = 'PC Object:.*?type: none'
     requirement = "The system shall allow a command-line PETSc preconditioner type option to "
-                  "displace a physics based shell preconditioner for a JFNK solve."
+                  "displace a physics based shell preconditioner for a JFNK solve without "
+                  "changing the solve type."
   []
 
   [check_petsc_options_test]

--- a/test/tests/preconditioners/pbp/tests
+++ b/test/tests/preconditioners/pbp/tests
@@ -24,13 +24,13 @@
     []
   []
 
-  [jfnk_pc_type_error]
-    type = 'RunException'
+  [jfnk_command_line_pc_type]
+    type = 'RunApp'
     input = 'pbp_test.i'
-    cli_args = '-pc_type lu Outputs/exodus=false'
-    expect_err = "PETSc option '-pc_type' requires an assembled preconditioning matrix"
-    requirement = "The system shall report an error when a JFNK solve uses an incompatible "
-                  "PETSc preconditioner type option."
+    cli_args = '-pc_type lu Outputs/exodus=false -ksp_view'
+    expect_out = 'PC Object:.*?type: lu'
+    requirement = "The system shall allow a command-line PETSc preconditioner type option to "
+                  "displace a physics based shell preconditioner for a JFNK solve."
   []
 
   [check_petsc_options_test]


### PR DESCRIPTION
This PR resolves issue #16517 

## Summary

  `solve_type = JFNK` could coexist with a user-provided PETSc `-pc_type`, and that PETSc option could silently override
  In the PBP reproducer, MOOSE installs a PETSc shell preconditioner for the physics-based preconditioner. Passing `-pc_type lu` on the command line interfered with that setup. The user did not get useful LU behavior, and the PBP shell preconditioner was effectively lost.

  ## Fix

  I added validation in PETSc option handling so MOOSE now errors when `-pc_type` targets a solver system using `solve_type = JFNK`.

  This covers both paths:

  - command-line PETSc options, e.g. `-pc_type lu`
  - input-file PETSc options, e.g. `petsc_options_iname = '-pc_type'`

  `PJFNK` is intentionally still allowed to use `-pc_type`, since many inputs rely on that for assembled preconditioning.

  ## Behavior Change

  ### Before

  Running:

  ```bash
  ./moose_test-opt -i tests/preconditioners/pbp/pbp_test.i -pc_type lu

  would still run, but the PBP shell preconditioner was displaced. The solve behaved like it had no useful preconditioner:

  0 Nonlinear |R| = 1.230049e+02
      0 Linear |R| = 1.230049e+02
      1 Linear |R| = 5.182619e+01
      2 Linear |R| = 1.430100e+01
      ...
      6 Linear |R| = 7.787060e-08

  Without -pc_type, the same input used PBP correctly:

  0 Nonlinear |R| = 1.230049e+02
      0 Linear |R| = 1.230049e+02
      1 Linear |R| = 3.870853e-06

  ### After

  The invalid combination now fails early:

  ./moose_test-opt -i tests/preconditioners/pbp/pbp_test.i -pc_type lu

  *** ERROR ***
  Setting PETSc option '-pc_type' is incompatible with a JFNK 'solve_type'

  ## Test Coverage

  Added a regression test under:

  test/tests/preconditioners/pbp

  The new test uses pbp_test.i with -pc_type lu and expects the new error message.
