### PR TITLE
[WIP] Add mortar contact performance regression gate

### DIFF
--- a/modules/contact/test/src/postprocessors/FrictionKKTErrorPostprocessor.C
+++ b/modules/contact/test/src/postprocessors/FrictionKKTErrorPostprocessor.C
@@ -1,0 +1,127 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#include "GeneralPostprocessor.h"
+#include "LMWeightedVelocitiesUserObject.h"
+#include "MooseVariableFieldBase.h"
+
+#include <algorithm>
+#include <cmath>
+
+/** Computes a formulation-independent Coulomb KKT error for mortar contact tests. */
+class FrictionKKTErrorPostprocessor : public GeneralPostprocessor
+{
+public:
+  static InputParameters validParams();
+
+  FrictionKKTErrorPostprocessor(const InputParameters & parameters);
+
+  void initialize() override;
+  void execute() override;
+  void finalize() override;
+  PostprocessorValue getValue() const override;
+
+private:
+  const LMWeightedVelocitiesUserObject & _weighted_velocities_uo;
+  const MooseVariableFieldBase & _normal_lm;
+  const MooseVariableFieldBase & _tangential_lm;
+  const Real _friction_coefficient;
+  const Real _normal_scale;
+  const Real _tangential_scale;
+  Real _value = 0;
+};
+
+registerMooseObject("ContactTestApp", FrictionKKTErrorPostprocessor);
+
+InputParameters
+FrictionKKTErrorPostprocessor::validParams()
+{
+  InputParameters params = GeneralPostprocessor::validParams();
+  params.addClassDescription(
+      "Computes a formulation-independent Coulomb KKT error for mortar contact tests.");
+  params.addRequiredParam<UserObjectName>("weighted_velocities_uo",
+                                          "The LM weighted-velocities user object.");
+  params.addRequiredParam<VariableName>("normal_lm", "The normal contact multiplier.");
+  params.addRequiredParam<VariableName>("tangential_lm", "The tangential contact multiplier.");
+  params.addRequiredParam<Real>("friction_coefficient", "The Coulomb friction coefficient.");
+  params.addRequiredRangeCheckedParam<Real>(
+      "normal_scale", "normal_scale > 0", "The physical normal pressure scale.");
+  params.addRequiredRangeCheckedParam<Real>(
+      "tangential_scale", "tangential_scale > 0", "The physical tangential pressure scale.");
+  return params;
+}
+
+FrictionKKTErrorPostprocessor::FrictionKKTErrorPostprocessor(const InputParameters & parameters)
+  : GeneralPostprocessor(parameters),
+    _weighted_velocities_uo(
+        getUserObject<LMWeightedVelocitiesUserObject>("weighted_velocities_uo")),
+    _normal_lm(_fe_problem.getVariable(_tid, getParam<VariableName>("normal_lm"))),
+    _tangential_lm(_fe_problem.getVariable(_tid, getParam<VariableName>("tangential_lm"))),
+    _friction_coefficient(getParam<Real>("friction_coefficient")),
+    _normal_scale(getParam<Real>("normal_scale")),
+    _tangential_scale(getParam<Real>("tangential_scale"))
+{
+}
+
+void
+FrictionKKTErrorPostprocessor::initialize()
+{
+  _value = 0;
+}
+
+void
+FrictionKKTErrorPostprocessor::execute()
+{
+  const auto value = [](const DofObject * const dof, const MooseVariableFieldBase & variable)
+  {
+    const auto index = dof->dof_number(variable.sys().number(), variable.number(), 0);
+    return (*variable.sys().currentSolution())(index);
+  };
+
+  for (const auto & [dof, gap_data] : _weighted_velocities_uo.dofToWeightedGap())
+  {
+    if (dof->processor_id() != processor_id())
+      continue;
+
+    const auto velocity_it = _weighted_velocities_uo.dofToWeightedVelocities().find(dof);
+    if (velocity_it == _weighted_velocities_uo.dofToWeightedVelocities().end())
+      mooseError("KKT postprocessor is missing a tangential velocity.");
+
+    const Real normalization = gap_data.second;
+    const Real gap = MetaPhysicL::raw_value(gap_data.first) / normalization;
+    const Real normal_pressure = value(dof, _normal_lm);
+    // Edge dropping zeros inactive multipliers even when their diagnostic gap data overlap.
+    if (normal_pressure == 0.0 && gap < 0.0)
+      continue;
+    const Real tangential_pressure = value(dof, _tangential_lm);
+    const Real augmented_tangential =
+        tangential_pressure + _tangential_scale *
+                                  MetaPhysicL::raw_value(velocity_it->second[0]) *
+                                  _fe_problem.dt() / normalization;
+    const Real radius = _friction_coefficient * std::max(0.0, normal_pressure);
+    const Real projected_tangential =
+        std::abs(augmented_tangential) <= radius
+            ? augmented_tangential
+            : std::copysign(radius, augmented_tangential);
+
+    _value = std::max(_value, std::abs(std::min(normal_pressure, _normal_scale * gap)));
+    _value = std::max(_value, std::abs(tangential_pressure - projected_tangential));
+  }
+}
+
+void
+FrictionKKTErrorPostprocessor::finalize()
+{
+  gatherMax(_value);
+}
+
+PostprocessorValue
+FrictionKKTErrorPostprocessor::getValue() const
+{
+  return _value;
+}

--- a/modules/contact/test/tests/3d-mortar-contact/performance
+++ b/modules/contact/test/tests/3d-mortar-contact/performance
@@ -1,0 +1,33 @@
+[Tests]
+  design = 'MortarPerformance.md ComputeFrictionalForceLMMechanicalContact.md'
+  issues = '#32856'
+  requirement = 'The system shall provide stable three-dimensional frictional mortar performance '
+                'candidates for both nonlinear complementarity formulations.'
+  capabilities = 'ad_size>=150 & method!=dbg & mumps'
+  [hsw]
+    type = RunApp
+    input = frictional-mortar-3d.i
+    cli_args = "Executioner/abort_on_solve_fail=true Executioner/petsc_options_value='lu mumps NONZERO 1e-14 1e-5' Outputs/file_base=performance_frictional_mortar_3d_hsw"
+  []
+  [ac]
+    type = RunApp
+    input = frictional-mortar-3d.i
+    cli_args = "Executioner/abort_on_solve_fail=true Executioner/petsc_options_value='lu mumps NONZERO 1e-14 1e-5' Outputs/file_base=performance_frictional_mortar_3d_ac"
+  []
+  [function_hsw]
+    type = RunApp
+    input = frictional-mortar-3d-function.i
+    cli_args = "Executioner/end_time=0.075 Executioner/abort_on_solve_fail=true Executioner/petsc_options_value='lu strumpack NONZERO 1e-14 1e-5' Outputs/file_base=performance_frictional_mortar_3d_function_hsw"
+    capabilities = 'ad_size>=150 & method!=dbg & strumpack'
+    requirement = 'The system shall provide a stable three-dimensional pressure- and '
+                  'velocity-dependent frictional mortar performance candidate labeled HSW.'
+  []
+  [function_ac]
+    type = RunApp
+    input = frictional-mortar-3d-function.i
+    cli_args = "Executioner/end_time=0.075 Executioner/abort_on_solve_fail=true Executioner/petsc_options_value='lu strumpack NONZERO 1e-14 1e-5' Outputs/file_base=performance_frictional_mortar_3d_function_ac"
+    capabilities = 'ad_size>=150 & method!=dbg & strumpack'
+    requirement = 'The system shall provide a stable three-dimensional pressure- and '
+                  'velocity-dependent frictional mortar performance candidate labeled AC.'
+  []
+[]

--- a/modules/contact/test/tests/mortar_performance/controlled.i
+++ b/modules/contact/test/tests/mortar_performance/controlled.i
@@ -1,0 +1,248 @@
+cycles = 800
+period = 2
+dt = 1
+name = controlled
+normal_lm_guess = 0
+tangential_lm_guess = 0
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+  scaling = 1
+[]
+
+[Mesh]
+  [top]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 4
+    ny = 1
+    xmin = 0
+    xmax = 4
+    ymin = 0
+    ymax = 2
+  []
+  [top_boundaries]
+    type = RenameBoundaryGenerator
+    input = top
+    old_boundary = '0 1 2 3'
+    new_boundary = 'top_bottom top_right top_top top_left'
+  []
+  [top_id]
+    type = SubdomainIDGenerator
+    input = top_boundaries
+    subdomain_id = 1
+  []
+  [bottom]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 4
+    ny = 1
+    xmin = 0
+    xmax = 4
+    ymin = -2
+    ymax = 0
+  []
+  [bottom_boundaries]
+    type = RenameBoundaryGenerator
+    input = bottom
+    old_boundary = '0 1 2 3'
+    new_boundary = '100 101 102 103'
+  []
+  [bottom_id]
+    type = SubdomainIDGenerator
+    input = bottom_boundaries
+    subdomain_id = 2
+  []
+  [combined]
+    type = MeshCollectionGenerator
+    inputs = 'top_id bottom_id'
+  []
+  [bottom_boundary_names]
+    type = RenameBoundaryGenerator
+    input = combined
+    old_boundary = '100 101 102 103'
+    new_boundary = 'bottom_bottom bottom_right bottom_top bottom_left'
+  []
+  [blocks]
+    type = RenameBlockGenerator
+    input = bottom_boundary_names
+    old_block = '1 2'
+    new_block = 'top bottom'
+  []
+  allow_renumbering = false
+[]
+
+[Physics/SolidMechanics/QuasiStatic]
+  [all]
+    add_variables = true
+    strain = SMALL
+    block = 'top bottom'
+  []
+[]
+
+[Materials]
+  [elasticity]
+    type = ComputeIsotropicElasticityTensor
+    block = 'top bottom'
+    youngs_modulus = 4
+    poissons_ratio = 0
+  []
+  [stress]
+    type = ComputeLinearElasticStress
+    block = 'top bottom'
+  []
+[]
+
+[Functions]
+  [normal_history]
+    type = ParsedFunction
+    expression = '-0.1 * min(t, 1)'
+  []
+  [tangential_history]
+    type = ParsedFunction
+    expression = 'if(t < 2, 0, 0.1 * cos(pi * (t - 2)))'
+  []
+[]
+
+[Contact]
+  [mortar]
+    primary = bottom_top
+    secondary = top_bottom
+    formulation = mortar
+    model = coulomb
+    friction_coefficient = 0.5
+    normalize_c = true
+    c_normal = 1
+    c_tangential = 1
+  []
+[]
+
+[BCs]
+  [bottom_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = bottom_bottom
+    value = 0
+  []
+  [bottom_y]
+    type = DirichletBC
+    variable = disp_y
+    boundary = bottom_bottom
+    value = 0
+  []
+  [top_x]
+    type = FunctionDirichletBC
+    variable = disp_x
+    boundary = top_top
+    function = tangential_history
+  []
+  [top_y]
+    type = FunctionDirichletBC
+    variable = disp_y
+    boundary = top_top
+    function = normal_history
+  []
+[]
+
+[ICs]
+  [normal_lm]
+    type = FunctionIC
+    variable = mortar_normal_lm
+    function = 'if(x<0.5,0,if(x>3.5,0,${normal_lm_guess}))'
+  []
+  [tangential_lm]
+    type = FunctionIC
+    variable = mortar_tangential_lm
+    function = 'if(x<0.5,0,if(x>3.5,0,${tangential_lm_guess}))'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  dt = ${dt}
+  dtmin = ${dt}
+  end_time = '${fparse cycles * period}'
+  abort_on_solve_fail = true
+  nl_max_its = 50
+  nl_abs_tol = 1e-12
+  nl_rel_tol = 1e-12
+  line_search = bt
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_type'
+  petsc_options_value = 'lu superlu_dist'
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Postprocessors]
+  [kkt_error]
+    type = FrictionKKTErrorPostprocessor
+    weighted_velocities_uo = lm_weightedvelocities_object_mortar
+    normal_lm = mortar_normal_lm
+    tangential_lm = mortar_tangential_lm
+    friction_coefficient = 0.5
+    normal_scale = 1
+    tangential_scale = 1
+    execute_on = timestep_end
+  []
+  [contact]
+    type = ContactDOFSetSize
+    variable = mortar_normal_lm
+    subdomain = mortar_secondary_subdomain
+    execute_on = 'nonlinear timestep_end'
+  []
+  [normal_pressure]
+    type = ElementAverageValue
+    variable = mortar_normal_lm
+    block = mortar_secondary_subdomain
+  []
+  [tangential_pressure]
+    type = ElementAverageValue
+    variable = mortar_tangential_lm
+    block = mortar_secondary_subdomain
+  []
+  [num_nonlinear_iterations]
+    type = NumNonlinearIterations
+  []
+  [total_nonlinear_iterations]
+    type = CumulativeValuePostprocessor
+    postprocessor = num_nonlinear_iterations
+  []
+  [num_residual_evaluations]
+    type = NumResidualEvaluations
+  []
+  [num_linear_iterations]
+    type = NumLinearIterations
+  []
+  [total_linear_iterations]
+    type = CumulativeValuePostprocessor
+    postprocessor = num_linear_iterations
+  []
+  [disp_x_residual]
+    type = DiscreteVariableResidualNorm
+    variable = disp_x
+    norm_type = l_inf
+    execute_on = timestep_end
+  []
+  [disp_y_residual]
+    type = DiscreteVariableResidualNorm
+    variable = disp_y
+    norm_type = l_inf
+    execute_on = timestep_end
+  []
+  [timestep_size]
+    type = TimestepSize
+  []
+[]
+
+[Outputs]
+  file_base = ${name}
+  [csv]
+    type = CSV
+  []
+[]

--- a/modules/contact/test/tests/mortar_performance/performance
+++ b/modules/contact/test/tests/mortar_performance/performance
@@ -1,0 +1,35 @@
+[Tests]
+  design = 'MortarPerformance.md ComputeFrictionalForceLMMechanicalContact.md '
+           'ComputeWeightedGapLMMechanicalContact.md'
+  issues = '#32856'
+  requirement = 'The system shall provide a controlled unit-pressure-scale frictional mortar '
+                'performance workload for both nonlinear complementarity formulations.'
+  [hsw]
+    type = RunApp
+    input = controlled.i
+    cli_args = 'name=performance_controlled_hsw'
+    allow_test_objects = true
+    validation_test = performance_validation.py
+    validation_csv = performance_controlled_hsw.csv
+    validation_end_time = 1600
+    validation_dt = 1
+    validation_max_nonlinear_iterations = 8000
+    validation_max_residual_evaluations = 9600
+    validation_max_linear_iterations = 8001
+  []
+  [ac]
+    type = RunApp
+    input = controlled.i
+    prereq = hsw
+    cli_args = 'name=performance_controlled_ac'
+    allow_test_objects = true
+    validation_test = performance_validation.py
+    validation_csv = performance_controlled_ac.csv
+    validation_comparison_csv = performance_controlled_hsw.csv
+    validation_end_time = 1600
+    validation_dt = 1
+    validation_max_nonlinear_iterations = 8000
+    validation_max_residual_evaluations = 9600
+    validation_max_linear_iterations = 8001
+  []
+[]

--- a/modules/contact/test/tests/mortar_performance/performance_validation.py
+++ b/modules/contact/test/tests/mortar_performance/performance_validation.py
@@ -1,0 +1,118 @@
+import math
+
+import pandas as pd
+
+from TestHarness.validation import ValidationCase
+
+
+class TestCase(ValidationCase):
+    @staticmethod
+    def validParams():
+        params = ValidationCase.validParams()
+        params.addRequiredParam("validation_csv", "The controlled-case CSV output")
+        params.addRequiredParam("validation_end_time", "The required final time")
+        params.addRequiredParam("validation_dt", "The required fixed time-step size")
+        params.addRequiredParam(
+            "validation_max_nonlinear_iterations",
+            "The benchmark solver-work budget for nonlinear iterations",
+        )
+        params.addRequiredParam(
+            "validation_max_residual_evaluations",
+            "The benchmark solver-work budget for residual evaluations",
+        )
+        params.addRequiredParam(
+            "validation_max_linear_iterations",
+            "The benchmark diagnostic linear-iteration budget",
+        )
+        params.addParam(
+            "validation_comparison_csv",
+            "An optional physically equivalent formulation output to compare",
+        )
+        return params
+
+    def initialize(self):
+        self.dataframe = pd.read_csv(self.getParam("validation_csv"))
+        self.final = self.dataframe.iloc[-1]
+
+    def testCompletionAndFiniteValues(self):
+        end_time = float(self.getParam("validation_end_time"))
+        self.addScalarData(
+            "final_time",
+            float(self.final["time"]),
+            "Completed simulation time",
+            None,
+            bounds=(end_time, end_time),
+        )
+        finite = all(
+            math.isfinite(float(value))
+            for value in self.dataframe.select_dtypes(include="number").to_numpy().flat
+        )
+        self.addScalarData(
+            "finite_values", int(finite), "All CSV metrics are finite", None, bounds=(1, 1)
+        )
+
+    def testNoCutbacks(self):
+        expected_dt = float(self.getParam("validation_dt"))
+        time_steps = self.dataframe[self.dataframe["time"] > 0]["timestep_size"]
+        self.addScalarData(
+            "minimum_timestep_size",
+            float(time_steps.min()),
+            "Minimum accepted time-step size",
+            None,
+            bounds=(expected_dt, expected_dt),
+        )
+        self.addScalarData(
+            "maximum_timestep_size",
+            float(time_steps.max()),
+            "Maximum accepted time-step size",
+            None,
+            bounds=(expected_dt, expected_dt),
+        )
+
+    def testPhysicalResiduals(self):
+        converged = self.dataframe[self.dataframe["time"] > 0]
+        for column in ("kkt_error", "disp_x_residual", "disp_y_residual"):
+            self.addScalarData(
+                f"maximum_{column}",
+                float(converged[column].max()),
+                f"Maximum converged {column}",
+                None,
+                bounds=(0, 1e-10),
+            )
+
+    def testSolverWork(self):
+        budgets = {
+            "total_nonlinear_iterations": "validation_max_nonlinear_iterations",
+            "num_residual_evaluations": "validation_max_residual_evaluations",
+            "total_linear_iterations": "validation_max_linear_iterations",
+        }
+        for column, parameter in budgets.items():
+            self.addScalarData(
+                column,
+                float(self.final[column]),
+                column.replace("_", " ").capitalize(),
+                None,
+                bounds=(0, int(self.getParam(parameter))),
+            )
+
+    def testPhysicalAgreement(self):
+        if not self.isParamValid("validation_comparison_csv"):
+            self.addResult(
+                self.Status.SKIP,
+                "No comparison formulation was requested",
+                validation=False,
+            )
+            return
+
+        comparison = pd.read_csv(self.getParam("validation_comparison_csv")).iloc[-1]
+        difference = max(
+            abs(float(self.final[column]) - float(comparison[column]))
+            for column in ("normal_pressure", "tangential_pressure")
+        )
+        self.addScalarData(
+            "formulation_physical_difference",
+            difference,
+            "Maximum AC/HSW final physical-pressure difference",
+            None,
+            bounds=(0, 1e-8),
+        )

--- a/modules/contact/test/tests/pdass_problems/performance
+++ b/modules/contact/test/tests/pdass_problems/performance
@@ -1,0 +1,17 @@
+[Tests]
+  design = 'MortarPerformance.md ComputeFrictionalForceLMMechanicalContact.md'
+  issues = '#32856'
+  requirement = 'The system shall provide stable bouncing-block frictional mortar performance '
+                'candidates for both nonlinear complementarity formulations.'
+  capabilities = 'mumps'
+  [hsw]
+    type = RunApp
+    input = frictional_bouncing_block.i
+    cli_args = "Executioner/end_time=11.5 Executioner/abort_on_solve_fail=true Executioner/petsc_options_value='lu mumps NONZERO 1e-15 1e-5' Outputs/file_base=performance_frictional_bouncing_block_hsw"
+  []
+  [ac]
+    type = RunApp
+    input = frictional_bouncing_block.i
+    cli_args = "Executioner/end_time=11.5 Executioner/abort_on_solve_fail=true Executioner/petsc_options_value='lu mumps NONZERO 1e-15 1e-5' Outputs/file_base=performance_frictional_bouncing_block_ac"
+  []
+[]


### PR DESCRIPTION
## Summary

- Add four mortar contact performance workloads: one controlled unit-scale case and three analyst cases.
- Give HSW and AC candidates stable names and separate outputs; on this benchmark branch both execute the current legacy HSW formulation.
- Fail hidden solve retries and validate controlled-case completion, solver work, finite values, KKT and equilibrium errors, and candidate agreement from repository-local CSV data.
- Record local commands, launch-shape characterization, timing ratios, and PerfGraph findings in MortarPerformance.md.

Refs #32856