### PR TITLE
Update base containers to improve valgrind, set `--track-origins=no` for valgrind

### DIFF
--- a/apptainer/libmesh.def
+++ b/apptainer/libmesh.def
@@ -17,6 +17,7 @@
    - METHODS: Methods to build (default: dbg devel oprof opt)
    - MOOSE_JOBS: Number of jobs to pass to the libmesh build script
    - MTUNE: Tuning to use for --mtune (default: generic)
+   - OPTFLAGS: Optional optimization flags to override (overrides -march and -mtune)
    - SKIP_FINGERPRINTS: Set to skip fingerprint verification (truthy, default: false)
 -#}
 
@@ -58,7 +59,11 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     fi
 
     # Optimization flags
+{% if OPTFLAGS is defined %}
+    IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
+{%- else %}
     OPTFLAGS=("-march={{ MARCH }}" "-mtune={{ MTUNE }}")
+{%- endif %}
 
     # Build VTK
     (

--- a/apptainer/moose-dev.def
+++ b/apptainer/moose-dev.def
@@ -20,6 +20,7 @@
    - MFEM_OPTIONS: Options to pass to mfem build
    - MOOSE_JOBS: Number of jobs to pass to the builds
    - MTUNE: Tuning to use for --mtune (default: generic)
+   - OPTFLAGS: Optional optimization flags to override (overrides -march and -mtune)
    - PROFILING: Whether or not to build with gperftools (truthy, default: false)
    - PYTORCH_GIT_SHA: The git SHA to use for pytorch
    - PYTORCH_GIT_REMOTE: The git remote to use to get pytorch
@@ -118,7 +119,11 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
 {%- endif %}
 
     # Optimization flags
+{% if OPTFLAGS is defined %}
+    IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
+{%- else %}
     OPTFLAGS=("-march={{ MARCH }}" "-mtune={{ MTUNE }}")
+{%- endif %}
 
     # Special setup for OpenMPI
     if [ -n "${MOOSE_OPENMPI_DIR:-}" ]; then

--- a/apptainer/mpi.def
+++ b/apptainer/mpi.def
@@ -67,7 +67,7 @@ From: {{ FROM_IMAGES.get(VARIANT, FROM_IMAGES.get("ubuntu24_gcc")) }}
     INSTALLS=(
         "autoconf" "automake" "bash-completion" "bison" "cmake" "diffutils"
         "doxygen" "emacs" "flex" "lcov" "libtool" "ninja-build" "patch" "patchelf"
-        "patchutils" "valgrind"
+        "patchutils"
     )
     ROCKY_INSTALLS=(
         "cppunit" "cppunit-devel" "fftw-devel" "glpk-devel" "gsl-devel" "libpng"
@@ -77,10 +77,11 @@ From: {{ FROM_IMAGES.get(VARIANT, FROM_IMAGES.get("ubuntu24_gcc")) }}
     UBUNTU_INSTALLS=(
         "libcppunit-dev" "libfftw3-dev" "libglpk-dev" "libgsl-dev" "libio-compress-perl"
         "libjson-perl" "libjson-pp-perl" "libpng-dev" "libtirpc3" "libtirpc-dev"
-        "zlib1g-dev"
+        "zlib1g-dev" "libc6-dbg"
     )
     if is_rocky; then
         dnf install -y "${INSTALLS[@]}" "${ROCKY_INSTALLS[@]}"
+        dnf debuginfo-install -y glibc
     elif is_ubuntu; then
         apt-get install -y --no-install-recommends "${INSTALLS[@]}" "${UBUNTU_INSTALLS[@]}"
     fi

--- a/apptainer/mpi.def
+++ b/apptainer/mpi.def
@@ -12,22 +12,22 @@
 {%- set FILES_DIR = MOOSE_DIR + '/apptainer/files/mpi' -%}
 
 {#- Image variant definitions
-    rocky8_gcc:        moose-mpi-rocky8-gcc:8.10-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260816
-    rocky8_oneapi:     moose-mpi-rocky8-oneapi:8.10-gcc13.3.1-oneapi2026.1.1-mpich4.3.2-20260816
-    rocky9_gcc:        moose-mpi-rocky9-gcc:9.7-gcc13.3.1-mpich4.3.2-openmpi5.0.10-20260816
-    ubuntu24_clang:    moose-mpi-ubuntu24-clang:24.04-clang22.1.8-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260816
-    ubuntu24_cuda_gcc: moose-mpi-ubuntu24-cuda-gcc:24.04-cuda13.3.1-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260816
-    ubuntu24_gcc:      moose-mpi-ubuntu24-gcc:24.04-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260816
-    ubuntu24_gccmin:   moose-mpi-ubuntu24-gccmin:24.04-gcc9.5.0-mpich5.0.1-20260816
+    rocky8_gcc:        moose-mpi-rocky8-gcc:8.10-gcc13.3.1-mpich5.0.1-openmpi5.0.10-20260822
+    rocky8_oneapi:     moose-mpi-rocky8-oneapi:8.10-gcc13.3.1-oneapi2026.1.1-mpich4.3.2-20260822
+    rocky9_gcc:        moose-mpi-rocky9-gcc:9.7-gcc13.3.1-mpich4.3.2-openmpi5.0.10-20260822
+    ubuntu24_clang:    moose-mpi-ubuntu24-clang:24.04-clang22.1.8-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260823
+    ubuntu24_cuda_gcc: moose-mpi-ubuntu24-cuda-gcc:24.04-cuda13.3.1-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260823
+    ubuntu24_gcc:      moose-mpi-ubuntu24-gcc:24.04-gcc14.2.0-mpich5.0.1-openmpi5.0.10-20260823
+    ubuntu24_gccmin:   moose-mpi-ubuntu24-gccmin:24.04-gcc9.5.0-mpich5.0.1-20260823
 -#}
 {%- set FROM_IMAGES = {
-  "rocky8_gcc":        "ghcr.io/idaholab/moose-containers/moose-mpi-rocky8-gcc@sha256:2acf202db6a4cb4134b3bcc9e3dd2d7a0eaf580a8952cdfdc4d8005f3531e862",
-  "rocky8_oneapi":     "ghcr.io/idaholab/moose-containers/moose-mpi-rocky8-oneapi@sha256:b39debf42c662abfab8c2e78749a80839e5cb340c67c07534fad192759ec923b",
-  "rocky9_gcc":        "ghcr.io/idaholab/moose-containers/moose-mpi-rocky9-gcc@sha256:7793a16f7a060aa81127e02c184d8e150eb67f722b614c2b5e493efb3d26269b",
-  "ubuntu24_clang":    "ghcr.io/idaholab/moose-containers/moose-mpi-ubuntu24-clang@sha256:ccb18d6e869b4215df94d34db6e0eb4222d9a87f083e378ebd6088ec38f7bc6e",
-  "ubuntu24_cuda_gcc": "ghcr.io/idaholab/moose-containers/moose-mpi-ubuntu24-cuda-gcc@sha256:a73ea9d79e7a632a365e0386b01672e3833621627cc577a353599242c12a3511",
-  "ubuntu24_gcc":      "ghcr.io/idaholab/moose-containers/moose-mpi-ubuntu24-gcc@sha256:5c9d891583ac96fbd7ac062d325a15f56e1a49061cccea8db21ab007a44ba5c0",
-  "ubuntu24_gccmin":   "ghcr.io/idaholab/moose-containers/moose-mpi-ubuntu24-gccmin@sha256:997ce51ef4f38e5480f22a8c35d20d9a6aff6a998bb3e84d6189102d559c2211"
+  "rocky8_gcc":        "ghcr.io/idaholab/moose-containers/moose-mpi-rocky8-gcc@sha256:01c4a2165728aa841f14f801cf811dcfe2fd6e5cbfb844de67563c0710e7ef1c",
+  "rocky8_oneapi":     "ghcr.io/idaholab/moose-containers/moose-mpi-rocky8-oneapi@sha256:c8d64a4ccb9a32dc4061ce48b55fbb60e689afe2b47c9d617a35b6f48e15de80",
+  "rocky9_gcc":        "ghcr.io/idaholab/moose-containers/moose-mpi-rocky9-gcc@sha256:04e82ba22859fe86552f7edbe54b0f5f85bc0a95b79846ee03d7ff2f641588f2",
+  "ubuntu24_clang":    "ghcr.io/idaholab/moose-containers/moose-mpi-ubuntu24-clang@sha256:54b368cfefa325a7fed53bf7b4c01fa217c85301d1e449d76aa1195165954776",
+  "ubuntu24_cuda_gcc": "ghcr.io/idaholab/moose-containers/moose-mpi-ubuntu24-cuda-gcc@sha256:db1a9740fdfce9a0378e6b451bf03967d62e3df09d29a2a4e6d5a4963378f943",
+  "ubuntu24_gcc":      "ghcr.io/idaholab/moose-containers/moose-mpi-ubuntu24-gcc@sha256:01b6fcadea485db93f6d265d960f6688e6bd3e5913f014c35e68ac6816946650",
+  "ubuntu24_gccmin":   "ghcr.io/idaholab/moose-containers/moose-mpi-ubuntu24-gccmin@sha256:7153a3528ec3925015d818b276c4a5b760d9f00b9ce0b712780df33c764354ad"
 } -%}
 
 Bootstrap: docker

--- a/apptainer/petsc.def
+++ b/apptainer/petsc.def
@@ -13,6 +13,7 @@
    - MOOSE_JOBS: Number of jobs to pass to the PETSc build script
    - MPI_FLAVOUR: The flavour of MPI to use (options: mpich, openmpi; default: mpich)
    - MTUNE: Tuning to use for --mtune (default: generic)
+   - OPTFLAGS: Optional optimization flags to override (overrides -march and -mtune)
    - PETSC_OPTIONS: Options to pass to the PETSc build script
    - PROFILING: Whether or not to build with gperftools (truthy, default: false)
    - SKIP_FINGERPRINTS: Set to skip fingerprint verification (truthy, default: false)
@@ -81,7 +82,11 @@ Fingerprints: 0CFFCAB55E806363601C442D211817B01E0911DB
     fi
 
     # Optimization flags
+{% if OPTFLAGS is defined %}
+    IFS=' ' read -r -a OPTFLAGS <<< "{{ OPTFLAGS }}"
+{%- else %}
     OPTFLAGS=("-O2" "-march={{ MARCH }}" "-mtune={{ MTUNE }}")
+{%- endif %}
 
     # Clone PETSc
     cd ${ROOT_BUILD_DIR}

--- a/conda/build/meta.yaml
+++ b/conda/build/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set version = "2026.08.19" %}
+{% set version = "2026.08.23" %}
 
 package:
   name: moose-build

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 0 %}
+{% set build = 1 %}
 {% set vtk_version = "9.7.0" %}
 {% set vtk_friendly_version = vtk_version.split('.')[:2] | join('.') %}
 {% set sha256 = "affdb7a15ec34ee0174407f911ab70b646c7af01161818bbab4e1160b7eff720" %}

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = "2026.08.18_0772c3d" %}
 
 package:
@@ -30,8 +30,8 @@ build:
     # things that depend on this moose-libmesh must use the
     # exact moose-petsc and moose-libmesh-vtk that this was
     # built with
-    - moose-petsc 3.25.4 {{ mpi }}_0
-    - moose-libmesh-vtk 9.7.0 {{ mpi }}_0
+    - moose-petsc 3.25.4 {{ mpi }}_1
+    - moose-libmesh-vtk 9.7.0 {{ mpi }}_1
 
 requirements:
   build:
@@ -45,8 +45,8 @@ requirements:
     - pkg-config
   host:
     - {{ mpi }} {{ mpi_version }}
-    - moose-petsc 3.25.4 {{ mpi }}_0
-    - moose-libmesh-vtk 9.7.0 {{ mpi }}_0
+    - moose-petsc 3.25.4 {{ mpi }}_1
+    - moose-libmesh-vtk 9.7.0 {{ mpi }}_1
     - _openmp_mutex # [linux]
     - hdf5 {{ hdf5 }}
     - hdf5 {{ hdf5 }} mpi_{{ mpi }}_*
@@ -58,8 +58,8 @@ requirements:
     - llvm-openmp # [osx]
     - zlib
   run:
-    - moose-petsc 3.25.4 {{ mpi }}_0
-    - moose-libmesh-vtk 9.7.0 {{ mpi }}_0
+    - moose-petsc 3.25.4 {{ mpi }}_1
+    - moose-libmesh-vtk 9.7.0 {{ mpi }}_1
 
 test:
   commands:

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   moose/conda_build_config.yaml
 # As well as any directions pertaining to modifying those files.
-{% set version = "2026.08.19" %}
+{% set version = "2026.08.23" %}
 
 package:
   name: moose-dev
@@ -19,17 +19,17 @@ build:
   run_exports:
     # things that depend on this moose-dev must use the
     # exact moose-* packages that this was built with
-    - moose-build 2026.08.19 {{ mpi }}
-    - moose-libmesh 2026.08.18_0772c3d {{ mpi }}_0
-    - moose-wasp 2026.08.13_ce25dcd build_0
-    - moose-tools 2026.08.19
+    - moose-build 2026.08.23 {{ mpi }}
+    - moose-libmesh 2026.08.18_0772c3d {{ mpi }}_1
+    - moose-wasp 2026.08.13_ce25dcd build_1
+    - moose-tools 2026.08.23
 
 requirements:
   run:
-    - moose-build 2026.08.19 {{ mpi }}
-    - moose-libmesh 2026.08.18_0772c3d {{ mpi }}_0
-    - moose-wasp 2026.08.13_ce25dcd build_0
-    - moose-tools 2026.08.19
+    - moose-build 2026.08.23 {{ mpi }}
+    - moose-libmesh 2026.08.18_0772c3d {{ mpi }}_1
+    - moose-wasp 2026.08.13_ce25dcd build_1
+    - moose-tools 2026.08.23
   run_constrained:
     - {{ moose_python_constrained }}
 

--- a/conda/moose/meta.yaml
+++ b/conda/moose/meta.yaml
@@ -29,14 +29,14 @@ requirements:
     - {{ compiler('fortran') }}
     - {{ stdlib('c') }}
     # for libmesh libtool
-    - moose-libmesh 2026.08.18_0772c3d mpich_0
+    - moose-libmesh 2026.08.18_0772c3d mpich_1
     # build utilities
     - make
     - packaging
     - patchelf # [linux]
     # python; for doc build + premake
     - python 3.14.*
-    - moose-tools 2026.08.19
+    - moose-tools 2026.08.23
   host:
     - mpich {{ mpich_version }}
     - hdf5 {{ hdf5 }}
@@ -44,19 +44,19 @@ requirements:
     # see libfabric entry in conda/conda_build_config.yaml (only for mpich)
     - libfabric {{ libfabric }} # [linux]
     - libpng
-    - moose-libmesh 2026.08.18_0772c3d mpich_0
-    - moose-wasp 2026.08.13_ce25dcd build_0
+    - moose-libmesh 2026.08.18_0772c3d mpich_1
+    - moose-wasp 2026.08.13_ce25dcd build_1
     - zlib
   run:
     - mpich {{ mpich_version }}
-    - moose-libmesh 2026.08.18_0772c3d mpich_0
-    - moose-wasp 2026.08.13_ce25dcd build_0
+    - moose-libmesh 2026.08.18_0772c3d mpich_1
+    - moose-wasp 2026.08.13_ce25dcd build_1
     # c++ compiler for jit
     - gxx_linux-64 {{ cxx_compiler_version }}.*               # [linux]
     - clangxx_osx-64 {{ cxx_compiler_version }}.*             # [osx and x86_64]
     - clangxx_osx-arm64 {{ cxx_compiler_version }}.*          # [osx and arm64]
     # for testharness/python utilities
-    - moose-tools 2026.08.19
+    - moose-tools 2026.08.23
     # for running app --copy-inputs
     - rsync
   run_constrained:

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -7,7 +7,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = "3.25.4" %}
 
 package:

--- a/conda/pyhit/meta.yaml
+++ b/conda/pyhit/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: moose-pyhit
-  version: 2026.08.19
+  version: 2026.08.23
 
 source:
   - path: ../../python/moosetree
@@ -25,19 +25,19 @@ source:
 build:
   number: 0
   run_exports:
-    - moose-wasp 2026.08.13_ce25dcd build_0
+    - moose-wasp 2026.08.13_ce25dcd build_1
 
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - moose-wasp 2026.08.13_ce25dcd build_0
+    - moose-wasp 2026.08.13_ce25dcd build_1
     - make
   host:
     - python {{ python }}
-    - moose-wasp 2026.08.13_ce25dcd build_0
+    - moose-wasp 2026.08.13_ce25dcd build_1
   run:
     - python {{ python }}
-    - moose-wasp 2026.08.13_ce25dcd build_0
+    - moose-wasp 2026.08.13_ce25dcd build_1
 
 test:
   imports:

--- a/conda/template/meta.yaml
+++ b/conda/template/meta.yaml
@@ -30,14 +30,14 @@ requirements:
     - {{ compiler('fortran') }}
     - {{ stdlib('c') }}
     # for libmesh libtool
-    - moose-libmesh 2026.08.18_0772c3d mpich_0
+    - moose-libmesh 2026.08.18_0772c3d mpich_1
     # build utilities
     - make
     - packaging
     - patchelf # [linux]
     # python; for doc build + premake
     - python 3.14.*
-    - moose-tools 2026.08.19
+    - moose-tools 2026.08.23
   host:
     # should eventually become 'mpich {{ mpich_version }}'
     - mpich 5.0.1
@@ -46,20 +46,20 @@ requirements:
     # see libfabric entry in conda/conda_build_config.yaml
     - libfabric {{ libfabric }} # [linux]
     - libpng
-    - moose-libmesh 2026.08.18_0772c3d mpich_0
-    - moose-wasp 2026.08.13_ce25dcd build_0
+    - moose-libmesh 2026.08.18_0772c3d mpich_1
+    - moose-wasp 2026.08.13_ce25dcd build_1
     - zlib
   run:
     # should eventually become 'mpich {{ mpich_version }}'
     - mpich 5.0.1
-    - moose-libmesh 2026.08.18_0772c3d mpich_0
-    - moose-wasp 2026.08.13_ce25dcd build_0
+    - moose-libmesh 2026.08.18_0772c3d mpich_1
+    - moose-wasp 2026.08.13_ce25dcd build_1
     # c++ compiler for jit
     - gxx_linux-64 {{ cxx_compiler_version }}.*               # [linux]
     - clangxx_osx-64 {{ cxx_compiler_version }}.*             # [osx and x86_64]
     - clangxx_osx-arm64 {{ cxx_compiler_version }}.*          # [osx and arm64]
     # for testharness/python utilities
-    - moose-tools 2026.08.19
+    - moose-tools 2026.08.23
     # for running app --copy-inputs
     - rsync
   run_constrained:

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,7 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2026.08.19" %}
+{% set version = "2026.08.23" %}
 
 package:
   name: moose-tools

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -16,8 +16,8 @@ source:
   - path: ../functions/retry_build.sh
 
 build:
-  number: 0
-  string: build_0
+  number: 1
+  string: build_1
   script_env:
     - MOOSE_JOBS
     - REQUESTS_CA_BUNDLE

--- a/framework/src/meshgenerators/CircularBoundaryCorrectionGenerator.C
+++ b/framework/src/meshgenerators/CircularBoundaryCorrectionGenerator.C
@@ -180,7 +180,7 @@ CircularBoundaryCorrectionGenerator::generate()
 
     // Check if the boundary is a full circle or partial
     // Also make an ordered array of nodes
-    Real dummy_max_rad;
+    Real dummy_max_rad = 0;
     std::vector<dof_id_type> ordered_node_list;
     bool is_bdry_closed;
     FillBetweenPointVectorsTools::isClosedLoop(*input_mesh,

--- a/modules/doc/content/newsletter/2026/2026_08.md
+++ b/modules/doc/content/newsletter/2026/2026_08.md
@@ -84,7 +84,7 @@ As a result, dependent applications that test using these containerized environm
 
 - Updated libmesh from [`ab36c00` to `0772c3d`](https://github.com/libMesh/libmesh/compare/ab36c007ae608290e097bdfbc2766a46d8192b70...0772c3d45eac8019a76f6dcdb8683231fe354c57)
 
-### `moose-wasp 2026.08.13_ce25dcd`
+### `moose-wasp 2026.08.13_ce25dcd_0`
 
 - Updated wasp from [`d8777a8` to `ce25dcd`](https://code.ornl.gov/neams-workbench/wasp/-/compare/d8777a831a90c32e13573b775c9284949e6571c3...ce25dcde73ba81c70c330204ea5bf856762b95ac)
 
@@ -101,6 +101,42 @@ As a result, dependent applications that test using these containerized environm
 - Updated pprof from [`92041b7` to `b9395ee`](https://github.com/google/pprof/compare/92041b743c966065641d7221da5403ad9a019bce...b9395ee17fa0d0013c3fd96ac9482318422ac337)
 
 ### `moose-seacas 2025.10.14_5`
+
+- Trigger rebuild; no package changes
+
+### `moose-tools 2026.08.23`
+
+- Trigger rebuild; no package changes
+
+### `moose-build 2026.08.23`
+
+- Trigger rebuild; no package changes
+
+### `moose-mpi 2026.08.23 [mpich,openmpi]`
+
+- Trigger rebuild; no package changes
+
+### `moose-libmesh-vtk 9.7.0_1 [mpich,openmpi]`
+
+- Trigger rebuild; no package changes
+
+### `moose-petsc 3.25.4_1 [mpich,openmpi]`
+
+- Trigger rebuild; no package changes
+
+### `moose-libmesh 2026.08.18_0772c3d_1 [mpich,openmpi]`
+
+- Trigger rebuild; no package changes
+
+### `moose-wasp 2026.08.13_ce25dcd_1`
+
+- Trigger rebuild; no package changes
+
+### `moose-pyhit 2026.08.23`
+
+- Trigger rebuild; no package changes
+
+### `moose-dev 2026.08.23 [mpich,openmpi]`
 
 - Trigger rebuild; no package changes
 
@@ -145,3 +181,23 @@ As a result, dependent applications that test using these containerized environm
 - Added `MARCH` and `MTUNE` definition template options for building with `-march` and `-mtune`
   - `-march` is set to `x86-64-v3` by default for building WASP, libtorch, NEML2, conduit, and MFEM
   - As MOOSE inherits its build flags from libMesh, this implies the same default for all MOOSE application builds
+
+### `moose-mpi:2026.08.23`
+
+- Update all base containers
+- Build valgrind with `--enable-lto=yes`
+
+### `moose-petsc:3.25.4_1`
+
+- Add `OPTFLAGS` generator variable to override `OPTFLAGS`
+- Build `ubuntu24-gcc-mpich-valgrind-x86_64` variant for valgrind with `OPTFLAGS="-O1 -g -march=x86-64"`
+
+### `moose-libmesh:2026.08.18_0772c3d_0`
+
+- Add `OPTFLAGS` generator variable to override `OPTFLAGS`
+- Build `ubuntu24-gcc-mpich-valgrind-x86_64` variant for valgrind with `OPTFLAGS="-O1 -g -march=x86-64"`
+
+### `moose-dev 2026.08.23`
+
+- Add `OPTFLAGS` generator variable to override `OPTFLAGS`
+- Build `ubuntu24-gcc-mpich-valgrind-x86_64` variant for valgrind with `OPTFLAGS="-O1 -g -march=x86-64"`

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1632,6 +1632,11 @@ class TestHarness:
             const="HEAVY",
             help="Run heavy valgrind tests",
         )
+        filtergroup.add_argument(
+            "--valgrind-track-origins",
+            action="store_true",
+            help="Enable --track-origins=yes when running valgrind",
+        )
 
         capabilitygroup = parser.add_argument_group(
             "Additional Capabilities",
@@ -2116,6 +2121,10 @@ class TestHarness:
 
         if not opts.valgrind_mode:
             opts.valgrind_mode = ""
+            if opts.valgrind_track_origins:
+                self.errorExit(
+                    "Cannot specify --valgrind-track-origins without --valgrind"
+                )
 
         # Set default
         if not opts.input_file_name:
@@ -2204,7 +2213,10 @@ class TestHarness:
         """
         Helper for printing an error and exiting
         """
-        util.errorExit(*args, colored=self.options.colored is True)
+        colored = True
+        if options := getattr(self, "options", None):
+            colored = options.colored
+        util.errorExit(*args, colored=colored is True)
 
     def printInfo(self, *args):
         """Print the given message as information."""

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -505,7 +505,8 @@ class RunApp(Tester):
                     "suppressions",
                     "errors.supp",
                 )
-                + " --leak-check=full --tool=memcheck --dsymutil=yes --track-origins=yes --demangle=yes --enable-debuginfod=no -v "
+                + " --leak-check=full --tool=memcheck --dsymutil=yes --demangle=yes --enable-debuginfod=no -v "
+                + f"--track-origins={"yes" if options.valgrind_track_origins else "no"} "
                 + command
             )
         elif nthreads > 1:

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1939,3 +1939,38 @@ c2b839ea0c891a2869dfce73d09bd66070122e01: # 33466
   wasp:
     full_version: 2026.08.13_ce25dcd_0
     hash: e13589e
+
+1e51b0831be5952e1ae0f9613288bdfa19148154: # 33595
+  build:
+    full_version: 2026.08.23
+    hash: 6da65d5
+  libmesh:
+    full_version: 2026.08.18_0772c3d_1
+    hash: 2c38194
+  libmesh-vtk:
+    full_version: 9.7.0_1
+    hash: 07f15f2
+  moose-dev:
+    full_version: 2026.08.23
+    hash: 553d1ad
+  mpi:
+    full_version: 2026.08.23
+    hash: 8f300ce
+  petsc:
+    full_version: 3.25.4_1
+    hash: '2947116'
+  pprof:
+    full_version: 2026.07.09_b9395ee_0
+    hash: fcbec3d
+  pyhit:
+    full_version: 2026.08.23
+    hash: c634224
+  seacas:
+    full_version: 2025.10.14_5
+    hash: f574e50
+  tools:
+    full_version: 2026.08.23
+    hash: 70892dc
+  wasp:
+    full_version: 2026.08.13_ce25dcd_1
+    hash: d5ba359

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -7,7 +7,7 @@
 packages:
   # dependers: moose-dev
   tools:
-    version: 2026.08.19
+    version: 2026.08.23
     conda: conda/tools
     templates:
       conda/tools/meta.yaml.template: conda/tools/meta.yaml
@@ -16,7 +16,7 @@ packages:
       - conda/tools
   # dependers: moose-dev
   build:
-    version: 2026.08.19
+    version: 2026.08.23
     conda: conda/build
     templates:
       conda/build/meta.yaml.template: conda/build/meta.yaml
@@ -25,7 +25,7 @@ packages:
       - conda/build
   # dependers: moose-dev
   mpi:
-    version: 2026.08.19
+    version: 2026.08.23
     influential:
       - apptainer/mpi.def
       - apptainer/files/mpi
@@ -33,7 +33,7 @@ packages:
   # dependers: libmesh, moose-dev
   libmesh-vtk:
     version: 9.7.0
-    build_number: 0
+    build_number: 1
     conda: conda/libmesh-vtk
     templates:
       conda/libmesh-vtk/meta.yaml.template: conda/libmesh-vtk/meta.yaml
@@ -44,7 +44,7 @@ packages:
   # dependers: libmesh, moose-dev
   petsc:
     version: 3.25.4
-    build_number: 0
+    build_number: 1
     conda: conda/petsc
     templates:
       conda/petsc/meta.yaml.template: conda/petsc/meta.yaml
@@ -63,7 +63,7 @@ packages:
   # dependers: moose-dev
   libmesh:
     version: 2026.08.18_0772c3d
-    build_number: 0
+    build_number: 1
     conda: conda/libmesh
     templates:
       conda/libmesh/meta.yaml.template: conda/libmesh/meta.yaml
@@ -83,7 +83,7 @@ packages:
   # dependers: pyhit, moose-dev
   wasp:
     version: 2026.08.13_ce25dcd
-    build_number: 0
+    build_number: 1
     conda: conda/wasp
     templates:
       conda/wasp/meta.yaml.template: conda/wasp/meta.yaml
@@ -96,7 +96,7 @@ packages:
       - scripts/update_and_rebuild_wasp.sh
   # dependers: none
   pyhit:
-    version: 2026.08.19
+    version: 2026.08.23
     conda: conda/pyhit
     dependencies:
       - wasp
@@ -112,7 +112,7 @@ packages:
       conda/pyhit/meta.yaml.template: conda/pyhit/meta.yaml
   # dependers: none
   moose-dev:
-    version: 2026.08.19
+    version: 2026.08.23
     conda: conda/moose-dev
     templates:
       conda/moose-dev/meta.yaml.template: conda/moose-dev/meta.yaml


### PR DESCRIPTION
## Conda packages

### `moose-mpi 2026.08.22 [mpich,openmpi]`

- Trigger rebuild; no package changes

### `moose-petsc 3.25.4_1 [mpich,openmpi]`

- Trigger rebuild; no package changes

### `moose-libmesh 2026.08.18_0772c3d_1 [mpich,openmpi]`

- Trigger rebuild; no package changes

### `moose-dev 2026.08.22 [mpich,openmpi]`

- Trigger rebuild; no package changes

## Apptainer containers

### `moose-mpi:2026.08.22`

- Update all base containers
- Build valgrind with `--enable-lto=yes`

### `moose-petsc:3.25.4_1`

- Add `OPTFLAGS` generator variable to override `OPTFLAGS`
- Build `ubuntu24-gcc-mpich-valgrind-x86_64` variant for valgrind with `OPTFLAGS="-O1 -g -march=x86-64"`

### `moose-libmesh:2026.08.18_0772c3d_0`

- Add `OPTFLAGS` generator variable to override `OPTFLAGS`
- Build `ubuntu24-gcc-mpich-valgrind-x86_64` variant for valgrind with `OPTFLAGS="-O1 -g -march=x86-64"`

### `moose-dev 2026.08.22`

- Add `OPTFLAGS` generator variable to override `OPTFLAGS`
- Build `ubuntu24-gcc-mpich-valgrind-x86_64` variant for valgrind with `OPTFLAGS="-O1 -g -march=x86-64"`
