### PR TITLE
Remove MFEMRefinementMarker::initialSetup()

### DIFF
--- a/framework/include/mfem/markers/MFEMRefinementMarker.h
+++ b/framework/include/mfem/markers/MFEMRefinementMarker.h
@@ -26,9 +26,6 @@ public:
 
   virtual ~MFEMRefinementMarker() = default;
 
-  /// Constructs associated mfem::ThresholdRefiner once mfem::ErrorEstimator is guaranteed to exist
-  void initialSetup();
-
   /// Applies p-refinement wherever the refiner sees fit
   bool pRefine();
 

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -553,6 +553,9 @@ addActionTypes(Syntax & syntax)
   registerTask("resolve_mfem_solvers", true);
   addTaskDependency("resolve_mfem_solvers", "add_mfem_solver");
   addTaskDependency("init_problem", "resolve_mfem_solvers");
+
+  // indicators/estimators before markers
+  addTaskDependency("add_marker", "add_indicator");
 #endif
 
   // Linear FV kernels fetch FVInterpolationMethod instances in their constructors. Some Physics

--- a/framework/src/mfem/markers/MFEMRefinementMarker.C
+++ b/framework/src/mfem/markers/MFEMRefinementMarker.C
@@ -43,16 +43,11 @@ MFEMRefinementMarker::MFEMRefinementMarker(const InputParameters & params)
     _max_h_level(getParam<unsigned>("max_h_level")),
     _max_p_level(getParam<unsigned>("max_p_level"))
 {
-}
-
-void
-MFEMRefinementMarker::initialSetup()
-{
   // fetch const ref to the estimator
   _estimator = &getMFEMProblem().getMFEMObject<MFEMIndicator>("Indicator", _estimator_name);
 
   // Check if p-refinement is supported by the fespace supplied with the variable
-  if (_max_p_level and !_estimator->getFESpace().PRefinementSupported())
+  if (_max_p_level && !_estimator->getFESpace().PRefinementSupported())
   {
     mooseWarning("Specified p-refinement on an unsupported FESpace or geometry. Only H1 and L2 "
                  "spaces on quad/hex meshes are supported by mfem. Disabling p-refinement.");
@@ -60,7 +55,7 @@ MFEMRefinementMarker::initialSetup()
   }
 
   // For now, we only allow one level of p-refinement exclusively.
-  if ((_max_h_level and _max_p_level) or _max_p_level > 1)
+  if ((_max_h_level && _max_p_level) || _max_p_level > 1)
   {
     mooseWarning("At present, only either a) h-refinement or b) one level of p-refinement is "
                  "supported. Disabling p-refinement.");
@@ -69,7 +64,7 @@ MFEMRefinementMarker::initialSetup()
 
   // We do not want to allow rebalancing if p-refinement is enabled, because that mesh-only
   // operation has no notion of p-refinement and the computational imbalance that may result.
-  if (_max_p_level and _rebalance)
+  if (_max_p_level && _rebalance)
   {
     mooseWarning("Asked for rebalancing as well as p-refinement, which is not supported.");
     _rebalance = false;

--- a/framework/src/mfem/problem/MFEMProblem.C
+++ b/framework/src/mfem/problem/MFEMProblem.C
@@ -97,13 +97,6 @@ MFEMProblem::initialSetup()
       .queryInto(objects);
   for (auto * const object : objects)
     object->initialSetup();
-
-  // MFEM indicators create their estimators during addIndicator(); markers still need an explicit
-  // setup pass because they are no longer initialized through the libMesh/MOOSE user-object path.
-  std::vector<MFEMRefinementMarker *> markers;
-  theWarehouse().query().condition<AttribSystem>("Marker").queryInto(markers);
-  for (auto marker : markers)
-    marker->initialSetup();
 }
 
 void


### PR DESCRIPTION
## Reason
Removing `MFEMRefinementMarker::initialSetup()` which requires special treatment as `MFEMRefinementMarker` isn't an `MFEMExecutedObject`.

## Design
Added a task dependency, applicable only when MOOSE is built with MFEM support, forcing `add_marker` to follow `add_indicator`.

## Impact
Tidier, perhaps nicer smelling, code.