### PR TITLE
Adding the capability for GeneralUserObjects to execute after FINAL.

### DIFF
--- a/framework/include/userobjects/GeneralUserObject.h
+++ b/framework/include/userobjects/GeneralUserObject.h
@@ -29,6 +29,12 @@ public:
 
   GeneralUserObject(const InputParameters & parameters);
 
+  /**
+   * Called during FEProblemBase::postExecute(). Intended for UserObjects that need the output files
+   * to be already written and available.
+   */
+  virtual void postExecute() {}
+
   ///@{
   /**
    * This method is not used and should not be used in a custom GeneralUserObject.

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6035,6 +6035,18 @@ FEProblemBase::postExecute()
 
   for (const auto & multi_app : multi_apps)
     multi_app->postExecute();
+
+  // Query all GeneralUserObjects (thread 0 only, since GeneralUserObjects are not threaded)
+  // and call postExecute() on any that override it.
+  std::vector<GeneralUserObject *> general_uos;
+  theWarehouse()
+      .query()
+      .condition<AttribThread>(0)
+      .condition<AttribInterfaces>(Interfaces::GeneralUserObject)
+      .queryInto(general_uos);
+
+  for (auto * uo : general_uos)
+    uo->postExecute();
 }
 
 void

--- a/test/include/userobjects/CheckOutputFile.h
+++ b/test/include/userobjects/CheckOutputFile.h
@@ -1,0 +1,29 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GeneralUserObject.h"
+
+class CheckOutputFile : public GeneralUserObject
+{
+public:
+  static InputParameters validParams();
+
+  CheckOutputFile(const InputParameters & parameters);
+  virtual void execute() override;
+  virtual void initialize() override;
+  virtual void finalize() override;
+
+  virtual void postExecute() override;
+
+private:
+  /// Name of the Output object whose file will be checked.
+  const std::string & _output_object_name;
+};

--- a/test/src/userobjects/CheckOutputFile.C
+++ b/test/src/userobjects/CheckOutputFile.C
@@ -9,15 +9,7 @@
 
 #include "CheckOutputFile.h"
 
-#include "MooseApp.h"
-#include "MooseError.h"
-#include "OutputWarehouse.h"
-#include "Output.h"
 #include "FileOutput.h"
-
-#include <nlohmann/json.hpp>
-#include <curl/curl.h>
-#include <sys/stat.h>
 
 registerMooseObject("MooseTestApp", CheckOutputFile);
 

--- a/test/src/userobjects/CheckOutputFile.C
+++ b/test/src/userobjects/CheckOutputFile.C
@@ -1,0 +1,67 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "CheckOutputFile.h"
+
+#include "MooseApp.h"
+#include "MooseError.h"
+#include "OutputWarehouse.h"
+#include "Output.h"
+#include "FileOutput.h"
+
+#include <nlohmann/json.hpp>
+#include <curl/curl.h>
+#include <sys/stat.h>
+
+registerMooseObject("MooseTestApp", CheckOutputFile);
+
+InputParameters
+CheckOutputFile::validParams()
+{
+  InputParameters params = GeneralUserObject::validParams();
+  params.addRequiredParam<std::string>("output_object",
+                                       "The name of the Output object whose file will be checked.");
+  return params;
+}
+
+CheckOutputFile::CheckOutputFile(const InputParameters & parameters)
+  : GeneralUserObject(parameters), _output_object_name(getParam<std::string>("output_object"))
+{
+}
+
+void
+CheckOutputFile::execute()
+{
+}
+
+void
+CheckOutputFile::initialize()
+{
+}
+
+void
+CheckOutputFile::finalize()
+{
+}
+
+void
+CheckOutputFile::postExecute()
+{
+  FileOutput * file_output =
+      dynamic_cast<FileOutput *>(_app.getOutputWarehouse().getOutput<Output>(_output_object_name));
+  std::string local_path = file_output->filename();
+
+  struct stat file_stat;
+  if (stat(local_path.c_str(), &file_stat) != 0)
+  {
+    mooseError("File not found at '", local_path, "'.");
+  }
+
+  _console << "File found at '" << local_path << "'. \n" << std::flush;
+}

--- a/test/tests/userobjects/accessing_files_during_postexecute/simple_diffusion.i
+++ b/test/tests/userobjects/accessing_files_during_postexecute/simple_diffusion.i
@@ -1,0 +1,58 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  []
+[]
+
+[Preconditioning]
+  [pre]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  [exodus_out]
+    type = Exodus
+  []
+[]
+
+[UserObjects]
+  [check_output_file]
+    type = CheckOutputFile
+    output_object = 'exodus_out'
+  []
+[]

--- a/test/tests/userobjects/accessing_files_during_postexecute/tests
+++ b/test/tests/userobjects/accessing_files_during_postexecute/tests
@@ -1,0 +1,11 @@
+[Tests]
+  [accessing_files_postexecute]
+    type = 'RunApp'
+    input = 'simple_diffusion.i'
+    expect_out = "File found at 'simple_diffusion_exodus_out.e'."
+
+    issues = '#33525'
+    design = 'UserObjects/index.md'
+    requirement = 'The system shall support the ability for objects inheriting from GeneralUserObject to execute after output files are written.'
+  []
+[]


### PR DESCRIPTION

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

This PR adds the capability for GeneralUserObjects to execute after FINAL.
closes #33525

## Design
<!--A concise description (design) of the enhancement.-->

A `postExecture()` function was added to `GeneralUserObject`, similar to the existing method for multi-apps (i.e., is executed during `FEProblemBase::postExecute()`). 

## Impact
<!--Will the enhancement change existing APIs or add something new?-->

Allows GeneralUserObjects access to the output file from the same simulation. Useful for when the user might want to edit / upload the output files in the same session.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
