### PR TITLE
Fix ElementQualityChecker Extrema Reporting

### DIFF
--- a/framework/src/userobjects/ElementQualityChecker.C
+++ b/framework/src/userobjects/ElementQualityChecker.C
@@ -15,6 +15,8 @@
 #include "libmesh/enum_elem_quality.h"
 #include "libmesh/string_to_enum.h"
 
+#include <limits>
+
 MooseEnum
 ElementQualityChecker::QualityMetricType()
 {
@@ -61,8 +63,8 @@ ElementQualityChecker::ElementQualityChecker(const InputParameters & parameters)
     _has_lower_bound(isParamValid("lower_bound")),
     _upper_bound(_has_upper_bound ? getParam<Real>("upper_bound") : 0.0),
     _lower_bound(_has_lower_bound ? getParam<Real>("lower_bound") : 0.0),
-    _m_min(0),
-    _m_max(0),
+    _m_min(std::numeric_limits<Real>::max()),
+    _m_max(std::numeric_limits<Real>::lowest()),
     _m_sum(0),
     _suppress_invalid_metric_warning(getParam<bool>("suppress_invalid_metric_warning")),
     _failure_type(getParam<MooseEnum>("failure_type").getEnum<FailureType>())
@@ -72,8 +74,8 @@ ElementQualityChecker::ElementQualityChecker(const InputParameters & parameters)
 void
 ElementQualityChecker::initialize()
 {
-  _m_min = 0;
-  _m_max = 0;
+  _m_min = std::numeric_limits<Real>::max();
+  _m_max = std::numeric_limits<Real>::lowest();
   _m_sum = 0;
   _checked_elem_num = 0;
   _elem_ids.clear();
@@ -129,10 +131,10 @@ ElementQualityChecker::execute()
 
   _checked_elem_num += 1;
   _m_sum += mv;
+  if (mv < _m_min)
+    _m_min = mv;
   if (mv > _m_max)
     _m_max = mv;
-  else if (mv < _m_min)
-    _m_min = mv;
 
   // check element quality metric, save ids of elements whose quality metrics exceeds the preset
   // bounds
@@ -172,11 +174,15 @@ ElementQualityChecker::finalize()
       mooseWarning("Provided quality metric doesn't apply to following element type: " +
                    Moose::stringify(_bypassed_elem_type));
 
-  _console << libMesh::Quality::name(_m_type) << " Metric values:"
-           << "\n";
-  _console << "              Minimum: " << _m_min << "\n";
-  _console << "              Maximum: " << _m_max << "\n";
-  _console << "              Average: " << _m_sum / _checked_elem_num << "\n";
+  _console << libMesh::Quality::name(_m_type) << " Metric values:\n";
+  if (_checked_elem_num)
+  {
+    _console << "              Minimum: " << _m_min << "\n";
+    _console << "              Maximum: " << _m_max << "\n";
+    _console << "              Average: " << _m_sum / _checked_elem_num << "\n";
+  }
+  else
+    _console << "              No elements were checked.\n";
 
   if (!_elem_ids.empty())
   {

--- a/test/tests/userobjects/element_quality_check/statistics.i
+++ b/test/tests/userobjects/element_quality_check/statistics.i
@@ -1,0 +1,22 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 1
+  elem_type = QUAD4
+[]
+
+[UserObjects]
+  [element_quality]
+    type = ElementQualityChecker
+    metric_type = MIN_ANGLE
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/userobjects/element_quality_check/tests
+++ b/test/tests/userobjects/element_quality_check/tests
@@ -4,6 +4,14 @@
 
   [quality_checks]
     requirement = 'The system shall evaluate the quality of all the mesh elements and '
+    [statistics]
+      type = 'RunApp'
+      input = 'statistics.i'
+      expect_out = 'Minimum Angle Metric values:\s+Minimum: 90\s+Maximum: 90\s+Average: 90'
+
+      detail = 'report the minimum, maximum, and average values, '
+    []
+
     [failure_warning]
       type = 'RunApp'
       input = 'failure_warning.i'
@@ -24,7 +32,8 @@
     [bypass_warning]
       type = 'RunApp'
       input = 'bypass_warning.i'
-      expect_out = "Provided quality metric doesn't apply to following element type:"
+      expect_out = "Provided quality metric doesn't apply to following element type:.*"
+                   "No elements were checked."
       allow_warnings = true
 
       detail = 'report a message when the selected metric does not apply to the element type being examined, or'


### PR DESCRIPTION
This PR is a proposed solution to issue refs#33394.

## Design
This redesign initializes minima and maxima to the respective minimum and maximum values, rather than initializing to 0 and updating based on relations.

## Impact
This solves issue #33394 and adds associated tests to reproduce behavior. It also adds a "no elements were checked" for null input.