### PR TITLE
Kokkos Array Kernels

### DIFF
--- a/framework/doc/content/source/kokkos/bcs/KokkosArrayDirichletBC.md
+++ b/framework/doc/content/source/kokkos/bcs/KokkosArrayDirichletBC.md
@@ -1,0 +1,20 @@
+# KokkosArrayDirichletBC
+
+!if! function=hasCapability('kokkos')
+
+This is the Kokkos version of [ArrayDirichletBC](ArrayDirichletBC.md). See the original document for details.
+
+## Example Input Syntax
+
+!listing test/tests/kokkos/bcs/array/kokkos_array_bcs.i start=[left] end=[] include-end=true
+
+!syntax parameters /BCs/KokkosArrayDirichletBC
+
+!syntax inputs /BCs/KokkosArrayDirichletBC
+
+!syntax children /BCs/KokkosArrayDirichletBC
+
+!if-end!
+
+!else
+!include kokkos/kokkos_warning.md

--- a/framework/doc/content/source/kokkos/bcs/KokkosArrayNeumannBC.md
+++ b/framework/doc/content/source/kokkos/bcs/KokkosArrayNeumannBC.md
@@ -1,0 +1,20 @@
+# KokkosArrayNeumannBC
+
+!if! function=hasCapability('kokkos')
+
+This is the Kokkos version of [ArrayNeumannBC](ArrayNeumannBC.md). See the original document for details.
+
+## Example Input Syntax
+
+!listing test/tests/kokkos/bcs/array/kokkos_array_bcs.i start=[right] end=[] include-end=true
+
+!syntax parameters /BCs/KokkosArrayNeumannBC
+
+!syntax inputs /BCs/KokkosArrayNeumannBC
+
+!syntax children /BCs/KokkosArrayNeumannBC
+
+!if-end!
+
+!else
+!include kokkos/kokkos_warning.md

--- a/framework/doc/content/source/kokkos/kernels/KokkosArrayDiffusion.md
+++ b/framework/doc/content/source/kokkos/kernels/KokkosArrayDiffusion.md
@@ -1,0 +1,19 @@
+# KokkosArrayDiffusion
+
+!if! function=hasCapability('kokkos')
+
+This is the Kokkos version of [ArrayDiffusion](ArrayDiffusion.md). See the original document for details.
+
+!alert note
+[!param](Kernels/KokkosArrayDiffusion/diffusion_coefficient) may be a scalar, one-dimensional, or two-dimensional Kokkos material property. A one-dimensional property acts as a diagonal matrix, while a two-dimensional property couples array components.
+
+!syntax parameters /Kernels/KokkosArrayDiffusion
+
+!syntax inputs /Kernels/KokkosArrayDiffusion
+
+!syntax children /Kernels/KokkosArrayDiffusion
+
+!if-end!
+
+!else
+!include kokkos/kokkos_warning.md

--- a/framework/include/kokkos/base/KokkosArray.h
+++ b/framework/include/kokkos/base/KokkosArray.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "KokkosArrayView.h"
+
 #ifdef MOOSE_KOKKOS_SCOPE
 #include "KokkosHeader.h"
 #endif
@@ -1561,7 +1563,8 @@ dataLoad(std::istream & stream, Array<T, dimension, index_type, layout> & array,
  */
 ///@{
 template <typename T, unsigned int dimension, typename index_type, LayoutType layout>
-class Array : public ArrayBase<T, dimension, index_type>
+class Array : public ArrayBase<T, dimension, index_type>,
+              public ArrayView<Array<T, dimension, index_type, layout>, dimension>
 {
 #ifdef MOOSE_KOKKOS_SCOPE
   usingKokkosArrayBaseMembers(T, dimension, index_type);
@@ -1707,7 +1710,9 @@ Array<T, dimension, index_type, layout>::linearIndex(indices... i) const
 #endif
 
 template <typename T, typename index_type>
-class Array<T, 1, index_type, LayoutType::LEFT> : public ArrayBase<T, 1, index_type>
+class Array<T, 1, index_type, LayoutType::LEFT>
+  : public ArrayBase<T, 1, index_type>,
+    public ArrayView<Array<T, 1, index_type, LayoutType::LEFT>, 1>
 {
 #ifdef MOOSE_KOKKOS_SCOPE
   usingKokkosArrayBaseMembers(T, 1, index_type);

--- a/framework/include/kokkos/base/KokkosArray.h
+++ b/framework/include/kokkos/base/KokkosArray.h
@@ -1743,6 +1743,17 @@ public:
   {
     *this = vector;
   }
+  /**
+   * Constructor
+   * Initialize and allocate a real array by copying a real Eigen vector
+   * This allocates and copies to both host and device data
+   * @param vector The real Eigen vector to copy
+   */
+  template <typename U = T, std::enable_if_t<std::is_same_v<U, Real>, int> = 0>
+  Array(const RealEigenVector & vector) : ArrayBase<T, 1, index_type>(LayoutType::LEFT)
+  {
+    *this = vector;
+  }
 #endif
 
   /**
@@ -1782,6 +1793,28 @@ public:
           this->deviceData(), vector.data(), this->size());
   }
   /**
+   * Copy a real Eigen vector variable
+   * This re-initializes and re-allocates the array with the size of the vector
+   * @tparam host Whether to allocate and copy to the host data
+   * @tparam device Whether to allocate and copy to the device data
+   * @param vector The real Eigen vector variable to copy
+   */
+  template <bool host,
+            bool device,
+            typename U = T,
+            std::enable_if_t<std::is_same_v<U, Real>, int> = 0>
+  void copyEigenVector(const RealEigenVector & vector)
+  {
+    this->template createInternal<host, device, false>({static_cast<index_type>(vector.size())});
+
+    if (host)
+      std::memcpy(this->hostData(), vector.data(), this->size() * sizeof(T));
+
+    if (device)
+      this->template copyInternal<MemSpace, ::Kokkos::HostSpace>(
+          this->deviceData(), vector.data(), this->size());
+  }
+  /**
    * Copy a standard set variable
    * This re-initializes and re-allocates array with the size of the set
    * @tparam host Whether to allocate and copy to the host data
@@ -1804,6 +1837,18 @@ public:
   auto & operator=(const std::vector<T> & vector)
   {
     copyVector<true, true>(vector);
+
+    return *this;
+  }
+  /**
+   * Copy a real Eigen vector variable
+   * This allocates and copies to both host and device data
+   * @param vector The real Eigen vector variable to copy
+   */
+  template <typename U = T, std::enable_if_t<std::is_same_v<U, Real>, int> = 0>
+  auto & operator=(const RealEigenVector & vector)
+  {
+    copyEigenVector<true, true>(vector);
 
     return *this;
   }

--- a/framework/include/kokkos/base/KokkosArrayView.h
+++ b/framework/include/kokkos/base/KokkosArrayView.h
@@ -1,0 +1,589 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#pragma once
+
+#ifdef MOOSE_KOKKOS_SCOPE
+#include "KokkosHeader.h"
+
+#include <type_traits>
+#endif
+
+namespace Moose::Kokkos
+{
+
+template <typename MatrixView>
+class ArrayDiagonalView;
+
+template <typename MatrixView>
+class ArrayTransposeView;
+
+template <typename Derived, unsigned int dimension>
+class ArrayViewBase;
+
+template <typename T>
+inline constexpr bool is_convertible_to_arithmetic_v =
+    std::is_convertible_v<T, bool> || std::is_convertible_v<T, char> ||
+    std::is_convertible_v<T, signed char> || std::is_convertible_v<T, unsigned char> ||
+    std::is_convertible_v<T, short> || std::is_convertible_v<T, unsigned short> ||
+    std::is_convertible_v<T, int> || std::is_convertible_v<T, unsigned int> ||
+    std::is_convertible_v<T, long> || std::is_convertible_v<T, unsigned long> ||
+    std::is_convertible_v<T, long long> || std::is_convertible_v<T, unsigned long long> ||
+    std::is_convertible_v<T, float> || std::is_convertible_v<T, double> ||
+    std::is_convertible_v<T, long double>;
+
+/**
+ * CRTP base for device-accessible rank-one array views.
+ */
+template <typename Derived>
+class ArrayViewBase<Derived, 1>
+{
+public:
+  static constexpr unsigned int rank = 1;
+  static constexpr bool has_active_component = false;
+
+#ifdef MOOSE_KOKKOS_SCOPE
+  /**
+   * Get the derived view
+   * @returns The derived view
+   */
+  KOKKOS_FUNCTION const Derived & derived() const { return static_cast<const Derived &>(*this); }
+
+  /**
+   * Forward indexing to the derived view
+   * @param indices The indices into the view
+   * @returns The indexed value
+   */
+  template <typename... Indices>
+  KOKKOS_FUNCTION decltype(auto) operator()(Indices... indices) const
+  {
+    return derived()(indices...);
+  }
+
+#endif
+};
+
+/**
+ * CRTP base for device-accessible rank-two array views.
+ */
+template <typename Derived>
+class ArrayViewBase<Derived, 2>
+{
+public:
+  static constexpr unsigned int rank = 2;
+  static constexpr bool has_active_component = false;
+
+#ifdef MOOSE_KOKKOS_SCOPE
+  /**
+   * Get the derived view
+   * @returns The derived view
+   */
+  KOKKOS_FUNCTION const Derived & derived() const { return static_cast<const Derived &>(*this); }
+
+  /**
+   * Forward indexing to the derived view
+   * @param indices The indices into the view
+   * @returns The indexed value
+   */
+  template <typename... Indices>
+  KOKKOS_FUNCTION decltype(auto) operator()(Indices... indices) const
+  {
+    return derived()(indices...);
+  }
+
+  /**
+   * Get the diagonal of a rank-two view
+   * @returns A rank-one view of the diagonal
+   */
+  KOKKOS_FUNCTION auto diagonal() const { return ArrayDiagonalView<Derived>(derived()); }
+
+  /**
+   * Get the transpose of a rank-two view
+   * @returns A rank-two transpose view
+   */
+  KOKKOS_FUNCTION auto transpose() const { return ArrayTransposeView<Derived>(derived()); }
+#endif
+};
+
+/**
+ * Selectively add an ArrayViewBase base for supported ranks
+ */
+template <typename Derived, unsigned int dimension>
+class ArrayView
+{
+};
+
+template <typename Derived>
+class ArrayView<Derived, 1> : public ArrayViewBase<Derived, 1>
+{
+};
+
+template <typename Derived>
+class ArrayView<Derived, 2> : public ArrayViewBase<Derived, 2>
+{
+};
+
+#ifdef MOOSE_KOKKOS_SCOPE
+/**
+ * A multidimensional array view that forwards to a bound context
+ */
+template <typename Context, unsigned int dimension, bool active_component = false>
+class ArrayContextView
+  : public ArrayView<ArrayContextView<Context, dimension, active_component>, dimension>
+{
+public:
+  static constexpr bool has_active_component = active_component;
+
+  /**
+   * Constructor
+   * @param context The bound array context
+   * @param comp The active component
+   */
+  KOKKOS_FUNCTION explicit ArrayContextView(const Context & context, const unsigned int comp = 0)
+    : _context(context), _comp(comp)
+  {
+  }
+
+  /**
+   * Forward writable indexing to the bound context
+   * @param indices The indices into the view
+   * @returns The indexed value
+   */
+  template <typename... Indices>
+  KOKKOS_FUNCTION decltype(auto) operator()(Indices... indices)
+  {
+    return _context(indices...);
+  }
+
+  /**
+   * Forward read-only indexing to the bound context
+   * @param indices The indices into the view
+   * @returns The indexed value
+   */
+  template <typename... Indices>
+  KOKKOS_FUNCTION decltype(auto) operator()(Indices... indices) const
+  {
+    return _context(indices...);
+  }
+
+  /**
+   * Get the size of a dimension
+   * @param dim The dimension index
+   * @returns The size of the dimension
+   */
+  KOKKOS_FUNCTION auto n(const unsigned int dim) const { return _context.n(dim); }
+
+  /**
+   * Get the active component
+   * @returns The active component
+   */
+  KOKKOS_FUNCTION unsigned int comp() const
+  {
+    static_assert(active_component, "This array context view has no active component");
+    return _comp;
+  }
+
+private:
+  Context _context;
+  const unsigned int _comp;
+};
+
+/**
+ * Rank-one view of the diagonal of a rank-two array view.
+ */
+template <typename MatrixView>
+class ArrayDiagonalView : public ArrayViewBase<ArrayDiagonalView<MatrixView>, 1>
+{
+public:
+  static constexpr bool has_active_component = MatrixView::has_active_component;
+
+  /**
+   * Constructor
+   * @param matrix The rank-two array view
+   */
+  KOKKOS_FUNCTION explicit ArrayDiagonalView(const MatrixView & matrix) : _matrix(matrix) {}
+
+  /**
+   * Get the diagonal length
+   * @returns The diagonal length
+   */
+  KOKKOS_FUNCTION auto n(const unsigned int) const
+  {
+    return _matrix.n(0) < _matrix.n(1) ? _matrix.n(0) : _matrix.n(1);
+  }
+
+  /**
+   * Get a diagonal entry
+   * @param i The diagonal entry index
+   * @returns The diagonal entry
+   */
+  KOKKOS_FUNCTION const auto & operator()(const unsigned int i) const { return _matrix(i, i); }
+
+  /**
+   * Get the active component
+   * @returns The active component of the rank-two view
+   */
+  KOKKOS_FUNCTION unsigned int comp() const;
+
+private:
+  const MatrixView & _matrix;
+};
+
+template <typename MatrixView>
+KOKKOS_FUNCTION unsigned int
+ArrayDiagonalView<MatrixView>::comp() const
+{
+  static_assert(has_active_component, "This array diagonal view has no active component");
+  return _matrix.comp();
+}
+
+/**
+ * Rank-two transpose view of a rank-two array view.
+ */
+template <typename MatrixView>
+class ArrayTransposeView : public ArrayViewBase<ArrayTransposeView<MatrixView>, 2>
+{
+public:
+  static constexpr bool has_active_component = MatrixView::has_active_component;
+
+  /**
+   * Constructor
+   * @param matrix The rank-two array view
+   */
+  KOKKOS_FUNCTION explicit ArrayTransposeView(const MatrixView & matrix) : _matrix(matrix) {}
+
+  /**
+   * Get the size of a dimension
+   * @param dim The dimension index
+   * @returns The size of the transposed dimension
+   */
+  KOKKOS_FUNCTION auto n(unsigned int dim) const;
+
+  /**
+   * Get an entry of the transpose
+   * @param i The row index
+   * @param j The column index
+   * @returns The transposed matrix entry
+   */
+  KOKKOS_FUNCTION const auto & operator()(unsigned int i, unsigned int j) const;
+
+  /**
+   * Get the active component
+   * @returns The active component of the rank-two view
+   */
+  KOKKOS_FUNCTION unsigned int comp() const;
+
+private:
+  const MatrixView & _matrix;
+};
+
+template <typename MatrixView>
+KOKKOS_FUNCTION auto
+ArrayTransposeView<MatrixView>::n(const unsigned int dim) const
+{
+  KOKKOS_ASSERT(dim < 2);
+  return dim == 0 ? _matrix.n(1) : _matrix.n(0);
+}
+
+template <typename MatrixView>
+KOKKOS_FUNCTION const auto &
+ArrayTransposeView<MatrixView>::operator()(const unsigned int i, const unsigned int j) const
+{
+  return _matrix(j, i);
+}
+
+template <typename MatrixView>
+KOKKOS_FUNCTION unsigned int
+ArrayTransposeView<MatrixView>::comp() const
+{
+  static_assert(has_active_component, "This array transpose view has no active component");
+  return _matrix.comp();
+}
+
+/**
+ * Get the active component shared by two rank-one views
+ * @param left_view The left rank-one view
+ * @param right_view The right rank-one view
+ * @returns The active component
+ */
+template <typename LeftDerived, typename RightDerived>
+KOKKOS_FUNCTION unsigned int
+activeComponent(const ArrayViewBase<LeftDerived, 1> & left_view,
+                const ArrayViewBase<RightDerived, 1> & right_view)
+{
+  static_assert(LeftDerived::has_active_component || RightDerived::has_active_component,
+                "Element-wise array products require an active component");
+
+  const auto & left = left_view.derived();
+  const auto & right = right_view.derived();
+
+  if constexpr (LeftDerived::has_active_component)
+  {
+    if constexpr (RightDerived::has_active_component)
+      KOKKOS_ASSERT(left.comp() == right.comp());
+
+    return left.comp();
+  }
+  else
+    return right.comp();
+}
+
+/**
+ * Get the active value of a rank-one view
+ * @param view The rank-one view
+ * @returns The value of the active component
+ */
+template <typename Derived>
+KOKKOS_FUNCTION auto
+activeValue(const ArrayViewBase<Derived, 1> & view)
+{
+  static_assert(Derived::has_active_component,
+                "Array-scalar operations require an active array component");
+
+  const auto & derived = view.derived();
+  return view(derived.comp());
+}
+
+/**
+ * Compute the active component of an element-wise rank-one product
+ * @param left_view The left rank-one view
+ * @param right_view The right rank-one view
+ * @returns The product of the active components
+ */
+template <typename LeftDerived, typename RightDerived>
+KOKKOS_FUNCTION auto
+operator*(const ArrayViewBase<LeftDerived, 1> & left_view,
+          const ArrayViewBase<RightDerived, 1> & right_view)
+{
+  KOKKOS_ASSERT(left_view.derived().n(0) == right_view.derived().n(0));
+
+  const auto comp = activeComponent(left_view, right_view);
+  return left_view(comp) * right_view(comp);
+}
+
+/**
+ * Compute the active component of an element-wise rank-one sum
+ * @param left_view The left rank-one view
+ * @param right_view The right rank-one view
+ * @returns The sum of the active components
+ */
+template <typename LeftDerived, typename RightDerived>
+KOKKOS_FUNCTION auto
+operator+(const ArrayViewBase<LeftDerived, 1> & left_view,
+          const ArrayViewBase<RightDerived, 1> & right_view)
+{
+  KOKKOS_ASSERT(left_view.derived().n(0) == right_view.derived().n(0));
+
+  const auto comp = activeComponent(left_view, right_view);
+  return left_view(comp) + right_view(comp);
+}
+
+/**
+ * Compute the active component of an element-wise rank-one difference
+ * @param left_view The left rank-one view
+ * @param right_view The right rank-one view
+ * @returns The difference of the active components
+ */
+template <typename LeftDerived, typename RightDerived>
+KOKKOS_FUNCTION auto
+operator-(const ArrayViewBase<LeftDerived, 1> & left_view,
+          const ArrayViewBase<RightDerived, 1> & right_view)
+{
+  KOKKOS_ASSERT(left_view.derived().n(0) == right_view.derived().n(0));
+
+  const auto comp = activeComponent(left_view, right_view);
+  return left_view(comp) - right_view(comp);
+}
+
+/**
+ * Compute the active component of an element-wise rank-one quotient
+ * @param left_view The left rank-one view
+ * @param right_view The right rank-one view
+ * @returns The quotient of the active components
+ */
+template <typename LeftDerived, typename RightDerived>
+KOKKOS_FUNCTION auto
+operator/(const ArrayViewBase<LeftDerived, 1> & left_view,
+          const ArrayViewBase<RightDerived, 1> & right_view)
+{
+  KOKKOS_ASSERT(left_view.derived().n(0) == right_view.derived().n(0));
+
+  const auto comp = activeComponent(left_view, right_view);
+  return left_view(comp) / right_view(comp);
+}
+
+/**
+ * Compute an active rank-one value multiplied by a scalar
+ * @param view The rank-one view
+ * @param scalar The scalar value
+ * @returns The active component multiplied by the scalar
+ */
+template <typename Derived,
+          typename Scalar,
+          std::enable_if_t<is_convertible_to_arithmetic_v<Scalar>, int> = 0>
+KOKKOS_FUNCTION auto
+operator*(const ArrayViewBase<Derived, 1> & view, const Scalar & scalar)
+{
+  return activeValue(view) * scalar;
+}
+
+/**
+ * Compute a scalar multiplied by an active rank-one value
+ * @param scalar The scalar value
+ * @param view The rank-one view
+ * @returns The scalar multiplied by the active component
+ */
+template <typename Scalar,
+          typename Derived,
+          std::enable_if_t<is_convertible_to_arithmetic_v<Scalar>, int> = 0>
+KOKKOS_FUNCTION auto
+operator*(const Scalar & scalar, const ArrayViewBase<Derived, 1> & view)
+{
+  return scalar * activeValue(view);
+}
+
+/**
+ * Compute an active rank-one value plus a scalar
+ * @param view The rank-one view
+ * @param scalar The scalar value
+ * @returns The active component plus the scalar
+ */
+template <typename Derived,
+          typename Scalar,
+          std::enable_if_t<is_convertible_to_arithmetic_v<Scalar>, int> = 0>
+KOKKOS_FUNCTION auto
+operator+(const ArrayViewBase<Derived, 1> & view, const Scalar & scalar)
+{
+  return activeValue(view) + scalar;
+}
+
+/**
+ * Compute a scalar plus an active rank-one value
+ * @param scalar The scalar value
+ * @param view The rank-one view
+ * @returns The scalar plus the active component
+ */
+template <typename Scalar,
+          typename Derived,
+          std::enable_if_t<is_convertible_to_arithmetic_v<Scalar>, int> = 0>
+KOKKOS_FUNCTION auto
+operator+(const Scalar & scalar, const ArrayViewBase<Derived, 1> & view)
+{
+  return scalar + activeValue(view);
+}
+
+/**
+ * Compute an active rank-one value minus a scalar
+ * @param view The rank-one view
+ * @param scalar The scalar value
+ * @returns The active component minus the scalar
+ */
+template <typename Derived,
+          typename Scalar,
+          std::enable_if_t<is_convertible_to_arithmetic_v<Scalar>, int> = 0>
+KOKKOS_FUNCTION auto
+operator-(const ArrayViewBase<Derived, 1> & view, const Scalar & scalar)
+{
+  return activeValue(view) - scalar;
+}
+
+/**
+ * Compute a scalar minus an active rank-one value
+ * @param scalar The scalar value
+ * @param view The rank-one view
+ * @returns The scalar minus the active component
+ */
+template <typename Scalar,
+          typename Derived,
+          std::enable_if_t<is_convertible_to_arithmetic_v<Scalar>, int> = 0>
+KOKKOS_FUNCTION auto
+operator-(const Scalar & scalar, const ArrayViewBase<Derived, 1> & view)
+{
+  return scalar - activeValue(view);
+}
+
+/**
+ * Compute an active rank-one value divided by a scalar
+ * @param view The rank-one view
+ * @param scalar The scalar value
+ * @returns The active component divided by the scalar
+ */
+template <typename Derived,
+          typename Scalar,
+          std::enable_if_t<is_convertible_to_arithmetic_v<Scalar>, int> = 0>
+KOKKOS_FUNCTION auto
+operator/(const ArrayViewBase<Derived, 1> & view, const Scalar & scalar)
+{
+  return activeValue(view) / scalar;
+}
+
+/**
+ * Compute a scalar divided by an active rank-one value
+ * @param scalar The scalar value
+ * @param view The rank-one view
+ * @returns The scalar divided by the active component
+ */
+template <typename Scalar,
+          typename Derived,
+          std::enable_if_t<is_convertible_to_arithmetic_v<Scalar>, int> = 0>
+KOKKOS_FUNCTION auto
+operator/(const Scalar & scalar, const ArrayViewBase<Derived, 1> & view)
+{
+  return scalar / activeValue(view);
+}
+
+/**
+ * Compute the dot product of two rank-one views
+ * @param left_view The left rank-one view
+ * @param right_view The right rank-one view
+ * @returns The dot product
+ */
+template <typename LeftDerived, typename RightDerived>
+KOKKOS_FUNCTION auto
+dot(const ArrayViewBase<LeftDerived, 1> & left_view,
+    const ArrayViewBase<RightDerived, 1> & right_view)
+{
+  KOKKOS_ASSERT(left_view.derived().n(0) == right_view.derived().n(0));
+
+  using result_type = decltype(left_view(0) * right_view(0));
+  result_type result = 0;
+
+  for (unsigned int i = 0; i < left_view.derived().n(0); ++i)
+    result += left_view(i) * right_view(i);
+
+  return result;
+}
+
+/**
+ * Compute the active row of a rank-two/rank-one product
+ * @param matrix_view The rank-two view
+ * @param vector_view The rank-one view
+ * @returns The active component of the matrix-vector product
+ */
+template <typename MatrixDerived, typename VectorDerived>
+KOKKOS_FUNCTION auto
+operator*(const ArrayViewBase<MatrixDerived, 2> & matrix_view,
+          const ArrayViewBase<VectorDerived, 1> & vector_view)
+{
+  const auto & vector = vector_view.derived();
+  static_assert(VectorDerived::has_active_component,
+                "Matrix-vector products require an active vector component");
+  KOKKOS_ASSERT(matrix_view.derived().n(0) > vector.comp());
+  KOKKOS_ASSERT(matrix_view.derived().n(1) == vector_view.derived().n(0));
+
+  using result_type = decltype(matrix_view(vector.comp(), 0) * vector_view(0));
+  result_type result = 0;
+
+  for (unsigned int j = 0; j < vector_view.derived().n(0); ++j)
+    result += matrix_view(vector.comp(), j) * vector_view(j);
+
+  return result;
+}
+#endif
+
+} // namespace Moose::Kokkos

--- a/framework/include/kokkos/base/KokkosDatum.h
+++ b/framework/include/kokkos/base/KokkosDatum.h
@@ -9,131 +9,15 @@
 
 #pragma once
 
-#include "KokkosTypes.h"
+#include "KokkosDatumDecl.h"
+
 #include "KokkosAssembly.h"
 #include "KokkosFESystem.h"
 #include "KokkosVariable.h"
+#include "KokkosMaterialPropertyDecl.h"
 
 namespace Moose::Kokkos
 {
-
-/**
- * Generic datum class containing geometric information related to the mesh. This is a base class
- * for derived datum classes for both finite volume and finite element system assembly.
- */
-class MeshDatum
-{
-public:
-  /**
-   * Constructor
-   * @param elem The contiguous element ID
-   * @param side The element side index, or \p libMesh::invalid_uint for element-only data
-   * @param mesh The Kokkos mesh
-   */
-  KOKKOS_FUNCTION
-  MeshDatum(ContiguousElementID elem, const unsigned int side, const Mesh & mesh);
-
-  /**
-   * Get the Kokkos mesh
-   * @returns The Kokkos mesh
-   */
-  KOKKOS_FUNCTION const Mesh & mesh() const { return _mesh; }
-
-  /**
-   * Get the element information object
-   * @returns The element information object
-   */
-  KOKKOS_FUNCTION const ElementInfo & elem() const { return _elem; }
-
-  /**
-   * Get the contiguous element ID
-   * @returns The contiguous element ID
-   */
-  KOKKOS_FUNCTION ContiguousElementID elemID() const { return _elem.id; }
-
-  /**
-   * Get whether the current side has a neighbor
-   * @returns Whether the current side has a neighbor
-   */
-  KOKKOS_FUNCTION bool hasNeighbor() const;
-
-  /**
-   * Get the neighbor element information object
-   * @returns The neighbor element information object. If there is no neighbor or if this datum is
-   * not meant to represent face data, then this will point to a default constructed \p ElementInfo
-   * whose data members represent invalid state (e.g. hold \p invalid_uint, \p invalid_id like
-   * values)
-   */
-  KOKKOS_FUNCTION const ElementInfo & neighbor() const { return _neighbor; }
-
-  /**
-   * Get the contiguous neighbor element ID
-   * @returns The contiguous neighbor element ID or \p libMesh::DofObject::invalid_id
-   */
-  KOKKOS_FUNCTION ContiguousElementID neighborID() const { return _neighbor.id; }
-
-  /**
-   * Get the side index
-   * @returns The side index
-   */
-  KOKKOS_FUNCTION unsigned int side() const { return _side; }
-
-  /**
-   * Get whether the current datum is on a side
-   * @returns Whether the current datum is on a side
-   */
-  KOKKOS_FUNCTION bool isSide() const { return _side != libMesh::invalid_uint; }
-
-  /**
-   * Get the contiguous subdomain ID
-   * @returns The contiguous subdomain ID
-   */
-  KOKKOS_FUNCTION ContiguousSubdomainID subdomain() const { return _elem.subdomain; }
-
-  /**
-   * Get the contiguous neighbor subdomain ID
-   * @returns The contiguous neighbor subdomain ID
-   */
-  KOKKOS_FUNCTION ContiguousSubdomainID neighborSubdomain() const { return _neighbor.subdomain; }
-
-protected:
-  /**
-   * Get the neighbor element information object for an element side
-   * @param elem The contiguous element ID
-   * @param side The side index
-   * @param mesh The Kokkos mesh
-   * @returns The neighbor element information object, or a default \p ElementInfo (a default
-   *          constructed \p ElementInfo's data members all represent invalid state) when \p elem is
-   *          \p libMesh::DofObject::invalid_id, \p side is \p libMesh::invalid_uint, or the Kokkos
-   *          mesh has no contiguous neighbor ID for the side. The latter includes exterior
-   *          boundary sides with no libMesh neighbor and sides whose libMesh neighbor is
-   *          \p libMesh::remote_elem. Off-process neighbors present as ghost elements have
-   *          contiguous IDs and return their \p ElementInfo.
-   */
-  static KOKKOS_FUNCTION ElementInfo neighborInfo(ContiguousElementID elem,
-                                                  const unsigned int side,
-                                                  const Mesh & mesh);
-
-  /**
-   * Reference to the Kokkos mesh
-   */
-  const Mesh & _mesh;
-
-  /**
-   * Current element information object
-   */
-  const ElementInfo _elem;
-
-  /**
-   * Current side index
-   */
-  const unsigned int _side = libMesh::invalid_uint;
-
-  /**
-   * Current neighbor element information object
-   */
-  const ElementInfo _neighbor;
-};
 
 KOKKOS_FUNCTION inline MeshDatum::MeshDatum(ContiguousElementID elem,
                                             const unsigned int side,
@@ -161,77 +45,6 @@ MeshDatum::neighborInfo(ContiguousElementID elem, const unsigned int side, const
   return neighbor == libMesh::DofObject::invalid_id ? ElementInfo{} : mesh.getElementInfo(neighbor);
 }
 
-/**
- * Device-side geometric context for finite volume kernels and boundary conditions.
- */
-class FVDatum : public MeshDatum
-{
-public:
-  /**
-   * Constructor
-   * @param elem The contiguous element ID
-   * @param side The element side index, or \p libMesh::invalid_uint for element-only data
-   * @param mesh The Kokkos mesh
-   */
-  KOKKOS_FUNCTION
-  FVDatum(ContiguousElementID elem, const unsigned int side, const Mesh & mesh);
-
-  /**
-   * Get the centroid of the current element side
-   * @pre This datum represents a valid side of a locally owned element.
-   * @returns The side centroid
-   */
-  KOKKOS_FUNCTION Real3 faceCentroid() const { return _mesh.getSideCentroid(_elem.id, _side); }
-
-  /**
-   * Get the outward unit normal of the current element side
-   * @pre This datum represents a valid side of a locally owned element.
-   * @returns The side normal
-   */
-  KOKKOS_FUNCTION Real3 faceNormal() const { return _mesh.getSideNormal(_elem.id, _side); }
-
-  /**
-   * Get the distance from the current element centroid to its neighbor centroid
-   * @pre This datum represents a side of a locally owned element with a neighbor.
-   * @returns The element-centroid to neighbor-centroid distance
-   */
-  KOKKOS_FUNCTION Real faceDCNMag() const
-  {
-    return _mesh.getElementCentroidToNeighborCentroidDistance(_elem.id, _side);
-  }
-
-  /**
-   * Get the distance from the current element centroid to the current side centroid
-   * @pre This datum represents a valid side of a locally owned element.
-   * @returns The element-centroid to side-centroid distance
-   */
-  KOKKOS_FUNCTION Real faceDCFMag() const
-  {
-    return _mesh.getElementCentroidToSideCentroidDistance(_elem.id, _side);
-  }
-
-  /**
-   * Get the coordinate-weighted area of the current element side
-   * @pre This datum represents a valid side of a locally owned element.
-   * @returns The side area including the coordinate transformation factor
-   */
-  KOKKOS_FUNCTION Real faceArea() const { return _mesh.getSideArea(_elem.id, _side); }
-
-  /**
-   * Get the current element centroid
-   * @pre The current element is locally owned.
-   * @returns The element centroid
-   */
-  KOKKOS_FUNCTION Real3 elementCentroid() const { return _mesh.getElementCentroid(_elem.id); }
-
-  /**
-   * Get the coordinate-weighted current element volume
-   * @pre The current element is locally owned.
-   * @returns The element volume including the coordinate transformation factor
-   */
-  KOKKOS_FUNCTION Real elementVolume() const { return _mesh.getElementVolume(_elem.id); }
-};
-
 KOKKOS_FUNCTION inline FVDatum::FVDatum(ContiguousElementID elem,
                                         const unsigned int side,
                                         const Mesh & mesh)
@@ -239,211 +52,11 @@ KOKKOS_FUNCTION inline FVDatum::FVDatum(ContiguousElementID elem,
 {
 }
 
-/**
- * The Kokkos object that holds thread-private data in the parallel operations of any Kokkos object
- */
-class Datum : public MeshDatum
+KOKKOS_FUNCTION inline const FESystem &
+Datum::system(const unsigned int sys) const
 {
-public:
-  /**
-   * Constructor for element and side data
-   * @param elem The contiguous element ID of the current thread
-   * @param side The side index of the current thread
-   * @param assembly The Kokkos assembly
-   * @param systems The Kokkos systems
-   */
-  KOKKOS_FUNCTION
-  Datum(const ContiguousElementID elem,
-        const unsigned int side,
-        const Assembly & assembly,
-        const Array<FESystem> & systems);
-
-  /**
-   * Constructor for node data
-   * @param node The contiguous node ID of the current thread
-   * @param assembly The Kokkos assembly
-   * @param systems The Kokkos systems
-   */
-  KOKKOS_FUNCTION
-  Datum(const ContiguousNodeID node, const Assembly & assembly, const Array<FESystem> & systems);
-
-  /**
-   * Get the Kokkos assembly
-   * @returns The Kokkos assembly
-   */
-  KOKKOS_FUNCTION const Assembly & assembly() const { return _assembly; }
-
-  /**
-   * Get the Kokkos system
-   * @param sys The system number
-   * @returns The Kokkos system
-   */
-  KOKKOS_FUNCTION const FESystem & system(unsigned int sys) const { return _systems[sys]; }
-
-  /**
-   * Get the extra element ID
-   * @param index The extra element ID index
-   * @returns The extra element ID
-   */
-  KOKKOS_FUNCTION dof_id_type extraElemID(unsigned int index) const
-  {
-    return isNodal() ? libMesh::DofObject::invalid_id : _mesh.getExtraElementID(_elem.id, index);
-  }
-
-  /**
-   * Get the contiguous node ID
-   * @returns The contiguous node ID
-   */
-  KOKKOS_FUNCTION ContiguousNodeID node() const { return _node; }
-
-  /**
-   * Get the number of local quadrature points
-   * @returns The number of local quadrature points
-   */
-  KOKKOS_FUNCTION unsigned int n_qps() const { return _n_qps; }
-
-  /**
-   * Get the starting offset into the global quadrature point index
-   * @returns The starting offset
-   */
-  KOKKOS_FUNCTION dof_id_type qpOffset() const { return _qp_offset; }
-
-  /**
-   * Get the index into the property data storage
-   * @param constant_option The property constant option
-   * @param qp The local quadrature point index
-   * @returns The index
-   */
-  KOKKOS_FUNCTION dof_id_type propertyIdx(const PropertyConstantOption constant_option,
-                                          const unsigned int qp) const;
-
-  /**
-   * Get whether the current datum is on a node
-   * @returns Whether the current datum is on a node
-   */
-  KOKKOS_FUNCTION bool isNodal() const { return _node != libMesh::DofObject::invalid_id; }
-
-  /**
-   * Get whether the a variable is defined on the current node
-   * @param var The variable
-   * @returns Whether the variable is defined on the current node
-   */
-  KOKKOS_FUNCTION bool isNodalDefined(const Variable & var) const;
-
-  /**
-   * Get the inverse of Jacobian matrix
-   * | dxi/dx deta/dx dzeta/dx |
-   * | dxi/dy deta/dy dzeta/dy |
-   * | dxi/dz deta/dz dzeta/dz |
-   * @param qp The local quadrature point index
-   * @returns The Jacobian matrix
-   */
-  KOKKOS_FUNCTION const Real33 & J(const unsigned int qp);
-
-  /**
-   * Get the transformed Jacobian weight
-   * @param qp The local quadrature point index
-   * @returns The transformed Jacobian weights
-   */
-  KOKKOS_FUNCTION Real JxW(const unsigned int qp);
-
-  /**
-   * Get the physical quadrature point coordinate
-   * @param qp The local quadrature point index
-   * @returns The physical quadrature point coordinate
-   */
-  KOKKOS_FUNCTION Real3 q_point(const unsigned int qp);
-
-  /**
-   * Get the normal vector on surface
-   * @param qp The local quadrature point index
-   * @returns The normal vector
-   */
-  KOKKOS_FUNCTION Real3 normals(const unsigned int qp);
-
-  /**
-   * Set local parallelization option
-   * @param local_thread_id The current local thread ID
-   * @param num_local_threads The number of local threads
-   */
-  KOKKOS_FUNCTION void set_local_parallel(const unsigned int local_thread_id,
-                                          const unsigned int num_local_threads)
-  {
-    _local_thread_id = local_thread_id;
-    _num_local_threads = num_local_threads;
-  }
-  /**
-   * Get the current local thread ID
-   * @returns The current local thread ID
-   */
-  KOKKOS_FUNCTION unsigned int local_thread_id() const { return _local_thread_id; }
-  /**
-   * Get the number of local threads
-   * @returns The number of local threads
-   */
-  KOKKOS_FUNCTION unsigned int num_local_threads() const { return _num_local_threads; }
-
-protected:
-  /**
-   * Reference of the Kokkos assembly
-   */
-  const Assembly & _assembly;
-
-  /**
-   * Reference of the Kokkos systems
-   */
-  const Array<FESystem> & _systems;
-
-  /**
-   * Current contiguous node ID
-   */
-  const ContiguousNodeID _node = libMesh::DofObject::invalid_id;
-
-  /**
-   * Number of local quadrature points
-   */
-  const unsigned int _n_qps = 1;
-
-  /**
-   * Starting offset into the global quadrature point index
-   */
-  const dof_id_type _qp_offset = libMesh::DofObject::invalid_id;
-
-  /**
-   * Index for element-constant material properties
-   */
-  const dof_id_type _elem_property_idx = libMesh::DofObject::invalid_id;
-
-private:
-  /**
-   * Compute and cache the physical transformation data
-   * @param qp The local quadrature point index
-   */
-  KOKKOS_FUNCTION void reinitTransform(const unsigned int qp);
-
-  /**
-   * Cached quadrature point index for checking whether the physical transformation data should be
-   * recomputed
-   */
-  unsigned int _cached_qp = libMesh::invalid_uint;
-  /**
-   * Cached physical transformation data
-   */
-  ///@{
-  Real33 _J;
-  Real _JxW;
-  Real3 _xyz;
-  Real3 _normal;
-  ///@}
-  /**
-   * Thread ID for local parallelization
-   */
-  unsigned int _local_thread_id = 0;
-  /**
-   * Number of threads for local parallelization
-   */
-  unsigned int _num_local_threads = 1;
-};
+  return _systems[sys];
+}
 
 KOKKOS_FUNCTION inline Datum::Datum(const ContiguousElementID elem,
                                     const unsigned int side,
@@ -553,157 +166,41 @@ Datum::reinitTransform(const unsigned int qp)
   _cached_qp = qp;
 }
 
-/**
- * The Kokkos object that holds thread-private data in the parallel operations of Kokkos kernels
- */
-class AssemblyDatum : public Datum
+KOKKOS_FUNCTION inline AssemblyDatum::AssemblyDatum(const ContiguousElementID elem,
+                                                    const unsigned int side,
+                                                    const Assembly & assembly,
+                                                    const Array<FESystem> & systems,
+                                                    const Variable & ivar,
+                                                    const unsigned int jvar,
+                                                    const unsigned int comp)
+  : Datum(elem, side, assembly, systems),
+    _tag(ivar.tag()),
+    _sys(ivar.sys(comp)),
+    _ivar(ivar.var(comp)),
+    _jvar(jvar),
+    _comp(comp),
+    _ife(systems[ivar.sys(comp)].getFETypeID(_ivar)),
+    _jfe(systems[ivar.sys(comp)].getFETypeID(_jvar)),
+    _n_idofs(assembly.getNumDofs(_elem.type, _ife)),
+    _n_jdofs(assembly.getNumDofs(_elem.type, _jfe))
 {
-public:
-  /**
-   * Constructor for element and side data
-   * @param elem The contiguous element ID of the current thread
-   * @param side The side index of the current thread
-   * @param assembly The Kokkos assembly
-   * @param systems The Kokkos systems
-   * @param ivar The Kokkos variable
-   * @param jvar The coupled variable number
-   * @param comp The variable component
-   */
-  KOKKOS_FUNCTION
-  AssemblyDatum(const ContiguousElementID elem,
-                const unsigned int side,
-                const Assembly & assembly,
-                const Array<FESystem> & systems,
-                const Variable & ivar,
-                const unsigned int jvar,
-                const unsigned int comp = 0)
-    : Datum(elem, side, assembly, systems),
-      _tag(ivar.tag()),
-      _sys(ivar.sys(comp)),
-      _ivar(ivar.var(comp)),
-      _jvar(jvar),
-      _ife(systems[ivar.sys(comp)].getFETypeID(_ivar)),
-      _jfe(systems[ivar.sys(comp)].getFETypeID(_jvar)),
-      _n_idofs(assembly.getNumDofs(_elem.type, _ife)),
-      _n_jdofs(assembly.getNumDofs(_elem.type, _jfe))
-  {
-  }
-  /**
-   * Constructor for node data
-   * @param elem The contiguous element ID of the current thread
-   * @param assembly The Kokkos assembly
-   * @param systems The Kokkos systems
-   * @param ivar The Kokkos variable
-   * @param jvar The coupled variable number
-   * @param comp The variable component
-   */
-  KOKKOS_FUNCTION
-  AssemblyDatum(const ContiguousNodeID node,
-                const Assembly & assembly,
-                const Array<FESystem> & systems,
-                const Variable & ivar,
-                const unsigned int jvar,
-                const unsigned int comp = 0)
-    : Datum(node, assembly, systems),
-      _tag(ivar.tag()),
-      _sys(ivar.sys(comp)),
-      _ivar(ivar.var(comp)),
-      _jvar(jvar),
-      _ife(systems[ivar.sys(comp)].getFETypeID(_ivar)),
-      _jfe(systems[ivar.sys(comp)].getFETypeID(_jvar))
-  {
-  }
+}
 
-  /**
-   * Get the number of local DOFs
-   * @returns The number of local DOFs
-   */
-  KOKKOS_FUNCTION unsigned int n_dofs() const { return _n_idofs; }
-  /**
-   * Get the number of local DOFs
-   * @returns The number of local DOFs
-   */
-  KOKKOS_FUNCTION unsigned int n_idofs() const { return _n_idofs; }
-  /**
-   * Get the number of local DOFs for the coupled variable
-   * @returns The number of local DOFs
-   */
-  KOKKOS_FUNCTION unsigned int n_jdofs() const { return _n_jdofs; }
-  /**
-   * Get the system number of variable
-   * @returns The system number of variable
-   */
-  KOKKOS_FUNCTION unsigned int sys() const { return _sys; }
-  /**
-   * Get the variable number
-   * @returns The variable number
-   */
-  KOKKOS_FUNCTION unsigned int var() const { return _ivar; }
-  /**
-   * Get the variable number
-   * @returns The variable number
-   */
-  KOKKOS_FUNCTION unsigned int ivar() const { return _ivar; }
-  /**
-   * Get the coupled variable number
-   * @returns The variable number
-   */
-  KOKKOS_FUNCTION unsigned int jvar() const { return _jvar; }
-  /**
-   * Get the variable FE type ID
-   * @returns The variable FE type ID
-   */
-  KOKKOS_FUNCTION unsigned int fe() const { return _ife; }
-  /**
-   * Get the variable FE type ID
-   * @returns The variable FE type ID
-   */
-  KOKKOS_FUNCTION unsigned int ife() const { return _ife; }
-  /**
-   * Get the coupled variable FE type ID
-   * @returns The variable FE type ID
-   */
-  KOKKOS_FUNCTION unsigned int jfe() const { return _jfe; }
-  /**
-   * Set whether to compute derivatives for automatic differentiation (AD)
-   * @param flag Whether to compute derivatives
-   */
-  KOKKOS_FUNCTION void do_derivatives(const bool flag) { _do_derivatives = flag; }
-  /**
-   * Get whether to compute derivatives for automatic differentiation (AD)
-   * @returns Whether to compute derivatives
-   */
-  KOKKOS_FUNCTION bool do_derivatives() const { return _do_derivatives; }
-
-protected:
-  /**
-   * Solution tag ID
-   */
-  const TagID _tag;
-  /**
-   * System number
-   */
-  const unsigned int _sys;
-  /**
-   * Variable numbers
-   */
-  const unsigned int _ivar, _jvar;
-  /**
-   * FE type IDs of variables
-   */
-  const unsigned int _ife, _jfe;
-  /**
-   * Number of local DOFs
-   */
-  const unsigned int _n_idofs = 1, _n_jdofs = 1;
-  /**
-   * Whether to compute derivatives for automatic differentiation (AD)
-   */
-  bool _do_derivatives = true;
-};
+KOKKOS_FUNCTION inline AssemblyDatum::AssemblyDatum(const ContiguousNodeID node,
+                                                    const Assembly & assembly,
+                                                    const Array<FESystem> & systems,
+                                                    const Variable & ivar,
+                                                    const unsigned int jvar,
+                                                    const unsigned int comp)
+  : Datum(node, assembly, systems),
+    _tag(ivar.tag()),
+    _sys(ivar.sys(comp)),
+    _ivar(ivar.var(comp)),
+    _jvar(jvar),
+    _comp(comp),
+    _ife(systems[ivar.sys(comp)].getFETypeID(_ivar)),
+    _jfe(systems[ivar.sys(comp)].getFETypeID(_jvar))
+{
+}
 
 } // namespace Moose::Kokkos
-
-using Datum = Moose::Kokkos::Datum;
-using AssemblyDatum = Moose::Kokkos::AssemblyDatum;
-using FVDatum = Moose::Kokkos::FVDatum;

--- a/framework/include/kokkos/base/KokkosDatumDecl.h
+++ b/framework/include/kokkos/base/KokkosDatumDecl.h
@@ -1,0 +1,560 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "KokkosMesh.h"
+
+namespace Moose::Kokkos
+{
+
+class Assembly;
+class FESystem;
+class Variable;
+
+enum class PropertyConstantOption;
+
+/**
+ * Generic datum class containing geometric information related to the mesh. This is a base class
+ * for derived datum classes for both finite volume and finite element system assembly.
+ */
+class MeshDatum
+{
+public:
+  /**
+   * Constructor
+   * @param elem The contiguous element ID
+   * @param side The element side index, or \p libMesh::invalid_uint for element-only data
+   * @param mesh The Kokkos mesh
+   */
+  KOKKOS_FUNCTION
+  MeshDatum(ContiguousElementID elem, const unsigned int side, const Mesh & mesh);
+
+  /**
+   * Get the Kokkos mesh
+   * @returns The Kokkos mesh
+   */
+  KOKKOS_FUNCTION const Mesh & mesh() const { return _mesh; }
+
+  /**
+   * Get the element information object
+   * @returns The element information object
+   */
+  KOKKOS_FUNCTION const ElementInfo & elem() const { return _elem; }
+
+  /**
+   * Get the contiguous element ID
+   * @returns The contiguous element ID
+   */
+  KOKKOS_FUNCTION ContiguousElementID elemID() const { return _elem.id; }
+
+  /**
+   * Get whether the current side has a neighbor
+   * @returns Whether the current side has a neighbor
+   */
+  KOKKOS_FUNCTION bool hasNeighbor() const;
+
+  /**
+   * Get the neighbor element information object
+   * @returns The neighbor element information object. If there is no neighbor or if this datum is
+   * not meant to represent face data, then this will point to a default constructed \p ElementInfo
+   * whose data members represent invalid state (e.g. hold \p invalid_uint, \p invalid_id like
+   * values)
+   */
+  KOKKOS_FUNCTION const ElementInfo & neighbor() const { return _neighbor; }
+
+  /**
+   * Get the contiguous neighbor element ID
+   * @returns The contiguous neighbor element ID or \p libMesh::DofObject::invalid_id
+   */
+  KOKKOS_FUNCTION ContiguousElementID neighborID() const { return _neighbor.id; }
+
+  /**
+   * Get the side index
+   * @returns The side index
+   */
+  KOKKOS_FUNCTION unsigned int side() const { return _side; }
+
+  /**
+   * Get whether the current datum is on a side
+   * @returns Whether the current datum is on a side
+   */
+  KOKKOS_FUNCTION bool isSide() const { return _side != libMesh::invalid_uint; }
+
+  /**
+   * Get the contiguous subdomain ID
+   * @returns The contiguous subdomain ID
+   */
+  KOKKOS_FUNCTION ContiguousSubdomainID subdomain() const { return _elem.subdomain; }
+
+  /**
+   * Get the contiguous neighbor subdomain ID
+   * @returns The contiguous neighbor subdomain ID
+   */
+  KOKKOS_FUNCTION ContiguousSubdomainID neighborSubdomain() const { return _neighbor.subdomain; }
+
+protected:
+  /**
+   * Get the neighbor element information object for an element side
+   * @param elem The contiguous element ID
+   * @param side The side index
+   * @param mesh The Kokkos mesh
+   * @returns The neighbor element information object, or a default \p ElementInfo (a default
+   *          constructed \p ElementInfo's data members all represent invalid state) when \p elem is
+   *          \p libMesh::DofObject::invalid_id, \p side is \p libMesh::invalid_uint, or the Kokkos
+   *          mesh has no contiguous neighbor ID for the side. The latter includes exterior
+   *          boundary sides with no libMesh neighbor and sides whose libMesh neighbor is
+   *          \p libMesh::remote_elem. Off-process neighbors present as ghost elements have
+   *          contiguous IDs and return their \p ElementInfo.
+   */
+  static KOKKOS_FUNCTION ElementInfo neighborInfo(ContiguousElementID elem,
+                                                  const unsigned int side,
+                                                  const Mesh & mesh);
+
+  /**
+   * Reference to the Kokkos mesh
+   */
+  const Mesh & _mesh;
+
+  /**
+   * Current element information object
+   */
+  const ElementInfo _elem;
+
+  /**
+   * Current side index
+   */
+  const unsigned int _side = libMesh::invalid_uint;
+
+  /**
+   * Current neighbor element information object
+   */
+  const ElementInfo _neighbor;
+};
+
+/**
+ * Device-side geometric context for finite volume kernels and boundary conditions.
+ */
+class FVDatum : public MeshDatum
+{
+public:
+  /**
+   * Constructor
+   * @param elem The contiguous element ID
+   * @param side The element side index, or \p libMesh::invalid_uint for element-only data
+   * @param mesh The Kokkos mesh
+   */
+  KOKKOS_FUNCTION
+  FVDatum(ContiguousElementID elem, const unsigned int side, const Mesh & mesh);
+
+  /**
+   * Get the centroid of the current element side
+   * @pre This datum represents a valid side of a locally owned element.
+   * @returns The side centroid
+   */
+  KOKKOS_FUNCTION Real3 faceCentroid() const { return _mesh.getSideCentroid(_elem.id, _side); }
+
+  /**
+   * Get the outward unit normal of the current element side
+   * @pre This datum represents a valid side of a locally owned element.
+   * @returns The side normal
+   */
+  KOKKOS_FUNCTION Real3 faceNormal() const { return _mesh.getSideNormal(_elem.id, _side); }
+
+  /**
+   * Get the distance from the current element centroid to its neighbor centroid
+   * @pre This datum represents a side of a locally owned element with a neighbor.
+   * @returns The element-centroid to neighbor-centroid distance
+   */
+  KOKKOS_FUNCTION Real faceDCNMag() const
+  {
+    return _mesh.getElementCentroidToNeighborCentroidDistance(_elem.id, _side);
+  }
+
+  /**
+   * Get the distance from the current element centroid to the current side centroid
+   * @pre This datum represents a valid side of a locally owned element.
+   * @returns The element-centroid to side-centroid distance
+   */
+  KOKKOS_FUNCTION Real faceDCFMag() const
+  {
+    return _mesh.getElementCentroidToSideCentroidDistance(_elem.id, _side);
+  }
+
+  /**
+   * Get the coordinate-weighted area of the current element side
+   * @pre This datum represents a valid side of a locally owned element.
+   * @returns The side area including the coordinate transformation factor
+   */
+  KOKKOS_FUNCTION Real faceArea() const { return _mesh.getSideArea(_elem.id, _side); }
+
+  /**
+   * Get the current element centroid
+   * @pre The current element is locally owned.
+   * @returns The element centroid
+   */
+  KOKKOS_FUNCTION Real3 elementCentroid() const { return _mesh.getElementCentroid(_elem.id); }
+
+  /**
+   * Get the coordinate-weighted current element volume
+   * @pre The current element is locally owned.
+   * @returns The element volume including the coordinate transformation factor
+   */
+  KOKKOS_FUNCTION Real elementVolume() const { return _mesh.getElementVolume(_elem.id); }
+};
+
+/**
+ * The Kokkos object that holds thread-private data in the parallel operations of any Kokkos object
+ */
+class Datum : public MeshDatum
+{
+public:
+  /**
+   * Constructor for element and side data
+   * @param elem The contiguous element ID of the current thread
+   * @param side The side index of the current thread
+   * @param assembly The Kokkos assembly
+   * @param systems The Kokkos systems
+   */
+  KOKKOS_FUNCTION
+  Datum(const ContiguousElementID elem,
+        const unsigned int side,
+        const Assembly & assembly,
+        const Array<FESystem> & systems);
+
+  /**
+   * Constructor for node data
+   * @param node The contiguous node ID of the current thread
+   * @param assembly The Kokkos assembly
+   * @param systems The Kokkos systems
+   */
+  KOKKOS_FUNCTION
+  Datum(const ContiguousNodeID node, const Assembly & assembly, const Array<FESystem> & systems);
+
+  /**
+   * Get the Kokkos assembly
+   * @returns The Kokkos assembly
+   */
+  KOKKOS_FUNCTION const Assembly & assembly() const { return _assembly; }
+
+  /**
+   * Get the Kokkos system
+   * @param sys The system number
+   * @returns The Kokkos system
+   */
+  KOKKOS_FUNCTION const FESystem & system(unsigned int sys) const;
+
+  /**
+   * Get the extra element ID
+   * @param index The extra element ID index
+   * @returns The extra element ID
+   */
+  KOKKOS_FUNCTION dof_id_type extraElemID(unsigned int index) const
+  {
+    return isNodal() ? libMesh::DofObject::invalid_id : _mesh.getExtraElementID(_elem.id, index);
+  }
+
+  /**
+   * Get the contiguous node ID
+   * @returns The contiguous node ID
+   */
+  KOKKOS_FUNCTION ContiguousNodeID node() const { return _node; }
+
+  /**
+   * Get the number of local quadrature points
+   * @returns The number of local quadrature points
+   */
+  KOKKOS_FUNCTION unsigned int n_qps() const { return _n_qps; }
+
+  /**
+   * Get the starting offset into the global quadrature point index
+   * @returns The starting offset
+   */
+  KOKKOS_FUNCTION dof_id_type qpOffset() const { return _qp_offset; }
+
+  /**
+   * Get the index into the property data storage
+   * @param constant_option The property constant option
+   * @param qp The local quadrature point index
+   * @returns The index
+   */
+  KOKKOS_FUNCTION dof_id_type propertyIdx(const PropertyConstantOption constant_option,
+                                          const unsigned int qp) const;
+
+  /**
+   * Get whether the current datum is on a node
+   * @returns Whether the current datum is on a node
+   */
+  KOKKOS_FUNCTION bool isNodal() const { return _node != libMesh::DofObject::invalid_id; }
+
+  /**
+   * Get whether the a variable is defined on the current node
+   * @param var The variable
+   * @returns Whether the variable is defined on the current node
+   */
+  KOKKOS_FUNCTION bool isNodalDefined(const Variable & var) const;
+
+  /**
+   * Get the inverse of Jacobian matrix
+   * | dxi/dx deta/dx dzeta/dx |
+   * | dxi/dy deta/dy dzeta/dy |
+   * | dxi/dz deta/dz dzeta/dz |
+   * @param qp The local quadrature point index
+   * @returns The Jacobian matrix
+   */
+  KOKKOS_FUNCTION const Real33 & J(const unsigned int qp);
+
+  /**
+   * Get the transformed Jacobian weight
+   * @param qp The local quadrature point index
+   * @returns The transformed Jacobian weights
+   */
+  KOKKOS_FUNCTION Real JxW(const unsigned int qp);
+
+  /**
+   * Get the physical quadrature point coordinate
+   * @param qp The local quadrature point index
+   * @returns The physical quadrature point coordinate
+   */
+  KOKKOS_FUNCTION Real3 q_point(const unsigned int qp);
+
+  /**
+   * Get the normal vector on surface
+   * @param qp The local quadrature point index
+   * @returns The normal vector
+   */
+  KOKKOS_FUNCTION Real3 normals(const unsigned int qp);
+
+  /**
+   * Set local parallelization option
+   * @param local_thread_id The current local thread ID
+   * @param num_local_threads The number of local threads
+   */
+  KOKKOS_FUNCTION void set_local_parallel(const unsigned int local_thread_id,
+                                          const unsigned int num_local_threads)
+  {
+    _local_thread_id = local_thread_id;
+    _num_local_threads = num_local_threads;
+  }
+  /**
+   * Get the current local thread ID
+   * @returns The current local thread ID
+   */
+  KOKKOS_FUNCTION unsigned int local_thread_id() const { return _local_thread_id; }
+  /**
+   * Get the number of local threads
+   * @returns The number of local threads
+   */
+  KOKKOS_FUNCTION unsigned int num_local_threads() const { return _num_local_threads; }
+
+protected:
+  /**
+   * Reference of the Kokkos assembly
+   */
+  const Assembly & _assembly;
+
+  /**
+   * Reference of the Kokkos systems
+   */
+  const Array<FESystem> & _systems;
+
+  /**
+   * Current contiguous node ID
+   */
+  const ContiguousNodeID _node = libMesh::DofObject::invalid_id;
+
+  /**
+   * Number of local quadrature points
+   */
+  const unsigned int _n_qps = 1;
+
+  /**
+   * Starting offset into the global quadrature point index
+   */
+  const dof_id_type _qp_offset = libMesh::DofObject::invalid_id;
+
+  /**
+   * Index for element-constant material properties
+   */
+  const dof_id_type _elem_property_idx = libMesh::DofObject::invalid_id;
+
+private:
+  /**
+   * Compute and cache the physical transformation data
+   * @param qp The local quadrature point index
+   */
+  KOKKOS_FUNCTION void reinitTransform(const unsigned int qp);
+
+  /**
+   * Cached quadrature point index for checking whether the physical transformation data should be
+   * recomputed
+   */
+  unsigned int _cached_qp = libMesh::invalid_uint;
+  /**
+   * Cached physical transformation data
+   */
+  ///@{
+  Real33 _J;
+  Real _JxW;
+  Real3 _xyz;
+  Real3 _normal;
+  ///@}
+  /**
+   * Thread ID for local parallelization
+   */
+  unsigned int _local_thread_id = 0;
+  /**
+   * Number of threads for local parallelization
+   */
+  unsigned int _num_local_threads = 1;
+};
+
+/**
+ * The Kokkos object that holds thread-private data in the parallel operations of Kokkos kernels
+ */
+class AssemblyDatum : public Datum
+{
+public:
+  /**
+   * Constructor for element and side data
+   * @param elem The contiguous element ID of the current thread
+   * @param side The side index of the current thread
+   * @param assembly The Kokkos assembly
+   * @param systems The Kokkos systems
+   * @param ivar The Kokkos variable
+   * @param jvar The coupled variable number
+   * @param comp The variable component
+   */
+  KOKKOS_FUNCTION
+  AssemblyDatum(const ContiguousElementID elem,
+                const unsigned int side,
+                const Assembly & assembly,
+                const Array<FESystem> & systems,
+                const Variable & ivar,
+                const unsigned int jvar,
+                const unsigned int comp = 0);
+  /**
+   * Constructor for node data
+   * @param elem The contiguous element ID of the current thread
+   * @param assembly The Kokkos assembly
+   * @param systems The Kokkos systems
+   * @param ivar The Kokkos variable
+   * @param jvar The coupled variable number
+   * @param comp The variable component
+   */
+  KOKKOS_FUNCTION
+  AssemblyDatum(const ContiguousNodeID node,
+                const Assembly & assembly,
+                const Array<FESystem> & systems,
+                const Variable & ivar,
+                const unsigned int jvar,
+                const unsigned int comp = 0);
+
+  /**
+   * Get the number of local DOFs
+   * @returns The number of local DOFs
+   */
+  KOKKOS_FUNCTION unsigned int n_dofs() const { return _n_idofs; }
+  /**
+   * Get the number of local DOFs
+   * @returns The number of local DOFs
+   */
+  KOKKOS_FUNCTION unsigned int n_idofs() const { return _n_idofs; }
+  /**
+   * Get the number of local DOFs for the coupled variable
+   * @returns The number of local DOFs
+   */
+  KOKKOS_FUNCTION unsigned int n_jdofs() const { return _n_jdofs; }
+  /**
+   * Get the system number of variable
+   * @returns The system number of variable
+   */
+  KOKKOS_FUNCTION unsigned int sys() const { return _sys; }
+  /**
+   * Get the variable number
+   * @returns The variable number
+   */
+  KOKKOS_FUNCTION unsigned int var() const { return _ivar; }
+  /**
+   * Get the variable number
+   * @returns The variable number
+   */
+  KOKKOS_FUNCTION unsigned int ivar() const { return _ivar; }
+  /**
+   * Get the coupled variable number
+   * @returns The variable number
+   */
+  KOKKOS_FUNCTION unsigned int jvar() const { return _jvar; }
+  /**
+   * Get the component of an array variable
+   * @returns The array variable component
+   */
+  KOKKOS_FUNCTION unsigned int comp() const { return _comp; }
+  /**
+   * Get the variable FE type ID
+   * @returns The variable FE type ID
+   */
+  KOKKOS_FUNCTION unsigned int fe() const { return _ife; }
+  /**
+   * Get the variable FE type ID
+   * @returns The variable FE type ID
+   */
+  KOKKOS_FUNCTION unsigned int ife() const { return _ife; }
+  /**
+   * Get the coupled variable FE type ID
+   * @returns The variable FE type ID
+   */
+  KOKKOS_FUNCTION unsigned int jfe() const { return _jfe; }
+  /**
+   * Set whether to compute derivatives for automatic differentiation (AD)
+   * @param flag Whether to compute derivatives
+   */
+  KOKKOS_FUNCTION void do_derivatives(const bool flag) { _do_derivatives = flag; }
+  /**
+   * Get whether to compute derivatives for automatic differentiation (AD)
+   * @returns Whether to compute derivatives
+   */
+  KOKKOS_FUNCTION bool do_derivatives() const { return _do_derivatives; }
+
+protected:
+  /**
+   * Solution tag ID
+   */
+  const TagID _tag;
+  /**
+   * System number
+   */
+  const unsigned int _sys;
+  /**
+   * Variable numbers
+   */
+  const unsigned int _ivar, _jvar;
+  /**
+   * Component of an array variable
+   */
+  const unsigned int _comp;
+  /**
+   * FE type IDs of variables
+   */
+  const unsigned int _ife, _jfe;
+  /**
+   * Number of local DOFs
+   */
+  const unsigned int _n_idofs = 1, _n_jdofs = 1;
+  /**
+   * Whether to compute derivatives for automatic differentiation (AD)
+   */
+  bool _do_derivatives = true;
+};
+
+} // namespace Moose::Kokkos
+
+using Datum = Moose::Kokkos::Datum;
+using AssemblyDatum = Moose::Kokkos::AssemblyDatum;
+using FVDatum = Moose::Kokkos::FVDatum;

--- a/framework/include/kokkos/base/KokkosJaggedArray.h
+++ b/framework/include/kokkos/base/KokkosJaggedArray.h
@@ -49,7 +49,7 @@ struct JaggedArrayInnerDim
  * @tparam layout The memory layout type
  */
 template <typename T, unsigned int inner, LayoutType layout>
-class JaggedArrayInnerData
+class JaggedArrayInnerData : public ArrayView<JaggedArrayInnerData<T, inner, layout>, inner>
 {
 public:
   /**

--- a/framework/include/kokkos/base/KokkosReferenceWrapper.h
+++ b/framework/include/kokkos/base/KokkosReferenceWrapper.h
@@ -17,32 +17,88 @@ namespace Moose::Kokkos
 {
 
 /**
- * The Kokkos object that can hold the reference of a variable.
+ * The Kokkos object that can hold a host reference and a device-compatible copy of a variable.
  * Reference of a host variable is not accessible on device, so if there is a variable that should
  * be stored as a reference but still needs to be accessed on device, define an instance of this
  * class and construct it with the reference of the variable.
  * This class holds the device copy as well as the host reference of the variable.
  * The copy constructor of this object that copies the host reference to the device copy is invoked
  * whenever a Kokkos functor containing this object is dispatched to device, so it is guaranteed
- * that the device copy is always up-to-date with the host reference when it is used on device
- * Therefore, the variable must be copy constructible.
+ * that the device copy is always up-to-date with the host reference when it is used on device.
+ * Therefore, D must be constructible from H.
+ * @tparam H The host reference type
+ * @tparam D The device copy type
  */
-template <typename T>
-class ReferenceWrapper
+template <typename H, typename D>
+class DualReferenceWrapper
 {
 public:
   /**
    * Constructor
-   * @param reference The writeable reference of the variable to store
+   * @param reference The host reference of the variable to store
    */
-  ReferenceWrapper(T & reference) : _reference(reference), _copy(reference) {}
+  DualReferenceWrapper(H & reference) : _reference(reference), _copy(reference) {}
   /**
    * Copy constructor
    */
-  ReferenceWrapper(const ReferenceWrapper<T> & object)
+  DualReferenceWrapper(const DualReferenceWrapper<H, D> & object)
     : _reference(object._reference), _copy(object._reference)
   {
   }
+
+  /**
+   * Get the host reference
+   * @returns The host reference
+   */
+  ///@{
+  H & host() { return _reference; }
+  const H & host() const { return _reference; }
+  ///@}
+
+#ifdef MOOSE_KOKKOS_SCOPE
+  /**
+   * Get the device copy
+   * @returns The device copy
+   */
+  KOKKOS_FUNCTION const D & device() const
+  {
+    KOKKOS_IF_ON_HOST(
+        mooseError("Kokkos reference wrapper error: device() should not be called from host.");)
+
+    return _copy;
+  }
+#endif
+
+protected:
+  /**
+   * Writeable host reference of the variable
+   */
+  H & _reference;
+  /**
+   * Device copy of the variable
+   */
+  const D _copy;
+};
+
+/**
+ * Specialization of DualReferenceWrapper for the same host and device data type
+ */
+template <typename T>
+class ReferenceWrapper : public DualReferenceWrapper<T, T>
+{
+public:
+  /**
+   * Constructor
+   * @param reference The host reference of the variable to store
+   */
+  ReferenceWrapper(T & reference) : DualReferenceWrapper<T, T>(reference) {}
+  /**
+   * Copy constructor
+   */
+  ReferenceWrapper(const ReferenceWrapper<T> & object) : DualReferenceWrapper<T, T>(object) {}
+
+  using DualReferenceWrapper<T, T>::_copy;
+  using DualReferenceWrapper<T, T>::_reference;
 
 #ifdef MOOSE_KOKKOS_SCOPE
   /**
@@ -140,16 +196,12 @@ public:
   {
     return _reference(std::forward<Args>(args)...);
   }
+};
 
-protected:
-  /**
-   * Writeable host reference of the variable
-   */
-  T & _reference;
-  /**
-   * Device copy of the variable
-   */
-  const T _copy;
+template <typename H, typename D>
+struct ArrayDeepCopy<DualReferenceWrapper<H, D>>
+{
+  static constexpr bool value = true;
 };
 
 template <typename T>

--- a/framework/include/kokkos/base/KokkosResidualObject.h
+++ b/framework/include/kokkos/base/KokkosResidualObject.h
@@ -503,7 +503,7 @@ ResidualObject::computeResidualInternal(AssemblyDatum & datum, function body) co
     body(local_re - ib, ib, ie);
 
     for (unsigned int i = ib; i < ie; ++i)
-      accumulateTaggedElementalResidual(local_re[i - ib], datum.elem().id, i);
+      accumulateTaggedElementalResidual(local_re[i - ib], datum.elem().id, i, datum.comp());
   }
 }
 
@@ -532,7 +532,8 @@ ResidualObject::computeJacobianInternal(AssemblyDatum & datum, function body) co
       body(local_ke - ib, ib, ie, j);
 
       for (unsigned int i = ib; i < ie; ++i)
-        accumulateTaggedElementalMatrix(local_ke[i - ib], datum.elem().id, i, j, datum.jvar());
+        accumulateTaggedElementalMatrix(
+            local_ke[i - ib], datum.elem().id, i, j, datum.jvar(), datum.comp());
     }
   }
 }

--- a/framework/include/kokkos/base/KokkosVariableValue.h
+++ b/framework/include/kokkos/base/KokkosVariableValue.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "KokkosArrayView.h"
 #include "KokkosDatum.h"
 
 #include "MooseError.h"
@@ -105,6 +106,14 @@ using VariablePhiValue = VariableShapeValue<false>;
 using VariablePhiGradient = VariableShapeGradient<false>;
 using VariableTestValue = VariableShapeValue<true>;
 using VariableTestGradient = VariableShapeGradient<true>;
+using ArrayVariablePhiValue = VariablePhiValue;
+using ArrayVariablePhiGradient = VariablePhiGradient;
+using ArrayVariableTestValue = VariableTestValue;
+using ArrayVariableTestGradient = VariableTestGradient;
+using ADArrayVariablePhiValue = ArrayVariablePhiValue;
+using ADArrayVariablePhiGradient = ArrayVariablePhiGradient;
+using ADArrayVariableTestValue = ArrayVariableTestValue;
+using ADArrayVariableTestGradient = ArrayVariableTestGradient;
 using ADVariablePhiValue = VariablePhiValue;
 using ADVariablePhiGradient = VariablePhiGradient;
 using ADVariableTestValue = VariableTestValue;
@@ -287,23 +296,29 @@ public:
    * Get the current variable value
    * @param datum The Datum object of the current thread
    * @param idx The local quadrature point or DOF index
-   * @param comp The variable component
-   * @returns The variable value
+   * @returns The variable value for the active component, or component zero when the datum does not
+   * have an active component
    */
-  KOKKOS_FUNCTION auto operator()(Datum & datum, unsigned int idx, unsigned int comp = 0) const
-  {
-    return get(datum, idx, comp);
-  }
+  template <typename DatumType>
+  KOKKOS_FUNCTION auto operator()(DatumType & datum, unsigned int idx) const;
 
   /**
-   * Get the current variable value
-   * @param datum The AssemblyDatum object of the current thread
+   * Get a selected component of the current variable value
+   * @param datum The Datum object of the current thread
    * @param idx The local quadrature point or DOF index
    * @param comp The variable component
-   * @returns The variable value
+   * @returns The selected component of the variable value
    */
-  KOKKOS_FUNCTION auto
-  operator()(AssemblyDatum & datum, unsigned int idx, unsigned int comp = 0) const;
+  template <typename DatumType>
+  KOKKOS_FUNCTION auto operator()(DatumType & datum, unsigned int idx, unsigned int comp) const;
+
+  /**
+   * Get a view of all variable components for array arithmetic
+   * @param datum The AssemblyDatum object of the current thread
+   * @param idx The local quadrature point or DOF index
+   * @returns The all-component variable view
+   */
+  KOKKOS_FUNCTION auto array(AssemblyDatum & datum, unsigned int idx) const;
 
   /**
    * Get the Kokkos variable
@@ -338,6 +353,38 @@ private:
 };
 
 template <bool is_ad>
+template <typename DatumType>
+KOKKOS_FUNCTION auto
+VariableValueTempl<is_ad>::operator()(DatumType & datum, const unsigned int idx) const
+{
+  static_assert(std::is_base_of_v<Datum, DatumType>, "DatumType must derive from Datum");
+
+  if constexpr (std::is_base_of_v<AssemblyDatum, DatumType>)
+    return (*this)(datum, idx, datum.comp());
+  else
+    return (*this)(datum, idx, 0);
+}
+
+template <bool is_ad>
+template <typename DatumType>
+KOKKOS_FUNCTION auto
+VariableValueTempl<is_ad>::operator()(DatumType & datum,
+                                      const unsigned int idx,
+                                      const unsigned int comp) const
+{
+  static_assert(std::is_base_of_v<Datum, DatumType>, "DatumType must derive from Datum");
+
+  if constexpr (is_ad && std::is_base_of_v<AssemblyDatum, DatumType>)
+  {
+    const Real seed =
+        datum.do_derivatives() && _var.coupled() && _var.sys(comp) == datum.sys() ? _seed[comp] : 0;
+    return get(datum, idx, comp, seed);
+  }
+  else
+    return get(datum, idx, comp);
+}
+
+template <bool is_ad>
 VariableValueTempl<is_ad>::VariableValueTempl(const VariableValueTempl<is_ad> & object)
   : _var(object._var), _seed(object._seed), _dof(object._dof)
 {
@@ -363,23 +410,6 @@ VariableValueTempl<is_ad>::operator=(const VariableValueTempl<is_ad> & object)
   _dof = object._dof;
 
   return *this;
-}
-
-template <bool is_ad>
-KOKKOS_FUNCTION auto
-VariableValueTempl<is_ad>::operator()(AssemblyDatum & datum,
-                                      unsigned int idx,
-                                      unsigned int comp) const
-{
-  if constexpr (is_ad)
-  {
-    Real seed =
-        datum.do_derivatives() && _var.coupled() && _var.sys(comp) == datum.sys() ? _seed[comp] : 0;
-
-    return get(datum, idx, comp, seed);
-  }
-  else
-    return get(datum, idx, comp);
 }
 
 template <bool is_ad>
@@ -508,23 +538,29 @@ public:
    * Get the current variable gradient
    * @param datum The Datum object of the current thread
    * @param qp The local quadrature point index
-   * @param comp The variable component
-   * @returns The variable gradient
+   * @returns The variable gradient for the active component, or component zero when the datum does
+   * not have an active component
    */
-  KOKKOS_FUNCTION auto operator()(Datum & datum, unsigned int qp, unsigned int comp = 0) const
-  {
-    return get(datum, qp, comp);
-  }
+  template <typename DatumType>
+  KOKKOS_FUNCTION auto operator()(DatumType & datum, unsigned int qp) const;
 
   /**
-   * Get the current variable gradient
-   * @param datum The AssemblyDatum object of the current thread
+   * Get a selected component of the current variable gradient
+   * @param datum The Datum object of the current thread
    * @param qp The local quadrature point index
    * @param comp The variable component
-   * @returns The variable gradient
+   * @returns The selected component of the variable gradient
    */
-  KOKKOS_FUNCTION auto
-  operator()(AssemblyDatum & datum, unsigned int qp, unsigned int comp = 0) const;
+  template <typename DatumType>
+  KOKKOS_FUNCTION auto operator()(DatumType & datum, unsigned int qp, unsigned int comp) const;
+
+  /**
+   * Get a view of all variable component gradients for array arithmetic
+   * @param datum The AssemblyDatum object of the current thread
+   * @param qp The local quadrature point index
+   * @returns The all-component variable gradient view
+   */
+  KOKKOS_FUNCTION auto array(AssemblyDatum & datum, unsigned int qp) const;
 
   /**
    * Get the Kokkos variable
@@ -555,6 +591,38 @@ private:
 };
 
 template <bool is_ad>
+template <typename DatumType>
+KOKKOS_FUNCTION auto
+VariableGradientTempl<is_ad>::operator()(DatumType & datum, const unsigned int qp) const
+{
+  static_assert(std::is_base_of_v<Datum, DatumType>, "DatumType must derive from Datum");
+
+  if constexpr (std::is_base_of_v<AssemblyDatum, DatumType>)
+    return (*this)(datum, qp, datum.comp());
+  else
+    return (*this)(datum, qp, 0);
+}
+
+template <bool is_ad>
+template <typename DatumType>
+KOKKOS_FUNCTION auto
+VariableGradientTempl<is_ad>::operator()(DatumType & datum,
+                                         const unsigned int qp,
+                                         const unsigned int comp) const
+{
+  static_assert(std::is_base_of_v<Datum, DatumType>, "DatumType must derive from Datum");
+
+  if constexpr (is_ad && std::is_base_of_v<AssemblyDatum, DatumType>)
+  {
+    const Real seed =
+        datum.do_derivatives() && _var.coupled() && _var.sys(comp) == datum.sys() ? _seed[comp] : 0;
+    return get(datum, qp, comp, seed);
+  }
+  else
+    return get(datum, qp, comp);
+}
+
+template <bool is_ad>
 VariableGradientTempl<is_ad>::VariableGradientTempl(const VariableGradientTempl<is_ad> & object)
   : _var(object._var), _seed(object._seed)
 {
@@ -579,23 +647,6 @@ VariableGradientTempl<is_ad>::operator=(const VariableGradientTempl<is_ad> & obj
   _var = object._var;
 
   return *this;
-}
-
-template <bool is_ad>
-KOKKOS_FUNCTION auto
-VariableGradientTempl<is_ad>::operator()(AssemblyDatum & datum,
-                                         unsigned int qp,
-                                         unsigned int comp) const
-{
-  if constexpr (is_ad)
-  {
-    Real seed =
-        datum.do_derivatives() && _var.coupled() && _var.sys(comp) == datum.sys() ? _seed[comp] : 0;
-
-    return get(datum, qp, comp, seed);
-  }
-  else
-    return get(datum, qp, comp);
 }
 
 template <bool is_ad>
@@ -637,10 +688,73 @@ VariableGradientTempl<is_ad>::get(Datum & datum,
   return grad;
 }
 
+/**
+ * Bound context for the components of a variable value or gradient
+ */
+template <typename VariableContext>
+class VariableArrayContext
+{
+public:
+  /**
+   * Constructor
+   * @param variable The variable value or gradient accessor
+   * @param datum The AssemblyDatum object of the current thread
+   * @param idx The local quadrature point or DOF index
+   */
+  KOKKOS_FUNCTION VariableArrayContext(const VariableContext & variable,
+                                       AssemblyDatum & datum,
+                                       const unsigned int idx)
+    : _variable(variable), _datum(datum), _idx(idx)
+  {
+  }
+
+  /**
+   * Get a selected component
+   * @param comp The variable component
+   * @returns The selected component
+   */
+  KOKKOS_FUNCTION auto operator()(const unsigned int comp) const
+  {
+    return _variable(_datum, _idx, comp);
+  }
+
+  /**
+   * Get the number of components
+   * @returns The number of components
+   */
+  KOKKOS_FUNCTION unsigned int n(const unsigned int) const
+  {
+    return _variable.variable().components();
+  }
+
+private:
+  const VariableContext & _variable;
+  AssemblyDatum & _datum;
+  const unsigned int _idx;
+};
+
+template <bool is_ad>
+KOKKOS_FUNCTION auto
+VariableValueTempl<is_ad>::array(AssemblyDatum & datum, const unsigned int idx) const
+{
+  return ArrayContextView<VariableArrayContext<VariableValueTempl<is_ad>>, 1, true>(
+      VariableArrayContext<VariableValueTempl<is_ad>>(*this, datum, idx), datum.comp());
+}
+
+template <bool is_ad>
+KOKKOS_FUNCTION auto
+VariableGradientTempl<is_ad>::array(AssemblyDatum & datum, const unsigned int qp) const
+{
+  return ArrayContextView<VariableArrayContext<VariableGradientTempl<is_ad>>, 1, true>(
+      VariableArrayContext<VariableGradientTempl<is_ad>>(*this, datum, qp), datum.comp());
+}
+
 using VariableValue = VariableValueTempl<false>;
 using ADVariableValue = VariableValueTempl<true>;
 using VariableGradient = VariableGradientTempl<false>;
 using ADVariableGradient = VariableGradientTempl<true>;
+using ArrayVariableValue = VariableValue;
+using ArrayVariableGradient = VariableGradient;
 
 class VectorVariableValue
 {

--- a/framework/include/kokkos/bcs/KokkosArrayDirichletBC.h
+++ b/framework/include/kokkos/bcs/KokkosArrayDirichletBC.h
@@ -1,0 +1,38 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#pragma once
+
+#include "KokkosArrayNodalBC.h"
+#include "KokkosReferenceWrapper.h"
+
+/**
+ * Imposes constant values on the components of a Kokkos array variable.
+ */
+class KokkosArrayDirichletBC : public Moose::Kokkos::ArrayNodalBC
+{
+public:
+  static InputParameters validParams();
+
+  KokkosArrayDirichletBC(const InputParameters & parameters);
+
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const;
+
+protected:
+  /// Controllable host values and their device-compatible copy
+  const Moose::Kokkos::DualReferenceWrapper<const RealEigenVector, Moose::Kokkos::Array<Real>>
+      _values;
+};
+
+template <typename Derived>
+KOKKOS_FUNCTION Real
+KokkosArrayDirichletBC::computeQpResidual(const unsigned int qp, AssemblyDatum & datum) const
+{
+  return _u.array(datum, qp) - _values.device();
+}

--- a/framework/include/kokkos/bcs/KokkosArrayIntegratedBC.h
+++ b/framework/include/kokkos/bcs/KokkosArrayIntegratedBC.h
@@ -1,0 +1,196 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#pragma once
+
+#include "KokkosIntegratedBCBase.h"
+
+namespace Moose::Kokkos
+{
+
+/**
+ * The base class for a user to derive their own Kokkos integrated boundary conditions on array
+ * variables.
+ *
+ * Each device invocation operates on the component returned by AssemblyDatum::comp().
+ */
+class ArrayIntegratedBC : public IntegratedBCBase
+{
+public:
+  static InputParameters validParams();
+
+  ArrayIntegratedBC(const InputParameters & parameters);
+
+  virtual void computeResidual() override;
+  virtual void computeJacobian() override;
+
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int /* i */,
+                                         const unsigned int /* j */,
+                                         const unsigned int /* qp */,
+                                         AssemblyDatum & /* datum */) const
+  {
+    ::Kokkos::abort("Default computeQpJacobian() should never be called. Make sure you properly "
+                    "redefined this method in your class without typos.");
+
+    return 0;
+  }
+
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int /* i */,
+                                                const unsigned int /* j */,
+                                                const unsigned int /* jvar */,
+                                                const unsigned int /* qp */,
+                                                AssemblyDatum & /* datum */) const
+  {
+    ::Kokkos::abort(
+        "Default computeQpOffDiagJacobian() should never be called. Make sure you properly "
+        "redefined this method in your class without typos.");
+
+    return 0;
+  }
+
+  template <typename Derived>
+  static auto defaultJacobian()
+  {
+    return &ArrayIntegratedBC::computeQpJacobian<Derived>;
+  }
+
+  template <typename Derived>
+  static auto defaultOffDiagJacobian()
+  {
+    return &ArrayIntegratedBC::computeQpOffDiagJacobian<Derived>;
+  }
+
+  template <typename Derived>
+  KOKKOS_FUNCTION void operator()(ResidualLoop, const ThreadID tid, const Derived & bc) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void operator()(JacobianLoop, const ThreadID tid, const Derived & bc) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void
+  operator()(OffDiagJacobianLoop, const ThreadID tid, const Derived & bc) const;
+
+  template <typename Derived>
+  KOKKOS_FUNCTION void computeResidualInternal(const Derived & bc, AssemblyDatum & datum) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void computeJacobianInternal(const Derived & bc, AssemblyDatum & datum) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void computeOffDiagJacobianInternal(const Derived & bc,
+                                                      AssemblyDatum & datum) const;
+
+protected:
+  const ArrayVariableTestValue _test;
+  const ArrayVariableTestGradient _grad_test;
+  const ArrayVariablePhiValue _phi;
+  const ArrayVariablePhiGradient _grad_phi;
+  const ArrayVariableValue _u;
+  const ArrayVariableGradient _grad_u;
+
+  /// Number of components of the array variable
+  const unsigned int _count;
+};
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayIntegratedBC::operator()(ResidualLoop, const ThreadID tid, const Derived & bc) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto [elem, side] = kokkosBoundaryElementSideID(_thread(tid, 2));
+
+  AssemblyDatum datum(
+      elem, side, kokkosAssembly(), kokkosSystems(), _kokkos_var, _kokkos_var.var(comp), comp);
+
+  datum.set_local_parallel(_thread(tid, 1), _thread.size(1));
+
+  bc.computeResidualInternal(bc, datum);
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayIntegratedBC::operator()(JacobianLoop, const ThreadID tid, const Derived & bc) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto [elem, side] = kokkosBoundaryElementSideID(_thread(tid, 2));
+
+  AssemblyDatum datum(
+      elem, side, kokkosAssembly(), kokkosSystems(), _kokkos_var, _kokkos_var.var(comp), comp);
+
+  datum.set_local_parallel(_thread(tid, 1), _thread.size(1));
+
+  bc.computeJacobianInternal(bc, datum);
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayIntegratedBC::operator()(OffDiagJacobianLoop, const ThreadID tid, const Derived & bc) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto [elem, side] = kokkosBoundaryElementSideID(_thread(tid, 3));
+  auto & sys = kokkosSystem(_kokkos_var.sys(comp));
+  const auto & coupling = sys.getCoupling(_kokkos_var.var(comp));
+  const auto coupling_index = _thread(tid, 2);
+
+  if (coupling_index >= coupling.size())
+    return;
+
+  const auto jvar = coupling[coupling_index];
+
+  if (!sys.isVariableActive(jvar, kokkosMesh().getElementInfo(elem).subdomain))
+    return;
+
+  AssemblyDatum datum(elem, side, kokkosAssembly(), kokkosSystems(), _kokkos_var, jvar, comp);
+
+  datum.set_local_parallel(_thread(tid, 1), _thread.size(1));
+
+  bc.computeOffDiagJacobianInternal(bc, datum);
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayIntegratedBC::computeResidualInternal(const Derived & bc, AssemblyDatum & datum) const
+{
+  ResidualObject::computeResidualInternal(
+      datum,
+      [&](Real * local_re, const unsigned int ib, const unsigned int ie)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+          for (unsigned int i = ib; i < ie; ++i)
+            local_re[i] += datum.JxW(qp) * bc.template computeQpResidual<Derived>(i, qp, datum);
+      });
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayIntegratedBC::computeJacobianInternal(const Derived & bc, AssemblyDatum & datum) const
+{
+  ResidualObject::computeJacobianInternal(
+      datum,
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += datum.JxW(qp) * bc.template computeQpJacobian<Derived>(i, j, qp, datum);
+      });
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayIntegratedBC::computeOffDiagJacobianInternal(const Derived & bc, AssemblyDatum & datum) const
+{
+  ResidualObject::computeJacobianInternal(
+      datum,
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += datum.JxW(qp) * bc.template computeQpOffDiagJacobian<Derived>(
+                                               i, j, datum.jvar(), qp, datum);
+      });
+}
+
+} // namespace Moose::Kokkos

--- a/framework/include/kokkos/bcs/KokkosArrayNeumannBC.h
+++ b/framework/include/kokkos/bcs/KokkosArrayNeumannBC.h
@@ -1,0 +1,44 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#pragma once
+
+#include "KokkosArrayIntegratedBC.h"
+#include "KokkosReferenceWrapper.h"
+
+/**
+ * Imposes constant normal gradients on the components of a Kokkos array variable.
+ */
+class KokkosArrayNeumannBC : public Moose::Kokkos::ArrayIntegratedBC
+{
+public:
+  static InputParameters validParams();
+
+  KokkosArrayNeumannBC(const InputParameters & parameters);
+
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
+                                         const unsigned int qp,
+                                         AssemblyDatum & datum) const;
+
+protected:
+  /// Host component values retained so controlled values can be copied to the device
+  const RealEigenVector _value_host;
+  /// Host component values and their device-compatible copy
+  const Moose::Kokkos::DualReferenceWrapper<const RealEigenVector, Moose::Kokkos::Array<Real>>
+      _value;
+};
+
+template <typename Derived>
+KOKKOS_FUNCTION Real
+KokkosArrayNeumannBC::computeQpResidual(const unsigned int i,
+                                        const unsigned int qp,
+                                        AssemblyDatum & datum) const
+{
+  return -_test(datum, i, qp) * _value.device()[datum.comp()];
+}

--- a/framework/include/kokkos/bcs/KokkosArrayNodalBC.h
+++ b/framework/include/kokkos/bcs/KokkosArrayNodalBC.h
@@ -1,0 +1,135 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#pragma once
+
+#include "KokkosNodalBCBase.h"
+
+namespace Moose::Kokkos
+{
+
+/**
+ * The base class for a user to derive their own Kokkos nodal boundary conditions on array
+ * variables. Each device invocation operates on the component returned by AssemblyDatum::comp().
+ */
+class ArrayNodalBC : public NodalBCBase
+{
+public:
+  static InputParameters validParams();
+
+  ArrayNodalBC(const InputParameters & parameters);
+
+  virtual void computeResidual() override;
+  virtual void computeJacobian() override;
+
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int /* qp */,
+                                         AssemblyDatum & /* datum */) const
+  {
+    return 1;
+  }
+
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int /* jvar */,
+                                                const unsigned int /* qp */,
+                                                AssemblyDatum & /* datum */) const
+  {
+    ::Kokkos::abort(
+        "Default computeQpOffDiagJacobian() should never be called. Make sure you properly "
+        "redefined this method in your class without typos.");
+
+    return 0;
+  }
+
+  template <typename Derived>
+  static auto defaultJacobian()
+  {
+    return &ArrayNodalBC::computeQpJacobian<Derived>;
+  }
+
+  template <typename Derived>
+  static auto defaultOffDiagJacobian()
+  {
+    return &ArrayNodalBC::computeQpOffDiagJacobian<Derived>;
+  }
+
+  template <typename Derived>
+  KOKKOS_FUNCTION void operator()(ResidualLoop, const ThreadID tid, const Derived & bc) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void operator()(JacobianLoop, const ThreadID tid, const Derived & bc) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void
+  operator()(OffDiagJacobianLoop, const ThreadID tid, const Derived & bc) const;
+
+protected:
+  const ArrayVariableValue _u;
+
+  /// Number of components of the array variable
+  const unsigned int _count;
+};
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayNodalBC::operator()(ResidualLoop, const ThreadID tid, const Derived & bc) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto node = kokkosBoundaryNodeID(_thread(tid, 1));
+  auto & sys = kokkosSystem(_kokkos_var.sys(comp));
+
+  if (!sys.isNodalDefined(node, _kokkos_var.var(comp)))
+    return;
+
+  AssemblyDatum datum(
+      node, kokkosAssembly(), kokkosSystems(), _kokkos_var, _kokkos_var.var(comp), comp);
+
+  const Real local_re = bc.template computeQpResidual<Derived>(0, datum);
+
+  accumulateTaggedNodalResidual(false, local_re, node, comp);
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayNodalBC::operator()(JacobianLoop, const ThreadID tid, const Derived & bc) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto node = kokkosBoundaryNodeID(_thread(tid, 1));
+  auto & sys = kokkosSystem(_kokkos_var.sys(comp));
+
+  if (!sys.isNodalDefined(node, _kokkos_var.var(comp)))
+    return;
+
+  AssemblyDatum datum(
+      node, kokkosAssembly(), kokkosSystems(), _kokkos_var, _kokkos_var.var(comp), comp);
+
+  const Real local_ke = bc.template computeQpJacobian<Derived>(0, datum);
+
+  accumulateTaggedNodalMatrix(false, local_ke, node, _kokkos_var.var(comp), comp);
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayNodalBC::operator()(OffDiagJacobianLoop, const ThreadID tid, const Derived & bc) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto node = kokkosBoundaryNodeID(_thread(tid, 2));
+  auto & sys = kokkosSystem(_kokkos_var.sys(comp));
+  const auto & coupling = sys.getCoupling(_kokkos_var.var(comp));
+  const auto coupling_index = _thread(tid, 1);
+
+  if (coupling_index >= coupling.size() || !sys.isNodalDefined(node, _kokkos_var.var(comp)))
+    return;
+
+  const auto jvar = coupling[coupling_index];
+  AssemblyDatum datum(node, kokkosAssembly(), kokkosSystems(), _kokkos_var, jvar, comp);
+
+  const Real local_ke = bc.template computeQpOffDiagJacobian<Derived>(jvar, 0, datum);
+
+  accumulateTaggedNodalMatrix(true, local_ke, node, jvar, comp);
+}
+
+} // namespace Moose::Kokkos

--- a/framework/include/kokkos/bcs/KokkosVectorDirichletBC.h
+++ b/framework/include/kokkos/bcs/KokkosVectorDirichletBC.h
@@ -17,16 +17,14 @@ public:
   static InputParameters validParams();
 
   KokkosVectorDirichletBC(const InputParameters & parameters);
-  KokkosVectorDirichletBC(const KokkosVectorDirichletBC & object);
 
   template <typename Derived>
   KOKKOS_FUNCTION Moose::Kokkos::Real3 computeQpResidual(const unsigned int qp,
                                                          AssemblyDatum & datum) const
   {
-    return _u(datum, qp) - _values;
+    return _u(datum, qp) - _values.device();
   }
 
 protected:
-  const RealVectorValue & _values_host;
-  const Moose::Kokkos::Real3 _values;
+  const Moose::Kokkos::DualReferenceWrapper<const RealVectorValue, Moose::Kokkos::Real3> _values;
 };

--- a/framework/include/kokkos/kernels/KokkosArrayDiffusion.h
+++ b/framework/include/kokkos/kernels/KokkosArrayDiffusion.h
@@ -1,0 +1,100 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#pragma once
+
+#include "KokkosArrayKernel.h"
+
+/**
+ * The array Laplacian operator with a scalar, diagonal array, or full matrix diffusivity.
+ */
+class KokkosArrayDiffusion : public Moose::Kokkos::ArrayKernel
+{
+public:
+  static InputParameters validParams();
+
+  KokkosArrayDiffusion(const InputParameters & parameters);
+
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpResidual(const unsigned int i,
+                                         const unsigned int qp,
+                                         AssemblyDatum & datum) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int i,
+                                         const unsigned int j,
+                                         const unsigned int qp,
+                                         AssemblyDatum & datum) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int i,
+                                                const unsigned int j,
+                                                const unsigned int jvar,
+                                                const unsigned int qp,
+                                                AssemblyDatum & datum) const;
+
+protected:
+  const bool _has_d;
+  const bool _has_d_1d;
+  const bool _has_d_2d;
+
+  const Moose::Kokkos::MaterialProperty<Real> _d;
+  const Moose::Kokkos::MaterialProperty<Real, 1> _d_1d;
+  const Moose::Kokkos::MaterialProperty<Real, 2> _d_2d;
+};
+
+template <typename Derived>
+KOKKOS_FUNCTION Real
+KokkosArrayDiffusion::computeQpResidual(const unsigned int i,
+                                        const unsigned int qp,
+                                        AssemblyDatum & datum) const
+{
+  if (_d)
+    return _d(datum, qp) * _grad_u.array(datum, qp) * _grad_test(datum, i, qp);
+  else if (_d_1d)
+    return _d_1d(datum, qp) * _grad_u.array(datum, qp) * _grad_test(datum, i, qp);
+  else
+    return _d_2d(datum, qp) * _grad_u.array(datum, qp) * _grad_test(datum, i, qp);
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION Real
+KokkosArrayDiffusion::computeQpJacobian(const unsigned int i,
+                                        const unsigned int j,
+                                        const unsigned int qp,
+                                        AssemblyDatum & datum) const
+{
+  const auto grad_product = _grad_phi(datum, j, qp) * _grad_test(datum, i, qp);
+
+  if (_d)
+    return _d(datum, qp) * grad_product;
+  else if (_d_1d)
+    return _d_1d.array(datum, qp) * grad_product;
+  else
+    return _d_2d.array(datum, qp).diagonal() * grad_product;
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION Real
+KokkosArrayDiffusion::computeQpOffDiagJacobian(const unsigned int i,
+                                               const unsigned int j,
+                                               const unsigned int jvar,
+                                               const unsigned int qp,
+                                               AssemblyDatum & datum) const
+{
+  if (!_d_2d)
+    return 0;
+
+  const auto first_var = _kokkos_var.var();
+  if (jvar < first_var || jvar - first_var >= _count)
+    return 0;
+
+  const auto icomp = datum.comp();
+  const auto jcomp = jvar - first_var;
+  const auto d = _d_2d(datum, qp);
+
+  return d(icomp, jcomp) * _grad_phi(datum, j, qp) * _grad_test(datum, i, qp);
+}

--- a/framework/include/kokkos/kernels/KokkosArrayKernel.h
+++ b/framework/include/kokkos/kernels/KokkosArrayKernel.h
@@ -1,0 +1,209 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#pragma once
+
+#include "KokkosKernelBase.h"
+
+namespace Moose::Kokkos
+{
+
+/**
+ * The base class for a user to derive their own Kokkos kernels on array variables.
+ *
+ * Each device invocation operates on the component returned by AssemblyDatum::comp(). Derived
+ * classes define the same scalar-valued hooks as Kokkos kernels on scalar variables, and the array
+ * value and gradient wrappers automatically access that component.
+ */
+class ArrayKernel : public KernelBase
+{
+public:
+  static InputParameters validParams();
+
+  ArrayKernel(const InputParameters & parameters);
+
+  virtual void computeResidual() override;
+  virtual void computeJacobian() override;
+
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int /* i */,
+                                         const unsigned int /* j */,
+                                         const unsigned int /* qp */,
+                                         AssemblyDatum & /* datum */) const
+  {
+    ::Kokkos::abort("Default computeQpJacobian() should never be called. Make sure you properly "
+                    "redefined this method in your class without typos.");
+
+    return 0;
+  }
+
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int /* i */,
+                                                const unsigned int /* j */,
+                                                const unsigned int /* jvar */,
+                                                const unsigned int /* qp */,
+                                                AssemblyDatum & /* datum */) const
+  {
+    ::Kokkos::abort(
+        "Default computeQpOffDiagJacobian() should never be called. Make sure you properly "
+        "redefined this method in your class without typos.");
+
+    return 0;
+  }
+
+  template <typename Derived>
+  static auto defaultJacobian()
+  {
+    return &ArrayKernel::computeQpJacobian<Derived>;
+  }
+
+  template <typename Derived>
+  static auto defaultOffDiagJacobian()
+  {
+    return &ArrayKernel::computeQpOffDiagJacobian<Derived>;
+  }
+
+  template <typename Derived>
+  KOKKOS_FUNCTION void operator()(ResidualLoop, const ThreadID tid, const Derived & kernel) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void operator()(JacobianLoop, const ThreadID tid, const Derived & kernel) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void
+  operator()(OffDiagJacobianLoop, const ThreadID tid, const Derived & kernel) const;
+
+  template <typename Derived>
+  KOKKOS_FUNCTION void computeResidualInternal(const Derived & kernel, AssemblyDatum & datum) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void computeOffDiagJacobianInternal(const Derived & kernel,
+                                                      AssemblyDatum & datum) const;
+
+protected:
+  const ArrayVariableTestValue _test;
+  const ArrayVariableTestGradient _grad_test;
+  const ArrayVariablePhiValue _phi;
+  const ArrayVariablePhiGradient _grad_phi;
+  const ArrayVariableValue _u;
+  const ArrayVariableGradient _grad_u;
+
+  /// Number of components of the array variable
+  const unsigned int _count;
+};
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayKernel::operator()(ResidualLoop, const ThreadID tid, const Derived & kernel) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto elem = kokkosBlockElementID(_thread(tid, 2));
+
+  AssemblyDatum datum(elem,
+                      libMesh::invalid_uint,
+                      kokkosAssembly(),
+                      kokkosSystems(),
+                      _kokkos_var,
+                      _kokkos_var.var(comp),
+                      comp);
+
+  datum.set_local_parallel(_thread(tid, 1), _thread.size(1));
+
+  kernel.computeResidualInternal(kernel, datum);
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayKernel::operator()(JacobianLoop, const ThreadID tid, const Derived & kernel) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto elem = kokkosBlockElementID(_thread(tid, 2));
+
+  AssemblyDatum datum(elem,
+                      libMesh::invalid_uint,
+                      kokkosAssembly(),
+                      kokkosSystems(),
+                      _kokkos_var,
+                      _kokkos_var.var(comp),
+                      comp);
+
+  datum.set_local_parallel(_thread(tid, 1), _thread.size(1));
+
+  kernel.computeJacobianInternal(kernel, datum);
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayKernel::operator()(OffDiagJacobianLoop, const ThreadID tid, const Derived & kernel) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto elem = kokkosBlockElementID(_thread(tid, 3));
+  auto & sys = kokkosSystem(_kokkos_var.sys(comp));
+  const auto & coupling = sys.getCoupling(_kokkos_var.var(comp));
+  const auto coupling_index = _thread(tid, 2);
+
+  if (coupling_index >= coupling.size())
+    return;
+
+  const auto jvar = coupling[coupling_index];
+
+  if (!sys.isVariableActive(jvar, kokkosMesh().getElementInfo(elem).subdomain))
+    return;
+
+  AssemblyDatum datum(
+      elem, libMesh::invalid_uint, kokkosAssembly(), kokkosSystems(), _kokkos_var, jvar, comp);
+
+  datum.set_local_parallel(_thread(tid, 1), _thread.size(1));
+
+  kernel.computeOffDiagJacobianInternal(kernel, datum);
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayKernel::computeResidualInternal(const Derived & kernel, AssemblyDatum & datum) const
+{
+  ResidualObject::computeResidualInternal(
+      datum,
+      [&](Real * local_re, const unsigned int ib, const unsigned int ie)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+          for (unsigned int i = ib; i < ie; ++i)
+            local_re[i] += datum.JxW(qp) * kernel.template computeQpResidual<Derived>(i, qp, datum);
+      });
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayKernel::computeJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const
+{
+  ResidualObject::computeJacobianInternal(
+      datum,
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] +=
+                datum.JxW(qp) * kernel.template computeQpJacobian<Derived>(i, j, qp, datum);
+      });
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayKernel::computeOffDiagJacobianInternal(const Derived & kernel, AssemblyDatum & datum) const
+{
+  ResidualObject::computeJacobianInternal(
+      datum,
+      [&](Real * local_ke, const unsigned int ib, const unsigned int ie, const unsigned int j)
+      {
+        for (unsigned int qp = 0; qp < datum.n_qps(); ++qp)
+          for (unsigned int i = ib; i < ie; ++i)
+            local_ke[i] += datum.JxW(qp) * kernel.template computeQpOffDiagJacobian<Derived>(
+                                               i, j, datum.jvar(), qp, datum);
+      });
+}
+
+} // namespace Moose::Kokkos

--- a/framework/include/kokkos/materials/KokkosMaterialProperty.h
+++ b/framework/include/kokkos/materials/KokkosMaterialProperty.h
@@ -13,6 +13,7 @@
 
 #ifdef MOOSE_KOKKOS_SCOPE
 #include "KokkosMaterialPropertyValueDecl.h"
+#include "KokkosDatumDecl.h"
 #endif
 
 #include "KokkosAssembly.h"
@@ -158,6 +159,15 @@ KOKKOS_FUNCTION MaterialPropertyValue<T, dimension>
 MaterialProperty<T, dimension>::operator()(const Datum & datum, const unsigned int qp) const
 {
   return MaterialPropertyValue<T, dimension>(*this, datum, qp);
+}
+
+template <typename T, unsigned int dimension>
+template <unsigned int D, std::enable_if_t<D == dimension && (D == 1 || D == 2), int>>
+KOKKOS_FUNCTION auto
+MaterialProperty<T, dimension>::array(const AssemblyDatum & datum, const unsigned int qp) const
+{
+  return ArrayContextView<MaterialPropertyValue<T, dimension>, dimension, true>((*this)(datum, qp),
+                                                                                datum.comp());
 }
 #endif
 

--- a/framework/include/kokkos/materials/KokkosMaterialPropertyDecl.h
+++ b/framework/include/kokkos/materials/KokkosMaterialPropertyDecl.h
@@ -30,9 +30,10 @@ class MaterialPropertyValueBase;
 template <typename T, unsigned int dimension>
 class MaterialPropertyValue;
 
-class Datum;
 class Assembly;
 class Mesh;
+class Datum;
+class AssemblyDatum;
 
 /**
  * Property constant options
@@ -287,6 +288,16 @@ public:
    */
   KOKKOS_FUNCTION MaterialPropertyValue<T, dimension> operator()(const Datum & datum,
                                                                  const unsigned int qp) const;
+
+  /**
+   * Get an array view of the property values of a quadrature point
+   * @param datum The AssemblyDatum object of the current thread
+   * @param qp The local quadrature point index
+   * @returns The array view of the property values
+   */
+  template <unsigned int D = dimension,
+            std::enable_if_t<D == dimension && (D == 1 || D == 2), int> = 0>
+  KOKKOS_FUNCTION auto array(const AssemblyDatum & datum, unsigned int qp) const;
 #endif
 
   virtual std::type_index propertyType() override

--- a/framework/include/kokkos/materials/KokkosMaterialPropertyValueDecl.h
+++ b/framework/include/kokkos/materials/KokkosMaterialPropertyValueDecl.h
@@ -67,7 +67,8 @@ protected:
 };
 
 template <typename T, unsigned int dimension>
-class MaterialPropertyValue : public MaterialPropertyValueBase<T, dimension>
+class MaterialPropertyValue : public MaterialPropertyValueBase<T, dimension>,
+                              public ArrayView<MaterialPropertyValue<T, dimension>, dimension>
 {
   usingKokkosMaterialPropertyValueBaseMembers(T, dimension);
 

--- a/framework/include/kokkos/nodalkernels/KokkosArrayNodalKernel.h
+++ b/framework/include/kokkos/nodalkernels/KokkosArrayNodalKernel.h
@@ -1,0 +1,144 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#pragma once
+
+#include "KokkosNodalKernelBase.h"
+
+namespace Moose::Kokkos
+{
+
+/**
+ * The base class for a user to derive their own Kokkos nodal kernels on array variables.
+ * Each device invocation operates on the component returned by AssemblyDatum::comp().
+ */
+class ArrayNodalKernel : public NodalKernelBase
+{
+public:
+  static InputParameters validParams();
+
+  ArrayNodalKernel(const InputParameters & parameters);
+
+  virtual void computeResidual() override;
+  virtual void computeJacobian() override;
+
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpJacobian(const unsigned int /* qp */,
+                                         AssemblyDatum & /* datum */) const
+  {
+    ::Kokkos::abort("Default computeQpJacobian() should never be called. Make sure you properly "
+                    "redefined this method in your class without typos.");
+
+    return 0;
+  }
+
+  template <typename Derived>
+  KOKKOS_FUNCTION Real computeQpOffDiagJacobian(const unsigned int /* jvar */,
+                                                const unsigned int /* qp */,
+                                                AssemblyDatum & /* datum */) const
+  {
+    ::Kokkos::abort(
+        "Default computeQpOffDiagJacobian() should never be called. Make sure you properly "
+        "redefined this method in your class without typos.");
+
+    return 0;
+  }
+
+  template <typename Derived>
+  static auto defaultJacobian()
+  {
+    return &ArrayNodalKernel::computeQpJacobian<Derived>;
+  }
+
+  template <typename Derived>
+  static auto defaultOffDiagJacobian()
+  {
+    return &ArrayNodalKernel::computeQpOffDiagJacobian<Derived>;
+  }
+
+  template <typename Derived>
+  KOKKOS_FUNCTION void operator()(ResidualLoop, const ThreadID tid, const Derived & kernel) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void operator()(JacobianLoop, const ThreadID tid, const Derived & kernel) const;
+  template <typename Derived>
+  KOKKOS_FUNCTION void
+  operator()(OffDiagJacobianLoop, const ThreadID tid, const Derived & kernel) const;
+
+protected:
+  const ArrayVariableValue _u;
+
+  /// Number of components of the array variable
+  const unsigned int _count;
+
+private:
+  const bool _boundary_restricted;
+};
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayNodalKernel::operator()(ResidualLoop, const ThreadID tid, const Derived & kernel) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto node = _boundary_restricted ? kokkosBoundaryNodeID(_thread(tid, 1))
+                                         : kokkosBlockNodeID(_thread(tid, 1));
+  auto & sys = kokkosSystem(_kokkos_var.sys(comp));
+
+  if (!sys.isNodalDefined(node, _kokkos_var.var(comp)))
+    return;
+
+  AssemblyDatum datum(
+      node, kokkosAssembly(), kokkosSystems(), _kokkos_var, _kokkos_var.var(comp), comp);
+
+  const Real local_re = kernel.template computeQpResidual<Derived>(0, datum);
+
+  accumulateTaggedNodalResidual(true, local_re, node, comp);
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayNodalKernel::operator()(JacobianLoop, const ThreadID tid, const Derived & kernel) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto node = _boundary_restricted ? kokkosBoundaryNodeID(_thread(tid, 1))
+                                         : kokkosBlockNodeID(_thread(tid, 1));
+  auto & sys = kokkosSystem(_kokkos_var.sys(comp));
+
+  if (!sys.isNodalDefined(node, _kokkos_var.var(comp)))
+    return;
+
+  AssemblyDatum datum(
+      node, kokkosAssembly(), kokkosSystems(), _kokkos_var, _kokkos_var.var(comp), comp);
+
+  const Real local_ke = kernel.template computeQpJacobian<Derived>(0, datum);
+
+  accumulateTaggedNodalMatrix(true, local_ke, node, _kokkos_var.var(comp), comp);
+}
+
+template <typename Derived>
+KOKKOS_FUNCTION void
+ArrayNodalKernel::operator()(OffDiagJacobianLoop, const ThreadID tid, const Derived & kernel) const
+{
+  const auto comp = _thread(tid, 0);
+  const auto node = _boundary_restricted ? kokkosBoundaryNodeID(_thread(tid, 2))
+                                         : kokkosBlockNodeID(_thread(tid, 2));
+  auto & sys = kokkosSystem(_kokkos_var.sys(comp));
+  const auto & coupling = sys.getCoupling(_kokkos_var.var(comp));
+  const auto coupling_index = _thread(tid, 1);
+
+  if (coupling_index >= coupling.size() || !sys.isNodalDefined(node, _kokkos_var.var(comp)))
+    return;
+
+  const auto jvar = coupling[coupling_index];
+  AssemblyDatum datum(node, kokkosAssembly(), kokkosSystems(), _kokkos_var, jvar, comp);
+
+  const Real local_ke = kernel.template computeQpOffDiagJacobian<Derived>(jvar, 0, datum);
+
+  accumulateTaggedNodalMatrix(true, local_ke, node, jvar, comp);
+}
+
+} // namespace Moose::Kokkos

--- a/framework/src/kokkos/base/KokkosResidualObject.K
+++ b/framework/src/kokkos/base/KokkosResidualObject.K
@@ -53,8 +53,17 @@ ResidualObject::ResidualObject(const InputParameters & parameters,
     _dt(TransientInterface::_dt),
     _dt_old(TransientInterface::_dt_old)
 {
-  if (_var.isVector() && field_type != Moose::VarFieldType::VAR_FIELD_VECTOR)
-    paramError("variable", "Vector variable specified to a scalar Kokkos residual object.");
+  std::string expected;
+
+  if (field_type == Moose::VarFieldType::VAR_FIELD_STANDARD)
+    expected = "standard";
+  else if (field_type == Moose::VarFieldType::VAR_FIELD_VECTOR)
+    expected = "vector";
+  else if (field_type == Moose::VarFieldType::VAR_FIELD_ARRAY)
+    expected = "array";
+
+  if (_var.fieldType() != field_type)
+    paramError("variable", type(), " expects ", expected, " variables.");
 
   _kokkos_var.init(_var);
 }

--- a/framework/src/kokkos/bcs/KokkosArrayDirichletBC.K
+++ b/framework/src/kokkos/bcs/KokkosArrayDirichletBC.K
@@ -1,0 +1,32 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#include "KokkosArrayDirichletBC.h"
+
+registerKokkosResidualObject("MooseApp", KokkosArrayDirichletBC);
+
+InputParameters
+KokkosArrayDirichletBC::validParams()
+{
+  InputParameters params = Moose::Kokkos::ArrayNodalBC::validParams();
+  params.addRequiredParam<RealEigenVector>("values",
+                                           "The values the components must take on the boundary");
+  params.declareControllable("values");
+  params.addClassDescription(
+      "Imposes the essential boundary condition $\\vec{u}=\\vec{g}$, where $\\vec{g}$ "
+      "are constant, controllable values.");
+  return params;
+}
+
+KokkosArrayDirichletBC::KokkosArrayDirichletBC(const InputParameters & parameters)
+  : Moose::Kokkos::ArrayNodalBC(parameters), _values(getParam<RealEigenVector>("values"))
+{
+  if (getParam<RealEigenVector>("values").size() != _count)
+    paramError(
+        "values", "Number of 'values' must equal number of variable components (", _count, ").");
+}

--- a/framework/src/kokkos/bcs/KokkosArrayIntegratedBC.K
+++ b/framework/src/kokkos/bcs/KokkosArrayIntegratedBC.K
@@ -1,0 +1,82 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#include "KokkosArrayIntegratedBC.h"
+
+namespace Moose::Kokkos
+{
+
+InputParameters
+ArrayIntegratedBC::validParams()
+{
+  InputParameters params = IntegratedBCBase::validParams();
+  return params;
+}
+
+ArrayIntegratedBC::ArrayIntegratedBC(const InputParameters & parameters)
+  : IntegratedBCBase(parameters, Moose::VarFieldType::VAR_FIELD_ARRAY),
+    _test(),
+    _grad_test(),
+    _phi(),
+    _grad_phi(),
+    _u(_var),
+    _grad_u(_var),
+    _count(_var.count())
+{
+  addMooseVariableDependency(&_var);
+}
+
+void
+ArrayIntegratedBC::computeResidual()
+{
+  _thread.resize(_count, _num_local_residual_threads, numKokkosBoundarySides());
+
+  Policy policy(0, _thread.size());
+
+  if (!_residual_dispatcher)
+    _residual_dispatcher = DispatcherRegistry::build<ResidualLoop>(this, type());
+
+  _residual_dispatcher->parallelFor(policy);
+}
+
+void
+ArrayIntegratedBC::computeJacobian()
+{
+  if (DispatcherRegistry::hasUserMethod<JacobianLoop>(type()))
+  {
+    _thread.resize(_count, _num_local_jacobian_threads, numKokkosBoundarySides());
+
+    Policy policy(0, _thread.size());
+
+    if (!_jacobian_dispatcher)
+      _jacobian_dispatcher = DispatcherRegistry::build<JacobianLoop>(this, type());
+
+    _jacobian_dispatcher->parallelFor(policy);
+  }
+
+  if (DispatcherRegistry::hasUserMethod<OffDiagJacobianLoop>(type()))
+  {
+    auto & sys = kokkosSystem(_kokkos_var.sys());
+    unsigned int max_couplings = 0;
+
+    for (const auto comp : make_range(_count))
+      if (sys.getCoupling(_kokkos_var.var(comp)).size() > max_couplings)
+        max_couplings = sys.getCoupling(_kokkos_var.var(comp)).size();
+
+    _thread.resize(_count, _num_local_jacobian_threads, max_couplings, numKokkosBoundarySides());
+
+    Policy policy(0, _thread.size());
+
+    if (!_offdiag_jacobian_dispatcher)
+      _offdiag_jacobian_dispatcher = DispatcherRegistry::build<OffDiagJacobianLoop>(this, type());
+
+    _offdiag_jacobian_dispatcher->parallelFor(policy);
+  }
+}
+
+} // namespace Moose::Kokkos

--- a/framework/src/kokkos/bcs/KokkosArrayNeumannBC.K
+++ b/framework/src/kokkos/bcs/KokkosArrayNeumannBC.K
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#include "KokkosArrayNeumannBC.h"
+
+registerKokkosResidualObject("MooseApp", KokkosArrayNeumannBC);
+
+InputParameters
+KokkosArrayNeumannBC::validParams()
+{
+  InputParameters params = Moose::Kokkos::ArrayIntegratedBC::validParams();
+  params.addParam<RealEigenVector>("value", "The value of the gradient on the boundary.");
+  params.declareControllable("value");
+  params.addClassDescription("Imposes the integrated boundary condition "
+                             "$\\frac{\\partial u}{\\partial n}=h$, "
+                             "where $h$ is a constant, controllable value.");
+  return params;
+}
+
+KokkosArrayNeumannBC::KokkosArrayNeumannBC(const InputParameters & parameters)
+  : Moose::Kokkos::ArrayIntegratedBC(parameters),
+    _value_host(isParamValid("value") ? getParam<RealEigenVector>("value")
+                                      : RealEigenVector::Zero(_count)),
+    _value(_value_host)
+{
+  if (_value_host.size() != _count)
+    paramError("value",
+               "Number of 'value' entries must equal number of variable components (",
+               _count,
+               ").");
+}

--- a/framework/src/kokkos/bcs/KokkosArrayNodalBC.K
+++ b/framework/src/kokkos/bcs/KokkosArrayNodalBC.K
@@ -1,0 +1,74 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#include "KokkosArrayNodalBC.h"
+
+namespace Moose::Kokkos
+{
+
+InputParameters
+ArrayNodalBC::validParams()
+{
+  InputParameters params = NodalBCBase::validParams();
+  return params;
+}
+
+ArrayNodalBC::ArrayNodalBC(const InputParameters & parameters)
+  : NodalBCBase(parameters, Moose::VarFieldType::VAR_FIELD_ARRAY),
+    _u(_var, Moose::SOLUTION_TAG, true),
+    _count(_var.count())
+{
+  addMooseVariableDependency(&_var);
+}
+
+void
+ArrayNodalBC::computeResidual()
+{
+  _thread.resize(_count, numKokkosBoundaryNodes());
+
+  Policy policy(0, _thread.size());
+
+  if (!_residual_dispatcher)
+    _residual_dispatcher = DispatcherRegistry::build<ResidualLoop>(this, type());
+
+  _residual_dispatcher->parallelFor(policy);
+}
+
+void
+ArrayNodalBC::computeJacobian()
+{
+  _thread.resize(_count, numKokkosBoundaryNodes());
+
+  Policy policy(0, _thread.size());
+
+  if (!_jacobian_dispatcher)
+    _jacobian_dispatcher = DispatcherRegistry::build<JacobianLoop>(this, type());
+
+  _jacobian_dispatcher->parallelFor(policy);
+
+  if (DispatcherRegistry::hasUserMethod<OffDiagJacobianLoop>(type()))
+  {
+    auto & sys = kokkosSystem(_kokkos_var.sys());
+    unsigned int max_couplings = 0;
+
+    for (const auto comp : make_range(_count))
+      if (sys.getCoupling(_kokkos_var.var(comp)).size() > max_couplings)
+        max_couplings = sys.getCoupling(_kokkos_var.var(comp)).size();
+
+    _thread.resize(_count, max_couplings, numKokkosBoundaryNodes());
+
+    Policy policy(0, _thread.size());
+
+    if (!_offdiag_jacobian_dispatcher)
+      _offdiag_jacobian_dispatcher = DispatcherRegistry::build<OffDiagJacobianLoop>(this, type());
+
+    _offdiag_jacobian_dispatcher->parallelFor(policy);
+  }
+}
+
+} // namespace Moose::Kokkos

--- a/framework/src/kokkos/bcs/KokkosVectorDirichletBC.K
+++ b/framework/src/kokkos/bcs/KokkosVectorDirichletBC.K
@@ -25,13 +25,6 @@ KokkosVectorDirichletBC::validParams()
 }
 
 KokkosVectorDirichletBC::KokkosVectorDirichletBC(const InputParameters & parameters)
-  : Moose::Kokkos::VectorNodalBC(parameters),
-    _values_host(getParam<RealVectorValue>("values")),
-    _values(_values_host)
-{
-}
-
-KokkosVectorDirichletBC::KokkosVectorDirichletBC(const KokkosVectorDirichletBC & object)
-  : Moose::Kokkos::VectorNodalBC(object), _values_host(object._values_host), _values(_values_host)
+  : Moose::Kokkos::VectorNodalBC(parameters), _values(getParam<RealVectorValue>("values"))
 {
 }

--- a/framework/src/kokkos/kernels/KokkosArrayDiffusion.K
+++ b/framework/src/kokkos/kernels/KokkosArrayDiffusion.K
@@ -1,0 +1,43 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#include "KokkosArrayDiffusion.h"
+
+registerKokkosResidualObject("MooseApp", KokkosArrayDiffusion);
+
+InputParameters
+KokkosArrayDiffusion::validParams()
+{
+  InputParameters params = ArrayKernel::validParams();
+  params.addRequiredParam<MaterialPropertyName>(
+      "diffusion_coefficient",
+      "The diffusivity, supplied as a scalar, one-dimensional, or two-dimensional Kokkos "
+      "material property.");
+  params.addClassDescription(
+      "The array Laplacian operator ($-\\nabla \\cdot \\nabla u$), with the weak form of "
+      "$(\\nabla \\phi_i, \\nabla u_h)$.");
+  return params;
+}
+
+KokkosArrayDiffusion::KokkosArrayDiffusion(const InputParameters & parameters)
+  : ArrayKernel(parameters),
+    _has_d(hasKokkosMaterialProperty<Real>("diffusion_coefficient")),
+    _has_d_1d(hasKokkosMaterialProperty<Real, 1>("diffusion_coefficient")),
+    _has_d_2d(hasKokkosMaterialProperty<Real, 2>("diffusion_coefficient")),
+    _d(_has_d ? getKokkosMaterialProperty<Real>("diffusion_coefficient")
+              : Moose::Kokkos::MaterialProperty<Real>()),
+    _d_1d(_has_d_1d ? getKokkosMaterialProperty<Real, 1>("diffusion_coefficient")
+                    : Moose::Kokkos::MaterialProperty<Real, 1>()),
+    _d_2d(_has_d_2d ? getKokkosMaterialProperty<Real, 2>("diffusion_coefficient")
+                    : Moose::Kokkos::MaterialProperty<Real, 2>())
+{
+  if (!_has_d && !_has_d_1d && !_has_d_2d)
+    paramError("diffusion_coefficient",
+               "The property is not a scalar, one-dimensional, or two-dimensional Kokkos "
+               "material property.");
+}

--- a/framework/src/kokkos/kernels/KokkosArrayKernel.K
+++ b/framework/src/kokkos/kernels/KokkosArrayKernel.K
@@ -1,0 +1,83 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#include "KokkosArrayKernel.h"
+
+namespace Moose::Kokkos
+{
+
+InputParameters
+ArrayKernel::validParams()
+{
+  InputParameters params = KernelBase::validParams();
+  params.registerBase("ArrayKernel");
+  return params;
+}
+
+ArrayKernel::ArrayKernel(const InputParameters & parameters)
+  : KernelBase(parameters, Moose::VarFieldType::VAR_FIELD_ARRAY),
+    _test(),
+    _grad_test(),
+    _phi(),
+    _grad_phi(),
+    _u(_var),
+    _grad_u(_var),
+    _count(_var.count())
+{
+  addMooseVariableDependency(&_var);
+}
+
+void
+ArrayKernel::computeResidual()
+{
+  _thread.resize(_count, _num_local_residual_threads, numKokkosBlockElements());
+
+  Policy policy(0, _thread.size());
+
+  if (!_residual_dispatcher)
+    _residual_dispatcher = DispatcherRegistry::build<ResidualLoop>(this, type());
+
+  _residual_dispatcher->parallelFor(policy);
+}
+
+void
+ArrayKernel::computeJacobian()
+{
+  if (DispatcherRegistry::hasUserMethod<JacobianLoop>(type()))
+  {
+    _thread.resize(_count, _num_local_jacobian_threads, numKokkosBlockElements());
+
+    Policy policy(0, _thread.size());
+
+    if (!_jacobian_dispatcher)
+      _jacobian_dispatcher = DispatcherRegistry::build<JacobianLoop>(this, type());
+
+    _jacobian_dispatcher->parallelFor(policy);
+  }
+
+  if (DispatcherRegistry::hasUserMethod<OffDiagJacobianLoop>(type()))
+  {
+    auto & sys = kokkosSystem(_kokkos_var.sys());
+    unsigned int max_couplings = 0;
+
+    for (const auto comp : make_range(_count))
+      if (sys.getCoupling(_kokkos_var.var(comp)).size() > max_couplings)
+        max_couplings = sys.getCoupling(_kokkos_var.var(comp)).size();
+
+    _thread.resize(_count, _num_local_jacobian_threads, max_couplings, numKokkosBlockElements());
+
+    Policy policy(0, _thread.size());
+
+    if (!_offdiag_jacobian_dispatcher)
+      _offdiag_jacobian_dispatcher = DispatcherRegistry::build<OffDiagJacobianLoop>(this, type());
+
+    _offdiag_jacobian_dispatcher->parallelFor(policy);
+  }
+}
+
+} // namespace Moose::Kokkos

--- a/framework/src/kokkos/nodalkernels/KokkosArrayNodalKernel.K
+++ b/framework/src/kokkos/nodalkernels/KokkosArrayNodalKernel.K
@@ -1,0 +1,80 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#include "KokkosArrayNodalKernel.h"
+
+namespace Moose::Kokkos
+{
+
+InputParameters
+ArrayNodalKernel::validParams()
+{
+  InputParameters params = NodalKernelBase::validParams();
+  return params;
+}
+
+ArrayNodalKernel::ArrayNodalKernel(const InputParameters & parameters)
+  : NodalKernelBase(parameters, Moose::VarFieldType::VAR_FIELD_ARRAY),
+    _u(_var, Moose::SOLUTION_TAG, true),
+    _count(_var.count()),
+    _boundary_restricted(boundaryRestricted())
+{
+  addMooseVariableDependency(&_var);
+}
+
+void
+ArrayNodalKernel::computeResidual()
+{
+  _thread.resize(_count, _boundary_restricted ? numKokkosBoundaryNodes() : numKokkosBlockNodes());
+
+  Policy policy(0, _thread.size());
+
+  if (!_residual_dispatcher)
+    _residual_dispatcher = DispatcherRegistry::build<ResidualLoop>(this, type());
+
+  _residual_dispatcher->parallelFor(policy);
+}
+
+void
+ArrayNodalKernel::computeJacobian()
+{
+  const auto num_nodes = _boundary_restricted ? numKokkosBoundaryNodes() : numKokkosBlockNodes();
+
+  if (DispatcherRegistry::hasUserMethod<JacobianLoop>(type()))
+  {
+    _thread.resize(_count, num_nodes);
+
+    Policy policy(0, _thread.size());
+
+    if (!_jacobian_dispatcher)
+      _jacobian_dispatcher = DispatcherRegistry::build<JacobianLoop>(this, type());
+
+    _jacobian_dispatcher->parallelFor(policy);
+  }
+
+  if (DispatcherRegistry::hasUserMethod<OffDiagJacobianLoop>(type()))
+  {
+    auto & sys = kokkosSystem(_kokkos_var.sys());
+    unsigned int max_couplings = 0;
+
+    for (const auto comp : make_range(_count))
+      if (sys.getCoupling(_kokkos_var.var(comp)).size() > max_couplings)
+        max_couplings = sys.getCoupling(_kokkos_var.var(comp)).size();
+
+    _thread.resize(_count, max_couplings, num_nodes);
+
+    Policy policy(0, _thread.size());
+
+    if (!_offdiag_jacobian_dispatcher)
+      _offdiag_jacobian_dispatcher = DispatcherRegistry::build<OffDiagJacobianLoop>(this, type());
+
+    _offdiag_jacobian_dispatcher->parallelFor(policy);
+  }
+}
+
+} // namespace Moose::Kokkos

--- a/framework/src/kokkos/systems/KokkosFESystem.K
+++ b/framework/src/kokkos/systems/KokkosFESystem.K
@@ -87,8 +87,15 @@ FESystem::setupCoupling()
     auto & ce = _system.feProblem().couplingEntries(0, nl_system->number());
 
     for (const auto & [ivar, jvar] : ce)
-      if (ivar->number() != jvar->number())
-        coupling[ivar->number()].push_back(jvar->number());
+      for (const auto icomp : make_range(ivar->count()))
+        for (const auto jcomp : make_range(jvar->count()))
+        {
+          const auto ivar_num = ivar->number() + icomp;
+          const auto jvar_num = jvar->number() + jcomp;
+
+          if (ivar_num != jvar_num)
+            coupling[ivar_num].push_back(jvar_num);
+        }
 
     for (const auto var : make_range(_num_vars))
       _coupling[var] = coupling[var];
@@ -165,8 +172,10 @@ FESystem::setupNodalBCDofs()
 void
 FESystem::getNodalBCDofs(const NodalBCBase * nbc, Array<bool> & dofs)
 {
-  auto var = nbc->variable().number();
-  auto num_dofs = _var_is_vector[var] ? kokkosAssembly().getDimension() : 1;
+  const auto & variable = nbc->variable();
+  const auto first_var = variable.number();
+  const auto num_vars = variable.count();
+  const auto num_dofs = _var_is_vector[first_var] ? kokkosAssembly().getDimension() : 1;
 
   if (!dofs.isAlloc())
   {
@@ -176,11 +185,14 @@ FESystem::getNodalBCDofs(const NodalBCBase * nbc, Array<bool> & dofs)
 
   for (auto node : nbc->getContiguousNodes())
   {
-    auto dof = _local_node_dof_index[var][node];
+    for (const auto comp : make_range(num_vars))
+    {
+      const auto dof = _local_node_dof_index[first_var + comp][node];
 
-    if (dof != libMesh::DofObject::invalid_id)
-      for (const auto i : make_range(num_dofs))
-        dofs[dof + i] = true;
+      if (dof != libMesh::DofObject::invalid_id)
+        for (const auto i : make_range(num_dofs))
+          dofs[dof + i] = true;
+    }
   }
 
   // Let remote processes know about ghost DOFs associated with nodal BCs not to contribute on them


### PR DESCRIPTION
## Reason
Array kernel is one of the main features of MOOSE and useful when solving the same or closely related PDE terms for many field components that share the same finite-element family and order (e.g., multigroup neutron transport). For the completeness of features, Kokkos should also provide array kernels. Array kernels in Kokkos can provide additional performance advantage by enabling parallelization on the variable components.

## Design
Add Kokkos array kernels with parallelization over variable components. Provide views for Kokkos arrays, material properties, and variable values for array operations.

## Impact
Array kernel support in Kokkos.