### PR TITLE
Update libMesh for SCALAR AMR projection

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,7 +5,7 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
-{% set version = "2026.06.05_ab36c00" %}
+{% set version = "2026.07.27_40b3894" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2026.06.16" %}
+{% set version = "2026.07.27" %}
 
 package:
   name: moose-dev
@@ -20,14 +20,14 @@ build:
     # things that depend on this moose-dev must use the
     # exact moose-* packages that this was built with
     - moose-build 2026.06.16 {{ mpi }}
-    - moose-libmesh 2026.06.05_ab36c00 {{ mpi }}_0
+    - moose-libmesh 2026.07.27_40b3894 {{ mpi }}_0
     - moose-wasp 2026.06.15_d8777a8 build_0
     - moose-tools 2026.06.16
 
 requirements:
   run:
     - moose-build 2026.06.16 {{ mpi }}
-    - moose-libmesh 2026.06.05_ab36c00 {{ mpi }}_0
+    - moose-libmesh 2026.07.27_40b3894 {{ mpi }}_0
     - moose-wasp 2026.06.15_d8777a8 build_0
     - moose-tools 2026.06.16
   run_constrained:

--- a/conda/moose/meta.yaml
+++ b/conda/moose/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - {{ compiler('fortran') }}
     - {{ stdlib('c') }}
     # for libmesh libtool
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.07.27_40b3894 mpich_0
     # build utilities
     - make
     - packaging
@@ -44,12 +44,12 @@ requirements:
     # see libfabric entry in conda/conda_build_config.yaml (only for mpich)
     - libfabric {{ libfabric }} # [linux]
     - libpng
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.07.27_40b3894 mpich_0
     - moose-wasp 2026.06.15_d8777a8 build_0
     - zlib
   run:
     - mpich {{ mpich_version }}
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.07.27_40b3894 mpich_0
     - moose-wasp 2026.06.15_d8777a8 build_0
     # c++ compiler for jit
     - gxx_linux-64 {{ cxx_compiler_version }}.*               # [linux]

--- a/conda/template/meta.yaml
+++ b/conda/template/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - {{ compiler('fortran') }}
     - {{ stdlib('c') }}
     # for libmesh libtool
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.07.27_40b3894 mpich_0
     # build utilities
     - make
     - packaging
@@ -46,13 +46,13 @@ requirements:
     # see libfabric entry in conda/conda_build_config.yaml
     - libfabric {{ libfabric }} # [linux]
     - libpng
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.07.27_40b3894 mpich_0
     - moose-wasp 2026.06.15_d8777a8 build_0
     - zlib
   run:
     # should eventually become 'mpich {{ mpich_version }}'
     - mpich 5.0.1
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.07.27_40b3894 mpich_0
     - moose-wasp 2026.06.15_d8777a8 build_0
     # c++ compiler for jit
     - gxx_linux-64 {{ cxx_compiler_version }}.*               # [linux]

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1869,3 +1869,38 @@ f255569fa6a7decb96241c472dbe1ba4fc85a0a0: # 33024
   wasp:
     full_version: 2026.06.15_d8777a8_0
     hash: 475155d
+3bba0533ad26f62ee35f9380e273a2224d09e387: # 33366
+  build:
+    full_version: 2026.06.16
+    hash: d2814f0
+  libmesh:
+    full_version: 2026.07.27_40b3894_0
+    hash: 6475d0a
+  libmesh-vtk:
+    full_version: 9.6.2_0
+    hash: 541d7ec
+  moose-dev:
+    full_version: 2026.07.27
+    hash: 0e46bbc
+  mpi:
+    full_version: 2026.06.07
+    hash: 46e85b3
+  petsc:
+    full_version: 3.25.2_0
+    hash: 5bee082
+  pprof:
+    full_version: 2026.05.06_92041b7_0
+    hash: 82f1795
+  pyhit:
+    full_version: 2026.06.16
+    hash: ec4aa51
+  seacas:
+    full_version: 2025.10.14_4
+    hash: d38503e
+  tools:
+    full_version: 2026.06.16
+    hash: 98d0467
+  wasp:
+    full_version: 2026.06.15_d8777a8_0
+    hash: 475155d
+

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -62,7 +62,7 @@ packages:
       - scripts/apple-silicon-hdf5-autogen.patch
   # dependers: moose-dev
   libmesh:
-    version: 2026.06.05_ab36c00
+    version: 2026.07.27_40b3894
     build_number: 0
     conda: conda/libmesh
     templates:
@@ -112,7 +112,7 @@ packages:
       conda/pyhit/meta.yaml.template: conda/pyhit/meta.yaml
   # dependers: none
   moose-dev:
-    version: 2026.06.16
+    version: 2026.07.27
     conda: conda/moose-dev
     templates:
       conda/moose-dev/meta.yaml.template: conda/moose-dev/meta.yaml


### PR DESCRIPTION
# Update libMesh for SCALAR AMR projection

## Summary

Update the libMesh submodule to include the merged fix for projecting systems that contain global `SCALAR` variables during mesh adaptivity.

The libMesh change excludes global `SCALAR` variables from spatial `GenericProjector` operations and continues to transfer their degrees of freedom through the existing direct mapping logic.

## Testing

The libMesh regression test:

* creates a refined two-dimensional mesh;
* combines a `CONSTANT MONOMIAL` spatial variable with a global `SCALAR` variable;
* performs fine-to-coarse projection through `EquationSystems::reinit()`;
* verifies that the global scalar value is preserved.

Without the libMesh fix, the test fails in `FE<2, SCALAR>::reinit()` through `GenericProjector::ProjectInteriors`.

With the fix:

* the new regression passes;
* all 47 selected `SystemsTest` and `EquationSystemsTest` tests pass;
* the reduced MOOSE reproducer completes adaptivity while preserving the scalar value.

Related discussion: https://github.com/idaholab/moose/discussions/33008

Closes #33366
