### PR TITLE
Update custom libMesh conda dependency docs

### DIFF
--- a/modules/doc/content/help/development/ccache.md
+++ b/modules/doc/content/help/development/ccache.md
@@ -9,7 +9,7 @@ In order to use ccache with MOOSE-based applications, it will be necessary to fi
 In other words If you are using our Conda moose-libmesh package, then you cannot use ccache. In order to begin using ccache, first create a new conda environment, free of moose-libmesh, and install everything necessary to build libMesh with ccache:
 
 ```bash
-conda create --name ccache-env moose-petsc moose-tools
+conda create --name ccache-env moose-build moose-petsc moose-tools ccache
 conda activate ccache-env
 export CC="ccache mpicc" CXX="ccache mpicxx"
 ```

--- a/modules/doc/content/help/faq/faq_build_libmesh-vtk.md
+++ b/modules/doc/content/help/faq/faq_build_libmesh-vtk.md
@@ -1,9 +1,12 @@
 ## How do I compile libMesh with VTK? id=libmesh-vtk
 
-[libMesh] by default is compiled with [VTK] when using our moose-libmesh Conda package. However, if you are attempting to build your own version of libMesh with VTK support, the easiest way to do so, is to install all the dependencies via Conda, and then run the `./update_and_rebuild_libmesh.sh` script:
+[libMesh] by default is compiled with [VTK] when using our `moose-libmesh` Conda package.
+However, if you are attempting to build your own version of libMesh with VTK support, the easiest
+way to do so is to install the MOOSE build stack, PETSc, VTK, and tooling dependencies via Conda,
+and then run the `./update_and_rebuild_libmesh.sh` script:
 
 ```bash
-conda create -n custom-libmesh moose-petsc moose-libmesh-vtk moose-tools
+conda create -n custom-libmesh moose-build moose-petsc moose-libmesh-vtk moose-tools
 conda activate custom-libmesh
 cd ~/projects/moose/scripts
 ./update_and_rebuild_libmesh.sh
@@ -12,7 +15,7 @@ cd ~/projects/moose/scripts
 Or, if you wish to build your own [VTK] (beyond the scope of this document), you need to explain to libMesh where this new installation of VTK is by providing the lib and include paths to it:
 
 ```bash
-conda create --name custom-libmesh moose-petsc moose-tools
+conda create --name custom-libmesh moose-build moose-petsc moose-tools
 conda activate custom-libmesh
 cd ~/projects/moose/scripts
 ./update_and_rebuild_libmesh.sh --with-vtk-lib=/path/to/vtk/lib --with-vtk-include=/path/to/vtk/include

--- a/modules/doc/content/help/faq/faq_build_libmesh.md
+++ b/modules/doc/content/help/faq/faq_build_libmesh.md
@@ -1,15 +1,20 @@
 ## How do I build and use my own libMesh? id=libmesh-myown
 
-libMesh is supplied by our Conda installation. However, if you wish to build and use your own libMesh installation, you can use our
-`update_and_rebuild_libmesh.sh` script.
+libMesh is supplied by our Conda installation. However, if you wish to build and use your own
+libMesh installation, you can use our `update_and_rebuild_libmesh.sh` script.
 
-Due to having moose-libmesh installed, Conda creates and sets an influential environment variable LIBMESH_DIR that you would have to continually `unset`. It is therefore advisable to create a new Conda environment without moose-libmesh installed:
+Due to having `moose-libmesh` installed, Conda creates and sets an influential environment
+variable `LIBMESH_DIR` that you would have to continually `unset`. It is therefore advisable to
+create a new Conda environment without `moose-libmesh` installed. Use `moose-build` for the MOOSE
+compiler/MPI toolchain, `moose-petsc` for the PETSc dependency, and `moose-tools` for the MOOSE
+Python/tooling dependencies:
 
 ```bash
-conda create -n custom-libmesh moose-petsc moose-tools
+conda create -n custom-libmesh moose-build moose-petsc moose-tools
 conda activate custom-libmesh
 cd ~/projects/moose/scripts
 ./update_and_rebuild_libmesh.sh
 ```
 
-The above creates a new Conda environment: 'custom-libmesh', installs the needed PETSc dependency so we can build our own libMesh, activates it, and then builds libMesh.
+The above creates a new Conda environment named `custom-libmesh`, installs the build tools and
+PETSc dependency needed to build your own libMesh, activates it, and then builds libMesh.

--- a/modules/doc/content/help/faq/faq_build_petsc.md
+++ b/modules/doc/content/help/faq/faq_build_petsc.md
@@ -13,4 +13,6 @@ cd ~/projects/moose/scripts
 ./update_and_rebuild_libmesh.sh
 ```
 
-The above creates a new Conda environment: 'custom-petsc', and installs the needed MPICH dependency. We then activate it, build PETSc, and then libMesh.
+The above creates a new Conda environment named `custom-petsc` and installs the compiler/MPI
+toolchain and MOOSE tooling dependencies. We then activate it, build PETSc, and then build libMesh
+against that PETSc installation.


### PR DESCRIPTION
## Summary
- add `moose-build` to custom libMesh Conda environment recipes
- update VTK and ccache variants that repeat the custom libMesh environment setup
- clarify that the custom PETSc recipe installs the compiler/MPI toolchain before building PETSc and libMesh

Closes #33278.

## Testing
- `git diff --check`