### PR TITLE
Fix AddMFEMFESpace(Hierarchy)Action docs

### DIFF
--- a/framework/doc/content/source/mfem/actions/AddMFEMFESpaceAction.md
+++ b/framework/doc/content/source/mfem/actions/AddMFEMFESpaceAction.md
@@ -5,7 +5,7 @@
 ## Overview
 
 Action called to add an MFEM finite element space to the problem, parsing content inside an
-[MFEMFESpace.md] block in the user input. Only has an effect if the
+[`FESpaces`](MFEMFESpace.md) block in the user input. Only has an effect if the
 `Problem` type is set to [MFEMProblem.md].
 
 ## Example Input File Syntax

--- a/framework/doc/content/source/mfem/actions/AddMFEMFESpaceHierarchyAction.md
+++ b/framework/doc/content/source/mfem/actions/AddMFEMFESpaceHierarchyAction.md
@@ -5,8 +5,8 @@
 ## Overview
 
 Action called to add an MFEM finite element space hierarchy to the problem, parsing content inside
-an [MFEMFESpaceHierarchy.md] block in the user input. Only has an effect if the
-`Problem` type is set to [MFEMProblem.md].
+an [`FESpaceHierarchies`](MFEMFESpaceHierarchy.md) block in the user input. Only has an effect if
+the `Problem` type is set to [MFEMProblem.md].
 
 ## Example Input File Syntax
 

--- a/framework/doc/content/source/mfem/equation_systems/EquationSystem.md
+++ b/framework/doc/content/source/mfem/equation_systems/EquationSystem.md
@@ -4,8 +4,7 @@
 
 The EquationSystem is responsible for defining and assembling the weak form of the PDE into an
 [`mfem::Operator`](https://docs.mfem.org/html/classmfem_1_1Operator.html) used to solve an iteration
-of the FE problem. This operator is passed to an
-[`mfem::NewtonSolver`](https://docs.mfem.org/html/classmfem_1_1NewtonSolver.html) in a
+of the FE problem. This operator is passed to a linear or nonlinear solver as appropriate in a
 [ProblemOperator.md], which handles the update of the
 state of all variables (including any required nonlinear iterations).
 

--- a/framework/doc/content/source/mfem/problem_operators/ProblemOperator.md
+++ b/framework/doc/content/source/mfem/problem_operators/ProblemOperator.md
@@ -6,12 +6,14 @@
 
 `ProblemOperator` objects are
 [`mfem::Operator`](https://docs.mfem.org/html/classmfem_1_1Operator.html) that are called inside
-[MFEMProblemSolve.md] to solve a step of the FE problem and update the
+[MFEMProblemSolve.md] to solve the FE problem and update the
 [`mfem::BlockVector`](https://docs.mfem.org/html/classmfem_1_1BlockVector.html) storing the true
 degrees of freedom of all variables.
 
 For more information on usage, see [MFEMProblemSolve.md] and its usage in the
-[MFEMSteady.md] and [MFEMTransient.md] executioner classes.
+[MFEMSteady.md] executioner class.
+
+See [TimeDependentProblemOperator.md] for the transient variant of this class.
 
 !if-end!
 

--- a/framework/doc/content/source/mfem/problem_operators/TimeDependentProblemOperator.md
+++ b/framework/doc/content/source/mfem/problem_operators/TimeDependentProblemOperator.md
@@ -1,0 +1,19 @@
+# TimeDependentProblemOperator
+
+!if! function=hasCapability('mfem')
+
+## Summary
+
+`TimeDependentProblemOperator` objects are
+[`mfem::TimeDependentOperator`](https://docs.mfem.org/html/classmfem_1_1TimeDependentOperator.html) that are called inside
+[MFEMProblemSolve.md] to solve a step of the FE problem and update the
+[`mfem::BlockVector`](https://docs.mfem.org/html/classmfem_1_1BlockVector.html) storing the true
+degrees of freedom of all variables.
+
+For more information on usage, see [MFEMProblemSolve.md] and its usage in the
+[MFEMTransient.md] executioner class.
+
+!if-end!
+
+!else
+!include mfem/mfem_warning.md

--- a/framework/doc/content/syntax/MFEM/index.md
+++ b/framework/doc/content/syntax/MFEM/index.md
@@ -69,7 +69,7 @@ Now we set up boundary conditions. Here, we choose scalar Dirichlet boundary con
 
 ### Solver and Executioner
 
-With the equation system set up, we specify how it is to be solved. Firstly, we choose a preconditioner and solver. For problems with high polynomial order, setting [!param](/Solvers/MFEMHypreGMRES/low_order_refined) to `true` may greatly increase performance, as explained [here](MFEMLinearSolverBase.md).
+With the equation system set up, we specify how it is to be solved. Firstly, we choose a preconditioner and solver. For problems with high polynomial order, setting [!param](/Solvers/MFEMHypreGMRES/low_order_refined) to `true` may greatly increase performance, as explained [here](MFEMLORLinearSolverBase.md).
 
 While in principle any solver may be used as the main solver or preconditioner, the main limitation to keep in mind is that Hypre solvers may only be preconditioned by other Hypre solvers. Furthermore, when a Hypre solver has its `low_order_refined` parameter set to `true`, it ceases to be considered a Hypre solver for preconditioning purposes.
 


### PR DESCRIPTION
## Reason
This minor mistake is propagating to new action docs (including in in-review PRs).

## Design
Mention the actual block syntax name, not the base class of the objects created as a byproduct of the action.

## Impact
Less confusing docs.