### PR TITLE
Implement more preconditioner reuse in SIMPLE

### DIFF
--- a/modules/navier_stokes/include/executioners/LinearAssemblySegregatedSolve.h
+++ b/modules/navier_stokes/include/executioners/LinearAssemblySegregatedSolve.h
@@ -60,6 +60,7 @@ protected:
   /// @param relaxation_factor The relaxation factor for matrix relaxation
   /// @param solver_config The solver configuration object for the linear solve
   /// @param abs_tol The scaled absolute tolerance for the linear solve
+  /// @param reuse_pc Whether to reuse the preconditioning from the previous solve
   /// @param field_relaxation (optional) The relaxation factor for fields if relax_fields is true. Default value is 1.0.
   /// @param min_value_limiter (optional) The minimum value for the solution field
   /// @return The normalized residual norm of the equation.
@@ -69,6 +70,7 @@ protected:
                       const Real relaxation_factor,
                       libMesh::SolverConfiguration & solver_config,
                       const Real abs_tol,
+                      const bool reuse_pc,
                       const Real field_relaxation = 1.0,
                       const Real min_value_limiter = std::numeric_limits<Real>::min());
 
@@ -112,6 +114,12 @@ protected:
   /// Pointer(s) to the system(s) corresponding to the momentum equation(s)
   std::vector<LinearSystem *> _momentum_systems;
 
+  /// How often to recompute the momentum equations preconditioner
+  const unsigned int _momentum_pc_recompute_frequency;
+
+  /// Number of momentum equations solves performed without recomputing the preconditioner
+  unsigned int _momentum_pc_solve_counter;
+
   /// The number of the system corresponding to the pressure equation
   const unsigned int _pressure_sys_number;
 
@@ -125,8 +133,7 @@ protected:
   /// every solve; a value of N rebuilds it once every N solves and reuses it in between.
   const unsigned int _pressure_pc_recompute_frequency;
 
-  /// Number of pressure corrector solves performed since the start of the current SIMPLE solve,
-  /// used together with _pressure_pc_recompute_frequency to decide when to reuse the preconditioner.
+  /// Number of pressure corrector solves performed without recomputing the preconditioner
   unsigned int _pressure_pc_solve_counter;
 
   /// The number of the system corresponding to the energy equation
@@ -135,11 +142,35 @@ protected:
   /// Pointer to the linear system corresponding to the fluid energy equation
   LinearSystem * _energy_system;
 
+  /// How often to recompute the energy equation preconditioner
+  const unsigned int _energy_pc_recompute_frequency;
+
+  /// Number of energy solves performed without recomputing the preconditioner
+  unsigned int _energy_pc_solve_counter;
+
   /// The number of the system corresponding to the solid energy equation
   const unsigned int _solid_energy_sys_number;
 
   /// Pointer to the linear system corresponding to the solid energy equation
   LinearSystem * _solid_energy_system;
+
+  /// How often to recompute the solid energy equation preconditioner
+  const unsigned int _solid_energy_pc_recompute_frequency;
+
+  /// Number of solid energy solves performed without recomputing the preconditioner
+  unsigned int _solid_energy_pc_solve_counter;
+
+  /// How often to recompute the passive scalar equations preconditioner
+  const unsigned int _passive_scalar_pc_recompute_frequency;
+
+  /// Number of passive scalar solves performed without recomputing the preconditioner
+  unsigned int _passive_scalar_pc_solve_counter;
+
+  /// How often to recompute the turbulence equations preconditioner
+  const unsigned int _turbulence_pc_recompute_frequency;
+
+  /// Number of turbulence equations solves performed without recomputing the preconditioner
+  unsigned int _turbulence_pc_solve_counter;
 
   /// Pointer(s) to the system(s) corresponding to the passive scalar equation(s)
   std::vector<LinearSystem *> _passive_scalar_systems;
@@ -195,6 +226,12 @@ protected:
 
   /// The user-defined absolute tolerance for determining the convergence in active scalars
   const std::vector<Real> _active_scalar_absolute_tolerance;
+
+  /// How often to recompute the active scalar equations preconditioner
+  const unsigned int _active_scalar_pc_recompute_frequency;
+
+  /// Number of active scalar solves performed without recomputing the preconditioner
+  unsigned int _active_scalar_pc_solve_counter;
 
   /// ********************** Conjugate heat transfer variables ************** //
 

--- a/modules/navier_stokes/src/executioners/LinearAssemblySegregatedSolve.C
+++ b/modules/navier_stokes/src/executioners/LinearAssemblySegregatedSolve.C
@@ -102,18 +102,61 @@ LinearAssemblySegregatedSolve::validParams()
    * operator changes slowly between SIMPLE iterations, so its preconditioner can be reused for
    * several iterations rather than rebuilt every solve.
    */
+  const std::string explanation =
+      "The default of 1 rebuilds it on every solve. A value of N rebuilds it once every N solves "
+      "and "
+      "reuses it in between, which can substantially reduce the solve cost when the "
+      "preconditioner setup dominates (e.g. algebraic multigrid). Larger values trade more reuse "
+      "for a possibly staler preconditioner (more Krylov iterations); for solves where the "
+      "operator operator changes significantly, prefer a smaller value.";
   params.addRangeCheckedParam<unsigned int>(
       "pressure_pc_recompute_frequency",
       1,
       "pressure_pc_recompute_frequency >= 1",
-      "How often (in pressure corrector solves) to recompute the pressure preconditioner. The "
-      "default of 1 rebuilds it on every solve. A value of N rebuilds it once every N solves and "
-      "reuses it in between, which can substantially reduce the pressure solve cost when the "
-      "preconditioner setup dominates (e.g. algebraic multigrid). Larger values trade more reuse "
-      "for a possibly staler preconditioner (more Krylov iterations); for solves where the "
-      "pressure "
-      "operator changes significantly, prefer a smaller value.");
+      "How often (in pressure corrector solves) to recompute the pressure preconditioner. " +
+          explanation);
   params.addParamNamesToGroup("pressure_pc_recompute_frequency", "Pressure Equation");
+  // Other preconditioner reuse
+  params.addRangeCheckedParam<unsigned int>(
+      "momentum_pc_recompute_frequency",
+      1,
+      "momentum_pc_recompute_frequency >= 1",
+      "How often (in SIMPLE iteration solves) to recompute the momentum preconditioner. " +
+          explanation);
+  params.addParamNamesToGroup("momentum_pc_recompute_frequency", "Momentum Equations");
+  params.addRangeCheckedParam<unsigned int>("energy_pc_recompute_frequency",
+                                            1,
+                                            "energy_pc_recompute_frequency >= 1",
+                                            "How often (in terms of CHT solves nested within "
+                                            "SIMPLE solves) to recompute the preconditioner. " +
+                                                explanation);
+  params.addParamNamesToGroup("energy_pc_recompute_frequency", "Energy Equation");
+  params.addRangeCheckedParam<unsigned int>("solid_energy_pc_recompute_frequency",
+                                            1,
+                                            "solid_energy_pc_recompute_frequency >= 1",
+                                            "How often (in terms of CHT solves nested within "
+                                            "SIMPLE solves) to recompute the preconditioner. " +
+                                                explanation);
+  params.addParamNamesToGroup("solid_energy_pc_recompute_frequency", "Solid Energy Equation");
+  params.addRangeCheckedParam<unsigned int>(
+      "passive_scalar_pc_recompute_frequency",
+      1,
+      "passive_scalar_pc_recompute_frequency >= 1",
+      "How often (in advection solves) to recompute the preconditioner. " + explanation);
+  params.addParamNamesToGroup("passive_scalar_pc_recompute_frequency",
+                              "Passive Scalars Advection Equation");
+  params.addRangeCheckedParam<unsigned int>(
+      "turbulence_pc_recompute_frequency",
+      1,
+      "turbulence_pc_recompute_frequency >= 1",
+      "How often (in advection solves) to recompute the preconditioner. " + explanation);
+  params.addParamNamesToGroup("turbulence_pc_recompute_frequency", "Turbulence Equation");
+  params.addRangeCheckedParam<unsigned int>(
+      "active_scalar_pc_recompute_frequency",
+      1,
+      "active_scalar_pc_recompute_frequency >= 1",
+      "How often (in advection solves) to recompute the preconditioner. " + explanation);
+  params.addParamNamesToGroup("active_scalar_pc_recompute_frequency", "Active Scalars Equation");
 
   /*
    * Parameters to control the conjugate heat transfer
@@ -125,6 +168,8 @@ LinearAssemblySegregatedSolve::validParams()
 
 LinearAssemblySegregatedSolve::LinearAssemblySegregatedSolve(Executioner & ex)
   : SIMPLESolveBase(ex),
+    _momentum_pc_recompute_frequency(getParam<unsigned int>("momentum_pc_recompute_frequency")),
+    _momentum_pc_solve_counter(0),
     _pressure_sys_number(_problem.linearSysNum(getParam<SolverSystemName>("pressure_system"))),
     _pressure_system(_problem.getLinearSystem(_pressure_sys_number)),
     _pressure_pc_recompute_frequency(getParam<unsigned int>("pressure_pc_recompute_frequency")),
@@ -133,12 +178,22 @@ LinearAssemblySegregatedSolve::LinearAssemblySegregatedSolve(Executioner & ex)
                            ? _problem.linearSysNum(getParam<SolverSystemName>("energy_system"))
                            : libMesh::invalid_uint),
     _energy_system(_has_energy_system ? &_problem.getLinearSystem(_energy_sys_number) : nullptr),
+    _energy_pc_recompute_frequency(getParam<unsigned int>("energy_pc_recompute_frequency")),
+    _energy_pc_solve_counter(0),
     _solid_energy_sys_number(
         _has_solid_energy_system
             ? _problem.linearSysNum(getParam<SolverSystemName>("solid_energy_system"))
             : libMesh::invalid_uint),
     _solid_energy_system(
         _has_solid_energy_system ? &_problem.getLinearSystem(_solid_energy_sys_number) : nullptr),
+    _solid_energy_pc_recompute_frequency(
+        getParam<unsigned int>("solid_energy_pc_recompute_frequency")),
+    _solid_energy_pc_solve_counter(0),
+    _passive_scalar_pc_recompute_frequency(
+        getParam<unsigned int>("passive_scalar_pc_recompute_frequency")),
+    _passive_scalar_pc_solve_counter(0),
+    _turbulence_pc_recompute_frequency(getParam<unsigned int>("turbulence_pc_recompute_frequency")),
+    _turbulence_pc_solve_counter(0),
     _should_solve_momentum(getParam<bool>("should_solve_momentum")),
     _should_solve_pressure(getParam<bool>("should_solve_pressure")),
     _should_solve_energy(getParam<bool>("should_solve_energy")),
@@ -154,6 +209,9 @@ LinearAssemblySegregatedSolve::LinearAssemblySegregatedSolve(Executioner & ex)
     _active_scalar_l_abs_tol(getParam<Real>("active_scalar_l_abs_tol")),
     _active_scalar_absolute_tolerance(
         getParam<std::vector<Real>>("active_scalar_absolute_tolerance")),
+    _active_scalar_pc_recompute_frequency(
+        getParam<unsigned int>("active_scalar_pc_recompute_frequency")),
+    _active_scalar_pc_solve_counter(0),
     _cht(ex.parameters())
 {
   if (!_should_solve_momentum && _should_solve_pressure)
@@ -183,6 +241,7 @@ LinearAssemblySegregatedSolve::LinearAssemblySegregatedSolve(Executioner & ex)
 
   if (_has_solid_energy_system && _should_solve_solid_energy)
     _systems_to_solve.push_back(_solid_energy_system);
+
   // and for the turbulence surrogate equations
   if (_has_turbulence_systems && _should_solve_turbulence)
     for (auto system_i : index_range(_turbulence_system_names))
@@ -381,9 +440,11 @@ LinearAssemblySegregatedSolve::solveMomentumPredictor()
     _momentum_systems[system_i]->copyPreviousSolutions(Moose::SolutionIterationType::Nonlinear);
   }
 
-  // We reset this to ensure the preconditioner is recomputed new time we go to the momentum
-  // predictor
-  momentum_solver.reuse_preconditioner(false);
+  // We reset this to ensure the preconditioner is computed again when we go to the momentum
+  // predictor, if the number of reuses has been met
+  momentum_solver.reuse_preconditioner(
+      (_momentum_pc_solve_counter % _momentum_pc_recompute_frequency) != 0);
+  ++_momentum_pc_solve_counter;
 
   return its_normalized_residuals;
 }
@@ -443,8 +504,7 @@ LinearAssemblySegregatedSolve::solvePressureCorrector()
   // cost. We rebuild it on the first solve and then once every _pressure_pc_recompute_frequency
   // solves, reusing it in between. With the default frequency of 1 this rebuilds on every solve.
   pressure_solver.reuse_preconditioner(
-      (_pressure_pc_solve_counter % _pressure_pc_recompute_frequency) != 0);
-  ++_pressure_pc_solve_counter;
+      (_pressure_pc_solve_counter++ % _pressure_pc_recompute_frequency) != 0);
 
   auto its_res_pair = pressure_solver.solve(mmat, mmat, solution, rhs);
   pressure_system.update();
@@ -505,6 +565,11 @@ LinearAssemblySegregatedSolve::solveSolidEnergy()
   // Setting the linear tolerances and maximum iteration counts
   _solid_energy_linear_control.real_valued_data["abs_tol"] = _solid_energy_l_abs_tol * norm_factor;
   solver.set_solver_configuration(_solid_energy_linear_control);
+
+  // Handle preconditioner reuse logic
+  solver.reuse_preconditioner(
+      (_solid_energy_pc_solve_counter % _solid_energy_pc_recompute_frequency) != 0);
+  ++_solid_energy_pc_solve_counter;
 
   auto its_res_pair = solver.solve(mmat, mmat, solution, rhs);
   system.update();
@@ -577,6 +642,7 @@ LinearAssemblySegregatedSolve::solveAdvectedSystem(const unsigned int system_num
                                                    const Real relaxation_factor,
                                                    SolverConfiguration & solver_config,
                                                    const Real absolute_tol,
+                                                   const bool reuse_pc,
                                                    const Real field_relaxation,
                                                    const Real min_value_limiter)
 {
@@ -619,6 +685,9 @@ LinearAssemblySegregatedSolve::solveAdvectedSystem(const unsigned int system_num
   // Setting the linear tolerances and maximum iteration counts
   solver_config.real_valued_data["abs_tol"] = absolute_tol * norm_factor;
   linear_solver.set_solver_configuration(solver_config);
+
+  // Preconditioner reuse to reduce computational cost
+  linear_solver.reuse_preconditioner(reuse_pc);
 
   // Solve the system and update current local solution
   auto its_res_pair = linear_solver.solve(mmat, mmat, solution, rhs);
@@ -675,9 +744,14 @@ LinearAssemblySegregatedSolve::solve()
   // Initialize the SIMPLE iteration counter
   unsigned int simple_iteration_counter = 0;
 
-  // Rebuild the pressure preconditioner on the first solve of this (e.g. time) step before reusing
-  // it according to _pressure_pc_recompute_frequency.
+  // Reset all the PC solve counters for preconditioner re-use
+  _momentum_pc_solve_counter = 0;
   _pressure_pc_solve_counter = 0;
+  _energy_pc_solve_counter = 0;
+  _solid_energy_pc_solve_counter = 0;
+  _passive_scalar_pc_solve_counter = 0;
+  _turbulence_pc_solve_counter = 0;
+  _active_scalar_pc_solve_counter = 0;
 
   // We set up the residual storage and the corresponding tolerances.
   ResidualStorage residual_storage = setupResidualStorage();
@@ -742,11 +816,13 @@ LinearAssemblySegregatedSolve::solve()
         // We set the preconditioner/controllable parameters through petsc options. Linear
         // tolerances will be overridden within the solver.
         Moose::PetscSupport::petscSetOptions(_energy_petsc_options, solver_params);
-        ns_residuals[energy_index] = solveAdvectedSystem(_energy_sys_number,
-                                                         *_energy_system,
-                                                         _energy_equation_relaxation,
-                                                         _energy_linear_control,
-                                                         _energy_l_abs_tol);
+        ns_residuals[energy_index] =
+            solveAdvectedSystem(_energy_sys_number,
+                                *_energy_system,
+                                _energy_equation_relaxation,
+                                _energy_linear_control,
+                                _energy_l_abs_tol,
+                                (_energy_pc_solve_counter++ % _energy_pc_recompute_frequency) != 0);
 
         if (_has_pm_radiation_systems && _should_solve_pm_radiation)
         {
@@ -760,7 +836,8 @@ LinearAssemblySegregatedSolve::solve()
                                     *_pm_radiation_systems[i],
                                     _pm_radiation_equation_relaxation[i],
                                     _pm_radiation_linear_control,
-                                    _pm_radiation_l_abs_tol);
+                                    _pm_radiation_l_abs_tol,
+                                    /*reuse_pc*/ false);
           }
         }
 
@@ -806,12 +883,14 @@ LinearAssemblySegregatedSolve::solve()
       // tolerances will be overridden within the solver.
       Moose::PetscSupport::petscSetOptions(_active_scalar_petsc_options, solver_params);
       for (const auto i : index_range(_active_scalar_system_names))
-        ns_residuals[active_scalar_indices[i]] =
-            solveAdvectedSystem(_active_scalar_system_numbers[i],
-                                *_active_scalar_systems[i],
-                                _active_scalar_equation_relaxation[i],
-                                _active_scalar_linear_control,
-                                _active_scalar_l_abs_tol);
+        ns_residuals[active_scalar_indices[i]] = solveAdvectedSystem(
+            _active_scalar_system_numbers[i],
+            *_active_scalar_systems[i],
+            _active_scalar_equation_relaxation[i],
+            _active_scalar_linear_control,
+            _active_scalar_l_abs_tol,
+            (_active_scalar_pc_solve_counter % _active_scalar_pc_recompute_frequency) != 0);
+      ++_active_scalar_pc_solve_counter;
     }
 
     // If we have turbulence equations, solve them here.
@@ -823,15 +902,17 @@ LinearAssemblySegregatedSolve::solve()
       Moose::PetscSupport::petscSetOptions(_turbulence_petsc_options, solver_params);
       for (const auto i : index_range(_turbulence_system_names))
       {
-        ns_residuals[turbulence_indices[i]] =
-            solveAdvectedSystem(_turbulence_system_numbers[i],
-                                *_turbulence_systems[i],
-                                _turbulence_equation_relaxation[i],
-                                _turbulence_linear_control,
-                                _turbulence_l_abs_tol,
-                                _turbulence_field_relaxation[i],
-                                _turbulence_field_min_limit[i]);
+        ns_residuals[turbulence_indices[i]] = solveAdvectedSystem(
+            _turbulence_system_numbers[i],
+            *_turbulence_systems[i],
+            _turbulence_equation_relaxation[i],
+            _turbulence_linear_control,
+            _turbulence_l_abs_tol,
+            (_turbulence_pc_solve_counter % _turbulence_pc_recompute_frequency) != 0,
+            _turbulence_field_relaxation[i],
+            _turbulence_field_min_limit[i]);
       }
+      ++_turbulence_pc_solve_counter;
     }
 
     _problem.execute(EXEC_NONLINEAR);
@@ -866,11 +947,14 @@ LinearAssemblySegregatedSolve::solve()
       // tolerances will be overridden within the solver.
       Moose::PetscSupport::petscSetOptions(_passive_scalar_petsc_options, solver_params);
       for (const auto i : index_range(_passive_scalar_system_names))
-        scalar_residuals[i] = solveAdvectedSystem(_passive_scalar_system_numbers[i],
-                                                  *_passive_scalar_systems[i],
-                                                  _passive_scalar_equation_relaxation[i],
-                                                  _passive_scalar_linear_control,
-                                                  _passive_scalar_l_abs_tol);
+        scalar_residuals[i] = solveAdvectedSystem(
+            _passive_scalar_system_numbers[i],
+            *_passive_scalar_systems[i],
+            _passive_scalar_equation_relaxation[i],
+            _passive_scalar_linear_control,
+            _passive_scalar_l_abs_tol,
+            (_passive_scalar_pc_solve_counter % _passive_scalar_pc_recompute_frequency) != 0);
+      ++_passive_scalar_pc_solve_counter;
 
       passive_scalar_converged = NS::FV::converged(scalar_residuals, scalar_abs_tols);
     }

--- a/modules/navier_stokes/src/executioners/LinearAssemblySegregatedSolve.C
+++ b/modules/navier_stokes/src/executioners/LinearAssemblySegregatedSolve.C
@@ -102,19 +102,19 @@ LinearAssemblySegregatedSolve::validParams()
    * operator changes slowly between SIMPLE iterations, so its preconditioner can be reused for
    * several iterations rather than rebuilt every solve.
    */
-  const std::string explanation =
+  const std::string recompute_frequency_explanation =
       "The default of 1 rebuilds it on every solve. A value of N rebuilds it once every N solves "
       "and "
       "reuses it in between, which can substantially reduce the solve cost when the "
       "preconditioner setup dominates (e.g. algebraic multigrid). Larger values trade more reuse "
       "for a possibly staler preconditioner (more Krylov iterations); for solves where the "
-      "operator operator changes significantly, prefer a smaller value.";
+      "operator changes significantly between linear solves, prefer a smaller value.";
   params.addRangeCheckedParam<unsigned int>(
       "pressure_pc_recompute_frequency",
       1,
       "pressure_pc_recompute_frequency >= 1",
       "How often (in pressure corrector solves) to recompute the pressure preconditioner. " +
-          explanation);
+          recompute_frequency_explanation);
   params.addParamNamesToGroup("pressure_pc_recompute_frequency", "Pressure Equation");
   // Other preconditioner reuse
   params.addRangeCheckedParam<unsigned int>(
@@ -122,40 +122,43 @@ LinearAssemblySegregatedSolve::validParams()
       1,
       "momentum_pc_recompute_frequency >= 1",
       "How often (in SIMPLE iteration solves) to recompute the momentum preconditioner. " +
-          explanation);
+          recompute_frequency_explanation);
   params.addParamNamesToGroup("momentum_pc_recompute_frequency", "Momentum Equations");
-  params.addRangeCheckedParam<unsigned int>("energy_pc_recompute_frequency",
-                                            1,
-                                            "energy_pc_recompute_frequency >= 1",
-                                            "How often (in terms of CHT solves nested within "
-                                            "SIMPLE solves) to recompute the preconditioner. " +
-                                                explanation);
+  params.addRangeCheckedParam<unsigned int>(
+      "energy_pc_recompute_frequency",
+      1,
+      "energy_pc_recompute_frequency >= 1",
+      "How often (in terms of CHT and SIMPLE iterations) to recompute the preconditioner. " +
+          recompute_frequency_explanation);
   params.addParamNamesToGroup("energy_pc_recompute_frequency", "Energy Equation");
   params.addRangeCheckedParam<unsigned int>("solid_energy_pc_recompute_frequency",
                                             1,
                                             "solid_energy_pc_recompute_frequency >= 1",
                                             "How often (in terms of CHT solves nested within "
                                             "SIMPLE solves) to recompute the preconditioner. " +
-                                                explanation);
+                                                recompute_frequency_explanation);
   params.addParamNamesToGroup("solid_energy_pc_recompute_frequency", "Solid Energy Equation");
   params.addRangeCheckedParam<unsigned int>(
       "passive_scalar_pc_recompute_frequency",
       1,
       "passive_scalar_pc_recompute_frequency >= 1",
-      "How often (in advection solves) to recompute the preconditioner. " + explanation);
+      "How often (in advection solves) to recompute the preconditioner. " +
+          recompute_frequency_explanation);
   params.addParamNamesToGroup("passive_scalar_pc_recompute_frequency",
                               "Passive Scalars Advection Equation");
   params.addRangeCheckedParam<unsigned int>(
       "turbulence_pc_recompute_frequency",
       1,
       "turbulence_pc_recompute_frequency >= 1",
-      "How often (in advection solves) to recompute the preconditioner. " + explanation);
+      "How often (in advection solves) to recompute the preconditioner. " +
+          recompute_frequency_explanation);
   params.addParamNamesToGroup("turbulence_pc_recompute_frequency", "Turbulence Equation");
   params.addRangeCheckedParam<unsigned int>(
       "active_scalar_pc_recompute_frequency",
       1,
       "active_scalar_pc_recompute_frequency >= 1",
-      "How often (in advection solves) to recompute the preconditioner. " + explanation);
+      "How often (in advection solves) to recompute the preconditioner. " +
+          recompute_frequency_explanation);
   params.addParamNamesToGroup("active_scalar_pc_recompute_frequency", "Active Scalars Equation");
 
   /*

--- a/modules/navier_stokes/src/executioners/SIMPLESolveBase.C
+++ b/modules/navier_stokes/src/executioners/SIMPLESolveBase.C
@@ -287,7 +287,7 @@ SIMPLESolveBase::validParams()
       "passive_scalar_petsc_options_value passive_scalar_petsc_options_value "
       "passive_scalar_absolute_tolerance "
       "passive_scalar_l_tol passive_scalar_l_abs_tol passive_scalar_l_max_its",
-      "passive_scalar Equation");
+      "Passive Scalars Advection Equation");
 
   /*
    * Parameters to control the solution of each participating media radiation equation

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/linear-segregated/1d-scalar/channel-conservation-physics.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/linear-segregated/1d-scalar/channel-conservation-physics.i
@@ -130,10 +130,14 @@ k2 = 0
 
   momentum_petsc_options_iname = '-pc_type -pc_hypre_type'
   momentum_petsc_options_value = 'hypre boomeramg'
+  # added to test PC reuse feature
+  momentum_pc_recompute_frequency = 2
   pressure_petsc_options_iname = '-pc_type -pc_hypre_type'
   pressure_petsc_options_value = 'hypre boomeramg'
   passive_scalar_petsc_options_iname = '-pc_type -pc_hypre_type'
   passive_scalar_petsc_options_value = 'hypre boomeramg'
+  # added to test PC reuse feature
+  passive_scalar_pc_recompute_frequency = 10
 
   print_fields = false
   continue_on_max_its = true

--- a/modules/navier_stokes/test/tests/finite_volume/ins/cht/bulk_heat_transfer/flow-around-square-linear-fluidonly-physics.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/cht/bulk_heat_transfer/flow-around-square-linear-fluidonly-physics.i
@@ -138,6 +138,8 @@ advected_interp_method = 'upwind'
   pressure_petsc_options_value = 'hypre boomeramg'
   energy_petsc_options_iname = '-pc_type -pc_hypre_type'
   energy_petsc_options_value = 'hypre boomeramg'
+  # added to test PC reuse feature
+  energy_pc_recompute_frequency = 10
   print_fields = false
   continue_on_max_its = true
 []

--- a/modules/navier_stokes/test/tests/finite_volume/ins/turbulence/channel/linear-segregated/executioner_regular_channel.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/turbulence/channel/linear-segregated/executioner_regular_channel.i
@@ -28,6 +28,8 @@
   pressure_petsc_options_value = 'hypre boomeramg'
   turbulence_petsc_options_iname = '-pc_type -pc_hypre_type'
   turbulence_petsc_options_value = 'hypre boomeramg'
+  # added to test PC reuse feature
+  turbulence_pc_recompute_frequency = 5
 
   print_fields = false
   continue_on_max_its = true


### PR DESCRIPTION
- momentum across SIMPLE iterations
- energy and solid energy
- turbulence
- active and passive scalars

This shaves another 80s of off the BFS case so roughly 15%
Note that a lot of the saving comes from nailing down the residual to 1e-8 so it might be lower for less converged cases

refs #33574

Timings on INL M4 pro:

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/giudgl/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/giudgl/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
-->
</style>
</head>

<body link="#467886" vlink="#96607D">


PC reuse |   |   |   |  
-- | -- | -- | -- | --
Momentum | Pressure | Turbulence | Runtime |  
1 | 1 | 1 | 674 | 635s in 2nd run
  | 2 |   | 602 |  
  | 100 |   | 576 |  
  | 1000 |   | 601.8 |  
  |   | 10 | 544 |  
  |   | 30 | 525 |  
2 |   |   | 507 |  
10 |   |   | 490 |  
20 |   |   | 500 |  



</body>

</html>
