### PR TITLE
Kokkos SYCL Updates

### DIFF
--- a/framework/include/kokkos/base/KokkosFunctorWrapper.h
+++ b/framework/include/kokkos/base/KokkosFunctorWrapper.h
@@ -30,7 +30,7 @@ public:
   /**
    * Virtual destructor
    */
-  KOKKOS_VIRTUAL_FUNCTION ~FunctorWrapperDeviceBase() {}
+  KOKKOS_FUNCTION KOKKOS_VIRTUAL ~FunctorWrapperDeviceBase() {}
 };
 
 /**

--- a/framework/include/kokkos/base/KokkosHeader.h
+++ b/framework/include/kokkos/base/KokkosHeader.h
@@ -35,19 +35,20 @@
 #ifdef KOKKOS_ENABLE_CUDA
 #define MemSpace ::Kokkos::CudaSpace
 #define ExecSpace ::Kokkos::Cuda
-#define KOKKOS_VIRTUAL_FUNCTION KOKKOS_FUNCTION virtual
+#define KOKKOS_VIRTUAL virtual
+#define KOKKOS_OVERRIDE override
 #endif
 #ifdef KOKKOS_ENABLE_HIP
 #define MemSpace ::Kokkos::HIPSpace
 #define ExecSpace ::Kokkos::HIP
-#define KOKKOS_VIRTUAL_FUNCTION KOKKOS_FUNCTION virtual
+#define KOKKOS_VIRTUAL virtual
+#define KOKKOS_OVERRIDE override
 #endif
 #ifdef KOKKOS_ENABLE_SYCL
 #define MemSpace ::Kokkos::SYCLDeviceUSMSpace
 #define ExecSpace ::Kokkos::SYCL
-#define KOKKOS_VIRTUAL_FUNCTION                                                                    \
-  KOKKOS_FUNCTION SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(                                               \
-      sycl::ext::oneapi::experimental::indirectly_callable) virtual
+#define KOKKOS_VIRTUAL
+#define KOKKOS_OVERRIDE
 #endif
 #else
 #define MemSpace ::Kokkos::HostSpace
@@ -56,7 +57,8 @@
 #define KOKKOS_FUNCTION
 #undef KOKKOS_INLINE_FUNCTION
 #define KOKKOS_INLINE_FUNCTION inline
-#define KOKKOS_VIRTUAL_FUNCTION KOKKOS_FUNCTION virtual
+#define KOKKOS_VIRTUAL virtual
+#define KOKKOS_OVERRIDE override
 #undef KOKKOS_IF_ON_HOST
 #define KOKKOS_IF_ON_HOST(code)                                                                    \
   if (!omp_get_level())                                                                            \

--- a/framework/include/kokkos/functions/KokkosFunctionWrapper.h
+++ b/framework/include/kokkos/functions/KokkosFunctionWrapper.h
@@ -30,21 +30,59 @@ public:
   /**
    * Virtual destructor
    */
-  KOKKOS_VIRTUAL_FUNCTION ~FunctionWrapperDeviceBase() {}
+  KOKKOS_FUNCTION KOKKOS_VIRTUAL ~FunctionWrapperDeviceBase() {}
 
   /**
    * Virtual shims that calls the corresponding methods of the actual stored function
    */
   ///@{
-  KOKKOS_VIRTUAL_FUNCTION Real value(Real t, Real3 p) const = 0;
-  KOKKOS_VIRTUAL_FUNCTION Real3 vectorValue(Real t, Real3 p) const = 0;
-  KOKKOS_VIRTUAL_FUNCTION Real3 gradient(Real t, Real3 p) const = 0;
-  KOKKOS_VIRTUAL_FUNCTION Real3 curl(Real t, Real3 p) const = 0;
-  KOKKOS_VIRTUAL_FUNCTION Real div(Real t, Real3 p) const = 0;
-  KOKKOS_VIRTUAL_FUNCTION Real timeDerivative(Real t, Real3 p) const = 0;
-  KOKKOS_VIRTUAL_FUNCTION Real timeIntegral(Real t1, Real t2, Real3 p) const = 0;
-  KOKKOS_VIRTUAL_FUNCTION Real integral() const = 0;
-  KOKKOS_VIRTUAL_FUNCTION Real average() const = 0;
+  KOKKOS_FUNCTION KOKKOS_VIRTUAL Real value(Real /* t */, Real3 /* p */) const
+  {
+    KOKKOS_ASSERT(false);
+    return 0;
+  }
+  KOKKOS_FUNCTION KOKKOS_VIRTUAL Real3 vectorValue(Real /* t */, Real3 /* p */) const
+  {
+    KOKKOS_ASSERT(false);
+    return Real3(0);
+  }
+  KOKKOS_FUNCTION KOKKOS_VIRTUAL Real3 gradient(Real /* t */, Real3 /* p */) const
+  {
+    KOKKOS_ASSERT(false);
+    return Real3(0);
+  }
+  KOKKOS_FUNCTION KOKKOS_VIRTUAL Real3 curl(Real /* t */, Real3 /* p */) const
+  {
+    KOKKOS_ASSERT(false);
+    return Real3(0);
+  }
+  KOKKOS_FUNCTION KOKKOS_VIRTUAL Real div(Real /* t */, Real3 /* p */) const
+  {
+    KOKKOS_ASSERT(false);
+    return 0;
+  }
+  KOKKOS_FUNCTION KOKKOS_VIRTUAL Real timeDerivative(Real /* t */, Real3 /* p */) const
+  {
+    KOKKOS_ASSERT(false);
+    return 0;
+  }
+  KOKKOS_FUNCTION KOKKOS_VIRTUAL Real timeIntegral(Real /* t1 */,
+                                                   Real /* t2 */,
+                                                   Real3 /* p */) const
+  {
+    KOKKOS_ASSERT(false);
+    return 0;
+  }
+  KOKKOS_FUNCTION KOKKOS_VIRTUAL Real integral() const
+  {
+    KOKKOS_ASSERT(false);
+    return 0;
+  }
+  KOKKOS_FUNCTION KOKKOS_VIRTUAL Real average() const
+  {
+    KOKKOS_ASSERT(false);
+    return 0;
+  }
   ///@}
 };
 
@@ -65,30 +103,33 @@ public:
    */
   KOKKOS_FUNCTION FunctionWrapperDevice() {}
 
-  KOKKOS_FUNCTION Real value(Real t, Real3 p) const override final
+  KOKKOS_FUNCTION Real value(Real t, Real3 p) const KOKKOS_OVERRIDE
   {
     return _function->value(t, p);
   }
-  KOKKOS_FUNCTION Real3 vectorValue(Real t, Real3 p) const override final
+  KOKKOS_FUNCTION Real3 vectorValue(Real t, Real3 p) const KOKKOS_OVERRIDE
   {
     return _function->vectorValue(t, p);
   }
-  KOKKOS_FUNCTION Real3 gradient(Real t, Real3 p) const override final
+  KOKKOS_FUNCTION Real3 gradient(Real t, Real3 p) const KOKKOS_OVERRIDE
   {
     return _function->gradient(t, p);
   }
-  KOKKOS_FUNCTION Real3 curl(Real t, Real3 p) const override final { return _function->curl(t, p); }
-  KOKKOS_FUNCTION Real div(Real t, Real3 p) const override final { return _function->div(t, p); }
-  KOKKOS_FUNCTION Real timeDerivative(Real t, Real3 p) const override final
+  KOKKOS_FUNCTION Real3 curl(Real t, Real3 p) const KOKKOS_OVERRIDE
+  {
+    return _function->curl(t, p);
+  }
+  KOKKOS_FUNCTION Real div(Real t, Real3 p) const KOKKOS_OVERRIDE { return _function->div(t, p); }
+  KOKKOS_FUNCTION Real timeDerivative(Real t, Real3 p) const KOKKOS_OVERRIDE
   {
     return _function->timeDerivative(t, p);
   }
-  KOKKOS_FUNCTION Real timeIntegral(Real t1, Real t2, Real3 p) const override final
+  KOKKOS_FUNCTION Real timeIntegral(Real t1, Real t2, Real3 p) const KOKKOS_OVERRIDE
   {
     return _function->timeIntegral(t1, t2, p);
   }
-  KOKKOS_FUNCTION Real integral() const override final { return _function->integral(); }
-  KOKKOS_FUNCTION Real average() const override final { return _function->average(); }
+  KOKKOS_FUNCTION Real integral() const KOKKOS_OVERRIDE { return _function->integral(); }
+  KOKKOS_FUNCTION Real average() const KOKKOS_OVERRIDE { return _function->average(); }
 
 protected:
   /**

--- a/framework/kokkos.mk
+++ b/framework/kokkos.mk
@@ -110,12 +110,13 @@ else ifneq ($(PETSC_HAVE_SYCL),)
   KOKKOS_ARCH       := $(KOKKOS_SYCL_ARCH_$(SYCL_ARCH))
   KOKKOS_COMPILER   := ICPX
   KOKKOS_CXX         = $(SYCL_COMPILER)
-  KOKKOS_CXXFLAGS    = -fsycl -fsycl-targets=spir64_gen -x c++ $(CXXFLAGS) $(libmesh_CXXFLAGS)
+  KOKKOS_CXXFLAGS    = -fsycl -fno-sycl-rdc -x c++ $(CXXFLAGS) $(libmesh_CXXFLAGS)
   KOKKOS_CXXFLAGS   += -Wno-deprecated-declarations -Wno-macro-redefined
   KOKKOS_CPPFLAGS    = $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) ${ADDITIONAL_KOKKOS_CPPFLAGS}
   KOKKOS_LDFLAGS     = -fsycl
   ifneq ($(SYCL_ARCH),)
-    KOKKOS_LDFLAGS  += -Xsycl-target-backend "-device $(SYCL_ARCH)"
+    KOKKOS_CXXLFAGS += -fsycl-targets=spir64_gen
+    KOKKOS_LDFLAGS  += -fsycl-targets=spir64_gen -Xsycl-target-backend "-device $(SYCL_ARCH)"
   endif
 else
   KOKKOS_COMPILER   := CPU

--- a/test/tests/kokkos/auxkernels/copy_value_aux/tests
+++ b/test/tests/kokkos/auxkernels/copy_value_aux/tests
@@ -7,7 +7,7 @@
     csvdiff = 'kokkos_copy_aux_out_results_0001.csv'
     requirement = 'The Kokkos system shall be able to copy from a variable to another of the same finite element family and order.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [copy_old]
     type = 'CSVDiff'
@@ -15,6 +15,6 @@
     csvdiff = 'kokkos_copy_old_aux_out.csv'
     requirement = 'The Kokkos system shall be able to copy from the old and older state of a variable to an auxiliary variable.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/auxkernels/extra_element_id_aux/tests
+++ b/test/tests/kokkos/auxkernels/extra_element_id_aux/tests
@@ -9,6 +9,6 @@
     requirement = 'The Kokkos system shall have the capability of visualizing element integers in an auxiliary variable.'
     recover = false
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/auxkernels/parsed/tests
+++ b/test/tests/kokkos/auxkernels/parsed/tests
@@ -10,7 +10,7 @@
       exodiff = 'kokkos_parsed_aux_test_out.e'
       detail = 'using field variables,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [matprop]
       type = 'Exodiff'
@@ -18,7 +18,7 @@
       exodiff = 'kokkos_parsed_aux_mat_test_out.e'
       detail = 'using material properties,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [xyzt]
       type = 'Exodiff'
@@ -26,7 +26,7 @@
       exodiff = 'kokkos_xyzt_out.e'
       detail = 'using quadrature/nodal point coordinates and time.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/auxkernels/pp_depend/tests
+++ b/test/tests/kokkos/auxkernels/pp_depend/tests
@@ -7,6 +7,6 @@
     exodiff = 'kokkos_pp_depend_out.e'
     requirement = 'The Kokkos system shall be able to execute user objects before the execution of an auxiliary kernel if the latter depends on the former.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/auxkernels/time_integration/tests
+++ b/test/tests/kokkos/auxkernels/time_integration/tests
@@ -7,6 +7,6 @@
     exodiff = 'kokkos_time_integration_out.e'
     requirement = 'The Kokkos system shall include the ability to compute the integral of a variable over time.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/bcs/1d_neumann/tests
+++ b/test/tests/kokkos/bcs/1d_neumann/tests
@@ -8,6 +8,6 @@
     exodiff = 'kokkos_1d_neumann_out.e'
     requirement = 'The Kokkos system shall support Neumann type boundary conditions for a 1D problem.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/bcs/ad_coupled_var_neumann/tests
+++ b/test/tests/kokkos/bcs/ad_coupled_var_neumann/tests
@@ -8,7 +8,7 @@
     exodiff = 'kokkos_ad_coupled_var_neumann_out.e'
     requirement = 'The Kokkos system shall support coupled Neumann type boundary conditions using automatic differentiation.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [nonlinear]
@@ -19,7 +19,7 @@
       exodiff = 'kokkos_ad_coupled_var_neumann_nl_out.e'
       detail = 'generate accurate results'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [jac]
       type = PetscJacobianTester
@@ -28,7 +28,7 @@
       difference_tol = 1e-6
       detail = 'generate a perfect Jacobian'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/bcs/coupled_dirichlet_bc/tests
+++ b/test/tests/kokkos/bcs/coupled_dirichlet_bc/tests
@@ -8,6 +8,6 @@
     exodiff = 'kokkos_coupled_dirichlet_bc_out.e'
     requirement = 'The Kokkos system shall support the creation of BoundaryCondition objects that couple to nonlinear variables.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/bcs/coupled_var_neumann/tests
+++ b/test/tests/kokkos/bcs/coupled_var_neumann/tests
@@ -8,7 +8,7 @@
     exodiff = 'kokkos_coupled_var_neumann_out.e'
     requirement = 'The Kokkos system shall support coupled Neumann type boundary conditions.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [on_off]
@@ -17,7 +17,7 @@
     exodiff = 'kokkos_on_off_out.e'
     requirement = 'The Kokkos system shall enable scaling of the Neumann type boundary conditions.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [nonlinear]
@@ -28,7 +28,7 @@
       exodiff = 'kokkos_coupled_var_neumann_nl_out.e'
       detail = 'generate accurate results'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [jac]
       type = PetscJacobianTester
@@ -37,7 +37,7 @@
       difference_tol = 1e-6
       detail = 'generate a perfect Jacobian'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/bcs/directional_neumann/tests
+++ b/test/tests/kokkos/bcs/directional_neumann/tests
@@ -10,7 +10,7 @@
       exodiff = 'kokkos_1d_directional_neumann_bc_test_out.e'
       detail = 'in 1D geometries'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [2d]
       type = Exodiff
@@ -18,7 +18,7 @@
       exodiff = 'kokkos_2d_directional_neumann_bc_test_out.e'
       detail = 'in 2D geometries'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [3d]
       type = Exodiff
@@ -26,7 +26,7 @@
       exodiff = 'kokkos_3d_directional_neumann_bc_test_out.e'
       detail = 'in 3D geometries'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/bcs/matched_value_bc/tests
+++ b/test/tests/kokkos/bcs/matched_value_bc/tests
@@ -8,6 +8,6 @@
     exodiff = 'kokkos_matched_value_bc_test_out.e'
     requirement = 'The Kokkos system shall support matching variable values on a boundary.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/bcs/misc_bcs/tests
+++ b/test/tests/kokkos/bcs/misc_bcs/tests
@@ -8,7 +8,7 @@
     exodiff = 'kokkos_convective_flux_bc_out.e'
     requirement = 'The Kokkos system shall support the ability to create convective flux boundary conditions.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [vacuumbc_test]
@@ -17,6 +17,6 @@
     exodiff = 'kokkos_vacuum_bc_test_out.e'
     requirement = 'The Kokkos system shall support a vacuum boundary condition for neutron diffusion on the boundary.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/bcs/pp_neumann/tests
+++ b/test/tests/kokkos/bcs/pp_neumann/tests
@@ -8,6 +8,6 @@
     exodiff = 'kokkos_pp_neumann_out.e'
     requirement = 'The Kokkos system shall support the application of a Neumann boundary condition computed via Postprocessor object.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/coord_type/tests
+++ b/test/tests/kokkos/coord_type/tests
@@ -10,7 +10,7 @@
       exodiff = 'kokkos_diffusion_rz_out.e'
       detail = 'R-Z,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [rspherical]
       type = 'Exodiff'
@@ -18,7 +18,7 @@
       exodiff = 'kokkos_diffusion_rspherical_out.e'
       detail = 'R-Spherical.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/fe-fv-interplay/tests
+++ b/test/tests/kokkos/fe-fv-interplay/tests
@@ -7,7 +7,7 @@
     input = aux-read-from-fv.i
     csvdiff = aux-read-from-fv_csv.csv
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
     max_threads = 1 # linear FV doesn't support threading
   []
   [mixing_fe_fv]
@@ -16,7 +16,7 @@
     input = multisystem.i
     csvdiff = multisystem_csv.csv
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
     max_threads = 1 # linear FV doesn't support threading
   []
 []

--- a/test/tests/kokkos/functions/concrete_type/tests
+++ b/test/tests/kokkos/functions/concrete_type/tests
@@ -7,7 +7,7 @@
     exodiff = 'kokkos_concrete_function_out.e'
     requirement = 'The Kokkos function system shall include the ability to explicitly retrieve a function in a concrete type to avoid virtual function calls.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [invalid_type]
     type = 'RunException'
@@ -16,6 +16,6 @@
     expect_err = 'Kokkos function \'piecewise_constant\' is not of type \'KokkosConstantFunction\''
     requirement = 'The Kokkos function system shall error when a provided function is not of the requested concrete type.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/functions/parsed_function/tests
+++ b/test/tests/kokkos/functions/parsed_function/tests
@@ -7,6 +7,6 @@
     exodiff = 'kokkos_parsed_function_out.e'
     requirement = 'The Kokkos function system shall include a parsed function.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/kernels/2d_diffusion/tests
+++ b/test/tests/kokkos/kernels/2d_diffusion/tests
@@ -8,7 +8,7 @@
     requirement = 'The Kokkos system shall provide an ability to solve a 2D diffusion problem with Dirichlet boundary conditions.'
     design = 'KokkosDiffusion.md KokkosDirichletBC.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [testneumann]
@@ -18,7 +18,7 @@
     requirement = 'The Kokkos system shall provide an ability to solve a 2D diffusion problem with Neumann boundary conditions.'
     design = 'KokkosDiffusion.md KokkosNeumannBC.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [testbodyforce]
@@ -28,7 +28,7 @@
     requirement = 'The Kokkos system shall provide an ability to solve a 2D diffusion problem including a volumetric source term.'
     design = 'KokkosDiffusion.md KokkosBodyForce.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [test_jacobian]
@@ -39,7 +39,7 @@
     requirement = 'The Kokkos system shall provide a tester that checks hand-coded Jacobian against finite difference Jacobian using -snes_type=test option.'
     design = 'framework_stp.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [test_force_iteration]
@@ -51,7 +51,7 @@
     requirement = 'The Kokkos system shall force the solver to take at least one iteration regardless of the initial residual norm when the snes_force_iteration option is specified.'
     design = 'Transient.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [actual_linear_solver]
@@ -62,6 +62,6 @@
     requirement = 'The Kokkos system shall not compute an extra residual if the linear solver is used.'
     design = 'FEProblem.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/kernels/ad_diffusion/tests
+++ b/test/tests/kokkos/kernels/ad_diffusion/tests
@@ -8,7 +8,7 @@
     requirement = 'The Kokkos system shall provide an ability to solve a 2D diffusion problem with Dirichlet boundary conditions using automatic differentation.'
     design = 'KokkosADDiffusion.md KokkosADDirichletBC.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [neumann]
     type = Exodiff
@@ -17,7 +17,7 @@
     requirement = 'The Kokkos system shall provide an ability to solve a 2D diffusion problem with Neumann boundary conditions using automatic differentation.'
     design = 'KokkosADDiffusion.md KokkosADNeumannBC.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [jacobian]
     type = PetscJacobianTester
@@ -27,6 +27,6 @@
     requirement = 'The Kokkos system shall provide an exact Jacobian using automatic differentation.'
     design = 'framework_stp.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/kernels/ad_time_derivative/tests
+++ b/test/tests/kokkos/kernels/ad_time_derivative/tests
@@ -8,7 +8,7 @@
     requirement = 'The Kokkos system shall provide a time derivative kernel using automatic differentation.'
     design = 'KokkosADTimeDerivative.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [test_jacobian]
     type = 'PetscJacobianTester'
@@ -20,7 +20,7 @@
     requirement = 'The Jacobian from a Kokkos-based time derivative kernel shall be perfect.'
     design = 'KokkosADTimeDerivative.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [coupled]
@@ -30,7 +30,7 @@
     requirement = 'The Kokkos system shall provide a coupled time derivative kernel using automatic differentation.'
     design = 'KokkosADCoupledTimeDerivative.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [coupled_jacobian]
     type = 'PetscJacobianTester'
@@ -42,7 +42,7 @@
     requirement = 'The Jacobian from a Kokkos-based coupled variable time derivative kernel shall be perfect.'
     design = 'KokkosADCoupledTimeDerivative.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [separate]
@@ -53,6 +53,6 @@
     requirement = 'The Kokkos system shall be able to compute residual and Jacobian separately with AD kernels.'
     design = 'Executioner.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/kernels/block_kernel/tests
+++ b/test/tests/kokkos/kernels/block_kernel/tests
@@ -11,7 +11,7 @@
       exodiff = 'kokkos_block_kernel_test_out.e'
       detail = 'through a subdomain restriction on the kernel, and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
 
     [variable]
@@ -20,7 +20,7 @@
       exodiff = 'kokkos_block_vars_out.e'
       detail = 'through a subdomain restriction on the variable.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/kernels/coupled_time_derivative/tests
+++ b/test/tests/kokkos/kernels/coupled_time_derivative/tests
@@ -8,7 +8,7 @@
     exodiff = 'kokkos_coupled_time_derivative_test_out.e'
     requirement = 'A coupled time derivative Kokkos kernel shall be provided.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [jac_test]
     type = 'PetscJacobianTester'
@@ -19,6 +19,6 @@
     difference_tol = 1e-6
     requirement = 'The Jacobian from coupled time derivative Kokkos kernel shall be perfect.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/kernels/kernel_precompute/tests
+++ b/test/tests/kokkos/kernels/kernel_precompute/tests
@@ -8,6 +8,6 @@
     exodiff = 'kokkos_kernel_precompute_test_out.e'
     requirement = 'The Kokkos system shall provide optimized kernels for residuals with the test function or its gradient factored out.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/kernels/material_coupled_force/tests
+++ b/test/tests/kokkos/kernels/material_coupled_force/tests
@@ -9,6 +9,6 @@
     abs_zero = 1e-6
     requirement = 'The Kokkos system shall support a kernel for coupling the sum of several products of material properties with variables and constant coefficients.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/kernels/transient_vector_diffusion/tests
+++ b/test/tests/kokkos/kernels/transient_vector_diffusion/tests
@@ -8,7 +8,7 @@
     exodiff = 'kokkos_transient_vector_diffusion_out.e'
     requirement = 'A time derivative Kokkos vector kernel shall be provided.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [jac_transient_vector_diffusion]
     type = 'PetscJacobianTester'
@@ -19,6 +19,6 @@
     difference_tol = 1e-6
     requirement = 'The Jacobian from time derivative Kokkos vector kernel shall be perfect.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/kernels/vector_fe/tests
+++ b/test/tests/kokkos/kernels/vector_fe/tests
@@ -8,7 +8,7 @@
     abs_zero = 1e-8
     requirement = "The Kokkos system shall be able to couple a vector variable into a standard kernel."
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [coupled_scalar_vector_jacobian]
     type = PetscJacobianTester
@@ -18,7 +18,7 @@
     difference_tol = 5e-7
     requirement = "The Kokkos system shall be able to couple a vector variable into a standard kernel and produce the correct Jacobian."
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [coupled_scalar_default_vector]
     type = Exodiff
@@ -26,7 +26,7 @@
     exodiff = 'kokkos_coupled_scalar_default_vector_value_out.e'
     requirement = "The Kokkos system shall be able to assign a default value for a vector variable."
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [coupled_scalar_default_vector_input_and_warn]
     type = Exodiff
@@ -38,7 +38,7 @@
     requirement = "The Kokkos system shall warn when assigning a default value with number of components less than 3, "
                   "and it shall be able to assign the default value from the input file."
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [coupled_scalar_default_vector_jacobian]
     type = PetscJacobianTester
@@ -50,7 +50,7 @@
     requirement = "The Kokkos system shall be able to assign a default value for a "
                   "vector variable from the input file and still have the correct jacobian."
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [coupled_vector_gradient]
     type = Exodiff
@@ -58,7 +58,7 @@
     exodiff = 'kokkos_coupled_vector_gradient_out.e'
     requirement = "The Kokkos system shall be able to obtain coupled vector variable gradients."
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [lagrange_vec]
     type = Exodiff
@@ -68,7 +68,7 @@
     requirement = "The Kokkos system shall be able to solve multi-dimensional "
                   "problems with vector Lagrange variables."
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [lagrange_vec_1d]
     type = Exodiff
@@ -77,7 +77,7 @@
     abs_zero = 1e-8
     requirement = "The Kokkos system shall be able to solve one-dimensional problems with vector Lagrange variables."
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [lagrange_vec_1d_jac]
     type = PetscJacobianTester
@@ -87,6 +87,6 @@
     cli_args = 'Outputs/exodus=false Mesh/nx=3'
     requirement = "The Kokkos system shall be able to solve one-dimensional problems with vector Lagrange variables and produce the correct Jacobian."
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/linearfvkernels/advection-diffusion/tests
+++ b/test/tests/kokkos/linearfvkernels/advection-diffusion/tests
@@ -7,7 +7,7 @@
     test_case = TestKokkosLinearFVAdvectionDiffusion1D
     requirement = 'The system shall be able to solve a one-dimensional advection-diffusion problem with a linear finite volume discretization using Kokkos boundary value and normal-gradient data.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
     max_threads = 1
   []
 []

--- a/test/tests/kokkos/linearfvkernels/diffusion/tests
+++ b/test/tests/kokkos/linearfvkernels/diffusion/tests
@@ -9,7 +9,7 @@
       test_case = TestKokkosLinearFVDiffusion2DOrthogonal
       detail = 'with only Dirichlet boundary conditions or'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
       max_threads = 1
     []
     [mixed_dirichlet_neumann]
@@ -18,7 +18,7 @@
       test_case = TestKokkosLinearFVDiffusion2DOrthogonalNeumann
       detail = 'with mixed Dirichlet and Neumann boundary conditions.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
       max_threads = 1
     []
     [internal_neumann_block_restricted]
@@ -27,7 +27,7 @@
       test_case = TestKokkosLinearFVDiffusion2DInternalNeumann
       detail = 'with Neumann boundary conditions on internal boundaries of two block-restricted variables.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
       max_threads = 1
     []
   []
@@ -38,7 +38,7 @@
     gold_dir = '../../../variables/linearfv/gold'
     requirement = 'The system shall produce the same linear finite volume diffusion solution using Kokkos process-local parallel dispatch as the host implementation.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
     max_threads = 1
   []
   [rz]
@@ -47,7 +47,7 @@
     test_case = TestKokkosLinearFVDiffusion1DRZ
     requirement = 'The system shall account for cylindrical coordinate factors in Kokkos linear finite volume element volumes and face areas.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
     max_threads = 1
   []
   [rspherical]
@@ -56,7 +56,7 @@
     test_case = TestKokkosLinearFVDiffusion1DRSpherical
     requirement = 'The system shall account for spherical coordinate factors in Kokkos linear finite volume element volumes and face areas.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
     max_threads = 1
     min_slots = 2
   []

--- a/test/tests/kokkos/materials/block_prop/tests
+++ b/test/tests/kokkos/materials/block_prop/tests
@@ -8,6 +8,6 @@
     exodiff = 'kokkos_block_prop_test_out.e'
     requirement = 'The Kokkos system shall support retrieving a material property along with the list of valid subdomains and bypass material property checks.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/materials/constant_on/tests
+++ b/test/tests/kokkos/materials/constant_on/tests
@@ -10,7 +10,7 @@
       exodiff = 'kokkos_constant_on_test_out.e'
       detail = 'quadrature points;'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [element]
       type = 'Exodiff'
@@ -19,7 +19,7 @@
       cli_args = 'Materials/mat/constant_on=ELEMENT'
       detail = 'elements;'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [subdomain]
       type = 'Exodiff'
@@ -28,7 +28,7 @@
       cli_args = 'Materials/mat/constant_on=SUBDOMAIN'
       detail = 'subdomains;'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [mixed]
       type = 'Exodiff'
@@ -36,7 +36,7 @@
       exodiff = 'kokkos_constant_on_test_out.e'
       detail = 'quadrature points, elements, and subdomains at the same time on different subdomains.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/materials/coupling/tests
+++ b/test/tests/kokkos/materials/coupling/tests
@@ -8,7 +8,7 @@
     exodiff = 'kokkos_var_coupling_out.e'
     requirement = 'The Kokkos material system shall be able to couple in variables to compute material properties.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [var_stateful_coupling]
@@ -19,7 +19,7 @@
                 Outputs/file_base=kokkos_var_stateful_coupling_out'
     requirement = 'The Kokkos material system shall be able to couple in variables to initialize stateful material properties.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [aux_coupling]
@@ -30,7 +30,7 @@
                 Outputs/file_base=kokkos_var_stateful_coupling_out'
     requirement = 'The Kokkos material system shall be able to couple in aux variables to compute material properties.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
     prereq = var_stateful_coupling
   []
 
@@ -43,7 +43,7 @@
                 Outputs/file_base=kokkos_var_stateful_coupling_out'
     requirement = 'The Kokkos material system shall be able to couple in aux variables to initialize stateful material properties.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
     prereq = aux_coupling
   []
 
@@ -55,7 +55,7 @@
                 Outputs/file_base=kokkos_prop_coupling_out'
     requirement = 'The Kokkos material system shall be able to couple in other material properties to compute material properties.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [prop_stateful_coupling]
@@ -64,6 +64,6 @@
     exodiff = 'kokkos_prop_stateful_coupling_out.e'
     requirement = 'The Kokkos material system shall be able to couple in other stateful material properties to compute material properties.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/materials/error/tests
+++ b/test/tests/kokkos/materials/error/tests
@@ -12,7 +12,7 @@
                   Materials/left/block=10'
       detail = 'multiple materials properties with the same name are declared on the same block.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [not_supplied]
       type = RunException
@@ -22,7 +22,7 @@
                   Materials/mat1/use_old_prop=false'
       detail = 'a material property was requested by a material but not supplied by another material.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [stateful_not_supplied]
       type = RunException
@@ -31,7 +31,7 @@
       cli_args = 'Materials/mat1/coupled_mat_prop=\'prop-c\''
       detail = 'a stateful material property was requested by a material but not supplied by another material.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [cyclic]
       type = RunException
@@ -40,7 +40,7 @@
       cli_args = 'Materials/mat1/use_old_prop=false'
       detail = 'two materials depend on each other.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [different_type]
       type = RunException
@@ -49,7 +49,7 @@
       cli_args = 'Materials/active=\'left_real_1D right_int_1D\''
       detail = 'the same material property was declared by different non-overlapping materials with different types'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [different_dim]
       type = RunException
@@ -58,7 +58,7 @@
       cli_args = 'Materials/active=\'left_real_1D right_real_2D\''
       detail = 'the same material property was declared by different non-overlapping materials with different dimensions'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [bnd_overlap_different_dim_size]
       type = RunException
@@ -66,7 +66,7 @@
       expect_err = 'The declared boundary-restricted Kokkos material property \'prop\' with dimensions \(2\) was already declared as a property with dimensions \(1\).'
       detail = 'the same material property was declared by different overlapping boundary-restricted materials with different size of dimensions'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [bnd_overlap_different_constant_on]
       type = RunException
@@ -75,7 +75,7 @@
       cli_args = 'Materials/mat2/dims=1 Materials/mat2/constant_on=ELEMENT'
       detail = 'the same material property was declared by different overlapping boundary-restricted materials with different constant_on options'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 
@@ -84,7 +84,7 @@
     input = 'kokkos_dependency.i'
     requirement = 'The Kokkos material system shall not create a dependency when old versions of material properties are retrieved and used in calculations.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [same_type_and_dim]
     type = RunApp
@@ -92,7 +92,7 @@
     cli_args = 'Materials/active=\'left_real_1D right_real_1D_correct\''
     requirement = 'The Kokkos material system shall not error when the same material property was declared by different non-overlapping materials with consistent type and dimension.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [different_dim_size_non_overlap]
     type = RunApp
@@ -100,6 +100,6 @@
     cli_args = 'Materials/active=\'left_real_1D right_real_1D\''
     requirement = 'The Kokkos material system shall not error when the same material property was declared by different non-overlapping materials with different size of dimensions.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/materials/on_demand_prop/tests
+++ b/test/tests/kokkos/materials/on_demand_prop/tests
@@ -8,6 +8,6 @@
     exodiff = 'kokkos_on_demand_prop_test_out.e'
     requirement = 'The Kokkos material system shall be able to declare on-demand material properties that are only allocated when there is a consumer.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/materials/stateful_prop/tests
+++ b/test/tests/kokkos/materials/stateful_prop/tests
@@ -12,7 +12,7 @@
                   Outputs/file_base=kokkos_stateful_prop_test_current_out'
       detail = 'use current state in other calculations.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [old]
       type = Exodiff
@@ -22,7 +22,7 @@
                   Outputs/file_base=kokkos_stateful_prop_test_old_out'
       detail = 'use old state in other calculations.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [older]
       type = Exodiff
@@ -32,7 +32,7 @@
                   Outputs/file_base=kokkos_stateful_prop_test_older_out'
       detail = 'use older state in other calculations.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 
@@ -44,7 +44,7 @@
       exodiff = 'kokkos_stateful_prop_spatial_test_out.e'
       detail = 'on blocks and boundaries.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [spatial_bnd_only]
       type = Exodiff
@@ -52,7 +52,7 @@
       exodiff = 'kokkos_stateful_prop_on_bnd_only_out.e'
       detail = 'only on boundaries.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/nodalkernels/constant_rate/tests
+++ b/test/tests/kokkos/nodalkernels/constant_rate/tests
@@ -10,6 +10,6 @@
     abs_zero = 1e-08
     requirement = 'The Kokkos system shall include ability to include constant contributions to the residual nodes of a finite element mesh.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/nodalkernels/constraint_enforcement/tests
+++ b/test/tests/kokkos/nodalkernels/constraint_enforcement/tests
@@ -10,7 +10,7 @@
       exodiff = kokkos_lower_bound_out.e
       detail = 'have no oscillations in the solution, and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [non_singular]
       input = kokkos_lower_bound.i
@@ -20,7 +20,7 @@
       cli_args = "nx=10 num_steps=5 Outputs/exodus=false Outputs/active='' -pc_type svd -pc_svd_monitor"
       detail = 'have a non-singular matrix'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda' # PETSc SVD hangs with XPU
     []
   []
   [upper_bound]
@@ -32,7 +32,7 @@
       exodiff = kokkos_upper_bound_out.e
       detail = 'have no oscillations in the solution, and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [non_singular]
       input = kokkos_upper_bound.i
@@ -42,7 +42,7 @@
       cli_args = "nx=10 num_steps=5 Outputs/exodus=false Outputs/active='' -pc_type svd -pc_svd_monitor"
       detail = 'have a non-singular matrix'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda' # PETSc SVD hangs with XPU
     []
   []
   [upper_and_lower_bound]
@@ -55,7 +55,7 @@
       detail = 'have no oscillations in the solution, and'
       cli_args = "Postprocessors/active='active_upper_lm upper_violations active_lower_lm lower_violations'"
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [non_singular]
       input = kokkos_upper_and_lower_bound.i
@@ -65,7 +65,7 @@
       cli_args = "nx=10 num_steps=5 Outputs/exodus=false Outputs/active='' -pc_type svd -pc_svd_monitor"
       detail = 'have a non-singular matrix, and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda' # PETSc SVD hangs with XPU
     []
     [amg_fail]
       input = kokkos_upper_and_lower_bound.i
@@ -74,7 +74,7 @@
       cli_args = "Outputs/exodus=false Outputs/active='' -pc_type hypre -pc_hypre_type boomeramg -ksp_converged_reason"
       detail = 'be incompataible with algebraic multigrid'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/nodalkernels/jac_test/tests
+++ b/test/tests/kokkos/nodalkernels/jac_test/tests
@@ -11,7 +11,7 @@
       difference_tol = 1E-10
       detail = 'subdomain and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [bc_jacobian_test]
       type = 'PetscJacobianTester'
@@ -20,7 +20,7 @@
       difference_tol = 1E-10
       detail = 'boundary restricted terms.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/nodalkernels/multiple_subdomains/tests
+++ b/test/tests/kokkos/nodalkernels/multiple_subdomains/tests
@@ -7,6 +7,6 @@
     requirement = 'The Kokkos system shall not duplicate computation of kernels on a node that is shared between two subdomains.'
     design = 'NodalKernels/index.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/nodalkernels/reaction/tests
+++ b/test/tests/kokkos/nodalkernels/reaction/tests
@@ -10,6 +10,6 @@
     abs_zero = 1e-08
     requirement = 'The Kokkos system shall include ability to include reaction contributions to the residual nodes of a finite element mesh.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/petsc_gpu/tests
+++ b/test/tests/kokkos/petsc_gpu/tests
@@ -11,7 +11,7 @@
       exodiff = 'kokkos_2d_diffusion_tag_vector_out.e'
       detail = 'tagged vectors and PJFNK,'
       capabilities = 'kokkos'
-      compute_devices = 'cuda'
+      compute_devices = 'cuda xpu'
       abs_zero = 1e-8
     []
     [tag_vector_newton]
@@ -20,7 +20,7 @@
       exodiff = 'kokkos_2d_diffusion_tag_vector_out.e'
       detail = 'tagged vectors and Newton.'
       capabilities = 'kokkos'
-      compute_devices = 'cuda'
+      compute_devices = 'cuda xpu'
       prereq = 'petsc_gpu/tag_vector_pjfnk'
     []
   []

--- a/test/tests/kokkos/postprocessors/dependency/tests
+++ b/test/tests/kokkos/postprocessors/dependency/tests
@@ -7,7 +7,7 @@
     csvdiff = 'kokkos_general_uo_dependency_test_out.csv'
     requirement = 'The Kokkos user objects shall be able to resolve dependencies with other Kokkos user objects implicitly.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [sum_pp_wrong_order]
     # Kokkos UO is executed before the MOOSE UOs, hence the sum is zero on initial
@@ -17,7 +17,7 @@
     cli_args = "Postprocessors/kokkos_sum/values='average1 average2' Outputs/file_base=kokkos_general_uo_dependency_test_wrong"
     requirement = 'The Kokkos user objects shall execute prior to original user objects in the same execution group.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [sum_pp_exec_group]
     type = 'CSVDiff'
@@ -26,6 +26,6 @@
     cli_args = "Postprocessors/kokkos_sum/values='average1 average2' Postprocessors/kokkos_sum/execution_order_group=1"
     requirement = 'The Kokkos user objects shall be able to specify execution order groups to resolve dependencies manually with original user objects.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/postprocessors/element_extreme_value/tests
+++ b/test/tests/kokkos/postprocessors/element_extreme_value/tests
@@ -10,7 +10,7 @@
       exodiff = 'kokkos_element_extreme_value_out.e'
       detail = 'the variable reaches the extreme (max/min) value and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [proxy]
       type = 'CSVDiff'
@@ -18,7 +18,7 @@
       csvdiff = 'kokkos_element_proxy_extreme_value_out.csv'
       detail = 'the proxy variable reaches the extreme (max/min) value.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/postprocessors/element_integral/tests
+++ b/test/tests/kokkos/postprocessors/element_integral/tests
@@ -11,7 +11,7 @@
       csvdiff = 'kokkos_element_integral_test_out.csv'
       detail = 'over the whole domain, and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
 
     [block_test]
@@ -20,7 +20,7 @@
       csvdiff = 'kokkos_element_block_integral_test_out.csv'
       detail = 'over a subset of the domain,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
       prereq = 'element_integral/test'
     []
 
@@ -31,7 +31,7 @@
       cli_args = 'BCs/right/value=-1 Postprocessors/integral/use_absolute_value=true'
       detail = 'and also optionally, using the absolute variable value.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 
@@ -41,6 +41,6 @@
     csvdiff = 'kokkos_element_block_average_test_out.csv'
     requirement = 'The Kokkos system shall compute the element average of a variable.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/postprocessors/element_integral_material_property/tests
+++ b/test/tests/kokkos/postprocessors/element_integral_material_property/tests
@@ -7,7 +7,7 @@
     requirement = 'The Kokkos system shall compute the integral quantity over an element of a scalar material property.'
     design = 'KokkosElementIntegralMaterialProperty.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
   [average]
     type = 'CSVDiff'
@@ -16,6 +16,6 @@
     requirement = 'The Kokkos system shall compute the average quantity over an element of a scalar material property.'
     design = 'KokkosElementAverageMaterialProperty.md'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/postprocessors/element_l2_norm/tests
+++ b/test/tests/kokkos/postprocessors/element_l2_norm/tests
@@ -7,6 +7,6 @@
     csvdiff = 'kokkos_element_l2_norm_out.csv'
     requirement = 'The Kokkos system shall compute the volumetric L2 norm of a variable over the mesh.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/postprocessors/nodal_extreme_value/tests
+++ b/test/tests/kokkos/postprocessors/nodal_extreme_value/tests
@@ -10,7 +10,7 @@
       exodiff = 'kokkos_nodal_extreme_pps_test_out.e'
       detail = 'the variable reaches the extreme (min/max) value and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [proxy]
       type = 'CSVDiff'
@@ -18,7 +18,7 @@
       csvdiff = 'kokkos_nodal_proxy_extreme_value_out.csv'
       detail = 'the proxy variable reaches the extreme (min/max) value.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 
@@ -31,7 +31,7 @@
       abs_zero = 1e-8
       detail = 'over the whole domain and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [block_restricted]
       type = 'Exodiff'
@@ -39,7 +39,7 @@
       exodiff = 'kokkos_block_nodal_pps_test_out.e'
       detail = 'within a subdomain.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/postprocessors/nodal_l2_norm/tests
+++ b/test/tests/kokkos/postprocessors/nodal_l2_norm/tests
@@ -8,6 +8,6 @@
     csvdiff = kokkos_nodal_l2_norm_out.csv
     requirement = 'The Kokkos system shall compute the L2 norm of nodal values of a variable.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/postprocessors/nodal_sum/tests
+++ b/test/tests/kokkos/postprocessors/nodal_sum/tests
@@ -12,7 +12,7 @@
       csvdiff = kokkos_nodal_sum_out.csv
       detail = 'on the whole domain,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
 
     [nodal_sum_block]
@@ -22,7 +22,7 @@
       csvdiff = 'kokkos_nodal_sum_block_out.csv'
       detail = 'on a subset of the domain, and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
 
     [nodal_sum_block_non_unique]
@@ -34,7 +34,7 @@
                   Outputs/file_base=kokkos_nodal_sum_block_non_unique_out'
       detail = 'on multiple overlapping blocks visiting some nodes multiple times.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/postprocessors/side_extreme_value/tests
+++ b/test/tests/kokkos/postprocessors/side_extreme_value/tests
@@ -10,7 +10,7 @@
       csvdiff = 'kokkos_nonlinear_variable_out.csv'
       detail = 'for a nonlinear variable,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [nonlinear_variable_proxy]
       type = 'CSVDiff'
@@ -18,7 +18,7 @@
       csvdiff = 'kokkos_nonlinear_variable_proxy_out.csv'
       detail = 'for a nonlinear variable using a proxy variable,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [aux_nodal]
       type = 'CSVDiff'
@@ -26,7 +26,7 @@
       csvdiff = 'kokkos_aux_nodal_out.csv'
       detail = 'for an auxiliary nodal variable,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [aux_elemental]
       type = 'CSVDiff'
@@ -35,7 +35,7 @@
       cli_args = 'AuxVariables/aux/family=MONOMIAL Outputs/file_base=kokkos_aux_elemental_out'
       detail = 'for an auxiliary elemental variable.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/postprocessors/side_integral/tests
+++ b/test/tests/kokkos/postprocessors/side_integral/tests
@@ -10,7 +10,7 @@
       csvdiff = 'kokkos_side_integral_value_test_out.csv'
       detail = 'a variable and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [material_property]
       type = 'CSVDiff'
@@ -18,7 +18,7 @@
       csvdiff = 'kokkos_side_integral_material_property_out.csv'
       detail = 'a scalar material property.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 
@@ -31,7 +31,7 @@
       csvdiff = 'kokkos_side_average_value_test_out.csv'
       detail = 'a variable and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [material_property]
       type = 'CSVDiff'
@@ -39,7 +39,7 @@
       csvdiff = 'kokkos_side_average_material_property_out.csv'
       detail = 'a scalar material property.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/problems/eigen_problem/tests
+++ b/test/tests/kokkos/problems/eigen_problem/tests
@@ -8,6 +8,6 @@
     csvdiff = 'kokkos_eigenvalue_test_out_eigenvalues_0001.csv'
     requirement = 'The Kokkos system shall support eigenvalue calculations.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/reporters/element_reporter/tests
+++ b/test/tests/kokkos/reporters/element_reporter/tests
@@ -8,6 +8,6 @@
     jsondiff = 'kokkos_elem_stats_stats.json'
     requirement = 'The Kokkos system shall be able to produce elememental statistics of a variable.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/reporters/nodal_reporter/tests
+++ b/test/tests/kokkos/reporters/nodal_reporter/tests
@@ -8,6 +8,6 @@
     jsondiff = 'kokkos_nodal_stats_stats.json'
     requirement = 'The Kokkos system shall be able to produce nodal statistics of a variable.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/restart/kernel_restartable/tests
+++ b/test/tests/kokkos/restart/kernel_restartable/tests
@@ -10,7 +10,7 @@
       exodiff = 'kokkos_kernel_restartable_out.e'
       detail = 'perform residual calculations that accumulate state and'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [test2]
       type = 'Exodiff'
@@ -19,7 +19,7 @@
       prereq = kernel/test
       detail = 'restart the calculation using the accumulated state.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/restart/stateful/tests
+++ b/test/tests/kokkos/restart/stateful/tests
@@ -9,7 +9,7 @@
       input = 'kokkos_stateful_prop_spatial_test.i'
       detail = 'writing the stateful material properties into a checkpoint file.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [load_checkpoint]
       type = Exodiff
@@ -17,7 +17,7 @@
       exodiff = 'kokkos_stateful_prop_spatial_test_restart_out.e'
       detail = 'loading the checkpoint file that contains the stateful material properties.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
       prereq = 'restart/write_checkpoint'
     []
   []
@@ -34,7 +34,7 @@
                   AuxKernels/active=\'\''
       detail = 'a restarted material declares a stateful material property that was not stored.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
       prereq = 'restart/write_checkpoint'
     []
     [state_mismatch]
@@ -44,7 +44,7 @@
       cli_args = 'Materials/stateful/declare_older=true'
       detail = 'a restarted material declares a stateful material property that has different number of states with the stored property.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
       prereq = 'restart/write_checkpoint'
     []
     [ambiguity]
@@ -54,7 +54,7 @@
       cli_args = 'Materials/active=another_stateful'
       detail = 'a new material declares a stateful property with the same name with a stored property.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
       prereq = 'restart/write_checkpoint'
     []
   []
@@ -69,7 +69,7 @@
                 AuxKernels/active=\'\''
     requirement = 'In a restarted calculation, the Kokkos system shall not error when a new material declares a new stateful property.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
     prereq = 'restart/write_checkpoint'
     recover = false
   []

--- a/test/tests/kokkos/tag/tests
+++ b/test/tests/kokkos/tag/tests
@@ -12,7 +12,7 @@
       exodiff = 'kokkos_2d_diffusion_tag_vector_out.e'
       detail = 'numeric vector,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [tag_matrix]
       type = 'Exodiff'
@@ -20,7 +20,7 @@
       exodiff = 'kokkos_2d_diffusion_tag_matrix_out.e'
       detail = 'numeric matrix,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [tag_multiple_vectors]
       type = 'Exodiff'
@@ -28,7 +28,7 @@
       exodiff = 'kokkos_2d_diffusion_vector_tag_test_out.e'
       detail = 'multiple numeric vectors simultaneously, or'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [tag_multiple_matrices]
       type = 'Exodiff'
@@ -36,7 +36,7 @@
       exodiff = 'kokkos_2d_diffusion_matrix_tag_test_out.e'
       detail = 'multiple numeric matrices simultaneously.'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 
@@ -45,7 +45,7 @@
     input = 'kokkos_tag_residual_call.i'
     requirement = 'The Kokkos system shall be able to accumulate tagged vectors individually with multiple residual computations.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 
   [systems]
@@ -57,7 +57,7 @@
       exodiff = 'kokkos_tag_neumann_out.e'
       detail = 'integrated boundary conditions,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
 
     [test_tag_nodal_kernels]
@@ -66,7 +66,7 @@
       exodiff = 'kokkos_tag_nodal_kernels_out.e'
       detail = 'the nodal kernel system,'
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 []

--- a/test/tests/kokkos/vectorpostprocessors/element_vpp/tests
+++ b/test/tests/kokkos/vectorpostprocessors/element_vpp/tests
@@ -8,6 +8,6 @@
     csvdiff = 'kokkos_element_vpp_test_out_block_solution_0001.csv'
     requirement = 'The Kokkos system shall be able to aggregate and output vector data by iterating over elements.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/vectorpostprocessors/extra_id_integral/tests
+++ b/test/tests/kokkos/vectorpostprocessors/extra_id_integral/tests
@@ -12,7 +12,7 @@
       detail = 'with a single variable integral and a single extra ID'
       recover = false
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [multi_ids]
       type = 'CSVDiff'
@@ -22,7 +22,7 @@
       detail = 'with a single variable integral and multiple extra IDs'
       recover = false
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [multi_ids_multi_vars]
       type = 'CSVDiff'
@@ -32,7 +32,7 @@
       detail = 'with multiple variable integrals and multiple extra IDs'
       recover = false
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [vars_and_mats]
       type = 'CSVDiff'
@@ -42,7 +42,7 @@
       detail = 'with multiple variable and material property integrals and multiple extra IDs'
       recover = false
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [vars_and_mats_average]
       type = 'CSVDiff'
@@ -52,7 +52,7 @@
       detail = 'with multiple variable and material property averages and multiple extra IDs'
       recover = false
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
   []
 
@@ -67,7 +67,7 @@
       recover = false
       prereq = atomic/default
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [multi_ids]
       type = 'CSVDiff'
@@ -78,7 +78,7 @@
       recover = false
       prereq = atomic/multi_ids
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [multi_ids_multi_vars]
       type = 'CSVDiff'
@@ -89,7 +89,7 @@
       recover = false
       prereq = atomic/multi_ids_multi_vars
       capabilities = 'kokkos'
-      compute_devices = 'cpu cuda'
+      compute_devices = 'cpu cuda xpu'
     []
     [vars_and_mats]
       type = 'CSVDiff'

--- a/test/tests/kokkos/vectorpostprocessors/nodal_vpp/tests
+++ b/test/tests/kokkos/vectorpostprocessors/nodal_vpp/tests
@@ -8,6 +8,6 @@
     csvdiff = 'kokkos_nodal_vpp_test_out_nodal_solution_0001.csv'
     requirement = 'The Kokkos system shall be able to aggregate and output vector data by iterating over nodes.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []

--- a/test/tests/kokkos/vectorpostprocessors/side_vpp/tests
+++ b/test/tests/kokkos/vectorpostprocessors/side_vpp/tests
@@ -8,6 +8,6 @@
     csvdiff = 'kokkos_side_vpp_test_out_boundary_solution_0001.csv'
     requirement = 'The Kokkos system shall be able to aggregate and output vector data by iterating over sides.'
     capabilities = 'kokkos'
-    compute_devices = 'cpu cuda'
+    compute_devices = 'cpu cuda xpu'
   []
 []


### PR DESCRIPTION
## Reason
Performed tests of Kokkos-MOOSE with Intel GPUs on Aurora. Most of the tests passed, except three tests that use PETSc's SVD preconditioner in common. So the failing (hanging) tests might be attributed to a PETSc issue.

Issues not yet addressed:
- Very long GPU warm up time (10+ seconds). A driver-level API called `urProgramBuildExp()` is the source of delay, so JIT compile is suspected to be the source, but I wasn't able to fix this even with device-specific AOT compile. This might not matter for practically large calculations but can significantly slow down small regression tests.
- [Intel's SYCL extension](https://www.intel.com/content/www/us/en/developer/articles/technical/sycl-expansion-virtual-functions-and-more.html) for device virtual function support did not work with shared library Kokkos build. Tried a WIP Kokkos PR which attempts to enable this feature (https://github.com/kokkos/kokkos/pull/8070), but it fails to run the most basic Kokkos example (not Kokkos-MOOSE), even without virtual functions. It appears that JIT linking step is failing with this extension.

## Design
- Remove device virtual functions for SYCL for now.
- Add XPU targets to working tests.
- Update build options based on the experience with Aurora.

## Impact
Kokkos-MOOSE works with SYCL.