### PR TITLE
Handle generator inputs in stochastic parallel worker

### DIFF
--- a/modules/stochastic_tools/python/moose_stochastic_tools/StochasticControl.py
+++ b/modules/stochastic_tools/python/moose_stochastic_tools/StochasticControl.py
@@ -694,14 +694,15 @@ class StochasticRunner:
             ...     from scipy.optimize import shgo
             ...     res = shgo(objective, bounds, workers=runner.parallelWorker)
         """
-        x = np.array([xi for xi in x_iter])
+        x_list = list(x_iter)
+        x = np.array(x_list)
         if self._result_cache is None:
-            self.configCache(len(x_iter))
+            self.configCache(len(x_list))
         elif self._result_cache.maxsize < x.shape[0]:
             self._result_cache.maxsize = x.shape[0]
 
         self(x)
-        for xi in x_iter:
+        for xi in x_list:
             yield func(xi)
 
     def configCache(self, maxsize: int = 10000, tol: float = 1e-14):

--- a/modules/stochastic_tools/python/moose_stochastic_tools/tests/test_stochastic_control.py
+++ b/modules/stochastic_tools/python/moose_stochastic_tools/tests/test_stochastic_control.py
@@ -704,6 +704,34 @@ class TestResultsCache(unittest.TestCase):
         runner.configCache(0, 1e-3)
         self.assertIsNone(runner._result_cache)
 
+    def testParallelWorkerWithGenerator(self):
+        """Test StochasticRunner.parallelWorker with one-shot iterables."""
+
+        class mockStochasticControl:
+            def __init__(self):
+                self.num_params = 2
+                self.num_qois = 1
+                self._x = None
+                self.run_calls = 0
+
+            def setInput(self, x):
+                self._x = x
+
+            def run(self):
+                self.run_calls += 1
+
+            def getOutput(self):
+                return np.sum(self._x, axis=1).reshape((-1, 1))
+
+        control = mockStochasticControl()
+        runner = StochasticRunner(control)
+        samples = (np.array([i, i + 1], dtype=np.float64) for i in range(3))
+
+        values = list(runner.parallelWorker(lambda x: runner(x), samples))
+
+        self.assertEqual(control.run_calls, 1)
+        self.assertTrue(np.allclose(values, [1.0, 3.0, 5.0]))
+
 
 if __name__ == "__main__":
     unittest.main(module=__name__, verbosity=2)


### PR DESCRIPTION
## Summary
- materialize `parallelWorker` inputs once so one-shot iterables are handled correctly
- reuse the materialized inputs when sizing the cache and yielding mapped results
- add a regression test that exercises `parallelWorker` with a generator input

Closes #32024.

## Testing
- `PYTHONPYCACHEPREFIX=/private/tmp/moose-pycache /Users/saqif/miniforge3/bin/python3.12 -m py_compile modules/stochastic_tools/python/moose_stochastic_tools/StochasticControl.py modules/stochastic_tools/python/moose_stochastic_tools/tests/test_stochastic_control.py`
- targeted Python 3.11 regression exercise with stubs for unavailable local `pyhit`/`moosecontrol`, confirming generator inputs produce `[1.0, 3.0, 5.0]` with one control run
- `git diff --check`

The full local unittest command is blocked in this checkout because importing `pyhit` cannot find the built `hit` module.