### PR TITLE
Fix dense Jacobian matrix tagging

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -1218,16 +1218,17 @@ public:
 
   /**
    * Cache a local Jacobian block with the provided rows (\p idof_indices) and columns (\p
-   * jdof_indices) for eventual accumulation into the global matrix specified by \p tag. The \p
-   * scaling_factor will be applied before caching. Only blessed framework classes may call this API
-   * by creating the requisiste \p LocalDataKey class
+   * jdof_indices) for eventual accumulation into the global matrices specified by \p tags. The \p
+   * scaling_factor will be applied before caching. The input block is left unchanged; any
+   * constraints and scaling are applied to Assembly's work matrix. Only blessed framework classes
+   * may call this API by creating the requisite \p LocalDataKey class.
    */
-  void cacheJacobianBlock(DenseMatrix<Number> & jac_block,
+  void cacheJacobianBlock(const DenseMatrix<Number> & jac_block,
                           const std::vector<dof_id_type> & idof_indices,
                           const std::vector<dof_id_type> & jdof_indices,
                           Real scaling_factor,
                           LocalDataKey,
-                          TagID tag);
+                          const std::set<TagID> & tags);
 
   /**
    * Process the supplied residual values. This is a mirror of of the non-templated version of \p

--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -1889,7 +1889,7 @@ public:
     }
   }
 
-  DenseVector<Real> getJacobianDiagonal(DenseMatrix<Number> & ke)
+  DenseVector<Real> getJacobianDiagonal(const DenseMatrix<Number> & ke)
   {
     unsigned int rows = ke.m();
     unsigned int cols = ke.n();
@@ -2136,7 +2136,7 @@ private:
   /**
    * Push a local Jacobian block with proper scaling into cache for a certain tag.
    */
-  void cacheJacobianBlock(DenseMatrix<Number> & jac_block,
+  void cacheJacobianBlock(const DenseMatrix<Number> & jac_block,
                           const MooseVariableBase & ivar,
                           const MooseVariableBase & jvar,
                           const std::vector<dof_id_type> & idof_indices,
@@ -2146,7 +2146,7 @@ private:
   /**
    * Push non-zeros of a local Jacobian block with proper scaling into cache for a certain tag.
    */
-  void cacheJacobianBlockNonzero(DenseMatrix<Number> & jac_block,
+  void cacheJacobianBlockNonzero(const DenseMatrix<Number> & jac_block,
                                  const MooseVariableBase & ivar,
                                  const MooseVariableBase & jvar,
                                  const std::vector<dof_id_type> & idof_indices,

--- a/framework/include/interfaces/TaggingInterface.h
+++ b/framework/include/interfaces/TaggingInterface.h
@@ -378,7 +378,7 @@ protected:
    * Add a local Jacobian matrix
    */
   void addJacobian(Assembly & assembly,
-                   DenseMatrix<Real> & local_k,
+                   const DenseMatrix<Real> & local_k,
                    const std::vector<dof_id_type> & row_indices,
                    const std::vector<dof_id_type> & column_indices,
                    Real scaling_factor);
@@ -648,14 +648,13 @@ TaggingInterface::addJacobianElement(Assembly & assembly,
 
 inline void
 TaggingInterface::addJacobian(Assembly & assembly,
-                              DenseMatrix<Real> & local_k,
+                              const DenseMatrix<Real> & local_k,
                               const std::vector<dof_id_type> & row_indices,
                               const std::vector<dof_id_type> & column_indices,
                               const Real scaling_factor)
 {
-  for (const auto matrix_tag : _matrix_tags)
-    assembly.cacheJacobianBlock(
-        local_k, row_indices, column_indices, scaling_factor, Assembly::LocalDataKey{}, matrix_tag);
+  assembly.cacheJacobianBlock(
+      local_k, row_indices, column_indices, scaling_factor, Assembly::LocalDataKey{}, _matrix_tags);
 }
 
 template <typename T>

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -387,6 +387,10 @@ public:
   setNeighborSubdomainID(const Elem * elem, unsigned int side, const THREAD_ID tid) override;
   virtual void setNeighborSubdomainID(const Elem * elem, const THREAD_ID tid);
   virtual void prepareAssembly(const THREAD_ID tid) override;
+  /**
+   * Begin a fresh neighbor accumulation phase by sizing and zeroing the neighbor blocks.
+   */
+  virtual void prepareAssemblyNeighbor(const THREAD_ID tid);
 
   virtual void addGhostedElem(dof_id_type elem_id) override;
   virtual void addGhostedBoundary(BoundaryID boundary_id) override;

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -34,6 +34,8 @@
 #include "libmesh/vector_value.h"
 #include "libmesh/fe.h"
 
+#include <algorithm>
+
 using namespace libMesh;
 
 template <typename P, typename C>
@@ -3657,6 +3659,8 @@ Assembly::cacheJacobianBlock(DenseMatrix<Number> & jac_block,
     }
   }
 
+  // The argument can alias several different reusable Assembly Jacobian blocks, so clear the
+  // selected block after caching its entries.
   jac_block.zero();
 }
 
@@ -3716,42 +3720,45 @@ Assembly::cacheJacobianBlockNonzero(DenseMatrix<Number> & jac_block,
     }
   }
 
+  // The argument can alias several different reusable Assembly Jacobian blocks, so clear the
+  // selected block after caching its entries.
   jac_block.zero();
 }
 
 void
-Assembly::cacheJacobianBlock(DenseMatrix<Number> & jac_block,
+Assembly::cacheJacobianBlock(const DenseMatrix<Number> & jac_block,
                              const std::vector<dof_id_type> & idof_indices,
                              const std::vector<dof_id_type> & jdof_indices,
                              Real scaling_factor,
                              LocalDataKey,
-                             TagID tag)
+                             const std::set<TagID> & tags)
 {
-  // Only cache data when the matrix exists
+  const auto has_matrix =
+      std::any_of(tags.begin(), tags.end(), [this](const auto tag) { return _sys.hasMatrix(tag); });
+
+  // Work on a reusable Assembly-owned copy so callers retain their local matrix. This also lets us
+  // apply constraints and scaling once before caching the same block to every requested matrix tag.
   if ((idof_indices.size() > 0) && (jdof_indices.size() > 0) && jac_block.n() && jac_block.m() &&
-      _sys.hasMatrix(tag))
+      has_matrix)
   {
-    std::vector<dof_id_type> di(idof_indices);
-    std::vector<dof_id_type> dj(jdof_indices);
+    _row_indices.assign(idof_indices.begin(), idof_indices.end());
+    _column_indices.assign(jdof_indices.begin(), jdof_indices.end());
+    _element_matrix = jac_block;
 
     // If we're computing the jacobian for automatically scaling variables we do not want to
     // constrain the element matrix because it introduces 1s on the diagonal for the constrained
     // dofs
     if (!_sys.computingScalingJacobian())
-      _dof_map.constrain_element_matrix(jac_block, di, dj, false);
+      _dof_map.constrain_element_matrix(_element_matrix, _row_indices, _column_indices, false);
 
     if (scaling_factor != 1.0)
-      jac_block *= scaling_factor;
+      _element_matrix *= scaling_factor;
 
-    for (MooseIndex(di) i = 0; i < di.size(); i++)
-      for (MooseIndex(dj) j = 0; j < dj.size(); j++)
-      {
-        _cached_jacobian_values[tag].push_back(jac_block(i, j));
-        _cached_jacobian_rows[tag].push_back(di[i]);
-        _cached_jacobian_cols[tag].push_back(dj[j]);
-      }
+    for (const auto i : index_range(_row_indices))
+      for (const auto j : index_range(_column_indices))
+        cacheJacobian(
+            _row_indices[i], _column_indices[j], _element_matrix(i, j), LocalDataKey{}, tags);
   }
-  jac_block.zero();
 }
 
 Real

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -3659,8 +3659,11 @@ Assembly::cacheJacobianBlock(DenseMatrix<Number> & jac_block,
     }
   }
 
-  // The argument can alias several different reusable Assembly Jacobian blocks, so clear the
-  // selected block after caching its entries.
+  // These Assembly-owned Jacobian blocks are accumulation buffers. Some paths reuse a block after
+  // caching without an intervening prepare call (and therefore without resize zeroing it), so
+  // clearing here prevents stale contributions from being accumulated and cached again. Keeping
+  // the clear here also avoids duplicating it at every element, neighbor, nonlocal, and mortar
+  // cache call site.
   jac_block.zero();
 }
 
@@ -3720,8 +3723,11 @@ Assembly::cacheJacobianBlockNonzero(DenseMatrix<Number> & jac_block,
     }
   }
 
-  // The argument can alias several different reusable Assembly Jacobian blocks, so clear the
-  // selected block after caching its entries.
+  // These Assembly-owned Jacobian blocks are accumulation buffers. Some paths reuse a block after
+  // caching without an intervening prepare call (and therefore without resize zeroing it), so
+  // clearing here prevents stale contributions from being accumulated and cached again. Keeping
+  // the clear here also avoids duplicating it at every element, neighbor, nonlocal, and mortar
+  // cache call site.
   jac_block.zero();
 }
 

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -3603,7 +3603,7 @@ Assembly::addJacobianBlock(SparseMatrix<Number> & jacobian,
 
 // private method, so no key required
 void
-Assembly::cacheJacobianBlock(DenseMatrix<Number> & jac_block,
+Assembly::cacheJacobianBlock(const DenseMatrix<Number> & jac_block,
                              const MooseVariableBase & ivar,
                              const MooseVariableBase & jvar,
                              const std::vector<dof_id_type> & idof_indices,
@@ -3658,18 +3658,11 @@ Assembly::cacheJacobianBlock(DenseMatrix<Number> & jac_block,
         }
     }
   }
-
-  // These Assembly-owned Jacobian blocks are accumulation buffers. Some paths reuse a block after
-  // caching without an intervening prepare call (and therefore without resize zeroing it), so
-  // clearing here prevents stale contributions from being accumulated and cached again. Keeping
-  // the clear here also avoids duplicating it at every element, neighbor, nonlocal, and mortar
-  // cache call site.
-  jac_block.zero();
 }
 
 // private method, so no key required
 void
-Assembly::cacheJacobianBlockNonzero(DenseMatrix<Number> & jac_block,
+Assembly::cacheJacobianBlockNonzero(const DenseMatrix<Number> & jac_block,
                                     const MooseVariableBase & ivar,
                                     const MooseVariableBase & jvar,
                                     const std::vector<dof_id_type> & idof_indices,
@@ -3722,13 +3715,6 @@ Assembly::cacheJacobianBlockNonzero(DenseMatrix<Number> & jac_block,
           }
     }
   }
-
-  // These Assembly-owned Jacobian blocks are accumulation buffers. Some paths reuse a block after
-  // caching without an intervening prepare call (and therefore without resize zeroing it), so
-  // clearing here prevents stale contributions from being accumulated and cached again. Keeping
-  // the clear here also avoids duplicating it at every element, neighbor, nonlocal, and mortar
-  // cache call site.
-  jac_block.zero();
 }
 
 void

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1929,12 +1929,22 @@ FEProblemBase::prepareAssembly(const THREAD_ID tid)
   if (_has_nonlocal_coupling)
     _assembly[tid][_current_nl_sys->number()]->prepareNonlocal();
 
-  if (_displaced_problem && (_reinit_displaced_elem || _reinit_displaced_face))
+  if (_displaced_problem &&
+      (_reinit_displaced_elem || _reinit_displaced_face || _reinit_displaced_neighbor))
   {
     _displaced_problem->prepareAssembly(tid);
     if (_has_nonlocal_coupling)
       _displaced_problem->prepareNonlocal(tid);
   }
+}
+
+void
+FEProblemBase::prepareAssemblyNeighbor(const THREAD_ID tid)
+{
+  _assembly[tid][_current_nl_sys->number()]->prepareNeighbor();
+
+  if (_displaced_problem && (_reinit_displaced_face || _reinit_displaced_neighbor))
+    _displaced_problem->prepareAssemblyNeighbor(tid);
 }
 
 void

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -2570,6 +2570,10 @@ NonlinearSystemBase::constraintJacobians(const SparseMatrix<Number> & jacobian_t
               {
                 constraints_applied = true;
 
+                // Begin the diagonal node-face constraint accumulation phase for neighbor Jacobian
+                // blocks.
+                _fe_problem.prepareAssemblyNeighbor(0);
+
                 nfc->prepareShapes(nfc->variable().number());
                 nfc->prepareNeighborShapes(nfc->variable().number());
 
@@ -2634,8 +2638,10 @@ NonlinearSystemBase::constraintJacobians(const SparseMatrix<Number> & jacobian_t
                           nfc->variable().number(), jvar->number(), this->number()))
                     continue;
 
-                  // Need to zero out the matrices first
+                  // Begin the off-diagonal node-face constraint accumulation phase for
+                  // element and neighbor Jacobian blocks.
                   _fe_problem.prepareAssembly(0);
+                  _fe_problem.prepareAssemblyNeighbor(0);
 
                   nfc->prepareShapes(nfc->variable().number());
                   nfc->prepareNeighborShapes(jvar->number());
@@ -2749,6 +2755,11 @@ NonlinearSystemBase::constraintJacobians(const SparseMatrix<Number> & jacobian_t
           _fe_problem.setNeighborSubdomainID(elem2, tid);
           subproblem.reinitNeighborPhys(elem2, info._elem2_constraint_q_point, tid);
 
+          // Begin the element-element constraint accumulation phase for element and neighbor
+          // Jacobian blocks.
+          _fe_problem.prepareAssembly(tid);
+          _fe_problem.prepareAssemblyNeighbor(tid);
+
           ec->prepareShapes(ec->variable().number());
           ec->prepareNeighborShapes(ec->variable().number());
 
@@ -2793,9 +2804,6 @@ NonlinearSystemBase::constraintJacobians(const SparseMatrix<Number> & jacobian_t
             // This reinits the variables that exist on the secondary node
             _fe_problem.reinitNodeFace(&secondary_node, secondary_id, 0);
 
-            // This will set aside residual and jacobian space for the variables that have dofs
-            // on the secondary node
-            _fe_problem.prepareAssembly(0);
             _fe_problem.reinitOffDiagScalars(0);
 
             for (const auto & nec : constraints)
@@ -2803,6 +2811,11 @@ NonlinearSystemBase::constraintJacobians(const SparseMatrix<Number> & jacobian_t
               if (nec->shouldApply())
               {
                 constraints_applied = true;
+
+                // Begin the diagonal node-element constraint accumulation phase for
+                // element and neighbor Jacobian blocks.
+                _fe_problem.prepareAssembly(0);
+                _fe_problem.prepareAssemblyNeighbor(0);
 
                 nec->_jacobian = &jacobian_to_view;
                 nec->prepareShapes(nec->variable().number());
@@ -2850,8 +2863,10 @@ NonlinearSystemBase::constraintJacobians(const SparseMatrix<Number> & jacobian_t
                           nec->variable().number(), jvar->number(), this->number()))
                     continue;
 
-                  // Need to zero out the matrices first
+                  // Begin the off-diagonal node-element constraint accumulation phase for
+                  // element and neighbor Jacobian blocks.
                   _fe_problem.prepareAssembly(0);
+                  _fe_problem.prepareAssemblyNeighbor(0);
 
                   nec->prepareShapes(nec->variable().number());
                   nec->prepareNeighborShapes(jvar->number());

--- a/test/tests/constraints/nodal_constraint/gold/nodal_constraint_extra_tag_test_out.csv
+++ b/test/tests/constraints/nodal_constraint/gold/nodal_constraint_extra_tag_test_out.csv
@@ -1,3 +1,3 @@
-time,react_u_at_primary,react_u_at_secondary
-0,0,0
-1,0,0
+time,react_u_at_primary,react_u_at_secondary,react_u_jacobian_at_primary,react_u_jacobian_at_secondary
+0,0,0,0,0
+1,0,0,100000,100000

--- a/test/tests/constraints/nodal_constraint/nodal_constraint_extra_tag_test.i
+++ b/test/tests/constraints/nodal_constraint/nodal_constraint_extra_tag_test.i
@@ -1,7 +1,5 @@
-# Test that NodalConstraint contributions to extra_vector_tags
-# are correctly written to the tagged system vector.
-# This tests that TagVectorAux can read the constraint's contribution
-# from the tagged vector.
+# Test that NodalConstraint contributions to extra tags are correctly
+# written to tagged system vectors and matrices.
 
 [Mesh]
   file = 2-lines.e
@@ -10,6 +8,7 @@
 
 [Problem]
   extra_tag_vectors = ref
+  extra_tag_matrices = ref_mat
 []
 
 [Variables]
@@ -21,6 +20,8 @@
 
 [AuxVariables]
   [react_u]
+  []
+  [react_u_jacobian]
   []
 []
 
@@ -38,6 +39,12 @@
     variable = react_u
     v = u
     vector_tag = ref
+  []
+  [react_u_jacobian_aux]
+    type = TagMatrixAux
+    variable = react_u_jacobian
+    v = u
+    matrix_tag = ref_mat
   []
 []
 
@@ -65,6 +72,7 @@
     secondary = 4
     penalty = 100000
     extra_vector_tags = ref
+    extra_matrix_tags = ref_mat
   []
 []
 
@@ -79,6 +87,16 @@
   [react_u_at_secondary]
     type = NodalVariableValue
     variable = react_u
+    nodeid = 4
+  []
+  [react_u_jacobian_at_primary]
+    type = NodalVariableValue
+    variable = react_u_jacobian
+    nodeid = 0
+  []
+  [react_u_jacobian_at_secondary]
+    type = NodalVariableValue
+    variable = react_u_jacobian
     nodeid = 4
   []
 []

--- a/test/tests/constraints/nodal_constraint/tests
+++ b/test/tests/constraints/nodal_constraint/tests
@@ -33,11 +33,14 @@
     requirement = "The system shall support the ability to constrain nodal values of different variables."
   []
 
-  [extra_vector_tags]
+  [extra_tags]
     type = 'CSVDiff'
     input = 'nodal_constraint_extra_tag_test.i'
     csvdiff = 'nodal_constraint_extra_tag_test_out.csv'
     max_parallel = 1
-    requirement = "The system shall be able to tally the contributions of nodal constraints in additional tagged system vectors."
+    issues = '#665 #33385'
+    design = 'syntax/Constraints/index.md interfaces/TaggingInterface.md'
+    requirement = "The system shall be able to tally the contributions of nodal constraints in "
+                  "additional tagged system vectors and matrices."
   []
 []

--- a/test/tests/linearfvbcs/scalar_symmetry/tests
+++ b/test/tests/linearfvbcs/scalar_symmetry/tests
@@ -33,6 +33,7 @@
     test_case = TestAdvection2DSymmetry
     requirement = 'The system shall display second-order convergence with respect to a manufactured solution for the 2D steady advection equation, which shall be solved numerically using a linear finite volume system with symmetry boundary conditions.'
     max_threads = 1 # see libmesh issue #3808
+    min_slots = 2 # Memory heavy
   []
 
   [diffusion-2d-symmetry-nonorthogonal]

--- a/test/tests/linearfvkernels/diffusion-reaction-advection/tests
+++ b/test/tests/linearfvkernels/diffusion-reaction-advection/tests
@@ -35,6 +35,7 @@
     test_case = TestADR2DNeumann
     requirement = 'The system shall display second-order convergence for advection-diffusion-reaction problems with Neumann boundary conditions using a linear finite volume system on a two-dimensional orthogonal mesh.'
     max_threads = 1 # see libmesh issue #3808
+    min_slots = 2
   []
   [mms-adr-2d-outflow]
     type = MMSTest

--- a/test/tests/mfem/submeshes/tests
+++ b/test/tests/mfem/submeshes/tests
@@ -93,7 +93,7 @@
     compute_devices = 'cpu cuda'
     recover = false
     valgrind = heavy
-    min_slots = 2 # memory heavy
+    min_slots = 3 # memory heavy
   []
   [MFEMVacuumCutTransitionSubMesh]
     design = 'syntax/MFEM/ClosedCoilMagnetostatic.md'


### PR DESCRIPTION
closes #33385

## Reason

`TaggingInterface::addJacobian()` passed the same dense local Jacobian block to every matrix tag, but the caller-facing `Assembly::cacheJacobianBlock()` consumed and cleared that block. Consequently, only the first matrix tag received the contribution and subsequent tags received zeros. The destructive API was also surprising for callers that retain their local matrix.

## Design

Make the caller-facing dense Jacobian caching API const and non-destructive. Copy the local block once into Assembly's existing work matrix, apply constraints and scaling once, and cache the processed entries to every requested matrix tag. Retain the existing clearing behavior in private caching paths that consume reusable Assembly-owned matrices. Extend the existing nodal-constraint tagging regression to verify the dense Jacobian contribution in an additional matrix tag.

## Impact

Dense Jacobian contributions are assembled correctly into multiple matrix tags, and caller-owned local matrices remain unchanged. The caller-facing internal C++ API is now const-correct; there are no user-facing input changes.
