### PR TITLE
Don't track origins with valgrind to speed it up

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1632,6 +1632,11 @@ class TestHarness:
             const="HEAVY",
             help="Run heavy valgrind tests",
         )
+        filtergroup.add_argument(
+            "--valgrind-track-origins",
+            action="store_true",
+            help="Enable --track-origins=yes when running valgrind",
+        )
 
         capabilitygroup = parser.add_argument_group(
             "Additional Capabilities",
@@ -2116,6 +2121,10 @@ class TestHarness:
 
         if not opts.valgrind_mode:
             opts.valgrind_mode = ""
+            if opts.valgrind_track_origins:
+                self.errorExit(
+                    "Cannot specify --valgrind-track-origins without --valgrind"
+                )
 
         # Set default
         if not opts.input_file_name:
@@ -2204,7 +2213,10 @@ class TestHarness:
         """
         Helper for printing an error and exiting
         """
-        util.errorExit(*args, colored=self.options.colored is True)
+        colored = True
+        if options := getattr(self, "options", None):
+            colored = options.colored
+        util.errorExit(*args, colored=colored is True)
 
     def printInfo(self, *args):
         """Print the given message as information."""

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -505,7 +505,8 @@ class RunApp(Tester):
                     "suppressions",
                     "errors.supp",
                 )
-                + " --leak-check=full --tool=memcheck --dsymutil=yes --track-origins=yes --demangle=yes --enable-debuginfod=no -v "
+                + " --leak-check=full --tool=memcheck --dsymutil=yes --demangle=yes --enable-debuginfod=no -v "
+                + f"--track-origins={"yes" if options.valgrind_track_origins else "no"} "
                 + command
             )
         elif nthreads > 1:


### PR DESCRIPTION
## Reason

Disable Valgrind origin tracking for routine test execution to reduce Memcheck runtime overhead. `--track-origins=yes` performs additional bookkeeping to identify where undefined values originate, which can significantly increase execution time. Disabling it does not prevent Memcheck from detecting undefined-value usage or other memory errors; it only removes the additional origin information from those diagnostics. Tests that report undefined-value errors can still be rerun with `--track-origins=yes` when deeper debugging information is needed.

## Design

Set `--track-origins=no` in valgrind execution.

## Impact

Will remove useful context from valgrind failures, but will enable faster execution. Origins can still be tracked by running it again locally.
