### PR TITLE
Register missing fluid properties apps

### DIFF
--- a/modules/combined/testroot
+++ b/modules/combined/testroot
@@ -2,4 +2,3 @@ app_name = combined
 allow_warnings = false
 allow_unused = false
 allow_override = false
-known_capabilities = "airapp carbondioxideapp heliumapp nitrogenapp potassiumapp sodiumapp"

--- a/modules/fluid_properties/src/base/FluidPropertiesApp.C
+++ b/modules/fluid_properties/src/base/FluidPropertiesApp.C
@@ -62,23 +62,44 @@ FluidPropertiesApp::registerApps()
 
   registerApp(FluidPropertiesApp);
   MiscApp::registerApps();
+
+  [[maybe_unused]] const auto missing_fp_capability = [](const std::string & name)
+  { addBoolCapability(name + "app", false, "Fluid property app " + name + " is not available."); };
+
 #ifdef AIR_FP_ENABLED
   registerApp(AirApp);
+#else
+  missing_fp_capability("air");
 #endif
+
 #ifdef CARBON_DIOXIDE_FP_ENABLED
   registerApp(CarbonDioxideApp);
+#else
+  missing_fp_capability("carbondioxide");
 #endif
+
 #ifdef HELIUM_FP_ENABLED
   registerApp(HeliumApp);
+#else
+  missing_fp_capability("helium");
 #endif
+
 #ifdef NITROGEN_FP_ENABLED
   registerApp(NitrogenApp);
+#else
+  missing_fp_capability("nitrogen");
 #endif
+
 #ifdef POTASSIUM_FP_ENABLED
   registerApp(PotassiumApp);
+#else
+  missing_fp_capability("potassium");
 #endif
+
 #ifdef SODIUM_FP_ENABLED
   registerApp(SodiumApp);
+#else
+  missing_fp_capability("sodium");
 #endif
 }
 

--- a/modules/fluid_properties/testroot
+++ b/modules/fluid_properties/testroot
@@ -2,4 +2,3 @@ app_name = fluid_properties
 allow_warnings = false
 allow_unused = false
 allow_override = false
-known_capabilities = "airapp carbondioxideapp heliumapp nitrogenapp potassiumapp sodiumapp"

--- a/modules/testroot
+++ b/modules/testroot
@@ -3,4 +3,3 @@ run_tests_args = '--color-first-directory'
 allow_warnings = false
 allow_unused = false
 allow_override = false
-known_capabilities = "airapp carbondioxideapp heliumapp nitrogenapp potassiumapp sodiumapp"

--- a/modules/thermal_hydraulics/testroot
+++ b/modules/thermal_hydraulics/testroot
@@ -2,4 +2,3 @@ app_name = thermal_hydraulics
 allow_warnings = false
 allow_unused = false
 allow_override = false
-known_capabilities = "airapp"

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -546,10 +546,8 @@ class TestHarness:
 
         # Add extra capabilities that are known even though they might not
         # exist (if they are not set by the app). This is needed in specific
-        # when testing against known applications. For example, in the
-        # fluid_properties module, we check against "airapp". We don't want
-        # to error when "airapp" doesn't exist in the app because we know
-        # that it could actually be false.
+        # when testing against known applications, even though they might
+        # not be available.
         if test_root_params is not None and (
             known_capabilities := test_root_params.get("known_capabilities")
         ):


### PR DESCRIPTION
## Reason
When a fluid property app is unavailable (source not available), we can register its corresponding app as false. This lets us avoid having to add known capabilities for fluid property apps.

## Design
Register airapp, carbondioxideapp, etc as false capabilities when not available.

## Impact
Makes it more convenient to work with skipping tests conditionally based on fluid property app availability.