### PR TITLE
Don't test color in regression tests

### DIFF
--- a/framework/include/utils/MooseUnitUtils.h
+++ b/framework/include/utils/MooseUnitUtils.h
@@ -13,6 +13,7 @@
 
 #include <filesystem>
 #include <string>
+#include <vector>
 
 #include "libmesh/utility.h"
 
@@ -127,8 +128,35 @@ public:
   const std::filesystem::path & path() const { return _path; }
 
 private:
-  static std::filesystem::path generatePath();
+  const std::filesystem::path _path;
+};
 
+/**
+ * Run a unit test from a unique temporary working directory.
+ *
+ * The provided inputs are copied into the temporary directory using their file names. The original
+ * working directory is restored and the temporary directory is removed upon destruction.
+ */
+class ScopedTestDirectory
+{
+public:
+  explicit ScopedTestDirectory(const std::vector<std::filesystem::path> & inputs);
+  ~ScopedTestDirectory();
+
+  ScopedTestDirectory(const ScopedTestDirectory &) = delete;
+  ScopedTestDirectory & operator=(const ScopedTestDirectory &) = delete;
+
+  /**
+   * @return The path to the temporary working directory.
+   */
+  const std::filesystem::path & path() const { return _path; }
+
+private:
+  static std::filesystem::path createPath();
+
+  /// Working directory to restore upon destruction
+  const std::filesystem::path _original_path;
+  /// Unique temporary working directory
   const std::filesystem::path _path;
 };
 

--- a/framework/src/utils/MooseUnitUtils.C
+++ b/framework/src/utils/MooseUnitUtils.C
@@ -11,6 +11,24 @@
 
 #include <random>
 
+namespace
+{
+std::filesystem::path
+generatePath()
+{
+  static const std::string chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  static thread_local std::mt19937 generator{std::random_device{}()};
+  std::uniform_int_distribution<std::size_t> distribution(0, chars.size() - 1);
+  std::string result;
+  // Ten base-36 characters provide more than 3e15 possible paths.
+  constexpr std::size_t random_name_length = 10;
+  result.reserve(random_name_length);
+  while (result.size() < random_name_length)
+    result += chars[distribution(generator)];
+  return std::filesystem::temp_directory_path() / std::filesystem::path("mooseunit." + result);
+}
+}
+
 namespace Moose::UnitUtils
 {
 TempFile::TempFile() : _path(generatePath()) {}
@@ -21,18 +39,41 @@ TempFile::~TempFile()
   std::filesystem::remove(path(), ec);
 }
 
-std::filesystem::path
-TempFile::generatePath()
+ScopedTestDirectory::ScopedTestDirectory(const std::vector<std::filesystem::path> & inputs)
+  : _original_path(std::filesystem::current_path()), _path(createPath())
 {
-  static const std::string chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-  static thread_local std::mt19937 generator{std::random_device{}()};
-  std::uniform_int_distribution<std::size_t> distribution(0, chars.size() - 1);
-  std::string result;
-  const std::size_t len = 10;
-  result.reserve(len);
-  for (std::size_t i = 0; i < len; ++i)
-    result += chars[distribution(generator)];
-  return std::filesystem::temp_directory_path() / std::filesystem::path("mooseunit." + result);
+  try
+  {
+    for (const auto & input : inputs)
+      std::filesystem::copy(
+          input, _path / input.filename(), std::filesystem::copy_options::recursive);
+    std::filesystem::current_path(_path);
+  }
+  catch (...)
+  {
+    std::error_code ec;
+    std::filesystem::remove_all(_path, ec);
+    throw;
+  }
+}
+
+ScopedTestDirectory::~ScopedTestDirectory()
+{
+  std::error_code ec;
+  std::filesystem::current_path(_original_path, ec);
+  if (!ec)
+    std::filesystem::remove_all(_path, ec);
+}
+
+std::filesystem::path
+ScopedTestDirectory::createPath()
+{
+  while (true)
+  {
+    const auto path = generatePath();
+    if (std::filesystem::create_directory(path))
+      return path;
+  }
 }
 
 }

--- a/test/tests/convergence/reference_residual_convergence/tests
+++ b/test/tests/convergence/reference_residual_convergence/tests
@@ -167,8 +167,8 @@
   [unscale]
     type = RunApp
     input = 'formatting.i'
-    cli_args = 'scaling=true'
-    expect_out = '\(a,\s*b,\s*variable_f\)->\s*res:\s*\033\[39m5\.00e\+06\033\[39m\s+ref:\s*6\.12e\+06\s+res/ref:\s*\033\[39m8\.16e-01\033\[39m'
+    cli_args = 'scaling=true --color off'
+    expect_out = '\(a,\s*b,\s*variable_f\)->\s*res:\s*5\.00e\+06\s+ref:\s*6\.12e\+06\s+res/ref:\s*8\.16e-01'
     requirement = 'The system shall be able to use a reference residual to converge to and reverse variable scaling to output the actual residual, while allowing variable scaling.'
   []
 

--- a/unit/files/ReferenceResidualConvergenceTest/color.i
+++ b/unit/files/ReferenceResidualConvergenceTest/color.i
@@ -1,0 +1,67 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 2
+[]
+
+[GlobalParams]
+  absolute_value_vector_tags = ref
+[]
+
+[Problem]
+  extra_tag_vectors = ref
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+  [force]
+    type = BodyForce
+    variable = u
+    value = 1
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 0
+  []
+[]
+
+[Convergence]
+  [reference]
+    type = ReferenceResidualConvergence
+    reference_vector = ref
+    # The direct linear solve drives both quantities below these standard convergence tolerances.
+    nl_abs_tol = 1e-9
+    nl_rel_tol = 1e-9
+  []
+[]
+
+[Executioner]
+  type = Steady
+  nonlinear_convergence = reference
+  solve_type = NEWTON
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/unit/src/ReferenceResidualConvergenceTest.C
+++ b/unit/src/ReferenceResidualConvergenceTest.C
@@ -11,6 +11,7 @@
 
 #include "Moose.h"
 #include "MooseMain.h"
+#include "MooseUnitUtils.h"
 #include "XTermConstants.h"
 
 namespace
@@ -21,11 +22,11 @@ struct Args
   {
     _args.insert(_args.begin(), "/path/to/exe");
     for (auto & arg : _args)
-      _argv.push_back((char *)arg.data());
+      _argv.push_back(arg.data());
     _argv.push_back(nullptr);
   }
 
-  int argc() const { return _argv.size() - 1; }
+  int argc() const { return static_cast<int>(_argv.size()) - 1; }
   char ** argv() { return _argv.data(); }
 
   std::vector<std::string> _args;
@@ -35,10 +36,12 @@ struct Args
 
 TEST(ReferenceResidualConvergenceTest, quantityColors)
 {
+  Moose::UnitUtils::ScopedTestDirectory test_directory(
+      {"files/ReferenceResidualConvergenceTest/color.i"});
   const bool color_was_enabled = Moose::colorConsole();
 
   testing::internal::CaptureStdout();
-  Args args({"-i", "files/ReferenceResidualConvergenceTest/color.i", "--color", "on"});
+  Args args({"-i", (test_directory.path() / "color.i").string(), "--color", "on"});
   const auto app = Moose::createMooseApp("MooseUnitApp", args.argc(), args.argv());
   app->run();
   Moose::out << std::flush;

--- a/unit/src/ReferenceResidualConvergenceTest.C
+++ b/unit/src/ReferenceResidualConvergenceTest.C
@@ -1,0 +1,77 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest_include.h"
+
+#include "Moose.h"
+#include "MooseMain.h"
+#include "XTermConstants.h"
+
+namespace
+{
+struct Args
+{
+  Args(const std::vector<std::string> & args) : _args(args)
+  {
+    _args.insert(_args.begin(), "/path/to/exe");
+    for (auto & arg : _args)
+      _argv.push_back((char *)arg.data());
+    _argv.push_back(nullptr);
+  }
+
+  int argc() const { return _argv.size() - 1; }
+  char ** argv() { return _argv.data(); }
+
+  std::vector<std::string> _args;
+  std::vector<char *> _argv;
+};
+}
+
+TEST(ReferenceResidualConvergenceTest, quantityColors)
+{
+  const bool color_was_enabled = Moose::colorConsole();
+
+  testing::internal::CaptureStdout();
+  Args args({"-i", "files/ReferenceResidualConvergenceTest/color.i", "--color", "on"});
+  const auto app = Moose::createMooseApp("MooseUnitApp", args.argc(), args.argv());
+  app->run();
+  Moose::out << std::flush;
+  const auto output = testing::internal::GetCapturedStdout();
+
+  Moose::setColorConsole(color_was_enabled, color_was_enabled);
+
+  bool found_colored_row = false;
+  std::size_t row_begin = 0;
+  while ((row_begin = output.find("u-> res: ", row_begin)) != std::string::npos)
+  {
+    const auto row_end = output.find('\n', row_begin);
+    const auto row = output.substr(row_begin, row_end - row_begin);
+    const auto residual_color = row.find(std::string("res: ") + XTERM_YELLOW);
+    const auto reference_label = row.find("  ref: ");
+    const auto residual_reset = row.find(XTERM_DEFAULT, residual_color);
+    const auto ratio_color = row.find(std::string("res/ref: ") + XTERM_GREEN);
+    const auto ratio_reset = row.find(XTERM_DEFAULT, ratio_color);
+
+    if (residual_color != std::string::npos && reference_label != std::string::npos &&
+        residual_reset < reference_label && ratio_color != std::string::npos &&
+        ratio_reset != std::string::npos)
+    {
+      found_colored_row = true;
+      break;
+    }
+
+    if (row_end == std::string::npos)
+      break;
+    row_begin = row_end + 1;
+  }
+
+  EXPECT_TRUE(found_colored_row)
+      << "Expected a reference residual row with a yellow residual and green ratio:\n"
+      << output;
+}


### PR DESCRIPTION
The test harness supports --no-color so we shouldn't have tests that rely on coloring. This is better supported by a unit test IMO.

Refs #33233