### PR TITLE
Add GPU memory tracking to TestHarness

### DIFF
--- a/framework/include/mfem/problem/MFEMProblem.h
+++ b/framework/include/mfem/problem/MFEMProblem.h
@@ -411,6 +411,17 @@ protected:
 
   /// Restartable MFEM solution state associated with this problem.
   Moose::MFEM::SolutionState & _solution_state_data;
+
+private:
+  /// Initialises Hypre and creates a dummy hypre PC to consume -hypre_umpire_device_pool_size
+  void initHypre()
+  {
+    PC pc;
+    LibmeshPetscCall(PCCreate(PETSC_COMM_SELF, &pc));
+    LibmeshPetscCall(PCSetType(pc, PCHYPRE));
+    LibmeshPetscCall(PCDestroy(&pc));
+    mfem::Hypre::Init();
+  }
 };
 
 template <typename T>

--- a/framework/src/mfem/problem/MFEMProblem.C
+++ b/framework/src/mfem/problem/MFEMProblem.C
@@ -75,7 +75,7 @@ MFEMProblem::MFEMProblem(const InputParameters & params)
         "mfem_solution_state", &_problem_data))
 {
   // Initialise Hypre for all MFEM problems.
-  mfem::Hypre::Init();
+  initHypre();
   // Disable multithreading for all MFEM problems (including any libMesh or MFEM subapps).
   libMesh::libMeshPrivateData::_n_threads = 1;
 #ifdef LIBMESH_HAVE_OPENMP

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -893,63 +893,66 @@ class TestHarness:
         else:
             return True
 
-    def shouldOutputMemory(self) -> bool:
-        """Whether or not memory should be output in the Job status."""
-        return self.scheduler.MONITOR_JOB_MEMORY and not self.options.no_memory_tracking
+    def shouldOutputCPUMemory(self) -> bool:
+        """Whether or not CPU memory should be output in the Job status."""
+        return self.scheduler.tracksCPUMemory()
+
+    def shouldOutputGPUMemory(self) -> bool:
+        """Whether or not CPU memory should be output in the Job status."""
+        return self.scheduler.tracksGPUMemory()
 
     def handleJobStatus(self, job, caveats=None):
         """
         The Scheduler is calling back the TestHarness to inform us of a status change.
         The job may or may not be finished yet (RUNNING), or failing, passing, etc.
         """
-        if self.options.show_last_run and job.isSkip():
+        if (self.options.show_last_run and job.isSkip()) or job.isSilent():
             return
-        elif not job.isSilent():
-            memory = None if self.shouldOutputMemory() else False
 
-            # Print results and perform any desired post job processing
-            if job.isFinished():
-                joint_status = job.getJointStatus()
-                self.error_code = self.error_code | joint_status.status_code
+        cpu_memory = None if self.shouldOutputCPUMemory() else False
+        gpu_memory = None if self.shouldOutputGPUMemory() else False
 
-                # perform printing of application output if so desired
-                output = job.getOutputForScreen()
-                if output:
-                    print(output)
+        # Helper for printing the job status for each branch
+        def print_status(**kwargs):
+            print(
+                util.formatJobResult(
+                    job,
+                    self.options,
+                    status_message=False,
+                    cpu_memory=cpu_memory,
+                    gpu_memory=gpu_memory,
+                    **kwargs,
+                ),
+                flush=True,
+            )
 
-                # Print status with caveats (if caveats not overridden)
-                caveats = True if caveats is None else caveats
-                print(
-                    util.formatJobResult(
-                        job, self.options, caveats=caveats, memory=memory
-                    ),
-                    flush=True,
-                )
+        # Print results and perform any desired post job processing
+        if job.isFinished():
+            joint_status = job.getJointStatus()
+            self.error_code = self.error_code | joint_status.status_code
 
-                # Store job as finished for printing
-                self.finished_jobs.append(job)
+            # perform printing of application output if so desired
+            output = job.getOutputForScreen()
+            if output:
+                print(output)
 
-                if job.isSkip():
-                    self.num_skipped += 1
-                elif job.isPass():
-                    self.num_passed += 1
-                elif job.isFail():
-                    self.num_failed += 1
-                else:
-                    self.num_pending += 1
-            # Just print current status without a status message
+            # Print status with caveats (if caveats not overridden)
+            print_status(caveats=(True if caveats is None else caveats))
+
+            # Store job as finished for printing
+            self.finished_jobs.append(job)
+
+            if job.isSkip():
+                self.num_skipped += 1
+            elif job.isPass():
+                self.num_passed += 1
+            elif job.isFail():
+                self.num_failed += 1
             else:
-                caveats = False if caveats is None else caveats
-                print(
-                    util.formatJobResult(
-                        job,
-                        self.options,
-                        status_message=False,
-                        caveats=caveats,
-                        memory=memory,
-                    ),
-                    flush=True,
-                )
+                self.num_pending += 1
+        # Just print current status without a status message
+        else:
+            print_status(caveats=(False if caveats is None else caveats))
 
     def getStats(self, time_total: float) -> dict:
         """
@@ -994,7 +997,7 @@ class TestHarness:
         jobs = [j for j in self.finished_jobs if (not j.isSkip() and j.getMaxMemory())]
         jobs = sorted(
             jobs,
-            key=lambda job: job.getMaxMemory() / job.getSlots(),
+            key=lambda job: job.getMaxMemory().cpu / job.getSlots(),
             reverse=True,
         )
         return jobs[0:num]
@@ -1053,39 +1056,44 @@ class TestHarness:
         if not self.finished_jobs:
             print("No tests ran")
 
+        def print_status(job, **kwargs):
+            print(
+                util.formatJobResult(job, self.options, **kwargs),
+                flush=True,
+            )
+
+        cpu_memory = None if self.shouldOutputCPUMemory() else False
+        gpu_memory = None if self.shouldOutputGPUMemory() else False
+
         # Longest jobs and longest folders
         if not self.options.dry_run and self.options.longest_jobs:
             longest_jobs = self.getLongestJobs(self.options.longest_jobs)
             if longest_jobs:
                 print(header(f"{self.options.longest_jobs} Longest Running Jobs"))
                 for job in longest_jobs:
-                    print(
-                        util.formatJobResult(
-                            job,
-                            self.options,
-                            caveats=True,
-                            timing=True,
-                            memory=None if self.shouldOutputMemory() else False,
-                        )
+                    print_status(
+                        job,
+                        timing=True,
+                        caveats=True,
+                        cpu_memory=cpu_memory,
+                        gpu_memory=gpu_memory,
                     )
 
             # Heaviest jobs by memory
-            if self.shouldOutputMemory() and (
+            if self.shouldOutputCPUMemory() and (
                 heaviest_jobs := self.getHeaviestJobs(self.options.longest_jobs)
             ):
                 print(
                     header(f"{self.options.longest_jobs} Heaviest Jobs (memory/slot)")
                 )
                 for job in heaviest_jobs:
-                    print(
-                        util.formatJobResult(
-                            job,
-                            self.options,
-                            caveats=True,
-                            timing=True,
-                            memory=True,
-                            memory_per_slot=True,
-                        )
+                    print_status(
+                        job,
+                        timing=True,
+                        caveats=True,
+                        cpu_memory=True,
+                        gpu_memory=(gpu_memory is True),
+                        memory_per_slot=True,
                     )
 
             longest_folders = self.getLongestFolders(self.options.longest_jobs)
@@ -1100,7 +1108,11 @@ class TestHarness:
                     entry = util.FormatResultEntry(name=folder, timing=time)
                     print(
                         util.formatResult(
-                            entry, self.options, timing=True, memory=False
+                            entry,
+                            self.options,
+                            timing=True,
+                            cpu_memory=False,
+                            gpu_memory=False,
                         )
                     )
 
@@ -1115,7 +1127,7 @@ class TestHarness:
         if failed_jobs := [j for j in self.finished_jobs if j.isFail()]:
             print(header("Failed Tests"))
             for job in failed_jobs:
-                print((util.formatJobResult(job, self.options, caveats=True)))
+                print_status(job, caveats=True)
 
         time_total = (datetime.datetime.now() - self.start_time).total_seconds()
         stats = self.getStats(time_total)

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1473,6 +1473,13 @@ class TestHarness:
                 raise argparse.ArgumentTypeError("must be positive")
             return value
 
+        # Helper for requiring a positive integer argument
+        def positive_int(value):
+            value = int(value)
+            if value <= 0:
+                raise argparse.ArgumentTypeError("must be a positive integer")
+            return value
+
         parser = argparse.ArgumentParser(
             description="A tool used to test MOOSE-based applications"
         )
@@ -1540,7 +1547,7 @@ class TestHarness:
             "--jobs",
             nargs="?",
             action="store",
-            type=int,
+            type=positive_int,
             dest="jobs",
             const=1,
             help="Set the number of parallel jobs for tests",
@@ -1549,7 +1556,7 @@ class TestHarness:
             "-l",
             "--load-average",
             action="store",
-            type=float,
+            type=positive_float,
             dest="load",
             help="Do not run additional tests if the load average is at least LOAD",
         )
@@ -1558,7 +1565,7 @@ class TestHarness:
             "--parallel",
             nargs="?",
             action="store",
-            type=int,
+            type=positive_int,
             dest="parallel",
             const=1,
             help="Number of MPI processes to use for each job",
@@ -1567,10 +1574,10 @@ class TestHarness:
             "--n-threads",
             nargs=1,
             action="store",
-            type=int,
+            type=positive_int,
             dest="nthreads",
             default=1,
-            help="Number of threads to use when running mpiexec",
+            help="Number of threads to use when running mpiexec (default: %(default)s)",
         )
 
         filtergroup = parser.add_argument_group(
@@ -1626,13 +1633,13 @@ class TestHarness:
         filtergroup.add_argument(
             "--min-parallel",
             dest="min_parallel",
-            type=int,
+            type=positive_int,
             help="Skip tests that cannot run with at least this many MPI procs",
         )
         filtergroup.add_argument(
             "--min-threads",
             dest="min_threads",
-            type=int,
+            type=positive_int,
             help="Skip tests that cannot run with at least this many threads",
         )
         filtergroup.add_argument(
@@ -1864,9 +1871,9 @@ class TestHarness:
         screengroup.add_argument(
             "--longest-jobs",
             action="store",
-            type=int,
+            type=positive_int,
             default=0,
-            help="Print the longest running jobs upon completion",
+            help="Print the longest LONGEST_JOBS running jobs upon completion",
         )
         screengroup.add_argument(
             "--no-report",
@@ -1885,9 +1892,9 @@ class TestHarness:
         screengroup.add_argument(
             "--term-cols",
             action="store",
-            type=int,
+            type=positive_int,
             default=term_cols,
-            help="The number columns to use in output",
+            help="The number columns to use in output (default: %(default)s)",
         )
         screengroup.add_argument(
             "--term-format",
@@ -1927,16 +1934,22 @@ class TestHarness:
         failgroup.add_argument(
             "--max-fails",
             nargs=1,
-            type=int,
+            type=positive_int,
             default=50,
-            help="The number of tests allowed to fail before any additional tests will run",
+            help=(
+                "The number of tests allowed to fail before any "
+                "additional tests will run (default: %(default)s)"
+            ),
         )
         failgroup.add_argument(
             "--valgrind-max-fails",
             nargs=1,
-            type=int,
+            type=positive_int,
             default=5,
-            help="The number of valgrind tests allowed to fail before any additional valgrind tests will run",
+            help=(
+                "The number of valgrind tests allowed to fail before "
+                "any additional valgrind tests will run (default: %(default)s)"
+            ),
         )
 
         resourcesgroup = parser.add_argument_group(
@@ -1945,26 +1958,29 @@ class TestHarness:
         resourcesgroup.add_argument(
             "--max-cpu-per-slot",
             nargs=1,
-            type=float,
+            type=positive_float,
             help=("The maximum percent CPU to allow for a job, per slot"),
         )
         resourcesgroup.add_argument(
             "--max-cpu-memory-per-slot",
             nargs=1,
-            type=float,
+            type=positive_float,
             help="The maximum CPU memory to allow for a job in MB, per slot",
         )
         resourcesgroup.add_argument(
             "--max-gpu-memory-per-slot",
             nargs=1,
-            type=float,
+            type=positive_float,
             help="The maximum GPU memory to allow for a job in MB, per slot",
         )
         resourcesgroup.add_argument(
             "--max-memory-per-slot",
             nargs=1,
-            type=float,
-            help="The maximum CPU memory to allow for a job in MB, per slot (deprecated, use --max-cpu-memory-per-slot)",
+            type=positive_float,
+            help=(
+                "The maximum CPU memory to allow for a job in MB,"
+                "per slot (deprecated, use --max-cpu-memory-per-slot)"
+            ),
         )
         resourcesgroup.add_argument(
             "--no-cpu-tracking",
@@ -2011,10 +2027,10 @@ class TestHarness:
         hpcgroup.add_argument(
             "--hpc-file-timeout",
             nargs=1,
-            type=int,
+            type=positive_float,
             action="store",
             default=300,
-            help="The time in seconds to wait for HPC output",
+            help="The time in seconds to wait for HPC output (default: %(default)s)",
         )
         hpcgroup.add_argument(
             "--hpc-host",
@@ -2055,11 +2071,14 @@ class TestHarness:
         hpcgroup.add_argument(
             "--hpc-scatter-procs",
             nargs=1,
-            type=int,
+            type=positive_int,
             action="store",
             dest="hpc_scatter_procs",
             default=None,
-            help="Set to run HPC jobs with scatter placement when the processor count is this or lower",
+            help=(
+                "Set to run HPC jobs with scatter placement processor count "
+                "is this or lower (default: %(default)s)"
+            ),
         )
         hpcgroup.add_argument(
             "--pbs-queue",

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -2148,22 +2148,6 @@ class TestHarness:
             )
             opts.minimal_capabilities = True
 
-        # Set --max-memory-per-slot from MOOSE_MAX_MEMORY_PER_SLOT
-        # if --max-memory-per-slot is not not set
-        if (
-            opts.max_memory_per_slot is None
-            and (
-                MOOSE_MAX_MEMORY_PER_SLOT := os.environ.get("MOOSE_MAX_MEMORY_PER_SLOT")
-            )
-            is not None
-        ):
-            value = float(MOOSE_MAX_MEMORY_PER_SLOT)
-            print_info(
-                f"Setting --max-memory-per-slot={value} MB from "
-                "MOOSE_MAX_MEMORY_PER_SLOT",
-            )
-            opts.max_memory_per_slot = value
-
         # Convert extend action params to lists if they have a single value
         for name in ["ignore_capability"]:
             if (value := getattr(opts, name)) is not None and isinstance(value, str):

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import typing
 from collections import defaultdict, namedtuple
+from enum import Enum
 from socket import gethostname
 from typing import TYPE_CHECKING, Optional, Tuple
 
@@ -33,6 +34,8 @@ from FactorySystem.Warehouse import Warehouse
 
 if TYPE_CHECKING:
     from pycapabilities import Capabilities
+
+    from TestHarness.schedulers.Job import Job
 
 from TestHarness import RaceChecker, util
 from TestHarness.capability_util import (
@@ -416,7 +419,7 @@ class TestHarness:
         self.factory.loadPlugins(dirs, "testers", "IS_TESTER")
 
         self.parse_errors = []
-        self.finished_jobs: list = []
+        self.finished_jobs: list[Job] = []
         self.num_passed = 0
         self.num_failed = 0
         self.num_skipped = 0
@@ -600,7 +603,7 @@ class TestHarness:
                     and name not in AUGMENTED_CAPABILITY_NAMES
                 ):
                     util.errorExit(
-                        "--ignore-capability: Unknown " f"capability '{name}'",
+                        f"--ignore-capability: Unknown capability '{name}'",
                         colored=options.colored,
                     )
 
@@ -697,7 +700,6 @@ class TestHarness:
                                 and os.path.abspath(os.path.join(dirpath, file))
                                 not in launched_tests
                             ):
-
                                 if self.notMySpecFile(dirpath, file):
                                     continue
 
@@ -757,7 +759,6 @@ class TestHarness:
 
         # Augment the Testers with additional information directly from the TestHarness
         for tester in testers:
-
             self.augmentParameters(file, tester, testroot_params)
             if testroot_params.get("caveats"):
                 # Show what executable we are using if using a different testroot file
@@ -990,16 +991,24 @@ class TestHarness:
         jobs = sorted(jobs, key=lambda job: job.getTiming(), reverse=True)
         return jobs[0:num]
 
-    def getHeaviestJobs(self, num: int) -> list:
-        """
-        Get the heaviest jobs by memory, if available
-        """
+    class MemoryType(Enum):
+        """A type of memory (cpu or GPU)."""
+
+        CPU = 0
+        GPU = 1
+
+    def getHeaviestJobs(self, num: int, memory_type: MemoryType) -> list:
+        """Get the heaviest jobs by memory, if available."""
         jobs = [j for j in self.finished_jobs if (not j.isSkip() and j.getMaxMemory())]
-        jobs = sorted(
-            jobs,
-            key=lambda job: job.getMaxMemory().cpu / job.getSlots(),
-            reverse=True,
-        )
+
+        def key(job):
+            max_memory = job.getMaxMemory()
+            numer = (
+                max_memory.cpu if memory_type == self.MemoryType.CPU else max_memory.gpu
+            )
+            return numer / job.getSlots()
+
+        jobs = sorted(jobs, key=key, reverse=True)
         return jobs[0:num]
 
     def getLongestFolders(self, num: int) -> list[typing.Tuple[str, float]]:
@@ -1062,8 +1071,8 @@ class TestHarness:
                 flush=True,
             )
 
-        cpu_memory = None if self.shouldOutputCPUMemory() else False
-        gpu_memory = None if self.shouldOutputGPUMemory() else False
+        cpu_memory = self.shouldOutputCPUMemory()
+        gpu_memory = self.shouldOutputGPUMemory()
 
         # Longest jobs and longest folders
         if not self.options.dry_run and self.options.longest_jobs:
@@ -1080,19 +1089,33 @@ class TestHarness:
                     )
 
             # Heaviest jobs by memory
-            if self.shouldOutputCPUMemory() and (
-                heaviest_jobs := self.getHeaviestJobs(self.options.longest_jobs)
-            ):
-                print(
-                    header(f"{self.options.longest_jobs} Heaviest Jobs (memory/slot)")
+            for condition, memory_type in [
+                (cpu_memory, self.MemoryType.CPU),
+                (gpu_memory, self.MemoryType.GPU),
+            ]:
+                if not condition:
+                    continue
+
+                heaviest_jobs = self.getHeaviestJobs(
+                    self.options.longest_jobs, memory_type
                 )
+                if not heaviest_jobs:
+                    continue
+
+                print(
+                    header(
+                        f"{self.options.longest_jobs} Heaviest {memory_type.name} "
+                        "Jobs (memory/slot)"
+                    )
+                )
+
                 for job in heaviest_jobs:
                     print_status(
                         job,
                         timing=True,
                         caveats=True,
-                        cpu_memory=True,
-                        gpu_memory=(gpu_memory is True),
+                        cpu_memory=cpu_memory,
+                        gpu_memory=gpu_memory,
                         memory_per_slot=True,
                     )
 
@@ -1135,12 +1158,12 @@ class TestHarness:
         # Final summary for the bottom
         summary = ""
         if self.options.dry_run:
-            summary += f'Processed {self.num_passed + self.num_skipped} tests in {stats["time_total"]:.1f} seconds.\n'
+            summary += f"Processed {self.num_passed + self.num_skipped} tests in {stats['time_total']:.1f} seconds.\n"
             summary += f"<b>{self.num_passed} would run</b>, <b>{self.num_skipped} would be skipped</b>"
         else:
-            summary += f'Ran {self.num_passed + self.num_failed} tests in {stats["time_total"]:.1f} seconds.'
-            summary += f' Average test time {stats["time_average"]:.1f} seconds,'
-            summary += f' maximum test time {stats["time_max"]:.1f} seconds.\n'
+            summary += f"Ran {self.num_passed + self.num_failed} tests in {stats['time_total']:.1f} seconds."
+            summary += f" Average test time {stats['time_average']:.1f} seconds,"
+            summary += f" maximum test time {stats['time_max']:.1f} seconds.\n"
 
             # Get additional results from the scheduler
             scheduler_summary = self.scheduler.appendResultFooter(stats)
@@ -1919,10 +1942,22 @@ class TestHarness:
             help=("The maximum percent CPU to allow for a job, per slot"),
         )
         resourcesgroup.add_argument(
+            "--max-cpu-memory-per-slot",
+            nargs=1,
+            type=float,
+            help="The maximum CPU memory to allow for a job in MB, per slot",
+        )
+        resourcesgroup.add_argument(
+            "--max-gpu-memory-per-slot",
+            nargs=1,
+            type=float,
+            help="The maximum GPU memory to allow for a job in MB, per slot",
+        )
+        resourcesgroup.add_argument(
             "--max-memory-per-slot",
             nargs=1,
             type=float,
-            help="The maximum memory to allow for a job in MB, per slot",
+            help="The maximum CPU memory to allow for a job in MB, per slot (deprecated, use --max-cpu-memory-per-slot)",
         )
         resourcesgroup.add_argument(
             "--no-cpu-tracking",
@@ -1933,6 +1968,11 @@ class TestHarness:
             "--no-memory-tracking",
             action="store_true",
             help="Disable all memory tracking of jobs",
+        )
+        resourcesgroup.add_argument(
+            "--no-gpu-memory-tracking",
+            action="store_true",
+            help="Disable all GPU memory tracking of jobs",
         )
 
         hpcgroup = parser.add_argument_group("HPC", "Enable and control HPC execution")
@@ -2148,6 +2188,17 @@ class TestHarness:
             )
             opts.minimal_capabilities = True
 
+        # Set --max-cpu-memory-per-slot from deprecated --max-memory-per-slot
+        if (
+            opts.max_memory_per_slot is not None
+            and opts.max_cpu_memory_per_slot is None
+        ):
+            opts.max_cpu_memory_per_slot = opts.max_memory_per_slot
+            print_info(
+                f"Setting --max-cpu-memory-per-slot={opts.max_cpu_memory_per_slot} "
+                "from deprecated --max-memory-per-slot"
+            )
+
         # Convert extend action params to lists if they have a single value
         for name in ["ignore_capability"]:
             if (value := getattr(opts, name)) is not None and isinstance(value, str):
@@ -2166,6 +2217,10 @@ class TestHarness:
 
     def getOptions(self):
         return self.options
+
+    def isGPUComputeDevice(self) -> bool:
+        """Whether or not the set --compute-device includes GPUs."""
+        return self.options.compute_device in ["cuda"]
 
     # Helper tuple for storing information about a cluster
     HPCCluster = namedtuple("HPCCluster", ["scheduler", "apptainer_modules", "srun"])

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1466,6 +1466,13 @@ class TestHarness:
         if term_format == "tpnsc":
             term_format = "tmpnsc"
 
+        # Helper for requiring a positive float argument
+        def positive_float(value):
+            value = float(value)
+            if value <= 0:
+                raise argparse.ArgumentTypeError("must be positive")
+            return value
+
         parser = argparse.ArgumentParser(
             description="A tool used to test MOOSE-based applications"
         )
@@ -1973,6 +1980,12 @@ class TestHarness:
             "--no-gpu-memory-tracking",
             action="store_true",
             help="Disable all GPU memory tracking of jobs",
+        )
+        resourcesgroup.add_argument(
+            "--memory-tracking-interval",
+            type=positive_float,
+            default=0.25,
+            help="Interval at which to poll for memory usage (default: %(default)s)",
         )
 
         hpcgroup = parser.add_argument_group("HPC", "Enable and control HPC execution")

--- a/python/TestHarness/runners/Runner.py
+++ b/python/TestHarness/runners/Runner.py
@@ -8,6 +8,7 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 import os
+from dataclasses import dataclass
 from threading import Lock
 from typing import TYPE_CHECKING, Optional
 
@@ -38,7 +39,7 @@ class Runner(OutputInterface):
         """The Scheduler options."""
         self.exit_code = None
         """The job's exit code, should be set after wait()."""
-        self._max_memory: Optional[int] = None
+        self._max_memory: Optional[Runner.MaxMemory] = None
         """The job's estimated max memory in bytes, if any."""
         self._max_memory_lock = Lock()
         """Thread lock for _max_memory."""
@@ -55,6 +56,15 @@ class Runner(OutputInterface):
         separately.
         """
 
+    @dataclass(slots=True)
+    class MaxMemory:
+        """Structure for storing a Job's max memory usage, CPU and GPU."""
+
+        cpu: int = 0
+        """The max CPU memory for the job, in bytes."""
+        gpu: Optional[int] = 0
+        """The max GPU memory for the job, in bytes."""
+
     @property
     def pid(self) -> Optional[int]:
         """Get the pid of the running local process, if any."""
@@ -62,7 +72,7 @@ class Runner(OutputInterface):
         return None
 
     @property
-    def max_memory(self) -> Optional[int]:
+    def max_memory(self) -> Optional[MaxMemory]:
         """
         Get the estimated max memory in bytes for the job.
 
@@ -71,9 +81,9 @@ class Runner(OutputInterface):
         with self._max_memory_lock:
             return self._max_memory
 
-    def updateMaxMemory(self, value: int) -> bool:
+    def updateMaxMemory(self, cpu_memory: int, gpu_memory: Optional[int]) -> bool:
         """
-        Update the max memory in bytes for the process, if greater.
+        Update the max CPU and GPU memory in bytes for the process, if greater.
 
         Should be used by derived runners to set the memory
         as it is running if available.
@@ -85,8 +95,15 @@ class Runner(OutputInterface):
         the value was greater than the current max memory).
         """
         with self._max_memory_lock:
-            if self._max_memory is None or value > self._max_memory:
-                self._max_memory = value
+            if self._max_memory is None:
+                self._max_memory = self.MaxMemory(cpu_memory, gpu_memory)
+            else:
+                if cpu_memory > self._max_memory.cpu:
+                    self._max_memory.cpu = cpu_memory
+                if gpu_memory is not None and (
+                    self._max_memory.gpu is None or gpu_memory > self._max_memory.gpu
+                ):
+                    self._max_memory.gpu = gpu_memory
                 return True
         return False
 

--- a/python/TestHarness/runners/Runner.py
+++ b/python/TestHarness/runners/Runner.py
@@ -98,13 +98,16 @@ class Runner(OutputInterface):
             if self._max_memory is None:
                 self._max_memory = self.MaxMemory(cpu_memory, gpu_memory)
             else:
+                updated = False
                 if cpu_memory > self._max_memory.cpu:
                     self._max_memory.cpu = cpu_memory
+                    updated = True
                 if gpu_memory is not None and (
                     self._max_memory.gpu is None or gpu_memory > self._max_memory.gpu
                 ):
                     self._max_memory.gpu = gpu_memory
-                return True
+                    updated = True
+                return updated
         return False
 
     @property

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -892,10 +892,10 @@ class Job(OutputInterface):
             return self.timer.totalTime()
         return 0.0
 
-    def getMaxMemory(self) -> Optional[int]:
+    def getMaxMemory(self) -> Optional[Runner.MaxMemory]:
         """Get the Job's estimated max memory usage in bytes, if any."""
         if self._runner is not None and (value := self._runner.max_memory) is not None:
-            return value
+            return copy.deepcopy(value)
         return None
 
     def getStatus(self):
@@ -1024,7 +1024,9 @@ class Job(OutputInterface):
         else:
             job_data["output"] = self.getAllOutput()
         if (max_memory := self.getMaxMemory()) is not None:
-            job_data["max_memory"] = max_memory
+            job_data["max_memory_cpu"] = max_memory.cpu
+            if max_memory.gpu is not None:
+                job_data["max_memory_gpu"] = max_memory.gpu
 
         unique_test_id = self.getTester().getUniqueTestID()
         if unique_test_id is not None:

--- a/python/TestHarness/schedulers/RunLocal.py
+++ b/python/TestHarness/schedulers/RunLocal.py
@@ -8,26 +8,34 @@
 # https://www.gnu.org/licenses/lgpl-2.1.html
 
 import os
-import platform
-from importlib.util import find_spec
 from typing import TYPE_CHECKING, Optional
 
 from TestHarness.runners.SubprocessRunner import Runner, SubprocessRunner
 from TestHarness.schedulers.Scheduler import Scheduler
 
-_MONITOR_JOB_MEMORY = platform.system() != "Windows" and find_spec("psutil") is not None
-if _MONITOR_JOB_MEMORY or TYPE_CHECKING:
-    from TestHarness.utils.monitor_processes import MemoryMonitor
+CANNOT_MONITOR_JOB_MEMORY_REASON: Optional[str] = None
+"""Reason for not being able to monitor job memory, if any."""
+try:
+    import TestHarness.utils.monitor_processes
+except ImportError as e:
+    CANNOT_MONITOR_JOB_MEMORY_REASON = str(e)
+
+if CANNOT_MONITOR_JOB_MEMORY_REASON is None or TYPE_CHECKING:
+    from TestHarness.utils.monitor_processes import (
+        NO_CUDA_TRACKING_REASON,
+        MemoryMonitor,
+    )
 
 
 class RunLocal(Scheduler):
     """A scheduler for executing tester commands locally."""
 
     CAN_SET_HWLOC_TOPOLOGY = True
-    CAN_SET_MAX_MEMORY = True
+    CAN_SET_MAX_CPU_MEMORY = True
+    CAN_SET_MAX_GPU_MEMORY = True
     CAN_OPENMPI_OVERSUBSCRIBE = True
     MONITOR_JOB_CPU = True
-    MONITOR_JOB_MEMORY = _MONITOR_JOB_MEMORY
+    MONITOR_JOB_MEMORY = CANNOT_MONITOR_JOB_MEMORY_REASON is None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -42,9 +50,26 @@ class RunLocal(Scheduler):
         """Whether or not CPU memory is being tracked."""
 
         # Setup the monitor if enabled
+        track_nvidia = False
         if self.scheduler_options.monitor_job_memory:
+            # Cannot monitor Job memory for some reason
+            if CANNOT_MONITOR_JOB_MEMORY_REASON is not None:
+                self.harness.errorExit(
+                    "Cannot monitor job memory: "
+                    + CANNOT_MONITOR_JOB_MEMORY_REASON
+                    + "; set --no-memory-tracking"
+                )
+
             # Whether or not we should track Nvidia GPU memory
-            track_nvidia = self.options.compute_device == "cuda"
+            track_nvidia = False
+            if self.scheduler_options.monitor_job_gpu_memory:
+                track_nvidia = self.options.compute_device == "cuda"
+                if track_nvidia and NO_CUDA_TRACKING_REASON is not None:
+                    self.harness.errorExit(
+                        "Cannot monitor job GPU memory: "
+                        + NO_CUDA_TRACKING_REASON
+                        + "; set --no-gpu-memory-tracking"
+                    )
 
             self._memory_monitor = MemoryMonitor(
                 os.getpid(), track_nvidia=track_nvidia, interval=0.1
@@ -82,7 +107,8 @@ class RunLocal(Scheduler):
         gpu_samples = self._memory_monitor.get_gpu_samples()
 
         # Update job memory and kill jobs over memory
-        max_memory_per_slot_mb = self.options.max_memory_per_slot
+        max_cpu_memory_per_slot = self.options.max_cpu_memory_per_slot
+        max_gpu_memory_per_slot = self.options.max_gpu_memory_per_slot
         for pid, job in pid_to_job.items():
             runner = job.getRunner()
             assert runner is not None
@@ -101,26 +127,37 @@ class RunLocal(Scheduler):
                 gpu_samples.get(pid, 0) if gpu_samples is not None else None
             )
 
-            # Update max memory, if greater; this is True if greater
-            updated = runner.updateMaxMemory(job_cpu_memory_bytes, job_gpu_memory_bytes)
+            # Update max memory; this will return True if something was updated
+            # (we hit a higher max). Thus, if not updated, return as we have
+            # no checking to perform
+            if not runner.updateMaxMemory(job_cpu_memory_bytes, job_gpu_memory_bytes):
+                return
 
-            # Check memory usage if needed
-            if (
-                updated
-                and max_memory_per_slot_mb
-                and (
-                    job_memory_per_slot_mb := (
-                        job_cpu_memory_bytes / job.getSlots() * 2**-20
-                    )
-                )
-                > max_memory_per_slot_mb
+            # Utility for checking CPU and GPU memory if appropriate
+            def check_memory(
+                memory_per_slot: float, memory_bytes: int, memory_type: str
             ):
-                message = (
-                    "JOB KILLED (OVER MEMORY): "
-                    f"Memory/slot {job_memory_per_slot_mb:.2f} "
-                    f"MB > allowed {max_memory_per_slot_mb:.2f} MB"
-                )
-                job.killProcess(job.error, "KILLED: OVER MEMORY", message)
+                if (
+                    memory_per_slot
+                    and (
+                        job_memory_per_slot_mb := (
+                            memory_bytes / job.getSlots() * 2**-20
+                        )
+                    )
+                    > memory_per_slot
+                ):
+                    message = (
+                        f"JOB KILLED (OVER {memory_type} MEMORY): "
+                        f"{memory_type} Memory/slot {job_memory_per_slot_mb:.2f} "
+                        f"MB > allowed {memory_per_slot:.2f} MB"
+                    )
+                    job.killProcess(
+                        job.error, f"KILLED: OVER {memory_type} MEMORY", message
+                    )
+
+            check_memory(max_cpu_memory_per_slot, job_cpu_memory_bytes, "CPU")
+            if job_gpu_memory_bytes:
+                check_memory(max_gpu_memory_per_slot, job_gpu_memory_bytes, "GPU")
 
     def tracksCPUMemory(self) -> bool:
         """Whether or not CPU memory is being tracked."""

--- a/python/TestHarness/schedulers/RunLocal.py
+++ b/python/TestHarness/schedulers/RunLocal.py
@@ -72,7 +72,9 @@ class RunLocal(Scheduler):
                     )
 
             self._memory_monitor = MemoryMonitor(
-                os.getpid(), track_nvidia=track_nvidia, interval=0.1
+                os.getpid(),
+                track_nvidia=track_nvidia,
+                interval=self.scheduler_options.memory_tracking_interval,
             )
 
             self._track_cpu_memory = True

--- a/python/TestHarness/schedulers/RunLocal.py
+++ b/python/TestHarness/schedulers/RunLocal.py
@@ -35,8 +35,24 @@ class RunLocal(Scheduler):
         self._memory_monitor: Optional[MemoryMonitor] = None
         """The MemoryMonitor for sampling child process memory, if any."""
 
+        self._track_cpu_memory: bool = False
+        """Whether or not CPU memory is being tracked."""
+
+        self._track_gpu_memory: bool = False
+        """Whether or not CPU memory is being tracked."""
+
+        # Setup the monitor if enabled
         if self.scheduler_options.monitor_job_memory:
-            self._memory_monitor = MemoryMonitor(os.getpid(), interval=0.1)
+            # Whether or not we should track Nvidia GPU memory
+            track_nvidia = self.options.compute_device == "cuda"
+
+            self._memory_monitor = MemoryMonitor(
+                os.getpid(), track_nvidia=track_nvidia, interval=0.1
+            )
+
+            self._track_cpu_memory = True
+            if track_nvidia:
+                self._track_gpu_memory = True
 
     def buildRunner(self, job, options) -> Runner:
         """Build a SubprocessRunner."""
@@ -44,8 +60,7 @@ class RunLocal(Scheduler):
 
     def waitFinish(self):
         # Start the memory monitor if enabled
-        if self.scheduler_options.monitor_job_memory:
-            self._memory_monitor = MemoryMonitor(os.getpid(), interval=0.2)
+        if self._memory_monitor is not None:
             self._memory_monitor.start()
 
         super().waitFinish()
@@ -63,23 +78,31 @@ class RunLocal(Scheduler):
         pid_to_job = self.getActiveJobPIDMap()
 
         # Get latest samples from the monitor
-        samples = self._memory_monitor.get_samples()
+        cpu_samples = self._memory_monitor.get_cpu_samples()
+        gpu_samples = self._memory_monitor.get_gpu_samples()
 
         # Update job memory and kill jobs over memory
         max_memory_per_slot_mb = self.options.max_memory_per_slot
         for pid, job in pid_to_job.items():
-            job_memory_bytes = samples.get(pid)
+            runner = job.getRunner()
+            assert runner is not None
+
+            job_cpu_memory_bytes = cpu_samples.get(pid)
 
             # Didn't get samples for this Job's process
-            if job_memory_bytes is None:
+            if job_cpu_memory_bytes is None:
                 continue
 
             # If the job is already an error (we may have killed it), nothing to do
             if job.getStatus() == job.error:
                 continue
 
+            job_gpu_memory_bytes = (
+                gpu_samples.get(pid, 0) if gpu_samples is not None else None
+            )
+
             # Update max memory, if greater; this is True if greater
-            updated = job.getRunner().updateMaxMemory(job_memory_bytes)
+            updated = runner.updateMaxMemory(job_cpu_memory_bytes, job_gpu_memory_bytes)
 
             # Check memory usage if needed
             if (
@@ -87,7 +110,7 @@ class RunLocal(Scheduler):
                 and max_memory_per_slot_mb
                 and (
                     job_memory_per_slot_mb := (
-                        job_memory_bytes / job.getSlots() * 2**-20
+                        job_cpu_memory_bytes / job.getSlots() * 2**-20
                     )
                 )
                 > max_memory_per_slot_mb
@@ -98,3 +121,11 @@ class RunLocal(Scheduler):
                     f"MB > allowed {max_memory_per_slot_mb:.2f} MB"
                 )
                 job.killProcess(job.error, "KILLED: OVER MEMORY", message)
+
+    def tracksCPUMemory(self) -> bool:
+        """Whether or not CPU memory is being tracked."""
+        return self._track_cpu_memory
+
+    def tracksGPUMemory(self) -> bool:
+        """Whether or not GPU memory is being tracked."""
+        return self._track_gpu_memory

--- a/python/TestHarness/schedulers/RunSlurm.py
+++ b/python/TestHarness/schedulers/RunSlurm.py
@@ -159,3 +159,11 @@ class RunSlurm(RunHPC):
         if not search:
             raise Exception(f'Failed to parse job ID from "{result}"')
         return str(search.group(1))
+
+    def tracksCPUMemory(self) -> bool:
+        """
+        Whether or not CPU memory is being tracked.
+
+        Always valid with slurm.
+        """
+        return True

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -817,8 +817,9 @@ class Scheduler(MooseObject):
             # Job is done (or needs to re-enter the queue)
             self.queueJobs(jobs)
 
-        except Exception:
-            print("runWorker Exception: %s" % (traceback.format_exc()))
+        except Exception as e:
+            if not isinstance(Exception, ValueError) and str(e) != "Pool not running":
+                print("runWorker Exception: %s" % (traceback.format_exc()))
             self.killRemaining()
 
         except KeyboardInterrupt:

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -61,7 +61,8 @@ class SchedulerOptions:
     """Whether or not to monitor Job memory usage."""
     monitor_job_gpu_memory: bool
     """Whether or not to monitor Job GPU memory usage."""
-
+    memory_tracking_interval: float
+    """Interval at which to poll for memory usage"""
     time_utility_path: Optional[str]
     """The path to the time utility found, if any."""
     time_utility_type: TimeUtilityType
@@ -276,6 +277,7 @@ class Scheduler(MooseObject):
             monitor_job_cpu=monitor_job_cpu,
             monitor_job_memory=monitor_job_memory,
             monitor_job_gpu_memory=monitor_job_gpu_memory,
+            memory_tracking_interval=self.options.memory_tracking_interval,
             time_utility_path=time_utility_path,
             time_utility_type=time_utility_type,
         )

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -817,3 +817,11 @@ class Scheduler(MooseObject):
     def appendStats(self) -> dict:
         """Entrypoint to add entries to the harness statistics"""
         return {}
+
+    def tracksCPUMemory(self) -> bool:
+        """Whether or not this Scheduler tracks CPU memory."""
+        return False
+
+    def tracksGPUMemory(self) -> bool:
+        """Whether or not this Scheduler tracks GPU memory."""
+        return False

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -59,6 +59,8 @@ class SchedulerOptions:
     """Whether or not to monitor Job CPU usage."""
     monitor_job_memory: bool
     """Whether or not to monitor Job memory usage."""
+    monitor_job_gpu_memory: bool
+    """Whether or not to monitor Job GPU memory usage."""
 
     time_utility_path: Optional[str]
     """The path to the time utility found, if any."""
@@ -102,8 +104,10 @@ class Scheduler(MooseObject):
 
     CAN_SET_HWLOC_TOPOLOGY = False
     """Whether or not to set hwloc topology if available."""
-    CAN_SET_MAX_MEMORY = False
-    """Whether or not Job max memory can be set (Jobs can be killed if over memory)."""
+    CAN_SET_MAX_CPU_MEMORY = False
+    """Whether or not Job max CPU memory can be set."""
+    CAN_SET_MAX_GPU_MEMORY = True
+    """Whether or not Job max GPU memory can be set."""
     CAN_OPENMPI_OVERSUBSCRIBE = False
     """Whether or not OpenMPI can be set to oversubscribe."""
     MONITOR_JOB_CPU = False
@@ -201,6 +205,9 @@ class Scheduler(MooseObject):
         monitor_job_memory: bool = (
             self.MONITOR_JOB_MEMORY is True and not options.no_memory_tracking
         )
+        monitor_job_gpu_memory: bool = (
+            monitor_job_memory is True and not options.no_gpu_memory_tracking
+        )
 
         # Find the time utility if needed, disabling CPU tracking
         # if enabled but no time utility available
@@ -220,27 +227,41 @@ class Scheduler(MooseObject):
             self.CAN_SET_HWLOC_TOPOLOGY
             and mpi_config.hwloc
             and not options.no_hwloc_topology
+            and (hwloc_topology_path := build_hwloc_topology())
         ):
-            if hwloc_topology_path := build_hwloc_topology():
-                self.harness.printInfo(
-                    f"Using cached hwloc topology in '{hwloc_topology_path}'"
-                )
+            self.harness.printInfo(
+                f"Using cached hwloc topology in '{hwloc_topology_path}'"
+            )
 
         # Can't restrict resources without tracking
         if self.options.max_cpu_per_slot and not monitor_job_cpu:
             self.harness.errorExit(
                 "Cannot specify --max-cpu-per-slot; CPU tracking is not available"
             )
-        if self.options.max_memory_per_slot and (
-            not monitor_job_memory or not self.CAN_SET_MAX_MEMORY
+        if self.options.max_cpu_memory_per_slot is not None and (
+            not monitor_job_memory or not self.CAN_SET_MAX_CPU_MEMORY
         ):
             self.harness.errorExit(
-                "Cannot specify --max-memory-per-slot; memory tracking is not available"
+                "Cannot specify --max-cpu-memory-per-slot; "
+                "CPU memory tracking is not available"
             )
+        if self.options.max_gpu_memory_per_slot is not None:
+            if not monitor_job_gpu_memory or not self.CAN_SET_MAX_GPU_MEMORY:
+                self.harness.errorExit(
+                    "Cannot specify --max-gpu-memory-per-slot; "
+                    "GPU memory tracking is not available"
+                )
+            if not self.harness.isGPUComputeDevice():
+                self.harness.errorExit(
+                    "Cannot specify --max-gpu-memory-per slot; "
+                    f"--compute-device={self.options.compute_device} is not a GPU"
+                )
+        if monitor_job_gpu_memory and not self.harness.isGPUComputeDevice():
+            monitor_job_gpu_memory = False
         # Can't disable hwloc topology
         if options.no_hwloc_topology and not self.CAN_SET_HWLOC_TOPOLOGY:
             self.harness.errorExit(
-                "Cannot --no-hwloc-topology; scheduler does not " "support setting it"
+                "Cannot --no-hwloc-topology; scheduler does not support setting it"
             )
         # Can't disable openmpi oversubscribe
         if options.no_openmpi_oversubscribe and not self.CAN_OPENMPI_OVERSUBSCRIBE:
@@ -254,6 +275,7 @@ class Scheduler(MooseObject):
             mpi_config=mpi_config,
             monitor_job_cpu=monitor_job_cpu,
             monitor_job_memory=monitor_job_memory,
+            monitor_job_gpu_memory=monitor_job_gpu_memory,
             time_utility_path=time_utility_path,
             time_utility_type=time_utility_type,
         )

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -144,12 +144,6 @@ class RunApp(Tester):
             "Set to (NONE, NORMAL, HEAVY) to determine which configurations where valgrind will run.",
         )
 
-        device_list_str = "', '".join(
-            d.upper() for d in TestHarness.validComputeDevices()
-        )
-        device_param_doc = f"The devices to use for this libtorch or MFEM test ('{device_list_str}'); device availability depends on library support and compilation settings; default ('CPU')"
-        params.addParam("compute_devices", ["CPU"], device_param_doc)
-
         return params
 
     def __init__(self, name, params):
@@ -191,10 +185,6 @@ class RunApp(Tester):
                 "The parameters 'command_proxy' and 'no_additional_cli_args' "
                 "cannot be supplied together"
             )
-
-        for value in params["compute_devices"]:
-            if value.lower() not in TestHarness.validComputeDevices():
-                raise Exception(f'Unknown device "{value}"')
 
         # The capabilities file that we need to set with
         # --testharness-capabilities, if any. This should
@@ -245,13 +235,6 @@ class RunApp(Tester):
             self.addCaveats("EXECUTABLE PATTERN")
             self.setStatus(self.skip)
             return False
-
-        devices_lower = [x.lower() for x in self.specs["compute_devices"]]
-        if options.compute_device not in devices_lower:
-            self.addCaveats(f"{options.compute_device} not in compute devices")
-            self.setStatus(self.skip)
-            return False
-
         if (
             options.hpc
             and self.specs.isValid("command_proxy")

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -21,7 +21,7 @@ import mooseutils
 from FactorySystem.InputParameters import InputParameters
 from FactorySystem.MooseObject import MooseObject
 
-from TestHarness import OutputInterface
+from TestHarness import OutputInterface, TestHarness
 from TestHarness.capability_util import checkAppCapabilities
 from TestHarness.StatusSystem import StatusSystem
 from TestHarness.validation import ValidationCase, ValidationCaseClasses
@@ -237,6 +237,13 @@ class Tester(MooseObject, OutputInterface):
             "hpc_mem_per_cpu", "Memory requirement per CPU to use for HPC submission"
         )
 
+        # Compute devices
+        device_list_str = "', '".join(
+            d.upper() for d in TestHarness.validComputeDevices()
+        )
+        device_param_doc = f"The devices to use for this libtorch or MFEM test ('{device_list_str}'); device availability depends on library support and compilation settings; default ('CPU')"
+        params.addParam("compute_devices", ["CPU"], device_param_doc)
+
         params.addParam(
             "validation_test", None, "List of validation scripts to run with this test"
         )
@@ -443,6 +450,10 @@ class Tester(MooseObject, OutputInterface):
 
         self._capability_names: Optional[set[str]] = None
         """The capability names from the checked "capabilities" param, if any."""
+
+        for value in params["compute_devices"]:
+            if value.lower() not in TestHarness.validComputeDevices():
+                raise Exception(f'Unknown compute_device="{value}"')
 
     def getStatus(self):
         return self.test_status.getStatus()
@@ -737,7 +748,7 @@ class Tester(MooseObject, OutputInterface):
     def processResults(self, moose_dir, options, exit_code, runner_output):
         """method to process the results of a finished tester"""
         if self.specs["expect_exit_code"] != exit_code:
-            reason = f'EXIT CODE {exit_code} != {self.specs["expect_exit_code"]}'
+            reason = f"EXIT CODE {exit_code} != {self.specs['expect_exit_code']}"
             self.setStatus(self.fail, str(reason))
             return f"\n\nExit Code: {exit_code}"
 
@@ -1084,6 +1095,12 @@ class Tester(MooseObject, OutputInterface):
         # Use shell not supported for HPC
         if self.specs["use_shell"] and options.hpc:
             reasons["use_shell"] = "no use_shell with hpc"
+
+        devices_lower = [x.lower() for x in self.specs["compute_devices"]]
+        if options.compute_device not in devices_lower:
+            reasons["invalid_compute_devices"] = (
+                f"{options.compute_device} not in compute_devices"
+            )
 
         ##### The below must be performed last to register all above caveats #####
         # Remove any matching user supplied caveats from accumulated checkRunnable caveats that

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -18,7 +18,7 @@ import time
 import typing
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Callable, Optional, Tuple
 
 from mooseutils import colorText
 
@@ -56,8 +56,10 @@ class FormatResultEntry:
     name: str
     # Timing for the entry, optional
     timing: Optional[float] = None
-    # Memory for the entry, optional
-    memory: Optional[int] = None
+    # CPU Memory for the entry, optional
+    cpu_memory: Optional[int] = None
+    # GPU memory for the entry, optional
+    gpu_memory: Optional[int] = None
     # JointStatus object for the entry, optional
     joint_status: Optional[str] = None
     # Detailed status message for the entry, optional
@@ -72,7 +74,8 @@ def formatResult(
     entry: FormatResultEntry,
     options,
     timing: Optional[bool] = None,
-    memory: Optional[bool] = None,
+    cpu_memory: Optional[bool] = None,
+    gpu_memory: Optional[bool] = None,
 ) -> str:
     """
     Helper for prenting a one-line result for something.
@@ -84,10 +87,12 @@ def formatResult(
         str(v) for v in list(OrderedDict.fromkeys(list(options.term_format)))
     ]
     # container for every printable item (message and color)
-    result = dict.fromkeys(term_format, (None, None))
+    result: dict[str, Tuple[Optional[str], Optional[str]]] = dict.fromkeys(
+        term_format, (None, None)
+    )
 
     # Helper for adding a formatted entry
-    def add(key: str, message: str, color: str = None) -> None:
+    def add(key: str, message: Optional[str], color: Optional[str] = None) -> None:
         assert key in result
         if message:
             if key.isupper():
@@ -138,22 +143,30 @@ def formatResult(
             int_len = len(str(int(actual)))
             precision = min(3, max(0, (4 - int_len)))
             message = "[" + "{0: <6}".format("%0.*fs" % (precision, actual)) + "]"
-        # Memory;
-        elif (
-            key_lower == "m"
-            and entry.timing is not None
-            and (options.timing or memory is True)
-            and memory is not False
-        ):
-            if entry.memory is not None or entry.timing == 0:
-                value = int(entry.memory * 2**-20) if entry.memory else 0
-                if value < 10000:
-                    message = f"[{value:>4}MB]"
+        # Memory (potentially multiple entries)
+        elif key_lower == "m" and entry.timing is not None:
+            # Helper for formatting a CPU or GPU memory entry
+            def format_memory(
+                memory_entry: Optional[int], condition: Optional[bool]
+            ) -> Optional[str]:
+                if not (options.timing or condition is True) or condition is False:
+                    return None
+                if memory_entry is not None or entry.timing == 0:
+                    value = int(memory_entry * 2**-20) if memory_entry else 0
+                    if value < 10000:
+                        message = f"{value:>4}MB"
+                    else:
+                        value = int(value / 1024)
+                        message = f"{value:>4}GB"
                 else:
-                    value = int(value / 1024)
-                    message = f"[{value:>4}GB]"
-            else:
-                message = "[   ?MB]"
+                    message = "   ?MB"
+                return message
+
+            if cpu_message := format_memory(entry.cpu_memory, cpu_memory):
+                if gpu_message := format_memory(entry.gpu_memory, gpu_memory):
+                    message = f"[C{cpu_message}] [G{gpu_message}]"
+                else:
+                    message = f"[{cpu_message}]"
 
         add(key, message, color)
 
@@ -200,7 +213,8 @@ def formatJobResult(
     options,
     status_message: bool = True,
     timing: Optional[bool] = None,
-    memory: Optional[bool] = None,
+    cpu_memory: Optional[bool] = None,
+    gpu_memory: Optional[bool] = None,
     memory_per_slot: bool = False,
     caveats: bool = False,
 ) -> str:
@@ -227,19 +241,33 @@ def formatJobResult(
         suffix = name.replace(first_directory, "", 1)
         name = prefix + suffix
 
-    max_memory = job.getMaxMemory()
-    if memory_per_slot and max_memory is not None:
-        max_memory = int(max_memory / job.getSlots())
+    max_cpu_memory = None
+    max_gpu_memory = None
+    if (job_max_memory := job.getMaxMemory()) is not None:
+        max_cpu_memory = job_max_memory.cpu
+        if memory_per_slot:
+            max_cpu_memory /= job.getSlots()
+        max_cpu_memory = int(max_cpu_memory)
+
+        if job_max_memory.gpu is not None:
+            max_gpu_memory = job_max_memory.gpu
+            if memory_per_slot:
+                max_gpu_memory /= job.getSlots()
+            max_gpu_memory = int(max_gpu_memory)
+
     entry = FormatResultEntry(
         name=name,
         timing=job.getTiming(),
-        memory=max_memory,
+        cpu_memory=max_cpu_memory,
+        gpu_memory=max_gpu_memory,
         joint_status=job.getJointStatus(),
         status_message=status_message,
         caveats=job.getCaveats() if caveats else [],
         caveat_color=joint_status.color if job.isFail() else "CYAN",
     )
-    return formatResult(entry, options, timing=timing, memory=memory)
+    return formatResult(
+        entry, options, timing=timing, cpu_memory=cpu_memory, gpu_memory=gpu_memory
+    )
 
 
 ## Color the error messages if the options permit, also do not color in bitten scripts because

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -12,12 +12,21 @@
 import os
 import sys
 from collections import defaultdict
-from multiprocessing import Process, get_context
+from contextlib import suppress
+from importlib.util import find_spec
+from multiprocessing import get_context
 from multiprocessing.context import ForkProcess
 from multiprocessing.managers import DictProxy
-from typing import Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import psutil
+
+HAS_PYNVML = find_spec("pynvml") is not None
+"""Whether or not pynvml is available."""
+
+# Load pynvml if available
+if TYPE_CHECKING or HAS_PYNVML:
+    import pynvml
 
 MEMORY_PSS = sys.platform.startswith("linux") and os.path.exists(
     f"/proc/{os.getpid()}/smaps_rollup"
@@ -64,7 +73,7 @@ def get_process_memory(process: psutil.Process) -> Optional[int]:
 class MemoryMonitor:
     """Monitor that runs in a separate thread to track children memory usage."""
 
-    def __init__(self, parent_pid: int, interval: float = 0.1):
+    def __init__(self, parent_pid: int, track_nvidia: bool, interval: float = 0.1):
         """Initialize state."""
         self._parent_pid: int = parent_pid
         """PID of the parent process to sample the children of."""
@@ -72,34 +81,109 @@ class MemoryMonitor:
         self._interval: float = interval
         """How often to sample in seconds."""
 
+        self._track_nvidia: bool = track_nvidia
+        """Whether or not to track Nvidia GPU memory usage."""
+
         self._process: Optional[ForkProcess] = None
         """The Multiprocessing process."""
 
         self._manager = None
         """Manager for sharing data with the Multiprocessing process, once started."""
 
-        self._samples: Optional[DictProxy[int, int]] = None
-        """The shareable samples (child pid -> memory in bytes), once started."""
+        self._cpu_samples: Optional[DictProxy[int, int]] = None
+        """The shareable CPU samples (child pid -> memory in bytes), once started."""
+
+        self._gpu_samples: Optional[DictProxy[int, int]] = None
+        """The shareable GPU samples (child pid -> memory in bytes), once started."""
 
         self._stop_event = None
         """Event to stop the Multiprocessing process, once started."""
 
-    def get_samples(self) -> dict[int, int]:
+        # If tracking nvidia GPUs, make sure we can actually
+        # poll at least one GPU for memory usage
+        if track_nvidia:
+            if not HAS_PYNVML:
+                print(
+                    "WARNING: Not tracking GPU memory usage; "
+                    "'pynvml' package unavailable"
+                )
+                self._track_nvidia = False
+            else:
+                self.init_pynvml_handles()
+                pynvml.nvmlShutdown()
+
+    @staticmethod
+    def init_pynvml_handles() -> list:
+        """Initialize pynvml and return the Nvidia GPU handlers, if possible."""
+        pynvml.nvmlInit()
+
+        handles = [
+            pynvml.nvmlDeviceGetHandleByIndex(i)
+            for i in range(pynvml.nvmlDeviceGetCount())
+        ]
+
+        if not handles:
+            with suppress(pynvml.NVMLError):
+                pynvml.nvmlShutdown()
+            raise RuntimeError("Process monitoring failed to discover a Nvidia GPU")
+
+        return handles
+
+    def get_cpu_samples(self) -> dict[int, int]:
         """
-        Get the last samples; child PID to cumulative memory usage in bytes.
+        Get the last CPU samples; child PID to cumulative memory usage in bytes.
 
         This returns a copy so that the dict can be accessed without
         locking (required for synchronization with the other thread).
         Thus, you should get a copy to this once and then use it many
         times as needed.
         """
-        assert self._samples is not None
-        return self._samples.copy()
+        assert self._cpu_samples is not None
+        return self._cpu_samples.copy()
+
+    def get_gpu_samples(self) -> Optional[dict[int, int]]:
+        """
+        Get the last GPU samples; child PID to cumulative memory usage in bytes.
+
+        This returns a copy so that the dict can be accessed without
+        locking (required for synchronization with the other thread).
+        Thus, you should get a copy to this once and then use it many
+        times as needed.
+        """
+        if not self._track_nvidia:
+            return None
+        assert self._gpu_samples is not None, "GPU samples not set"
+        return self._gpu_samples.copy()
 
     @staticmethod
-    def _sampler(parent_pid: int, interval: float, stop_event, samples: DictProxy):
+    def _sampler(
+        parent_pid: int,
+        interval: float,
+        track_nvidia: bool,
+        stop_event,
+        cpu_samples: DictProxy,
+        gpu_samples: DictProxy,
+    ):
         """Run the sampler process; internal method called by start()."""
+        # Load the pynvml handles if we have any GPUs available
+        pynvml_handles = MemoryMonitor.init_pynvml_handles() if track_nvidia else None
+
         while not stop_event.is_set():
+            # Accumulate nvidia GPU processes if we have handlers
+            pynvml_processes: Optional[dict[int, Any]] = None
+            if pynvml_handles is not None:
+                pynvml_processes = {}
+                for handle in pynvml_handles:
+                    with suppress(pynvml.NVMLError):
+                        pynvml_processes.update(
+                            {
+                                p.pid: p.usedGpuMemory
+                                for p in pynvml.nvmlDeviceGetComputeRunningProcesses(
+                                    handle
+                                )
+                            }
+                        )
+
             # Get the entire flattened process tree, removing process 0 as
             # it's the exit condition when searching recursively
             all_processes: dict[int, psutil.Process] = {
@@ -124,19 +208,34 @@ class MemoryMonitor:
                 return in_children_pids(pp) if (pp := all_processes.get(ppid)) else None
 
             # Accumulate memory from relevant processes
-            result = defaultdict(int)
+            cpu_result = defaultdict(int)
+            gpu_result = defaultdict(int)
             for pid, p in all_processes.items():
                 if (
                     ppid := pid if pid in children_pids else in_children_pids(p)
-                ) is not None and (memory := get_process_memory(p)) is not None:
-                    result[ppid] += memory
+                ) is not None:
+                    if (cpu_memory := get_process_memory(p)) is not None:
+                        cpu_result[ppid] += cpu_memory
+                    if (
+                        pynvml_processes is not None
+                        and (gpu_memory := pynvml_processes.get(p.pid)) is not None
+                    ):
+                        gpu_result[ppid] += gpu_memory
 
             # And update the shared state
-            samples.clear()
-            samples.update(result)
+            cpu_samples.clear()
+            cpu_samples.update(cpu_result)
+            if pynvml_handles is not None:
+                gpu_samples.clear()
+                gpu_samples.update(gpu_result)
 
             # Wait, but wake early if stop_event is set
             stop_event.wait(interval)
+
+        # Shutdown our nvml reference if we had any handles
+        if pynvml_handles is not None:
+            with suppress(pynvml.NVMLError):
+                pynvml.nvmlShutdown()
 
     def start(self):
         """Start the sampler process."""
@@ -144,15 +243,18 @@ class MemoryMonitor:
 
         ctx = get_context("fork")
         self._manager = ctx.Manager()
-        self._samples = self._manager.dict()
+        self._cpu_samples = self._manager.dict()
+        self._gpu_samples = self._manager.dict()
         self._stop_event = ctx.Event()
         self._process = ctx.Process(
             target=self._sampler,
             args=(
                 self._parent_pid,
                 self._interval,
+                self._track_nvidia,
                 self._stop_event,
-                self._samples,
+                self._cpu_samples,
+                self._gpu_samples,
             ),
             daemon=True,
         )

--- a/python/TestHarness/utils/monitor_processes.py
+++ b/python/TestHarness/utils/monitor_processes.py
@@ -21,11 +21,13 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import psutil
 
-HAS_PYNVML = find_spec("pynvml") is not None
-"""Whether or not pynvml is available."""
+NO_CUDA_TRACKING_REASON: Optional[str] = (
+    "Python package 'pynvml' is not available" if find_spec("pynvml") is None else None
+)
+"""The reason why cuda tracking cannot be done, if any."""
 
 # Load pynvml if available
-if TYPE_CHECKING or HAS_PYNVML:
+if TYPE_CHECKING or NO_CUDA_TRACKING_REASON is None:
     import pynvml
 
 MEMORY_PSS = sys.platform.startswith("linux") and os.path.exists(
@@ -34,7 +36,7 @@ MEMORY_PSS = sys.platform.startswith("linux") and os.path.exists(
 """Whether or not to use PSS for memory tracking from smaps_rollup."""
 
 
-def get_process_memory(process: psutil.Process) -> Optional[int]:
+def get_process_cpu_memory(process: psutil.Process) -> Optional[int]:
     """
     Get the memory of a process, if running.
 
@@ -70,6 +72,20 @@ def get_process_memory(process: psutil.Process) -> Optional[int]:
     return None
 
 
+def get_cuda_running_processes(handles: list) -> dict[int, Any]:
+    """Get the running CUDA processes from the pynvml GPU handles (pid -> process)."""
+    processes = {}
+    for handle in handles:
+        with suppress(pynvml.NVMLError):
+            processes.update(
+                {
+                    p.pid: p.usedGpuMemory
+                    for p in pynvml.nvmlDeviceGetComputeRunningProcesses(handle)
+                }
+            )
+    return processes
+
+
 class MemoryMonitor:
     """Monitor that runs in a separate thread to track children memory usage."""
 
@@ -102,15 +118,8 @@ class MemoryMonitor:
         # If tracking nvidia GPUs, make sure we can actually
         # poll at least one GPU for memory usage
         if track_nvidia:
-            if not HAS_PYNVML:
-                print(
-                    "WARNING: Not tracking GPU memory usage; "
-                    "'pynvml' package unavailable"
-                )
-                self._track_nvidia = False
-            else:
-                self.init_pynvml_handles()
-                pynvml.nvmlShutdown()
+            self.init_pynvml_handles()
+            pynvml.nvmlShutdown()
 
     @staticmethod
     def init_pynvml_handles() -> list:
@@ -170,19 +179,11 @@ class MemoryMonitor:
 
         while not stop_event.is_set():
             # Accumulate nvidia GPU processes if we have handlers
-            pynvml_processes: Optional[dict[int, Any]] = None
-            if pynvml_handles is not None:
-                pynvml_processes = {}
-                for handle in pynvml_handles:
-                    with suppress(pynvml.NVMLError):
-                        pynvml_processes.update(
-                            {
-                                p.pid: p.usedGpuMemory
-                                for p in pynvml.nvmlDeviceGetComputeRunningProcesses(
-                                    handle
-                                )
-                            }
-                        )
+            pynvml_processes: Optional[dict[int, Any]] = (
+                get_cuda_running_processes(pynvml_handles)
+                if pynvml_handles is not None
+                else None
+            )
 
             # Get the entire flattened process tree, removing process 0 as
             # it's the exit condition when searching recursively
@@ -214,7 +215,7 @@ class MemoryMonitor:
                 if (
                     ppid := pid if pid in children_pids else in_children_pids(p)
                 ) is not None:
-                    if (cpu_memory := get_process_memory(p)) is not None:
+                    if (cpu_memory := get_process_cpu_memory(p)) is not None:
                         cpu_result[ppid] += cpu_memory
                     if (
                         pynvml_processes is not None


### PR DESCRIPTION
## Reason
We have CPU memory tracking in the TestHarness. We should add GPU memory tracking too as this would enable capping test GPU memory usage.

## Design
Add GPU memory tracking to the TestHarness.

## Impact
Will add minimal overhead to the TestHarness for memory tracking, but will also enable limiting GPU memory usage.