### PR TITLE
Unlock tests prev limited to one rank due to (de)alloc issue

### DIFF
--- a/test/tests/mfem/complex/tests
+++ b/test/tests/mfem/complex/tests
@@ -38,7 +38,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     recover = false
-    max_parallel = 1 # idaholab/moose#32250
     min_slots = 2 # memory heavy
   []
   [MFEMComplexVariableRequiresComplexNumericType]

--- a/test/tests/mfem/transfers/mfem_parent_mfem_sub/tests
+++ b/test/tests/mfem/transfers/mfem_parent_mfem_sub/tests
@@ -37,7 +37,6 @@
         recover = false
         cli_args = 'Transfers/active=general_transfer_from_sub'
         detail = 'running the inputs, and '
-        max_parallel = 1 # idaholab/moose#32250
       []
       [verify]
         type = RunCommand
@@ -163,7 +162,6 @@
         compute_devices = 'cpu cuda'
         recover = false
         detail = 'running the inputs, and'
-        max_parallel = 1 # idaholab/moose#32250
       []
       [verify]
         type = RunCommand
@@ -189,7 +187,6 @@
         cli_args = 'MultiApps/active=subapp Transfers/active=to_sub '
                   'subapp:MultiApps/active="" subapp:Transfers/active=""'
         detail = 'running the inputs, and'
-        max_parallel = 1 # idaholab/moose#32250
       []
       [verify]
         type = RunCommand


### PR DESCRIPTION
## Reason
Refs #32250. Updated mfem submodule includes upstream fix.

## Design
Remove `max_parallel = 1` from previously affected tests.

## Impact
Increased test robustness.