### PR TITLE
Rebuild displaced mortar meshes during standalone Jacobian evaluation

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -7955,8 +7955,12 @@ FEProblemBase::computeJacobianTags(const std::set<TagID> & tags)
         {
           computeSystems(EXEC_PRE_DISPLACE);
           _displaced_problem->updateMesh();
-          // Displaced mortar segments must use the same coordinates as their parent elements.
-          if (_mortar_data->hasDisplacedObjects())
+          // A standalone scaling Jacobian is assembled without a preceding residual evaluation, so
+          // the displaced mortar segment mesh can be stale relative to the just-updated displaced
+          // parent mesh. Every other Jacobian evaluation is preceded by a residual (or combined
+          // residual/Jacobian) evaluation that already rebuilt the mortar mesh, so doing it here in
+          // the general case would be duplicative.
+          if (_current_nl_sys->computingScalingJacobian() && _mortar_data->hasDisplacedObjects())
             updateMortarMesh();
         }
 

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -7955,6 +7955,9 @@ FEProblemBase::computeJacobianTags(const std::set<TagID> & tags)
         {
           computeSystems(EXEC_PRE_DISPLACE);
           _displaced_problem->updateMesh();
+          // Displaced mortar segments must use the same coordinates as their parent elements.
+          if (_mortar_data->hasDisplacedObjects())
+            updateMortarMesh();
         }
 
         for (unsigned int tid = 0; tid < n_threads; tid++)

--- a/test/include/problems/MortarMeshUpdateTestProblem.h
+++ b/test/include/problems/MortarMeshUpdateTestProblem.h
@@ -1,0 +1,28 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#pragma once
+
+#include "FEProblem.h"
+
+/**
+ * Test problem that verifies displaced mortar meshes are rebuilt during Jacobian assembly.
+ */
+class MortarMeshUpdateTestProblem : public FEProblem
+{
+public:
+  static InputParameters validParams();
+
+  MortarMeshUpdateTestProblem(const InputParameters & params);
+
+  void computeJacobianTags(const std::set<TagID> & tags) override;
+  void updateMortarMesh() override;
+
+private:
+  bool _updated_mortar_mesh = false;
+};

--- a/test/src/problems/MortarMeshUpdateTestProblem.C
+++ b/test/src/problems/MortarMeshUpdateTestProblem.C
@@ -1,0 +1,42 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#include "MortarMeshUpdateTestProblem.h"
+
+registerMooseObject("MooseTestApp", MortarMeshUpdateTestProblem);
+
+InputParameters
+MortarMeshUpdateTestProblem::validParams()
+{
+  InputParameters params = FEProblem::validParams();
+  params.addClassDescription(
+      "Verifies that displaced mortar meshes are rebuilt during Jacobian assembly.");
+  return params;
+}
+
+MortarMeshUpdateTestProblem::MortarMeshUpdateTestProblem(const InputParameters & params)
+  : FEProblem(params)
+{
+}
+
+void
+MortarMeshUpdateTestProblem::computeJacobianTags(const std::set<TagID> & tags)
+{
+  _updated_mortar_mesh = false;
+  FEProblem::computeJacobianTags(tags);
+
+  if (!_updated_mortar_mesh)
+    mooseError("The displaced mortar mesh was not rebuilt during Jacobian assembly.");
+}
+
+void
+MortarMeshUpdateTestProblem::updateMortarMesh()
+{
+  FEProblem::updateMortarMesh();
+  _updated_mortar_mesh = true;
+}

--- a/test/src/problems/MortarMeshUpdateTestProblem.C
+++ b/test/src/problems/MortarMeshUpdateTestProblem.C
@@ -27,11 +27,14 @@ MortarMeshUpdateTestProblem::MortarMeshUpdateTestProblem(const InputParameters &
 void
 MortarMeshUpdateTestProblem::computeJacobianTags(const std::set<TagID> & tags)
 {
+  // Only the standalone scaling Jacobian is expected to rebuild the displaced mortar mesh; ordinary
+  // Jacobian evaluations are preceded by a residual evaluation that already did so.
+  const bool computing_scaling = computingScalingJacobian();
   _updated_mortar_mesh = false;
   FEProblem::computeJacobianTags(tags);
 
-  if (!_updated_mortar_mesh)
-    mooseError("The displaced mortar mesh was not rebuilt during Jacobian assembly.");
+  if (computing_scaling && !_updated_mortar_mesh)
+    mooseError("The displaced mortar mesh was not rebuilt during the scaling Jacobian evaluation.");
 }
 
 void

--- a/test/tests/mortar/continuity-3d-non-conforming/displaced_mortar_jacobian_update.i
+++ b/test/tests/mortar/continuity-3d-non-conforming/displaced_mortar_jacobian_update.i
@@ -1,0 +1,30 @@
+!include normal_projection_distorted_quad.i
+
+[Mesh]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[AuxVariables]
+  [disp_x]
+  []
+  [disp_y]
+  []
+  [disp_z]
+  []
+[]
+
+[Problem]
+  type = MortarMeshUpdateTestProblem
+[]
+
+[Constraints]
+  [mortar]
+    use_displaced_mesh = true
+  []
+[]
+
+[Executioner]
+  automatic_scaling = true
+  # Force automatic scaling to assemble a standalone Jacobian.
+  resid_vs_jac_scaling_param = 0
+[]

--- a/test/tests/mortar/continuity-3d-non-conforming/tests
+++ b/test/tests/mortar/continuity-3d-non-conforming/tests
@@ -100,6 +100,14 @@
     requirement = 'The system shall not produce an out-of-bounds error when normal-projecting '
                   'retained 3D mortar quadrature points to distorted QUAD4 parent faces.'
   []
+  [displaced-mortar-jacobian-update]
+    type = 'RunApp'
+    input = 'displaced_mortar_jacobian_update.i'
+    design = 'FEProblemBase.md AutomaticMortarGeneration.md'
+    issues = '#33503'
+    requirement = 'The system shall rebuild displaced mortar segment meshes after updating the '
+                  'displaced parent mesh during standalone Jacobian assembly.'
+  []
   [continuity_sphere_hex27-debug-mesh]
     type = 'Exodiff'
     issues = '#33282'

--- a/test/tests/mortar/continuity-3d-non-conforming/tests
+++ b/test/tests/mortar/continuity-3d-non-conforming/tests
@@ -106,7 +106,7 @@
     design = 'FEProblemBase.md AutomaticMortarGeneration.md'
     issues = '#33503'
     requirement = 'The system shall rebuild displaced mortar segment meshes after updating the '
-                  'displaced parent mesh during standalone Jacobian assembly.'
+                  'displaced parent mesh when assembling a standalone automatic-scaling Jacobian.'
   []
   [continuity_sphere_hex27-debug-mesh]
     type = 'Exodiff'


### PR DESCRIPTION
Refs #33503

Standalone Jacobian assembly updated displaced parent meshes without rebuilding displaced mortar segments, leaving them on stale coordinates. This adds the missing rebuild immediately after the displaced-mesh update and a focused automatic-scaling regression.

Verification: focused displaced-mortar tests and the non-heavy 3D mortar-contact suite pass.

*(generated by GPT-5 via Codex)*
