### PR TITLE
Fix gcc 15.2.0 warning (-Wfree-nonheap-object)

### DIFF
--- a/framework/include/utils/InputParametersChecksUtils.h
+++ b/framework/include/utils/InputParametersChecksUtils.h
@@ -150,7 +150,7 @@ private:
   // MooseObjects and Actions (MooseParameterInterface-derived classes)
   /// Forwards parameter check to the class using this utility
   template <typename T>
-  T forwardGetParam(const std::string & param_name) const
+  const T & forwardGetParam(const std::string & param_name) const
   {
     return _customer_class->template getParam<T>(param_name);
   }


### PR DESCRIPTION
## Reason
Avoid gcc 15.2.0 warning (-Wfree-nonheap-object).

## Design
Return by reference instead of by value to avoid unnecessary copy.
(courtesy of codex @lindsayad 😜)

## Impact
One fewer warning. None on my machine now.