### PR TITLE
Ensure that `!param` command respects external / optional content

### DIFF
--- a/python/MooseDocs/common/load_config.py
+++ b/python/MooseDocs/common/load_config.py
@@ -72,6 +72,18 @@ def load_config(filename, **kwargs):
     """
     Read the config.yml file and create the Translator object.
     """
+    # Log entries can be emitted by the external mooseutils.yaml_load logger used by 'yaml_load'
+    # below, which lives outside the 'MooseDocs' logger hierarchy and so bypasses the MooseDocs
+    # handler (which leaves it uncolored, unprefixed, and uncounted). Here, before calling
+    # 'yaml_load', we lend the custom handling to the "external" logger to achieve proper formatting
+    # and expected handling.
+    ext_log = logging.getLogger("mooseutils.yaml_load")
+    md_log = logging.getLogger("MooseDocs")
+    if md_log.handlers and not ext_log.handlers:
+        for handler in md_log.handlers:
+            ext_log.addHandler(handler)
+        ext_log.setLevel(md_log.level)
+        ext_log.propagate = False
     config = yaml_load(filename, root=MooseDocs.ROOT_DIR)
 
     # Drop any configuration that referenced an optional include ('!include?') whose file was

--- a/python/MooseDocs/extensions/appsyntax.py
+++ b/python/MooseDocs/extensions/appsyntax.py
@@ -503,6 +503,7 @@ class SyntaxParameterCommand(SyntaxCommandBase):
         obj_syntax, param_name = info[MarkdownReader.INLINE].rsplit("/", 1)
         settings["syntax"] = obj_syntax
         settings["_param"] = param_name
+        settings["_external"] = getattr(page, "external", False)
         return SyntaxCommandBase.createToken(self, parent, info, page, settings)
 
     def createTokenFromSyntax(self, parent, info, page, obj, settings):
@@ -513,9 +514,20 @@ class SyntaxParameterCommand(SyntaxCommandBase):
         elif obj.parameters:
             parameters.update(obj.parameters)
 
+        obj_syntax = settings["syntax"]
         param_name = settings["_param"]
-        if param_name not in parameters:
-            obj_syntax = settings["syntax"]
+        param_external = settings["_external"]
+
+        if param_external:
+            msg = "The parameter '{}/{}' is being invoked using the '!param' command on a page ({}) associated with content marked 'external' and will be skipped. If this is not intended, please check 'doc/config.yml' in your application.".format(
+                obj_syntax, param_name, page.local
+            )
+            # Display warning and return parameter name as content placeholder (to leave no gaps in
+            # rendered page)
+            LOG.warning(msg)
+            return tokens.String(parent, content="{}/{}".format(obj_syntax, param_name))
+
+        if param_name not in parameters and not param_external:
             results = mooseutils.levenshteinDistance(param_name, parameters.keys(), 5)
             msg = "Unable to locate the parameter '{}/{}', did you mean:\n".format(
                 obj_syntax, param_name

--- a/python/MooseDocs/test/extensions/test_appsyntax.py
+++ b/python/MooseDocs/test/extensions/test_appsyntax.py
@@ -316,6 +316,25 @@ class TestParam(AppSyntaxTestCase):
         )
         self.assertIn("    /Kernels/Diffusion/", message)
 
+    def testExternal(self):
+        self._MooseDocsTestCase__text.external = True
+        with self.assertLogs(level=logging.WARNING) as cm:
+            ast = self.tokenize(self.TEXT)
+
+        self.assertSize(ast, 1)
+        self.assertToken(ast(0), "Paragraph", size=1)
+        self.assertToken(
+            ast(0, 0), "String", content="/Kernels/Diffusion/variable"
+        )
+
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn(
+            "The parameter '/Kernels/Diffusion/variable' is being invoked using "
+            "the '!param' command on a page (_text_) associated with content "
+            "marked 'external' and will be skipped.",
+            cm.output[0],
+        )
+
     def testUnit(self):
         all_types_showing_no_unit = [
             "double",

--- a/python/MooseDocs/test/extensions/test_appsyntax.py
+++ b/python/MooseDocs/test/extensions/test_appsyntax.py
@@ -323,9 +323,7 @@ class TestParam(AppSyntaxTestCase):
 
         self.assertSize(ast, 1)
         self.assertToken(ast(0), "Paragraph", size=1)
-        self.assertToken(
-            ast(0, 0), "String", content="/Kernels/Diffusion/variable"
-        )
+        self.assertToken(ast(0, 0), "String", content="/Kernels/Diffusion/variable")
 
         self.assertEqual(len(cm.output), 1)
         self.assertIn(

--- a/python/doc/content/python/MooseDocs/extensions/appsyntax.md
+++ b/python/doc/content/python/MooseDocs/extensions/appsyntax.md
@@ -88,6 +88,31 @@ available settings for the `children` command are provided below.
                 id=appsyntax-children-settings
                 caption=Command settings for the `!syntax children` command.
 
+## Object Parameter (`!param`) id=param
+
+While the `!syntax parameters` command (see [appsyntax-parameters-example]) displays an entire
+input parameters table, the `param` command displays a single input file parameter inline within a
+sentence, which is useful for referring to a specific parameter within descriptive text. Unlike the
+other commands on this page, `param` is invoked using the markdown link syntax rather than the
+`!command subcommand` form, with the object syntax and parameter name (separated by a slash)
+supplied as the link target, as in [appsyntax-param-example].
+
+!devel! example id=appsyntax-param-example caption=Example use of the `!param` command.
+The `variable` parameter, [!param](/Kernels/Diffusion/variable), of the Diffusion kernel is required.
+!devel-end!
+
+The resulting link opens a modal window containing the same information (type, description, default,
+etc.) that would appear for that parameter within a `!syntax parameters` table.
+
+If the referenced object syntax or parameter name cannot be found, an error is raised that lists the
+closest matching parameter names, to aid in catching typos.
+
+If the page containing the `!param` command is associated with content marked `external` (see
+[MooseDocs/config.md#optional-dependencies]), the parameter information is not available because the
+application supplying that syntax was not built. In this case, `!param` skips creating the modal
+link, logs a warning, and instead renders the plain object syntax and parameter name as placeholder
+text so that the surrounding sentence is not left with a gap.
+
 ## Actions, Objects, and Systems (`!syntax list`)
 
 MOOSE is based on systems (e.g., Kernels), where each system contains a set of objects, actions,


### PR DESCRIPTION
When using the changes from #33166 in SALAMANDER (idaholab/salamander#146), it was discovered that the `!param` command within the MooseDocs `appsyntax` extension does not respect the `external` parameter used in a `config.yml` file's `Content:` section.

This PR fixes up that gap by making the command aware of the `external` parameter, using it to catch when a parameter comes from external / optional content, and then logging a warning that it will be skipped. A String token is then generated and returned to leave rendered text in that location instead of a gap. 

While fixing this up, I noticed that I made an oversight in #33166: the `yaml_load` utility emits warnings that are easily missed by the user visually and not counted by MooseDocs. So, I extend the custom MooseDocs log handling to the `yaml_load` handler before `yaml_load` is invoked. This brings any warnings about skipped content, for example, up to the level of any other warnings or errors emitted by MooseDocs without modifying `yaml_load` itself, which was my goal (as it is  a common utility outside of MooseDocs). 

I reasoned through the latter change with Claude, so marking this as "AI-assisted".

TODO before review:

- [x] A test case for the `!param` changes.
