### PR TITLE
Adding the Capability to Allow Output Objects to Depend on Other Output Objects.

### DIFF
--- a/framework/include/outputs/Output.h
+++ b/framework/include/outputs/Output.h
@@ -21,6 +21,7 @@
 #include "ReporterInterface.h"
 #include "AdvancedOutputUtils.h"
 #include "PerfGraphInterface.h"
+#include "DependencyResolverInterface.h"
 #include "FunctionInterface.h"
 
 class MooseMesh;
@@ -48,7 +49,8 @@ class Output : public MooseObject,
                public PostprocessorInterface,
                public VectorPostprocessorInterface,
                public ReporterInterface,
-               public PerfGraphInterface
+               public PerfGraphInterface,
+               public DependencyResolverInterface
 {
 public:
   static InputParameters validParams();
@@ -149,6 +151,10 @@ public:
    */
   virtual bool supportsMaterialPropertyOutput() const { return false; }
 
+  virtual const std::set<std::string> & getRequestedItems() override { return _depend_obj; }
+
+  virtual const std::set<std::string> & getSuppliedItems() override { return _supplied_obj; }
+
 protected:
   /**
    * Overload this function with the desired output activities
@@ -180,6 +186,13 @@ protected:
    *
    */
   void setWallTimeIntervalFromCommandLineParam();
+
+  /**
+   * Function to add output objects when users on an output to depend on another output.
+   * @param object_name The name of the output object to be dependent on
+   *
+   */
+  void addOutputDependency(const OutputName & object_name) { _depend_obj.insert(object_name); }
 
   /// Pointer the the FEProblemBase object for output object (use this)
   FEProblemBase * _problem_ptr;
@@ -284,6 +297,12 @@ protected:
 
   /// time in seconds since last output
   Real _wall_time_since_last_output;
+
+  /// Set of dependency
+  std::set<std::string> _depend_obj;
+
+  /// Set containing the declared object
+  std::set<std::string> _supplied_obj;
 
   friend class OutputWarehouse;
 };

--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -336,6 +336,13 @@ private:
    */
   void resetFileBase();
 
+  /**
+   * Sorts output objects based on dependencies and Checkpoints.
+   * For dependencies, DependencyResolver determines the ordering and afterwards
+   * all Checkpoint objects are attached to the end.
+   */
+  void sortOutputs();
+
   /// MooseApp
   MooseApp & _app;
 

--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -218,6 +218,9 @@ Output::Output(const InputParameters & parameters)
       // we must ensure that we set the `_sync_times` in the constructor
       _sync_times = _sync_times_object->getUniqueTimes();
   }
+
+  // The declared object supplies itself
+  _supplied_obj.insert(name());
 }
 
 void

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -51,6 +51,8 @@ OutputWarehouse::initialSetup()
   TIME_SECTION("initialSetup", 5, "Setting Up Outputs");
 
   resetFileBase();
+  // NOTE: Is this the best place to sort all the Outputs based on dependencies?
+  sortOutputs();
 
   for (const auto & obj : _all_objects)
     obj->initialSetup();
@@ -103,12 +105,7 @@ OutputWarehouse::addOutput(std::shared_ptr<Output> const output)
 {
   _all_ptrs.push_back(output);
 
-  // Add the object to the warehouse storage, Checkpoint placed at end so they are called last
-  Checkpoint * cp = dynamic_cast<Checkpoint *>(output.get());
-  if (cp != NULL)
-    _all_objects.push_back(output.get());
-  else
-    _all_objects.insert(_all_objects.begin(), output.get());
+  _all_objects.insert(_all_objects.begin(), output.get());
 
   // Store the name and pointer
   _object_map[output->name()] = output.get();
@@ -427,4 +424,54 @@ OutputWarehouse::resetFileBase()
       file_output->setFileBase(file_base);
       addOutputFilename(obj->name(), file_output->filename());
     }
+}
+
+void
+OutputWarehouse::sortOutputs()
+{
+
+  DependencyResolver<Output *> resolver;
+  std::vector<Output *> cp_objects;
+
+  // Register all objects by dependencies, non-dependencies, and Checkpoints
+  for (const auto & obj : _all_objects)
+  {
+    Checkpoint * cp = dynamic_cast<Checkpoint *>(obj);
+    auto * dep_obj = dynamic_cast<DependencyResolverInterface *>(obj);
+
+    // Sort out the Checkpoints
+    if (cp != NULL)
+    {
+      if (dep_obj)
+        mooseError("Output object '",
+                   obj->name(),
+                   "' should not be Checkpoint and depended on other outputs.");
+
+      cp_objects.push_back(obj);
+      continue;
+    }
+
+    resolver.addItem(obj);
+
+    // Check and label dependencies
+    if (!dep_obj)
+      continue;
+
+    for (const auto & dep_name : dep_obj->getRequestedItems())
+    {
+      auto it = _object_map.find(dep_name);
+      if (it == _object_map.end())
+        mooseError("Output object '",
+                   obj->name(),
+                   "' declares a dependency on '",
+                   dep_name,
+                   "' but no output object with that name exists in [Outputs].");
+      resolver.addEdge(it->second, obj);
+    }
+  }
+
+  // Sort based on dependencies
+  _all_objects = resolver.getSortedValues();
+  // Add the Checkpoint objects at the end
+  _all_objects.insert(_all_objects.end(), cp_objects.begin(), cp_objects.end());
 }

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -437,25 +437,16 @@ OutputWarehouse::sortOutputs()
   for (const auto & obj : _all_objects)
   {
     Checkpoint * cp = dynamic_cast<Checkpoint *>(obj);
-    auto * dep_obj = dynamic_cast<DependencyResolverInterface *>(obj);
 
     // Sort out the Checkpoints
     if (cp != NULL)
     {
-      if (dep_obj)
-        mooseError("Output object '",
-                   obj->name(),
-                   "' should not be Checkpoint and depended on other outputs.");
-
       cp_objects.push_back(obj);
       continue;
     }
 
+    auto * dep_obj = dynamic_cast<DependencyResolverInterface *>(obj);
     resolver.addItem(obj);
-
-    // Check and label dependencies
-    if (!dep_obj)
-      continue;
 
     for (const auto & dep_name : dep_obj->getRequestedItems())
     {

--- a/test/include/outputs/OutputFileCheck.h
+++ b/test/include/outputs/OutputFileCheck.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Output.h"
+#include "FileOutput.h"
+#include "DependencyResolverInterface.h"
+
+class OutputFileCheck;
+
+class OutputFileCheck : public Output, public DependencyResolverInterface
+{
+public:
+  static InputParameters validParams();
+
+  OutputFileCheck(const InputParameters & parameters);
+
+  virtual const std::set<std::string> & getRequestedItems() override { return _depend_obj; }
+
+  virtual const std::set<std::string> & getSuppliedItems() override { return _supplied_obj; }
+
+protected:
+  virtual void initialSetup() override;
+  virtual void output() override;
+
+private:
+  /// Name of the Output object to dependency
+  const std::string & _output_object_name;
+
+  /// Set of dependency
+  std::set<std::string> _depend_obj;
+
+  /// Set containing this object
+  std::set<std::string> _supplied_obj;
+};

--- a/test/include/outputs/OutputFileCheck.h
+++ b/test/include/outputs/OutputFileCheck.h
@@ -11,20 +11,15 @@
 
 #include "Output.h"
 #include "FileOutput.h"
-#include "DependencyResolverInterface.h"
 
 class OutputFileCheck;
 
-class OutputFileCheck : public Output, public DependencyResolverInterface
+class OutputFileCheck : public Output
 {
 public:
   static InputParameters validParams();
 
   OutputFileCheck(const InputParameters & parameters);
-
-  virtual const std::set<std::string> & getRequestedItems() override { return _depend_obj; }
-
-  virtual const std::set<std::string> & getSuppliedItems() override { return _supplied_obj; }
 
 protected:
   virtual void initialSetup() override;
@@ -33,10 +28,4 @@ protected:
 private:
   /// Name of the Output object to dependency
   const std::string & _output_object_name;
-
-  /// Set of dependency
-  std::set<std::string> _depend_obj;
-
-  /// Set containing this object
-  std::set<std::string> _supplied_obj;
 };

--- a/test/include/outputs/OutputFileCheck.h
+++ b/test/include/outputs/OutputFileCheck.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Output.h"

--- a/test/src/outputs/OutputFileCheck.C
+++ b/test/src/outputs/OutputFileCheck.C
@@ -1,0 +1,63 @@
+#include "OutputFileCheck.h"
+
+#include "MooseApp.h"
+
+registerMooseObject("MooseTestApp", OutputFileCheck);
+
+InputParameters
+OutputFileCheck::validParams()
+{
+  InputParameters params = Output::validParams();
+
+  params.addClassDescription("This object depend on other Output objects and check if the "
+                             "corresponding output file was written.");
+
+  params.addRequiredParam<std::string>("output_object",
+                                       "The name of the Output object whose file will be checked.");
+
+  return params;
+}
+
+OutputFileCheck::OutputFileCheck(const InputParameters & parameters)
+  : Output(parameters), _output_object_name(getParam<std::string>("output_object"))
+{
+  // Declare dependency on the target output object.
+  // OutputWarehouse::sortOutputs() reads this set to
+  // ensure the target executes before this object.
+  _depend_obj.insert(_output_object_name);
+
+  // This object supplies itself
+  _supplied_obj.insert(name());
+}
+
+void
+OutputFileCheck::initialSetup()
+{
+  // If the user did not explicitly set execute_on,
+  // inherit it from the target output object so the
+  // two always fire on the same events.
+  if (!isParamSetByUser("execute_on"))
+  {
+    OutputWarehouse & warehouse = _app.getOutputWarehouse();
+    _execute_on =
+        warehouse.getOutput<Output>(_output_object_name)->getParam<ExecFlagEnum>("execute_on");
+  }
+}
+
+void
+OutputFileCheck::output()
+{
+  OutputWarehouse & warehouse = _app.getOutputWarehouse();
+  FileOutput * _file_output =
+      dynamic_cast<FileOutput *>(warehouse.getOutput<Output>(_output_object_name));
+
+  std::string local_path = _file_output->filename();
+
+  struct stat file_stat;
+  if (stat(local_path.c_str(), &file_stat) != 0)
+  {
+    mooseError("OutputFileCheck: File not found at '", local_path, "'.");
+  }
+
+  _console << "File found at '" << local_path << "'. \n" << std::flush;
+}

--- a/test/src/outputs/OutputFileCheck.C
+++ b/test/src/outputs/OutputFileCheck.C
@@ -21,22 +21,19 @@ OutputFileCheck::validParams()
   params.addClassDescription("This object depend on other Output objects and check if the "
                              "corresponding output file was written.");
 
-  params.addRequiredParam<std::string>("output_object",
-                                       "The name of the Output object whose file will be checked.");
+  params.addRequiredParam<OutputName>("output_object",
+                                      "The name of the Output object whose file will be checked.");
 
   return params;
 }
 
 OutputFileCheck::OutputFileCheck(const InputParameters & parameters)
-  : Output(parameters), _output_object_name(getParam<std::string>("output_object"))
+  : Output(parameters), _output_object_name(getParam<OutputName>("output_object"))
 {
   // Declare dependency on the target output object.
   // OutputWarehouse::sortOutputs() reads this set to
   // ensure the target executes before this object.
-  _depend_obj.insert(_output_object_name);
-
-  // This object supplies itself
-  _supplied_obj.insert(name());
+  addOutputDependency(_output_object_name);
 }
 
 void

--- a/test/src/outputs/OutputFileCheck.C
+++ b/test/src/outputs/OutputFileCheck.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "OutputFileCheck.h"
 
 #include "MooseApp.h"

--- a/test/tests/outputs/output_dependency/simple_diffusion.i
+++ b/test/tests/outputs/output_dependency/simple_diffusion.i
@@ -1,0 +1,60 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  []
+[]
+
+[Preconditioning]
+  [pre]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  active = 'check_output_file exodus_out'
+  [check_output_file]
+    type = OutputFileCheck
+    output_object = 'exodus_out'
+  []
+
+  [exodus_out]
+    type = Exodus
+    file_base = 'output_FINAL'
+    execute_on = 'FINAL'
+  []
+[]
+

--- a/test/tests/outputs/output_dependency/tests
+++ b/test/tests/outputs/output_dependency/tests
@@ -1,0 +1,34 @@
+[Tests]
+  issues = ''
+  design = 'outputs/OutputWarehouse.md'
+  [default_execute_based_on_dependency]
+    type = 'RunApp'
+    input = 'simple_diffusion.i'
+    expect_out = "File found at 'output_FINAL.e'."
+    requirement = 'The system shall support output objects being dependent on other output objects and inherent execution flag by default.'
+  []
+
+  [execute_after_dependency]
+    type = 'RunApp'
+    input = 'simple_diffusion.i'
+    expect_out = "File found at 'output_TIMESTEP_END.e'."
+    cli_args = "Outputs/exodus_out/execute_on='TIMESTEP_END' Outputs/exodus_out/file_base='output_TIMESTEP_END' Outputs/check_output_file/execute_on='FINAL'"
+    requirement = 'The system shall support output objects being dependent on other output objects and allowing them have different execute flags.'
+  []
+
+  [execute_before_dependency]
+    type = 'RunException'
+    input = 'simple_diffusion.i'
+    cli_args = "Outputs/check_output_file/execute_on='TIMESTEP_END' Outputs/exodus_out/file_base='output_FINAL_fail'"
+    expect_err = "OutputFileCheck: File not found at 'output_FINAL_fail.e'."
+    requirement = 'The system shall support the failure of outputs objects dependencies when dependent object execute before the independent object.'
+  []
+
+  [missing_dependency]
+    type = 'RunException'
+    input = 'simple_diffusion.i'
+    cli_args = "Outputs/active='check_output_file'"
+    expect_err = "Output object 'check_output_file' declares a dependency on 'exodus_out' but no output object with that name exists"
+    requirement = 'The system shall support the failure of outputs objects dependencies when the dependency is missing.'
+  []
+[]

--- a/test/tests/outputs/output_dependency/tests
+++ b/test/tests/outputs/output_dependency/tests
@@ -1,6 +1,6 @@
 [Tests]
-  issues = ''
-  design = 'outputs/OutputWarehouse.md'
+  issues = '#33571'
+  design = 'syntax/Outputs/index.md'
   [default_execute_based_on_dependency]
     type = 'RunApp'
     input = 'simple_diffusion.i'


### PR DESCRIPTION

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

There is a need for a way to access output files during the simulation in a way to ensure the files are always written first (e.g., in the case where we want to upload files during or at the end of a run). It was mention in PR #33526 that such a method should be a `Output` object. 

As such, this PR enable `Output` objects to depend on other `Output` objects.

## Design
<!--A concise description (design) of the enhancement.-->

Dependencies were added to the `Output` system through the uses for the `DependencyResolverInterface` object (similar to existing dependencies methods currently existing in MOOSE).

## Impact
<!--Will the enhancement change existing APIs or add something new?-->

This PR will allow `Output` objects to depend on other `Output` objects.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
