### PR TITLE
Improvements following #32736

### DIFF
--- a/framework/doc/content/source/mfem/vectorpostprocessors/MFEMComplexVariablePointValueSampler.md
+++ b/framework/doc/content/source/mfem/vectorpostprocessors/MFEMComplexVariablePointValueSampler.md
@@ -1,4 +1,4 @@
-# MFEMComplexPointVariableValueSampler
+# MFEMComplexVariablePointValueSampler
 
 !if! function=hasCapability('mfem')
 
@@ -13,11 +13,11 @@ The real and imaginary parts of each sampled component are output as separate co
 
 !listing mfem/variables/complex_aux_recovery.i block=VectorPostprocessors
 
-!syntax parameters /VectorPostprocessors/MFEMComplexPointVariableValueSampler
+!syntax parameters /VectorPostprocessors/MFEMComplexVariablePointValueSampler
 
-!syntax inputs /VectorPostprocessors/MFEMComplexPointVariableValueSampler
+!syntax inputs /VectorPostprocessors/MFEMComplexVariablePointValueSampler
 
-!syntax children /VectorPostprocessors/MFEMComplexPointVariableValueSampler
+!syntax children /VectorPostprocessors/MFEMComplexVariablePointValueSampler
 
 !if-end!
 

--- a/framework/doc/content/source/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.md
+++ b/framework/doc/content/source/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.md
@@ -10,12 +10,8 @@ element operators and need not belong to a finite element space. The sampler
 therefore evaluates the coefficient directly in the owning element selected by
 MFEM's [`FindPointsGSLIB`](https://mfem.org/howto/findpts/) point search.
 
-An arbitrary coefficient may be discontinuous across an element boundary, and
-MFEM coefficients do not provide general continuity metadata. When a sample is
-classified as lying on an element boundary, the sampler issues a warning and
-returns the value from the element selected by GSLIB. The variable sampler's
-`side_interpolation_type` arithmetic and harmonic averages do not apply to
-coefficients.
+!alert note An arbitrary coefficient may be discontinuous anywhere in space.
+Beware of sampling at discontinuity surfaces.
 
 Quadrature-function-backed coefficients are defined only at the quadrature
 points configured by their quadrature rule. They cannot be evaluated at

--- a/framework/doc/content/source/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.md
+++ b/framework/doc/content/source/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.md
@@ -1,4 +1,4 @@
-# MFEMPointScalarCoefficientValueSampler
+# MFEMScalarCoefficientPointValueSampler
 
 !if! function=hasCapability('mfem')
 
@@ -25,11 +25,11 @@ arbitrary sample points and are rejected by this sampler.
 
 !listing mfem/vectorpostprocessors/coefficient_value_sampler/coefficient_value_sampler.i block=VectorPostprocessors
 
-!syntax parameters /VectorPostprocessors/MFEMPointScalarCoefficientValueSampler
+!syntax parameters /VectorPostprocessors/MFEMScalarCoefficientPointValueSampler
 
-!syntax inputs /VectorPostprocessors/MFEMPointScalarCoefficientValueSampler
+!syntax inputs /VectorPostprocessors/MFEMScalarCoefficientPointValueSampler
 
-!syntax children /VectorPostprocessors/MFEMPointScalarCoefficientValueSampler
+!syntax children /VectorPostprocessors/MFEMScalarCoefficientPointValueSampler
 
 !if-end!
 

--- a/framework/doc/content/source/mfem/vectorpostprocessors/MFEMVariableLineValueSampler.md
+++ b/framework/doc/content/source/mfem/vectorpostprocessors/MFEMVariableLineValueSampler.md
@@ -1,4 +1,4 @@
-# MFEMLineVariableValueSampler
+# MFEMVariableLineValueSampler
 
 !if! function=hasCapability('mfem')
 
@@ -12,11 +12,11 @@ along a specified line using MFEM's
 
 !listing mfem/vectorpostprocessors/line_value_sampler/line_value_sampler_diffusion.i block=VectorPostprocessors
 
-!syntax parameters /VectorPostprocessors/MFEMLineVariableValueSampler
+!syntax parameters /VectorPostprocessors/MFEMVariableLineValueSampler
 
-!syntax inputs /VectorPostprocessors/MFEMLineVariableValueSampler
+!syntax inputs /VectorPostprocessors/MFEMVariableLineValueSampler
 
-!syntax children /VectorPostprocessors/MFEMLineVariableValueSampler
+!syntax children /VectorPostprocessors/MFEMVariableLineValueSampler
 
 !if-end!
 

--- a/framework/doc/content/source/mfem/vectorpostprocessors/MFEMVariablePointValueSampler.md
+++ b/framework/doc/content/source/mfem/vectorpostprocessors/MFEMVariablePointValueSampler.md
@@ -1,4 +1,4 @@
-# MFEMPointVariableValueSampler
+# MFEMVariablePointValueSampler
 
 !if! function=hasCapability('mfem')
 
@@ -12,11 +12,11 @@ set of specified points using MFEM's
 
 !listing mfem/vectorpostprocessors/point_value_sampler/point_value_sampler_diffusion.i block=VectorPostprocessors
 
-!syntax parameters /VectorPostprocessors/MFEMPointVariableValueSampler
+!syntax parameters /VectorPostprocessors/MFEMVariablePointValueSampler
 
-!syntax inputs /VectorPostprocessors/MFEMPointVariableValueSampler
+!syntax inputs /VectorPostprocessors/MFEMVariablePointValueSampler
 
-!syntax children /VectorPostprocessors/MFEMPointVariableValueSampler
+!syntax children /VectorPostprocessors/MFEMVariablePointValueSampler
 
 !if-end!
 

--- a/framework/include/mfem/vectorpostprocessors/MFEMComplexVariablePointValueSampler.h
+++ b/framework/include/mfem/vectorpostprocessors/MFEMComplexVariablePointValueSampler.h
@@ -11,18 +11,18 @@
 
 #pragma once
 
-#include "MFEMVariableValueSamplerBase.h"
+#include "MFEMComplexVariableValueSamplerBase.h"
 
-/*
- * MFEM Postprocessor which samples values at a set of points evenly
- * distributed along a line.
+/**
+ * Samples a complex-valued MFEM variable at specific points.
+ * Outputs real and imaginary parts as separate VPP columns.
  */
-class MFEMLineVariableValueSampler : public MFEMVariableValueSamplerBase
+class MFEMComplexVariablePointValueSampler : public MFEMComplexVariableValueSamplerBase
 {
 public:
   static InputParameters validParams();
 
-  MFEMLineVariableValueSampler(const InputParameters & parameters);
+  MFEMComplexVariablePointValueSampler(const InputParameters & parameters);
 };
 
 #endif // MOOSE_MFEM_ENABLED

--- a/framework/include/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.h
+++ b/framework/include/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.h
@@ -16,12 +16,12 @@
 /**
  * Samples a real scalar MFEM coefficient at specified points.
  */
-class MFEMPointScalarCoefficientValueSampler : public MFEMSamplerBase
+class MFEMScalarCoefficientPointValueSampler : public MFEMSamplerBase
 {
 public:
   static InputParameters validParams();
 
-  MFEMPointScalarCoefficientValueSampler(const InputParameters & parameters);
+  MFEMScalarCoefficientPointValueSampler(const InputParameters & parameters);
 
   /// Checks point locations and warns when GSLIB selects an element at a boundary.
   void initialSetup() override;

--- a/framework/include/mfem/vectorpostprocessors/MFEMVariableLineValueSampler.h
+++ b/framework/include/mfem/vectorpostprocessors/MFEMVariableLineValueSampler.h
@@ -14,14 +14,15 @@
 #include "MFEMVariableValueSamplerBase.h"
 
 /*
- * MFEM Postprocessor which samples values at points.
+ * MFEM Postprocessor which samples values at a set of points evenly
+ * distributed along a line.
  */
-class MFEMPointVariableValueSampler : public MFEMVariableValueSamplerBase
+class MFEMVariableLineValueSampler : public MFEMVariableValueSamplerBase
 {
 public:
   static InputParameters validParams();
 
-  MFEMPointVariableValueSampler(const InputParameters & parameters);
+  MFEMVariableLineValueSampler(const InputParameters & parameters);
 };
 
 #endif // MOOSE_MFEM_ENABLED

--- a/framework/include/mfem/vectorpostprocessors/MFEMVariablePointValueSampler.h
+++ b/framework/include/mfem/vectorpostprocessors/MFEMVariablePointValueSampler.h
@@ -11,18 +11,17 @@
 
 #pragma once
 
-#include "MFEMComplexVariableValueSamplerBase.h"
+#include "MFEMVariableValueSamplerBase.h"
 
-/**
- * Samples a complex-valued MFEM variable at specific points.
- * Outputs real and imaginary parts as separate VPP columns.
+/*
+ * MFEM Postprocessor which samples values at points.
  */
-class MFEMComplexPointVariableValueSampler : public MFEMComplexVariableValueSamplerBase
+class MFEMVariablePointValueSampler : public MFEMVariableValueSamplerBase
 {
 public:
   static InputParameters validParams();
 
-  MFEMComplexPointVariableValueSampler(const InputParameters & parameters);
+  MFEMVariablePointValueSampler(const InputParameters & parameters);
 };
 
 #endif // MOOSE_MFEM_ENABLED

--- a/framework/src/mfem/outputs/MFEMConduitDataCollection.C
+++ b/framework/src/mfem/outputs/MFEMConduitDataCollection.C
@@ -18,7 +18,7 @@ MFEMConduitDataCollection::validParams()
 {
   InputParameters params = MFEMDataCollection::validParams();
   params.addClassDescription("Output for controlling MFEMConduitDataCollection inherited data.");
-  MooseEnum protocol("hdf5 json conduit_json conduit_bin", "hdf5", false);
+  MooseEnum protocol("hdf5 json conduit_json conduit_bin", "hdf5");
   params.addParam<MooseEnum>("protocol",
                              protocol,
                              "Conduit relay I/O protocol to use. Options: hdf5 (default), json, "

--- a/framework/src/mfem/problem/SolutionStateData.C
+++ b/framework/src/mfem/problem/SolutionStateData.C
@@ -12,10 +12,6 @@
 #include "DataIO.h"
 #include "MFEMProblemData.h"
 
-#include "libmesh/int_range.h"
-
-using libMesh::make_range;
-
 namespace
 {
 void
@@ -80,7 +76,7 @@ dataLoad(std::istream & stream, Moose::MFEM::SolutionState & /*state*/, void * c
 
   int num_gridfunctions = 0;
   dataLoad(stream, num_gridfunctions, context);
-  for (int i = 0; i < num_gridfunctions; ++i)
+  for ([[maybe_unused]] const auto i : make_range(num_gridfunctions))
   {
     std::string name;
     dataLoad(stream, name, context);
@@ -90,7 +86,7 @@ dataLoad(std::istream & stream, Moose::MFEM::SolutionState & /*state*/, void * c
 
   int num_complex_gridfunctions = 0;
   dataLoad(stream, num_complex_gridfunctions, context);
-  for (int i = 0; i < num_complex_gridfunctions; ++i)
+  for ([[maybe_unused]] const auto i : make_range(num_complex_gridfunctions))
   {
     std::string name;
     dataLoad(stream, name, context);

--- a/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
+++ b/framework/src/mfem/solvers/MFEMHypreBoomerAMG.C
@@ -28,7 +28,7 @@ MFEMHypreBoomerAMG::validParams()
       "fespace", "H1 FESpace to use in HypreBoomerAMG setup for elasticity problems.");
   params.addParam<mfem::real_t>(
       "strength_threshold", 0.25, "HypreBoomerAMG strong threshold. Defaults to 0.25.");
-  MooseEnum errmode("ignore=0 warn=1 abort=2", "abort", false);
+  MooseEnum errmode("ignore=0 warn=1 abort=2", "abort");
   params.addParam<MooseEnum>("error_mode", errmode, "Set the behavior for treating hypre errors.");
   return params;
 }

--- a/framework/src/mfem/vectorpostprocessors/MFEMComplexVariablePointValueSampler.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMComplexVariablePointValueSampler.C
@@ -9,12 +9,12 @@
 
 #ifdef MOOSE_MFEM_ENABLED
 
-#include "MFEMComplexPointVariableValueSampler.h"
+#include "MFEMComplexVariablePointValueSampler.h"
 
-registerMooseObject("MooseApp", MFEMComplexPointVariableValueSampler);
+registerMooseObject("MooseApp", MFEMComplexVariablePointValueSampler);
 
 InputParameters
-MFEMComplexPointVariableValueSampler::validParams()
+MFEMComplexVariablePointValueSampler::validParams()
 {
   InputParameters params = MFEMComplexVariableValueSamplerBase::validParams();
   params.addClassDescription("Sample a complex MFEM variable at specific points, outputting "
@@ -24,7 +24,7 @@ MFEMComplexPointVariableValueSampler::validParams()
   return params;
 }
 
-MFEMComplexPointVariableValueSampler::MFEMComplexPointVariableValueSampler(
+MFEMComplexVariablePointValueSampler::MFEMComplexVariablePointValueSampler(
     const InputParameters & parameters)
   : MFEMComplexVariableValueSamplerBase(parameters, parameters.get<std::vector<Point>>("points"))
 {

--- a/framework/src/mfem/vectorpostprocessors/MFEMComplexVariableValueSamplerBase.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMComplexVariableValueSamplerBase.C
@@ -28,7 +28,7 @@ MFEMComplexVariableValueSamplerBase::MFEMComplexVariableValueSamplerBase(
     _real_interp_vals(points.size()),
     _imag_interp_vals(points.size())
 {
-  const auto val_dim = _var.real().VectorDim();
+  const auto val_dim = _var.VectorDim();
   for (const auto i : make_range(val_dim))
   {
     auto & real_declared = this->declareVector(_var_name + "_real_" + std::to_string(i));
@@ -44,7 +44,7 @@ MFEMComplexVariableValueSamplerBase::MFEMComplexVariableValueSamplerBase(
 int
 MFEMComplexVariableValueSamplerBase::getFESpaceContinuityType() const
 {
-  return _var.real().FESpace()->FEColl()->GetContType();
+  return _var.FESpace()->FEColl()->GetContType();
 }
 
 void
@@ -60,9 +60,9 @@ MFEMComplexVariableValueSamplerBase::finalizeValues()
   _real_interp_vals.HostReadWrite();
   _imag_interp_vals.HostReadWrite();
 
-  const auto val_dims = _var.real().VectorDim();
+  const auto val_dims = _var.VectorDim();
   const auto num_points = _declared_points[0].get().size();
-  const auto val_fespace_ordering = _var.real().FESpace()->GetOrdering();
+  const auto val_fespace_ordering = _var.FESpace()->GetOrdering();
   for (const auto i_dim : index_range(_declared_real_vals))
     for (const auto i_point : make_range(num_points))
     {

--- a/framework/src/mfem/vectorpostprocessors/MFEMLineVariableValueSampler.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMLineVariableValueSampler.C
@@ -42,7 +42,7 @@ generateLinePoints(const Point & start_point,
   // initialize and populate vector with linearly-spaced points along line
   std::vector<Point> points;
   points.reserve(num_points);
-  for (unsigned int i_point = 0; i_point < num_points; i_point++)
+  for (const auto i_point : make_range(num_points))
   {
     // fractional distance along line [0, 1]
     Real t = static_cast<Real>(i_point) / static_cast<Real>(num_points - 1);

--- a/framework/src/mfem/vectorpostprocessors/MFEMSamplerBase.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMSamplerBase.C
@@ -19,7 +19,7 @@ MFEMSamplerBase::validParams()
 {
   InputParameters params = MFEMVectorPostprocessor::validParams();
   // The MFEM ordering option names the index that varies fastest in the flattened point vector.
-  MooseEnum ordering("NODES VDIM", "VDIM", false);
+  MooseEnum ordering("NODES VDIM", "VDIM");
   ordering.addDocumentation("NODES", "Point/node index varies fastest: x0 x1 ... y0 y1 ...");
   ordering.addDocumentation("VDIM",
                             "Spatial-component index varies fastest: x0 y0 z0 x1 y1 z1 ...");
@@ -39,8 +39,7 @@ MFEMSamplerBase::MFEMSamplerBase(const InputParameters & parameters,
     _query_points(points),
     _mesh(mesh),
     _finder(this->comm().get()),
-    _points_ordering(getParam<MooseEnum>("point_ordering") == "NODES" ? mfem::Ordering::byNODES
-                                                                      : mfem::Ordering::byVDIM),
+    _points_ordering(getParam<MooseEnum>("point_ordering").getEnum<mfem::Ordering::Type>()),
     _points(
         Moose::MFEM::libMeshPointsToMFEMVector(points, _mesh.SpaceDimension(), _points_ordering))
 {

--- a/framework/src/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.C
@@ -76,15 +76,7 @@ MFEMScalarCoefficientPointValueSampler::execute()
   for (const auto i : make_range(received_elements.Size()))
   {
     mfem::IntegrationPoint integration_point;
-    if (mesh_dim == 1)
-      integration_point.Set1(received_reference_points[i]);
-    else if (mesh_dim == 2)
-      integration_point.Set2(received_reference_points[2 * i],
-                             received_reference_points[2 * i + 1]);
-    else
-      integration_point.Set3(received_reference_points[3 * i],
-                             received_reference_points[3 * i + 1],
-                             received_reference_points[3 * i + 2]);
+    integration_point.Set(&received_reference_points[mesh_dim * i], mesh_dim);
 
     auto & transformation = *_mesh.GetElementTransformation(received_elements[i]);
     transformation.SetIntPoint(&integration_point);

--- a/framework/src/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.C
@@ -60,15 +60,6 @@ MFEMScalarCoefficientPointValueSampler::initialSetup()
                "points.");
 
   MFEMSamplerBase::initialSetup();
-
-  const auto & point_codes = _finder.GetCode();
-  for (const auto i : index_range(_query_points))
-    if (PointLocationCode(point_codes[i]) == PointLocationCode::BORDER)
-      mooseWarning(typeAndName(),
-                   " found point ",
-                   _query_points[i],
-                   " on an element boundary. An arbitrary coefficient may be discontinuous "
-                   "there, so the element selected by GSLIB will supply the sampled value.");
 }
 
 void

--- a/framework/src/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.C
@@ -9,12 +9,12 @@
 
 #ifdef MOOSE_MFEM_ENABLED
 
-#include "MFEMPointScalarCoefficientValueSampler.h"
+#include "MFEMScalarCoefficientPointValueSampler.h"
 
 #include "MFEMProblem.h"
 #include "SubProblem.h"
 
-registerMooseObject("MooseApp", MFEMPointScalarCoefficientValueSampler);
+registerMooseObject("MooseApp", MFEMScalarCoefficientPointValueSampler);
 
 namespace
 {
@@ -28,7 +28,7 @@ mainMesh(const InputParameters & parameters)
 }
 
 InputParameters
-MFEMPointScalarCoefficientValueSampler::validParams()
+MFEMScalarCoefficientPointValueSampler::validParams()
 {
   InputParameters params = MFEMSamplerBase::validParams();
   params.addClassDescription("Sample a real scalar MFEM coefficient at specific points.");
@@ -39,7 +39,7 @@ MFEMPointScalarCoefficientValueSampler::validParams()
   return params;
 }
 
-MFEMPointScalarCoefficientValueSampler::MFEMPointScalarCoefficientValueSampler(
+MFEMScalarCoefficientPointValueSampler::MFEMScalarCoefficientPointValueSampler(
     const InputParameters & parameters)
   : MFEMSamplerBase(parameters, parameters.get<std::vector<Point>>("points"), mainMesh(parameters)),
     _coefficient(nullptr),
@@ -50,7 +50,7 @@ MFEMPointScalarCoefficientValueSampler::MFEMPointScalarCoefficientValueSampler(
 }
 
 void
-MFEMPointScalarCoefficientValueSampler::initialSetup()
+MFEMScalarCoefficientPointValueSampler::initialSetup()
 {
   _coefficient = &getScalarCoefficient("coefficient");
   if (dynamic_cast<mfem::QuadratureFunctionCoefficient *>(_coefficient))
@@ -72,7 +72,7 @@ MFEMPointScalarCoefficientValueSampler::initialSetup()
 }
 
 void
-MFEMPointScalarCoefficientValueSampler::execute()
+MFEMScalarCoefficientPointValueSampler::execute()
 {
   mfem::Array<unsigned int> received_elements;
   mfem::Array<unsigned int> received_codes;
@@ -105,7 +105,7 @@ MFEMPointScalarCoefficientValueSampler::execute()
 }
 
 void
-MFEMPointScalarCoefficientValueSampler::finalizeValues()
+MFEMScalarCoefficientPointValueSampler::finalizeValues()
 {
   const auto * const interp_vals = _interp_vals.HostRead();
   for (const auto i : index_range(_declared_vals))

--- a/framework/src/mfem/vectorpostprocessors/MFEMVariableLineValueSampler.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMVariableLineValueSampler.C
@@ -9,7 +9,7 @@
 
 #ifdef MOOSE_MFEM_ENABLED
 
-#include "MFEMLineVariableValueSampler.h"
+#include "MFEMVariableLineValueSampler.h"
 
 #include "libmesh/point.h"
 #include "MooseError.h"
@@ -17,11 +17,7 @@
 
 #include <vector>
 
-registerMooseObject("MooseApp", MFEMLineVariableValueSampler);
-registerMooseObjectRenamed("MooseApp",
-                           MFEMLineValueSampler,
-                           "06/30/2027 24:00",
-                           MFEMLineVariableValueSampler);
+registerMooseObject("MooseApp", MFEMVariableLineValueSampler);
 
 namespace
 {
@@ -32,12 +28,10 @@ generateLinePoints(const Point & start_point,
                    const std::string & object_name)
 {
   if (num_points < 2)
-  {
-    mooseError("In MFEMLineVariableValueSampler \"",
+    mooseError("In MFEMVariableLineValueSampler \"",
                object_name,
                "\": line must have at least 2 points, "
-               "for single points use MFEMPointVariableValueSampler.");
-  }
+               "for single points use MFEMVariablePointValueSampler.");
 
   // initialize and populate vector with linearly-spaced points along line
   std::vector<Point> points;
@@ -54,7 +48,7 @@ generateLinePoints(const Point & start_point,
 }
 
 InputParameters
-MFEMLineVariableValueSampler::validParams()
+MFEMVariableLineValueSampler::validParams()
 {
   InputParameters params = MFEMVariableValueSamplerBase::validParams();
 
@@ -70,7 +64,7 @@ MFEMLineVariableValueSampler::validParams()
   return params;
 }
 
-MFEMLineVariableValueSampler::MFEMLineVariableValueSampler(const InputParameters & parameters)
+MFEMVariableLineValueSampler::MFEMVariableLineValueSampler(const InputParameters & parameters)
   : MFEMVariableValueSamplerBase(parameters,
                                  // can't call getParam as that requires initialized base class
                                  // so calling parameters.get directly

--- a/framework/src/mfem/vectorpostprocessors/MFEMVariablePointValueSampler.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMVariablePointValueSampler.C
@@ -9,16 +9,12 @@
 
 #ifdef MOOSE_MFEM_ENABLED
 
-#include "MFEMPointVariableValueSampler.h"
+#include "MFEMVariablePointValueSampler.h"
 
-registerMooseObject("MooseApp", MFEMPointVariableValueSampler);
-registerMooseObjectRenamed("MooseApp",
-                           MFEMPointValueSampler,
-                           "06/30/2027 24:00",
-                           MFEMPointVariableValueSampler);
+registerMooseObject("MooseApp", MFEMVariablePointValueSampler);
 
 InputParameters
-MFEMPointVariableValueSampler::validParams()
+MFEMVariablePointValueSampler::validParams()
 {
   InputParameters params = MFEMVariableValueSamplerBase::validParams();
 
@@ -29,7 +25,7 @@ MFEMPointVariableValueSampler::validParams()
   return params;
 }
 
-MFEMPointVariableValueSampler::MFEMPointVariableValueSampler(const InputParameters & parameters)
+MFEMVariablePointValueSampler::MFEMVariablePointValueSampler(const InputParameters & parameters)
   : MFEMVariableValueSamplerBase(parameters, parameters.get<std::vector<Point>>("points"))
 {
 }

--- a/framework/src/mfem/vectorpostprocessors/MFEMVariableSamplerBase.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMVariableSamplerBase.C
@@ -35,7 +35,7 @@ MFEMVariableSamplerBase::validParams()
   InputParameters params = MFEMSamplerBase::validParams();
   MFEMExecutedObject::addRequiredDependencyParam<VariableName>(
       params, "variable", "The variable that this VectorPostprocessor samples");
-  MooseEnum avg_type(getL2AverageTypeOptions(), "ARITHMETIC", false);
+  MooseEnum avg_type(getL2AverageTypeOptions(), "ARITHMETIC");
   params.addParam<MooseEnum>("side_interpolation_type",
                              avg_type,
                              "Average type used when sampling L2 functions at element boundaries.");

--- a/modules/doc/content/newsletter/2026/2026_02.md
+++ b/modules/doc/content/newsletter/2026/2026_02.md
@@ -84,7 +84,7 @@ mandatory when using `keep_solution_during_restore` because either behavior may 
 
 - [MultiAppMFEMCopyTransfer.md] has been extended to provide complex variable transfers between MFEM apps.
   ([idaholab/moose#32017](https://github.com/idaholab/moose/pull/32017))
-- A couple new vector postprocessors, [MFEMLineVariableValueSampler.md] and [MFEMPointVariableValueSampler.md], add support
+- A couple new vector postprocessors, [MFEMVariableLineValueSampler.md] and [MFEMVariablePointValueSampler.md], add support
   for sampling MFEM variables at arbitrary points using GSLIB, opening the door to convert many of the existing
   XMLDiff tests over to CSVDiff tests, significantly reducing output sizes and unlocking parallel executions.
   ([idaholab/moose#31250](https://github.com/idaholab/moose/pull/31250))

--- a/test/tests/mfem/auxkernels/2Dmagnetostatic.i
+++ b/test/tests/mfem/auxkernels/2Dmagnetostatic.i
@@ -116,7 +116,7 @@
 
 [VectorPostprocessors]
   [line_sample]
-    type = MFEMLineVariableValueSampler
+    type = MFEMVariableLineValueSampler
     variable = 'B'
     start_point = '0 1.99 0'
     end_point = '0 -1.99 0'

--- a/test/tests/mfem/nonlinear/nldiffusion_common.i
+++ b/test/tests/mfem/nonlinear/nldiffusion_common.i
@@ -69,7 +69,7 @@
 [VectorPostprocessors]
   active = ''
   [point_sample]
-    type = MFEMPointVariableValueSampler
+    type = MFEMVariablePointValueSampler
     variable = concentration
     points = '0.5 0.25 0
               0.5 0.50 0

--- a/test/tests/mfem/nonlinear/nlheatconduction.i
+++ b/test/tests/mfem/nonlinear/nlheatconduction.i
@@ -111,7 +111,7 @@ alpha = 1e-2
 
 [VectorPostprocessors]
   [centre_temperature]
-    type = MFEMPointVariableValueSampler
+    type = MFEMVariablePointValueSampler
     variable = 'temperature'
     points = '0.0 0.0 0.0'
     execute_on = TIMESTEP_END

--- a/test/tests/mfem/nonlinear/nlheatconduction_qf.i
+++ b/test/tests/mfem/nonlinear/nlheatconduction_qf.i
@@ -104,7 +104,7 @@ alpha = 1e-2
 
 [VectorPostprocessors]
   [centre_temperature]
-    type = MFEMPointVariableValueSampler
+    type = MFEMVariablePointValueSampler
     variable = 'temperature'
     points = '0.0 0.0 0.0'
     execute_on = TIMESTEP_END

--- a/test/tests/mfem/nonlinear/nlheattransfer.i
+++ b/test/tests/mfem/nonlinear/nlheattransfer.i
@@ -105,7 +105,7 @@
 
 [VectorPostprocessors]
   [line_sample]
-    type = MFEMLineVariableValueSampler
+    type = MFEMVariableLineValueSampler
     variable = 'temperature'
     start_point = '0.0 0.5 0.5'
     end_point = '1.0 0.5 0.5'

--- a/test/tests/mfem/transfers/sibling_transfers/mfem_sub_between_diffusion.i
+++ b/test/tests/mfem/transfers/sibling_transfers/mfem_sub_between_diffusion.i
@@ -91,7 +91,7 @@
 
 [VectorPostprocessors]
   [nodal_sample]
-    type = MFEMLineVariableValueSampler
+    type = MFEMVariableLineValueSampler
     variable = 'received_nodal'
     start_point = '0.0 0.0 0.0'
     end_point = '1.0 1.0 0.0'
@@ -99,7 +99,7 @@
     execute_on = TIMESTEP_END
   []
   [elem_sample]
-    type = MFEMLineVariableValueSampler
+    type = MFEMVariableLineValueSampler
     variable = 'received_elem'
     start_point = '0.0 0.0 0.0'
     end_point = '1.0 1.0 0.0'

--- a/test/tests/mfem/variables/complex_aux_recovery.i
+++ b/test/tests/mfem/variables/complex_aux_recovery.i
@@ -20,7 +20,7 @@
 []
 
 [VectorPostprocessors/complex_state_sample]
-  type = MFEMComplexPointVariableValueSampler
+  type = MFEMComplexVariablePointValueSampler
   variable = complex_state
   points = '2.125 0 -1.375'
   execute_on = TIMESTEP_END

--- a/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/coefficient_value_sampler.i
+++ b/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/coefficient_value_sampler.i
@@ -30,14 +30,14 @@
 
 [VectorPostprocessors]
   [function_sample]
-    type = MFEMPointScalarCoefficientValueSampler
+    type = MFEMScalarCoefficientPointValueSampler
     coefficient = linear_coefficient
     points = '0.125 0.125 0
               0.375 0.625 0
               0.875 0.875 0'
   []
   [material_sample]
-    type = MFEMPointScalarCoefficientValueSampler
+    type = MFEMScalarCoefficientPointValueSampler
     coefficient = material_coefficient
     points = '0.125 0.125 0
               0.375 0.625 0

--- a/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/coefficient_value_sampler_boundary.i
+++ b/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/coefficient_value_sampler_boundary.i
@@ -30,7 +30,7 @@
 
 [VectorPostprocessors]
   [boundary_sample]
-    type = MFEMPointScalarCoefficientValueSampler
+    type = MFEMScalarCoefficientPointValueSampler
     coefficient = piecewise_coefficient
     points = '0.5 0.5 0'
   []

--- a/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/coefficient_value_sampler_qf.i
+++ b/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/coefficient_value_sampler_qf.i
@@ -10,7 +10,7 @@
 
 [VectorPostprocessors]
   [quadrature_sample]
-    type = MFEMPointScalarCoefficientValueSampler
+    type = MFEMScalarCoefficientPointValueSampler
     coefficient = quadrature_coefficient
     points = '0.125 0.125 0'
   []

--- a/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/tests
+++ b/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/tests
@@ -13,18 +13,6 @@
     recover = false
   []
 
-  [coefficient_boundary_warning]
-    type = RunException
-    input = coefficient_value_sampler_boundary.i
-    cli_args = 'FunctorMaterials/right/prop_values=20'
-    expect_err = 'MFEMScalarCoefficientPointValueSampler "boundary_sample" found point .* on an '
-                 'element boundary.*element selected by GSLIB will supply the sampled value'
-    requirement = 'The system shall warn that GSLIB selects the element used to evaluate an MFEM '
-                  'coefficient at an element boundary.'
-    capabilities = 'mfem'
-    recover = false
-  []
-
   [coefficient_boundary_sampling]
     type = CSVDiff
     input = coefficient_value_sampler_boundary.i

--- a/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/tests
+++ b/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'MFEMPointScalarCoefficientValueSampler.md'
+  design = 'MFEMScalarCoefficientPointValueSampler.md'
   issues = '#33439'
 
   [coefficient_sampling]
@@ -17,7 +17,7 @@
     type = RunException
     input = coefficient_value_sampler_boundary.i
     cli_args = 'FunctorMaterials/right/prop_values=20'
-    expect_err = 'MFEMPointScalarCoefficientValueSampler "boundary_sample" found point .* on an '
+    expect_err = 'MFEMScalarCoefficientPointValueSampler "boundary_sample" found point .* on an '
                  'element boundary.*element selected by GSLIB will supply the sampled value'
     requirement = 'The system shall warn that GSLIB selects the element used to evaluate an MFEM '
                   'coefficient at an element boundary.'

--- a/test/tests/mfem/vectorpostprocessors/line_value_sampler/line_value_sampler_curlcurl.i
+++ b/test/tests/mfem/vectorpostprocessors/line_value_sampler/line_value_sampler_curlcurl.i
@@ -1,11 +1,11 @@
 # Definite Maxwell problem solved with Nedelec elements of the first kind
-# based on MFEM Example 3. Sampled with MFEMLineVariableValueSampler.
+# based on MFEM Example 3. Sampled with MFEMVariableLineValueSampler.
 
 !include ../../kernels/curlcurl.i
 
 [VectorPostprocessors]
   [line_sample]
-    type = MFEMLineVariableValueSampler
+    type = MFEMVariableLineValueSampler
     variable = 'e_field'
     start_point = '0.99 0.99 -0.99'
     end_point = '0.99 0.99 0.99'

--- a/test/tests/mfem/vectorpostprocessors/line_value_sampler/line_value_sampler_diffusion.i
+++ b/test/tests/mfem/vectorpostprocessors/line_value_sampler/line_value_sampler_diffusion.i
@@ -1,10 +1,10 @@
-# MFEM diffusion problem sampled with MFEMLineVariableValueSampler.
+# MFEM diffusion problem sampled with MFEMVariableLineValueSampler.
 
 !include ../../kernels/diffusion.i
 
 [VectorPostprocessors]
   [line_sample]
-    type = MFEMLineVariableValueSampler
+    type = MFEMVariableLineValueSampler
     variable = 'concentration'
     start_point = '2.125 0 -2.375'
     end_point = '2.125 0 2.625'

--- a/test/tests/mfem/vectorpostprocessors/line_value_sampler/tests
+++ b/test/tests/mfem/vectorpostprocessors/line_value_sampler/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'MFEMLineVariableValueSampler.md'
+  design = 'MFEMVariableLineValueSampler.md'
   issues = '#31249'
   [MFEMLineVariableValueSamplerDiffusion]
     type = CSVDiff
@@ -27,7 +27,7 @@
     type = RunException
     input = line_value_sampler_diffusion.i
     cli_args = 'VectorPostprocessors/line_sample/num_points=1'
-    expect_err = 'In MFEMLineVariableValueSampler "line_sample": line must have at least 2 points'
+    expect_err = 'In MFEMVariableLineValueSampler "line_sample": line must have at least 2 points'
     requirement = 'The system shall identify the input block when a line variable sampler is '
                   'configured with fewer than two points.'
     capabilities = 'mfem'

--- a/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_value_sampler_boundary_tol.i
+++ b/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_value_sampler_boundary_tol.i
@@ -30,7 +30,7 @@
 
 [VectorPostprocessors]
   [point_sample]
-    type = MFEMPointVariableValueSampler
+    type = MFEMVariablePointValueSampler
     variable = 'h1_scalar'
     # this point is considered found
     # unless tolerance is tightened, then it is outside the mesh

--- a/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_value_sampler_boundary_warn.i
+++ b/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_value_sampler_boundary_warn.i
@@ -83,7 +83,7 @@
 
 [VectorPostprocessors]
   [point_sample]
-    type = MFEMPointVariableValueSampler
+    type = MFEMVariablePointValueSampler
     variable = 'l2_scalar'
     # this is a point very close to an internal element face
     points = '0.1 1e-13 -2.3125'

--- a/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_value_sampler_curlcurl.i
+++ b/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_value_sampler_curlcurl.i
@@ -1,11 +1,11 @@
 # Definite Maxwell problem solved with Nedelec elements of the first kind
-# based on MFEM Example 3. Sampled with MFEMPointVariableValueSampler.
+# based on MFEM Example 3. Sampled with MFEMVariablePointValueSampler.
 
 !include ../../kernels/curlcurl.i
 
 [VectorPostprocessors]
   [point_sample]
-    type = MFEMPointVariableValueSampler
+    type = MFEMVariablePointValueSampler
     variable = 'e_field'
     points = '0.99 0.99 -0.49  0.99 0.99 0.49'
   []

--- a/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_value_sampler_diffusion.i
+++ b/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_value_sampler_diffusion.i
@@ -1,10 +1,10 @@
-# MFEM diffusion problem sampled with MFEMPointVariableValueSampler.
+# MFEM diffusion problem sampled with MFEMVariablePointValueSampler.
 
 !include ../../kernels/diffusion.i
 
 [VectorPostprocessors]
   [point_sample]
-    type = MFEMPointVariableValueSampler
+    type = MFEMVariablePointValueSampler
     variable = 'concentration'
     points = '2.125 0 -1.375  2.125 0 1.125'
   []

--- a/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_value_sampler_point_not_found.i
+++ b/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_value_sampler_point_not_found.i
@@ -30,7 +30,7 @@
 
 [VectorPostprocessors]
   [point_sample]
-    type = MFEMPointVariableValueSampler
+    type = MFEMVariablePointValueSampler
     variable = 'h1_scalar'
     points = '0 0 1000'
   []

--- a/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_variable_value_sampler_submesh.i
+++ b/test/tests/mfem/vectorpostprocessors/point_value_sampler/point_variable_value_sampler_submesh.i
@@ -2,7 +2,7 @@
 
 [VectorPostprocessors]
   [submesh_sample]
-    type = MFEMPointVariableValueSampler
+    type = MFEMVariablePointValueSampler
     variable = submesh_potential
     points = '0 0 0.5'
   []

--- a/test/tests/mfem/vectorpostprocessors/point_value_sampler/tests
+++ b/test/tests/mfem/vectorpostprocessors/point_value_sampler/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'MFEMPointVariableValueSampler.md'
+  design = 'MFEMVariablePointValueSampler.md'
   issues = '#31249'
   [MFEMPointVariableValueSamplerDiffusion]
     type = CSVDiff
@@ -26,7 +26,7 @@
   [MFEMVariableValueSamplerPointNotFoundError]
     type = RunException
     input = point_value_sampler_point_not_found.i
-    expect_err = 'MFEMPointVariableValueSampler "point_sample" could not find point at'
+    expect_err = 'MFEMVariablePointValueSampler "point_sample" could not find point at'
     requirement = "The system shall issue an error if an attempt is made to sample at a point that is not inside the mesh."
     capabilities = 'mfem'
     recover = false
@@ -36,7 +36,7 @@
     type = RunException
     input = point_value_sampler_boundary_warn.i
     cli_args = 'VectorPostprocessors/point_sample/variable=rt_vector'
-    expect_err = 'MFEMPointVariableValueSampler "point_sample" found point .* on an element '
+    expect_err = 'MFEMVariablePointValueSampler "point_sample" found point .* on an element '
                  'boundary.*H\(div\).*continuous normal trace.*tangential component may differ '
                  'between elements.*element selected by GSLIB will supply the sampled value'
     issues = '#32988'
@@ -49,7 +49,7 @@
     type = RunException
     input = point_value_sampler_boundary_warn.i
     cli_args = 'VectorPostprocessors/point_sample/variable=nd_vector'
-    expect_err = 'MFEMPointVariableValueSampler "point_sample" found point .* on an element '
+    expect_err = 'MFEMVariablePointValueSampler "point_sample" found point .* on an element '
                  'boundary.*H\(curl\).*continuous tangential trace.*normal component may differ '
                  'between elements.*element selected by GSLIB will supply the sampled value'
     issues = '#32988'
@@ -61,7 +61,7 @@
   [MFEMValueSamplerBoundaryDiscontinuousWarningL2]
     type = RunException
     input = point_value_sampler_boundary_warn.i
-    expect_err = 'MFEMPointVariableValueSampler "point_sample" found a point on an element boundary but the FE space is discontinuous at element boundaries'
+    expect_err = 'MFEMVariablePointValueSampler "point_sample" found a point on an element boundary but the FE space is discontinuous at element boundaries'
     issues = '#32988'
     requirement = "The system shall issue a warning if an attempt is made to sample an L2 variable near an element boundary."
     capabilities = 'mfem'
@@ -71,11 +71,11 @@
   [MFEMComplexVariableValueSamplerPointNotFoundError]
     type = RunException
     input = complex_point_value_sampler_boundary_warn.i
-    cli_args = 'VectorPostprocessors/point_sample/type=MFEMComplexPointVariableValueSampler '
+    cli_args = 'VectorPostprocessors/point_sample/type=MFEMComplexVariablePointValueSampler '
                'VectorPostprocessors/point_sample/variable=l2_complex '
                'VectorPostprocessors/point_sample/points="0 0 1000"'
-    expect_err = 'MFEMComplexPointVariableValueSampler "point_sample" could not find point at'
-    design = 'MFEMComplexPointVariableValueSampler.md'
+    expect_err = 'MFEMComplexVariablePointValueSampler "point_sample" could not find point at'
+    design = 'MFEMComplexVariablePointValueSampler.md'
     issues = '#30076'
     requirement = "The system shall issue an error if a complex variable is sampled at a point that is not inside the mesh."
     capabilities = 'mfem'
@@ -85,10 +85,10 @@
   [MFEMComplexVariableValueSamplerBoundaryDiscontinuousWarning]
     type = RunException
     input = complex_point_value_sampler_boundary_warn.i
-    cli_args = 'VectorPostprocessors/point_sample/type=MFEMComplexPointVariableValueSampler '
+    cli_args = 'VectorPostprocessors/point_sample/type=MFEMComplexVariablePointValueSampler '
                'VectorPostprocessors/point_sample/variable=l2_complex'
-    expect_err = 'MFEMComplexPointVariableValueSampler "point_sample" found a point on an element boundary but the FE space is discontinuous at element boundaries'
-    design = 'MFEMComplexPointVariableValueSampler.md'
+    expect_err = 'MFEMComplexVariablePointValueSampler "point_sample" found a point on an element boundary but the FE space is discontinuous at element boundaries'
+    design = 'MFEMComplexVariablePointValueSampler.md'
     issues = '#30076 #32988'
     requirement = "The system shall issue a warning if a complex variable is sampled near a boundary where it is discontinuous."
     capabilities = 'mfem'
@@ -106,7 +106,7 @@
   [MFEMVariableValueSamplerBoundaryTolOnBoundary]
     type = RunException
     input = point_value_sampler_boundary_tol.i
-    expect_err = 'MFEMPointVariableValueSampler "point_sample" could not find point at'
+    expect_err = 'MFEMVariablePointValueSampler "point_sample" could not find point at'
     cli_args = 'VectorPostprocessors/point_sample/mesh_boundary_tolerance=1e-10'
     requirement = "The system shall issue an error for a point near but outside a boundary when the tolerance is tight."
     capabilities = 'mfem'


### PR DESCRIPTION
## Reason
Most importantly, to rename samplers (e.g. `MFEMComplexPointVariableValueSampler` -> `MFEMComplexVariablePointValueSampler` so it's clear we are sampling a complex variable at given point values, and not a complex point or a point variable) and to avoid a misleading warning when sampling coefficients on element boundaries (for an arbitrary coefficient, which can be arbitrarily misbehaved, i.e. discontinuous anywhere, I don't feel it makes sense to tell the user when they sample at an element boundary, implying that sampling well-within an element is any safer).

## Design
Renamed sampler classes, moved warning to docs and shortened/simplified the code.

## Impact
Simpler, easier-to-read/understand code/messaging.
Hopefully teaching the agents how to do better.