### PR TITLE
Change `InputParameters::checkForRename()` to return `const std::string &` instead of `std::string`

### DIFF
--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -2174,7 +2174,7 @@ template <typename T>
 T *
 Coupleable::getVarHelper(const std::string & var_name_in, unsigned int comp)
 {
-  const auto var_name = _c_parameters.checkForRename(var_name_in);
+  const auto & var_name = _c_parameters.checkForRename(var_name_in);
   auto name_to_use = var_name;
 
   // First check for supplied name

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -1280,7 +1280,7 @@ public:
    * @param name The name to check for whether it is a renamed name
    * @return The new name if the incoming \p name is a renamed name, else \p name
    */
-  std::string checkForRename(const std::string & name) const;
+  const std::string & checkForRename(const std::string & name) const;
 
   /**
    * A wrapper around the \p Parameters base class method. Checks for parameter rename before
@@ -1460,14 +1460,14 @@ private:
 
   Metadata & at(const std::string & param_name)
   {
-    const auto param = checkForRename(param_name);
+    const auto & param = checkForRename(param_name);
     if (_params.count(param) == 0)
       mooseError("param '", param, "' not present in InputParams");
     return _params[param];
   }
   const Metadata & at(const std::string & param_name) const
   {
-    const auto param = checkForRename(param_name);
+    const auto & param = checkForRename(param_name);
     if (_params.count(param) == 0)
       mooseError("param '", param, "' not present in InputParams");
     return _params.at(param);
@@ -1595,7 +1595,7 @@ template <typename T>
 T &
 InputParameters::set(const std::string & name_in, bool quiet_mode)
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
 
   checkParamName(name);
   checkConsistentType<T>(name);
@@ -1790,7 +1790,7 @@ T
 InputParameters::getCheckedPointerParam(const std::string & name_in,
                                         const std::string & error_string) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
 
   T param = this->get<T>(name);
 
@@ -2099,7 +2099,7 @@ template <typename T>
 void
 InputParameters::checkConsistentType(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
 
   // If we don't currently have the Parameter, can't be any inconsistency
   InputParameters::const_iterator it = _values.find(name);
@@ -2122,7 +2122,7 @@ template <typename T>
 void
 InputParameters::suppressParameter(const std::string & name_in)
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   if (!this->have_parameter<T>(name))
     mooseError("Unable to suppress nonexistent parameter: ", name);
 
@@ -2136,7 +2136,7 @@ template <typename T>
 void
 InputParameters::ignoreParameter(const std::string & name_in)
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   suppressParameter<T>(name);
   _params[name]._ignore = true;
 }
@@ -2145,7 +2145,7 @@ template <typename T>
 void
 InputParameters::makeParamRequired(const std::string & name_in)
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
 
   if (!this->have_parameter<T>(name))
     mooseError("Unable to require nonexistent parameter: ", name);
@@ -2157,7 +2157,7 @@ template <typename T>
 void
 InputParameters::makeParamNotRequired(const std::string & name_in)
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
 
   if (!this->have_parameter<T>(name))
     mooseError("Unable to un-require nonexistent parameter: ", name);
@@ -2317,7 +2317,7 @@ template <typename T>
 const T &
 InputParameters::getParamHelper(const std::string & name_in, const InputParameters & pars)
 {
-  const auto name = pars.checkForRename(name_in);
+  const auto & name = pars.checkForRename(name_in);
 
   if (!pars.isParamValid(name))
     pars.mooseError("The parameter \"", name, "\" is being retrieved before being set.");
@@ -2341,8 +2341,8 @@ template <typename R1, typename R2, typename V1, typename V2>
 std::vector<std::pair<R1, R2>>
 InputParameters::get(const std::string & param1_in, const std::string & param2_in) const
 {
-  const auto param1 = checkForRename(param1_in);
-  const auto param2 = checkForRename(param2_in);
+  const auto & param1 = checkForRename(param1_in);
+  const auto & param2 = checkForRename(param2_in);
 
   const auto & v1 = get<V1>(param1);
   const auto & v2 = get<V2>(param2);
@@ -2380,7 +2380,7 @@ template <typename T>
 bool
 InputParameters::isType(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
 
   if (!_params.count(name))
     mooseError("Parameter \"", name, "\" is not valid.");
@@ -2391,7 +2391,8 @@ template <typename T>
 const T &
 InputParameters::get(std::string_view name_in) const
 {
-  const auto name = checkForRename(std::string(name_in));
+  const std::string name_str(name_in);
+  const auto & name = checkForRename(name_str);
 
   return Parameters::get<T>(name);
 }
@@ -2400,7 +2401,8 @@ template <typename T>
 bool
 InputParameters::have_parameter(std::string_view name_in) const
 {
-  const auto name = checkForRename(std::string(name_in));
+  const std::string name_str(name_in);
+  const auto & name = checkForRename(name_str);
 
   return Parameters::have_parameter<T>(name);
 }
@@ -2412,7 +2414,7 @@ InputParameters::transferParam(const InputParameters & source_params,
                                const std::string & new_name,
                                const std::string & new_description)
 {
-  const auto name = source_params.checkForRename(std::string(name_in));
+  const auto & name = source_params.checkForRename(name_in);
   const auto p_name = new_name.empty() ? name_in : new_name;
   if (!source_params.have_parameter<T>(name) && !source_params.hasCoupledVar(name))
     mooseError("The '",

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -153,7 +153,7 @@ Coupleable::Coupleable(const Coupleable & object, const Moose::Kokkos::FunctorCo
 bool
 Coupleable::isCoupled(const std::string & var_name_in, unsigned int i) const
 {
-  const auto var_name = _c_parameters.checkForRename(var_name_in);
+  const auto & var_name = _c_parameters.checkForRename(var_name_in);
 
   auto it = _coupled_vars.find(var_name);
   if (it != _coupled_vars.end())
@@ -182,7 +182,7 @@ Coupleable::isCoupledConstant(const std::string & var_name) const
 unsigned int
 Coupleable::coupledComponents(const std::string & var_name_in) const
 {
-  const auto var_name = _c_parameters.checkForRename(var_name_in);
+  const auto & var_name = _c_parameters.checkForRename(var_name_in);
 
   if (isCoupled(var_name))
   {
@@ -235,7 +235,7 @@ Coupleable::checkVar(const std::string & var_name_in,
                      unsigned int comp,
                      unsigned int comp_bound) const
 {
-  const auto var_name = _c_parameters.checkForRename(var_name_in);
+  const auto & var_name = _c_parameters.checkForRename(var_name_in);
   auto it = _c_coupled_scalar_vars.find(var_name);
   if (it != _c_coupled_scalar_vars.end())
   {

--- a/framework/src/interfaces/ScalarCoupleable.C
+++ b/framework/src/interfaces/ScalarCoupleable.C
@@ -84,7 +84,7 @@ ScalarCoupleable::ScalarCoupleable(const ScalarCoupleable & object,
 bool
 ScalarCoupleable::isCoupledScalar(const std::string & var_name_in, unsigned int i) const
 {
-  const auto var_name = _sc_parameters.checkForRename(var_name_in);
+  const auto & var_name = _sc_parameters.checkForRename(var_name_in);
 
   auto it = _coupled_scalar_vars.find(var_name);
   if (it != _coupled_scalar_vars.end())
@@ -314,7 +314,7 @@ ScalarCoupleable::coupledScalarDotDotDu(const std::string & var_name, const unsi
 void
 ScalarCoupleable::checkVar(const std::string & var_name_in) const
 {
-  const auto var_name = _sc_parameters.checkForRename(var_name_in);
+  const auto & var_name = _sc_parameters.checkForRename(var_name_in);
 
   auto it = _sc_coupled_vars.find(var_name);
   if (it != _sc_coupled_vars.end())
@@ -335,7 +335,7 @@ ScalarCoupleable::checkVar(const std::string & var_name_in) const
 const MooseVariableScalar *
 ScalarCoupleable::getScalarVar(const std::string & var_name_in, const unsigned int comp) const
 {
-  const auto var_name = _sc_parameters.checkForRename(var_name_in);
+  const auto & var_name = _sc_parameters.checkForRename(var_name_in);
 
   const auto it = _coupled_scalar_vars.find(var_name);
   if (it != _coupled_scalar_vars.end())
@@ -367,7 +367,7 @@ ScalarCoupleable::validateExecutionerType(const std::string & name,
 unsigned int
 ScalarCoupleable::coupledScalarComponents(const std::string & var_name_in) const
 {
-  const auto var_name = _sc_parameters.checkForRename(var_name_in);
+  const auto & var_name = _sc_parameters.checkForRename(var_name_in);
 
   const auto it = _coupled_scalar_vars.find(var_name);
   if (it != _coupled_scalar_vars.end())

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -86,7 +86,7 @@ InputParameters::addClassDescription(const std::string & doc_string)
 void
 InputParameters::set_attributes(const std::string & name_in, bool inserted_only)
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
 
   if (!inserted_only)
   {
@@ -108,7 +108,7 @@ InputParameters::set_attributes(const std::string & name_in, bool inserted_only)
 std::optional<std::string>
 InputParameters::queryDeprecatedParamMessage(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   if (_show_deprecated_message)
   {
     auto deprecation_message = [this](const auto & name, const auto & message) -> std::string
@@ -323,7 +323,7 @@ InputParameters::addRequiredCoupledVar(const std::string & name, const std::stri
 std::string
 InputParameters::getDocString(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
 
   std::string doc_string;
   auto it = _params.find(name);
@@ -342,7 +342,7 @@ InputParameters::getDocString(const std::string & name_in) const
 void
 InputParameters::setDocString(const std::string & name_in, const std::string & doc)
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
 
   auto it = _params.find(name);
   if (it == _params.end())
@@ -355,28 +355,28 @@ InputParameters::setDocString(const std::string & name_in, const std::string & d
 std::string
 InputParameters::getDocUnit(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   return _params.at(name)._doc_unit;
 }
 
 void
 InputParameters::setDocUnit(const std::string & name_in, const std::string & doc_unit)
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   _params[name]._doc_unit = doc_unit;
 }
 
 bool
 InputParameters::isParamRequired(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   return _params.count(name) > 0 && _params.at(name)._required;
 }
 
 void
 InputParameters::makeParamNotRequired(const std::string & name_in)
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
 
   if (_params.count(name))
     _params[name]._required = false;
@@ -385,7 +385,7 @@ InputParameters::makeParamNotRequired(const std::string & name_in)
 bool
 InputParameters::isParamValid(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   if (have_parameter<MooseEnum>(name))
     return get<MooseEnum>(name).isValid();
   else if (have_parameter<std::vector<MooseEnum>>(name))
@@ -417,14 +417,14 @@ InputParameters::isParamValid(const std::string & name_in) const
 bool
 InputParameters::isParamSetByAddParam(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   return _params.count(name) > 0 && _params.at(name)._set_by_add_param;
 }
 
 bool
 InputParameters::isParamDeprecated(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   return _params.count(name) > 0 && !_params.at(name)._deprecation_message.empty();
 }
 
@@ -448,7 +448,7 @@ InputParameters::areAllRequiredParamsValid() const
 bool
 InputParameters::isPrivate(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   return _params.count(name) > 0 && _params.at(name)._is_private;
 }
 
@@ -460,7 +460,7 @@ InputParameters::declareControllable(const std::string & input_names,
   MooseUtils::tokenize<std::string>(input_names, names, 1, " ");
   for (auto & name_in : names)
   {
-    const auto name = checkForRename(name_in);
+    const auto & name = checkForRename(name_in);
     auto map_iter = _params.find(name);
     if (map_iter != _params.end()) // error is handled by checkParams method
     {
@@ -477,14 +477,14 @@ InputParameters::declareControllable(const std::string & input_names,
 bool
 InputParameters::isControllable(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   return _params.count(name) > 0 && _params.at(name)._controllable;
 }
 
 const std::set<ExecFlagType> &
 InputParameters::getControllableExecuteOnTypes(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   return at(name)._controllable_flags;
 }
 
@@ -594,7 +594,7 @@ InputParameters::checkParams(const std::string & parsing_syntax)
   std::vector<std::string> required_param_errors;
   for (const auto & it : *this)
   {
-    const auto param_name = checkForRename(it.first);
+    const auto & param_name = checkForRename(it.first);
     if (!isParamValid(param_name) && isParamRequired(param_name))
     {
       // check if an old, deprecated name exists for this parameter that may be specified
@@ -791,21 +791,21 @@ InputParameters::getFileBase(const std::optional<std::string> & param_name) cons
 bool
 InputParameters::isRangeChecked(const std::string & param_name) const
 {
-  const auto name = checkForRename(param_name);
+  const auto & name = checkForRename(param_name);
   return !_params.find(name)->second._range_function.empty();
 }
 
 std::string
 InputParameters::rangeCheckedFunction(const std::string & param_name) const
 {
-  const auto name = checkForRename(param_name);
+  const auto & name = checkForRename(param_name);
   return _params.at(name)._range_function;
 }
 
 bool
 InputParameters::hasDefault(const std::string & param_name) const
 {
-  const auto name = checkForRename(param_name);
+  const auto & name = checkForRename(param_name);
   if (hasDefaultCoupledValue(name))
     return true;
   // If it has a default, it's already valid
@@ -833,7 +833,7 @@ void
 InputParameters::setCoupledVar(const std::string & coupling_name,
                                const std::vector<VariableName> & values)
 {
-  const auto actual_name = checkForRename(coupling_name);
+  const auto & actual_name = checkForRename(coupling_name);
 
   if (!hasCoupledVar(actual_name))
     mooseError("Unable to set coupled variable parameter '",
@@ -846,7 +846,7 @@ InputParameters::setCoupledVar(const std::string & coupling_name,
 const std::vector<VariableName> &
 InputParameters::getCoupledVar(const std::string & coupling_name) const
 {
-  const auto actual_name = checkForRename(coupling_name);
+  const auto & actual_name = checkForRename(coupling_name);
 
   if (!hasCoupledVar(actual_name))
     mooseError("Unable to get coupled variable parameter '",
@@ -866,7 +866,7 @@ InputParameters::hasDefaultCoupledValue(const std::string & coupling_name) const
 void
 InputParameters::defaultCoupledValue(const std::string & coupling_name, Real value, unsigned int i)
 {
-  const auto actual_name = checkForRename(coupling_name);
+  const auto & actual_name = checkForRename(coupling_name);
   _params[actual_name]._coupled_default.resize(i + 1);
   _params[actual_name]._coupled_default[i] = value;
   _params[actual_name]._have_coupled_default = true;
@@ -915,7 +915,7 @@ InputParameters::getAutoBuildVectors() const
 std::string
 InputParameters::type(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   if (!_values.count(name))
     mooseError("Parameter \"", name, "\" not found.\n\n", *this);
 
@@ -929,7 +929,7 @@ InputParameters::type(const std::string & name_in) const
 std::string
 InputParameters::getMooseType(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   std::string var;
 
   if (have_parameter<VariableName>(name))
@@ -959,7 +959,7 @@ InputParameters::getMooseType(const std::string & name_in) const
 std::vector<std::string>
 InputParameters::getVecMooseType(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   std::vector<std::string> svars;
 
   if (have_parameter<std::vector<VariableName>>(name))
@@ -1106,7 +1106,7 @@ InputParameters::commandLineParamSet(const std::string & name, const CommandLine
 std::string
 InputParameters::getGroupName(const std::string & param_name_in) const
 {
-  const auto param_name = checkForRename(param_name_in);
+  const auto & param_name = checkForRename(param_name_in);
   auto it = _params.find(param_name);
   if (it != _params.end())
     return it->second._group;
@@ -1240,7 +1240,7 @@ InputParameters::applyParameter(const InputParameters & common,
   // of messages
   _show_deprecated_message = false;
 
-  const auto local_name = checkForRename(common_name);
+  const auto & local_name = checkForRename(common_name);
 
   // Extract the properties from the local parameter for the current common parameter name
   const bool local_exist = _values.find(local_name) != _values.end();
@@ -1292,7 +1292,7 @@ InputParameters::paramSetByUser(const std::string & name) const
 bool
 InputParameters::isParamSetByUser(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   // Invalid; for sure not set by the user
   if (!isParamValid(name))
     return false;
@@ -1309,14 +1309,14 @@ InputParameters::isParamSetByUser(const std::string & name_in) const
 bool
 InputParameters::isParamDefined(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   return _params.count(name) > 0;
 }
 
 const std::string &
 InputParameters::getDescription(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   auto it = _params.find(name);
   if (it == _params.end())
     mooseError("No parameter exists with the name ", name);
@@ -1576,7 +1576,7 @@ const MooseEnum &
 InputParameters::getParamHelper<MooseEnum>(const std::string & name_in,
                                            const InputParameters & pars)
 {
-  const auto name = pars.checkForRename(name_in);
+  const auto & name = pars.checkForRename(name_in);
   return pars.get<MooseEnum>(name);
 }
 
@@ -1585,7 +1585,7 @@ const MultiMooseEnum &
 InputParameters::getParamHelper<MultiMooseEnum>(const std::string & name_in,
                                                 const InputParameters & pars)
 {
-  const auto name = pars.checkForRename(name_in);
+  const auto & name = pars.checkForRename(name_in);
   return pars.get<MultiMooseEnum>(name);
 }
 
@@ -1593,14 +1593,14 @@ void
 InputParameters::setReservedValues(const std::string & name_in,
                                    const std::set<std::string> & reserved)
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   _params[name]._reserved_values = reserved;
 }
 
 std::set<std::string>
 InputParameters::reservedValues(const std::string & name_in) const
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   auto it = _params.find(name);
   if (it == _params.end())
     return std::set<std::string>();
@@ -1665,7 +1665,7 @@ InputParameters::checkParamName(const std::string & name) const
 bool
 InputParameters::shouldIgnore(const std::string & name_in)
 {
-  const auto name = checkForRename(name_in);
+  const auto & name = checkForRename(name_in);
   auto it = _params.find(name);
   if (it != _params.end())
     return it->second._ignore;
@@ -1833,7 +1833,7 @@ InputParameters::deprecateCoupledVar(const std::string & old_name,
   renameCoupledVarInternal(old_name, new_name, "", removal_date);
 }
 
-std::string
+const std::string &
 InputParameters::checkForRename(const std::string & name) const
 {
   if (auto it = _old_to_new_name_and_dep.find(name); it != _old_to_new_name_and_dep.end())

--- a/unit/src/InputParametersTest.C
+++ b/unit/src/InputParametersTest.C
@@ -520,6 +520,69 @@ TEST(InputParametersTest, transferParameters)
   EXPECT_EQ(p1.getDocString("od3b"), p2.getDocString("od3b"));
 }
 
+TEST(InputParametersTest, checkForRename)
+{
+  InputParameters params = emptyInputParameters();
+  params.addParam<Real>("new_param", 1.5, "Documentation");
+  params.renameParam("new_param", "renamed_param", "Updated documentation");
+
+  const std::string old_name = "new_param";
+  const std::string current_name = "renamed_param";
+  const std::string unknown = "does_not_exist";
+
+  // Renamed name resolves to the current name; address must be stable rename metadata
+  const auto & resolved_old = params.checkForRename(old_name);
+  EXPECT_EQ(resolved_old, current_name);
+  EXPECT_EQ(std::addressof(resolved_old), std::addressof(params.checkForRename(old_name)));
+
+  // Current / unknown names return a reference to the input argument (no allocation)
+  const auto & resolved_current = params.checkForRename(current_name);
+  EXPECT_EQ(resolved_current, current_name);
+  EXPECT_EQ(std::addressof(resolved_current), std::addressof(current_name));
+
+  const auto & resolved_unknown = params.checkForRename(unknown);
+  EXPECT_EQ(resolved_unknown, unknown);
+  EXPECT_EQ(std::addressof(resolved_unknown), std::addressof(unknown));
+
+  // Access through the old name still works after rename
+  EXPECT_TRUE(params.have_parameter<Real>(old_name));
+  EXPECT_TRUE(params.have_parameter<Real>(current_name));
+  EXPECT_EQ(params.get<Real>(old_name), 1.5);
+  EXPECT_EQ(params.get<Real>(current_name), 1.5);
+  EXPECT_EQ(params.getDocString(old_name), "Updated documentation");
+  EXPECT_EQ(params.getDocString(current_name), "Updated documentation");
+
+  // Aliases include both the current name and the old name
+  const auto aliases = params.paramAliases(current_name);
+  ASSERT_EQ(aliases.size(), 2);
+  EXPECT_EQ(aliases[0], current_name);
+  EXPECT_EQ(aliases[1], old_name);
+}
+
+TEST(InputParametersTest, deprecateCoupledVar)
+{
+  InputParameters params = emptyInputParameters();
+  params.addCoupledVar("old_var", "An old coupled variable");
+  params.deprecateCoupledVar("old_var", "new_var", "01/01/2099");
+
+  // The coupled-var set stores only the current name; the old name resolves via checkForRename
+  EXPECT_TRUE(params.hasCoupledVar("new_var"));
+  EXPECT_FALSE(params.hasCoupledVar("old_var"));
+  EXPECT_EQ(params.checkForRename("old_var"), "new_var");
+  EXPECT_EQ(params.checkForRename("new_var"), "new_var");
+
+  // Setting / reading through the deprecated name uses the new name under the hood
+  params.setCoupledVar("old_var", NonlinearVariableName("u"));
+  EXPECT_EQ(params.getCoupledVar("new_var"), std::vector<VariableName>{"u"});
+  EXPECT_EQ(params.getCoupledVar("old_var"), std::vector<VariableName>{"u"});
+
+  const auto message = params.queryDeprecatedParamMessage("old_var");
+  ASSERT_TRUE(message.has_value());
+  EXPECT_NE(message->find("old_var"), std::string::npos);
+  EXPECT_NE(message->find("new_var"), std::string::npos);
+  EXPECT_NE(message->find("01/01/2099"), std::string::npos);
+}
+
 TEST(InputParametersTest, noDefaultValueError)
 {
   InputParameters params = emptyInputParameters();


### PR DESCRIPTION
closes #33247

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

## Impact
- Did I miss any docs which should be updated?
- I believe this is a breaking change (albeit minor) since `InputParameters::checkForRename()`'s signature has changed. Is there additional action I need to take due to this impact?


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
