### PR TITLE
Correct and scale the HSW mortar friction residual

### DIFF
--- a/automate_mortar_constants_design.md
+++ b/automate_mortar_constants_design.md
@@ -1,0 +1,451 @@
+# Automated Mortar Contact Scaling Parameters Design
+
+**Issue:** #32856
+**Branch:** `automate-mortar-constants-32856`
+
+## Motivation
+
+The mortar-based frictional contact implementation in MOOSE requires two numerical scaling
+parameters, `c_normal` and `c_tangential`, that must currently be set by trial and error. These
+parameters appear in the primal-dual active set strategy (PDASS) complementarity constraints that
+enforce normal and tangential contact conditions.
+
+In `ComputeWeightedGapLMMechanicalContact::enforceConstraintOnDof`:
+```cpp
+const ADReal dof_residual = std::min(lm_value, weighted_gap * c);
+```
+
+In `ComputeFrictionalForceLMMechanicalContact::enforceConstraintOnDof{3d}`:
+```cpp
+const auto lambda_plus_cg    = contact_pressure + c   * weighted_gap;
+lambda_t_plus_ctu[i]         = friction_lm_values[i]  + c_t * *tangential_vel[i] * _dt;
+```
+
+The intent of this design is to add an optional, fully automatic mode that computes both
+parameters from the elasticity tensors of the contacting bodies — zero additional user input
+required. The feature must be strictly opt-in and must not affect any existing simulation.
+
+---
+
+## Background: Physical Meaning of c_normal and c_tangential
+
+**`c_normal`** (units: Pa/m = stiffness per unit volume) appears in `contact_pressure + c *
+weighted_gap`. The weighted gap is area-integrated: `normalization_i` (the weighting function
+norm stored alongside the gap) converts it back to a physical gap in meters. With
+`normalize_c = true` the effective scaling becomes:
+
+```
+c_effective = c / normalization_i   [Pa/m]
+```
+
+For PDASS to be well-conditioned, `c_effective * gap_typical` must be comparable in magnitude
+to `contact_pressure_typical`. Contact pressure scales as `E * gap / h` (Hertz-like), so:
+
+```
+c_effective ~ E / h   →   c = E   (when normalize_c handles the 1/h factor)
+```
+
+This is the standard result from mortar/penalty contact literature. The existing `normalize_c`
+mechanism already provides the `1/h` factor; `c_normal` just needs to be on the order of the
+material's Young's modulus.
+
+**`c_tangential`** (same units) appears in `friction_lm + c_t * weighted_velocity * dt`. For
+problems with steady sliding the same stiffness argument applies: `c_t = c_normal` is a
+natural default. For problems where the sliding velocity varies widely, a per-node dynamic
+adaptation (see §3) can improve convergence.
+
+---
+
+## Key Architectural Observation
+
+`WeightedGapUserObject` is the base class for both LM-based contact UOs
+(`LMWeightedGapUserObject`, `LMWeightedVelocitiesUserObject`) and penalty/cohesive-zone UOs
+(`PenaltyWeightedGapUserObject`, `PenaltyFrictionUserObject`, `CohesiveZoneModelBase`). The
+`c_normal` parameter only exists in LM-based mortar contact, so the new feature belongs in
+`LMWeightedGapUserObject`, not the base class.
+
+`WeightedGapUserObject` already inherits `TwoMaterialPropertyInterface`
+(`WeightedGapUserObject.C:26`: `params += TwoMaterialPropertyInterface::validParams()`), so
+`LMWeightedGapUserObject` can call `getMaterialProperty<RankFourTensor>("elasticity_tensor")`
+for the secondary side and `getNeighborMaterialProperty<RankFourTensor>("elasticity_tensor")`
+for the primary side — with no new infrastructure.
+
+The contact normal `_normals[_i]` is already available in `computeQpIProperties()` — it is
+used there to project the gap vector onto the surface normal. This is the right place to
+accumulate the normal-direction stiffness: the acoustic tensor contraction
+`n_i n_j C_ijkl n_k n_l` uses the same per-node normal and the same test-function weight
+`(*_test)[_i][_qp] * _qp_factor` that already accumulates the gap normalization, keeping
+the two quantities on a consistent basis. The result is reduced across processors in
+`finalize()` alongside the existing gap communication.
+
+---
+
+## Proposed Changes
+
+### 1. New `ContactAction` Parameters
+
+Add one new parameter to `ContactAction::validParams()` alongside the existing `c_normal`
+and `c_tangential` declarations (currently lines 192–201):
+
+| Parameter | Type | Default | Purpose |
+|-----------|------|---------|---------|
+| `c_normal_strategy` | `MooseEnum` | `"user"` | `user` (current behavior) or `physical` (fully automatic) |
+| `c_tangential_strategy` | `MooseEnum` | `"user"` | `user` (current behavior) or `physical` (velocity-scaled, linked to `c_normal_eff`) |
+| `secondary_elasticity_tensor_base_name` | `std::string` | `""` | Base name prefix of the elasticity tensor property on the secondary body; only used when `c_normal_strategy = physical` |
+| `primary_elasticity_tensor_base_name` | `std::string` | `""` | Base name prefix of the elasticity tensor property on the primary body; only used when `c_normal_strategy = physical` |
+| `use_automatic_differentiation` | `bool` | `false` | Set to true if the elasticity tensor material property was declared as AD; only used when `c_normal_strategy = physical` |
+
+When `c_normal_strategy = physical`:
+- `ContactAction` emits a `paramError` if `c_normal` was explicitly set by the user
+  (`isParamSetByUser("c_normal")`). The two options are mutually exclusive: `physical` means
+  the value is derived from the material system and no manual override is meaningful.
+- `ContactAction` sets `derive_c_from_elasticity = true` on the weighted gap UserObject it
+  already creates (passing through `params.set<bool>`).
+- `ContactAction` forces `normalize_c = true` on the downstream constraint objects.
+
+When `c_tangential_strategy = physical`:
+- Only valid for Coulomb friction mortar; `paramError` otherwise.
+- `c_t` is derived per-node from `c_normal_eff` with dynamic velocity scaling: `c_t = c_normal_eff / (vt_mag * dt)` during sliding, falling back to `c_normal_eff` during stick (see §3).
+- `ContactAction` sets `dynamic_c_t = true` on the frictional constraint.
+
+All new parameters are mortar-only, consistent with the existing validation for `c_normal`
+(lines 387–392).
+
+### 2. Automatic Effective Modulus in `LMWeightedGapUserObject`
+
+**New parameters** (added to `LMWeightedGapUserObject::validParams()`):
+```cpp
+params.addParam<bool>("derive_c_from_elasticity", false,
+    "Compute an effective elastic modulus from contact surface material properties "
+    "for use as the c_normal constraint parameter.");
+params.addParam<std::string>("secondary_base_name", "",
+    "Base name prefix of the elasticity_tensor material property on the secondary body. "
+    "Must match the base_name used on the secondary material block that computes the "
+    "elasticity tensor.");
+params.addParam<std::string>("primary_base_name", "",
+    "Base name prefix of the elasticity_tensor material property on the primary body. "
+    "Must match the base_name used on the primary material block that computes the "
+    "elasticity tensor.");
+params.addParam<bool>("use_automatic_differentiation", false,
+    "Whether the elasticity tensor material property was declared as an AD property. "
+    "Set to true if the material block uses an AD elasticity tensor.");
+```
+
+**Implementation note — `base_name` and property lookup:**
+`ComputeElasticityTensorBase` (the base class for standard MOOSE elasticity tensor materials)
+declares its property as `_base_name + "elasticity_tensor"`, where `_base_name` is either
+empty or `"<prefix>_"`. The UO must construct the same name:
+```cpp
+const std::string sec_base = getParam<std::string>("secondary_base_name");
+const std::string pri_base = getParam<std::string>("primary_base_name");
+const std::string sec_name = sec_base.empty() ? "elasticity_tensor" : sec_base + "_elasticity_tensor";
+const std::string pri_name = pri_base.empty() ? "elasticity_tensor" : pri_base + "_elasticity_tensor";
+// dispatches to the template helper described under "New members" below
+if (_use_automatic_differentiation)
+  fetchElasticityTensorProperties<true>(sec_name, pri_name);
+else
+  fetchElasticityTensorProperties<false>(sec_name, pri_name);
+```
+
+`ContactAction` does not currently have a `base_name` parameter. Three new optional
+parameters, `secondary_elasticity_tensor_base_name`, `primary_elasticity_tensor_base_name`,
+and `use_automatic_differentiation`, should be added to `ContactAction` and forwarded to the UO
+when `derive_c_from_elasticity = true`. The secondary and primary bodies may have different
+`base_name` prefixes on their respective elasticity tensor materials, so a single shared name
+is insufficient. This keeps the user from having to set these directly on the UO, which is
+an implementation detail they should not need to know about.
+
+**New members** (added to `LMWeightedGapUserObject.h`):
+```cpp
+const bool _derive_c_from_elasticity;
+const bool _use_automatic_differentiation;
+// Exactly one pointer per side is non-null depending on _use_automatic_differentiation
+const MaterialProperty<RankFourTensor>   * _elasticity_tensor_secondary    = nullptr;
+const MaterialProperty<RankFourTensor>   * _elasticity_tensor_primary      = nullptr;
+const ADMaterialProperty<RankFourTensor> * _elasticity_tensor_secondary_ad = nullptr;
+const ADMaterialProperty<RankFourTensor> * _elasticity_tensor_primary_ad   = nullptr;
+// Per-node derived c values; pair is {accumulated C_nn * weight, accumulated weight}
+// mirrors the layout of _dof_to_weighted_gap
+std::unordered_map<const DofObject *, std::pair<ADReal, Real>> _dof_to_derived_c;
+```
+
+Mirroring `_dof_to_weighted_gap`, accumulation is per-node so each entry carries its own
+AD derivative information. A private template helper is the only place that calls
+`getGenericMaterialProperty` / `getGenericNeighborMaterialProperty`:
+```cpp
+template <bool is_ad>
+void fetchElasticityTensorProperties(const std::string & sec_name,
+                                     const std::string & pri_name)
+{
+  if constexpr (is_ad)
+  {
+    _elasticity_tensor_secondary_ad = &getGenericMaterialProperty<RankFourTensor, true>(sec_name);
+    _elasticity_tensor_primary_ad   = &getGenericNeighborMaterialProperty<RankFourTensor, true>(pri_name);
+  }
+  else
+  {
+    _elasticity_tensor_secondary = &getGenericMaterialProperty<RankFourTensor, false>(sec_name);
+    _elasticity_tensor_primary   = &getGenericNeighborMaterialProperty<RankFourTensor, false>(pri_name);
+  }
+}
+```
+
+Called in the constructor as:
+```cpp
+if (_use_automatic_differentiation)
+  fetchElasticityTensorProperties<true>(sec_name, pri_name);
+else
+  fetchElasticityTensorProperties<false>(sec_name, pri_name);
+```
+
+In `computeQpIProperties`, dispatch to a second template helper so each instantiation
+has a single consistent type and `auto` deduces correctly within it:
+```cpp
+// Called from computeQpIProperties:
+if (_use_automatic_differentiation)
+  accumulateDerivedC<true>();
+else
+  accumulateDerivedC<false>();
+```
+
+```cpp
+template <bool is_ad>
+void LMWeightedGapUserObject::accumulateDerivedC()
+{
+  const auto & sec_prop = [&]() -> const auto &
+  {
+    if constexpr (is_ad) return *_elasticity_tensor_secondary_ad;
+    else                 return *_elasticity_tensor_secondary;
+  }();
+  const auto & pri_prop = [&]() -> const auto &
+  {
+    if constexpr (is_ad) return *_elasticity_tensor_primary_ad;
+    else                 return *_elasticity_tensor_primary;
+  }();
+
+  const RealVectorValue & n = _normals[_i];
+  auto C_nn_sec = decltype(sec_prop[_qp](0,0,0,0)){0};
+  auto C_nn_pri = decltype(pri_prop[_qp](0,0,0,0)){0};
+  for (const auto a : make_range(3))
+    for (const auto b : make_range(3))
+      for (const auto c : make_range(3))
+        for (const auto d : make_range(3))
+        {
+          const auto w = n(a) * n(b) * n(c) * n(d);
+          C_nn_sec += w * sec_prop[_qp](a, b, c, d);
+          C_nn_pri += w * pri_prop[_qp](a, b, c, d);
+        }
+  const auto C_nn_harm = 2.0 * C_nn_sec * C_nn_pri / (C_nn_sec + C_nn_pri);
+  const auto test_weight = (*_test)[_i][_qp] * _qp_factor;
+  const auto * const dof = static_cast<const DofObject *>(_lower_secondary_elem->node_ptr(_i));
+  auto & [c_num, c_denom] = _dof_to_derived_c[dof];
+  c_num   += C_nn_harm * test_weight;
+  c_denom += test_weight;
+}
+```
+
+In `finalize()`, after communicating gaps, divide `c_num` by `c_denom` for each node
+(and perform the parallel reduction analogous to `communicateGaps`), then expose via:
+```cpp
+const std::unordered_map<const DofObject *, std::pair<ADReal, Real>> & dofToDerivedC() const;
+```
+
+After `finalize()`, `c_num / c_denom` is the test-function-weighted average of `C_nn` over
+the mortar segments touching that node — a representative elastic stiffness at that node in
+units of Pa. This normalization is internal to the UO and is purely about averaging the
+material property across quadrature points; it has nothing to do with element size.
+
+The constraint then reads `c_nn` (the first pair element, already averaged) and optionally
+applies `normalize_c`, which is a separate and independent operation:
+```cpp
+const auto & [c_nn, _] = libmesh_map_find(_weighted_gap_uo.dofToDerivedC(), dof_object);
+const ADReal c = _normalize_c ? c_nn / *_normalization_ptr : c_nn;
+```
+
+`normalize_c` divides by `*_normalization_ptr`, the weighting function norm for that node
+(units of area). This accounts for the fact that the weighted gap is area-integrated: without
+it, `c` would have an implicit element-size dependence. The two normalizations are therefore
+independent: the UO's `c_denom` converts accumulated C_nn integrals into a material stiffness
+value; `normalize_c` in the constraint converts that stiffness value into the correct scale
+relative to the area-integrated gap.
+
+No `raw_value` is needed anywhere: AD derivatives propagate from the elasticity tensor
+through the acoustic tensor contraction into the constraint residual and Jacobian.
+
+The material properties are only retrieved in the constructor when `_derive_c_from_elasticity`
+is true, so there is zero overhead for the default path.
+
+The acoustic tensor contraction `n_i n_j C_ijkl n_k n_l` gives the normal-direction stiffness
+for any elasticity tensor — isotropic, orthotropic, or fully anisotropic — without requiring
+extraction of scalar moduli. For isotropic materials it equals λ+2μ regardless of the contact
+normal direction.
+
+**In `LMWeightedGapUserObject::initialize()`**: clear `_dof_to_derived_c`.
+
+**In `LMWeightedGapUserObject::finalize()`** (after calling `WeightedGapUserObject::finalize()`):
+communicate the per-node map across processors (analogous to `communicateGaps`), then
+normalize each entry:
+```cpp
+for (auto & [dof, c_pr] : _dof_to_derived_c)
+  c_pr.first /= c_pr.second;
+```
+
+### 3. Constraint Changes
+
+#### Normal constraint (`ComputeWeightedGapLMMechanicalContact`)
+
+The constraint already holds a reference to `_weighted_gap_uo`. In physical mode the
+per-node `c` is read directly from `dofToDerivedC()` during `enforceConstraintOnDof` rather
+than from the scalar `_c` member, so `_c` is bypassed entirely for this code path.
+
+**In `ContactAction::act()`** (inside the mortar setup block, near line 1072):
+```cpp
+if (getParam<MooseEnum>("c_normal_strategy") == "physical")
+{
+  if (isParamSetByUser("c_normal"))
+    paramError("c_normal",
+               "Cannot set 'c_normal' when 'c_normal_strategy = physical'; "
+               "the value is derived from the material elasticity tensor.");
+  params.set<bool>("normalize_c") = true;
+  params.set<bool>("use_derived_c_normal") = true;
+}
+else
+  params.set<Real>("c") = getParam<Real>("c_normal");
+```
+
+Add a `use_derived_c_normal` bool to `ComputeWeightedGapLMMechanicalContact`. When set,
+`enforceConstraintOnDof` looks up `c_nn` from `_weighted_gap_uo.dofToDerivedC()` instead
+of using `_c`, as shown in the constraint snippet in §2 above.
+
+#### Tangential constraint (`ComputeFrictionalForceLMMechanicalContact`)
+
+**Tightening UO member types in the constraint classes**
+
+The existing `_weighted_gap_uo` and `_weighted_velocities_uo` members in
+`ComputeWeightedGapLMMechanicalContact` and `ComputeFrictionalForceLMMechanicalContact` are
+currently typed as the base classes `WeightedGapUserObject` and `WeightedVelocitiesUserObject`.
+Inspection of the full test suite shows that every test using `ComputeFrictionalForceLMMechanicalContact`
+pairs it exclusively with `LMWeightedVelocitiesUserObject`; no test uses a non-LM UO
+(e.g. `PenaltyFrictionUserObject`) with this constraint. The broad base-class typing is
+therefore over-generalization with no demonstrated need.
+
+As part of this change, retype both members to their LM-specific derived classes:
+
+- `ComputeWeightedGapLMMechanicalContact`: `_weighted_gap_uo` → `const LMWeightedGapUserObject &`
+- `ComputeFrictionalForceLMMechanicalContact`: `_weighted_velocities_uo` → `const LMWeightedVelocitiesUserObject &`
+
+With `_weighted_gap_uo` already typed as `LMWeightedGapUserObject`, `dofToDerivedC()` is
+directly accessible with no downcast needed. In `enforceConstraintOnDof`, `c` is resolved
+per-node as:
+```cpp
+ADReal c;
+if (_use_derived_c_normal)
+{
+  const auto & [c_nn, _] = libmesh_map_find(_weighted_gap_uo.dofToDerivedC(), dof_object);
+  c = _normalize_c ? c_nn / *_normalization_ptr : c_nn;
+}
+else
+  c = _normalize_c ? _c / *_normalization_ptr : _c;
+```
+
+The existing `Real _c` member is used unchanged in the `user` strategy path.
+
+**`physical` c_t computation**
+
+The `physical` strategy requires per-node `c_t` in `enforceConstraintOnDof{,3d}`.
+Add:
+
+```cpp
+const bool _dynamic_c_t;
+const Real _vel_floor;  // fallback threshold: below this velocity magnitude, use c_normal_eff
+```
+
+`c_t` is `ADReal` throughout so that derivatives from the normal stiffness (in physical mode)
+and from the tangential velocity (already `ADReal`) propagate into the Jacobian. The normal
+reference stiffness is resolved by the same two-path logic used in the normal constraint:
+```cpp
+// Resolve normal reference stiffness (physical or user mode)
+ADReal c_normal_eff;
+if (_use_derived_c_normal)
+{
+  const auto & [c_nn, _] = libmesh_map_find(_weighted_velocities_uo.dofToDerivedC(), dof_object);
+  c_normal_eff = _normalize_c ? c_nn / *_normalization_ptr : c_nn;
+}
+else
+  c_normal_eff = _normalize_c ? _c / *_normalization_ptr : _c;
+
+ADReal c_t;
+if (_dynamic_c_t)
+{
+  // In 3D use the full tangential velocity magnitude to avoid directional bias
+  const auto vt_sq = *_tangential_vel_ptr[0] * *_tangential_vel_ptr[0] + 1e-48;
+  const auto vt_mag = std::sqrt(vt_sq);  // 3D variant adds vt_1^2 + vt_2^2
+  if (MetaPhysicL::raw_value(vt_mag) < _vel_floor)
+    c_t = c_normal_eff;  // sticking: fall back to normal stiffness
+  else
+    c_t = c_normal_eff / (vt_mag * _dt);
+}
+else
+  c_t = _normalize_c ? _c_t / *_normalization_ptr : _c_t;
+```
+
+`c_normal_eff` serves as the reference stiffness so that `c_t * v_t * dt ~ c * gap` when
+`v_t * dt ~ gap` — keeping both constraint terms on the same scale. During stick
+(`vt_mag < _vel_floor`), `c_t` falls back to `c_normal_eff` rather than blowing up.
+
+`ContactAction` sets `dynamic_c_t = true` on the frictional constraint when
+`c_tangential_strategy == physical`.
+
+### 4. Files to Create or Modify
+
+| File | Change |
+|------|--------|
+| `modules/contact/src/actions/ContactAction.C` | New enum params; physical-mode logic; pass `derive_c_from_elasticity` / `use_derived_c_normal` / `dynamic_c_t` flags |
+| `modules/contact/include/userobjects/LMWeightedGapUserObject.h` | New members + `derivedCNormal()` accessor |
+| `modules/contact/src/userobjects/LMWeightedGapUserObject.C` | Elasticity tensor reads in `computeQpIProperties`; accumulation + reduction in `initialize`/`finalize` |
+| `modules/contact/include/constraints/ComputeWeightedGapLMMechanicalContact.h` | `_use_derived_c_normal` bool; retype `_weighted_gap_uo` from `WeightedGapUserObject` to `LMWeightedGapUserObject` |
+| `modules/contact/src/constraints/ComputeWeightedGapLMMechanicalContact.C` | `enforceConstraintOnDof` reads per-node `c_nn` from `_weighted_gap_uo.dofToDerivedC()` when `_use_derived_c_normal` is set |
+| `modules/contact/include/constraints/ComputeFrictionalForceLMMechanicalContact.h` | `_dynamic_c_t`, `_vel_floor` members; retype `_weighted_velocities_uo` from `WeightedVelocitiesUserObject` to `LMWeightedVelocitiesUserObject` |
+| `modules/contact/src/constraints/ComputeFrictionalForceLMMechanicalContact.C` | Dynamic `ADReal c_t` in `enforceConstraintOnDof` and `enforceConstraintOnDof3d`; call `_weighted_velocities_uo.dofToDerivedC()` for physical-mode `_c` |
+| `modules/contact/test/tests/physical_mortar_constants/` | New test directory (see §5) |
+
+No new files outside `contact/` are required.
+
+---
+
+## Backward Compatibility
+
+- Both enums default to `"user"`, so all existing input files are unaffected.
+- `c_normal` and `c_tangential` parameters remain in `validParams()` with their existing
+  defaults (1e6 and 1). They are used unchanged when the corresponding strategy is `"user"`.
+- `derive_c_from_elasticity` defaults to `false` on `LMWeightedGapUserObject`, so the material
+  property reads and accumulation code are never reached for existing problems.
+
+---
+
+## Testing Plan
+
+### New Tests
+
+1. **`physical_mortar_constants/frictionless_physical.i`**
+   Single-material Hertz contact geometry. Set `c_normal_strategy = physical`. Verify
+   convergence and that the resulting contact pressure matches a reference run that uses the
+   manually-computed equivalent `c_normal` (i.e., `E_material` with `normalize_c = true`).
+
+2. **`physical_mortar_constants/bimaterial_physical.i`**
+   Two-body contact with different moduli (e.g., steel on softer polymer). Confirm the harmonic
+   mean is used and that the simulation converges without user-tuned parameters.
+
+3. **`physical_mortar_constants/frictional_physical.i`**
+   Sliding block with nonzero sliding velocity. Set `c_tangential_strategy = physical`.
+   Verify convergence and check that nonlinear iteration count is equal to or lower than a
+   reference run with fixed `c_t`.
+
+4. **Parameter validation tests**
+   - `c_tangential_strategy = physical` on a frictionless contact pair → `paramError`
+   - `c_normal_strategy = physical` with `c_normal` explicitly set by the user → `paramError`
+
+### Existing Test Suite
+
+Run the full `modules/contact` test suite. All existing tests use fixed `c_normal`/`c_tangential`
+values (strategy = `"user"`) and must produce identical results.

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -21,6 +21,9 @@
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/linear_solver.h"
 
+#include <unordered_map>
+#include <unordered_set>
+
 // Forward declarations
 class FEProblemBase;
 class MoosePreconditioner;
@@ -87,6 +90,21 @@ public:
   virtual libMesh::NonlinearSolver<Number> * nonlinearSolver() = 0;
 
   virtual SNES getSNES() = 0;
+
+  /** Request the parallel per-DOF vector used for PETSc KSP right diagonal scaling. */
+  void requestKSPRightDiagonalScale();
+
+  /** Reset the requested KSP right diagonal scale to one and attach it to the PETSc KSP. */
+  void resetKSPRightDiagonalScale();
+
+  /** Set an owned entry of the KSP right diagonal scale, checking repeated writes. */
+  void setKSPRightDiagonalScale(dof_id_type dof, Real value);
+
+  /** Collectively close the KSP right diagonal scale if any rank set one or more entries. */
+  void closeKSPRightDiagonalScale();
+
+  /** Return whether a KSP right diagonal scale has been requested. */
+  bool hasKSPRightDiagonalScale() const { return _has_ksp_right_diagonal_scale; }
 
   virtual unsigned int getCurrentNonlinearIterationNumber() = 0;
 
@@ -901,6 +919,18 @@ protected:
 
   /// Copy of the residual vector, or nullptr if a copy is not needed
   std::unique_ptr<NumericVector<Number>> _residual_copy;
+
+  /// Whether an object has requested solver-side per-DOF right scaling
+  bool _has_ksp_right_diagonal_scale = false;
+
+  /// Whether this rank has unclosed right scaling vector writes
+  bool _ksp_right_diagonal_scale_dirty = false;
+
+  /// Last installed values, used to avoid changing an unchanged scale vector
+  std::unordered_map<dof_id_type, Real> _ksp_right_diagonal_scale_values;
+
+  /// Entries written during the current mortar assembly, used to detect conflicting contributors
+  std::unordered_set<dof_id_type> _ksp_right_diagonal_scale_written_dofs;
 
   /// \f$ {du^dot}\over{du} \f$
   Number _du_dot_du;

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -167,6 +167,8 @@ NonlinearSystem::solve()
   if (!presolve_succeeded)
     return;
 
+  resetKSPRightDiagonalScale();
+
   potentiallySetupFiniteDifferencing();
 
   const bool time_integrator_solve = std::any_of(_time_integrators.begin(),

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -102,6 +102,7 @@
 #include "libmesh/petsc_solver_exception.h"
 
 #include <ios>
+#include <cmath>
 
 #include "petscsnes.h"
 #include <PetscDMMoose.h>
@@ -3962,6 +3963,10 @@ NonlinearSystemBase::mortarConstraints(const Moose::ComputeType compute_type,
 {
   parallel_object_only();
 
+  // Values may change between residual evaluations, for example when an unnormalized contact
+  // scale contains the current mortar weight. Repeated writes within this assembly must agree.
+  _ksp_right_diagonal_scale_written_dofs.clear();
+
   try
   {
     for (auto & map_pr : _undisplaced_mortar_functors)
@@ -4282,6 +4287,94 @@ NonlinearSystemBase::preSolve()
   assembleScalingVector();
 
   return true;
+}
+
+void
+NonlinearSystemBase::requestKSPRightDiagonalScale()
+{
+  if (_has_ksp_right_diagonal_scale)
+    return;
+
+  addVector("ksp_right_diagonal_scale", /*project=*/false, libMesh::PARALLEL);
+  _has_ksp_right_diagonal_scale = true;
+}
+
+void
+NonlinearSystemBase::resetKSPRightDiagonalScale()
+{
+  if (!_has_ksp_right_diagonal_scale)
+    return;
+
+  auto & scale = getVector("ksp_right_diagonal_scale");
+  scale = 1.0;
+  scale.close();
+  _ksp_right_diagonal_scale_values.clear();
+  _ksp_right_diagonal_scale_written_dofs.clear();
+  _ksp_right_diagonal_scale_dirty = false;
+
+  auto * const petsc_solver =
+      dynamic_cast<libMesh::PetscNonlinearSolver<Number> *>(nonlinearSolver());
+  if (!petsc_solver)
+    mooseError(
+        "KSP right diagonal scaling requires a PETSc nonlinear solver for system '", name(), "'.");
+
+  auto & petsc_scale = libMesh::cast_ref<libMesh::PetscVector<Number> &>(scale);
+  KSP ksp;
+  LibmeshPetscCall(SNESGetKSP(getSNES(), &ksp));
+  LibmeshPetscCall(KSPSetRightDiagonalScale(ksp, petsc_scale.vec()));
+}
+
+void
+NonlinearSystemBase::setKSPRightDiagonalScale(const dof_id_type dof, const Real value)
+{
+  if (!_has_ksp_right_diagonal_scale)
+    mooseError("The KSP right diagonal scale must be requested before setting its entries.");
+  if (!std::isfinite(value) || value <= 0.0)
+    mooseError("KSP right diagonal scale entry for DOF ", dof, " must be finite and positive.");
+
+  auto & scale = getVector("ksp_right_diagonal_scale");
+  if (dof < scale.first_local_index() || dof >= scale.last_local_index())
+    mooseError("KSP right diagonal scale entry for non-owned DOF ", dof, " was supplied.");
+
+  const bool first_write = _ksp_right_diagonal_scale_written_dofs.emplace(dof).second;
+  const auto value_it = _ksp_right_diagonal_scale_values.find(dof);
+  if (!first_write)
+  {
+    mooseAssert(value_it != _ksp_right_diagonal_scale_values.end(),
+                "A written right diagonal scale must have an installed value.");
+    if (!MooseUtils::relativeFuzzyEqual(value_it->second, value, 1e-12))
+      mooseError("Conflicting KSP right diagonal scales ",
+                 value_it->second,
+                 " and ",
+                 value,
+                 " were supplied for DOF ",
+                 dof,
+                 ".");
+    return;
+  }
+
+  if (value_it != _ksp_right_diagonal_scale_values.end() &&
+      MooseUtils::relativeFuzzyEqual(value_it->second, value, 1e-12))
+    return;
+
+  _ksp_right_diagonal_scale_values[dof] = value;
+  scale.set(dof, value);
+  _ksp_right_diagonal_scale_dirty = true;
+}
+
+void
+NonlinearSystemBase::closeKSPRightDiagonalScale()
+{
+  if (!_has_ksp_right_diagonal_scale)
+    return;
+
+  auto any_dirty = _ksp_right_diagonal_scale_dirty;
+  _communicator.max(any_dirty);
+  if (!any_dirty)
+    return;
+
+  getVector("ksp_right_diagonal_scale").close();
+  _ksp_right_diagonal_scale_dirty = false;
 }
 
 void

--- a/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d-rz/finite.i
+++ b/modules/combined/test/tests/gap_heat_transfer_mortar/finite-2d-rz/finite.i
@@ -56,20 +56,6 @@ name = 'finite'
     new_block = 'plank block'
   []
 
-  [secondary]
-    input = block_rename
-    type = LowerDBlockFromSidesetGenerator
-    sidesets = 'block_left'
-    new_block_id = '30'
-    new_block_name = 'frictionless_secondary_subdomain'
-  []
-  [primary]
-    input = secondary
-    type = LowerDBlockFromSidesetGenerator
-    sidesets = 'plank_right'
-    new_block_id = '20'
-    new_block_name = 'frictionless_primary_subdomain'
-  []
 []
 
 [GlobalParams]
@@ -97,11 +83,6 @@ name = 'finite'
     block = 'frictionless_secondary_subdomain'
     scaling = 1e-7
   []
-  [frictionless_normal_lm]
-    order = ${order}
-    block = 'frictionless_secondary_subdomain'
-    use_dual = true
-  []
 []
 
 [Physics/SolidMechanics/QuasiStatic]
@@ -122,58 +103,16 @@ name = 'finite'
   []
 []
 
-[UserObjects]
-  [weighted_gap_uo]
-    type = LMWeightedGapUserObject
-    primary_boundary = plank_right
-    secondary_boundary = block_left
-    primary_subdomain = frictionless_primary_subdomain
-    secondary_subdomain = frictionless_secondary_subdomain
-    lm_variable = frictionless_normal_lm
-    disp_x = disp_x
-    disp_y = disp_y
+[Contact]
+  [frictionless]
+    primary = plank_right
+    secondary = block_left
+    formulation = mortar
+    model = frictionless
   []
 []
 
 [Constraints]
-  [weighted_gap_lm]
-    type = ComputeWeightedGapLMMechanicalContact
-    primary_boundary = plank_right
-    secondary_boundary = block_left
-    primary_subdomain = frictionless_primary_subdomain
-    secondary_subdomain = frictionless_secondary_subdomain
-    variable = frictionless_normal_lm
-    disp_x = disp_x
-    disp_y = disp_y
-    use_displaced_mesh = true
-    weighted_gap_uo = weighted_gap_uo
-  []
-  [normal_x]
-    type = NormalMortarMechanicalContact
-    primary_boundary = plank_right
-    secondary_boundary = block_left
-    primary_subdomain = frictionless_primary_subdomain
-    secondary_subdomain = frictionless_secondary_subdomain
-    variable = frictionless_normal_lm
-    secondary_variable = disp_x
-    component = x
-    use_displaced_mesh = true
-    compute_lm_residuals = false
-    weighted_gap_uo = weighted_gap_uo
-  []
-  [normal_y]
-    type = NormalMortarMechanicalContact
-    primary_boundary = plank_right
-    secondary_boundary = block_left
-    primary_subdomain = frictionless_primary_subdomain
-    secondary_subdomain = frictionless_secondary_subdomain
-    variable = frictionless_normal_lm
-    secondary_variable = disp_y
-    component = y
-    use_displaced_mesh = true
-    compute_lm_residuals = false
-    weighted_gap_uo = weighted_gap_uo
-  []
   [thermal_contact]
     type = GapConductanceConstraint
     variable = thermal_lm

--- a/modules/contact/include/constraints/ComputeFrictionalForceLMMechanicalContact.h
+++ b/modules/contact/include/constraints/ComputeFrictionalForceLMMechanicalContact.h
@@ -67,6 +67,9 @@ protected:
                               const ADReal & tangential_vel,
                               const ADReal & tangential_vel_dir);
 
+  /// Return the positive nodal tangential pressure scale for \p dof.
+  Real tangentialContactScale(const DofObject * dof) const;
+
   /// A map from node to two weighted tangential velocities
   std::unordered_map<const DofObject *, std::array<ADReal, 2>> _dof_to_weighted_tangential_velocity;
 
@@ -94,11 +97,8 @@ protected:
   /// Numerical factor used in the tangential constraints for convergence purposes
   const Real _c_t;
 
-  /// When true, c_t is derived per-node from c_normal_eff and the tangential velocity magnitude
+  /// When true, use the physical normal stiffness as the tangential right/column scale
   const bool _dynamic_c_t;
-
-  /// Tangential velocity magnitude below which c_t falls back to c_normal_eff (stick regime)
-  const Real _vel_floor;
 
   /// Frictional Lagrange's multiplier variable pointers
   std::vector<MooseVariable *> _friction_vars;
@@ -120,9 +120,6 @@ protected:
 
   /// z-velocity on the primary face
   const ADVariableValue * const _primary_z_dot;
-
-  /// Small contact pressure value to trigger computation of frictional forces
-  const Real _epsilon;
 
   /// Friction coefficient
   const Real _mu;

--- a/modules/contact/include/constraints/ComputeFrictionalForceLMMechanicalContact.h
+++ b/modules/contact/include/constraints/ComputeFrictionalForceLMMechanicalContact.h
@@ -10,9 +10,8 @@
 #pragma once
 
 #include "ComputeWeightedGapLMMechanicalContact.h"
+#include "LMWeightedVelocitiesUserObject.h"
 #include "Function.h"
-
-class WeightedVelocitiesUserObject;
 
 /**
  * Computes frictional constraints (and normal contact constraints by calling its parent object)
@@ -90,10 +89,16 @@ protected:
   ADRealVectorValue _qp_real_tangential_velocity_nodal;
 
   /// The weighted gap user object
-  const WeightedVelocitiesUserObject & _weighted_velocities_uo;
+  const LMWeightedVelocitiesUserObject & _weighted_velocities_uo;
 
   /// Numerical factor used in the tangential constraints for convergence purposes
   const Real _c_t;
+
+  /// When true, c_t is derived per-node from c_normal_eff and the tangential velocity magnitude
+  const bool _dynamic_c_t;
+
+  /// Tangential velocity magnitude below which c_t falls back to c_normal_eff (stick regime)
+  const Real _vel_floor;
 
   /// Frictional Lagrange's multiplier variable pointers
   std::vector<MooseVariable *> _friction_vars;

--- a/modules/contact/include/constraints/ComputeWeightedGapLMMechanicalContact.h
+++ b/modules/contact/include/constraints/ComputeWeightedGapLMMechanicalContact.h
@@ -10,10 +10,9 @@
 #pragma once
 
 #include "ADMortarConstraint.h"
+#include "LMWeightedGapUserObject.h"
 
 #include <unordered_map>
-
-class WeightedGapUserObject;
 
 /**
  * Computes the weighted gap that will later be used to enforce the
@@ -61,6 +60,18 @@ protected:
    */
   virtual void enforceConstraintOnDof(const DofObject * const dof);
 
+  /// Return the positive characteristic displacement equation scaling used by contact scaling.
+  Real displacementScaling() const;
+
+  /// Return the row compensation between displacement and multiplier equations.
+  Real equationCompensation(const MooseVariable & multiplier) const;
+
+  /// Return the positive nodal normal pressure scale for \p dof.
+  Real normalContactScale(const DofObject * dof) const;
+
+  /// Return the positive mortar weight used to normalize gap and slip values.
+  Real contactNormalization() const;
+
   /// x-displacement on the secondary face
   const ADVariableValue & _secondary_disp_x;
   /// x-displacement on the primary face
@@ -81,6 +92,9 @@ protected:
   /// should be of a value such that its product with the gap is on the same scale as the lagrange
   /// multiplier
   const Real _c;
+
+  /// When true, c is read per-node from the UO's dofToDerivedC() instead of _c
+  const bool _use_derived_c_normal;
 
   /// The value of the gap at the current quadrature point
   ADReal _qp_gap;
@@ -109,5 +123,5 @@ protected:
   const Real * _normalization_ptr = nullptr;
 
   /// The weighted gap user object
-  const WeightedGapUserObject & _weighted_gap_uo;
+  const LMWeightedGapUserObject & _weighted_gap_uo;
 };

--- a/modules/contact/include/userobjects/LMWeightedGapUserObject.h
+++ b/modules/contact/include/userobjects/LMWeightedGapUserObject.h
@@ -10,6 +10,10 @@
 #pragma once
 
 #include "WeightedGapUserObject.h"
+#include "RankFourTensor.h"
+#include "MaterialProperty.h"
+
+#include <array>
 
 template <typename>
 class MooseVariableFE;
@@ -33,7 +37,20 @@ public:
   virtual void reinit() override {}
   virtual Real getNormalContactPressure(const Node * const /*node*/) const override;
 
+  virtual void initialize() override;
+  virtual void finalize() override;
+  virtual void timestepSetup() override;
+  virtual void meshChanged() override;
+
+  /**
+   * Per-node physical normal stiffness scale and its accumulated mortar weight.
+   * Only populated when derive_c_from_elasticity = true; after finalize() the scale has already
+   * been divided by the accumulated weight.
+   */
+  const std::unordered_map<const DofObject *, std::array<Real, 2>> & dofToDerivedC() const;
+
 protected:
+  virtual void computeQpIProperties() override;
   virtual const VariableTestValue & test() const override;
   virtual bool constrainedByOwner() const override { return true; }
 
@@ -47,6 +64,23 @@ protected:
    */
   void verifyLagrange(const MooseVariable & var, const std::string & var_name) const;
 
+  // Non-virtual helpers so diamond-derived classes can call them without re-entering the base chain
+  void clearDerivedC();
+  void finalizeDerivedC();
+  void accumulateDerivedCIfNeeded();
+
+  /// Whether to derive the physical normal stiffness from elasticity tensor material properties
+  const bool _derive_c_from_elasticity;
+
+  /// Whether the elasticity tensor material property was declared as an AD property
+  const bool _use_automatic_differentiation;
+
+  /// Per-node accumulated (physical stiffness scale * weight, weight)
+  std::unordered_map<const DofObject *, std::array<Real, 2>> _dof_to_derived_c;
+
+  /// Whether the physical stiffness scale must be refreshed at the next mortar execution
+  bool _derived_c_needs_update = true;
+
   /// The Lagrange multiplier variable representing the contact pressure
   const MooseVariableFE<Real> * const _lm_var;
 
@@ -55,4 +89,26 @@ protected:
 
   /// The auxiliary Lagrange multiplier variable (used together whith the Petrov-Galerkin approach)
   const MooseVariable * const _aux_lm_var;
+
+private:
+  template <bool is_ad>
+  void fetchElasticityTensorProperties(const std::string & sec_name, const std::string & pri_name);
+
+  template <bool is_ad>
+  void accumulateDerivedC();
+
+  /// Non-AD elasticity tensor on secondary side (non-null when !_use_automatic_differentiation)
+  const GenericMaterialProperty<RankFourTensor, false> * _elasticity_tensor_secondary = nullptr;
+  /// Non-AD elasticity tensor on primary side
+  const GenericMaterialProperty<RankFourTensor, false> * _elasticity_tensor_primary = nullptr;
+  /// AD elasticity tensor on secondary side (non-null when _use_automatic_differentiation)
+  const GenericMaterialProperty<RankFourTensor, true> * _elasticity_tensor_secondary_ad = nullptr;
+  /// AD elasticity tensor on primary side
+  const GenericMaterialProperty<RankFourTensor, true> * _elasticity_tensor_primary_ad = nullptr;
 };
+
+inline const std::unordered_map<const DofObject *, std::array<Real, 2>> &
+LMWeightedGapUserObject::dofToDerivedC() const
+{
+  return _dof_to_derived_c;
+}

--- a/modules/contact/include/userobjects/LMWeightedVelocitiesUserObject.h
+++ b/modules/contact/include/userobjects/LMWeightedVelocitiesUserObject.h
@@ -29,6 +29,12 @@ public:
   virtual const ADVariableValue & contactTangentialPressureDirOne() const override;
   virtual const ADVariableValue & contactTangentialPressureDirTwo() const override;
 
+  // Resolve diamond ambiguity: WeightedVelocitiesUserObject and LMWeightedGapUserObject
+  // both override these; we pick WeightedVelocitiesUserObject's chain then add LM-specific work.
+  void initialize() override;
+  void finalize() override;
+  void computeQpIProperties() override;
+
 protected:
   /// The Lagrange multiplier variables representing the tangential contact pressure
   const MooseVariableFE<Real> * const _lm_variable_tangential_one;

--- a/modules/contact/include/utils/MortarContactUtils.h
+++ b/modules/contact/include/utils/MortarContactUtils.h
@@ -26,7 +26,9 @@
 #include "timpi/parallel_sync.h"
 
 #include <utility>
+#include <algorithm>
 #include <array>
+#include <cmath>
 #include <unordered_map>
 #include <vector>
 
@@ -56,6 +58,91 @@ namespace Mortar
 {
 namespace Contact
 {
+
+/** Return the augmented normal pressure p_n - C_n g_bar. */
+template <typename T>
+T
+augmentedNormalPressure(const T & normal_pressure, const T & scaled_normal_gap)
+{
+  return normal_pressure - scaled_normal_gap;
+}
+
+/** Return the nonnegative Coulomb-ball radius. */
+template <typename T>
+T
+coulombFrictionRadius(const T & friction_coefficient, const T & augmented_normal_pressure)
+{
+  return friction_coefficient * std::max(T(0), augmented_normal_pressure);
+}
+
+/** Return the Euclidean norm of a tangential contact vector. */
+template <typename T, std::size_t N>
+T
+tangentialNorm(const std::array<T, N> & vector)
+{
+  T norm_squared = 0;
+  for (const auto & component : vector)
+    norm_squared += component * component;
+
+  using std::sqrt;
+  return sqrt(norm_squared);
+}
+
+/** Project a tangential contact vector onto the closed ball of radius \p radius. */
+template <typename T, std::size_t N>
+std::array<T, N>
+projectToFrictionBall(const std::array<T, N> & vector, const T & radius)
+{
+  const T norm = tangentialNorm(vector);
+  if (norm <= radius)
+    return vector;
+
+  std::array<T, N> projection;
+  for (const auto i : index_range(projection))
+    projection[i] = radius * vector[i] / norm;
+  return projection;
+}
+
+/**
+ * Return the degree-one Alart-Curnier friction residual
+ * p_t - Proj_{B_radius}(q_t).
+ */
+template <typename T, std::size_t N>
+std::array<T, N>
+alartCurnierFrictionResidual(const std::array<T, N> & tangential_pressure,
+                             const std::array<T, N> & augmented_tangential_pressure,
+                             const T & radius)
+{
+  const auto projection = projectToFrictionBall(augmented_tangential_pressure, radius);
+  std::array<T, N> residual;
+  for (const auto i : index_range(residual))
+    residual[i] = tangential_pressure[i] - projection[i];
+  return residual;
+}
+
+/**
+ * Return the degree-two Hueber-Stadler-Wohlmuth friction residual
+ * max(radius, ||q_t||) p_t - radius q_t.
+ *
+ * At radius = ||q_t|| = 0 the degree-two expression vanishes for every p_t. Returning p_t in
+ * that state preserves the Coulomb solution set during separation.
+ */
+template <typename T, std::size_t N>
+std::array<T, N>
+hueberStadlerWohlmuthFrictionResidual(const std::array<T, N> & tangential_pressure,
+                                      const std::array<T, N> & augmented_tangential_pressure,
+                                      const T & radius)
+{
+  const T augmented_norm = tangentialNorm(augmented_tangential_pressure);
+  const T weight = std::max(radius, augmented_norm);
+  if (weight == 0)
+    return tangential_pressure;
+
+  std::array<T, N> residual;
+  for (const auto i : index_range(residual))
+    residual[i] = weight * tangential_pressure[i] - radius * augmented_tangential_pressure[i];
+  return residual;
+}
 
 /**
  * This function is used to communicate velocities across processes

--- a/modules/contact/src/actions/ContactAction.C
+++ b/modules/contact/src/actions/ContactAction.C
@@ -205,6 +205,39 @@ ContactAction::validParams()
       "parameter if the default value generates poor contact convergence.");
   params.addParam<Real>(
       "c_tangential", 1, "Numerical parameter for nonlinear mortar frictional constraints");
+  MooseEnum c_normal_strategy("user physical", "user");
+  c_normal_strategy.addDocumentation("user", "Use the value supplied via 'c_normal' (default).");
+  c_normal_strategy.addDocumentation(
+      "physical",
+      "Derive c_normal automatically from the harmonic mean of the acoustic tensor normal "
+      "stiffness on the two contacting bodies. Requires 'normalize_c = true'.");
+  params.addParam<MooseEnum>(
+      "c_normal_strategy", c_normal_strategy, "Strategy for setting the normal contact scaling.");
+  MooseEnum c_tangential_strategy("user physical", "user");
+  c_tangential_strategy.addDocumentation("user",
+                                         "Use the value supplied via 'c_tangential' (default).");
+  c_tangential_strategy.addDocumentation(
+      "physical",
+      "Derive c_tangential per-node from c_normal_eff / (vt_mag * dt). Only valid for Coulomb "
+      "friction mortar contact.");
+  params.addParam<MooseEnum>("c_tangential_strategy",
+                             c_tangential_strategy,
+                             "Strategy for setting the tangential contact scaling.");
+  params.addParam<std::string>(
+      "secondary_elasticity_tensor_base_name",
+      "",
+      "Base name prefix of the elasticity_tensor material property on the secondary body. "
+      "Used when 'c_normal_strategy = physical'.");
+  params.addParam<std::string>(
+      "primary_elasticity_tensor_base_name",
+      "",
+      "Base name prefix of the elasticity_tensor material property on the primary body. "
+      "Used when 'c_normal_strategy = physical'.");
+  params.addParam<bool>(
+      "use_automatic_differentiation",
+      false,
+      "Whether the elasticity tensor material property was declared as an AD property. "
+      "Used when 'c_normal_strategy = physical'.");
   params.addParam<bool>("ping_pong_protection",
                         false,
                         "Whether to protect against ping-ponging, e.g. the oscillation of the "
@@ -443,6 +476,17 @@ ContactAction::ContactAction(const InputParameters & params)
       paramError("penalty",
                  "The 'penalty' parameter is not used for the 'mortar' formulation which instead "
                  "uses Lagrange multipliers");
+
+    if (getParam<MooseEnum>("c_normal_strategy") == "physical" && isParamSetByUser("c_normal"))
+      paramError("c_normal",
+                 "Cannot set 'c_normal' when 'c_normal_strategy = physical'; "
+                 "the value is derived from the material elasticity tensor.");
+
+    if (getParam<MooseEnum>("c_tangential_strategy") == "physical" &&
+        _model != ContactModel::COULOMB)
+      paramError("c_tangential_strategy",
+                 "'c_tangential_strategy = physical' is only valid for Coulomb friction mortar "
+                 "contact.");
   }
   else
   {
@@ -470,6 +514,13 @@ ContactAction::ContactAction(const InputParameters & params)
     else if (params.isParamSetByUser("c_tangential"))
       paramError("c_tangential",
                  "The 'c_tangential' option can only be used with the 'mortar' formulation");
+    else if (params.isParamSetByUser("c_normal_strategy"))
+      paramError("c_normal_strategy",
+                 "The 'c_normal_strategy' option can only be used with the 'mortar' formulation");
+    else if (params.isParamSetByUser("c_tangential_strategy"))
+      paramError("c_tangential_strategy",
+                 "The 'c_tangential_strategy' option can only be used with the 'mortar' "
+                 "formulation");
     else if (params.isParamSetByUser("mortar_dynamics"))
       paramError("mortar_dynamics",
                  "The 'mortar_dynamics' constraint option can only be used with the 'mortar' "
@@ -1030,6 +1081,16 @@ ContactAction::addMortarContact()
                                          "debug_mesh"});
       if (getParam<bool>("use_petrov_galerkin"))
         uo_params.set<std::vector<VariableName>>("aux_lm") = {auxiliary_lagrange_multiplier_name};
+      if (getParam<MooseEnum>("c_normal_strategy") == "physical")
+      {
+        uo_params.set<bool>("derive_c_from_elasticity") = true;
+        uo_params.set<bool>("use_automatic_differentiation") =
+            getParam<bool>("use_automatic_differentiation");
+        uo_params.set<std::string>("secondary_base_name") =
+            getParam<std::string>("secondary_elasticity_tensor_base_name");
+        uo_params.set<std::string>("primary_base_name") =
+            getParam<std::string>("primary_elasticity_tensor_base_name");
+      }
 
       _problem->addUserObject("LMWeightedGapUserObject",
                               register_mortar_uo_name(_boundary_pairs[0], "lm_weightedgap_object_"),
@@ -1064,6 +1125,16 @@ ContactAction::addMortarContact()
                                          "debug_mesh"});
       if (getParam<bool>("use_petrov_galerkin"))
         uo_params.set<std::vector<VariableName>>("aux_lm") = {auxiliary_lagrange_multiplier_name};
+      if (getParam<MooseEnum>("c_normal_strategy") == "physical")
+      {
+        uo_params.set<bool>("derive_c_from_elasticity") = true;
+        uo_params.set<bool>("use_automatic_differentiation") =
+            getParam<bool>("use_automatic_differentiation");
+        uo_params.set<std::string>("secondary_base_name") =
+            getParam<std::string>("secondary_elasticity_tensor_base_name");
+        uo_params.set<std::string>("primary_base_name") =
+            getParam<std::string>("primary_elasticity_tensor_base_name");
+      }
 
       const auto uo_name = _problem->addUserObject(
           "LMWeightedVelocitiesUserObject",
@@ -1196,7 +1267,16 @@ ContactAction::addMortarContact()
       params.set<SubdomainName>("secondary_subdomain") = secondary_subdomain_name;
       params.set<NonlinearVariableName>("variable") = normal_lagrange_multiplier_name;
       params.set<std::vector<VariableName>>("disp_x") = {displacements[0]};
-      params.set<Real>("c") = getParam<Real>("c_normal");
+      if (getParam<MooseEnum>("c_normal_strategy") == "physical")
+      {
+        params.set<bool>("normalize_c") = true;
+        params.set<bool>("use_derived_c_normal") = true;
+      }
+      else
+      {
+        params.set<Real>("c") = getParam<Real>("c_normal");
+        params.applySpecificParameters(parameters(), {"normalize_c"});
+      }
 
       if (ndisp > 1)
         params.set<std::vector<VariableName>>("disp_y") = {displacements[1]};
@@ -1209,7 +1289,6 @@ ContactAction::addMortarContact()
                                      {"correct_edge_dropping",
                                       "triangulation",
                                       "triangulate_triangles",
-                                      "normalize_c",
                                       "extra_vector_tags",
                                       "absolute_value_vector_tags",
                                       "debug_mesh"});
@@ -1245,9 +1324,20 @@ ContactAction::addMortarContact()
       params.set<SubdomainName>("primary_subdomain") = primary_subdomain_name;
       params.set<SubdomainName>("secondary_subdomain") = secondary_subdomain_name;
       params.set<bool>("use_displaced_mesh") = true;
-      params.set<Real>("c_t") = getParam<Real>("c_tangential");
-      params.set<Real>("c") = getParam<Real>("c_normal");
-      params.set<bool>("normalize_c") = getParam<bool>("normalize_c");
+      if (getParam<MooseEnum>("c_normal_strategy") == "physical")
+      {
+        params.set<bool>("normalize_c") = true;
+        params.set<bool>("use_derived_c_normal") = true;
+      }
+      else
+      {
+        params.set<Real>("c") = getParam<Real>("c_normal");
+        params.set<bool>("normalize_c") = getParam<bool>("normalize_c");
+      }
+      if (getParam<MooseEnum>("c_tangential_strategy") == "physical")
+        params.set<bool>("dynamic_c_t") = true;
+      else
+        params.set<Real>("c_t") = getParam<Real>("c_tangential");
       params.set<bool>("compute_primal_residuals") = false;
 
       params.set<MooseEnum>("segment_quadrature") = getParam<MooseEnum>("segment_quadrature");

--- a/modules/contact/src/actions/ContactAction.C
+++ b/modules/contact/src/actions/ContactAction.C
@@ -209,8 +209,8 @@ ContactAction::validParams()
   c_normal_strategy.addDocumentation("user", "Use the value supplied via 'c_normal' (default).");
   c_normal_strategy.addDocumentation(
       "physical",
-      "Derive c_normal automatically from the harmonic mean of the acoustic tensor normal "
-      "stiffness on the two contacting bodies. Requires 'normalize_c = true'.");
+      "Derive a per-node physical stiffness per normal length from the two contacting bodies and "
+      "use it for solver-side contact pressure scaling. Requires 'normalize_c = true'.");
   params.addParam<MooseEnum>(
       "c_normal_strategy", c_normal_strategy, "Strategy for setting the normal contact scaling.");
   MooseEnum c_tangential_strategy("user physical", "user");
@@ -218,8 +218,8 @@ ContactAction::validParams()
                                          "Use the value supplied via 'c_tangential' (default).");
   c_tangential_strategy.addDocumentation(
       "physical",
-      "Derive c_tangential per-node from c_normal_eff / (vt_mag * dt). Only valid for Coulomb "
-      "friction mortar contact.");
+      "Use the physical normal stiffness as the per-node scale in both tangential directions. "
+      "Only valid for Coulomb friction mortar contact with physical normal scaling.");
   params.addParam<MooseEnum>("c_tangential_strategy",
                              c_tangential_strategy,
                              "Strategy for setting the tangential contact scaling.");
@@ -355,7 +355,8 @@ ContactAction::validParams()
   // Friction
   params.addParamNamesToGroup("friction_coefficient tension_release", "Friction");
   // Mortar-specific parameters
-  params.addParamNamesToGroup("c_normal c_tangential normal_lm_scaling tangential_lm_scaling "
+  params.addParamNamesToGroup("c_normal c_tangential c_normal_strategy c_tangential_strategy "
+                              "normal_lm_scaling tangential_lm_scaling "
                               "lm_space "
                               "use_dual correct_edge_dropping normalize_c use_petrov_galerkin "
                               "generate_mortar_mesh segment_quadrature wear_depth debug_mesh",
@@ -487,6 +488,18 @@ ContactAction::ContactAction(const InputParameters & params)
       paramError("c_tangential_strategy",
                  "'c_tangential_strategy = physical' is only valid for Coulomb friction mortar "
                  "contact.");
+
+    if (getParam<MooseEnum>("c_tangential_strategy") == "physical" &&
+        getParam<MooseEnum>("c_normal_strategy") != "physical")
+      paramError("c_tangential_strategy",
+                 "'c_tangential_strategy = physical' requires 'c_normal_strategy = physical'.");
+
+    if (getParam<bool>("mortar_dynamics") &&
+        (getParam<MooseEnum>("c_normal_strategy") == "physical" ||
+         getParam<MooseEnum>("c_tangential_strategy") == "physical"))
+      paramError("mortar_dynamics",
+                 "Physical mortar contact scaling is not supported with 'mortar_dynamics'.");
+
   }
   else
   {

--- a/modules/contact/src/constraints/ComputeFrictionalForceLMMechanicalContact.C
+++ b/modules/contact/src/constraints/ComputeFrictionalForceLMMechanicalContact.C
@@ -11,6 +11,7 @@
 #include "DisplacedProblem.h"
 #include "Assembly.h"
 #include "MortarContactUtils.h"
+#include "NonlinearSystemBase.h"
 
 #include "metaphysicl/metaphysicl_version.h"
 #include "metaphysicl/dualsemidynamicsparsenumberarray.h"
@@ -43,20 +44,14 @@ ComputeFrictionalForceLMMechanicalContact::validParams()
   params.addParam<Real>(
       "epsilon",
       1.0e-7,
-      "Minimum value of contact pressure that will trigger frictional enforcement");
+      "Legacy separation threshold retained for input compatibility; quasistatic friction uses "
+      "the exact projection degeneracy guard.");
   params.addRangeCheckedParam<Real>(
       "mu", "mu > 0", "The friction coefficient for the Coulomb friction law");
   params.addRequiredParam<UserObjectName>("weighted_velocities_uo",
                                           "The weighted tangential velocities user object.");
-  params.addParam<bool>("dynamic_c_t",
-                        false,
-                        "Derive c_t per-node from c_normal_eff / (vt_mag * dt). "
-                        "During stick (vt_mag < vel_floor) falls back to c_normal_eff.");
-  params.addParam<Real>("vel_floor",
-                        1e-10,
-                        "Tangential velocity magnitude below which dynamic c_t falls back to "
-                        "c_normal_eff (stick regime guard).");
-
+  params.addParam<bool>(
+      "dynamic_c_t", false, "Use the physical normal stiffness as the per-node tangential scale.");
   return params;
 }
 
@@ -67,14 +62,12 @@ ComputeFrictionalForceLMMechanicalContact::ComputeFrictionalForceLMMechanicalCon
         getUserObject<LMWeightedVelocitiesUserObject>("weighted_velocities_uo")),
     _c_t(getParam<Real>("c_t")),
     _dynamic_c_t(getParam<bool>("dynamic_c_t")),
-    _vel_floor(getParam<Real>("vel_floor")),
     _secondary_x_dot(_secondary_var.adUDot()),
     _primary_x_dot(_primary_var.adUDotNeighbor()),
     _secondary_y_dot(adCoupledDot("disp_y")),
     _primary_y_dot(adCoupledNeighborValueDot("disp_y")),
     _secondary_z_dot(_has_disp_z ? &adCoupledDot("disp_z") : nullptr),
     _primary_z_dot(_has_disp_z ? &adCoupledNeighborValueDot("disp_z") : nullptr),
-    _epsilon(getParam<Real>("epsilon")),
     _mu(isParamValid("function_friction") ? std::numeric_limits<double>::quiet_NaN()
                                           : getParam<Real>("mu")),
     _function_friction(isParamValid("function_friction") ? &getFunction("function_friction")
@@ -110,6 +103,14 @@ ComputeFrictionalForceLMMechanicalContact::ComputeFrictionalForceLMMechanicalCon
       paramError(
           "friction_lm",
           "Frictional contact constraints only support elemental variables of CONSTANT order");
+
+  if (_dynamic_c_t && !_use_derived_c_normal)
+    paramError("dynamic_c_t",
+               "Physical tangential scaling requires physical normal contact scaling.");
+
+  if (!_dynamic_c_t && (!std::isfinite(_c_t) || _c_t <= 0.0))
+    paramError("c_t",
+               "The user-supplied tangential contact pressure scale must be positive and finite.");
 }
 
 void
@@ -157,6 +158,8 @@ ComputeFrictionalForceLMMechanicalContact::post()
     else
       enforceConstraintOnDof(dof_object);
   }
+
+  _fe_problem.getNonlinearSystemBase(_sys.number()).closeKSPRightDiagonalScale();
 }
 
 void
@@ -187,13 +190,13 @@ ComputeFrictionalForceLMMechanicalContact::incorrectEdgeDroppingPost(
     else
       enforceConstraintOnDof(dof_object);
   }
+
+  _fe_problem.getNonlinearSystemBase(_sys.number()).closeKSPRightDiagonalScale();
 }
 
 void
 ComputeFrictionalForceLMMechanicalContact::enforceConstraintOnDof3d(const DofObject * const dof)
 {
-  using std::max, std::sqrt;
-
   ComputeWeightedGapLMMechanicalContact::enforceConstraintOnDof(dof);
 
   // Get normal LM
@@ -215,84 +218,53 @@ ComputeFrictionalForceLMMechanicalContact::enforceConstraintOnDof3d(const DofObj
     Moose::derivInsert(friction_lm_values[i].derivatives(), friction_dof_indices[i], 1.);
   }
 
-  // Resolve normal reference stiffness (physical or user mode)
-  ADReal c;
-  if (_use_derived_c_normal)
-  {
-    const auto & [c_nn, ignored] = libmesh_map_find(_weighted_velocities_uo.dofToDerivedC(), dof);
-    c = _normalize_c ? c_nn / *_normalization_ptr : c_nn;
-  }
-  else
-    c = _normalize_c ? _c / *_normalization_ptr : _c;
-
-  // Resolve tangential scaling
-  ADReal c_t;
-  if (_dynamic_c_t)
-    // c_t = c_normal_eff: the tangential penalty matches the normal-constraint
-    // scaling.  Tangential contact stiffness (shear modulus ~ E/2) is the same
-    // order as normal (Young's modulus), so this is physically motivated and
-    // dimensionally correct.
-    c_t = c;
-  else
-    c_t = _normalize_c ? _c_t / *_normalization_ptr : _c_t;
+  const Real normalization = contactNormalization();
+  const Real normal_scale = normalContactScale(dof);
+  const Real tangential_scale = tangentialContactScale(dof);
+  const Real c = normal_scale / normalization;
+  const Real c_t = tangential_scale / normalization;
 
   // Compute the friction coefficient (constant or function)
   ADReal mu_ad = computeFrictionValue(contact_pressure,
                                       _dof_to_real_tangential_velocity[dof][0],
                                       _dof_to_real_tangential_velocity[dof][1]);
 
-  ADReal dof_residual;
-  ADReal dof_residual_dir;
+  const Real equation_scaling = _friction_vars[0]->scalingFactor();
+  const Real equation_scaling_dir = _friction_vars[1]->scalingFactor();
 
-  // Primal-dual active set strategy (PDASS)
-  if (contact_pressure < _epsilon)
-  {
-    dof_residual = friction_lm_values[0];
-    dof_residual_dir = friction_lm_values[1];
-  }
-  else
-  {
-    // Espilon to avoid automatic differentiation singularity
-    const Real epsilon_sqrt = 1.0e-48;
+  auto & nonlinear_system = _fe_problem.getNonlinearSystemBase(_sys.number());
+  for (const auto i : make_range(num_tangents))
+    nonlinear_system.setKSPRightDiagonalScale(friction_dof_indices[i], tangential_scale);
 
-    const auto lamdba_plus_cg = contact_pressure + c * weighted_gap;
-    std::array<ADReal, 2> lambda_t_plus_ctu;
-    lambda_t_plus_ctu[0] = friction_lm_values[0] + c_t * *tangential_vel[0] * _dt;
-    lambda_t_plus_ctu[1] = friction_lm_values[1] + c_t * *tangential_vel[1] * _dt;
+  const ADReal augmented_normal_pressure =
+      Moose::Mortar::Contact::augmentedNormalPressure(contact_pressure, c * weighted_gap);
+  const ADReal friction_limit =
+      Moose::Mortar::Contact::coulombFrictionRadius(mu_ad, augmented_normal_pressure);
+  const std::array<ADReal, 2> augmented_tangential_pressure = {
+      friction_lm_values[0] + c_t * *tangential_vel[0] * _dt,
+      friction_lm_values[1] + c_t * *tangential_vel[1] * _dt};
+  const auto friction_residual = Moose::Mortar::Contact::hueberStadlerWohlmuthFrictionResidual(
+      friction_lm_values, augmented_tangential_pressure, friction_limit);
+  const Real formulation_row_scale = 1.0 / tangential_scale;
 
-    const auto term_1_x = max(mu_ad * lamdba_plus_cg,
-                              sqrt(lambda_t_plus_ctu[0] * lambda_t_plus_ctu[0] +
-                                   lambda_t_plus_ctu[1] * lambda_t_plus_ctu[1] + epsilon_sqrt)) *
-                          friction_lm_values[0];
-
-    const auto term_1_y = max(mu_ad * lamdba_plus_cg,
-                              sqrt(lambda_t_plus_ctu[0] * lambda_t_plus_ctu[0] +
-                                   lambda_t_plus_ctu[1] * lambda_t_plus_ctu[1] + epsilon_sqrt)) *
-                          friction_lm_values[1];
-
-    const auto term_2_x = mu_ad * max(0.0, lamdba_plus_cg) * lambda_t_plus_ctu[0];
-
-    const auto term_2_y = mu_ad * max(0.0, lamdba_plus_cg) * lambda_t_plus_ctu[1];
-
-    dof_residual = term_1_x - term_2_x;
-    dof_residual_dir = term_1_y - term_2_y;
-  }
+  const ADReal dof_residual =
+      equationCompensation(*_friction_vars[0]) * formulation_row_scale * friction_residual[0];
+  const ADReal dof_residual_dir =
+      equationCompensation(*_friction_vars[1]) * formulation_row_scale * friction_residual[1];
 
   addResidualsAndJacobian(_assembly,
                           std::array<ADReal, 1>{{dof_residual}},
                           std::array<dof_id_type, 1>{{friction_dof_indices[0]}},
-                          _friction_vars[0]->scalingFactor());
+                          equation_scaling);
   addResidualsAndJacobian(_assembly,
                           std::array<ADReal, 1>{{dof_residual_dir}},
                           std::array<dof_id_type, 1>{{friction_dof_indices[1]}},
-                          _friction_vars[1]->scalingFactor());
+                          equation_scaling_dir);
 }
 
 void
 ComputeFrictionalForceLMMechanicalContact::enforceConstraintOnDof(const DofObject * const dof)
 {
-  using std::abs, std::max;
-
   ComputeWeightedGapLMMechanicalContact::enforceConstraintOnDof(dof);
 
   // Get friction LM
@@ -307,47 +279,47 @@ ComputeFrictionalForceLMMechanicalContact::enforceConstraintOnDof(const DofObjec
   ADReal contact_pressure = (*_sys.currentSolution())(normal_dof_index);
   Moose::derivInsert(contact_pressure.derivatives(), normal_dof_index, 1.);
 
-  // Resolve normal reference stiffness (physical or user mode)
-  ADReal c;
-  if (_use_derived_c_normal)
-  {
-    const auto & [c_nn, ignored] = libmesh_map_find(_weighted_velocities_uo.dofToDerivedC(), dof);
-    c = _normalize_c ? c_nn / *_normalization_ptr : c_nn;
-  }
-  else
-    c = _normalize_c ? _c / *_normalization_ptr : _c;
-
-  // Resolve tangential scaling
-  ADReal c_t;
-  if (_dynamic_c_t)
-    // c_t = c_normal_eff: see 3D path above for explanation.
-    c_t = c;
-  else
-    c_t = _normalize_c ? _c_t / *_normalization_ptr : _c_t;
+  const Real normalization = contactNormalization();
+  const Real normal_scale = normalContactScale(dof);
+  const Real tangential_scale = tangentialContactScale(dof);
+  const Real c = normal_scale / normalization;
+  const Real c_t = tangential_scale / normalization;
 
   // Compute the friction coefficient (constant or function)
   ADReal mu_ad =
       computeFrictionValue(contact_pressure, _dof_to_real_tangential_velocity[dof][0], 0.0);
 
-  ADReal dof_residual;
-  // Primal-dual active set strategy (PDASS)
-  if (contact_pressure < _epsilon)
-    dof_residual = friction_lm_value;
-  else
-  {
-    const auto term_1 = max(mu_ad * (contact_pressure + c * weighted_gap),
-                            abs(friction_lm_value + c_t * tangential_vel * _dt)) *
-                        friction_lm_value;
-    const auto term_2 = mu_ad * max(0.0, contact_pressure + c * weighted_gap) *
-                        (friction_lm_value + c_t * tangential_vel * _dt);
+  const Real equation_scaling = _friction_vars[0]->scalingFactor();
+  _fe_problem.getNonlinearSystemBase(_sys.number())
+      .setKSPRightDiagonalScale(friction_dof_index, tangential_scale);
 
-    dof_residual = term_1 - term_2;
-  }
+  const ADReal augmented_normal_pressure =
+      Moose::Mortar::Contact::augmentedNormalPressure(contact_pressure, c * weighted_gap);
+  const ADReal friction_limit =
+      Moose::Mortar::Contact::coulombFrictionRadius(mu_ad, augmented_normal_pressure);
+  const std::array<ADReal, 1> tangential_pressure = {friction_lm_value};
+  const std::array<ADReal, 1> augmented_tangential_pressure = {friction_lm_value +
+                                                               c_t * tangential_vel * _dt};
+  const auto friction_residual = Moose::Mortar::Contact::hueberStadlerWohlmuthFrictionResidual(
+      tangential_pressure, augmented_tangential_pressure, friction_limit);
+  const Real formulation_row_scale = 1.0 / tangential_scale;
+  const ADReal dof_residual =
+      equationCompensation(*_friction_vars[0]) * formulation_row_scale * friction_residual[0];
 
   addResidualsAndJacobian(_assembly,
                           std::array<ADReal, 1>{{dof_residual}},
                           std::array<dof_id_type, 1>{{friction_dof_index}},
-                          _friction_vars[0]->scalingFactor());
+                          equation_scaling);
+}
+
+Real
+ComputeFrictionalForceLMMechanicalContact::tangentialContactScale(const DofObject * const dof) const
+{
+  const Real scale =
+      _dynamic_c_t ? normalContactScale(dof) : _c_t * (_normalize_c ? 1.0 : contactNormalization());
+  if (!std::isfinite(scale) || scale <= 0.0)
+    mooseError("Mortar contact requires positive, finite nodal tangential pressure scales.");
+  return scale;
 }
 
 ADReal

--- a/modules/contact/src/constraints/ComputeFrictionalForceLMMechanicalContact.C
+++ b/modules/contact/src/constraints/ComputeFrictionalForceLMMechanicalContact.C
@@ -11,7 +11,6 @@
 #include "DisplacedProblem.h"
 #include "Assembly.h"
 #include "MortarContactUtils.h"
-#include "WeightedVelocitiesUserObject.h"
 
 #include "metaphysicl/metaphysicl_version.h"
 #include "metaphysicl/dualsemidynamicsparsenumberarray.h"
@@ -49,6 +48,14 @@ ComputeFrictionalForceLMMechanicalContact::validParams()
       "mu", "mu > 0", "The friction coefficient for the Coulomb friction law");
   params.addRequiredParam<UserObjectName>("weighted_velocities_uo",
                                           "The weighted tangential velocities user object.");
+  params.addParam<bool>("dynamic_c_t",
+                        false,
+                        "Derive c_t per-node from c_normal_eff / (vt_mag * dt). "
+                        "During stick (vt_mag < vel_floor) falls back to c_normal_eff.");
+  params.addParam<Real>("vel_floor",
+                        1e-10,
+                        "Tangential velocity magnitude below which dynamic c_t falls back to "
+                        "c_normal_eff (stick regime guard).");
 
   return params;
 }
@@ -56,8 +63,11 @@ ComputeFrictionalForceLMMechanicalContact::validParams()
 ComputeFrictionalForceLMMechanicalContact::ComputeFrictionalForceLMMechanicalContact(
     const InputParameters & parameters)
   : ComputeWeightedGapLMMechanicalContact(parameters),
-    _weighted_velocities_uo(getUserObject<WeightedVelocitiesUserObject>("weighted_velocities_uo")),
+    _weighted_velocities_uo(
+        getUserObject<LMWeightedVelocitiesUserObject>("weighted_velocities_uo")),
     _c_t(getParam<Real>("c_t")),
+    _dynamic_c_t(getParam<bool>("dynamic_c_t")),
+    _vel_floor(getParam<Real>("vel_floor")),
     _secondary_x_dot(_secondary_var.adUDot()),
     _primary_x_dot(_primary_var.adUDotNeighbor()),
     _secondary_y_dot(adCoupledDot("disp_y")),
@@ -205,9 +215,26 @@ ComputeFrictionalForceLMMechanicalContact::enforceConstraintOnDof3d(const DofObj
     Moose::derivInsert(friction_lm_values[i].derivatives(), friction_dof_indices[i], 1.);
   }
 
-  // Get normalized c and c_t values (if normalization specified
-  const Real c = _normalize_c ? _c / *_normalization_ptr : _c;
-  const Real c_t = _normalize_c ? _c_t / *_normalization_ptr : _c_t;
+  // Resolve normal reference stiffness (physical or user mode)
+  ADReal c;
+  if (_use_derived_c_normal)
+  {
+    const auto & [c_nn, ignored] = libmesh_map_find(_weighted_velocities_uo.dofToDerivedC(), dof);
+    c = _normalize_c ? c_nn / *_normalization_ptr : c_nn;
+  }
+  else
+    c = _normalize_c ? _c / *_normalization_ptr : _c;
+
+  // Resolve tangential scaling
+  ADReal c_t;
+  if (_dynamic_c_t)
+    // c_t = c_normal_eff: the tangential penalty matches the normal-constraint
+    // scaling.  Tangential contact stiffness (shear modulus ~ E/2) is the same
+    // order as normal (Young's modulus), so this is physically motivated and
+    // dimensionally correct.
+    c_t = c;
+  else
+    c_t = _normalize_c ? _c_t / *_normalization_ptr : _c_t;
 
   // Compute the friction coefficient (constant or function)
   ADReal mu_ad = computeFrictionValue(contact_pressure,
@@ -280,9 +307,23 @@ ComputeFrictionalForceLMMechanicalContact::enforceConstraintOnDof(const DofObjec
   ADReal contact_pressure = (*_sys.currentSolution())(normal_dof_index);
   Moose::derivInsert(contact_pressure.derivatives(), normal_dof_index, 1.);
 
-  // Get normalized c and c_t values (if normalization specified
-  const Real c = _normalize_c ? _c / *_normalization_ptr : _c;
-  const Real c_t = _normalize_c ? _c_t / *_normalization_ptr : _c_t;
+  // Resolve normal reference stiffness (physical or user mode)
+  ADReal c;
+  if (_use_derived_c_normal)
+  {
+    const auto & [c_nn, ignored] = libmesh_map_find(_weighted_velocities_uo.dofToDerivedC(), dof);
+    c = _normalize_c ? c_nn / *_normalization_ptr : c_nn;
+  }
+  else
+    c = _normalize_c ? _c / *_normalization_ptr : _c;
+
+  // Resolve tangential scaling
+  ADReal c_t;
+  if (_dynamic_c_t)
+    // c_t = c_normal_eff: see 3D path above for explanation.
+    c_t = c;
+  else
+    c_t = _normalize_c ? _c_t / *_normalization_ptr : _c_t;
 
   // Compute the friction coefficient (constant or function)
   ADReal mu_ad =

--- a/modules/contact/src/constraints/ComputeWeightedGapLMMechanicalContact.C
+++ b/modules/contact/src/constraints/ComputeWeightedGapLMMechanicalContact.C
@@ -11,7 +11,7 @@
 #include "DisplacedProblem.h"
 #include "Assembly.h"
 #include "MortarContactUtils.h"
-#include "WeightedGapUserObject.h"
+#include "NonlinearSystemBase.h"
 #include "metaphysicl/metaphysicl_version.h"
 #include "metaphysicl/dualsemidynamicsparsenumberarray.h"
 #include "metaphysicl/parallel_dualnumber.h"
@@ -22,6 +22,8 @@
 #endif
 #include "metaphysicl/parallel_semidynamicsparsenumberarray.h"
 #include "timpi/parallel_sync.h"
+
+#include <cmath>
 
 registerMooseObject("ContactApp", ComputeWeightedGapLMMechanicalContact);
 
@@ -63,6 +65,10 @@ ComputeWeightedGapLMMechanicalContact::validParams()
       "the value of c effectively depends on element size since in the constraint we compare nodal "
       "Lagrange Multiplier values to integrated gap values (LM nodal value is independent of "
       "element size, where integrated values are dependent on element size).");
+  params.addParam<bool>("use_derived_c_normal",
+                        false,
+                        "Read c_normal per-node from the weighted gap UO's dofToDerivedC() map "
+                        "instead of using the scalar 'c' parameter.");
   params.set<bool>("use_displaced_mesh") = true;
   params.set<bool>("interpolate_normals") = false;
   params.addRequiredParam<UserObjectName>("weighted_gap_uo", "The weighted gap user object");
@@ -80,12 +86,13 @@ ComputeWeightedGapLMMechanicalContact::ComputeWeightedGapLMMechanicalContact(
     _secondary_disp_z(_has_disp_z ? &adCoupledValue("disp_z") : nullptr),
     _primary_disp_z(_has_disp_z ? &adCoupledNeighborValue("disp_z") : nullptr),
     _c(getParam<Real>("c")),
+    _use_derived_c_normal(getParam<bool>("use_derived_c_normal")),
     _normalize_c(getParam<bool>("normalize_c")),
     _nodal(getVar("disp_x", 0)->feType().family == LAGRANGE),
     _disp_x_var(getVar("disp_x", 0)),
     _disp_y_var(getVar("disp_y", 0)),
     _disp_z_var(_has_disp_z ? getVar("disp_z", 0) : nullptr),
-    _weighted_gap_uo(getUserObject<WeightedGapUserObject>("weighted_gap_uo"))
+    _weighted_gap_uo(getUserObject<LMWeightedGapUserObject>("weighted_gap_uo"))
 {
   if (!getParam<bool>("use_displaced_mesh"))
     paramError(
@@ -95,6 +102,11 @@ ComputeWeightedGapLMMechanicalContact::ComputeWeightedGapLMMechanicalContact(
   if (!_var->isNodal())
     if (_var->feType().order != static_cast<Order>(0))
       mooseError("Normal contact constraints only support elemental variables of CONSTANT order");
+
+  if (!_use_derived_c_normal && (!std::isfinite(_c) || _c <= 0.0))
+    paramError("c", "The user-supplied normal contact pressure scale must be positive and finite.");
+
+  _fe_problem.getNonlinearSystemBase(_sys.number()).requestKSPRightDiagonalScale();
 }
 
 ADReal
@@ -158,6 +170,8 @@ ComputeWeightedGapLMMechanicalContact::post()
 
     enforceConstraintOnDof(dof_object);
   }
+
+  _fe_problem.getNonlinearSystemBase(_sys.number()).closeKSPRightDiagonalScale();
 }
 
 void
@@ -179,19 +193,81 @@ ComputeWeightedGapLMMechanicalContact::incorrectEdgeDroppingPost(
 
     enforceConstraintOnDof(dof_object);
   }
+
+  _fe_problem.getNonlinearSystemBase(_sys.number()).closeKSPRightDiagonalScale();
+}
+
+Real
+ComputeWeightedGapLMMechanicalContact::displacementScaling() const
+{
+  const std::array<Real, 3> scalings = {_disp_x_var->scalingFactor(),
+                                        _disp_y_var->scalingFactor(),
+                                        _disp_z_var ? _disp_z_var->scalingFactor() : 1.0};
+  const auto num_displacements = _disp_z_var ? 3 : 2;
+  Real log_sum = 0.0;
+  for (const auto i : make_range(num_displacements))
+  {
+    if (!std::isfinite(scalings[i]) || scalings[i] <= 0.0)
+      mooseError("Mortar contact scaling requires positive, finite displacement variable scaling "
+                 "factors.");
+    log_sum += std::log(scalings[i]);
+  }
+
+  if (MooseUtils::relativeFuzzyEqual(scalings[0], scalings[1], 1e-12) &&
+      (!_disp_z_var || MooseUtils::relativeFuzzyEqual(scalings[0], scalings[2], 1e-12)))
+    return scalings[0];
+
+  // A contact pressure contributes to every displacement component. Use one symmetric
+  // characteristic scale for its multiplier equation when component scalings differ.
+  return std::exp(log_sum / num_displacements);
+}
+
+Real
+ComputeWeightedGapLMMechanicalContact::equationCompensation(const MooseVariable & multiplier) const
+{
+  const Real multiplier_scaling = multiplier.scalingFactor();
+  if (!std::isfinite(multiplier_scaling) || multiplier_scaling <= 0.0)
+    mooseError("Mortar contact scaling requires positive, finite Lagrange multiplier scaling "
+               "factors.");
+  return displacementScaling() / multiplier_scaling;
+}
+
+Real
+ComputeWeightedGapLMMechanicalContact::contactNormalization() const
+{
+  const Real normalization = *_normalization_ptr;
+  if (!std::isfinite(normalization) || normalization <= 0.0)
+    mooseError("Mortar contact requires positive, finite nodal mortar weights.");
+  return normalization;
+}
+
+Real
+ComputeWeightedGapLMMechanicalContact::normalContactScale(const DofObject * const dof) const
+{
+  const Real scale = _use_derived_c_normal
+                         ? libmesh_map_find(_weighted_gap_uo.dofToDerivedC(), dof)[0]
+                         : _c * (_normalize_c ? 1.0 : contactNormalization());
+  if (!std::isfinite(scale) || scale <= 0.0)
+    mooseError("Mortar contact requires positive, finite nodal normal pressure scales.");
+  return scale;
 }
 
 void
 ComputeWeightedGapLMMechanicalContact::enforceConstraintOnDof(const DofObject * const dof)
 {
   const auto & weighted_gap = *_weighted_gap_ptr;
-  const Real c = _normalize_c ? _c / *_normalization_ptr : _c;
+
+  const Real normal_scale = normalContactScale(dof);
+  const Real c = normal_scale / contactNormalization();
 
   const auto dof_index = dof->dof_number(_sys.number(), _var->number(), 0);
   ADReal lm_value = (*_sys.currentSolution())(dof_index);
   Moose::derivInsert(lm_value.derivatives(), dof_index, 1.);
 
-  const ADReal dof_residual = std::min(lm_value, weighted_gap * c);
+  _fe_problem.getNonlinearSystemBase(_sys.number())
+      .setKSPRightDiagonalScale(dof_index, normal_scale);
+
+  const ADReal dof_residual = equationCompensation(*_var) * std::min(lm_value, weighted_gap * c);
 
   addResidualsAndJacobian(_assembly,
                           std::array<ADReal, 1>{{dof_residual}},

--- a/modules/contact/src/userobjects/LMWeightedGapUserObject.C
+++ b/modules/contact/src/userobjects/LMWeightedGapUserObject.C
@@ -10,6 +10,9 @@
 #include "LMWeightedGapUserObject.h"
 #include "MooseVariableFE.h"
 #include "SystemBase.h"
+#include "MortarContactUtils.h"
+
+#include <cmath>
 
 registerMooseObject("ContactApp", LMWeightedGapUserObject);
 
@@ -24,6 +27,27 @@ LMWeightedGapUserObject::newParams()
   params.addCoupledVar("aux_lm",
                        "Auxiliary Lagrange multiplier variable that is utilized together with the "
                        "Petrov-Galerkin approach.");
+  params.addParam<bool>("derive_c_from_elasticity",
+                        false,
+                        "Compute a physical stiffness per normal length from the contact surface "
+                        "material properties and adjacent element depths.");
+  params.addParam<std::string>(
+      "secondary_base_name",
+      "",
+      "Base name prefix of the elasticity_tensor material property on the secondary body. "
+      "Must match the base_name used on the secondary material block that computes the "
+      "elasticity tensor.");
+  params.addParam<std::string>(
+      "primary_base_name",
+      "",
+      "Base name prefix of the elasticity_tensor material property on the primary body. "
+      "Must match the base_name used on the primary material block that computes the "
+      "elasticity tensor.");
+  params.addParam<bool>(
+      "use_automatic_differentiation",
+      false,
+      "Whether the elasticity tensor material property was declared as an AD property. "
+      "Set to true if the material block uses an AD elasticity tensor.");
   return params;
 }
 
@@ -39,6 +63,8 @@ LMWeightedGapUserObject::validParams()
 
 LMWeightedGapUserObject::LMWeightedGapUserObject(const InputParameters & parameters)
   : WeightedGapUserObject(parameters),
+    _derive_c_from_elasticity(getParam<bool>("derive_c_from_elasticity")),
+    _use_automatic_differentiation(getParam<bool>("use_automatic_differentiation")),
     _lm_var(getVar("lm_variable", 0)),
     _use_petrov_galerkin(getParam<bool>("use_petrov_galerkin")),
     _aux_lm_var(isCoupled("aux_lm") ? getVar("aux_lm", 0) : nullptr)
@@ -55,6 +81,20 @@ LMWeightedGapUserObject::LMWeightedGapUserObject(const InputParameters & paramet
     paramError("aux_lm",
                "Auxiliary LM variable needs to use standard shape function, i.e., set `use_dual = "
                "false`.");
+
+  if (_derive_c_from_elasticity)
+  {
+    const std::string sec_base = getParam<std::string>("secondary_base_name");
+    const std::string pri_base = getParam<std::string>("primary_base_name");
+    const std::string sec_name =
+        sec_base.empty() ? "elasticity_tensor" : sec_base + "_elasticity_tensor";
+    const std::string pri_name =
+        pri_base.empty() ? "elasticity_tensor" : pri_base + "_elasticity_tensor";
+    if (_use_automatic_differentiation)
+      fetchElasticityTensorProperties<true>(sec_name, pri_name);
+    else
+      fetchElasticityTensorProperties<false>(sec_name, pri_name);
+  }
 }
 
 void
@@ -102,3 +142,170 @@ LMWeightedGapUserObject::getNormalContactPressure(const Node * const node) const
   const auto dof_number = node->dof_number(sys_num, var_num, /*component=*/0);
   return (*_lm_var->sys().currentSolution())(dof_number);
 }
+
+void
+LMWeightedGapUserObject::initialize()
+{
+  WeightedGapUserObject::initialize();
+  clearDerivedC();
+}
+
+void
+LMWeightedGapUserObject::timestepSetup()
+{
+  WeightedGapUserObject::timestepSetup();
+  _derived_c_needs_update = true;
+}
+
+void
+LMWeightedGapUserObject::meshChanged()
+{
+  WeightedGapUserObject::meshChanged();
+  _derived_c_needs_update = true;
+}
+
+void
+LMWeightedGapUserObject::clearDerivedC()
+{
+  if (_derived_c_needs_update)
+    _dof_to_derived_c.clear();
+}
+
+void
+LMWeightedGapUserObject::finalize()
+{
+  WeightedGapUserObject::finalize();
+  if (_derive_c_from_elasticity && _derived_c_needs_update)
+    finalizeDerivedC();
+}
+
+void
+LMWeightedGapUserObject::computeQpIProperties()
+{
+  WeightedGapUserObject::computeQpIProperties();
+  accumulateDerivedCIfNeeded();
+}
+
+void
+LMWeightedGapUserObject::finalizeDerivedC()
+{
+  Moose::Mortar::Contact::communicateVelocities(_dof_to_derived_c,
+                                                _subproblem.mesh(),
+                                                _nodal,
+                                                _communicator,
+                                                /*send_data_back=*/false);
+  for (auto & [dof, scale_and_weight] : _dof_to_derived_c)
+  {
+    auto & [scale, weight] = scale_and_weight;
+    if (!std::isfinite(weight) || weight <= 0.0)
+      mooseError("The mortar normalization for physical contact scaling at DOF ",
+                 dof->id(),
+                 " must be finite and positive.");
+    scale /= weight;
+    if (!std::isfinite(scale) || scale <= 0.0)
+      mooseError("The physical contact stiffness scale at DOF ",
+                 dof->id(),
+                 " must be finite and positive.");
+  }
+  _derived_c_needs_update = false;
+}
+
+void
+LMWeightedGapUserObject::accumulateDerivedCIfNeeded()
+{
+  if (!_derive_c_from_elasticity || !_derived_c_needs_update)
+    return;
+  if (_use_automatic_differentiation)
+    accumulateDerivedC<true>();
+  else
+    accumulateDerivedC<false>();
+}
+
+template <bool is_ad>
+void
+LMWeightedGapUserObject::fetchElasticityTensorProperties(const std::string & sec_name,
+                                                         const std::string & pri_name)
+{
+  if constexpr (is_ad)
+  {
+    _elasticity_tensor_secondary_ad = &getGenericMaterialProperty<RankFourTensor, true>(sec_name);
+    _elasticity_tensor_primary_ad =
+        &getGenericNeighborMaterialProperty<RankFourTensor, true>(pri_name);
+  }
+  else
+  {
+    _elasticity_tensor_secondary = &getGenericMaterialProperty<RankFourTensor, false>(sec_name);
+    _elasticity_tensor_primary =
+        &getGenericNeighborMaterialProperty<RankFourTensor, false>(pri_name);
+  }
+}
+
+template <bool is_ad>
+void
+LMWeightedGapUserObject::accumulateDerivedC()
+{
+  const GenericMaterialProperty<RankFourTensor, is_ad> * sec_ptr;
+  const GenericMaterialProperty<RankFourTensor, is_ad> * pri_ptr;
+  if constexpr (is_ad)
+  {
+    sec_ptr = _elasticity_tensor_secondary_ad;
+    pri_ptr = _elasticity_tensor_primary_ad;
+  }
+  else
+  {
+    sec_ptr = _elasticity_tensor_secondary;
+    pri_ptr = _elasticity_tensor_primary;
+  }
+
+  const RealVectorValue & n = _normals[_i];
+  GenericReal<is_ad> C_nn_sec_generic = 0;
+  GenericReal<is_ad> C_nn_pri_generic = 0;
+  for (const auto a : make_range(3))
+    for (const auto b : make_range(3))
+      for (const auto c : make_range(3))
+        for (const auto d : make_range(3))
+        {
+          const Real w = n(a) * n(b) * n(c) * n(d);
+          C_nn_sec_generic += w * (*sec_ptr)[_qp](a, b, c, d);
+          C_nn_pri_generic += w * (*pri_ptr)[_qp](a, b, c, d);
+        }
+
+  const Real C_nn_sec = MetaPhysicL::raw_value(C_nn_sec_generic);
+  const Real C_nn_pri = MetaPhysicL::raw_value(C_nn_pri_generic);
+  const auto & reference_mesh = _fe_problem.mesh();
+  const auto * const reference_secondary_face = reference_mesh.elemPtr(_lower_secondary_elem->id());
+  const auto * const reference_primary_face = reference_mesh.elemPtr(_lower_primary_elem->id());
+  const auto * const reference_secondary_parent =
+      reference_mesh.elemPtr(_lower_secondary_elem->interior_parent()->id());
+  const auto * const reference_primary_parent =
+      reference_mesh.elemPtr(_lower_primary_elem->interior_parent()->id());
+  const Real secondary_face_measure = reference_secondary_face->volume();
+  const Real primary_face_measure = reference_primary_face->volume();
+  const Real secondary_parent_volume = reference_secondary_parent->volume();
+  const Real primary_parent_volume = reference_primary_parent->volume();
+  if (!std::isfinite(C_nn_sec) || C_nn_sec <= 0.0 || !std::isfinite(C_nn_pri) || C_nn_pri <= 0.0)
+    mooseError("The normal acoustic stiffness on both contact bodies must be finite and positive ",
+               "when physical contact scaling is used.");
+  if (!std::isfinite(secondary_face_measure) || secondary_face_measure <= 0.0 ||
+      !std::isfinite(primary_face_measure) || primary_face_measure <= 0.0 ||
+      !std::isfinite(secondary_parent_volume) || secondary_parent_volume <= 0.0 ||
+      !std::isfinite(primary_parent_volume) || primary_parent_volume <= 0.0)
+    mooseError("The normal contact lengths on both contact bodies must be finite and positive ",
+               "when physical contact scaling is used.");
+
+  const Real h_secondary = secondary_parent_volume / secondary_face_measure;
+  const Real h_primary = primary_parent_volume / primary_face_measure;
+  const Real physical_scale = 1.0 / (h_secondary / C_nn_sec + h_primary / C_nn_pri);
+  const Real test_weight = (*_test)[_i][_qp] * _qp_factor;
+  const auto * const dof = static_cast<const DofObject *>(_lower_secondary_elem->node_ptr(_i));
+  auto & [scale_sum, weight_sum] = _dof_to_derived_c[dof];
+  scale_sum += physical_scale * test_weight;
+  weight_sum += test_weight;
+}
+
+template void LMWeightedGapUserObject::fetchElasticityTensorProperties<false>(const std::string &,
+                                                                              const std::string &);
+template void LMWeightedGapUserObject::fetchElasticityTensorProperties<true>(const std::string &,
+                                                                             const std::string &);
+template void LMWeightedGapUserObject::accumulateDerivedC<false>();
+template void LMWeightedGapUserObject::accumulateDerivedC<true>();

--- a/modules/contact/src/userobjects/LMWeightedVelocitiesUserObject.C
+++ b/modules/contact/src/userobjects/LMWeightedVelocitiesUserObject.C
@@ -62,3 +62,25 @@ LMWeightedVelocitiesUserObject::contactTangentialPressureDirTwo() const
 {
   return _lm_variable_tangential_two->adSlnLower();
 }
+
+void
+LMWeightedVelocitiesUserObject::initialize()
+{
+  WeightedVelocitiesUserObject::initialize();
+  LMWeightedGapUserObject::clearDerivedC();
+}
+
+void
+LMWeightedVelocitiesUserObject::finalize()
+{
+  WeightedVelocitiesUserObject::finalize();
+  if (_derive_c_from_elasticity && _derived_c_needs_update)
+    LMWeightedGapUserObject::finalizeDerivedC();
+}
+
+void
+LMWeightedVelocitiesUserObject::computeQpIProperties()
+{
+  WeightedVelocitiesUserObject::computeQpIProperties();
+  LMWeightedGapUserObject::accumulateDerivedCIfNeeded();
+}

--- a/modules/contact/unit/inputs/frictional_physical.i
+++ b/modules/contact/unit/inputs/frictional_physical.i
@@ -1,0 +1,247 @@
+starting_point = 0.04
+offset = 0.00
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+  volumetric_locking_correction = true
+  # scaling=1/E so physical c constants (scaled by scalingFactor ~ 1/E) are
+  # far smaller than the defaults (c_normal=1e6, c_tangential=1), making the
+  # convergence gap between physical and default clearly observable.
+  scaling = 1e-4
+[]
+
+[Mesh]
+  [top_block]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 3
+    ny = 3
+    nz = 3
+    xmin = -0.25
+    xmax = 0.25
+    ymin = -0.25
+    ymax = 0.25
+    zmin = -0.25
+    zmax = 0.25
+    elem_type = HEX8
+  []
+  [rotate_top_block]
+    type = TransformGenerator
+    input = top_block
+    transform = ROTATE
+    vector_value = '0 0 0'
+  []
+  [top_block_sidesets]
+    type = RenameBoundaryGenerator
+    input = rotate_top_block
+    old_boundary = '0 1 2 3 4 5'
+    new_boundary = 'top_bottom top_back top_right top_front top_left top_top'
+  []
+  [top_block_id]
+    type = SubdomainIDGenerator
+    input = top_block_sidesets
+    subdomain_id = 1
+  []
+  [bottom_block]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 10
+    ny = 10
+    nz = 2
+    xmin = -.5
+    xmax = .5
+    ymin = -.5
+    ymax = .5
+    zmin = -.3
+    zmax = -.25
+    elem_type = HEX8
+  []
+  [bottom_block_id]
+    type = SubdomainIDGenerator
+    input = bottom_block
+    subdomain_id = 2
+  []
+  [bottom_block_change_boundary_id]
+    type = RenameBoundaryGenerator
+    input = bottom_block_id
+    old_boundary = '0 1 2 3 4 5'
+    new_boundary = '100 101 102 103 104 105'
+  []
+  [combined]
+    type = MeshCollectionGenerator
+    inputs = 'top_block_id bottom_block_change_boundary_id'
+  []
+  [block_rename]
+    type = RenameBlockGenerator
+    input = combined
+    old_block = '1 2'
+    new_block = 'top_block bottom_block'
+  []
+  [bottom_right_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = block_rename
+    new_boundary = bottom_right
+    block = bottom_block
+    normal = '1 0 0'
+  []
+  [bottom_left_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = bottom_right_sideset
+    new_boundary = bottom_left
+    block = bottom_block
+    normal = '-1 0 0'
+  []
+  [bottom_top_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = bottom_left_sideset
+    new_boundary = bottom_top
+    block = bottom_block
+    normal = '0 0 1'
+  []
+  [bottom_bottom_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = bottom_top_sideset
+    new_boundary = bottom_bottom
+    block = bottom_block
+    normal = '0  0 -1'
+  []
+  [bottom_front_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = bottom_bottom_sideset
+    new_boundary = bottom_front
+    block = bottom_block
+    normal = '0 1 0'
+  []
+  [bottom_back_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = bottom_front_sideset
+    new_boundary = bottom_back
+    block = bottom_block
+    normal = '0 -1 0'
+  []
+  allow_renumbering = false
+[]
+
+[Physics/SolidMechanics/QuasiStatic]
+  [all]
+    add_variables = true
+    strain = FINITE
+    block = '1 2'
+    use_automatic_differentiation = false
+  []
+[]
+
+[Materials]
+  [tensor]
+    type = ComputeIsotropicElasticityTensor
+    block = '1'
+    youngs_modulus = 1.0e4
+    poissons_ratio = 0.0
+  []
+  [stress]
+    type = ComputeFiniteStrainElasticStress
+    block = '1'
+  []
+  [tensor_1000]
+    type = ComputeIsotropicElasticityTensor
+    block = '2'
+    youngs_modulus = 1e5
+    poissons_ratio = 0.0
+  []
+  [stress_1000]
+    type = ComputeFiniteStrainElasticStress
+    block = '2'
+  []
+[]
+
+[Contact]
+  [mortar]
+    primary = 'bottom_top'
+    secondary = 'top_bottom'
+    formulation = mortar
+    model = coulomb
+    friction_coefficient = 0.4
+  []
+[]
+
+[BCs]
+  [botx]
+    type = DirichletBC
+    variable = disp_x
+    boundary = 'bottom_left bottom_right bottom_front bottom_back'
+    value = 0.0
+  []
+  [boty]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 'bottom_left bottom_right bottom_front bottom_back'
+    value = 0.0
+  []
+  [botz]
+    type = DirichletBC
+    variable = disp_z
+    boundary = 'bottom_left bottom_right bottom_front bottom_back'
+    value = 0.0
+  []
+  # Small tangential sliding to activate c_tangential
+  [topx]
+    type = FunctionDirichletBC
+    variable = disp_x
+    boundary = 'top_top'
+    function = '0.05 * t'
+  []
+  [topy]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 'top_top'
+    value = 0.0
+  []
+  [topz]
+    type = FunctionDirichletBC
+    variable = disp_z
+    boundary = 'top_top'
+    function = '-${starting_point} * t / 0.125 + ${offset}'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  end_time = .025
+  dt = .025
+  dtmin = .001
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_type -pc_factor_shift_type -pc_factor_shift_amount -mat_mffd_err'
+  petsc_options_value = 'lu       superlu_dist                  NONZERO               1e-14                  1e-5'
+  l_max_its = 100
+  nl_max_its = 100
+  nl_rel_tol = 1e-9
+  nl_abs_tol = 1e-10
+  line_search = 'basic'
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Postprocessors]
+  active = 'num_nl cumulative contact'
+  [num_nl]
+    type = NumNonlinearIterations
+  []
+  [cumulative]
+    type = CumulativeValuePostprocessor
+    postprocessor = num_nl
+  []
+  [contact]
+    type = ContactDOFSetSize
+    variable = mortar_normal_lm
+    subdomain = 'mortar_secondary_subdomain'
+    execute_on = 'nonlinear timestep_end'
+  []
+[]
+
+[Outputs]
+[]

--- a/modules/contact/unit/inputs/frictionless_physical.i
+++ b/modules/contact/unit/inputs/frictionless_physical.i
@@ -1,0 +1,244 @@
+starting_point = 0.04
+offset = 0.00
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+  volumetric_locking_correction = true
+  # scaling=1/E so physical c_normal (= scalingFactor * C_nn_harmonic ~ 1)
+  # is far smaller than the default c_normal=1e6, making the gap visible.
+  scaling = 1e-4
+[]
+
+[Mesh]
+  [top_block]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 3
+    ny = 3
+    nz = 3
+    xmin = -0.25
+    xmax = 0.25
+    ymin = -0.25
+    ymax = 0.25
+    zmin = -0.25
+    zmax = 0.25
+    elem_type = HEX8
+  []
+  [rotate_top_block]
+    type = TransformGenerator
+    input = top_block
+    transform = ROTATE
+    vector_value = '0 0 0'
+  []
+  [top_block_sidesets]
+    type = RenameBoundaryGenerator
+    input = rotate_top_block
+    old_boundary = '0 1 2 3 4 5'
+    new_boundary = 'top_bottom top_back top_right top_front top_left top_top'
+  []
+  [top_block_id]
+    type = SubdomainIDGenerator
+    input = top_block_sidesets
+    subdomain_id = 1
+  []
+  [bottom_block]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 10
+    ny = 10
+    nz = 2
+    xmin = -.5
+    xmax = .5
+    ymin = -.5
+    ymax = .5
+    zmin = -.3
+    zmax = -.25
+    elem_type = HEX8
+  []
+  [bottom_block_id]
+    type = SubdomainIDGenerator
+    input = bottom_block
+    subdomain_id = 2
+  []
+  [bottom_block_change_boundary_id]
+    type = RenameBoundaryGenerator
+    input = bottom_block_id
+    old_boundary = '0 1 2 3 4 5'
+    new_boundary = '100 101 102 103 104 105'
+  []
+  [combined]
+    type = MeshCollectionGenerator
+    inputs = 'top_block_id bottom_block_change_boundary_id'
+  []
+  [block_rename]
+    type = RenameBlockGenerator
+    input = combined
+    old_block = '1 2'
+    new_block = 'top_block bottom_block'
+  []
+  [bottom_right_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = block_rename
+    new_boundary = bottom_right
+    block = bottom_block
+    normal = '1 0 0'
+  []
+  [bottom_left_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = bottom_right_sideset
+    new_boundary = bottom_left
+    block = bottom_block
+    normal = '-1 0 0'
+  []
+  [bottom_top_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = bottom_left_sideset
+    new_boundary = bottom_top
+    block = bottom_block
+    normal = '0 0 1'
+  []
+  [bottom_bottom_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = bottom_top_sideset
+    new_boundary = bottom_bottom
+    block = bottom_block
+    normal = '0  0 -1'
+  []
+  [bottom_front_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = bottom_bottom_sideset
+    new_boundary = bottom_front
+    block = bottom_block
+    normal = '0 1 0'
+  []
+  [bottom_back_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = bottom_front_sideset
+    new_boundary = bottom_back
+    block = bottom_block
+    normal = '0 -1 0'
+  []
+  allow_renumbering = false
+[]
+
+[Physics/SolidMechanics/QuasiStatic]
+  [all]
+    add_variables = true
+    strain = FINITE
+    block = '1 2'
+    use_automatic_differentiation = false
+  []
+[]
+
+[Materials]
+  [tensor]
+    type = ComputeIsotropicElasticityTensor
+    block = '1'
+    youngs_modulus = 1.0e4
+    poissons_ratio = 0.0
+  []
+  [stress]
+    type = ComputeFiniteStrainElasticStress
+    block = '1'
+  []
+  [tensor_1000]
+    type = ComputeIsotropicElasticityTensor
+    block = '2'
+    youngs_modulus = 1e5
+    poissons_ratio = 0.0
+  []
+  [stress_1000]
+    type = ComputeFiniteStrainElasticStress
+    block = '2'
+  []
+[]
+
+[Contact]
+  [mortar]
+    primary = 'bottom_top'
+    secondary = 'top_bottom'
+    formulation = mortar
+    model = frictionless
+  []
+[]
+
+[BCs]
+  [botx]
+    type = DirichletBC
+    variable = disp_x
+    boundary = 'bottom_left bottom_right bottom_front bottom_back'
+    value = 0.0
+  []
+  [boty]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 'bottom_left bottom_right bottom_front bottom_back'
+    value = 0.0
+  []
+  [botz]
+    type = DirichletBC
+    variable = disp_z
+    boundary = 'bottom_left bottom_right bottom_front bottom_back'
+    value = 0.0
+  []
+  [topx]
+    type = DirichletBC
+    variable = disp_x
+    boundary = 'top_top'
+    value = 0.0
+  []
+  [topy]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 'top_top'
+    value = 0.0
+  []
+  [topz]
+    type = FunctionDirichletBC
+    variable = disp_z
+    boundary = 'top_top'
+    function = '-${starting_point} * t / 0.125 + ${offset}'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  end_time = 0.125
+  dt = .025
+  dtmin = .001
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_type -pc_factor_shift_type -pc_factor_shift_amount -mat_mffd_err'
+  petsc_options_value = 'lu       superlu_dist                  NONZERO               1e-14                  1e-5'
+  l_max_its = 100
+  nl_max_its = 100
+  nl_rel_tol = 1e-9
+  nl_abs_tol = 1e-10
+  line_search = 'basic'
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Postprocessors]
+  active = 'num_nl cumulative contact'
+  [num_nl]
+    type = NumNonlinearIterations
+  []
+  [cumulative]
+    type = CumulativeValuePostprocessor
+    postprocessor = num_nl
+  []
+  [contact]
+    type = ContactDOFSetSize
+    variable = mortar_normal_lm
+    subdomain = 'mortar_secondary_subdomain'
+    execute_on = 'nonlinear timestep_end'
+  []
+[]
+
+[Outputs]
+[]

--- a/modules/contact/unit/src/FrictionProjectionTest.C
+++ b/modules/contact/unit/src/FrictionProjectionTest.C
@@ -1,0 +1,136 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest/gtest.h"
+
+#include "MortarContactUtils.h"
+
+#include <array>
+#include <cmath>
+
+namespace ContactUtils = Moose::Mortar::Contact;
+
+TEST(FrictionProjection, StickAndSlipRoots)
+{
+  const std::array<Real, 1> stick_pressure = {1.0};
+  const std::array<Real, 1> stick_augmented = {1.0};
+  const auto ac_stick =
+      ContactUtils::alartCurnierFrictionResidual(stick_pressure, stick_augmented, 2.0);
+  const auto hsw_stick =
+      ContactUtils::hueberStadlerWohlmuthFrictionResidual(stick_pressure, stick_augmented, 2.0);
+  EXPECT_DOUBLE_EQ(ac_stick[0], 0.0);
+  EXPECT_DOUBLE_EQ(hsw_stick[0], 0.0);
+
+  const std::array<Real, 1> slip_pressure = {2.0};
+  const std::array<Real, 1> slip_augmented = {4.0};
+  const auto ac_slip =
+      ContactUtils::alartCurnierFrictionResidual(slip_pressure, slip_augmented, 2.0);
+  const auto hsw_slip =
+      ContactUtils::hueberStadlerWohlmuthFrictionResidual(slip_pressure, slip_augmented, 2.0);
+  EXPECT_DOUBLE_EQ(ac_slip[0], 0.0);
+  EXPECT_DOUBLE_EQ(hsw_slip[0], 0.0);
+}
+
+TEST(FrictionProjection, SeparationAndAugmentedNormalSign)
+{
+  const Real open_augmented_pressure = ContactUtils::augmentedNormalPressure(1.0, 2.0);
+  EXPECT_DOUBLE_EQ(open_augmented_pressure, -1.0);
+  EXPECT_DOUBLE_EQ(ContactUtils::coulombFrictionRadius(0.5, open_augmented_pressure), 0.0);
+
+  const std::array<Real, 1> pressure = {0.0};
+  const std::array<Real, 1> augmented_pressure = {3.0};
+  const auto ac = ContactUtils::alartCurnierFrictionResidual(pressure, augmented_pressure, 0.0);
+  const auto hsw =
+      ContactUtils::hueberStadlerWohlmuthFrictionResidual(pressure, augmented_pressure, 0.0);
+  EXPECT_DOUBLE_EQ(ac[0], 0.0);
+  EXPECT_DOUBLE_EQ(hsw[0], 0.0);
+}
+
+TEST(FrictionProjection, ThreeDimensionalProjection)
+{
+  const std::array<Real, 2> augmented_pressure = {3.0, 4.0};
+  const auto projection = ContactUtils::projectToFrictionBall(augmented_pressure, 2.0);
+  EXPECT_DOUBLE_EQ(projection[0], 1.2);
+  EXPECT_DOUBLE_EQ(projection[1], 1.6);
+  EXPECT_DOUBLE_EQ(ContactUtils::tangentialNorm(projection), 2.0);
+}
+
+TEST(FrictionProjection, Homogeneity)
+{
+  const std::array<Real, 2> pressure = {0.7, -0.2};
+  const std::array<Real, 2> augmented_pressure = {2.0, -1.0};
+  const Real radius = 0.8;
+  const Real alpha = 3.0;
+  const std::array<Real, 2> scaled_pressure = {alpha * pressure[0], alpha * pressure[1]};
+  const std::array<Real, 2> scaled_augmented = {alpha * augmented_pressure[0],
+                                                alpha * augmented_pressure[1]};
+
+  const auto ac = ContactUtils::alartCurnierFrictionResidual(pressure, augmented_pressure, radius);
+  const auto ac_scaled =
+      ContactUtils::alartCurnierFrictionResidual(scaled_pressure, scaled_augmented, alpha * radius);
+  const auto hsw =
+      ContactUtils::hueberStadlerWohlmuthFrictionResidual(pressure, augmented_pressure, radius);
+  const auto hsw_scaled = ContactUtils::hueberStadlerWohlmuthFrictionResidual(
+      scaled_pressure, scaled_augmented, alpha * radius);
+
+  for (const auto i : index_range(pressure))
+  {
+    EXPECT_NEAR(ac_scaled[i], alpha * ac[i], 1e-14);
+    EXPECT_NEAR(hsw_scaled[i], alpha * alpha * hsw[i], 1e-14);
+  }
+}
+
+TEST(FrictionProjection, PositiveWeightRelationship)
+{
+  const std::array<Real, 2> pressure = {0.6, -0.1};
+  const std::array<Real, 2> augmented_pressure = {1.5, -0.5};
+  const Real radius = 0.9;
+  const Real weight = std::max(radius, ContactUtils::tangentialNorm(augmented_pressure));
+  ASSERT_GT(weight, 0.0);
+
+  const auto ac = ContactUtils::alartCurnierFrictionResidual(pressure, augmented_pressure, radius);
+  const auto hsw =
+      ContactUtils::hueberStadlerWohlmuthFrictionResidual(pressure, augmented_pressure, radius);
+  for (const auto i : index_range(pressure))
+    EXPECT_NEAR(hsw[i], weight * ac[i], 1e-14);
+}
+
+TEST(FrictionProjection, DegreeTwoPressureScaleCompensation)
+{
+  const std::array<Real, 2> pressure = {0.6, -0.1};
+  const std::array<Real, 2> augmented_pressure = {1.5, -0.5};
+  const Real radius = 0.9;
+  const Real pressure_scale = 2.0;
+  const Real alpha = 3.0;
+  const std::array<Real, 2> scaled_pressure = {alpha * pressure[0], alpha * pressure[1]};
+  const std::array<Real, 2> scaled_augmented = {alpha * augmented_pressure[0],
+                                                alpha * augmented_pressure[1]};
+
+  const auto hsw =
+      ContactUtils::hueberStadlerWohlmuthFrictionResidual(pressure, augmented_pressure, radius);
+  const auto hsw_scaled = ContactUtils::hueberStadlerWohlmuthFrictionResidual(
+      scaled_pressure, scaled_augmented, alpha * radius);
+  for (const auto i : index_range(pressure))
+    EXPECT_NEAR(hsw_scaled[i] / (alpha * pressure_scale), alpha * hsw[i] / pressure_scale, 1e-14);
+}
+
+TEST(FrictionProjection, DegreeTwoDegenerateState)
+{
+  const std::array<Real, 2> pressure = {2.0, -3.0};
+  const std::array<Real, 2> augmented_pressure = {0.0, 0.0};
+  const auto ac = ContactUtils::alartCurnierFrictionResidual(pressure, augmented_pressure, 0.0);
+  const auto hsw =
+      ContactUtils::hueberStadlerWohlmuthFrictionResidual(pressure, augmented_pressure, 0.0);
+
+  for (const auto i : index_range(pressure))
+  {
+    EXPECT_DOUBLE_EQ(ac[i], pressure[i]);
+    EXPECT_DOUBLE_EQ(hsw[i], pressure[i]);
+  }
+}

--- a/modules/contact/unit/src/PhysicalMortarConstantsTest.C
+++ b/modules/contact/unit/src/PhysicalMortarConstantsTest.C
@@ -1,0 +1,104 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest/gtest.h"
+
+#include "AppFactory.h"
+#include "Executioner.h"
+#include "FEProblemBase.h"
+#include "MooseConfig.h"
+#include "MooseMain.h"
+
+// 3-D mortar contact requires enough AD derivative slots for the coupled
+// displacement and LM DOFs on each element.
+#if MOOSE_AD_MAX_DOFS_PER_ELEM >= 250
+
+// Compute the absolute path to an input file stored alongside this source file in
+// ../inputs/ by navigating from __FILE__ (the absolute path to this .C file).
+static std::string
+inputPath(const std::string & name)
+{
+  const std::string src = __FILE__;
+  const auto pos = src.rfind("/src/");
+  return src.substr(0, pos + 1) + "inputs/" + name;
+}
+
+// Run the given input file with additional CLI args and return the cumulative
+// nonlinear iteration count accumulated by the "cumulative" postprocessor.
+static Real
+runCumulativeNL(const std::string & input,
+                const std::vector<std::string> & extra_args,
+                Real * contact_dofs = nullptr)
+{
+  // Build an argv suitable for Moose::createMooseApp
+  std::vector<std::string> str_args = {"contact-unit", "-i", inputPath(input)};
+  str_args.insert(str_args.end(), extra_args.begin(), extra_args.end());
+
+  std::vector<char *> argv_vec;
+  for (auto & s : str_args)
+    argv_vec.push_back(s.data());
+  int argc = static_cast<int>(argv_vec.size());
+
+  auto app = Moose::createMooseApp("ContactApp", argc, argv_vec.data());
+  app->run();
+  auto & problem = app->getExecutioner()->feProblem();
+  if (contact_dofs)
+    *contact_dofs = problem.getPostprocessorValueByName("contact");
+  return problem.getPostprocessorValueByName("cumulative");
+}
+
+// Verify that c_normal_strategy=physical reduces cumulative nonlinear iterations
+// compared to the default c_normal=1e6 for frictionless mortar contact.
+TEST(PhysicalMortarConstants, FrictionlessBeatsDefault)
+{
+  Real contact_dofs = 0;
+  const Real default_its = runCumulativeNL("frictionless_physical.i", {}, &contact_dofs);
+  EXPECT_GT(contact_dofs, 0) << "no contact DOFs active - test is not exercising contact";
+  const Real physical_its =
+      runCumulativeNL("frictionless_physical.i", {"Contact/mortar/c_normal_strategy=physical"});
+  EXPECT_LT(physical_its, default_its)
+      << "physical c_normal (" << physical_its
+      << " cumulative NL iters) should beat default c_normal=1e6 (" << default_its << " iters)";
+}
+
+// Verify that c_normal_strategy=physical + c_tangential_strategy=physical reduces
+// cumulative nonlinear iterations compared to default c_normal=1e6/c_tangential=1
+// for frictional (Coulomb) mortar contact with sliding.
+TEST(PhysicalMortarConstants, FrictionalBeatsDefault)
+{
+  Real contact_dofs = 0;
+  const Real default_its = runCumulativeNL("frictional_physical.i", {}, &contact_dofs);
+  EXPECT_GT(contact_dofs, 0) << "no contact DOFs active - test is not exercising contact";
+  const Real physical_its = runCumulativeNL(
+      "frictional_physical.i",
+      {"Contact/mortar/c_normal_strategy=physical", "Contact/mortar/c_tangential_strategy=physical"});
+  EXPECT_LT(physical_its, default_its)
+      << "physical c_normal+c_tangential (" << physical_its
+      << " cumulative NL iters) should beat defaults c_normal=1e6/c_tangential=1 (" << default_its
+      << " iters)";
+}
+
+// Verify that setting c_normal together with c_normal_strategy=physical is an error.
+TEST(PhysicalMortarConstants, CNormalSetWithPhysicalThrows)
+{
+  EXPECT_THROW(
+      runCumulativeNL("frictionless_physical.i",
+                      {"Contact/mortar/c_normal_strategy=physical", "Contact/mortar/c_normal=1e6"}),
+      std::exception);
+}
+
+// Verify that c_tangential_strategy=physical is rejected on a frictionless contact pair.
+TEST(PhysicalMortarConstants, CTangentialPhysicalOnFrictionlessThrows)
+{
+  EXPECT_THROW(runCumulativeNL("frictionless_physical.i",
+                               {"Contact/mortar/c_tangential_strategy=physical"}),
+               std::exception);
+}
+
+#endif // MOOSE_AD_MAX_DOFS_PER_ELEM >= 250


### PR DESCRIPTION
## Summary

- Correct the augmented-normal-pressure gap sign in the HSW friction residual.
- Replace the legacy open-pressure cutoff with the exact projection degeneracy treatment.
- Normalize the degree-two HSW row by the tangential pressure scale and apply the matching tangent right scale.
- Keep this PR HSW-only; it does not add the Alart-Curnier selector.

## Dependencies

- #33099: physical mortar scaling
- #33407: generic PETSc KSP right scaling
- #33408: mortar friction projection utilities

Performance and solver-work evidence is recorded in MortarPerformance.md. Remote performance timing remains required before merge.

Refs #32856