### PR TITLE
Axe extraneous semicolons

### DIFF
--- a/framework/include/auxkernels/NodalPatchRecovery.h
+++ b/framework/include/auxkernels/NodalPatchRecovery.h
@@ -28,7 +28,7 @@ public:
   static InputParameters validParams();
 
   NodalPatchRecovery(const InputParameters & parameters);
-  virtual ~NodalPatchRecovery() {};
+  virtual ~NodalPatchRecovery() {}
   /**
    * This function overrides the one implemented in AuxKernel.C to suppress warnings when retrieving
    * material properties

--- a/framework/include/base/Registry.h
+++ b/framework/include/base/Registry.h
@@ -324,7 +324,7 @@ private:
   ///@}
 #endif
 
-  Registry() {};
+  Registry() {}
 
   /**
    * Manually set the data file paths.

--- a/framework/include/controls/WebServerControl.h
+++ b/framework/include/controls/WebServerControl.h
@@ -253,7 +253,7 @@ protected:
   /**
    * Entrypoint for controls derived from this one to add additional actions
    */
-  virtual void addServerActions() {};
+  virtual void addServerActions() {}
 
   /**
    * Helper for converting a value to JSON for the given key

--- a/framework/include/executioners/SolveObject.h
+++ b/framework/include/executioners/SolveObject.h
@@ -29,7 +29,7 @@ public:
   /**
    * Method that should be executed once, before any solve calls
    */
-  virtual void initialSetup() {};
+  virtual void initialSetup() {}
 
   /**
    * Solve routine provided by this object.

--- a/framework/include/geomsearch/ElementPairLocator.h
+++ b/framework/include/geomsearch/ElementPairLocator.h
@@ -43,9 +43,9 @@ public:
 
   typedef std::list<std::pair<const Elem *, const Elem *>> ElementPairList;
 
-  virtual void reinit() {};
+  virtual void reinit() {}
 
-  virtual void update() {};
+  virtual void update() {}
 
   const ElementPairList & getElemPairs() const
   {

--- a/framework/include/indicators/Indicator.h
+++ b/framework/include/indicators/Indicator.h
@@ -39,7 +39,7 @@ public:
 
   Indicator(const InputParameters & parameters);
 
-  virtual ~Indicator() {};
+  virtual ~Indicator() {}
 
   /**
    * Pure virtual that must be overridden.

--- a/framework/include/loops/ThreadedElementLoopBase.h
+++ b/framework/include/loops/ThreadedElementLoopBase.h
@@ -152,7 +152,7 @@ public:
    * Called if a MooseException is caught anywhere during the computation.
    * The single input parameter taken is a MooseException object.
    */
-  virtual void caughtMooseException(MooseException &) {};
+  virtual void caughtMooseException(MooseException &) {}
 
   /**
    * Whether or not the loop should continue.

--- a/framework/include/loops/ThreadedNodeLoop.h
+++ b/framework/include/loops/ThreadedNodeLoop.h
@@ -23,7 +23,7 @@ public:
   // Splitting Constructor
   ThreadedNodeLoop(ThreadedNodeLoop & x, Threads::split split);
 
-  virtual ~ThreadedNodeLoop() {};
+  virtual ~ThreadedNodeLoop() {}
 
   void operator()(const RangeType & range);
 

--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -42,7 +42,7 @@ public:
 
   PropertyValue(const id_type id) : _id(id) {}
 
-  virtual ~PropertyValue() {};
+  virtual ~PropertyValue() {}
 
   /// The material property ID for an invalid property
   /// We only have this because there are a few cases where folks want to instantiate their

--- a/framework/include/meshgenerators/ParsedSubdomainGeneratorBase.h
+++ b/framework/include/meshgenerators/ParsedSubdomainGeneratorBase.h
@@ -53,5 +53,5 @@ protected:
 
   virtual void assignElemSubdomainID(Elem * elem) = 0;
 
-  virtual void setBlockName(std::unique_ptr<MeshBase> &) {};
+  virtual void setBlockName(std::unique_ptr<MeshBase> &) {}
 };

--- a/framework/include/mfem/auxkernels/MFEMComplexAuxKernel.h
+++ b/framework/include/mfem/auxkernels/MFEMComplexAuxKernel.h
@@ -26,7 +26,7 @@ public:
   virtual ~MFEMComplexAuxKernel() = default;
 
   /// Method called to update any owned objects upon an FE space update
-  virtual void update() {};
+  virtual void update() {}
 
   virtual std::optional<std::string> suppliedVariableName() const override;
 

--- a/framework/include/mfem/solvers/MFEMSuperLU.h
+++ b/framework/include/mfem/solvers/MFEMSuperLU.h
@@ -23,7 +23,9 @@ class SuperLUSolver : public mfem::SuperLUSolver
 {
 public:
   SuperLUSolver(MPI_Comm comm, int npdep = 1)
-    : mfem::SuperLUSolver(comm), _s_superlu(std::make_unique<mfem::SuperLUSolver>(comm, npdep)) {};
+    : mfem::SuperLUSolver(comm), _s_superlu(std::make_unique<mfem::SuperLUSolver>(comm, npdep))
+  {
+  }
   void SetOperator(const mfem::Operator & op) override
   {
     _a_superlu = std::make_unique<mfem::SuperLURowLocMatrix>(op);

--- a/framework/include/outputs/AdvancedOutputUtils.h
+++ b/framework/include/outputs/AdvancedOutputUtils.h
@@ -63,7 +63,7 @@ public:
   /**
    * Constructor
    */
-  OutputMapWrapper() {};
+  OutputMapWrapper() {}
 
   /**
    * A map accessor that errors if the key is not found

--- a/framework/include/parser/ParameterRegistry.h
+++ b/framework/include/parser/ParameterRegistry.h
@@ -63,7 +63,7 @@ private:
   /**
    * Constructor; private so that it can only be created with the singleton
    */
-  ParameterRegistry() {};
+  ParameterRegistry() {}
 
 #ifdef MOOSE_UNIT_TEST
   FRIEND_TEST(::ParameterRegistryTest, add);

--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -72,7 +72,7 @@ class CompileParamWalker : public hit::Walker
 {
 public:
   typedef std::map<std::string, hit::Node *> ParamMap;
-  CompileParamWalker(ParamMap & map) : _map(map) {};
+  CompileParamWalker(ParamMap & map) : _map(map) {}
 
   virtual void
   walk(const std::string & fullpath, const std::string & /*nodepath*/, hit::Node * n) override;

--- a/framework/include/partitioner/PetscExternalPartitioner.h
+++ b/framework/include/partitioner/PetscExternalPartitioner.h
@@ -52,7 +52,7 @@ public:
   /**
    * Called immediately before partitioning
    */
-  virtual void initialize(MeshBase & /* mesh */) {};
+  virtual void initialize(MeshBase & /* mesh */) {}
 
 protected:
   virtual void _do_partition(MeshBase & mesh, const unsigned int n) override;

--- a/framework/include/reporters/ReporterName.h
+++ b/framework/include/reporters/ReporterName.h
@@ -33,7 +33,7 @@ public:
   ReporterName(const std::string & object_name, const std::string & value_name);
   ReporterName(const std::string & object_and_value_name);
   ReporterName(const char * combined_name);
-  ReporterName() {}; // empty constructor for InputParameters
+  ReporterName() {} // empty constructor for InputParameters
 
   /**
    * Determines if the inputted string is convertible to a ReporterName.

--- a/framework/include/userobjects/InterfaceQpMaterialPropertyBaseUserObject.h
+++ b/framework/include/userobjects/InterfaceQpMaterialPropertyBaseUserObject.h
@@ -25,7 +25,7 @@ public:
    * @param parameters The input parameters for this object
    */
   InterfaceQpMaterialPropertyBaseUserObject(const InputParameters & parameters);
-  virtual ~InterfaceQpMaterialPropertyBaseUserObject() {};
+  virtual ~InterfaceQpMaterialPropertyBaseUserObject() {}
 
 protected:
   /**

--- a/framework/include/userobjects/InterfaceQpMaterialPropertyRealUO.h
+++ b/framework/include/userobjects/InterfaceQpMaterialPropertyRealUO.h
@@ -23,7 +23,7 @@ public:
    * @param parameters The input parameters for this object
    */
   InterfaceQpMaterialPropertyRealUO(const InputParameters & parameters);
-  virtual ~InterfaceQpMaterialPropertyRealUO() {};
+  virtual ~InterfaceQpMaterialPropertyRealUO() {}
 
 protected:
   /**

--- a/framework/include/userobjects/InterfaceQpUserObjectBase.h
+++ b/framework/include/userobjects/InterfaceQpUserObjectBase.h
@@ -29,7 +29,7 @@ public:
   static MooseEnum valueOptions() { return MooseEnum("value rate increment", "value"); }
 
   InterfaceQpUserObjectBase(const InputParameters & parameters);
-  virtual ~InterfaceQpUserObjectBase() {};
+  virtual ~InterfaceQpUserObjectBase() {}
   virtual void initialSetup() override;
   virtual void initialize() override {};
   virtual void execute() override;

--- a/framework/include/userobjects/InterfaceQpValueUserObject.h
+++ b/framework/include/userobjects/InterfaceQpValueUserObject.h
@@ -19,7 +19,7 @@ class InterfaceQpValueUserObject : public InterfaceQpUserObjectBase
 public:
   static InputParameters validParams();
   InterfaceQpValueUserObject(const InputParameters & parameters);
-  virtual ~InterfaceQpValueUserObject() {};
+  virtual ~InterfaceQpValueUserObject() {}
 
 protected:
   virtual Real computeRealValue(const unsigned int qp) override;

--- a/framework/include/utils/PeriodicBCHelper.h
+++ b/framework/include/utils/PeriodicBCHelper.h
@@ -53,7 +53,7 @@ protected:
   /**
    * Entry-point for derived actions to extend the addition of a periodic boundary.
    */
-  virtual void onSetupPeriodicBoundary(libMesh::PeriodicBoundaryBase & /* p */) {};
+  virtual void onSetupPeriodicBoundary(libMesh::PeriodicBoundaryBase & /* p */) {}
 
   /**
    * Get the PeriodicBoundaries map produced in setupPeriodicBoundaries().

--- a/framework/src/bcs/ArrayNodalBC.C
+++ b/framework/src/bcs/ArrayNodalBC.C
@@ -97,7 +97,6 @@ RealEigenVector
 ArrayNodalBC::computeQpJacobian()
 {
   return RealEigenVector::Ones(_var.count());
-  ;
 }
 
 RealEigenMatrix

--- a/framework/src/fvkernels/FVMatAdvection.C
+++ b/framework/src/fvkernels/FVMatAdvection.C
@@ -70,5 +70,4 @@ FVMatAdvection::computeQpResidual()
                  determineState());
 
   return _normal * v * adv_quant_interface;
-  ;
 }

--- a/framework/src/mfem/bcs/MFEMVectorFEMassIntegratedBC.C
+++ b/framework/src/mfem/bcs/MFEMVectorFEMassIntegratedBC.C
@@ -34,7 +34,6 @@ mfem::BilinearFormIntegrator *
 MFEMVectorFEMassIntegratedBC::createBFIntegrator()
 {
   return new mfem::VectorFEMassIntegrator(_coef);
-  ;
 }
 
 #endif

--- a/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
@@ -96,7 +96,6 @@ CoupledDiffusionReactionSub::computeQpResidual()
   mooseAssert(_gamma_eq[_qp] > 0.0, "Activity coefficient must be greater than zero");
   return _weight * std::pow(10.0, _log_k[_qp]) * _diffusivity[_qp] * _grad_test[_i][_qp] *
          (diff1 + diff2_sum) / _gamma_eq[_qp];
-  ;
 }
 
 Real

--- a/modules/functional_expansion_tools/include/coefficients/MutableCoefficientsInterface.h
+++ b/modules/functional_expansion_tools/include/coefficients/MutableCoefficientsInterface.h
@@ -102,7 +102,7 @@ protected:
   /**
    * Called when the coefficients have been changed
    */
-  virtual void coefficientsChanged() {};
+  virtual void coefficientsChanged() {}
 
   /// An array of integer characteristics that can be used to check compatibility
   std::vector<std::size_t> & _characteristics;

--- a/modules/geochemistry/include/utils/GeochemicalDatabaseReader.h
+++ b/modules/geochemistry/include/utils/GeochemicalDatabaseReader.h
@@ -23,7 +23,7 @@
  */
 struct GeochemistryBasisSpecies
 {
-  GeochemistryBasisSpecies() {};
+  GeochemistryBasisSpecies() {}
 
   std::string name;
   std::map<std::string, Real> elements;
@@ -44,7 +44,7 @@ struct GeochemistryBasisSpecies
  */
 struct GeochemistryEquilibriumSpecies
 {
-  GeochemistryEquilibriumSpecies() {};
+  GeochemistryEquilibriumSpecies() {}
 
   std::string name;
   std::map<std::string, Real> basis_species;
@@ -67,7 +67,7 @@ struct GeochemistryEquilibriumSpecies
  */
 struct GeochemistryMineralSpecies
 {
-  GeochemistryMineralSpecies() {};
+  GeochemistryMineralSpecies() {}
 
   std::string name;
   Real molecular_volume;
@@ -90,7 +90,7 @@ struct GeochemistryMineralSpecies
  */
 struct GeochemistryGasSpecies
 {
-  GeochemistryGasSpecies() {};
+  GeochemistryGasSpecies() {}
 
   std::string name;
   std::map<std::string, Real> basis_species;
@@ -114,7 +114,7 @@ struct GeochemistryGasSpecies
  */
 struct GeochemistryRedoxSpecies
 {
-  GeochemistryRedoxSpecies() {};
+  GeochemistryRedoxSpecies() {}
 
   std::string name;
   std::map<std::string, Real> basis_species;
@@ -133,7 +133,7 @@ struct GeochemistryRedoxSpecies
  */
 struct GeochemistryOxideSpecies
 {
-  GeochemistryOxideSpecies() {};
+  GeochemistryOxideSpecies() {}
 
   std::string name;
   std::map<std::string, Real> basis_species;
@@ -150,7 +150,7 @@ struct GeochemistryOxideSpecies
  */
 struct GeochemistrySurfaceSpecies
 {
-  GeochemistrySurfaceSpecies() {};
+  GeochemistrySurfaceSpecies() {}
 
   std::string name;
   std::map<std::string, Real> basis_species;
@@ -169,7 +169,7 @@ struct GeochemistrySurfaceSpecies
  */
 struct GeochemistryDebyeHuckel
 {
-  GeochemistryDebyeHuckel() {};
+  GeochemistryDebyeHuckel() {}
 
   std::vector<Real> adh;
   std::vector<Real> bdh;
@@ -184,7 +184,7 @@ struct GeochemistryDebyeHuckel
  */
 struct GeochemistryElements
 {
-  GeochemistryElements() {};
+  GeochemistryElements() {}
 
   std::string name;
   Real molecular_weight;
@@ -197,9 +197,11 @@ struct GeochemistryElements
  */
 struct GeochemistryNeutralSpeciesActivity
 {
-  GeochemistryNeutralSpeciesActivity() {};
+  GeochemistryNeutralSpeciesActivity() {}
   GeochemistryNeutralSpeciesActivity(std::vector<std::vector<Real>> coeffs)
-    : a(coeffs[0]), b(coeffs[1]), c(coeffs[2]), d(coeffs[3]) {};
+    : a(coeffs[0]), b(coeffs[1]), c(coeffs[2]), d(coeffs[3])
+  {
+  }
 
   std::vector<Real> a;
   std::vector<Real> b;

--- a/modules/geochemistry/include/utils/GeochemistryActivityCoefficients.h
+++ b/modules/geochemistry/include/utils/GeochemistryActivityCoefficients.h
@@ -18,7 +18,7 @@
 class GeochemistryActivityCoefficients
 {
 public:
-  GeochemistryActivityCoefficients() {};
+  GeochemistryActivityCoefficients() {}
 
   bool operator==(const GeochemistryActivityCoefficients & /*rhs*/) const { return true; };
 

--- a/modules/geochemistry/include/utils/PertinentGeochemicalSystem.h
+++ b/modules/geochemistry/include/utils/PertinentGeochemicalSystem.h
@@ -24,7 +24,7 @@
  */
 struct SurfaceComplexationInfo
 {
-  SurfaceComplexationInfo() {};
+  SurfaceComplexationInfo() {}
 
   bool operator==(const SurfaceComplexationInfo & rhs) const
   {
@@ -68,7 +68,9 @@ struct KineticRateDefinition
       promoting_monod_indices(promoting_monod_indices),
       promoting_half_saturation(promoting_half_saturation),
       progeny_index(progeny_index),
-      description(description) {};
+      description(description)
+  {
+  }
 
   bool operator==(const KineticRateDefinition & rhs) const
   {
@@ -103,7 +105,9 @@ struct ModelGeochemicalDatabase
    * attempt to reduce memory consumption
    */
   ModelGeochemicalDatabase(const GeochemicalDatabaseReader & db)
-    : original_database(&db), swap_to_original_basis(DenseMatrix<Real>()) {};
+    : original_database(&db), swap_to_original_basis(DenseMatrix<Real>())
+  {
+  }
 
   bool operator==(const ModelGeochemicalDatabase & rhs) const
   {

--- a/modules/optimization/include/optimizationreporters/OptimizationReporterBase.h
+++ b/modules/optimization/include/optimizationreporters/OptimizationReporterBase.h
@@ -52,7 +52,7 @@ public:
    * Function to override misfit values with the simulated values from the matrix free hessian
    * forward solve.
    */
-  virtual void setMisfitToSimulatedValues() {};
+  virtual void setMisfitToSimulatedValues() {}
 
   /**
    * Upper and lower bounds for each parameter being controlled
@@ -119,7 +119,7 @@ protected:
   parseInputData(std::string type, Real default_value, unsigned int param_id) const;
 
   /// Sets the initial conditions and bounds right before it is needed.
-  virtual void setICsandBounds() {};
+  virtual void setICsandBounds() {}
 
   /// Parameter names
   const std::vector<ReporterValueName> & _parameter_names;

--- a/modules/peridynamics/include/kernels/MechanicsBasePD.h
+++ b/modules/peridynamics/include/kernels/MechanicsBasePD.h
@@ -29,7 +29,9 @@ public:
    * @param coupled_component   The coupled variable number
    */
   virtual void computeLocalOffDiagJacobian(unsigned int /* jvar_num */,
-                                           unsigned int /* coupled_component */) {};
+                                           unsigned int /* coupled_component */)
+  {
+  }
 
   /**
    * Function to compute nonlocal contribution to the off-diagonal Jacobian at the current nodes
@@ -37,7 +39,9 @@ public:
    * @param coupled_component   The component number of the second coupled variable
    */
   virtual void computePDNonlocalOffDiagJacobian(unsigned int /* jvar_num */,
-                                                unsigned int /* coupled_component */) {};
+                                                unsigned int /* coupled_component */)
+  {
+  }
 
   virtual void initialSetup() override;
   virtual void prepare() override;

--- a/modules/peridynamics/include/kernels/PeridynamicsKernelBase.h
+++ b/modules/peridynamics/include/kernels/PeridynamicsKernelBase.h
@@ -37,12 +37,12 @@ protected:
   /**
    * Function to compute nonlocal contribution to the residual at the current nodes
    */
-  virtual void computeNonlocalResidual() {};
+  virtual void computeNonlocalResidual() {}
 
   /**
    * Function to compute local contribution to the diagonal Jacobian at the current nodes
    */
-  virtual void computeLocalJacobian() {};
+  virtual void computeLocalJacobian() {}
 
   /**
    * Function to precalculate data which will be used in the derived classes

--- a/modules/phase_field/include/kernels/ConservedLangevinNoise.h
+++ b/modules/phase_field/include/kernels/ConservedLangevinNoise.h
@@ -20,7 +20,7 @@ public:
   ConservedLangevinNoise(const InputParameters & parameters);
 
 protected:
-  virtual void residualSetup() {};
+  virtual void residualSetup() {}
   virtual Real computeQpResidual();
 
 private:

--- a/modules/phase_field/include/userobjects/GrainForceAndTorqueSum.h
+++ b/modules/phase_field/include/userobjects/GrainForceAndTorqueSum.h
@@ -26,8 +26,8 @@ public:
   GrainForceAndTorqueSum(const InputParameters & parameters);
 
   virtual void initialize();
-  virtual void execute() {};
-  virtual void finalize() {};
+  virtual void execute() {}
+  virtual void finalize() {}
 
   virtual const std::vector<RealGradient> & getForceValues() const;
   virtual const std::vector<RealGradient> & getTorqueValues() const;

--- a/modules/phase_field/include/userobjects/MaskedGrainForceAndTorque.h
+++ b/modules/phase_field/include/userobjects/MaskedGrainForceAndTorque.h
@@ -26,8 +26,8 @@ public:
   MaskedGrainForceAndTorque(const InputParameters & parameters);
 
   virtual void initialize();
-  virtual void execute() {};
-  virtual void finalize() {};
+  virtual void execute() {}
+  virtual void finalize() {}
 
   virtual const std::vector<RealGradient> & getForceValues() const;
   virtual const std::vector<RealGradient> & getTorqueValues() const;

--- a/modules/phase_field/include/utils/EBSDAccessFunctors.h
+++ b/modules/phase_field/include/utils/EBSDAccessFunctors.h
@@ -77,13 +77,13 @@ public:
   struct EBSDPointDataFunctor
   {
     virtual Real operator()(const EBSDPointData &) = 0;
-    virtual ~EBSDPointDataFunctor() {};
+    virtual ~EBSDPointDataFunctor() {}
   };
   /// Access functor base class for EBSDAvgData
   struct EBSDAvgDataFunctor
   {
     virtual Real operator()(const EBSDAvgData &) = 0;
-    virtual ~EBSDAvgDataFunctor() {};
+    virtual ~EBSDAvgDataFunctor() {}
   };
 
   // List of specialized access functors (one for each field in EBSDPointData)

--- a/modules/phase_field/include/utils/ExpressionBuilder.h
+++ b/modules/phase_field/include/utils/ExpressionBuilder.h
@@ -47,7 +47,7 @@ using namespace libMesh;
 class ExpressionBuilder
 {
 public:
-  ExpressionBuilder() {};
+  ExpressionBuilder() {}
 
   // forward delcarations
   class EBTerm;
@@ -62,7 +62,7 @@ public:
   class EBTermNode
   {
   public:
-    virtual ~EBTermNode() {};
+    virtual ~EBTermNode() {}
     virtual EBTermNode * clone() const = 0;
 
     virtual std::string stringify() const = 0;
@@ -81,7 +81,7 @@ public:
     T _value;
 
   public:
-    EBNumberNode(T value) : _value(value) {};
+    EBNumberNode(T value) : _value(value) {}
     virtual EBNumberNode<T> * clone() const { return new EBNumberNode(_value); }
 
     virtual std::string stringify() const;
@@ -94,7 +94,7 @@ public:
     std::string _symbol;
 
   public:
-    EBSymbolNode(std::string symbol) : _symbol(symbol) {};
+    EBSymbolNode(std::string symbol) : _symbol(symbol) {}
     virtual EBSymbolNode * clone() const { return new EBSymbolNode(_symbol); }
 
     virtual std::string stringify() const;
@@ -110,7 +110,7 @@ public:
     unsigned long _id;
 
   public:
-    EBTempIDNode(unsigned int id) : _id(id) {};
+    EBTempIDNode(unsigned int id) : _id(id) {}
     virtual EBTempIDNode * clone() const { return new EBTempIDNode(_id); }
 
     virtual std::string stringify() const; // returns "[idnumber]"
@@ -121,7 +121,7 @@ public:
   class EBUnaryTermNode : public EBTermNode
   {
   public:
-    EBUnaryTermNode(EBTermNode * subnode) : _subnode(subnode) {};
+    EBUnaryTermNode(EBTermNode * subnode) : _subnode(subnode) {}
     virtual ~EBUnaryTermNode() { delete _subnode; };
 
     virtual unsigned int substitute(const EBSubstitutionRuleList & rule);
@@ -150,8 +150,9 @@ public:
       TANH
     } _type;
 
-    EBUnaryFuncTermNode(EBTermNode * subnode, NodeType type)
-      : EBUnaryTermNode(subnode), _type(type) {};
+    EBUnaryFuncTermNode(EBTermNode * subnode, NodeType type) : EBUnaryTermNode(subnode), _type(type)
+    {
+    }
     virtual EBUnaryFuncTermNode * clone() const
     {
       return new EBUnaryFuncTermNode(_subnode->clone(), _type);
@@ -171,8 +172,9 @@ public:
       LOGICNOT
     } _type;
 
-    EBUnaryOpTermNode(EBTermNode * subnode, NodeType type)
-      : EBUnaryTermNode(subnode), _type(type) {};
+    EBUnaryOpTermNode(EBTermNode * subnode, NodeType type) : EBUnaryTermNode(subnode), _type(type)
+    {
+    }
     virtual EBUnaryOpTermNode * clone() const
     {
       return new EBUnaryOpTermNode(_subnode->clone(), _type);
@@ -186,7 +188,7 @@ public:
   class EBBinaryTermNode : public EBTermNode
   {
   public:
-    EBBinaryTermNode(EBTermNode * left, EBTermNode * right) : _left(left), _right(right) {};
+    EBBinaryTermNode(EBTermNode * left, EBTermNode * right) : _left(left), _right(right) {}
     virtual ~EBBinaryTermNode()
     {
       delete _left;
@@ -221,7 +223,9 @@ public:
     };
 
     EBBinaryOpTermNode(EBTermNode * left, EBTermNode * right, NodeType type)
-      : EBBinaryTermNode(left, right), _type(type) {};
+      : EBBinaryTermNode(left, right), _type(type)
+    {
+    }
     virtual EBBinaryOpTermNode * clone() const
     {
       return new EBBinaryOpTermNode(_left->clone(), _right->clone(), _type);
@@ -248,7 +252,9 @@ public:
     } _type;
 
     EBBinaryFuncTermNode(EBTermNode * left, EBTermNode * right, NodeType type)
-      : EBBinaryTermNode(left, right), _type(type) {};
+      : EBBinaryTermNode(left, right), _type(type)
+    {
+    }
     virtual EBBinaryFuncTermNode * clone() const
     {
       return new EBBinaryFuncTermNode(_left->clone(), _right->clone(), _type);
@@ -263,7 +269,9 @@ public:
   {
   public:
     EBTernaryTermNode(EBTermNode * left, EBTermNode * middle, EBTermNode * right)
-      : EBBinaryTermNode(left, right), _middle(middle) {};
+      : EBBinaryTermNode(left, right), _middle(middle)
+    {
+    }
     virtual ~EBTernaryTermNode() { delete _middle; };
 
     virtual unsigned int substitute(const EBSubstitutionRuleList & rule);
@@ -282,7 +290,9 @@ public:
     } _type;
 
     EBTernaryFuncTermNode(EBTermNode * left, EBTermNode * middle, EBTermNode * right, NodeType type)
-      : EBTernaryTermNode(left, middle, right), _type(type) {};
+      : EBTernaryTermNode(left, middle, right), _type(type)
+    {
+    }
     virtual EBTernaryFuncTermNode * clone() const
     {
       return new EBTernaryFuncTermNode(_left->clone(), _middle->clone(), _right->clone(), _type);
@@ -364,14 +374,16 @@ public:
     // current EBTerm object as the ID. This could be problematic if we create and destroy terms,
     // but then we should not expect the substitution to do sane things anyways.
     __attribute__((noinline)) EBTerm()
-      : _root(new EBTempIDNode(reinterpret_cast<unsigned long long>(this))) {};
+      : _root(new EBTempIDNode(reinterpret_cast<unsigned long long>(this)))
+    {
+    }
 
-    EBTerm(const EBTerm & term) : _root(term.cloneRoot()) {};
+    EBTerm(const EBTerm & term) : _root(term.cloneRoot()) {}
     ~EBTerm() { delete _root; };
 
   private:
     // construct a term from a node
-    EBTerm(EBTermNode * root) : _root(root) {};
+    EBTerm(EBTermNode * root) : _root(root) {}
 
   public:
     // construct from number or string
@@ -525,7 +537,7 @@ public:
   class EBFunction
   {
   public:
-    EBFunction() {};
+    EBFunction() {}
 
     /// @{
     /// set the temporary argument list which is either used for evaluation

--- a/modules/phase_field/include/vectorpostprocessors/GrainCentersPostprocessor.h
+++ b/modules/phase_field/include/vectorpostprocessors/GrainCentersPostprocessor.h
@@ -27,7 +27,7 @@ public:
   GrainCentersPostprocessor(const InputParameters & parameters);
 
   virtual ~GrainCentersPostprocessor() {}
-  virtual void initialize() {};
+  virtual void initialize() {}
   virtual void execute();
 
 protected:

--- a/modules/phase_field/src/kernels/ACInterfaceKobayashi1.C
+++ b/modules/phase_field/src/kernels/ACInterfaceKobayashi1.C
@@ -76,7 +76,6 @@ ACInterfaceKobayashi1::precomputeQpJacobian()
   // Derivative of epsilon wrt nodal op values
   Real depsdop_i = _depsdgrad_op[_qp] * _grad_phi[_j][_qp];
   Real ddepsdop_i = _ddepsdgrad_op[_qp] * _grad_phi[_j][_qp];
-  ;
 
   // Set the Jacobian
   RealGradient jac1 = _eps[_qp] * _deps[_qp] * dv;

--- a/modules/porous_flow/include/userobjects/PorousFlowFluidStateBase.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowFluidStateBase.h
@@ -23,7 +23,7 @@ enum class FluidStatePhaseEnum
 /// AD data structure to pass calculated thermophysical properties
 struct FluidStateProperties
 {
-  FluidStateProperties() {};
+  FluidStateProperties() {}
   FluidStateProperties(unsigned int n)
     : pressure(0.0),
       temperature(0, 0),
@@ -32,7 +32,9 @@ struct FluidStateProperties
       viscosity(1.0), // to guard against division by zero
       enthalpy(0.0),
       internal_energy(0.0),
-      mass_fraction(n, 0.0) {};
+      mass_fraction(n, 0.0)
+  {
+  }
 
   ADReal pressure;
   ADReal temperature;

--- a/modules/porous_flow/include/utils/PorousFlowVanGenuchten.h
+++ b/modules/porous_flow/include/utils/PorousFlowVanGenuchten.h
@@ -194,10 +194,14 @@ struct LowCapillaryPressureExtension
     : strategy(LowCapillaryPressureExtension::NONE),
       S(0.0),
       Pc(std::numeric_limits<Real>::max()),
-      dPc(std::numeric_limits<Real>::lowest()) {};
+      dPc(std::numeric_limits<Real>::lowest())
+  {
+  }
 
   LowCapillaryPressureExtension(const ExtensionStrategy & strategy, Real S, Real Pc, Real dPc)
-    : strategy(strategy), S(S), Pc(Pc), dPc(dPc) {};
+    : strategy(strategy), S(S), Pc(Pc), dPc(dPc)
+  {
+  }
 };
 
 /**
@@ -224,10 +228,14 @@ struct HighCapillaryPressureExtension
     : strategy(HighCapillaryPressureExtension::NONE),
       S(1.0),
       Pc(0.0),
-      dPc(std::numeric_limits<Real>::lowest()) {};
+      dPc(std::numeric_limits<Real>::lowest())
+  {
+  }
 
   HighCapillaryPressureExtension(const ExtensionStrategy & strategy, Real S, Real Pc, Real dPc)
-    : strategy(strategy), S(S), Pc(Pc), dPc(dPc) {};
+    : strategy(strategy), S(S), Pc(Pc), dPc(dPc)
+  {
+  }
 };
 
 /**

--- a/modules/ray_tracing/include/base/RayTracingObject.h
+++ b/modules/ray_tracing/include/base/RayTracingObject.h
@@ -70,11 +70,11 @@ public:
   /**
    * Insertion point called immediately before executing the RayTracingStudy.
    */
-  virtual void preExecuteStudy() {};
+  virtual void preExecuteStudy() {}
   /**
    * Insertion point called immediately after executing the RayTracingStudy.
    */
-  virtual void postExecuteStudy() {};
+  virtual void postExecuteStudy() {}
 
 protected:
   /**

--- a/modules/ray_tracing/include/raykernels/ADRayKernel.h
+++ b/modules/ray_tracing/include/raykernels/ADRayKernel.h
@@ -53,7 +53,7 @@ protected:
   /**
    * Insertion point for calculation before the residual computation
    */
-  virtual void precalculateResidual() {};
+  virtual void precalculateResidual() {}
 
   /// The MooseVariable this kernel contributes to
   MooseVariableField<T> & _var;

--- a/modules/ray_tracing/include/raykernels/RayKernel.h
+++ b/modules/ray_tracing/include/raykernels/RayKernel.h
@@ -62,15 +62,15 @@ protected:
   /**
    * Insertion point for calculation before the residual contribution
    */
-  virtual void precalculateResidual() {};
+  virtual void precalculateResidual() {}
   /**
    * Insertion point for calculation before the Jacobian contribution
    */
-  virtual void precalculateJacobian() {};
+  virtual void precalculateJacobian() {}
   /**
    * Insertion point for calculation before an off-diagonal Jacobian contribution
    */
-  virtual void precalculateOffDiagJacobian(unsigned int /* jvar_num */) {};
+  virtual void precalculateOffDiagJacobian(unsigned int /* jvar_num */) {}
 
   /// This is a regular kernel so we cast to a regular MooseVariable
   MooseVariableFE<T> & _var;

--- a/modules/ray_tracing/test/include/userobjects/RayTracingAngularQuadratureErrorTest.h
+++ b/modules/ray_tracing/test/include/userobjects/RayTracingAngularQuadratureErrorTest.h
@@ -18,7 +18,7 @@ public:
 
   static InputParameters validParams();
 
-  void initialize() {};
-  void finalize() {};
-  void execute() {};
+  void initialize() {}
+  void finalize() {}
+  void execute() {}
 };

--- a/modules/scalar_transport/include/userobjects/GasLiquidMassTransfer.h
+++ b/modules/scalar_transport/include/userobjects/GasLiquidMassTransfer.h
@@ -25,10 +25,10 @@ public:
   GasLiquidMassTransfer(const InputParameters & parameters);
   virtual ~GasLiquidMassTransfer() {}
 
-  virtual void initialSetup() {};
-  virtual void initialize() {};
-  virtual void finalize() {};
-  virtual void execute() {};
+  virtual void initialSetup() {}
+  virtual void initialize() {}
+  virtual void finalize() {}
+  virtual void execute() {}
   virtual Real mtc(Real pressure, Real temperature, Real fluid_velocity) const;
 
   /// Boltzman constant [J/K]

--- a/modules/solid_mechanics/include/materials/ADComputeIncrementalShellStrain.h
+++ b/modules/solid_mechanics/include/materials/ADComputeIncrementalShellStrain.h
@@ -39,10 +39,10 @@ protected:
   virtual void computeNodeNormal();
 
   /// Updates the vectors required for shear locking computation for finite rotations
-  virtual void updateGVectors() {};
+  virtual void updateGVectors() {}
 
   /// Updates covariant vectors at each qp for finite rotations
-  virtual void updatedxyz() {};
+  virtual void updatedxyz() {}
 
   /// Computes the transformation matrix from natural coordinates to local cartesian coordinates for elasticity tensor transformation
   virtual void computeGMatrix();

--- a/modules/solid_mechanics/include/materials/StressUpdateBase.h
+++ b/modules/solid_mechanics/include/materials/StressUpdateBase.h
@@ -169,7 +169,7 @@ public:
   /**
    * Reset material properties. Useful for substepping with inelastic models.
    */
-  virtual void resetIncrementalMaterialProperties() {};
+  virtual void resetIncrementalMaterialProperties() {}
 
   /**
    * Compute the strain energy rate density for this inelastic model for the current step.

--- a/modules/solid_mechanics/include/materials/lagrangian/ComputeLagrangianStressPK1.h
+++ b/modules/solid_mechanics/include/materials/lagrangian/ComputeLagrangianStressPK1.h
@@ -27,7 +27,7 @@ class ComputeLagrangianStressPK1 : public ComputeLagrangianStressBase
 public:
   static InputParameters validParams();
   ComputeLagrangianStressPK1(const InputParameters & parameters);
-  virtual ~ComputeLagrangianStressPK1() {};
+  virtual ~ComputeLagrangianStressPK1() {}
 
 protected:
   /// Calculate the stress update to provide both measures (cauchy and pk1)

--- a/modules/solid_mechanics/include/userobjects/EulerAngleFileReader.h
+++ b/modules/solid_mechanics/include/userobjects/EulerAngleFileReader.h
@@ -24,9 +24,9 @@ public:
 
   EulerAngleFileReader(const InputParameters & parameters);
 
-  virtual void initialize() {};
-  virtual void execute() {};
-  virtual void finalize() {};
+  virtual void initialize() {}
+  virtual void execute() {}
+  virtual void finalize() {}
 
 protected:
   void readFile();

--- a/modules/solid_mechanics/include/userobjects/GlobalStrainUserObject.h
+++ b/modules/solid_mechanics/include/userobjects/GlobalStrainUserObject.h
@@ -33,7 +33,7 @@ public:
   /**
    * Calculate additional applied stresses
    */
-  virtual void computeAdditionalStress() {};
+  virtual void computeAdditionalStress() {}
 
 protected:
   /// Base name of the material system

--- a/modules/solid_mechanics/include/userobjects/SubblockIndexProvider.h
+++ b/modules/solid_mechanics/include/userobjects/SubblockIndexProvider.h
@@ -21,7 +21,7 @@ using libMesh::Elem;
 class SubblockIndexProvider
 {
 public:
-  virtual ~SubblockIndexProvider() {};
+  virtual ~SubblockIndexProvider() {}
   /**
    * The index of subblock this element is on.
    */

--- a/modules/solid_mechanics/src/actions/CohesiveZoneAction.C
+++ b/modules/solid_mechanics/src/actions/CohesiveZoneAction.C
@@ -157,7 +157,7 @@ CohesiveZoneAction::addRequiredCZMInterfaceMaterials()
   std::string unique_material_name = _disp_jump_provider_name + "_" + _name;
   InputParameters paramsm = _factory.getValidParams(_disp_jump_provider_name);
   paramsm.set<std::vector<BoundaryName>>("boundary") = _boundary;
-  ;
+
   paramsm.set<std::vector<VariableName>>("displacements") = _displacements;
   paramsm.set<std::string>("base_name") = _base_name;
   _problem->addInterfaceMaterial(_disp_jump_provider_name, unique_material_name, paramsm);
@@ -166,7 +166,7 @@ CohesiveZoneAction::addRequiredCZMInterfaceMaterials()
   unique_material_name = _equilibrium_traction_calculator_name + "_" + _name;
   paramsm = _factory.getValidParams(_equilibrium_traction_calculator_name);
   paramsm.set<std::vector<BoundaryName>>("boundary") = _boundary;
-  ;
+
   paramsm.set<std::string>("base_name") = _base_name;
   _problem->addInterfaceMaterial(
       _equilibrium_traction_calculator_name, unique_material_name, paramsm);

--- a/modules/stochastic_tools/include/utils/MultiDimPolynomialGenerator.h
+++ b/modules/stochastic_tools/include/utils/MultiDimPolynomialGenerator.h
@@ -26,7 +26,7 @@ namespace StochasticTools
 class MultiDimPolynomialGenerator
 {
 public:
-  MultiDimPolynomialGenerator() {};
+  MultiDimPolynomialGenerator() {}
 
   ~MultiDimPolynomialGenerator() = default;
 

--- a/test/include/controls/TestControl.h
+++ b/test/include/controls/TestControl.h
@@ -21,7 +21,7 @@ public:
   static InputParameters validParams();
 
   TestControl(const InputParameters & parameters);
-  virtual ~TestControl() {};
+  virtual ~TestControl() {}
   virtual void execute();
 
 private:

--- a/test/include/kernels/DotCouplingKernel.h
+++ b/test/include/kernels/DotCouplingKernel.h
@@ -20,7 +20,7 @@ public:
   static InputParameters validParams();
 
   DotCouplingKernel(const InputParameters & parameters);
-  virtual ~DotCouplingKernel() {};
+  virtual ~DotCouplingKernel() {}
 
 protected:
   virtual Real computeQpResidual() override;

--- a/test/include/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTest.h
+++ b/test/include/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTest.h
@@ -24,9 +24,9 @@ public:
 
   LibtorchArtificialNeuralNetTest(const InputParameters & params);
 
-  virtual void initialize() {};
+  virtual void initialize() {}
   virtual void execute();
-  virtual void finalize() {};
+  virtual void finalize() {}
 
 protected:
   /// We create a vector to store the output of the neural net

--- a/test/include/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTrainerTest.h
+++ b/test/include/libtorch/vectorpostprocessors/LibtorchArtificialNeuralNetTrainerTest.h
@@ -23,9 +23,9 @@ public:
 
   LibtorchArtificialNeuralNetTrainerTest(const InputParameters & params);
 
-  virtual void initialize() {};
+  virtual void initialize() {}
   virtual void execute();
-  virtual void finalize() {};
+  virtual void finalize() {}
 
 protected:
   // We create a vector to store the output of the neural net

--- a/test/include/libtorch/vectorpostprocessors/TorchScriptModuleTest.h
+++ b/test/include/libtorch/vectorpostprocessors/TorchScriptModuleTest.h
@@ -23,9 +23,9 @@ public:
 
   TorchScriptModuleTest(const InputParameters & params);
 
-  virtual void initialize() {};
-  virtual void execute() {};
-  virtual void finalize() {};
+  virtual void initialize() {}
+  virtual void execute() {}
+  virtual void finalize() {}
 
 protected:
   // We create vectors to store our parameters (x,y,z) and NN output

--- a/test/include/markers/CircleMarker.h
+++ b/test/include/markers/CircleMarker.h
@@ -19,7 +19,7 @@ public:
   static InputParameters validParams();
 
   CircleMarker(const InputParameters & parameters);
-  virtual ~CircleMarker() {};
+  virtual ~CircleMarker() {}
 
 protected:
   virtual MarkerValue computeElementMarker();

--- a/test/include/markers/QPointMarker.h
+++ b/test/include/markers/QPointMarker.h
@@ -22,7 +22,7 @@ public:
   static InputParameters validParams();
 
   QPointMarker(const InputParameters & parameters);
-  virtual ~QPointMarker() {};
+  virtual ~QPointMarker() {}
 
 protected:
   virtual MarkerValue computeQpMarker();

--- a/test/include/markers/RandomHitMarker.h
+++ b/test/include/markers/RandomHitMarker.h
@@ -19,7 +19,7 @@ public:
   static InputParameters validParams();
 
   RandomHitMarker(const InputParameters & parameters);
-  virtual ~RandomHitMarker() {};
+  virtual ~RandomHitMarker() {}
 
 protected:
   virtual MarkerValue computeElementMarker();

--- a/test/include/markers/TwoCircleMarker.h
+++ b/test/include/markers/TwoCircleMarker.h
@@ -19,7 +19,7 @@ public:
   static InputParameters validParams();
 
   TwoCircleMarker(const InputParameters & parameters);
-  virtual ~TwoCircleMarker() {};
+  virtual ~TwoCircleMarker() {}
 
 protected:
   virtual MarkerValue computeElementMarker();

--- a/test/include/materials/NewtonMaterial.h
+++ b/test/include/materials/NewtonMaterial.h
@@ -24,7 +24,7 @@ public:
   static InputParameters validParams();
 
   NewtonMaterial(const InputParameters & parameters);
-  virtual ~NewtonMaterial() {};
+  virtual ~NewtonMaterial() {}
 
   virtual void initialSetup() override;
 

--- a/test/include/postprocessors/TestDiscontinuousValuePP.h
+++ b/test/include/postprocessors/TestDiscontinuousValuePP.h
@@ -25,7 +25,7 @@ public:
 
   TestDiscontinuousValuePP(const InputParameters & parameters);
 
-  virtual ~TestDiscontinuousValuePP() {};
+  virtual ~TestDiscontinuousValuePP() {}
 
   virtual void initialize() override {};
 

--- a/test/include/postprocessors/TestPostprocessor.h
+++ b/test/include/postprocessors/TestPostprocessor.h
@@ -31,7 +31,7 @@ public:
   /**
    * These methods are intentionally empty
    */
-  virtual ~TestPostprocessor() {};
+  virtual ~TestPostprocessor() {}
   virtual void initialize() override {}
   virtual void execute() override {}
   ///@}

--- a/test/include/userobjects/CheckGhostedBoundaries.h
+++ b/test/include/userobjects/CheckGhostedBoundaries.h
@@ -21,11 +21,11 @@ public:
 
   CheckGhostedBoundaries(const InputParameters & params);
 
-  virtual void initialSetup() {};
+  virtual void initialSetup() {}
 
-  virtual void initialize() {};
+  virtual void initialize() {}
   virtual void execute();
-  virtual void finalize() {};
+  virtual void finalize() {}
 
 private:
   dof_id_type _total_num_bdry_sides;

--- a/test/include/userobjects/DataFileNameTest.h
+++ b/test/include/userobjects/DataFileNameTest.h
@@ -21,9 +21,9 @@ public:
 
   DataFileNameTest(const InputParameters & params);
 
-  virtual void initialSetup() {};
+  virtual void initialSetup() {}
 
-  virtual void initialize() {};
-  virtual void execute() {};
-  virtual void finalize() {};
+  virtual void initialize() {}
+  virtual void execute() {}
+  virtual void finalize() {}
 };

--- a/test/include/userobjects/GetMaterialPropertyBoundaryBlockNamesTest.h
+++ b/test/include/userobjects/GetMaterialPropertyBoundaryBlockNamesTest.h
@@ -22,10 +22,10 @@ public:
   static InputParameters validParams();
 
   GetMaterialPropertyBoundaryBlockNamesTest(const InputParameters & parameters);
-  virtual ~GetMaterialPropertyBoundaryBlockNamesTest() {};
-  virtual void execute() {};
-  virtual void initialize() {};
-  virtual void finalize() {};
+  virtual ~GetMaterialPropertyBoundaryBlockNamesTest() {}
+  virtual void execute() {}
+  virtual void initialize() {}
+  virtual void finalize() {}
   virtual void initialSetup();
 
 private:

--- a/test/include/userobjects/MeshMetaDataInterfaceTest.h
+++ b/test/include/userobjects/MeshMetaDataInterfaceTest.h
@@ -21,7 +21,7 @@ public:
 
   MeshMetaDataInterfaceTest(const InputParameters & params);
 
-  virtual void initialize() {};
-  virtual void execute() {};
-  virtual void finalize() {};
+  virtual void initialize() {}
+  virtual void execute() {}
+  virtual void finalize() {}
 };

--- a/test/include/userobjects/PerfGraphTest.h
+++ b/test/include/userobjects/PerfGraphTest.h
@@ -21,7 +21,7 @@ public:
 
   PerfGraphTest(const InputParameters & params);
 
-  virtual void initialize() {};
-  virtual void execute() {};
-  virtual void finalize() {};
+  virtual void initialize() {}
+  virtual void execute() {}
+  virtual void finalize() {}
 };

--- a/test/include/userobjects/PointerLoadError.h
+++ b/test/include/userobjects/PointerLoadError.h
@@ -36,9 +36,9 @@ public:
   virtual void initialSetup();
   virtual void timestepSetup();
 
-  virtual void initialize() {};
+  virtual void initialize() {}
   virtual void execute();
-  virtual void finalize() {};
+  virtual void finalize() {}
 
 protected:
   TypeWithNoLoad *& _pointer_data;

--- a/test/include/userobjects/PointerStoreError.h
+++ b/test/include/userobjects/PointerStoreError.h
@@ -28,9 +28,9 @@ public:
   virtual void initialSetup();
   virtual void timestepSetup();
 
-  virtual void initialize() {};
+  virtual void initialize() {}
   virtual void execute();
-  virtual void finalize() {};
+  virtual void finalize() {}
 
 protected:
   TypeWithNoStore *& _pointer_data;

--- a/test/include/userobjects/ReadDoubleIndex.h
+++ b/test/include/userobjects/ReadDoubleIndex.h
@@ -21,9 +21,9 @@ public:
 
   ReadDoubleIndex(const InputParameters & params);
 
-  virtual void initialize() {};
+  virtual void initialize() {}
   virtual void execute();
-  virtual void finalize() {};
+  virtual void finalize() {}
 
 protected:
   const std::vector<std::vector<Real>> & _real_di;

--- a/test/include/userobjects/ReadTripleIndex.h
+++ b/test/include/userobjects/ReadTripleIndex.h
@@ -21,9 +21,9 @@ public:
 
   ReadTripleIndex(const InputParameters & params);
 
-  virtual void initialize() {};
+  virtual void initialize() {}
   virtual void execute();
-  virtual void finalize() {};
+  virtual void finalize() {}
 
 protected:
   const std::vector<std::vector<std::vector<Real>>> & _real_tri;

--- a/test/include/userobjects/RestartableTypes.h
+++ b/test/include/userobjects/RestartableTypes.h
@@ -89,9 +89,9 @@ public:
   virtual void initialSetup();
   virtual void timestepSetup();
 
-  virtual void initialize() {};
+  virtual void initialize() {}
   virtual void execute();
-  virtual void finalize() {};
+  virtual void finalize() {}
 
 protected:
   int _context_int;

--- a/test/include/userobjects/RestartableTypesChecker.h
+++ b/test/include/userobjects/RestartableTypesChecker.h
@@ -25,9 +25,9 @@ public:
   virtual void initialSetup();
   virtual void timestepSetup();
 
-  virtual void initialize() {};
+  virtual void initialize() {}
   virtual void execute();
-  virtual void finalize() {};
+  virtual void finalize() {}
 
   void checkData();
   void clearTypes();

--- a/test/include/userobjects/TestSaveInMesh.h
+++ b/test/include/userobjects/TestSaveInMesh.h
@@ -18,7 +18,7 @@ public:
 
   TestSaveInMesh(const InputParameters & parameters);
 
-  virtual void initialize() {};
-  virtual void execute() {};
-  virtual void finalize() {};
+  virtual void initialize() {}
+  virtual void execute() {}
+  virtual void finalize() {}
 };

--- a/test/include/userobjects/ToggleMeshAdaptivity.h
+++ b/test/include/userobjects/ToggleMeshAdaptivity.h
@@ -20,9 +20,9 @@ public:
 
   virtual void initialSetup();
 
-  virtual void initialize() {};
+  virtual void initialize() {}
   virtual void execute();
-  virtual void finalize() {};
+  virtual void finalize() {}
 
 protected:
   void checkState();

--- a/test/include/userobjects/UserObjectInterfaceTest.h
+++ b/test/include/userobjects/UserObjectInterfaceTest.h
@@ -21,7 +21,7 @@ public:
 
   UserObjectInterfaceTest(const InputParameters & params);
 
-  virtual void initialize() {};
-  virtual void execute() {};
-  virtual void finalize() {};
+  virtual void initialize() {}
+  virtual void execute() {}
+  virtual void finalize() {}
 };

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -77,7 +77,7 @@ struct LineCase
 class LineWalker : public hit::Walker
 {
 public:
-  LineWalker(int i, const std::vector<int> & want_lines) : _case(i), _want(want_lines) {};
+  LineWalker(int i, const std::vector<int> & want_lines) : _case(i), _want(want_lines) {}
   virtual void
   walk(const std::string & fullpath, const std::string & /*nodepath*/, hit::Node * n) override
   {

--- a/unit/src/MooseFunctorTest.C
+++ b/unit/src/MooseFunctorTest.C
@@ -34,7 +34,7 @@ class TestFunctor : public FunctorBase<T>
 public:
   using typename FunctorBase<T>::ValueType;
 
-  TestFunctor() : FunctorBase<T>("test") {};
+  TestFunctor() : FunctorBase<T>("test") {}
 
   bool hasBlocks(SubdomainID) const override { return true; }
 

--- a/unit/src/TestNonLinearIntegrators.C
+++ b/unit/src/TestNonLinearIntegrators.C
@@ -135,7 +135,9 @@ public:
       _nlf(nlf_),
 
       _x1(height),
-      _ess_tdof_list(ess_tdof_list_) {};
+      _ess_tdof_list(ess_tdof_list_)
+  {
+  }
 
   /// Set current dt, v, x values - needed to compute action and Jacobian.
   void SetParameters(double dt_, const mfem::Vector * x0_)


### PR DESCRIPTION
## Reason
We don't need unnecessary empty declarations.

## Design
Remove extraneous semicolons. This is probably not exhaustive.

## Impact
Fewer unnecessary, but innocuous, empty declarations.
