### PR TITLE
Report unsupported whitespace in MOOSE build paths

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -7,8 +7,14 @@
 # FRAMEWORK_DIR - Location of the MOOSE framework
 #
 ###############################################################################
-MOOSE_DIR          ?= $(shell dirname `pwd`)
+MOOSE_DIR          ?= $(shell dirname "$$PWD")
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ifneq ($(words $(MOOSE_DIR)),1)
+  $(error MOOSE_DIR contains whitespace: '$(MOOSE_DIR)'. MOOSE Makefiles do not support paths with whitespace; move the checkout or set MOOSE_DIR to a path without whitespace)
+endif
+ifneq ($(words $(FRAMEWORK_DIR)),1)
+  $(error FRAMEWORK_DIR contains whitespace: '$(FRAMEWORK_DIR)'. MOOSE Makefiles do not support paths with whitespace; move the checkout or set FRAMEWORK_DIR to a path without whitespace)
+endif
 ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -7,8 +7,14 @@
 # FRAMEWORK_DIR - Location of the MOOSE framework
 #
 ###############################################################################
-MOOSE_DIR          ?= $(shell dirname `pwd`)
+MOOSE_DIR          ?= $(shell dirname "$$PWD")
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ifneq ($(words $(MOOSE_DIR)),1)
+  $(error MOOSE_DIR contains whitespace: '$(MOOSE_DIR)'. MOOSE Makefiles do not support paths with whitespace; move the checkout or set MOOSE_DIR to a path without whitespace)
+endif
+ifneq ($(words $(FRAMEWORK_DIR)),1)
+  $(error FRAMEWORK_DIR contains whitespace: '$(FRAMEWORK_DIR)'. MOOSE Makefiles do not support paths with whitespace; move the checkout or set FRAMEWORK_DIR to a path without whitespace)
+endif
 ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -7,8 +7,14 @@
 # FRAMEWORK_DIR - Location of the MOOSE framework
 #
 ###############################################################################
-MOOSE_DIR          ?= $(shell dirname `pwd`)
+MOOSE_DIR          ?= $(shell dirname "$$PWD")
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ifneq ($(words $(MOOSE_DIR)),1)
+  $(error MOOSE_DIR contains whitespace: '$(MOOSE_DIR)'. MOOSE Makefiles do not support paths with whitespace; move the checkout or set MOOSE_DIR to a path without whitespace)
+endif
+ifneq ($(words $(FRAMEWORK_DIR)),1)
+  $(error FRAMEWORK_DIR contains whitespace: '$(FRAMEWORK_DIR)'. MOOSE Makefiles do not support paths with whitespace; move the checkout or set FRAMEWORK_DIR to a path without whitespace)
+endif
 ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,8 +7,14 @@
 # FRAMEWORK_DIR - Location of the MOOSE framework
 #
 ###############################################################################
-MOOSE_DIR          ?= $(shell dirname `pwd`)
+MOOSE_DIR          ?= $(shell dirname "$$PWD")
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ifneq ($(words $(MOOSE_DIR)),1)
+  $(error MOOSE_DIR contains whitespace: '$(MOOSE_DIR)'. MOOSE Makefiles do not support paths with whitespace; move the checkout or set MOOSE_DIR to a path without whitespace)
+endif
+ifneq ($(words $(FRAMEWORK_DIR)),1)
+  $(error FRAMEWORK_DIR contains whitespace: '$(FRAMEWORK_DIR)'. MOOSE Makefiles do not support paths with whitespace; move the checkout or set FRAMEWORK_DIR to a path without whitespace)
+endif
 ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -10,8 +10,14 @@
 # FRAMEWORK_DIR - Location of the MOOSE framework
 #
 ###############################################################################
-MOOSE_DIR          ?= $(shell dirname `pwd`)
+MOOSE_DIR          ?= $(shell dirname "$$PWD")
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ifneq ($(words $(MOOSE_DIR)),1)
+  $(error MOOSE_DIR contains whitespace: '$(MOOSE_DIR)'. MOOSE Makefiles do not support paths with whitespace; move the checkout or set MOOSE_DIR to a path without whitespace)
+endif
+ifneq ($(words $(FRAMEWORK_DIR)),1)
+  $(error FRAMEWORK_DIR contains whitespace: '$(FRAMEWORK_DIR)'. MOOSE Makefiles do not support paths with whitespace; move the checkout or set FRAMEWORK_DIR to a path without whitespace)
+endif
 ADDITIONAL_CPPFLAGS += -Wall -Wextra -DMOOSE_UNIT_TEST
 ###############################################################################
 


### PR DESCRIPTION
## Summary
- quote the default PWD-based MOOSE_DIR computation in the main framework/test/unit/modules/examples entry Makefiles
- add an early diagnostic when MOOSE_DIR or FRAMEWORK_DIR contains whitespace
- replace the previous cryptic Make parse failure with an actionable message to move the checkout or set a whitespace-free path

## Motivation
A checkout under a path such as `/Users/saqif/Documents/OpenSees Project/MOOSE` currently fails before users get a useful build-system message because Make splits `include $(FRAMEWORK_DIR)/build.mk` on whitespace. This does not make the full build system whitespace-safe, but it turns the common failure mode into a clear preflight diagnostic.

Fixes #33431

## Verification
- `make -C test -n` from `/Users/saqif/Documents/OpenSees Project/MOOSE` now reports `MOOSE_DIR contains whitespace: ...`
- `make -C /tmp/moose-path-guard-commit.y0DxmZ/test -n` from a no-space worktree reaches the normal dependency checks without triggering the whitespace guard
- `git diff --check HEAD~1..HEAD`