### PR TITLE
Fix solution state out-of-bounds, generalize solution state access

### DIFF
--- a/framework/include/systems/SystemBase.h
+++ b/framework/include/systems/SystemBase.h
@@ -1123,9 +1123,11 @@ private:
 inline const std::vector<NumericVector<Number> *> &
 SystemBase::getSolutionStates(const Moose::SolutionIterationType iteration_type) const
 {
-  const auto index = static_cast<unsigned short>(iteration_type);
-  mooseAssert(index < _solution_states.size(), "Invalid solution iteration type");
-  return _solution_states[index];
+  const auto iteration_type_index = static_cast<std::size_t>(iteration_type);
+  mooseAssert(iteration_type_index < static_cast<std::size_t>(Moose::SolutionIterationType::Count),
+              "Invalid solution iteration type");
+  mooseAssert(iteration_type_index < _solution_states.size(), "_solution_states sized incorrectly");
+  return _solution_states[iteration_type_index];
 }
 
 inline std::size_t

--- a/framework/include/systems/SystemBase.h
+++ b/framework/include/systems/SystemBase.h
@@ -183,10 +183,15 @@ public:
    */
   virtual void solve();
 
-  virtual void copyOldSolutions();
-  virtual void copyPreviousNonlinearSolutions();
-  virtual void copyPreviousMultiAppFixedPointSolutions();
-  virtual void copyPreviousMultiSystemFixedPointSolutions();
+  /**
+   * Copy the solution back in time (older -> old, etc).
+   */
+  void copyOldSolutions();
+  /**
+   * Copy a specific type of solution back in time (older -> old, etc).
+   */
+  void copyPreviousSolutions(const Moose::SolutionIterationType iteration_type);
+
   virtual void restoreSolutions();
 
   /**
@@ -209,6 +214,18 @@ public:
    * Initializes the solution state.
    */
   virtual void initSolutionState();
+
+  /**
+   * Get all of the solution states (current, old, ...) for the given iteration type.
+   */
+  const std::vector<NumericVector<Number> *> &
+  getSolutionStates(const Moose::SolutionIterationType iteration_type) const;
+
+  /**
+   * Get the number of solution states (0 = current, 1 = current + old, ...)
+   * for the given iteration type.
+   */
+  std::size_t getNumSolutionStates(const Moose::SolutionIterationType iteration_type) const;
 
   /**
    * Get a state of the solution (0 = current, 1 = old, 2 = older, etc).
@@ -1075,20 +1092,46 @@ private:
   TagName oldSolutionStateVectorName(const unsigned int,
                                      Moose::SolutionIterationType iteration_type) const;
 
+  /**
+   * Get all of the solution states (current, old, ...) for the given iteration type.
+   */
+  std::vector<NumericVector<Number> *> &
+  getSolutionStates(const Moose::SolutionIterationType iteration_type)
+  {
+    return const_cast<std::vector<NumericVector<Number> *> &>(
+        static_cast<const SystemBase *>(this)->getSolutionStates(iteration_type));
+  }
+
   /// 2D array of solution state vector pointers; first index corresponds to
   /// SolutionIterationType, second index corresponds to state index (0=current, 1=old, 2=older)
-  std::array<std::vector<NumericVector<Number> *>, 3> _solution_states;
+  std::array<std::vector<NumericVector<Number> *>,
+             static_cast<size_t>(Moose::SolutionIterationType::Count)>
+      _solution_states;
   /// The saved solution states (0 = current, 1 = old, 2 = older, etc)
   std::vector<NumericVector<Number> *> _saved_solution_states;
   /// Whether to skip the next copy from the solution to the old vector
   bool _skip_next_solution_to_old_copy;
 };
 
+inline const std::vector<NumericVector<Number> *> &
+SystemBase::getSolutionStates(const Moose::SolutionIterationType iteration_type) const
+{
+  const auto index = static_cast<unsigned short>(iteration_type);
+  mooseAssert(index < _solution_states.size(), "Invalid solution iteration type");
+  return _solution_states[index];
+}
+
+inline std::size_t
+SystemBase::getNumSolutionStates(const Moose::SolutionIterationType iteration_type) const
+{
+  return getSolutionStates(iteration_type).size();
+}
+
 inline bool
 SystemBase::hasSolutionState(const unsigned int state,
                              const Moose::SolutionIterationType iteration_type) const
 {
-  return _solution_states[static_cast<unsigned short>(iteration_type)].size() > state;
+  return getNumSolutionStates(iteration_type) > state;
 }
 
 #define PARALLEL_TRY

--- a/framework/include/systems/SystemBase.h
+++ b/framework/include/systems/SystemBase.h
@@ -1102,8 +1102,15 @@ private:
         static_cast<const SystemBase *>(this)->getSolutionStates(iteration_type));
   }
 
-  /// 2D array of solution state vector pointers; first index corresponds to
-  /// SolutionIterationType, second index corresponds to state index (0=current, 1=old, 2=older)
+  /**
+   * 2D array of solution state vector pointers.
+   *
+   * Outer (array) index: SolutionIterationType (Time, Nonlinear, ...)
+   * Inner (vector) index: State (0=current, 1=old, ...)
+   *
+   * Should only be accessed through getSolutionStates() when possible
+   * for bounds checking.
+   */
   std::array<std::vector<NumericVector<Number> *>,
              static_cast<size_t>(Moose::SolutionIterationType::Count)>
       _solution_states;

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -269,9 +269,13 @@ enum SolutionState : int
 enum class SolutionIterationType : unsigned short
 {
   Time = 0,
-  Nonlinear = 1,
-  MultiAppFixedPoint = 2,
-  MultiSystemFixedPoint = 3
+  Nonlinear,
+  MultiAppFixedPoint,
+  MultiSystemFixedPoint,
+  // Special name for determing the total size of
+  // iteration types. If adding a new type, it should
+  // always be above this entry.
+  Count
 };
 
 // These are used by MooseVariableData and MooseVariableDataFV

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -469,7 +469,7 @@ FEProblemSolve::solve()
 
       // Copy back systems as needed/requested
       for (auto * sys : _systems_to_copy_back_multi_sys_fp)
-        sys->copyPreviousMultiSystemFixedPointSolutions();
+        sys->copyPreviousSolutions(Moose::SolutionIterationType::MultiSystemFixedPoint);
 
       // Loop over each system
       for (const auto sys_i : index_range(_systems))

--- a/framework/src/executioners/FixedPointSolve.C
+++ b/framework/src/executioners/FixedPointSolve.C
@@ -475,7 +475,7 @@ FixedPointSolve::solveStep(const std::set<dof_id_type> & transformed_dofs)
 
   // Save the previous fixed point iteration solution and aux variables if requested
   for (auto * sys : _systems_to_copy_previous_solutions_for)
-    sys->copyPreviousMultiAppFixedPointSolutions();
+    sys->copyPreviousSolutions(Moose::SolutionIterationType::MultiAppFixedPoint);
 
   if (_has_fixed_point_its)
     _console << COLOR_MAGENTA << "\nMain app solve:" << COLOR_DEFAULT << std::endl;

--- a/framework/src/executioners/PicardSolve.C
+++ b/framework/src/executioners/PicardSolve.C
@@ -66,7 +66,7 @@ PicardSolve::allocateStorage(const bool primary)
 void
 PicardSolve::saveVariableValues(const bool primary)
 {
-  // Primary is copied back by _transformed_sys->copyPreviousMultiAppFixedPointSolutions()
+  // Primary is copied back by _transformed_sys->copyPreviousSolutions(MultiAppFixedPoint)
   if (!performingRelaxation(primary) || primary)
     return;
 

--- a/framework/src/executioners/SecantSolve.C
+++ b/framework/src/executioners/SecantSolve.C
@@ -114,7 +114,7 @@ SecantSolve::saveVariableValues(const bool primary)
   xn_m2 = xn_m1;
 
   // Before a solve, solution is a sequence term, after a solve, solution is the evaluated term
-  // Primary is copied back by _transformed_sys->copyPreviousMultiAppFixedPointSolutions()
+  // Primary is copied back by _transformed_sys->copyPreviousSolutions(MultiAppFixedPoint)
   if (!primary)
     xn_m1 = solution;
 

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -510,17 +510,16 @@ SystemBase::augmentSendList(std::vector<dof_id_type> & send_list)
 void
 SystemBase::saveOldSolutions()
 {
-  const auto states =
-      _solution_states[static_cast<unsigned short>(Moose::SolutionIterationType::Time)].size();
-  if (states > 1)
+  const auto num_states = getNumSolutionStates(Moose::SolutionIterationType::Time);
+  if (num_states > 1)
   {
-    _saved_solution_states.resize(states);
-    for (unsigned int i = 1; i <= states - 1; ++i)
+    _saved_solution_states.resize(num_states);
+    for (unsigned int i = 1; i <= num_states - 1; ++i)
       if (!_saved_solution_states[i])
         _saved_solution_states[i] =
             &addVector("save_solution_state_" + std::to_string(i), false, PARALLEL);
 
-    for (unsigned int i = 1; i <= states - 1; ++i)
+    for (unsigned int i = 1; i <= num_states - 1; ++i)
       *(_saved_solution_states[i]) = solutionState(i);
   }
 
@@ -542,10 +541,9 @@ SystemBase::saveOldSolutions()
 void
 SystemBase::restoreOldSolutions()
 {
-  const auto states =
-      _solution_states[static_cast<unsigned short>(Moose::SolutionIterationType::Time)].size();
-  if (states > 1)
-    for (unsigned int i = 1; i <= states - 1; ++i)
+  const auto num_states = getNumSolutionStates(Moose::SolutionIterationType::Time);
+  if (num_states > 1)
+    for (unsigned int i = 1; i <= num_states - 1; ++i)
       if (_saved_solution_states[i])
       {
         solutionState(i) = *(_saved_solution_states[i]);
@@ -1259,25 +1257,46 @@ void
 SystemBase::copySolutionsBackwards()
 {
   system().update();
-  copyOldSolutions();
-  copyPreviousNonlinearSolutions();
+  copyPreviousSolutions(Moose::SolutionIterationType::Time);
+  copyPreviousSolutions(Moose::SolutionIterationType::Nonlinear);
 }
 
-/**
- * Shifts the solutions backwards in nonlinear iteration history
- */
 void
-SystemBase::copyPreviousNonlinearSolutions()
+SystemBase::copyPreviousSolutions(const Moose::SolutionIterationType iteration_type)
 {
-  const auto states =
-      _solution_states[static_cast<unsigned short>(Moose::SolutionIterationType::Nonlinear)].size();
-  if (states > 1)
-    for (unsigned int i = states - 1; i > 0; --i)
-      solutionState(i, Moose::SolutionIterationType::Nonlinear) =
-          solutionState(i - 1, Moose::SolutionIterationType::Nonlinear);
+  auto & solution_states = getSolutionStates(iteration_type);
+  const auto num_states = solution_states.size();
+  if (num_states > 1)
+  {
+    // Normally copy through old (index 1). For Time, optionally stop at older
+    // and leave old unchanged.
+    const bool skip_old =
+        iteration_type == Moose::SolutionIterationType::Time && _skip_next_solution_to_old_copy;
 
-  if (solutionPreviousNewton())
-    *solutionPreviousNewton() = *currentSolution();
+    const std::size_t stop = skip_old ? 1 : 0;
+    for (std::size_t i = num_states - 1; i > stop; --i)
+      solution_states[i] = solution_states[i - 1];
+  }
+
+  // Custom logic for changing state based on iteration type
+  switch (iteration_type)
+  {
+    case Moose::SolutionIterationType::Time:
+      _skip_next_solution_to_old_copy = false;
+      if (solutionUDotOld())
+        *solutionUDotOld() = *solutionUDot();
+      if (solutionUDotDotOld())
+        *solutionUDotDotOld() = *solutionUDotDot();
+      break;
+    case Moose::SolutionIterationType::Nonlinear:
+      if (solutionPreviousNewton())
+        *solutionPreviousNewton() = *currentSolution();
+      break;
+    case Moose::SolutionIterationType::MultiAppFixedPoint:
+    case Moose::SolutionIterationType::MultiSystemFixedPoint:
+    case Moose::SolutionIterationType::Count:
+      break;
+  }
 }
 
 /**
@@ -1286,42 +1305,7 @@ SystemBase::copyPreviousNonlinearSolutions()
 void
 SystemBase::copyOldSolutions()
 {
-  // copy the solutions backward: current->old, old->older
-  const auto states =
-      _solution_states[static_cast<unsigned short>(Moose::SolutionIterationType::Time)].size();
-  if (states > 1)
-    for (unsigned int i = states - 1; i > uint(_skip_next_solution_to_old_copy); --i)
-      solutionState(i) = solutionState(i - 1);
-  _skip_next_solution_to_old_copy = false;
-
-  if (solutionUDotOld())
-    *solutionUDotOld() = *solutionUDot();
-  if (solutionUDotDotOld())
-    *solutionUDotDotOld() = *solutionUDotDot();
-}
-
-void
-SystemBase::copyPreviousMultiAppFixedPointSolutions()
-{
-  const auto n_states = _solution_states[static_cast<unsigned short>(
-                                             Moose::SolutionIterationType::MultiAppFixedPoint)]
-                            .size();
-  if (n_states > 1)
-    for (unsigned int i = n_states - 1; i > 0; --i)
-      solutionState(i, Moose::SolutionIterationType::MultiAppFixedPoint) =
-          solutionState(i - 1, Moose::SolutionIterationType::MultiAppFixedPoint);
-}
-
-void
-SystemBase::copyPreviousMultiSystemFixedPointSolutions()
-{
-  const auto n_states = _solution_states[static_cast<unsigned short>(
-                                             Moose::SolutionIterationType::MultiSystemFixedPoint)]
-                            .size();
-  if (n_states > 1)
-    for (unsigned int i = n_states - 1; i > 0; --i)
-      solutionState(i, Moose::SolutionIterationType::MultiSystemFixedPoint) =
-          solutionState(i - 1, Moose::SolutionIterationType::MultiSystemFixedPoint);
+  copyPreviousSolutions(Moose::SolutionIterationType::Time);
 }
 
 /**
@@ -1419,6 +1403,8 @@ SystemBase::solutionState(const unsigned int state,
                           const Moose::SolutionIterationType iteration_type) const
 {
   if (!hasSolutionState(state, iteration_type))
+  {
+    const auto num_states = getNumSolutionStates(iteration_type);
     mooseError("For iteration type '",
                Moose::stringify(iteration_type),
                "': solution state ",
@@ -1426,12 +1412,11 @@ SystemBase::solutionState(const unsigned int state,
                " was requested in ",
                name(),
                " but only up to state ",
-               (_solution_states[static_cast<unsigned short>(iteration_type)].size() == 0)
-                   ? 0
-                   : _solution_states[static_cast<unsigned short>(iteration_type)].size() - 1,
+               (num_states == 0) ? 0 : num_states - 1,
                " is available.");
+  }
 
-  const auto & solution_states = _solution_states[static_cast<unsigned short>(iteration_type)];
+  const auto & solution_states = getSolutionStates(iteration_type);
 
   if (state == 0)
     mooseAssert(solution_states[0] == &solutionInternal(), "Inconsistent current solution");
@@ -1449,7 +1434,7 @@ SystemBase::solutionState(const unsigned int state,
 {
   if (!hasSolutionState(state, iteration_type))
     needSolutionState(state, iteration_type);
-  return *_solution_states[static_cast<unsigned short>(iteration_type)][state];
+  return *getSolutionStates(iteration_type)[state];
 }
 
 libMesh::ParallelType
@@ -1458,8 +1443,7 @@ SystemBase::solutionStateParallelType(const unsigned int state,
 {
   if (!hasSolutionState(state, iteration_type))
     mooseError("solutionStateParallelType() may only be called if the solution state exists.");
-
-  return _solution_states[static_cast<unsigned short>(iteration_type)][state]->type();
+  return getSolutionStates(iteration_type)[state]->type();
 }
 
 void

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -1471,7 +1471,7 @@ SystemBase::needSolutionState(const unsigned int state,
   if (hasSolutionState(state, iteration_type))
     return;
 
-  auto & solution_states = _solution_states[static_cast<unsigned short>(iteration_type)];
+  auto & solution_states = getSolutionStates(iteration_type);
   solution_states.resize(state + 1);
 
   // The 0-th (current) solution state is owned by libMesh

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -1379,20 +1379,33 @@ SystemBase::oldSolutionStateVectorName(const unsigned int state,
                                        const Moose::SolutionIterationType iteration_type) const
 {
   mooseAssert(state != 0, "Not an old state");
+  mooseAssert(static_cast<unsigned short>(iteration_type) <
+                  static_cast<unsigned short>(Moose::SolutionIterationType::Count),
+              "Invalid iteration_type");
 
-  if (iteration_type == Moose::SolutionIterationType::Time)
+  switch (iteration_type)
   {
-    if (state == 1)
-      return Moose::OLD_SOLUTION_TAG;
-    else if (state == 2)
-      return Moose::OLDER_SOLUTION_TAG;
+    case Moose::SolutionIterationType::Time:
+      if (state == 1)
+        return Moose::OLD_SOLUTION_TAG;
+      else if (state == 2)
+        return Moose::OLDER_SOLUTION_TAG;
+      break;
+    case Moose::SolutionIterationType::Nonlinear:
+      if (state == 1)
+        return Moose::PREVIOUS_NL_SOLUTION_TAG;
+      break;
+    case Moose::SolutionIterationType::MultiAppFixedPoint:
+      if (state == 1)
+        return Moose::PREVIOUS_MULTIAPP_FP_SOLUTION_TAG;
+      break;
+    case Moose::SolutionIterationType::MultiSystemFixedPoint:
+      if (state == 1)
+        return Moose::PREVIOUS_MULTISYSTEM_FP_SOLUTION_TAG;
+      break;
+    case Moose::SolutionIterationType::Count:
+      break;
   }
-  else if (iteration_type == Moose::SolutionIterationType::Nonlinear && state == 1)
-    return Moose::PREVIOUS_NL_SOLUTION_TAG;
-  else if (iteration_type == Moose::SolutionIterationType::MultiAppFixedPoint && state == 1)
-    return Moose::PREVIOUS_MULTIAPP_FP_SOLUTION_TAG;
-  else if (iteration_type == Moose::SolutionIterationType::MultiSystemFixedPoint && state == 1)
-    return Moose::PREVIOUS_MULTISYSTEM_FP_SOLUTION_TAG;
 
   return "solution_state_" + std::to_string(state) + "_" + Moose::stringify(iteration_type);
 }

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -1264,8 +1264,7 @@ SystemBase::copySolutionsBackwards()
 void
 SystemBase::copyPreviousSolutions(const Moose::SolutionIterationType iteration_type)
 {
-  auto & solution_states = getSolutionStates(iteration_type);
-  const auto num_states = solution_states.size();
+  const auto num_states = getNumSolutionStates(iteration_type);
   if (num_states > 1)
   {
     // Normally copy through old (index 1). For Time, optionally stop at older
@@ -1275,7 +1274,7 @@ SystemBase::copyPreviousSolutions(const Moose::SolutionIterationType iteration_t
 
     const std::size_t stop = skip_old ? 1 : 0;
     for (std::size_t i = num_states - 1; i > stop; --i)
-      solution_states[i] = solution_states[i - 1];
+      solutionState(i, iteration_type) = solutionState(i - 1, iteration_type);
   }
 
   // Custom logic for changing state based on iteration type

--- a/modules/navier_stokes/src/executioners/LinearAssemblySegregatedSolve.C
+++ b/modules/navier_stokes/src/executioners/LinearAssemblySegregatedSolve.C
@@ -358,7 +358,7 @@ LinearAssemblySegregatedSolve::solveMomentumPredictor()
     LinearImplicitSystem & momentum_system =
         libMesh::cast_ref<LinearImplicitSystem &>(_momentum_systems[system_i]->system());
     _momentum_systems[system_i]->setSolution(*(momentum_system.current_local_solution));
-    _momentum_systems[system_i]->copyPreviousNonlinearSolutions();
+    _momentum_systems[system_i]->copyPreviousSolutions(Moose::SolutionIterationType::Nonlinear);
   }
 
   // We reset this to ensure the preconditioner is recomputed new time we go to the momentum

--- a/modules/navier_stokes/src/executioners/SIMPLESolveNonlinearAssembly.C
+++ b/modules/navier_stokes/src/executioners/SIMPLESolveNonlinearAssembly.C
@@ -235,7 +235,7 @@ SIMPLESolveNonlinearAssembly::solveMomentumPredictor()
     }
 
     _momentum_systems[system_i]->setSolution(*(momentum_system.current_local_solution));
-    _momentum_systems[system_i]->copyPreviousNonlinearSolutions();
+    _momentum_systems[system_i]->copyPreviousSolutions(Moose::SolutionIterationType::Nonlinear);
   }
 
   return its_normalized_residuals;


### PR DESCRIPTION
#33328 added the `SolutionIterationType::MultiSystemFixedPoint` solution state type. However, `SystemBase::_solution_states` (which `SolutionIterationType` is an index into) is an array and was not sized (increased by one) correctly to accommodate this change. See the errors in https://civet.inl.gov/job/4068301/.

- Adds a `SolutionIterationType::Count` as the last entry, which can be used to properly size `SystemBase::_solution_states` and removes the need to manually size this again in the future so long as new enumerations are added above `Count`.
- Adds getters for `SystemBase::_solution_states` so that we'll get assertions instead of crashes in the future.
- Generalizes all of the `SystemBase::copyPrevious<TYPE>Solutions()` methods into a single `SystemBase::copyPreviousSolutions(const SolutionIterationType)`.

refs #33321