### PR TITLE
Use trust-region Newton for notched_plastic_block biaxial_planar

### DIFF
--- a/modules/solid_mechanics/test/tests/notched_plastic_block/biaxial_planar.i
+++ b/modules/solid_mechanics/test/tests/notched_plastic_block/biaxial_planar.i
@@ -255,8 +255,13 @@
   l_max_its = 200
   nl_max_its = 400
 
-  petsc_options_iname = '-pc_type -pc_asm_overlap -sub_pc_type -ksp_type -ksp_gmres_restart'
-  petsc_options_value = ' asm      2              lu            gmres     200'
+  # Trust-region Newton (with a smaller minimum trust radius than the PETSc default of 1e-12) is
+  # used here instead of the default line-search Newton because this problem drives the block to
+  # a widespread plastic failure state where the tangent stiffness is nearly singular; right at
+  # that point a line search can fail to find any accepting step length even though the Newton
+  # direction is fine, whereas trust-region shrinks and keeps trying until it converges.
+  petsc_options_iname = '-pc_type -pc_asm_overlap -sub_pc_type -ksp_type -ksp_gmres_restart -snes_type -snes_tr_deltamin'
+  petsc_options_value = ' asm      2              lu            gmres     200        newtontr    1e-18'
 []
 
 


### PR DESCRIPTION
closes #33420

## Reason

After #33006 merged, `solid_mechanics/test:notched_plastic_block.confined_uniaxial/biaxial_planar` started failing CI deterministically with `DIVERGED_LINE_SEARCH`. Bisected to `928aa49f021` ("Dispatch RankFourTensor R4xR2 product to Eigen for Real tensors") — see #33420 for the full investigation. The new implementation is algebraically identical to the old scalar loop; the only difference is floating-point summation order, but that's enough to tip this test's near-singular tangent stiffness (block driven to widespread plastic failure) past what the default line-search Newton can handle.

## Design

Switch this one test's PETSc options from the default line-search Newton to trust-region Newton (`-snes_type newtontr`) with a smaller minimum trust radius (`-snes_tr_deltamin 1e-18` vs. the PETSc default `1e-12`). This lets the solver shrink its step and keep trying past the rough patch instead of giving up when no single accepting step length can be found along the (perfectly fine) Newton direction.

## Impact

Test-only change, scoped to `biaxial_planar.i`'s `[Executioner]` block. No change to the RankFourTensor optimization or any other test:
- `biaxial_planar` now converges via the test's existing `nl_rel_tol` (no MOOSE-level tolerances loosened) and reproduces the exact `s_zz` values already in the gold CSV — no gold regeneration needed.
- The other 7 sibling tests in `notched_plastic_block/tests` (`cmc_planar`, `cmc_smooth`, `biaxial_abbo`, `biaxial_smooth_{cos,poly1,poly2,poly3}`) are untouched and still pass.

## Test plan
- [x] `./run_tests --re notched_plastic_block --heavy`: 8 passed, 0 failed (was 1 failed before this change)
- [x] Reproduced the original failure at the exact CI commit (517b7e09e4) locally, confirmed this fix resolves it there
