### PR TITLE
Attempt to fix mismatched gcc versions for conda linux recipes

### DIFF
--- a/conda/build/conda_build_config.yaml
+++ b/conda/build/conda_build_config.yaml
@@ -6,16 +6,16 @@
 ##
 
 moose_c_compiler:
-  - gcc_linux-64 14.3.*                                     # [linux]
+  - gcc_linux-64 14.*                                       # [linux]
   - clang_osx-64 19.1.*                                     # [osx and x86_64]
   - clang_osx-arm64 19.1.*                                  # [osx and arm64]
 
 moose_cxx_compiler:
-  - gxx_linux-64 14.3.*                                     # [linux]
+  - gxx_linux-64 14.*                                       # [linux]
   - clangxx_osx-64 19.1.*                                   # [osx and x86_64]
   - clangxx_osx-arm64 19.1.*                                # [osx and arm64]
 
 moose_fortran_compiler:
-  - gfortran_linux-64 14.3.*                                # [linux]
-  - gfortran_osx-64 14.3.*                                  # [osx and x86_64]
-  - gfortran_osx-arm64 14.3.*                               # [osx and arm64]
+  - gfortran_linux-64 14.*                                  # [linux]
+  - gfortran_osx-64 14.*                                    # [osx and x86_64]
+  - gfortran_osx-arm64 14.*                                 # [osx and arm64]

--- a/conda/build/meta.yaml
+++ b/conda/build/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2026.06.16" %}
+{% set version = "2026.07.30" %}
 
 package:
   name: moose-build

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = "2026.06.05_ab36c00" %}
 
 package:

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2026.06.16" %}
+{% set version = "2026.07.30" %}
 
 package:
   name: moose-dev
@@ -19,15 +19,15 @@ build:
   run_exports:
     # things that depend on this moose-dev must use the
     # exact moose-* packages that this was built with
-    - moose-build 2026.06.16 {{ mpi }}
-    - moose-libmesh 2026.06.05_ab36c00 {{ mpi }}_0
+    - moose-build 2026.07.30 {{ mpi }}
+    - moose-libmesh 2026.06.05_ab36c00 {{ mpi }}_1
     - moose-wasp 2026.06.15_d8777a8 build_0
     - moose-tools 2026.06.16
 
 requirements:
   run:
-    - moose-build 2026.06.16 {{ mpi }}
-    - moose-libmesh 2026.06.05_ab36c00 {{ mpi }}_0
+    - moose-build 2026.07.30 {{ mpi }}
+    - moose-libmesh 2026.06.05_ab36c00 {{ mpi }}_1
     - moose-wasp 2026.06.15_d8777a8 build_0
     - moose-tools 2026.06.16
   run_constrained:

--- a/conda/moose/meta.yaml
+++ b/conda/moose/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - {{ compiler('fortran') }}
     - {{ stdlib('c') }}
     # for libmesh libtool
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.06.05_ab36c00 mpich_1
     # build utilities
     - make
     - packaging
@@ -44,12 +44,12 @@ requirements:
     # see libfabric entry in conda/conda_build_config.yaml (only for mpich)
     - libfabric {{ libfabric }} # [linux]
     - libpng
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.06.05_ab36c00 mpich_1
     - moose-wasp 2026.06.15_d8777a8 build_0
     - zlib
   run:
     - mpich {{ mpich_version }}
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.06.05_ab36c00 mpich_1
     - moose-wasp 2026.06.15_d8777a8 build_0
     # c++ compiler for jit
     - gxx_linux-64 {{ cxx_compiler_version }}.*               # [linux]

--- a/conda/template/meta.yaml
+++ b/conda/template/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - {{ compiler('fortran') }}
     - {{ stdlib('c') }}
     # for libmesh libtool
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.06.05_ab36c00 mpich_1
     # build utilities
     - make
     - packaging
@@ -46,13 +46,13 @@ requirements:
     # see libfabric entry in conda/conda_build_config.yaml
     - libfabric {{ libfabric }} # [linux]
     - libpng
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.06.05_ab36c00 mpich_1
     - moose-wasp 2026.06.15_d8777a8 build_0
     - zlib
   run:
     # should eventually become 'mpich {{ mpich_version }}'
     - mpich 5.0.1
-    - moose-libmesh 2026.06.05_ab36c00 mpich_0
+    - moose-libmesh 2026.06.05_ab36c00 mpich_1
     - moose-wasp 2026.06.15_d8777a8 build_0
     # c++ compiler for jit
     - gxx_linux-64 {{ cxx_compiler_version }}.*               # [linux]

--- a/modules/doc/content/newsletter/2026/2026_07.md
+++ b/modules/doc/content/newsletter/2026/2026_07.md
@@ -17,4 +17,24 @@ for a complete description of all MOOSE changes.
 
 ## Conda Package Updates
 
+### `moose-build 2026.07.30`
+
+- Loosen pinning for compilers to major version only
+
+### `moose-libmesh 2026.06.05_ab36c00_1 [mpich,openmpi]`
+
+- Force rebuild to use new conda linkers; MOOSE inherits compiler flags from libmesh so this is required to resolve ld issues
+
+### `moose-dev 2026.07.30 [mpich,openmpi]`
+
+- Use updated `moose-libmesh 2026.06.05_ab36c00_1 [mpich,openmpi]` to fix ld issues
+
 ## Apptainer Package Updates
+
+### `moose-libmesh:2026.06.05_ab36c00_1`
+
+- Forced rebuild due to conda package `moose-libmesh 2026.06.05_ab36c00_1 [mpich,openmpi]`
+
+### `moose-dev:2026.07.30`
+
+- Forced rebuild due to conda package `moose-dev 2026.07.30 [mpich,openmpi]`

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1869,3 +1869,38 @@ f255569fa6a7decb96241c472dbe1ba4fc85a0a0: # 33024
   wasp:
     full_version: 2026.06.15_d8777a8_0
     hash: 475155d
+
+ed633437b48c821cc2e4f84795e457744b7b1370: # 33460
+  build:
+    full_version: 2026.07.30
+    hash: cf419cc
+  libmesh:
+    full_version: 2026.06.05_ab36c00_1
+    hash: 8f0b7da
+  libmesh-vtk:
+    full_version: 9.6.2_0
+    hash: 541d7ec
+  moose-dev:
+    full_version: 2026.07.30
+    hash: 356a606
+  mpi:
+    full_version: 2026.06.07
+    hash: 46e85b3
+  petsc:
+    full_version: 3.25.2_0
+    hash: 5bee082
+  pprof:
+    full_version: 2026.05.06_92041b7_0
+    hash: 82f1795
+  pyhit:
+    full_version: 2026.06.16
+    hash: ec4aa51
+  seacas:
+    full_version: 2025.10.14_4
+    hash: d38503e
+  tools:
+    full_version: 2026.06.16
+    hash: 98d0467
+  wasp:
+    full_version: 2026.06.15_d8777a8_0
+    hash: 475155d

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -16,7 +16,7 @@ packages:
       - conda/tools
   # dependers: moose-dev
   build:
-    version: 2026.06.16
+    version: 2026.07.30
     conda: conda/build
     templates:
       conda/build/meta.yaml.template: conda/build/meta.yaml
@@ -63,7 +63,7 @@ packages:
   # dependers: moose-dev
   libmesh:
     version: 2026.06.05_ab36c00
-    build_number: 0
+    build_number: 1
     conda: conda/libmesh
     templates:
       conda/libmesh/meta.yaml.template: conda/libmesh/meta.yaml
@@ -112,7 +112,7 @@ packages:
       conda/pyhit/meta.yaml.template: conda/pyhit/meta.yaml
   # dependers: none
   moose-dev:
-    version: 2026.06.16
+    version: 2026.07.30
     conda: conda/moose-dev
     templates:
       conda/moose-dev/meta.yaml.template: conda/moose-dev/meta.yaml


### PR DESCRIPTION
## Conda packages

### `moose-build 2026.07.30`

- Loosen pinning for compilers to major version only

### `moose-libmesh 2026.06.05_ab36c00_1 [mpich,openmpi]`

- Force rebuild to use new conda linkers; MOOSE inherits compiler flags from libmesh so this is required to resolve ld issues

### `moose-dev 2026.07.30 [mpich,openmpi]`

- Use updated `moose-libmesh 2026.06.05_ab36c00_1 [mpich,openmpi]` to fix ld issues

## Apptainer containers

### `moose-libmesh:2026.06.05_ab36c00_1`

- Forced rebuild due to conda package `moose-libmesh 2026.06.05_ab36c00_1 [mpich,openmpi]`

### `moose-dev:2026.07.30`

- Forced rebuild due to conda package `moose-dev 2026.07.30 [mpich,openmpi]`
