### PR TITLE
Update packages, switch to docker builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libmesh"]
     path = libmesh
-    url = ../../libMesh/libmesh
+    url = ../../loganharbour/libmesh
     ignore = dirty
 [submodule "large_media"]
     path = large_media

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -13,7 +13,6 @@
 {#- MOOSE_SKIP_DOCS: Set to anything to skip the docs build                                   -#}
 {#- MOOSE_DOCS_FLAGS: Doc options to pass during the make install                             -#}
 {#- METHOD: The method to build; defaults to "opt"                                            -#}
-{#- OPTFLAGS: Optimization flags to set when building                                         -#}
 {#- SKIP_FINGERPRINTS: Set to skip fingerprint verification                                   -#}
 {#- TEST_DIRS: Directories to test in the %test section; defaults to just "tests"             -#}
 {#- WITH_LIBTORCH: Set to enable libtorch                                                     -#}
@@ -124,14 +123,6 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     TEMP_LOC={{ ROOT_BUILD_DIR }}
     APPLICATION_DIR=${TEMP_LOC}/${APPLICATION_NAME}
     export MOOSE_DIR=${TEMP_LOC}/moose
-
-    # Optimization flags
-{%- if OPTFLAGS is not defined %}
-    OPTFLAGS=("-march=$(default_march)" "-mtune=generic")
-{%- else %}
-    IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
-{%- endif %}
-    export ADDITIONAL_CPPFLAGS="${OPTFLAGS[*]}"
 
     # Load WITH_XXX variables
     if_true() {

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -1,46 +1,48 @@
-{#- Required jinja arguments                                                                  -#}
-{#- APPTAINER_BOOTSTRAP: The BootStrap to use (typically localimage or oras)                  -#}
-{#- APPTAINER_FROM: The From to use (path to an image or an oras URI)                         -#}
-{#- APPLICATION_DIR: Path on the host to the application repository                           -#}
-{#- MOOSE_DIR: Path on the host to the MOOSE repository                                       -#}
-{#- BINARY_NAME: Name of the application binary                                               -#}
+{#-
+   Required jinja arguments:
 
-{#- Optional jinja arguments                                                                  -#}
-{#- EXTRA_MAMBA_PACKAGES: Extra mamba packages to install                                     -#}
-{#- EXTRA_BINARIES: Colon separated list of extra binaries that this application installs     -#}
-{#- MOOSE_JOBS: Number of jobs to pass to the build                                           -#}
-{#- MOOSE_OPTIONS: Options to pass to the MOOSE configure                                     -#}
-{#- MOOSE_SKIP_DOCS: Set to anything to skip the docs build                                   -#}
-{#- MOOSE_DOCS_FLAGS: Doc options to pass during the make install                             -#}
-{#- METHOD: The method to build; defaults to "opt"                                            -#}
-{#- SKIP_FINGERPRINTS: Set to skip fingerprint verification                                   -#}
-{#- TEST_DIRS: Directories to test in the %test section; defaults to just "tests"             -#}
-{#- WITH_LIBTORCH: Set to enable libtorch                                                     -#}
-{#- WITH_MFEM : Set to enable mfem                                                            -#}
-{#- WITH_NEML2: Set to enable neml2 (sets WITH_LIBTORCH=1)                                    -#}
+   - APPLICATION_DIR: Path on the host to the application repository
+   - APPTAINER_BOOTSTRAP: The BootStrap to use (typically localimage or oras)
+   - APPTAINER_FROM: The From to use (path to an image or an oras URI)
+   - BINARY_NAME: Name of the application binary
+   - MOOSE_DIR: Path on the host to the MOOSE repository
+   - PETSC_GIT_REMOTE: The git remote to use to get PETSc
+   - PETSC_GIT_SHA: The git SHA to use for PETSc
 
-{#- Civet Specific jinja arguments                                                            -#}
-{#- CIVET_STEP_ALLOWED_TO_FAIL: BOOL, specific to Civet. Available in %post, %test section    -#}
+   Optional jinja arguments:
 
-{#- Optional Application specific jinja arguments                                             -#}
-{#- SECTION_ENVIRONMENT: Adds additional environment variables set upon entering container    -#}
-{#- SECTION_POST: Partially replaces %post (make, make install, section)                      -#}
-{#- SECTION_TEST: Partially replaces %test (for loop section)                                 -#}
+   - EXTRA_BINARIES: Colon separated list of extra binaries that this application installs
+   - METHOD: The method to build (default: opt)
+   - MOOSE_DOCS_FLAGS: Doc options to pass during the make install
+   - MOOSE_JOBS: Number of jobs to pass to the PETSc build script
+   - MOOSE_OPTIONS: Options to pass to the MOOSE configure
+   - MOOSE_SKIP_DOCS: Set to anything to skip the docs build
+   - SECTION_ENVIRONMENT: Adds additional environment variables set upon entering container
+   - SECTION_POST: Partially replaces %post (make, make install, section)
+   - SECTION_TEST: Partially replaces %test (for loop section)
+   - SKIP_FINGERPRINTS: Set to skip fingerprint verification (truthy, default: false)
+   - TEST_DIRS: Directories to test in the %test section; (default: tests)
+   - WITH_LIBTORCH: Set to enable libtorch (truthy, default: false)
+   - WITH_MFEM : Set to enable mfem (truthy, default: false)
+   - WITH_NEML2: Set to enable neml2 (truthy, default: false)
 
-{#- The within-container build directory to use                                               -#}
-{%- set ROOT_BUILD_DIR = '/root/build' -%}
-{#- Set method if not set                                                                     -#}
-{%- if METHOD is not defined %}
-{%- set METHOD = 'opt' -%}
-{%- endif %}
-{#- Set default test dirs if not set                                                          -#}
-{%- if TEST_DIRS is not defined %}
-{%- set TEST_DIRS = 'tests' -%}
-{%- endif %}
+-#}
+
+{#- Set defaults for any variables not provided                -#}
+{%- set METHOD = METHOD | default('opt')                       -%}
+{%- set SKIP_FINGERPRINTS = SKIP_FINGERPRINTS | default(false) -%}
+{%- set TEST_DIRS = TEST_DIRS | default('tests')               -%}
+{%- set WITH_LIBTORCH = WITH_LIBTORCH | default(false)         -%}
+{%- set WITH_MFEM = WITH_MFEM | default(false)                 -%}
+{%- set WITH_NEML2 = WITH_NEML2 | default(false)               -%}
+
+{#- Installation locations and build scripts for third-party dependencies -#}
+{%- set PETSC_DIR = '/opt/petsc'                                          -%}
+{%- set ROOT_BUILD_DIR = '/root/build'                                    -%}
 
 BootStrap: {{ APPTAINER_BOOTSTRAP }}
 From: {{ APPTAINER_FROM }}
-{%- if SKIP_FINGERPRINTS is not defined %}
+{%- if not SKIP_FINGERPRINTS | to_bool %}
 # MOOSE-NCRC key
 Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 {%- endif %}
@@ -124,16 +126,9 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     APPLICATION_DIR=${TEMP_LOC}/${APPLICATION_NAME}
     export MOOSE_DIR=${TEMP_LOC}/moose
 
-    # Load WITH_XXX variables
-    if_true() {
-        local val="${1,,}"  # Convert to lowercase
-        if [[ "$val" == "1" || "$val" == "true" || "$val" == "on" ]]; then
-            echo "1"
-        fi
-    }
-    WITH_LIBTORCH=$(if_true "{{ WITH_LIBTORCH }}")
-    WITH_MFEM=$(if_true "{{ WITH_MFEM }}")
-    WITH_NEML2=$(if_true "{{ WITH_NEML2 }}")
+    WITH_LIBTORCH={{ '1' if (WITH_LIBTORCH | to_bool) else ''}}
+    WITH_MFEM={{ '1' if (WITH_MFEM | to_bool) else ''}}
+    WITH_NEML2={{ '1' if (WITH_NEML2 | to_bool) else ''}}
     unset -f if_true
     if [ -n "$WITH_NEML2" ] && [ -z "$WITH_LIBTORCH" ]; then
         echo "Must set WITH_LIBTORCH if using WITH_NEML2"

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -104,7 +104,12 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     {{ SECTION_ENVIRONMENT }}
 {%- endif %}
 
-%post
+%post -c /bin/bash
+    set -uexo pipefail
+
+    source /.singularity.d/os_functions.sh
+    update_system_packages
+
 {%- if SECTION_POST_BEGIN is defined %}
     {{ SECTION_POST_BEGIN }}
 {%- endif %}
@@ -254,6 +259,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 {%- endif %}
     # Cleanup
     rm -rf $TEMP_LOC
+    clean_system_packages
 
 %test
     # If we're using openmpi, we need to allow running as root

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -13,6 +13,7 @@
 {#- MOOSE_SKIP_DOCS: Set to anything to skip the docs build                                   -#}
 {#- MOOSE_DOCS_FLAGS: Doc options to pass during the make install                             -#}
 {#- METHOD: The method to build; defaults to "opt"                                            -#}
+{#- OPTFLAGS: Optimization flags to set when building                                         -#}
 {#- SKIP_FINGERPRINTS: Set to skip fingerprint verification                                   -#}
 {#- TEST_DIRS: Directories to test in the %test section; defaults to just "tests"             -#}
 {#- WITH_LIBTORCH: Set to enable libtorch                                                     -#}
@@ -118,6 +119,14 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     TEMP_LOC={{ ROOT_BUILD_DIR }}
     APPLICATION_DIR=${TEMP_LOC}/${APPLICATION_NAME}
     export MOOSE_DIR=${TEMP_LOC}/moose
+
+    # Optimization flags
+{%- if OPTFLAGS is not defined %}
+    OPTFLAGS=("-march=x86-64-v3" "-mtune=generic")
+{%- else %}
+    IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
+{%- endif %}
+    export ADDITIONAL_CPPFLAGS="${OPTFLAGS[*]}"
 
     # Load WITH_XXX variables
     if_true() {

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -107,7 +107,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 %post -c /bin/bash
     set -uexo pipefail
 
-    source /.singularity.d/os_functions.sh
+    source /.singularity.d/build_utils.sh
     update_system_packages
 
 {%- if SECTION_POST_BEGIN is defined %}
@@ -127,7 +127,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 
     # Optimization flags
 {%- if OPTFLAGS is not defined %}
-    OPTFLAGS=("-march=x86-64-v3" "-mtune=generic")
+    OPTFLAGS=("-march=$(default_march)" "-mtune=generic")
 {%- else %}
     IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
 {%- endif %}

--- a/apptainer/files/mpi/.singularity.d/build_utils.sh
+++ b/apptainer/files/mpi/.singularity.d/build_utils.sh
@@ -44,3 +44,26 @@ clean_system_packages() {
         rm -rf /var/lib/apt/lists/*
     fi
 }
+
+default_march() {
+    if ! command -v mpicxx >/dev/null 2>&1; then
+        echo "mpicxx not found" >&2
+        return 1
+    fi
+
+    COMPILER="$(mpicxx -show | awk '{print $1}')"
+
+    if "$COMPILER" --version | grep -qi clang; then
+        echo "x86-64-v3"
+    elif "$COMPILER" --version | grep -qi "gcc\|g++"; then
+        GCC_MAJOR=$("$COMPILER" -dumpfullversion -dumpversion | cut -d. -f1)
+        if [ "$GCC_MAJOR" -ge 10 ]; then
+            echo "x86-64-v3"
+        else
+            echo "haswell"
+        fi
+    else
+        echo "unknown compiler" >&2
+        return 1
+    fi
+}

--- a/apptainer/files/mpi/.singularity.d/build_utils.sh
+++ b/apptainer/files/mpi/.singularity.d/build_utils.sh
@@ -64,17 +64,12 @@ default_march() {
 
     COMPILER="$(mpicxx -show | awk '{print $1}')"
 
-    if "$COMPILER" --version | grep -qi clang; then
-        echo "x86-64-v3"
-    elif "$COMPILER" --version | grep -qi "gcc\|g++"; then
+    if "$COMPILER" --version | grep -qi "gcc\|g++"; then
         GCC_MAJOR=$("$COMPILER" -dumpfullversion -dumpversion | cut -d. -f1)
-        if [ "$GCC_MAJOR" -ge 10 ]; then
-            echo "x86-64-v3"
-        else
+        if [ "$GCC_MAJOR" -lt 10 ]; then
             echo "haswell"
+            return 0
         fi
-    else
-        echo "unknown compiler" >&2
-        return 1
     fi
+    echo "x86-64-v3"
 }

--- a/apptainer/files/mpi/.singularity.d/build_utils.sh
+++ b/apptainer/files/mpi/.singularity.d/build_utils.sh
@@ -5,36 +5,44 @@ if ! which grep; then
     exit 1
 fi
 
+# Whether or not the operating system is rocky-based,
 is_rocky() {
     if ! grep -q "NAME=\"Rocky" /etc/os-release; then
         return 1
     fi
 }
 
+# Whether or not the operating system is rocky 8,
 is_rocky8() {
     if is_rocky && ! grep -q 'VERSION=\"8.' /etc/os-release; then
         return 1
     fi
 }
 
+# Whether or not the operating system is rocky 9,
 is_rocky9() {
     if is_rocky && ! grep -q 'VERSION=\"9.' /etc/os-release; then
         return 1
     fi
 }
 
+# Whether or not the operating system is ubuntu,
 is_ubuntu() {
     if ! grep -q "NAME=\"Ubuntu" /etc/os-release; then
         return 1
     fi
 }
 
+# Update the system packages. Useful at the beginning of
+# a build, in which ubuntu requires an update before installing,
 update_system_packages() {
     if is_ubuntu; then
         apt-get update
     fi
 }
 
+# Cleanup the system packages. Useful at the end of a build,
+# in which the downloaded package cache should be cleaned up.
 clean_system_packages() {
     if is_rocky; then
         dnf clean all
@@ -45,6 +53,9 @@ clean_system_packages() {
     fi
 }
 
+# Determine the default value for -march for a build. Needed
+# because older compilers (GCC 9, our minimum) do not support
+# things like "x86-64-v3".
 default_march() {
     if ! command -v mpicxx >/dev/null 2>&1; then
         echo "mpicxx not found" >&2

--- a/apptainer/files/mpi/.singularity.d/os_functions.sh
+++ b/apptainer/files/mpi/.singularity.d/os_functions.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+if ! which grep; then
+    echo "grep is not available"
+    exit 1
+fi
+
+is_rocky() {
+    if ! grep -q "NAME=\"Rocky" /etc/os-release; then
+        return 1
+    fi
+}
+
+is_rocky8() {
+    if is_rocky && ! grep -q 'VERSION=\"8.' /etc/os-release; then
+        return 1
+    fi
+}
+
+is_rocky9() {
+    if is_rocky && ! grep -q 'VERSION=\"9.' /etc/os-release; then
+        return 1
+    fi
+}
+
+is_ubuntu() {
+    if ! grep -q "NAME=\"Ubuntu" /etc/os-release; then
+        return 1
+    fi
+}
+
+update_system_packages() {
+    if is_ubuntu; then
+        apt-get update
+    fi
+}
+
+clean_system_packages() {
+    if is_rocky; then
+        dnf clean all
+    elif is_ubuntu; then
+        apt-get autoremove -y
+        apt-get clean
+        rm -rf /var/lib/apt/lists/*
+    fi
+}

--- a/apptainer/libmesh.def
+++ b/apptainer/libmesh.def
@@ -1,36 +1,38 @@
-{#- Required jinja arguments                                                                  -#}
-{#- APPTAINER_BOOTSTRAP: The BootStrap to use (typically localimage or oras)                  -#}
-{#- APPTAINER_FROM: The From to use (path to an image or an oras URI)                         -#}
-{#- LIBMESH_GIT_SHA: The git SHA to use for libmesh                                           -#}
-{#- LIBMESH_GIT_REMOTE: The git remote to use to get libmesh                                  -#}
-{#- MOOSE_DIR: Path on the host to the MOOSE repository                                       -#}
-{#- vtk_url: URL to download VTK                                                              -#}
-{#- vtk_sha256: The shasum for downloaded file                                                -#}
-{#- vtk_vtk_friendly_version: The short version name. vtk_vtk_ is not a typo                  -#}
+{#-
+   Required jinja arguments:
 
-{#- Optional jinja arguments                                                                  -#}
-{#- LIBMESH_OPTIONS: Options to pass to the libMesh build script                              -#}
-{#- MOOSE_JOBS: Number of jobs to pass to the libMesh build script                            -#}
-{#- METHODS: Methods to build (defaults to all methods)                                       -#}
-{#- OPTFLAGS: Optimization flags to set when building                                         -#}
-{#- SKIP_FINGERPRINTS: Set to skip fingerprint verification                                   -#}
+   - APPTAINER_BOOTSTRAP: The BootStrap to use (typically localimage or oras)
+   - APPTAINER_FROM: The From to use (path to an image or an oras URI)
+   - LIBMESH_GIT_REMOTE: The git remote to use to get libmesh
+   - LIBMESH_GIT_SHA: The git SHA to use for libmesh
+   - PETSC_GIT_SHA: The git SHA to use for PETSc
+   - vtk_url: URL to download VTK
+   - vtk_sha256: The shasum for the VTK download file
+   - vtk_vtk_friendly_version: The short version name for VTK; vtk_vtk_ is not a typo
 
-{#- The within-container build directory to use                                               -#}
-{%- set ROOT_BUILD_DIR = '/root/build' -%}
+   Optional jinja arguments:
 
-{#- The installation location for libMesh                                                     -#}
-{%- set LIBMESH_DIR = '/opt/libmesh' -%}
+   - LIBMESH_OPTIONS: Options to pass to the libMesh build script
+   - METHODS: Methods to build (default: dbg devel oprof opt)
+   - MOOSE_JOBS: Number of jobs to pass to the libmesh build script
+   - OPTFLAGS: Optimization flags to set when building
+   - SKIP_FINGERPRINTS: Set to skip fingerprint verification (truthy, default: false)
+-#}
 
-{#- The installation location for VTK                                                         -#}
-{%- set VTK_DIR = '/opt/vtk' -%}
+{#- Set defaults for any variables not provided                      -#}
+{%- set METHODS           = METHODS | default("dbg devel oprof opt") -%}
+{%- set SKIP_FINGERPRINTS = SKIP_FINGERPRINTS | default(false)       -%}
 
-{#- Libmesh install scripts                                                                   -#}
-{%- set LIBMESH_BUILD_SCRIPT = 'update_and_rebuild_libmesh.sh' -%}
-{%- set LIBMESH_CONFIGURE_SCRIPT = 'configure_libmesh.sh' -%}
+{#- Installation locations and build scripts for third-party dependencies -#}
+{%- set LIBMESH_BUILD_SCRIPT = 'update_and_rebuild_libmesh.sh'            -%}
+{%- set LIBMESH_CONFIGURE_SCRIPT = 'configure_libmesh.sh'                 -%}
+{%- set LIBMESH_DIR = '/opt/libmesh'                                      -%}
+{%- set ROOT_BUILD_DIR = '/root/build'                                    -%}
+{%- set VTK_DIR = '/opt/vtk'                                              -%}
 
 BootStrap: {{ APPTAINER_BOOTSTRAP }}
 From: {{ APPTAINER_FROM }}
-{%- if SKIP_FINGERPRINTS is not defined %}
+{%- if not SKIP_FINGERPRINTS | to_bool %}
 # MOOSE-NCRC key
 Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 {%- endif %}
@@ -127,7 +129,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
         git submodule update --init --depth 1 --recursive
 
         # Determine libMesh flags and options
-        METHODS="{{ METHODS or "opt dbg oprof devel" }}"
+        METHODS="{{ METHODS }}"
         IFS=' ' read -r -a LIBMESH_ARR_OPTIONS <<< "{{ LIBMESH_OPTIONS }}"
         SUB_LDFLAGS=""
         if [ -n "${CUDA_DIR:-}" ]; then

--- a/apptainer/libmesh.def
+++ b/apptainer/libmesh.def
@@ -53,7 +53,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 
     # Optimization flags
 {%- if OPTFLAGS is not defined %}
-    OPTFLAGS=("-march=x86-64-v3" "-mtune=generic")
+    OPTFLAGS=("-march=$(default_march)" "-mtune=generic")
 {%- else %}
     IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
 {%- endif %}

--- a/apptainer/libmesh.def
+++ b/apptainer/libmesh.def
@@ -40,11 +40,8 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     export VTKINCLUDE_DIR={{ VTK_DIR }}/include/vtk-{{ vtk_vtk_friendly_version }}
     export VTKLIB_DIR={{ VTK_DIR }}/lib
 
-%post
-    # So that piping things to tee fails
-    set -o pipefail
-    # Be careful about unknown variables
-    set -u
+%post -c /bin/bash
+    set -uexo pipefail
 
     ROOT_BUILD_DIR={{ ROOT_BUILD_DIR }}
     export MOOSE_JOBS={{ MOOSE_JOBS }}
@@ -167,7 +164,6 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 
     # Cleanup
     rm -rf ${ROOT_BUILD_DIR}
-    dnf clean all
 
 %files
     {{ MOOSE_DIR }}/scripts/{{ LIBMESH_BUILD_SCRIPT }} {{ ROOT_BUILD_DIR }}/scripts/{{ LIBMESH_BUILD_SCRIPT }}

--- a/apptainer/libmesh.def
+++ b/apptainer/libmesh.def
@@ -43,6 +43,8 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 %post -c /bin/bash
     set -uexo pipefail
 
+    source /.singularity.d/build_utils.sh
+
     ROOT_BUILD_DIR={{ ROOT_BUILD_DIR }}
     export MOOSE_JOBS={{ MOOSE_JOBS }}
 

--- a/apptainer/libmesh.def
+++ b/apptainer/libmesh.def
@@ -12,6 +12,7 @@
 {#- LIBMESH_OPTIONS: Options to pass to the libMesh build script                              -#}
 {#- MOOSE_JOBS: Number of jobs to pass to the libMesh build script                            -#}
 {#- METHODS: Methods to build (defaults to all methods)                                       -#}
+{#- OPTFLAGS: Optimization flags to set when building                                         -#}
 {#- SKIP_FINGERPRINTS: Set to skip fingerprint verification                                   -#}
 
 {#- The within-container build directory to use                                               -#}
@@ -53,6 +54,13 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
         export LD_LIBRARY_PATH=${CUDA_DIR}/compat:${LD_LIBRARY_PATH:-}
     fi
 
+    # Optimization flags
+{%- if OPTFLAGS is not defined %}
+    OPTFLAGS=("-march=x86-64-v3" "-mtune=generic")
+{%- else %}
+    IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
+{%- endif %}
+
     # Build VTK
     (
         cd ${ROOT_BUILD_DIR}
@@ -92,7 +100,9 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
             -DVTK_GROUP_ENABLE_Rendering:STRING=DONT_WANT \
             -DVTK_GROUP_ENABLE_Qt::STRING=NO \
             -DVTK_GROUP_ENABLE_Views:STRING=NO \
-            -DVTK_GROUP_ENABLE_Web:STRING=NO 2>&1 | tee ${VTK_LOGS}/cmake.log
+            -DVTK_GROUP_ENABLE_Web:STRING=NO \
+            -DCMAKE_C_FLAGS="${OPTFLAGS[*]}" \
+            -DCMAKE_CXX_FLAGS="${OPTFLAGS[*]}" 2>&1 | tee ${VTK_LOGS}/cmake.log
         cmake --build . --parallel ${MOOSE_JOBS} 2>&1 | tee ${VTK_LOGS}/build.log
         cmake --install . 2>&1 | tee ${VTK_LOGS}/install.log
 
@@ -140,7 +150,13 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
         METHODS=${METHODS} \
             ./scripts/{{ LIBMESH_BUILD_SCRIPT }} \
                 "${LIBMESH_ARR_OPTIONS[@]}" \
-                --skip-submodule-update 2>&1 | tee ${LIBMESH_LOGS}/build.log
+                --skip-submodule-update \
+                CFLAGS="${OPTFLAGS[*]}" \
+                CXXFLAGS="${OPTFLAGS[*]}" \
+                FCFLAGS="${OPTFLAGS[*]}" \
+                libmesh_CFLAGS="${OPTFLAGS[*]}" \
+                libmesh_CXXFLAGS="${OPTFLAGS[*]}" \
+                libmesh_FCFLAGS="${OPTFLAGS[*]}" 2>&1 | tee ${LIBMESH_LOGS}/build.log
         cp ${LIBMESH_SRC_DIR}/build/config.log ${LIBMESH_LOGS}/
 
         # Cleanup

--- a/apptainer/moose-dev.def
+++ b/apptainer/moose-dev.def
@@ -20,13 +20,21 @@
 {#- PYTORCH_GIT_SHA: The git SHA to use for pytorch                                           -#}
 {#- PYTORCH_GIT_REMOTE: The git remote to use to get pytorch                                  -#}
 {#- SKIP_FINGERPRINTS: Set to skip fingerprint verification                                   -#}
-{#- WITH_MFEM: Whether or not to build mfem (default: 1 to build, 0 to not build)             -#}
-{#- WITH_FMU: Whether or not to install python fmu utilities (default: false)                 -#}
-{#- WITHOUT_PYTORCH: Set to anything to not build/download pytorch and neml2                  -#}
+{#- WITH_MFEM: Whether or not to build mfem (truthy, default: true)                           -#}
+{#- WITH_FMU: Whether or not to install python fmu utilities (truthy, default: false)         -#}
+{#- WITHOUT_PYTORCH: Whether to not build pytorch and neml2 (truthy, default: false)          -#}
 
 {#- Set WITH_MFEM default if not set                                                          -#}
 {%- if WITH_MFEM is not defined %}
-{%- set WITH_MFEM = '1' %}
+{%- set WITH_MFEM = True %}
+{%- endif %}
+{#- Set WITH_FMU default if not set                                                           -#}
+{%- if WITH_FMU is not defined %}
+{%- set WITH_FMU = False %}
+{%- endif %}
+{#- Set WITHOUT_PYTORCH default if not set                                                    -#}
+{%- if WITHOUT_PYTORCH is not defined %}
+{%- set WITHOUT_PYTORCH = False %}
 {%- endif %}
 
 {#- The within-container build directory to use                                               -#}
@@ -83,7 +91,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     test -d {{ MFEM_DIR }} && export MFEM_DIR={{ MFEM_DIR }}
 {%- endif %}
 
-{% if WITHOUT_PYTORCH is not defined %}
+{% if not (WITHOUT_PYTORCH | to_bool) %}
     test -d {{ LIBTORCH_DIR }} && export LIBTORCH_DIR={{ LIBTORCH_DIR }}
     test -d {{ NEML2_DIR }} && export NEML2_DIR={{ NEML2_DIR }}
 {%- endif %}
@@ -111,7 +119,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     MOOSE_LANGUAGE_SUPPORT_VERSION=1.5.2
     # python
     PYTHON_VERSION=3.14.6
-{% if WITH_FMU %}
+{% if WITH_FMU | to_bool %}
     # PyFMI python package and its dependencies
     FMI_LIBRARY_VERSION=3.0.4
     ASSIMULO_VERSION=3.8.0
@@ -388,7 +396,7 @@ EOF
     )
 {%- endif %}
 
-{% if WITHOUT_PYTORCH is not defined %}
+{% if not (WITHOUT_PYTORCH | to_bool) %}
     # Build libtorch
     (
         cd ${ROOT_BUILD_DIR}
@@ -500,7 +508,7 @@ EOF
         export LD_LIBRARY_PATH=${CUDA_DIR}/compat:${LD_LIBRARY_PATH:-}
     fi
 
-{% if WITHOUT_PYTORCH is not defined %}
+{% if not (WITHOUT_PYTORCH | to_bool) %}
     # Build neml2
     (
         cd ${ROOT_BUILD_DIR}
@@ -541,7 +549,7 @@ EOF
     )
 {%- endif %}
 
-{%- if WITH_MFEM %}
+{%- if WITH_MFEM | to_bool %}
     # Build conduit
     (
         cd ${ROOT_BUILD_DIR}
@@ -643,7 +651,7 @@ EOF
     # mfem
     {{ MOOSE_DIR }}/scripts/{{ MFEM_BUILD_SCRIPT }} {{ ROOT_BUILD_DIR }}/{{ MFEM_BUILD_SCRIPT }}
     {{ MOOSE_DIR }}/scripts/{{ CONDUIT_BUILD_SCRIPT }} {{ ROOT_BUILD_DIR }}/{{ CONDUIT_BUILD_SCRIPT }}
-{% if WITHOUT_PYTORCH is not defined %}
+{% if not (WITHOUT_PYTORCH | to_bool) %}
     # libtorch
     {{ MOOSE_DIR }}/scripts/configure_libtorch.sh {{ ROOT_BUILD_DIR }}/configure_libtorch.sh
     # neml2

--- a/apptainer/moose-dev.def
+++ b/apptainer/moose-dev.def
@@ -95,13 +95,11 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     export METHOD=oprof
 {%- endif %}
 
-%post
-    umask 022
+%post -c /bin/bash
+    set -uexo pipefail
 
-    # So that piping things to tee fails
-    set -o pipefail
-    # Be careful about unknown variables
-    set -u
+    source /.singularity.d/os_functions.sh
+    update_system_packages
 
     ROOT_BUILD_DIR={{ ROOT_BUILD_DIR }}
     export MOOSE_JOBS={{ MOOSE_JOBS }}
@@ -156,7 +154,11 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
                 export LD_LIBRARY_PATH=${CUDA_DIR}/compat:${LD_LIBRARY_PATH:-}
             fi
             if mpiexec --version | grep -q hwloc; then
-                dnf install -y hwloc-gui
+                if is_rocky; then
+                    dnf install -y hwloc-gui
+                elif is_ubuntu; then
+                    apt-get install -y --no-install-recommends hwloc-nox
+                fi
             fi
         )
     fi
@@ -177,11 +179,18 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 
         CODE_SERVER_DIR={{ CODE_SERVER_DIR }}
 
-        # Install code-server rpm
-        CODE_SERVER_FILE=code-server-${CODE_SERVER_VERSION}-amd64.rpm
-        curl -fOL https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/${CODE_SERVER_FILE}
-        rpm -i ${CODE_SERVER_FILE}
-        rm ${CODE_SERVER_FILE}
+        # Install code-server
+        if is_rocky; then
+            CODE_SERVER_FILE=code-server-${CODE_SERVER_VERSION}-amd64.rpm
+            curl -fOL https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/${CODE_SERVER_FILE}
+            rpm -i ${CODE_SERVER_FILE}
+            rm ${CODE_SERVER_FILE}
+        elif is_ubuntu; then
+            CODE_SERVER_FILE=code-server_${CODE_SERVER_VERSION}_amd64.deb
+            curl -fOL https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/${CODE_SERVER_FILE}
+            apt install ./${CODE_SERVER_FILE}
+            rm ${CODE_SERVER_FILE}
+        fi
 
         # Setup directory for code-server extensions. The extensions folder can be
         # filled by other applications as they wish to have extensions auto installed
@@ -216,6 +225,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
         mkdir -p ${WASP_LOGS}
         WASP_SRC_DIR=${WASP_SRC_DIR} \
             ${ROOT_BUILD_DIR}/{{ WASP_BUILD_SCRIPT }} \
+                -DCMAKE_CXX_FLAGS="${OPTFLAGS[*]}" \
                 -DCMAKE_INSTALL_PREFIX:STRING=${WASP_DIR} 2>&1 | tee ${WASP_LOGS}/build.log
 
         # Cleanup
@@ -610,10 +620,15 @@ EOF
 {%- endif %}
 
     # Install node.js. Requested by dschwen for bison
-    dnf install -y nodejs npm
+    INSTALLS=("nodejs" "npm")
+    if is_rocky; then
+        dnf install -y "${INSTALLS[@]}"
+    elif is_ubuntu; then
+        apt-get install -y --no-install-recommends "${INSTALLS[@]}"
+    fi
 
     # Clean up
-    dnf clean all
+    clean_system_packages
     rm -rf ${ROOT_BUILD_DIR}
 
 %files

--- a/apptainer/moose-dev.def
+++ b/apptainer/moose-dev.def
@@ -28,30 +28,30 @@
    - WITHOUT_PYTORCH: Whether to not build pytorch and neml2 (truthy, default: false)
 -#}
 
-{#- Set defaults for any variables not provided                                               -#}
-{%- set PROFILING         = PROFILING | default(false) %}
+{#- Set defaults for any variables not provided                #}
+{%- set PROFILING         = PROFILING | default(false)         %}
 {%- set SKIP_FINGERPRINTS = SKIP_FINGERPRINTS | default(false) %}
-{%- set WITH_MFEM         = WITH_MFEM | default(true) %}
-{%- set WITH_FMU          = WITH_FMU | default(false) %}
-{%- set WITHOUT_PYTORCH   = WITHOUT_PYTORCH | default(false) %}
+{%- set WITH_MFEM         = WITH_MFEM | default(true)          %}
+{%- set WITH_FMU          = WITH_FMU | default(false)          %}
+{%- set WITHOUT_PYTORCH   = WITHOUT_PYTORCH | default(false)   %}
 
-{#- Installation locations and build scripts for third-party dependencies                     -#}
-{%- set CODE_SERVER_DIR      = '/opt/code-server' -%}
-{%- set CONDUIT_BUILD_SCRIPT = 'update_and_rebuild_conduit.sh' -%}
-{%- set CONDUIT_DIR          = '/opt/conduit' -%}
-{%- set FILES_DIR            = MOOSE_DIR + '/apptainer/files/moose-dev' -%}
-{%- set GPERF_DIR            = '/opt/gperftools' -%}
-{%- set LIBTORCH_DIR         = '/opt/libtorch' -%}
-{%- set MFEM_BUILD_SCRIPT    = 'update_and_rebuild_mfem.sh' -%}
-{%- set MFEM_DIR             = '/opt/mfem' -%}
-{%- set NEML2_BUILD_SCRIPT   = 'update_and_rebuild_neml2.sh' -%}
-{%- set NEML2_DIR            = '/opt/neml2' -%}
-{%- set PPROF_DIR            = '/opt/pprof' -%}
-{%- set PYTHON_DIR           = '/opt/python' -%}
-{%- set ROOT_BUILD_DIR       = '/root/build' -%}
-{%- set UV_DIR               = '/opt/uv' -%}
-{%- set WASP_BUILD_SCRIPT    = 'update_and_rebuild_wasp.sh' -%}
-{%- set WASP_DIR             = '/opt/wasp' -%}
+{#- Installation locations and build scripts for third-party dependencies -#}
+{%- set CODE_SERVER_DIR      = '/opt/code-server'                         -%}
+{%- set CONDUIT_BUILD_SCRIPT = 'update_and_rebuild_conduit.sh'            -%}
+{%- set CONDUIT_DIR          = '/opt/conduit'                             -%}
+{%- set FILES_DIR            = MOOSE_DIR + '/apptainer/files/moose-dev'   -%}
+{%- set GPERF_DIR            = '/opt/gperftools'                          -%}
+{%- set LIBTORCH_DIR         = '/opt/libtorch'                            -%}
+{%- set MFEM_BUILD_SCRIPT    = 'update_and_rebuild_mfem.sh'               -%}
+{%- set MFEM_DIR             = '/opt/mfem'                                -%}
+{%- set NEML2_BUILD_SCRIPT   = 'update_and_rebuild_neml2.sh'              -%}
+{%- set NEML2_DIR            = '/opt/neml2'                               -%}
+{%- set PPROF_DIR            = '/opt/pprof'                               -%}
+{%- set PYTHON_DIR           = '/opt/python'                              -%}
+{%- set ROOT_BUILD_DIR       = '/root/build'                              -%}
+{%- set UV_DIR               = '/opt/uv'                                  -%}
+{%- set WASP_BUILD_SCRIPT    = 'update_and_rebuild_wasp.sh'               -%}
+{%- set WASP_DIR             = '/opt/wasp'                                -%}
 
 BootStrap: {{ APPTAINER_BOOTSTRAP }}
 From: {{ APPTAINER_FROM }}

--- a/apptainer/moose-dev.def
+++ b/apptainer/moose-dev.def
@@ -108,7 +108,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     # Individual versions for packages to install, in the order
     # in which they are installed below.
     # code-server and code-server plugins
-    CODE_SERVER_VERSION=4.123.0
+    CODE_SERVER_VERSION=4.128.0
     MOOSE_LANGUAGE_SUPPORT_VERSION=1.5.2
     # python
     PYTHON_VERSION=3.14.6

--- a/apptainer/moose-dev.def
+++ b/apptainer/moose-dev.def
@@ -98,7 +98,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 %post -c /bin/bash
     set -uexo pipefail
 
-    source /.singularity.d/os_functions.sh
+    source /.singularity.d/build_utils.sh
     update_system_packages
 
     ROOT_BUILD_DIR={{ ROOT_BUILD_DIR }}
@@ -128,7 +128,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 
     # Optimization flags
 {%- if OPTFLAGS is not defined %}
-    OPTFLAGS=("-march=x86-64-v3" "-mtune=generic")
+    OPTFLAGS=("-march=$(default_march)" "-mtune=generic")
 {%- else %}
     IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
 {%- endif %}

--- a/apptainer/moose-dev.def
+++ b/apptainer/moose-dev.def
@@ -15,6 +15,7 @@
 {#- MFEM_GIT_REMOTE: The git remote to use to get MFEM                                        -#}
 {#- MFEM_OPTIONS: Options to pass to mfem build                                               -#}
 {#- MOOSE_JOBS: Number of jobs to pass to the builds                                          -#}
+{#- OPTFLAGS: Optimization flags to set when building                                         -#}
 {#- PROFILING: Set to anything to build for profiling (add gperftools)                        -#}
 {#- PYTORCH_GIT_SHA: The git SHA to use for pytorch                                           -#}
 {#- PYTORCH_GIT_REMOTE: The git remote to use to get pytorch                                  -#}
@@ -125,6 +126,13 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     GPERFTOOLS_VERSION=2.18.1
     GO_VERSION=1.26.1
     PPROF_SHA=a0b0bb1d4134f37be44de6c328680339b0fc13ad
+{%- endif %}
+
+    # Optimization flags
+{%- if OPTFLAGS is not defined %}
+    OPTFLAGS=("-march=x86-64-v3" "-mtune=generic")
+{%- else %}
+    IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
 {%- endif %}
 
     # Special setup for OpenMPI
@@ -414,8 +422,8 @@ EOF
             "$PYTORCH_SRC_DIR" \
             "$LIBTORCH_BUILD_DIR" \
             "$LIBTORCH_DIR" \
-            -DCMAKE_C_FLAGS="-w" \
-            -DCMAKE_CXX_FLAGS="-w" \
+            -DCMAKE_C_FLAGS="-w ${OPTFLAGS[*]}" \
+            -DCMAKE_CXX_FLAGS="-w ${OPTFLAGS[*]}" \
             "${LIBTORCH_FLAGS[@]}" 2>&1 | tee ${LIBTORCH_LOGS}/cmake.log
         build_libtorch "$LIBTORCH_BUILD_DIR" "$MOOSE_JOBS" 2>&1 | tee ${LIBTORCH_LOGS}/build.log
         install_libtorch "$LIBTORCH_BUILD_DIR" "$LIBTORCH_DIR" 2>&1 | tee ${LIBTORCH_LOGS}/install.log
@@ -514,7 +522,9 @@ EOF
         LIBTORCH_DIR={{ LIBTORCH_DIR }} \
         WASP_DIR={{ WASP_DIR }} \
             ${NEML2_BUILD_SCRIPT} \
-                --skip-submodule-update 2>&1 | tee ${NEML2_LOGS}/build.log
+                --skip-submodule-update \
+                -DCMAKE_C_FLAGS="${OPTFLAGS[*]}" \
+                -DCMAKE_CXX_FLAGS="${OPTFLAGS[*]}" 2>&1 | tee ${NEML2_LOGS}/build.log
 
         # Cleanup
         rm -rf ${NEML2_SRC_DIR} ${NEML2_BUILD_SCRIPT}
@@ -545,6 +555,8 @@ EOF
         CONDUIT_DIR=${CONDUIT_DIR} \
         CONDUIT_SRC_DIR=${CONDUIT_SRC_DIR} \
             ${CONDUIT_BUILD_SCRIPT} \
+                -DCMAKE_C_FLAGS="${OPTFLAGS[*]}" \
+                -DCMAKE_CXX_FLAGS="${OPTFLAGS[*]}" \
                 "${CONDUIT_OPTIONS[@]}" 2>&1 | tee ${CONDUIT_LOGS}/build.log
 
         # Cleanup
@@ -588,6 +600,8 @@ EOF
         MFEM_SRC_DIR=${MFEM_SRC_DIR} \
         CONDUIT_DIR={{ CONDUIT_DIR }} \
             ${MFEM_BUILD_SCRIPT} \
+                -DCMAKE_C_FLAGS="${OPTFLAGS[*]}" \
+                -DCMAKE_CXX_FLAGS="${OPTFLAGS[*]}" \
                 "${MFEM_OPTIONS[@]}" 2>&1 | tee ${MFEM_LOGS}/build.log
 
         # Cleanup

--- a/apptainer/moose-dev.def
+++ b/apptainer/moose-dev.def
@@ -19,19 +19,21 @@
    - MFEM_OPTIONS: Options to pass to mfem build
    - MOOSE_JOBS: Number of jobs to pass to the builds
    - OPTFLAGS: Optimization flags to set when building
-   - PROFILING: Set to anything to build for profiling (add gperftools)
+   - PROFILING: Whether or not to build with gperftools (truthy, default: false)
    - PYTORCH_GIT_SHA: The git SHA to use for pytorch
    - PYTORCH_GIT_REMOTE: The git remote to use to get pytorch
-   - SKIP_FINGERPRINTS: Set to skip fingerprint verification
+   - SKIP_FINGERPRINTS: Set to skip fingerprint verification (truthy, default: false)
    - WITH_MFEM: Whether or not to build mfem (truthy, default: true)
    - WITH_FMU: Whether or not to install python fmu utilities (truthy, default: false)
    - WITHOUT_PYTORCH: Whether to not build pytorch and neml2 (truthy, default: false)
 -#}
 
 {#- Set defaults for any variables not provided                                               -#}
-{%- set WITH_MFEM       = WITH_MFEM | default(true) %}
-{%- set WITH_FMU        = WITH_FMU | default(false) %}
-{%- set WITHOUT_PYTORCH = WITHOUT_PYTORCH | default(false) %}
+{%- set PROFILING         = PROFILING | default(false) %}
+{%- set SKIP_FINGERPRINTS = SKIP_FINGERPRINTS | default(false) %}
+{%- set WITH_MFEM         = WITH_MFEM | default(true) %}
+{%- set WITH_FMU          = WITH_FMU | default(false) %}
+{%- set WITHOUT_PYTORCH   = WITHOUT_PYTORCH | default(false) %}
 
 {#- Installation locations and build scripts for third-party dependencies                     -#}
 {%- set CODE_SERVER_DIR      = '/opt/code-server' -%}
@@ -53,7 +55,7 @@
 
 BootStrap: {{ APPTAINER_BOOTSTRAP }}
 From: {{ APPTAINER_FROM }}
-{%- if SKIP_FINGERPRINTS is not defined %}
+{%- if not SKIP_FINGERPRINTS | to_bool %}
 # MOOSE-NCRC key
 Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 {%- endif %}
@@ -65,17 +67,17 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     export WASP_DIR={{ WASP_DIR }}
     export PATH=${WASP_DIR}/bin:$PATH
 
-{%- if WITH_MFEM %}
+{%- if WITH_MFEM | to_bool %}
     test -d {{ CONDUIT_DIR }} && export CONDUIT_DIR={{ CONDUIT_DIR }}
     test -d {{ MFEM_DIR }} && export MFEM_DIR={{ MFEM_DIR }}
 {%- endif %}
 
-{% if not (WITHOUT_PYTORCH | to_bool) %}
+{% if not WITHOUT_PYTORCH | to_bool %}
     test -d {{ LIBTORCH_DIR }} && export LIBTORCH_DIR={{ LIBTORCH_DIR }}
     test -d {{ NEML2_DIR }} && export NEML2_DIR={{ NEML2_DIR }}
 {%- endif %}
 
-{% if PROFILING is defined %}
+{% if PROFILING | to_bool %}
     # For profiling
     export GPERF_DIR={{ GPERF_DIR }}
     export PATH={{ PPROF_DIR }}/bin:$PATH
@@ -106,7 +108,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     # PythonFMU python package
     PYTHONFMU_VERSION=0.7.0
 {%- endif %}
-{% if PROFILING is defined %}
+{% if PROFILING | to_bool %}
     # pprof and its dependencies
     GPERFTOOLS_VERSION=2.18.1
     GO_VERSION=1.26.1
@@ -261,7 +263,7 @@ EOF
         ${PYTHON_DIR}/bin/pip install -r /root/requirements.txt && rm /root/requirements.txt
     )
 
-{% if WITH_FMU %}
+{% if WITH_FMU | to_bool %}
     # Install fmi-library dependency for pyfmi
     FMI_LIBRARY_DIR=/opt/fmi-library
     (
@@ -375,7 +377,7 @@ EOF
     )
 {%- endif %}
 
-{% if not (WITHOUT_PYTORCH | to_bool) %}
+{% if not WITHOUT_PYTORCH | to_bool %}
     # Build libtorch
     (
         cd ${ROOT_BUILD_DIR}
@@ -431,7 +433,7 @@ EOF
     )
 {%- endif %}
 
-{% if PROFILING is defined %}
+{% if PROFILING | to_bool %}
     # Install gperftools
     (
         cd ${ROOT_BUILD_DIR}
@@ -487,7 +489,7 @@ EOF
         export LD_LIBRARY_PATH=${CUDA_DIR}/compat:${LD_LIBRARY_PATH:-}
     fi
 
-{% if not (WITHOUT_PYTORCH | to_bool) %}
+{% if not WITHOUT_PYTORCH | to_bool %}
     # Build neml2
     (
         cd ${ROOT_BUILD_DIR}
@@ -503,7 +505,7 @@ EOF
         git checkout {{ NEML2_GIT_SHA }}
         git submodule update --init --recursive --depth 1
 
-{% if PROFILING is defined %}
+{% if PROFILING | to_bool %}
         METHODS="oprof"
 {%- else %}
         METHODS="opt devel dbg"
@@ -630,7 +632,7 @@ EOF
     # mfem
     {{ MOOSE_DIR }}/scripts/{{ MFEM_BUILD_SCRIPT }} {{ ROOT_BUILD_DIR }}/{{ MFEM_BUILD_SCRIPT }}
     {{ MOOSE_DIR }}/scripts/{{ CONDUIT_BUILD_SCRIPT }} {{ ROOT_BUILD_DIR }}/{{ CONDUIT_BUILD_SCRIPT }}
-{% if not (WITHOUT_PYTORCH | to_bool) %}
+{% if not WITHOUT_PYTORCH | to_bool %}
     # libtorch
     {{ MOOSE_DIR }}/scripts/configure_libtorch.sh {{ ROOT_BUILD_DIR }}/configure_libtorch.sh
     # neml2

--- a/apptainer/moose-dev.def
+++ b/apptainer/moose-dev.def
@@ -1,76 +1,55 @@
-{#- Required jinja arguments                                                                  -#}
-{#- APPTAINER_BOOTSTRAP: The BootStrap to use (typically localimage or oras)                  -#}
-{#- APPTAINER_FROM: The From to use (path to an image or an oras URI)                         -#}
-{#- MOOSE_DIR: Path on the host to the MOOSE repository                                       -#}
-{#- NEML2_GIT_SHA: The git SHA to use for neml2                                               -#}
-{#- NEML2_GIT_REMOTE: The git remote to use to get neml2                                      -#}
-{#- WASP_GIT_SHA: The git SHA to use for WASP                                                 -#}
-{#- WASP_GIT_REMOTE: The git remote to use to get WASP                                        -#}
+{#-
+   Required jinja arguments:
 
-{#- Optional jinja arguments                                                                  -#}
-{#- CONDUIT_GIT_SHA: The git SHA to use for conduit                                           -#}
-{#- CONDUIT_GIT_REMOTE: The git remote to use to get conduit                                  -#}
-{#- CONDUIT_OPTIONS: Options to pass to conduit build                                         -#}
-{#- MFEM_GIT_SHA: The git SHA to use for MFEM                                                 -#}
-{#- MFEM_GIT_REMOTE: The git remote to use to get MFEM                                        -#}
-{#- MFEM_OPTIONS: Options to pass to mfem build                                               -#}
-{#- MOOSE_JOBS: Number of jobs to pass to the builds                                          -#}
-{#- OPTFLAGS: Optimization flags to set when building                                         -#}
-{#- PROFILING: Set to anything to build for profiling (add gperftools)                        -#}
-{#- PYTORCH_GIT_SHA: The git SHA to use for pytorch                                           -#}
-{#- PYTORCH_GIT_REMOTE: The git remote to use to get pytorch                                  -#}
-{#- SKIP_FINGERPRINTS: Set to skip fingerprint verification                                   -#}
-{#- WITH_MFEM: Whether or not to build mfem (truthy, default: true)                           -#}
-{#- WITH_FMU: Whether or not to install python fmu utilities (truthy, default: false)         -#}
-{#- WITHOUT_PYTORCH: Whether to not build pytorch and neml2 (truthy, default: false)          -#}
+   - APPTAINER_BOOTSTRAP: The BootStrap to use (typically localimage or oras)
+   - APPTAINER_FROM: The From to use (path to an image or an oras URI)
+   - MOOSE_DIR: Path on the host to the MOOSE repository
+   - NEML2_GIT_SHA: The git SHA to use for neml2
+   - NEML2_GIT_REMOTE: The git remote to use to get neml2
+   - WASP_GIT_SHA: The git SHA to use for WASP
+   - WASP_GIT_REMOTE: The git remote to use to get WASP
 
-{#- Set WITH_MFEM default if not set                                                          -#}
-{%- if WITH_MFEM is not defined %}
-{%- set WITH_MFEM = True %}
-{%- endif %}
-{#- Set WITH_FMU default if not set                                                           -#}
-{%- if WITH_FMU is not defined %}
-{%- set WITH_FMU = False %}
-{%- endif %}
-{#- Set WITHOUT_PYTORCH default if not set                                                    -#}
-{%- if WITHOUT_PYTORCH is not defined %}
-{%- set WITHOUT_PYTORCH = False %}
-{%- endif %}
+   Optional jinja arguments:
 
-{#- The within-container build directory to use                                               -#}
-{%- set ROOT_BUILD_DIR = '/root/build' -%}
+   - CONDUIT_GIT_SHA: The git SHA to use for conduit
+   - CONDUIT_GIT_REMOTE: The git remote to use to get conduit
+   - CONDUIT_OPTIONS: Options to pass to conduit build
+   - MFEM_GIT_SHA: The git SHA to use for MFEM
+   - MFEM_GIT_REMOTE: The git remote to use to get MFEM
+   - MFEM_OPTIONS: Options to pass to mfem build
+   - MOOSE_JOBS: Number of jobs to pass to the builds
+   - OPTFLAGS: Optimization flags to set when building
+   - PROFILING: Set to anything to build for profiling (add gperftools)
+   - PYTORCH_GIT_SHA: The git SHA to use for pytorch
+   - PYTORCH_GIT_REMOTE: The git remote to use to get pytorch
+   - SKIP_FINGERPRINTS: Set to skip fingerprint verification
+   - WITH_MFEM: Whether or not to build mfem (truthy, default: true)
+   - WITH_FMU: Whether or not to install python fmu utilities (truthy, default: false)
+   - WITHOUT_PYTORCH: Whether to not build pytorch and neml2 (truthy, default: false)
+-#}
 
-{#- The installation location for gperftools                                                  -#}
-{%- set GPERF_DIR = '/opt/gperftools' -%}
-{#- The installation location for pprof                                                       -#}
-{%- set PPROF_DIR = '/opt/pprof' -%}
-{#- The installation location for libtorch                                                    -#}
-{%- set LIBTORCH_DIR = '/opt/libtorch' -%}
-{#- The script used to install conduit                                                        -#}
+{#- Set defaults for any variables not provided                                               -#}
+{%- set WITH_MFEM       = WITH_MFEM | default(true) %}
+{%- set WITH_FMU        = WITH_FMU | default(false) %}
+{%- set WITHOUT_PYTORCH = WITHOUT_PYTORCH | default(false) %}
+
+{#- Installation locations and build scripts for third-party dependencies                     -#}
+{%- set CODE_SERVER_DIR      = '/opt/code-server' -%}
 {%- set CONDUIT_BUILD_SCRIPT = 'update_and_rebuild_conduit.sh' -%}
-{#- The installation location for conduit                                                     -#}
-{%- set CONDUIT_DIR = '/opt/conduit' -%}
-{#- The script used to install mfem                                                           -#}
-{%- set MFEM_BUILD_SCRIPT = 'update_and_rebuild_mfem.sh' -%}
-{#- The installation location for mfem                                                        -#}
-{%- set MFEM_DIR = '/opt/mfem' -%}
-{#- The script used to install wasp                                                           -#}
-{%- set WASP_BUILD_SCRIPT = 'update_and_rebuild_wasp.sh' -%}
-{#- The installation location for wasp                                                        -#}
-{%- set WASP_DIR = '/opt/wasp' -%}
-{#- The script used to install neml2                                                          -#}
-{%- set NEML2_BUILD_SCRIPT = 'update_and_rebuild_neml2.sh' -%}
-{#- The installation location for neml2                                                       -#}
-{%- set NEML2_DIR = '/opt/neml2' -%}
-{#- The installation location for uv                                                          -#}
-{%- set UV_DIR = '/opt/uv' -%}
-{#- The installation location for python                                                      -#}
-{%- set PYTHON_DIR = '/opt/python' -%}
-{#- The installation location for code-server                                                 -#}
-{%- set CODE_SERVER_DIR = '/opt/code-server' -%}
-
-{#- The files directory for this definition                                                   -#}
-{%- set FILES_DIR = MOOSE_DIR + '/apptainer/files/moose-dev' -%}
+{%- set CONDUIT_DIR          = '/opt/conduit' -%}
+{%- set FILES_DIR            = MOOSE_DIR + '/apptainer/files/moose-dev' -%}
+{%- set GPERF_DIR            = '/opt/gperftools' -%}
+{%- set LIBTORCH_DIR         = '/opt/libtorch' -%}
+{%- set MFEM_BUILD_SCRIPT    = 'update_and_rebuild_mfem.sh' -%}
+{%- set MFEM_DIR             = '/opt/mfem' -%}
+{%- set NEML2_BUILD_SCRIPT   = 'update_and_rebuild_neml2.sh' -%}
+{%- set NEML2_DIR            = '/opt/neml2' -%}
+{%- set PPROF_DIR            = '/opt/pprof' -%}
+{%- set PYTHON_DIR           = '/opt/python' -%}
+{%- set ROOT_BUILD_DIR       = '/root/build' -%}
+{%- set UV_DIR               = '/opt/uv' -%}
+{%- set WASP_BUILD_SCRIPT    = 'update_and_rebuild_wasp.sh' -%}
+{%- set WASP_DIR             = '/opt/wasp' -%}
 
 BootStrap: {{ APPTAINER_BOOTSTRAP }}
 From: {{ APPTAINER_FROM }}

--- a/apptainer/mpi.def
+++ b/apptainer/mpi.def
@@ -17,7 +17,7 @@ From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-gcc:pr30-8.10-gcc13.
 {%- elif ALTERNATE_FROM == "rocky9_gcc" %}
 From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky9-gcc:pr30-9.7-gcc13.3.1-mpich4.3.2-openmpi5.0.10-20260714
 {%- elif ALTERNATE_FROM == "ubuntu24_clang" %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-clang:pr30-24.04-clang22.1.8-gcc13.3.0-mpich5.0.1-openmpi5.0.10-20260714
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-clang:pr30-24.04-clang22.1.8-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714
 {%- elif ALTERNATE_FROM == "ubuntu24_cuda_gcc" %}
 From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-cuda-gcc:pr30-24.04-cuda13.3.0-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714
 {%- elif ALTERNATE_FROM == "ubuntu24_gccmin" %}

--- a/apptainer/mpi.def
+++ b/apptainer/mpi.def
@@ -13,13 +13,15 @@
 
 {#- Image from definitions                            -#}
 {%- set ALTERNATE_FROM = ALTERNATE_FROM | default("") -%}
-{%- set DEFAULT_IMAGE = "ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-gcc:pr30-24.04-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714" -%}
+{%- set DEFAULT_IMAGE = "ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-gcc:pr30-8.10-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260714" -%}
 {%- set FROM_IMAGES = {
   "intel":             "ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-oneapi:pr30-8.10-gcc13.3.1-oneapi2026.1.0-mpich4.3.2-20260714",
   "rocky8_gcc":        "ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-gcc:pr30-8.10-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260714",
+  "rocky9":            "ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky9-gcc:pr30-9.7-gcc13.3.1-mpich4.3.2-openmpi5.0.10-20260714",
   "rocky9_gcc":        "ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky9-gcc:pr30-9.7-gcc13.3.1-mpich4.3.2-openmpi5.0.10-20260714",
   "ubuntu24_clang":    "ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-clang:pr30-24.04-clang22.1.8-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714",
   "ubuntu24_cuda_gcc": "ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-cuda-gcc:pr30-24.04-cuda13.3.0-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714",
+  "ubuntu24_gcc":      "ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-gcc:pr30-24.04-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714",
   "ubuntu24_gccmin":   "ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-gccmin:pr30-24.04-gcc9.5.0-mpich5.0.1-20260714",
 } -%}
 

--- a/apptainer/mpi.def
+++ b/apptainer/mpi.def
@@ -10,18 +10,20 @@
 
 # TODO: Update packages to production versions
 Bootstrap: docker
-{%- if ALTERNATE_FROM == "clang" %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-clang:pr30-8.10-clang21.1.8-gcc15.2.1-mpich5.0.1-20260714
-{%- elif ALTERNATE_FROM == "cuda" %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-cuda-gcc:pr30-8.10-cuda13.3.0-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260714
-{%- elif ALTERNATE_FROM == "gcc_min" %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-gccmin:pr30-8.10-gcc9.2.1-mpich5.0.1-20260714
-{%- elif ALTERNATE_FROM == "intel" %}
+{%- if ALTERNATE_FROM == "intel" %}
 From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-oneapi:pr30-8.10-gcc13.3.1-oneapi2026.1.0-mpich4.3.2-20260714
-{%- elif ALTERNATE_FROM == "rocky9" %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky9-gcc:pr30-9.7-gcc13.3.1-mpich4.3.2-openmpi5.0.10-20260714
-{%- else %}
+{%- elif ALTERNATE_FROM == "rocky8_gcc" %}
 From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-gcc:pr30-8.10-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260714
+{%- elif ALTERNATE_FROM == "rocky9_gcc" %}
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky9-gcc:pr30-9.7-gcc13.3.1-mpich4.3.2-openmpi5.0.10-20260714
+{%- elif ALTERNATE_FROM == "ubuntu24_clang" %}
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-clang:pr30-24.04-clang22.1.8-gcc13.3.0-mpich5.0.1-openmpi5.0.10-20260714
+{%- elif ALTERNATE_FROM == "ubuntu24_cuda_gcc" %}
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-cuda-gcc:pr30-24.04-cuda13.3.0-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714
+{%- elif ALTERNATE_FROM == "ubuntu24_gccmin" %}
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-gccmin:pr30-24.04-gcc9.5.0-mpich5.0.1-20260714
+{%- else %}
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-gcc:pr30-24.04-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714
 {%- endif %}
 
 %environment
@@ -31,40 +33,53 @@ From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-gcc:pr30-8.10-gcc13.
     # Environment from underyling docker image
     test -f /moose_env.sh && . /moose_env.sh
 
-%post
-    # Be careful about unknown variables
-    set -u
+%post -c /bin/bash
+    set -uexo pipefail
 
-    # Determine rocky version
-    grep -q "Rocky" /etc/os-release && IS_ROCKY=1
-    if [ -n "${IS_ROCKY:-}" ]; then
-        grep 'VERSION=\"8.' /etc/os-release && IS_ROCKY_8=1
-        grep 'VERSION=\"9.' /etc/os-release && IS_ROCKY_9=1
-    fi
+    source /.singularity.d/os_functions.sh
+    update_system_packages
 
     # Remove apptainer if it's installed
-    if dnf list installed apptainer &> /dev/null; then
+    if is_rocky && dnf list installed apptainer &> /dev/null; then
         dnf remove -y apptainer
     fi
 
-    # Enable additional repos
-    dnf install -y dnf-plugins-core
-    if [ -n "${IS_ROCKY_8:-}" ]; then
-        dnf config-manager --set-enabled powertools
-        dnf install -y redhat-lsb-core.x86_64
-    elif [ -n "${IS_ROCKY_9:-}" ]; then
-        dnf config-manager --set-enabled crb
+    # Enable additional rocky repos
+    if is_rocky; then
+        dnf install -y dnf-plugins-core
+        if is_rocky8; then
+            dnf config-manager --set-enabled powertools
+            dnf install -y redhat-lsb-core.x86_64
+        elif is_rocky9; then
+            dnf config-manager --set-enabled crb
+        fi
+        dnf install -y epel-release
     fi
-    dnf install -y epel-release
 
     # Additional installs
-    dnf install -y emacs make cmake diffutils bison flex perl-IO-Compress perl-JSON \
-        perl-JSON-PP libtirpc libtirpc-devel zlib-devel patch patchutils libpng \
-        libpng-devel valgrind cppunit doxygen fftw-devel gsl-devel libtool autoconf \
-        automake cppunit-devel glpk-devel patchelf lcov bash-completion ninja-build
+    INSTALLS=(
+        "autoconf" "automake" "bash-completion" "bison" "cmake" "diffutils"
+        "doxygen" "emacs" "flex" "lcov" "libtool" "ninja-build" "patch" "patchelf"
+        "patchutils" "valgrind"
+    )
+    ROCKY_INSTALLS=(
+        "cppunit" "cppunit-devel" "fftw-devel" "glpk-devel" "gsl-devel" "libpng"
+        "libpng-devel" "libtirpc" "libtirpc-devel" "perl-IO-Compress" "perl-JSON"
+        "perl-JSON-PP" "zlib-devel"
+    )
+    UBUNTU_INSTALLS=(
+        "libcppunit-dev" "libfftw3-dev" "libglpk-dev" "libgsl-dev" "libio-compress-perl"
+        "libjson-perl" "libjson-pp-perl" "libpng-dev" "libtirpc3" "libtirpc-dev"
+        "zlib1g-dev"
+    )
+    if is_rocky; then
+        dnf install -y "${INSTALLS[@]}" "${ROCKY_INSTALLS[@]}"
+    elif is_ubuntu; then
+        apt-get install -y --no-install-recommends "${INSTALLS[@]}" "${UBUNTU_INSTALLS[@]}"
+    fi
 
     # Clean after install
-    dnf clean all
+    clean_system_packages
 
 %test
     if [ -n "$MOOSE_MPICH_DIR" ]; then
@@ -78,3 +93,4 @@ From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-gcc:pr30-8.10-gcc13.
 %files
     {{ FILES_DIR }}/.singularity.d/env/02-fix-actions.sh /.singularity.d/env/02-fix-actions.sh
     {{ FILES_DIR }}/.singularity.d/moose_bashrc /.singularity.d/moose_bashrc
+    {{ FILES_DIR }}/.singularity.d/os_functions.sh /.singularity.d/os_functions.sh

--- a/apptainer/mpi.def
+++ b/apptainer/mpi.def
@@ -11,17 +11,17 @@
 # TODO: Update packages to production versions
 Bootstrap: docker
 {%- if ALTERNATE_FROM == "clang" %}
-From: ghcr.io/idaholab/moose-containers/moose-mpi-rocky8-clang:8.10-clang21.1.8-gcc15.2.1-mpich5.0.1-20260605
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-clang:pr30-8.10-clang21.1.8-gcc15.2.1-mpich5.0.1-20260714
 {%- elif ALTERNATE_FROM == "cuda" %}
-From: ghcr.io/idaholab/moose-containers/moose-mpi-rocky8-cuda-gcc:8.10-cuda13.2.1-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260605
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-cuda-gcc:pr30-8.10-cuda13.3.0-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260714
 {%- elif ALTERNATE_FROM == "gcc_min" %}
-From: ghcr.io/idaholab/moose-containers/moose-mpi-rocky8-gccmin:8.10-gcc9.2.1-mpich5.0.1-20260605
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-gccmin:pr30-8.10-gcc9.2.1-mpich5.0.1-20260714
 {%- elif ALTERNATE_FROM == "intel" %}
-From: ghcr.io/idaholab/moose-containers/moose-mpi-rocky8-oneapi:8.10-gcc13.3.1-oneapi2026.0.0-mpich4.3.2-20260605
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-oneapi:pr30-8.10-gcc13.3.1-oneapi2026.1.0-mpich4.3.2-20260714
 {%- elif ALTERNATE_FROM == "rocky9" %}
-From: ghcr.io/idaholab/moose-containers/moose-mpi-rocky9-gcc:9.7-gcc13.3.1-mpich4.3.2-openmpi5.0.10-20260605
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky9-gcc:pr30-9.7-gcc13.3.1-mpich4.3.2-openmpi5.0.10-20260714
 {%- else %}
-From: ghcr.io/idaholab/moose-containers/moose-mpi-rocky8-gcc:8.10-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260605
+From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-gcc:pr30-8.10-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260714
 {%- endif %}
 
 %environment

--- a/apptainer/mpi.def
+++ b/apptainer/mpi.def
@@ -1,30 +1,30 @@
-{#- Required jinja arguments                                                                  -#}
-{#- MOOSE_DIR: Path on the host to the MOOSE repository                                       -#}
+{#-
+   Required jinja arguments:
 
-{#- Optional jinja arguments                                                                  -#}
-{#- MOOSE_JOBS: Number of jobs to pass to the builds                                          -#}
-{#- ALTERNATE_FROM: Set an alternate from (currently supported: clang, clang_min, gcc_min)    -#}
+   - MOOSE_DIR: Path on the host to the MOOSE repository
 
-{#- The files directory for this definition                                                   -#}
+   Optional jinja arguments:
+
+   - ALTERNATE_FROM: Set an alternate from image
+-#}
+
+{#- Directory definitions                              -#}
 {%- set FILES_DIR = MOOSE_DIR + '/apptainer/files/mpi' -%}
 
-# TODO: Update packages to production versions
+{#- Image from definitions                            -#}
+{%- set ALTERNATE_FROM = ALTERNATE_FROM | default("") -%}
+{%- set DEFAULT_IMAGE = "ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-gcc:pr30-24.04-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714" -%}
+{%- set FROM_IMAGES = {
+  "intel":             "ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-oneapi:pr30-8.10-gcc13.3.1-oneapi2026.1.0-mpich4.3.2-20260714",
+  "rocky8_gcc":        "ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-gcc:pr30-8.10-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260714",
+  "rocky9_gcc":        "ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky9-gcc:pr30-9.7-gcc13.3.1-mpich4.3.2-openmpi5.0.10-20260714",
+  "ubuntu24_clang":    "ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-clang:pr30-24.04-clang22.1.8-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714",
+  "ubuntu24_cuda_gcc": "ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-cuda-gcc:pr30-24.04-cuda13.3.0-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714",
+  "ubuntu24_gccmin":   "ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-gccmin:pr30-24.04-gcc9.5.0-mpich5.0.1-20260714",
+} -%}
+
 Bootstrap: docker
-{%- if ALTERNATE_FROM == "intel" %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-oneapi:pr30-8.10-gcc13.3.1-oneapi2026.1.0-mpich4.3.2-20260714
-{%- elif ALTERNATE_FROM == "rocky8_gcc" %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky8-gcc:pr30-8.10-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260714
-{%- elif ALTERNATE_FROM == "rocky9_gcc" %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-rocky9-gcc:pr30-9.7-gcc13.3.1-mpich4.3.2-openmpi5.0.10-20260714
-{%- elif ALTERNATE_FROM == "ubuntu24_clang" %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-clang:pr30-24.04-clang22.1.8-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714
-{%- elif ALTERNATE_FROM == "ubuntu24_cuda_gcc" %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-cuda-gcc:pr30-24.04-cuda13.3.0-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714
-{%- elif ALTERNATE_FROM == "ubuntu24_gccmin" %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-gccmin:pr30-24.04-gcc9.5.0-mpich5.0.1-20260714
-{%- else %}
-From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-gcc:pr30-24.04-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260714
-{%- endif %}
+From: {{ FROM_IMAGES.get(ALTERNATE_FROM, DEFAULT_IMAGE) }}
 
 %environment
     # Fix locale warnings

--- a/apptainer/mpi.def
+++ b/apptainer/mpi.def
@@ -36,7 +36,7 @@ From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-gcc:pr30-24.04-gcc
 %post -c /bin/bash
     set -uexo pipefail
 
-    source /.singularity.d/os_functions.sh
+    source /.singularity.d/build_utils.sh
     update_system_packages
 
     # Remove apptainer if it's installed
@@ -93,4 +93,4 @@ From: ghcr.io/idaholab/moose-containers/pr-moose-mpi-ubuntu24-gcc:pr30-24.04-gcc
 %files
     {{ FILES_DIR }}/.singularity.d/env/02-fix-actions.sh /.singularity.d/env/02-fix-actions.sh
     {{ FILES_DIR }}/.singularity.d/moose_bashrc /.singularity.d/moose_bashrc
-    {{ FILES_DIR }}/.singularity.d/os_functions.sh /.singularity.d/os_functions.sh
+    {{ FILES_DIR }}/.singularity.d/build_utils.sh /.singularity.d/build_utils.sh

--- a/apptainer/petsc.def
+++ b/apptainer/petsc.def
@@ -44,7 +44,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 %post -c /bin/bash
     set -uexo pipefail
 
-    source /.singularity.d/os_functions.sh
+    source /.singularity.d/build_utils.sh
     update_system_packages
 
     # Set the MPI environment
@@ -76,7 +76,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 
     # Optimization flags
 {%- if OPTFLAGS is not defined %}
-    OPTFLAGS=("-O2" "-march=x86-64-v3" "-mtune=generic")
+    OPTFLAGS=("-O2" "-march=$(default_march)" "-mtune=generic")
 {%- else %}
     IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
 {%- endif %}

--- a/apptainer/petsc.def
+++ b/apptainer/petsc.def
@@ -1,30 +1,34 @@
-{#- Required jinja arguments                                                                  -#}
-{#- APPTAINER_BOOTSTRAP: The BootStrap to use (typically localimage or oras)                  -#}
-{#- APPTAINER_FROM: The From to use (path to an image or an oras URI)                         -#}
-{#- PETSC_GIT_SHA: The git SHA to use for PETSc                                               -#}
-{#- PETSC_GIT_REMOTE: The git remote to use to get PETSc                                      -#}
+{#-
+   Required jinja arguments:
 
-{#- Optional jinja arguments                                                                  -#}
-{#- MOOSE_JOBS: Number of jobs to pass to the PETSc build script                              -#}
-{#- MPI_FLAVOUR: The flavour of MPI to use (options: mpich, openmpi; default: mpich)          -#}
-{#- OPTFLAGS: Optimization flags to set when building                                         -#}
-{#- PETSC_OPTIONS: Options to pass to the PETSc build script                                  -#}
-{#- PROFILING: Set to anything to build for profiling (set petsc flags)                       -#}
-{#- SKIP_FINGERPRINTS: Set to skip fingerprint verification                                   -#}
+   - APPTAINER_BOOTSTRAP: The BootStrap to use (typically localimage or oras)
+   - APPTAINER_FROM: The From to use (path to an image or an oras URI)
+   - MOOSE_DIR: Path on the host to the MOOSE repository
+   - PETSC_GIT_REMOTE: The git remote to use to get PETSc
+   - PETSC_GIT_SHA: The git SHA to use for PETSc
 
-{#- The within-container build directory to use                                               -#}
-{%- set ROOT_BUILD_DIR = '/root/build' -%}
+   Optional jinja arguments:
 
-{#- The installation location for PETSc                                                       -#}
-{%- set PETSC_DIR = '/opt/petsc' -%}
+   - MOOSE_JOBS: Number of jobs to pass to the PETSc build script
+   - MPI_FLAVOUR: The flavour of MPI to use (options: mpich, openmpi; default: mpich)
+   - OPTFLAGS: Optimization flags to set when building
+   - PETSC_OPTIONS: Options to pass to the PETSc build script
+   - PROFILING: Whether or not to build with gperftools (truthy, default: false)
+   - SKIP_FINGERPRINTS: Set to skip fingerprint verification (truthy, default: false)
+-#}
 
-{%- if MPI_FLAVOUR is not defined %}
-{%- set MPI_FLAVOUR = 'mpich' -%}
-{%- endif %}
+{#- Set defaults for any variables not provided                -#}
+{%- set PROFILING         = PROFILING | default(false)         -%}
+{%- set MPI_FLAVOUR = MPI_FLAVOUR | default('mpich')           -%}
+{%- set SKIP_FINGERPRINTS = SKIP_FINGERPRINTS | default(false) -%}
+
+{#- Installation locations and build scripts for third-party dependencies -#}
+{%- set PETSC_DIR = '/opt/petsc'                                          -%}
+{%- set ROOT_BUILD_DIR = '/root/build'                                    -%}
 
 BootStrap: {{ APPTAINER_BOOTSTRAP }}
 From: {{ APPTAINER_FROM }}
-{%- if SKIP_FINGERPRINTS is not defined %}
+{%- if not SKIP_FINGERPRINTS | to_bool %}
 # MOOSE-NCRC key
 Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 {%- endif %}
@@ -91,7 +95,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 
     # Load PETSc options, split by word so that globbing works correctly
     IFS=' ' read -r -a PETSC_OPTIONS <<< "{{ PETSC_OPTIONS }}"
-{%- if PROFILING is defined %}
+{% if PROFILING | to_bool %}
     # Flags needed for profiling
     PETSC_OPTIONS+=(
         "--CFLAGS=-fno-omit-frame-pointer"

--- a/apptainer/petsc.def
+++ b/apptainer/petsc.def
@@ -7,6 +7,7 @@
 {#- Optional jinja arguments                                                                  -#}
 {#- MOOSE_JOBS: Number of jobs to pass to the PETSc build script                              -#}
 {#- MPI_FLAVOUR: The flavour of MPI to use (options: mpich, openmpi; default: mpich)          -#}
+{#- OPTFLAGS: Optimization flags to set when building                                         -#}
 {#- PETSC_OPTIONS: Options to pass to the PETSc build script                                  -#}
 {#- PROFILING: Set to anything to build for profiling (set petsc flags)                       -#}
 {#- SKIP_FINGERPRINTS: Set to skip fingerprint verification                                   -#}
@@ -69,6 +70,13 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
         dnf install -y libX11-devel
     fi
 
+    # Optimization flags
+{%- if OPTFLAGS is not defined %}
+    OPTFLAGS=("-O2" "-march=x86-64-v3" "-mtune=generic")
+{%- else %}
+    IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
+{%- endif %}
+
     # Clone PETSc
     cd ${ROOT_BUILD_DIR}
     PETSC_SRC_DIR=${ROOT_BUILD_DIR}/petsc
@@ -119,6 +127,12 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     PETSC_PREFIX=${PETSC_DIR} \
     PETSC_SRC_DIR=${PETSC_SRC_DIR} \
         ${ROOT_BUILD_DIR}/scripts/update_and_rebuild_petsc.sh \
+            --with-cc="$CC" \
+            --with-cxx="$CXX" \
+            --with-fc="$FC" \
+            COPTFLAGS="${OPTFLAGS[*]}" \
+            CXXOPTFLAGS="${OPTFLAGS[*]}" \
+            FOPTFLAGS="${OPTFLAGS[*]}" \
             "${PETSC_OPTIONS[@]}" 2>&1 | tee ${PETSC_LOGS}/build.log
 
 {%- if MPI_FLAVOUR == "openmpi" %}

--- a/apptainer/petsc.def
+++ b/apptainer/petsc.def
@@ -41,11 +41,11 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 
     export PETSC_DIR={{ PETSC_DIR }}
 
-%post
-    # So that piping things to tee fails
-    set -o pipefail
-    # Be careful about unknown variables
-    set -u
+%post -c /bin/bash
+    set -uexo pipefail
+
+    source /.singularity.d/os_functions.sh
+    update_system_packages
 
     # Set the MPI environment
 {%- if MPI_FLAVOUR == "mpich" %}
@@ -67,7 +67,11 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 
     # Additional installs needed for petsc with cuda
     if [ -n "${CUDA_DIR:-}" ]; then
-        dnf install -y libX11-devel
+        if is_rocky; then
+            dnf install -y libX11-devel
+        else
+            apt-get install -y --no-install-recommends libx11-dev
+        fi
     fi
 
     # Optimization flags
@@ -152,7 +156,7 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 
     # Clean Up
     rm -rf ${ROOT_BUILD_DIR}
-    dnf clean all
+    clean_system_packages
 
 %files
     {{ MOOSE_DIR }}/scripts/configure_petsc.sh {{ ROOT_BUILD_DIR }}/scripts/configure_petsc.sh

--- a/conda/build/meta.yaml
+++ b/conda/build/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2026.06.16" %}
+{% set version = "2026.07.14" %}
 
 package:
   name: moose-build

--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -93,7 +93,7 @@ krb5:
 libaec:
   - '1'
 libcap:
-  - '2.77'
+  - '2.78'
 libcurl:
   - 8
 libffi:

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 0 %}
+{% set build = 1 %}
 {% set vtk_version = "9.6.2" %}
 {% set vtk_friendly_version = vtk_version.split('.')[:2] | join('.') %}
 {% set sha256 = "aed12cec12a9609179bf66329070266627ca64244a10856a452b2a17ffb04a1d" %}

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2026.06.05_ab36c00" %}
+{% set version = "2026.07.13_80b5e97" %}
 
 package:
   name: moose-libmesh
@@ -30,8 +30,8 @@ build:
     # things that depend on this moose-libmesh must use the
     # exact moose-petsc and moose-libmesh-vtk that this was
     # built with
-    - moose-petsc 3.25.2 {{ mpi }}_0
-    - moose-libmesh-vtk 9.6.2 {{ mpi }}_0
+    - moose-petsc 3.25.3 {{ mpi }}_0
+    - moose-libmesh-vtk 9.6.2 {{ mpi }}_1
 
 requirements:
   build:
@@ -45,8 +45,8 @@ requirements:
     - pkg-config
   host:
     - {{ mpi }} {{ mpi_version }}
-    - moose-petsc 3.25.2 {{ mpi }}_0
-    - moose-libmesh-vtk 9.6.2 {{ mpi }}_0
+    - moose-petsc 3.25.3 {{ mpi }}_0
+    - moose-libmesh-vtk 9.6.2 {{ mpi }}_1
     - _openmp_mutex # [linux]
     - hdf5 {{ hdf5 }}
     - hdf5 {{ hdf5 }} mpi_{{ mpi }}_*
@@ -58,8 +58,8 @@ requirements:
     - llvm-openmp # [osx]
     - zlib
   run:
-    - moose-petsc 3.25.2 {{ mpi }}_0
-    - moose-libmesh-vtk 9.6.2 {{ mpi }}_0
+    - moose-petsc 3.25.3 {{ mpi }}_0
+    - moose-libmesh-vtk 9.6.2 {{ mpi }}_1
 
 test:
   commands:

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2026.06.16" %}
+{% set version = "2026.07.14" %}
 
 package:
   name: moose-dev
@@ -19,17 +19,17 @@ build:
   run_exports:
     # things that depend on this moose-dev must use the
     # exact moose-* packages that this was built with
-    - moose-build 2026.06.16 {{ mpi }}
-    - moose-libmesh 2026.06.05_ab36c00 {{ mpi }}_0
-    - moose-wasp 2026.06.15_d8777a8 build_0
-    - moose-tools 2026.06.16
+    - moose-build 2026.07.14 {{ mpi }}
+    - moose-libmesh 2026.07.13_80b5e97 {{ mpi }}_0
+    - moose-wasp 2026.06.19_0edc884 build_0
+    - moose-tools 2026.07.14
 
 requirements:
   run:
-    - moose-build 2026.06.16 {{ mpi }}
-    - moose-libmesh 2026.06.05_ab36c00 {{ mpi }}_0
-    - moose-wasp 2026.06.15_d8777a8 build_0
-    - moose-tools 2026.06.16
+    - moose-build 2026.07.14 {{ mpi }}
+    - moose-libmesh 2026.07.13_80b5e97 {{ mpi }}_0
+    - moose-wasp 2026.06.19_0edc884 build_0
+    - moose-tools 2026.07.14
   run_constrained:
     - {{ moose_python_constrained }}
 

--- a/conda/moose/meta.yaml
+++ b/conda/moose/meta.yaml
@@ -29,14 +29,14 @@ requirements:
     - {{ compiler('fortran') }}
     - {{ stdlib('c') }}
     # for libmesh libtool
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.07.13_80b5e97 mpich_0
     # build utilities
     - make
     - packaging
     - patchelf # [linux]
     # python; for doc build + premake
     - python 3.14.*
-    - moose-tools 2026.06.16
+    - moose-tools 2026.07.14
   host:
     - mpich {{ mpich_version }}
     - hdf5 {{ hdf5 }}
@@ -44,19 +44,19 @@ requirements:
     # see libfabric entry in conda/conda_build_config.yaml (only for mpich)
     - libfabric {{ libfabric }} # [linux]
     - libpng
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
-    - moose-wasp 2026.06.15_d8777a8 build_0
+    - moose-libmesh 2026.07.13_80b5e97 mpich_0
+    - moose-wasp 2026.06.19_0edc884 build_0
     - zlib
   run:
     - mpich {{ mpich_version }}
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
-    - moose-wasp 2026.06.15_d8777a8 build_0
+    - moose-libmesh 2026.07.13_80b5e97 mpich_0
+    - moose-wasp 2026.06.19_0edc884 build_0
     # c++ compiler for jit
     - gxx_linux-64 {{ cxx_compiler_version }}.*               # [linux]
     - clangxx_osx-64 {{ cxx_compiler_version }}.*             # [osx and x86_64]
     - clangxx_osx-arm64 {{ cxx_compiler_version }}.*          # [osx and arm64]
     # for testharness/python utilities
-    - moose-tools 2026.06.16
+    - moose-tools 2026.07.14
     # for running app --copy-inputs
     - rsync
   run_constrained:

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -8,7 +8,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "3.25.2" %}
+{% set version = "3.25.3" %}
 
 package:
   name: moose-petsc

--- a/conda/pprof/meta.yaml
+++ b/conda/pprof/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2026.05.06_92041b7" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: moose-pprof

--- a/conda/pyhit/meta.yaml
+++ b/conda/pyhit/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: moose-pyhit
-  version: 2026.06.16
+  version: 2026.07.14
 
 source:
   - path: ../../python/moosetree
@@ -25,19 +25,19 @@ source:
 build:
   number: 0
   run_exports:
-    - moose-wasp 2026.06.15_d8777a8 build_0
+    - moose-wasp 2026.06.19_0edc884 build_0
 
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - moose-wasp 2026.06.15_d8777a8 build_0
+    - moose-wasp 2026.06.19_0edc884 build_0
     - make
   host:
     - python {{ python }}
-    - moose-wasp 2026.06.15_d8777a8 build_0
+    - moose-wasp 2026.06.19_0edc884 build_0
   run:
     - python {{ python }}
-    - moose-wasp 2026.06.15_d8777a8 build_0
+    - moose-wasp 2026.06.19_0edc884 build_0
 
 test:
   imports:

--- a/conda/seacas/meta.yaml
+++ b/conda/seacas/meta.yaml
@@ -1,5 +1,5 @@
 # MAKE SURE THAT seacas_version and seacas_git_rev match if performing a version update!
-{% set build = "4" %}
+{% set build = "5" %}
 {% set seacas_version = "2025.10.14" %}
 {% set seacas_git_rev = "v" ~ seacas_version.replace(".", "-") %}
 {% set strbuild = "build_" + build|string %}

--- a/conda/template/meta.yaml
+++ b/conda/template/meta.yaml
@@ -30,14 +30,14 @@ requirements:
     - {{ compiler('fortran') }}
     - {{ stdlib('c') }}
     # for libmesh libtool
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.07.13_80b5e97 mpich_0
     # build utilities
     - make
     - packaging
     - patchelf # [linux]
     # python; for doc build + premake
     - python 3.14.*
-    - moose-tools 2026.06.16
+    - moose-tools 2026.07.14
   host:
     # should eventually become 'mpich {{ mpich_version }}'
     - mpich 5.0.1
@@ -46,20 +46,20 @@ requirements:
     # see libfabric entry in conda/conda_build_config.yaml
     - libfabric {{ libfabric }} # [linux]
     - libpng
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
-    - moose-wasp 2026.06.15_d8777a8 build_0
+    - moose-libmesh 2026.07.13_80b5e97 mpich_0
+    - moose-wasp 2026.06.19_0edc884 build_0
     - zlib
   run:
     # should eventually become 'mpich {{ mpich_version }}'
     - mpich 5.0.1
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
-    - moose-wasp 2026.06.15_d8777a8 build_0
+    - moose-libmesh 2026.07.13_80b5e97 mpich_0
+    - moose-wasp 2026.06.19_0edc884 build_0
     # c++ compiler for jit
     - gxx_linux-64 {{ cxx_compiler_version }}.*               # [linux]
     - clangxx_osx-64 {{ cxx_compiler_version }}.*             # [osx and x86_64]
     - clangxx_osx-arm64 {{ cxx_compiler_version }}.*          # [osx and arm64]
     # for testharness/python utilities
-    - moose-tools 2026.06.16
+    - moose-tools 2026.07.14
     # for running app --copy-inputs
     - rsync
   run_constrained:

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,7 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2026.06.16" %}
+{% set version = "2026.07.14" %}
 
 package:
   name: moose-tools

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2026.06.15_d8777a8" %}
+{% set version = "2026.06.19_0edc884" %}
 
 package:
   name: moose-wasp

--- a/scripts/apptainer_generator.py
+++ b/scripts/apptainer_generator.py
@@ -841,8 +841,13 @@ class ApptainerGenerator:
         # Add extra conditional vars
         self.add_definition_vars(jinja_data)
 
-        # Use jinja to fill the definition file
+        # jinja2 filter for converting to a bool
+        def to_bool(value):
+            return str(value).strip().lower() in ("true", "1", "yes", "on")
+
+        # Setup jinja2 environment
         jinja_env = jinja2.Environment()
+        jinja_env.filters["to_bool"] = to_bool
         definition_template = jinja_env.from_string(definition)
         jinja_env.trim_blocks = True
         jinja_env.lstrip_blocks = True

--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -167,7 +167,7 @@ if [ -z "$go_fast" ]; then
   source $SCRIPT_DIR/configure_libmesh.sh
   SRC_DIR=${LIBMESH_SRC_DIR} configure_libmesh $DISABLE_TIMESTAMPS \
                                                $VTK_OPTIONS \
-                                               $* | tee -a "$SCRIPT_DIR/$DIAGNOSTIC_LOG" || exit 1
+                                               "$@" | tee -a "$SCRIPT_DIR/$DIAGNOSTIC_LOG" || exit 1
 else
   # The build directory must already exist: you can't do --fast for
   # an initial build.

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -7,7 +7,7 @@
 packages:
   # dependers: moose-dev
   tools:
-    version: 2026.06.16
+    version: 2026.07.14
     conda: conda/tools
     templates:
       conda/tools/meta.yaml.template: conda/tools/meta.yaml
@@ -16,7 +16,7 @@ packages:
       - conda/tools
   # dependers: moose-dev
   build:
-    version: 2026.06.16
+    version: 2026.07.14
     conda: conda/build
     templates:
       conda/build/meta.yaml.template: conda/build/meta.yaml
@@ -25,7 +25,7 @@ packages:
       - conda/build
   # dependers: moose-dev
   mpi:
-    version: 2026.06.07
+    version: 2026.07.14
     influential:
       - apptainer/mpi.def
       - apptainer/files/mpi
@@ -33,7 +33,7 @@ packages:
   # dependers: libmesh, moose-dev
   libmesh-vtk:
     version: 9.6.2
-    build_number: 0
+    build_number: 1
     conda: conda/libmesh-vtk
     templates:
       conda/libmesh-vtk/meta.yaml.template: conda/libmesh-vtk/meta.yaml
@@ -43,7 +43,7 @@ packages:
       - conda/libmesh-vtk
   # dependers: libmesh, moose-dev
   petsc:
-    version: 3.25.2
+    version: 3.25.3
     build_number: 0
     conda: conda/petsc
     templates:
@@ -62,7 +62,7 @@ packages:
       - scripts/apple-silicon-hdf5-autogen.patch
   # dependers: moose-dev
   libmesh:
-    version: 2026.06.05_ab36c00
+    version: 2026.07.13_80b5e97
     build_number: 0
     conda: conda/libmesh
     templates:
@@ -82,7 +82,7 @@ packages:
       - scripts/update_and_rebuild_libmesh.sh
   # dependers: pyhit, moose-dev
   wasp:
-    version: 2026.06.15_d8777a8
+    version: 2026.06.19_0edc884
     build_number: 0
     conda: conda/wasp
     templates:
@@ -96,7 +96,7 @@ packages:
       - scripts/update_and_rebuild_wasp.sh
   # dependers: none
   pyhit:
-    version: 2026.06.16
+    version: 2026.07.14
     conda: conda/pyhit
     dependencies:
       - wasp
@@ -112,7 +112,7 @@ packages:
       conda/pyhit/meta.yaml.template: conda/pyhit/meta.yaml
   # dependers: none
   moose-dev:
-    version: 2026.06.16
+    version: 2026.07.14
     conda: conda/moose-dev
     templates:
       conda/moose-dev/meta.yaml.template: conda/moose-dev/meta.yaml
@@ -150,7 +150,7 @@ packages:
   # dependers: none
   pprof:
     version: 2026.05.06_92041b7
-    build_number: 0
+    build_number: 1
     conda: conda/pprof
     templates:
       conda/pprof/meta.yaml.template: conda/pprof/meta.yaml
@@ -160,7 +160,7 @@ packages:
   # dependers: none
   seacas:
     version: 2025.10.14
-    build_number: 4
+    build_number: 5
     conda: conda/seacas
     templates:
       conda/seacas/meta.yaml.template: conda/seacas/meta.yaml

--- a/test/tests/kernels/vector_fe/tests
+++ b/test/tests/kernels/vector_fe/tests
@@ -379,7 +379,7 @@
       input = grad_div.i
       exodiff = grad_div_tet14.e
       # tolerance increased from inter-platform differences
-      abs_zero = 8e-9
+      abs_zero = 5e-7
       rel_err = 6e-4
       # Reduce the size of the penalty to get reproducible results across platforms
       cli_args = 'Mesh/gmg/elem_type=TET14 Mesh/gmg/nx=6 Mesh/gmg/ny=6 BCs/sides/penalty=1e5 '


### PR DESCRIPTION
## Conda packages

### `moose-build 2026.06.16`

- Rebuild

### `moose-wasp 2026.06.15_d8777a8`

- Update wasp [`2cdbeb7..d8777a8`](https://github.com/ornl-neams-workbench/wasp/compare/2cdbeb74fa4bcea175ca8ff202a6f5b79d41dbd3...d8777a831a90c32e13573b775c9284949e6571c3)

### `moose-tools 2026.06.16`

- Re-add clang-tools, needed for `git clang-format`
- Downgrade clang-format from 22.1.5 to 19.1.7 (required due to version pinning with clang-tools and clang)

### `moose-dev 2026.06.16 [mpich,openmpi]`

- Rebuild due to updated pins in `conda/conda_build_config.yaml`
- Use updated moose-tools dependency `moose-tools 2026.06.07`

## Apptainer containers

### `moose-dev:2026.06.16`

- Downgrade clang-format from 22.1.5 to 19.1.7 (required due to version pinning with conda clang-tools and clang)
- Update python from 3.14.5 to 3.14.6
- Update code-server from 4.122.0 to 4.123.0
- Add fastcov to python for parallel lcov/gcov generation
- Update NEML2 [`9b8d8b9..95801ac`](https://github.com/applied-material-modeling/neml2/compare/9b8d8b934095b7f49fe2f92eb00937e9209c38aa...95801ac8db50c62ec850a47989aaacd971e2eb7d)
- Update wasp [`2cdbeb7..d8777a8`](https://github.com/ornl-neams-workbench/wasp/compare/2cdbeb74fa4bcea175ca8ff202a6f5b79d41dbd3...d8777a831a90c32e13573b775c9284949e6571c3)

## To do

- [x] Add #33094
- [x] Re-add `clang-tools` to conda `moose-tools` package