### PR TITLE
Require Python 3.10 for TestHarness

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -44,6 +44,22 @@ from TestHarness.capability_util import (
 # Directory the test harness is in
 testharness_dir = os.path.dirname(os.path.realpath(__file__))
 
+MINIMUM_PYTHON_VERSION = (3, 10)
+
+
+def checkPythonVersion(version_info=None):
+    if version_info is None:
+        version_info = sys.version_info
+
+    if tuple(version_info[:2]) < MINIMUM_PYTHON_VERSION:
+        required = ".".join(str(value) for value in MINIMUM_PYTHON_VERSION)
+        found = ".".join(str(value) for value in version_info[:3])
+        raise RuntimeError(
+            f"MOOSE TestHarness requires Python {required} or newer; "
+            f"found Python {found}. Activate a current MOOSE environment "
+            "or run with a newer python3."
+        )
+
 
 def readTestRoot(fname):
 
@@ -283,6 +299,8 @@ class TestHarness:
         moose_python: Optional[str] = None,
         skip_testroot: bool = False,
     ) -> "TestHarness":
+        checkPythonVersion()
+
         # Cannot skip the testroot if we don't have an application name
         if skip_testroot and not app_name:
             raise ValueError(f'Must provide "app_name" when skip_testroot=True')

--- a/python/TestHarness/__init__.py
+++ b/python/TestHarness/__init__.py
@@ -6,6 +6,6 @@
 #
 # Licensed under LGPL 2.1, please see LICENSE for details
 # https://www.gnu.org/licenses/lgpl-2.1.html
-from .TestHarness import TestHarness
+from .TestHarness import TestHarness, checkPythonVersion
 from .OutputInterface import OutputInterface
 from .TestHarness import findDepApps

--- a/python/TestHarness/tests/test_PythonVersion.py
+++ b/python/TestHarness/tests/test_PythonVersion.py
@@ -8,9 +8,16 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 from TestHarnessTestCase import TestHarnessTestCase
+from TestHarness import checkPythonVersion
 
 
 class TestHarnessTester(TestHarnessTestCase):
+    def testMinimumVersion(self):
+        """Test that the TestHarness rejects unsupported Python versions."""
+        checkPythonVersion((3, 10, 0))
+        with self.assertRaisesRegex(RuntimeError, "requires Python 3.10 or newer"):
+            checkPythonVersion((3, 9, 20))
+
     def testVersion(self):
         """Test that python=... is working."""
         output = self.runTests("-i", "python_version").output

--- a/scripts/functions/diagnostic_environment.sh
+++ b/scripts/functions/diagnostic_environment.sh
@@ -79,14 +79,19 @@ function python_test()
 {
     print_sep
     printf "Python Sanity Checks\n\n"
+    local error_cnt=0
     my_version="$(/usr/bin/env python3 --version || printf 'NONE')"
     if [[ "${my_version}" != 'NONE' ]]; then
+        if ! /usr/bin/env python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' 2>/dev/null; then
+            print_red "FAIL: "
+            printf 'MOOSE requires Python 3.10 or newer; found %s\n\n' "${my_version}"
+            (( error_cnt+=1 ))
+        fi
         printf '%s (reporting as: %s) matches\n%s\n\n' \
         "$(print_bold "/usr/bin/env python3 --version");" \
         "${my_version}" \
         "$(print_bold "which python3 python");"
         which_pythons=('python3' 'python')
-        local error_cnt=0
         for which_python in "${which_pythons[@]}"; do
             local my_python
             my_python="$(which "${which_python}")"


### PR DESCRIPTION
## Summary
- add an explicit Python >= 3.10 check at TestHarness startup
- make diagnostics fail when `/usr/bin/env python3` is older than 3.10
- add unit coverage for the TestHarness version-check helper

## Motivation
Python 3.9 can no longer run parts of MOOSE, but diagnostics previously allowed it through. This makes the unsupported interpreter failure immediate and actionable for diagnostics and TestHarness startup.

Fixes #32408

## Verification
- sourced `scripts/functions/diagnostic_environment.sh` and ran `python_test` with local Python 3.9.6; it now returns failure and reports the Python 3.10 requirement
- simulated `checkPythonVersion((3, 9, 20))` with Python 3.11 and confirmed it raises `MOOSE TestHarness requires Python 3.10 or newer`
- `/opt/homebrew/bin/python3.11 -m py_compile python/TestHarness/__init__.py python/TestHarness/TestHarness.py python/TestHarness/tests/test_PythonVersion.py`
- `/tmp/moose-black-venv-33408/bin/black --config pyproject.toml --check python/TestHarness/__init__.py python/TestHarness/TestHarness.py python/TestHarness/tests/test_PythonVersion.py`
- `git diff --check`

Note: running the full TestHarness unit file locally is blocked in this checkout by the existing unbuilt `pyhit`/HIT dependency state, which is separate from this change.