### PR TITLE
Remove recover = false from almost all mfem tests

### DIFF
--- a/framework/src/mfem/executioners/MFEMSteady.C
+++ b/framework/src/mfem/executioners/MFEMSteady.C
@@ -102,6 +102,7 @@ MFEMSteady::execute()
   if (_app.isRecovering())
   {
     _console << "\nCannot recover steady solves!\nExiting...\n" << std::endl;
+    _last_solve_converged = true;
     return;
   }
 

--- a/test/tests/mfem/auxkernels/tests
+++ b/test/tests/mfem/auxkernels/tests
@@ -10,7 +10,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMScalarTimeAverageAux]
     type = XMLDiff
@@ -27,7 +26,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     restep = false
   []
   [MFEMInnerProductAux]
@@ -46,7 +44,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     restep = false
   []
   [MFEMCrossProductAux]
@@ -60,7 +57,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     restep = false
   []
   [MFEMNDtoRTAux]
@@ -72,7 +68,6 @@
     requirement = 'The system shall have the ability to map between 2D Nedelec and Raviart-Thomas MFEM variables'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
-    recover = false
     restep = false
   []
 []

--- a/test/tests/mfem/complex/tests
+++ b/test/tests/mfem/complex/tests
@@ -10,7 +10,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1
-    recover = false
   []
   [MFEMComplex2DTri]
     type = XMLDiff
@@ -28,7 +27,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1
-    recover = false
   []
   [MFEMComplexWaveguide]
     type = CSVDiff
@@ -37,7 +35,6 @@
     requirement = 'The system shall have the ability to solve a complex-valued problem using MFEM with vector Robin boundary conditions applied.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
-    recover = false
     max_parallel = 1 # idaholab/moose#32250
     min_slots = 2 # memory heavy
   []
@@ -49,7 +46,6 @@
     requirement = 'The system shall reject a complex-valued primary MFEM variable when the problem uses a real-valued equation system.'
     capabilities = 'mfem'
     compute_devices = 'cpu'
-    recover = false
   []
   [MFEMRealVariableRequiresRealNumericType]
     type = RunException
@@ -59,6 +55,5 @@
     requirement = 'The system shall reject a real-valued primary MFEM variable when the problem uses a complex-valued equation system.'
     capabilities = 'mfem'
     compute_devices = 'cpu'
-    recover = false
   []
 []

--- a/test/tests/mfem/functions/tests
+++ b/test/tests/mfem/functions/tests
@@ -8,7 +8,6 @@
     requirement = 'The system shall have the ability to parse non-linear functions of problem variables'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
-    recover = false
   []
   [MFEMScalarQuadratureFunction]
     type = CSVDiff
@@ -20,7 +19,6 @@
                   'points and reuse the stored values in place of the original coefficient.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
-    recover = false
   []
   [MFEMScalarQuadratureFunctionOrderMismatch]
     type = RunException

--- a/test/tests/mfem/ics/tests
+++ b/test/tests/mfem/ics/tests
@@ -10,7 +10,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMVectorIC]
     type = XMLDiff
@@ -21,7 +20,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMTransientScalarIC]
     type = XMLDiff
@@ -33,7 +31,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     restep = false
   []
 []

--- a/test/tests/mfem/kernels/tests
+++ b/test/tests/mfem/kernels/tests
@@ -10,7 +10,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMCurlCurlPartial]
     type = XMLDiff
@@ -24,7 +23,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMDiffusion]
     type = XMLDiff
@@ -35,7 +33,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     expect_out = 'Parallel Type:.*distributed.*Mesh Dimension.*3.*Spatial Dimension.*3.*Elems.*2476.*Num Subdomains.*1.*Solver.*MFEMHypreGMRES'
   []
   [MFEMDiffusion1D]
@@ -51,7 +48,6 @@
     requirement = 'The system shall have the ability to solve a 1D diffusion problem using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
-    recover = false
     expect_out = 'Parallel Type:.*distributed.*Mesh Dimension.*1.*Spatial Dimension.*1.*Elems.*32.*Num Subdomains.*1.*Solver.*MFEMHypreGMRES'
   []
   [MFEMDiffusionAMR]
@@ -64,7 +60,6 @@
       csvdiff = 'OutputData/DiffusionHRefinement.csv'
       capabilities = 'mfem'
       compute_devices = 'cpu cuda'
-      recover = false
       detail = 'h-refinement, '
     []
     [pRefinement]
@@ -92,7 +87,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMDiffusionMatFree]
     type = XMLDiff
@@ -108,7 +102,6 @@
     abs_zero = 5e-10
     capabilities = 'mfem'
     max_parallel = 1
-    recover = false
   []
   [MFEMDiffusionPartialMultiGPUAwareMPI]
     type = CSVDiff
@@ -125,7 +118,6 @@
     capabilities = 'mfem'
     compute_devices = 'cuda'
     min_parallel = 2
-    recover = false
   []
   [MFEMDiffusionPartialMultiGPUNoAwareMPI]
     type = CSVDiff
@@ -142,7 +134,6 @@
     capabilities = 'mfem'
     compute_devices = 'cuda'
     min_parallel = 2
-    recover = false
   []
   [MFEMDiffusionDG]
     type = XMLDiff
@@ -153,7 +144,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMGradDiv]
     type = XMLDiff
@@ -164,7 +154,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     errors = 'foobarbaz' # allow cuda errors I guess?
   []
   [MFEMHeatConduction]
@@ -180,7 +169,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     restep = false
   []
   [MFEMHeatConductionElement]
@@ -200,7 +188,6 @@
     compute_devices = 'cpu cuda'
     valgrind = none
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     restep = false
   []
   [MFEMHeatConductionMatFree]
@@ -221,7 +208,6 @@
     capabilities = 'mfem'
     valgrind = none
     max_parallel = 1
-    recover = false
     restep = false
   []
   [MFEMHeatTransfer]
@@ -233,7 +219,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     restep = false
   []
   [MFEMTransientScheme]
@@ -254,7 +239,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     restep = false
   []
   [MFEMLinearElasticity]
@@ -266,7 +250,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMGravity]
     type = XMLDiff
@@ -280,7 +263,6 @@
     max_parallel = 1 # schemadiff with multiple ranks
     # diffs at 9e-4 with -march=x86-64-v3
     rel_err = 2e-3
-    recover = false
   []
   [MFEMGravityQuadratureFunction]
     type = CSVDiff
@@ -290,7 +272,6 @@
     requirement = 'The system shall have the ability to precompute a vector coefficient at quadrature points and reuse the stored values in place of the original coefficient.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
-    recover = false
   []
   [MFEMIrrotational]
     type = CSVDiff
@@ -301,7 +282,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     valgrind = heavy
-    recover = false
   []
   [MFEMDarcy]
     type = CSVDiff
@@ -310,7 +290,6 @@
     requirement = 'The system shall have the ability to solve a mixed Darcy problem in two dimensions using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
-    recover = false
   []
   [MFEMDiffusionEigenproblem]
     type = CSVDiff
@@ -319,7 +298,6 @@
     requirement = 'The system shall have the ability to solve a scalar eigenproblem with Dirichlet BCs using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
-    recover = false
   []
   [MFEMMaxwellEigenproblem]
     type = CSVDiff
@@ -328,6 +306,5 @@
     requirement = 'The system shall have the ability to solve a vector-valued eigenproblem with Dirichlet BCs using MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
-    recover = false
   []
 []

--- a/test/tests/mfem/lor/tests
+++ b/test/tests/mfem/lor/tests
@@ -18,7 +18,6 @@
     compute_devices = 'cpu cuda'
     valgrind = heavy
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     min_slots = 2 # memory heavy
     abs_zero = 5e-7
   []
@@ -36,7 +35,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     abs_zero = 2e-9
   []
   [MFEMGradDivLOR]
@@ -54,7 +52,6 @@
     compute_devices = 'cpu cuda'
     valgrind = heavy
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     abs_zero = 8e-10
   []
   [MFEMHeatConductionLOR]
@@ -74,7 +71,6 @@
     capabilities = 'mfem & method!=dbg'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     restep = false
   []
 []

--- a/test/tests/mfem/multiapps/tests
+++ b/test/tests/mfem/multiapps/tests
@@ -10,7 +10,6 @@
       detail = "with a time step governed by the MFEM parent application,"
       capabilities = 'mfem'
       compute_devices = 'cpu cuda'
-      recover = false
       restep = false
     []
     [MFEM_sub_cycling]
@@ -20,7 +19,6 @@
       detail = "and with the sub-app running multiple timesteps for each timestep of the parent app."
       capabilities = 'mfem'
       compute_devices = 'cpu cuda'
-      recover = false
       restep = false
     []
   []
@@ -33,7 +31,6 @@
       detail = "with a transient problem running in the parent app."
       capabilities = 'mfem'
       compute_devices = 'cpu cuda'
-      recover = false
       restep = false
     []
   []

--- a/test/tests/mfem/nonlinear/tests
+++ b/test/tests/mfem/nonlinear/tests
@@ -11,7 +11,6 @@
       detail = 'MFEM PETSc nonlinear solver, and the'
       capabilities = 'mfem'
       compute_devices = 'cpu'
-      recover = false
       max_parallel = 15 # mfem/mfem#5375
     []
     [MFEMNewtonNonLinearDiffusion]
@@ -22,7 +21,6 @@
       detail = 'native MFEM Newton solver. Additionally the system shall support nesting both nonlinear and linear solvers under a common solvers syntax block.'
       capabilities = 'mfem'
       compute_devices = 'cpu'
-      recover = false
     []
   []
   [MFEMNonLinearDiffusionNonZeroRHS]
@@ -37,7 +35,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMNonLinearHeatTransfer]
     design = 'EquationSystem.md'
@@ -94,7 +91,6 @@
                 NLHeatConductionQF_centre_temperature_0050.csv'
     capabilities = 'mfem'
     compute_devices = 'cpu'
-    recover = false
     restep = false
   []
 []

--- a/test/tests/mfem/outputs/tests
+++ b/test/tests/mfem/outputs/tests
@@ -18,6 +18,5 @@
                   'ParaView, VisIt and Conduit data collections.'
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
-    recover = false
   []
 []

--- a/test/tests/mfem/solvers/tests
+++ b/test/tests/mfem/solvers/tests
@@ -9,7 +9,6 @@
                   'p-multigrid (geometric multigrid) preconditioner with MFEM.'
     capabilities = 'mfem'
     compute_devices = 'cpu'
-    recover = false
     abs_zero = 1e-6
   []
   [MFEMPMGRejectsNonlinear]

--- a/test/tests/mfem/submeshes/tests
+++ b/test/tests/mfem/submeshes/tests
@@ -10,7 +10,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMBoundarySubMeshTransfer]
     type = XMLDiff
@@ -21,7 +20,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMDomainSubMeshTransfer]
     type = XMLDiff
@@ -32,7 +30,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
   [MFEMCoupledVariableSource]
     type = XMLDiff
@@ -44,7 +41,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1
-    recover = false
   []
   [MFEMCoupledCoefficientSource]
     type = XMLDiff
@@ -60,7 +56,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1
-    recover = false
   []
   [MFEMGeometryCutTransitionSubMesh]
     design = 'syntax/MFEM/ClosedCoilMagnetostatic.md'

--- a/test/tests/mfem/transfers/displaced/tests
+++ b/test/tests/mfem/transfers/displaced/tests
@@ -10,7 +10,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     restep = false
   []
   [MFEMTransferTolibMeshDisplaced]

--- a/test/tests/mfem/transfers/h1_libmesh_parent_mfem_sub/tests
+++ b/test/tests/mfem/transfers/h1_libmesh_parent_mfem_sub/tests
@@ -9,7 +9,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_quads.csv'
       detail = 'first order scalar Lagrange variables defined on quads,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
     []
     [H1QuadSecondOrder]
@@ -19,7 +18,6 @@
       detail = 'second order scalar Lagrange variables defined on quads,'
       abs_zero = 4e-10
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Variables/libmesh_scalar_var/order=SECOND '
                 'AuxVariables/mfem_scalar_var/order=SECOND '
@@ -32,7 +30,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_tris.csv'
       detail = 'first order scalar Lagrange variables defined on tris,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_tri6.e '
                 'mfem_app0:Mesh/file=../../mesh/square_tri6.e '
@@ -45,7 +42,6 @@
       detail = 'second order scalar Lagrange variables defined on tris,'
       abs_zero = 9e-10
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_tri6.e '
                 'Outputs/file_base=libmesh_parent_scalar_mfem_sub_tris_order_2 '
@@ -60,7 +56,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_tri_to_quad.csv'
       detail = 'first order scalar Lagrange variables from tris to quads,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_quad9.e '
                 'mfem_app0:Mesh/file=../../mesh/square_tri6.e '
@@ -72,7 +67,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_tri_to_quad_order_2.csv'
       detail = 'second order scalar Lagrange variables from tris to quads,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_quad9.e '
                 'Outputs/file_base=libmesh_parent_scalar_mfem_sub_tri_to_quad_order_2 '
@@ -87,7 +81,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_hexes.csv'
       detail = 'first order scalar Lagrange variables defined on hexes,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'BCs/sides/boundary=Sides '
@@ -100,7 +93,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_hexes_order_2.csv'
       detail = 'second order scalar Lagrange variables defined on hexes,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'BCs/sides/boundary=Sides '
@@ -116,7 +108,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_tets.csv'
       detail = 'first order scalar Lagrange variables defined on tetrahedra,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube_tet10.e '
                 'BCs/sides/boundary=Sides '
@@ -130,7 +121,6 @@
       detail = 'second order scalar Lagrange variables defined on tetrahedra,'
       abs_zero = 2e-10
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube_tet10.e '
                 'BCs/sides/boundary=Sides '
@@ -146,7 +136,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_tet_to_hex.csv'
       detail = 'first order scalar Lagrange variables from tets to hexes,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'BCs/sides/boundary=Sides '
@@ -159,7 +148,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_tet_to_hex_order_2.csv'
       detail = 'and second order scalar Lagrange variables from tets to hexes.'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'BCs/sides/boundary=Sides '

--- a/test/tests/mfem/transfers/h1_mfem_parent_libmesh_sub/tests
+++ b/test/tests/mfem/transfers/h1_mfem_parent_libmesh_sub/tests
@@ -9,7 +9,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_quads.csv'
       detail = 'first order scalar Lagrange variables defined on quads,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
     []
     [H1QuadSecondOrder]
@@ -19,7 +18,6 @@
       detail = 'second order scalar Lagrange variables defined on quads,'
       abs_zero = 4e-10
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'FESpaces/H1FESpace/fec_order=SECOND '
                 'libmesh_app0:Variables/libmesh_scalar_var/order=SECOND '
@@ -31,7 +29,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_tris.csv'
       detail = 'first order scalar Lagrange variables defined on tris,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_tri6.e '
                 'libmesh_app0:Mesh/file=../../mesh/square_tri6.e '
@@ -44,7 +41,6 @@
       detail = 'second order Lagrange variables defined on tris,'
       abs_zero = 9e-10
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_tri6.e '
                 'FESpaces/H1FESpace/fec_order=SECOND '
@@ -58,7 +54,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_tri_to_quad.csv'
       detail = 'first order scalar Lagrange variables from tris to quads,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_quad9.e '
                 'libmesh_app0:Mesh/file=../../mesh/square_tri6.e '
@@ -70,7 +65,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_tri_to_quad_order_2.csv'
       detail = 'second order Lagrange variables from tris to quads,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_quad9.e '
                 'FESpaces/H1FESpace/fec_order=SECOND '
@@ -84,7 +78,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_hexes.csv'
       detail = 'first order scalar Lagrange variables defined on hexes,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_hexes '
@@ -97,7 +90,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_hexes_order_2.csv'
       detail = 'second order scalar Lagrange variables defined on hexes,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'FESpaces/H1FESpace/fec_order=SECOND '
@@ -112,7 +104,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_tets.csv'
       detail = 'first order scalar Lagrange variables defined on tetrahedra,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube_tet10.e '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tets '
@@ -126,7 +117,6 @@
       detail = 'second order scalar Lagrange variables defined on tetrahedra,'
       abs_zero = 2e-10
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube_tet10.e '
                 'FESpaces/H1FESpace/fec_order=SECOND '
@@ -141,7 +131,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_tet_to_hex.csv'
       detail = 'first order scalar Lagrange variables from tets to hexes,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tet_to_hex '
@@ -154,7 +143,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_tet_to_hex_order_2.csv'
       detail = 'and second order scalar Lagrange variables from tets to hexes.'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'FESpaces/H1FESpace/fec_order=SECOND '

--- a/test/tests/mfem/transfers/l2_libmesh_parent_mfem_sub/tests
+++ b/test/tests/mfem/transfers/l2_libmesh_parent_mfem_sub/tests
@@ -9,7 +9,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_quads.csv'
       detail = 'constant elemental variables defined on quads,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
     []
     [L2Tri]
@@ -18,7 +17,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_tris.csv'
       detail = 'constant elemental variables defined on tris,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_tri6.e '
                 'Outputs/file_base=libmesh_parent_scalar_mfem_sub_tris '
@@ -30,7 +28,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_tri_to_quad.csv'
       detail = 'constant elemental variables from tris to quads,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_quad9.e '
                 'Outputs/file_base=libmesh_parent_scalar_mfem_sub_tri_to_quad '
@@ -42,7 +39,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_hexes.csv'
       detail = 'constant elemental variables defined on hexes,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'Outputs/file_base=libmesh_parent_scalar_mfem_sub_hexes '
@@ -54,7 +50,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_tets.csv'
       detail = 'constant elemental variables defined on tetrahedra,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube_tet10.e '
                 'Outputs/file_base=libmesh_parent_scalar_mfem_sub_tets '
@@ -66,7 +61,6 @@
       csvdiff = 'libmesh_parent_scalar_mfem_sub_tet_to_hex.csv'
       detail = 'and constant elemental variables from tets to hexes.'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'Outputs/file_base=libmesh_parent_scalar_mfem_sub_tet_to_hex '

--- a/test/tests/mfem/transfers/l2_mfem_parent_libmesh_sub/tests
+++ b/test/tests/mfem/transfers/l2_mfem_parent_libmesh_sub/tests
@@ -9,7 +9,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_quads.csv'
       detail = 'scalar elemental variables defined on quads,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
     []
     [L2Tri]
@@ -18,7 +17,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_tris.csv'
       detail = 'constant elemental variables defined on tris,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_tri6.e '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tris '
@@ -30,7 +28,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_tri_to_quad.csv'
       detail = 'constant elemental variables from tris to quads,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/square_quad9.e '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tri_to_quad '
@@ -42,7 +39,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_hexes.csv'
       detail = 'constant elemental variables defined on hexes,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_hexes '
@@ -54,7 +50,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_tets.csv'
       detail = 'constant elemental variables defined on tetrahedra,'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube_tet10.e '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tets '
@@ -66,7 +61,6 @@
       csvdiff = 'mfem_parent_libmesh_sub_scalar_tet_to_hex.csv'
       detail = 'and constant elemental variables from tets to hexes.'
       capabilities = 'mfem'
-      recover = false
       compute_devices = 'cpu cuda'
       cli_args = 'Mesh/file=../../mesh/cube.e '
                 'Outputs/file_base=mfem_parent_libmesh_sub_scalar_tet_to_hex '

--- a/test/tests/mfem/transfers/mfem_parent_mfem_sub/tests
+++ b/test/tests/mfem/transfers/mfem_parent_mfem_sub/tests
@@ -10,7 +10,6 @@
         input = parent.i
         capabilities = 'mfem'
         compute_devices = 'cpu cuda'
-        recover = false
         cli_args = 'Transfers/active=general_transfer_from_sub '
         detail = 'running the inputs, and'
       []
@@ -23,7 +22,6 @@
                   OutputData/DiffusionSub/Run0/Cycle000001/proc000000.vtu'
         prereq = MFEMShapeEvaluationTransfer/FromSubToParent/run
         capabilities = 'mfem'
-        recover = false
         detail = 'checking the sub-application and parent application outputs against each other.'
       []
     []
@@ -34,7 +32,6 @@
         input = parent_complex.i
         capabilities = 'mfem'
         compute_devices = 'cpu cuda'
-        recover = false
         cli_args = 'Transfers/active=general_transfer_from_sub'
         detail = 'running the inputs, and '
         max_parallel = 1 # idaholab/moose#32250
@@ -48,7 +45,6 @@
                   OutputData/DiffusionSubComplex/Run0/Cycle000001/proc000000.vtu'
         prereq = MFEMShapeEvaluationTransfer/ComplexFromSubToParent/run
         capabilities = 'mfem'
-        recover = false
         detail = 'checking the sub-application and parent application outputs against each other.'
       []
     []
@@ -60,7 +56,6 @@
         csvdiff = 'mfem_parent_mfem_sub_vector_h1_hcurl_hdiv_l2_hex.csv'
         detail = 'between hex meshes,'
         capabilities = 'mfem'
-        recover = false
         compute_devices = 'cpu cuda'
       []
       [Tetra]
@@ -69,7 +64,6 @@
         csvdiff = 'mfem_parent_mfem_sub_vector_h1_hcurl_hdiv_l2_tet.csv'
         detail = 'between tetrahedral meshes,'
         capabilities = 'mfem'
-        recover = false
         compute_devices = 'cpu cuda'
         cli_args = 'Mesh/file=../../mesh/cube_tet10.e '
                   'mfem_app0:Mesh/file=../../mesh/cube_tet10.e '
@@ -81,7 +75,6 @@
         csvdiff = 'mfem_parent_mfem_sub_vector_h1_hcurl_hdiv_l2_tet_to_hex.csv'
         detail = 'and from tetrahedral meshes to hex meshes.'
         capabilities = 'mfem'
-        recover = false
         compute_devices = 'cpu cuda'
         cli_args = 'Mesh/file=../../mesh/cube.e '
                   'mfem_app0:Mesh/file=../../mesh/cube_tet10.e '
@@ -97,7 +90,6 @@
         detail = 'from a smaller submesh to a larger mesh containing the smaller submes as a subdomain.'
         max_parallel = 1 # XMLDiff on ParaViewDataCollection schemadiffs with multiple ranks
         capabilities = 'mfem'
-        recover = false
         compute_devices = 'cpu cuda'
       []
     []
@@ -113,7 +105,6 @@
         input = parent.i
         capabilities = 'mfem'
         compute_devices = 'cpu cuda'
-        recover = false
         detail = 'running the inputs, and'
       []
       [verify]
@@ -125,7 +116,6 @@
                   OutputData/DiffusionSub/Run0/Cycle000001/proc000000.vtu'
         prereq = MFEMCopyTransfer/FromSubToParent/run
         capabilities = 'mfem'
-        recover = false
         detail = 'checking the sub-application and parent application outputs against each other.'
       []
     []
@@ -136,7 +126,6 @@
         input = sub.i
         capabilities = 'mfem'
         compute_devices = 'cpu cuda'
-        recover = false
         cli_args = 'MultiApps/active=subapp Transfers/active=to_sub '
                   'subapp:MultiApps/active="" subapp:Transfers/active=""'
         detail = 'running the inputs, and'
@@ -150,7 +139,6 @@
                   OutputData/DiffusionSub/Run0/Cycle000001/proc000000.vtu'
         prereq = MFEMCopyTransfer/ToSubFromParent/run
         capabilities = 'mfem'
-        recover = false
         detail = 'checking the sub-application and parent application outputs against each other.'
       []
     []
@@ -161,7 +149,6 @@
         input = parent_complex.i
         capabilities = 'mfem'
         compute_devices = 'cpu cuda'
-        recover = false
         detail = 'running the inputs, and'
         max_parallel = 1 # idaholab/moose#32250
       []
@@ -174,7 +161,6 @@
                   OutputData/DiffusionSubComplex/Run0/Cycle000001/proc000000.vtu'
         prereq = MFEMCopyTransfer/ComplexFromSubToParent/run
         capabilities = 'mfem'
-        recover = false
         detail = 'checking the complex sub-application and complex parent application outputs against each other.'
       []
     []
@@ -185,7 +171,6 @@
         input = sub_complex.i
         capabilities = 'mfem'
         compute_devices = 'cpu cuda'
-        recover = false
         cli_args = 'MultiApps/active=subapp Transfers/active=to_sub '
                   'subapp:MultiApps/active="" subapp:Transfers/active=""'
         detail = 'running the inputs, and'
@@ -200,7 +185,6 @@
                   OutputData/DiffusionSubComplex/Run0/Cycle000001/proc000000.vtu'
         prereq = MFEMCopyTransfer/ComplexToSubFromParent/run
         capabilities = 'mfem'
-        recover = false
         detail = 'checking the complex sub-application and complex parent application outputs against each other.'
       []
     []

--- a/test/tests/mfem/transfers/mfem_sub_mfem_sub/tests
+++ b/test/tests/mfem/transfers/mfem_sub_mfem_sub/tests
@@ -10,7 +10,6 @@
         input = parent.i
         capabilities = 'mfem'
         compute_devices = 'cpu cuda'
-        recover = false
         detail = 'running the inputs, and'
       []
       [verify]
@@ -22,7 +21,6 @@
                   OutputData/DiffusionSendApp/Run0/Cycle000001/proc000000.vtu'
         prereq = MFEMCopyTransfer/test/run
         capabilities = 'mfem'
-        recover = false
         detail = 'checking the sub-application and parent application outputs against each other.'
       []
     []

--- a/test/tests/mfem/transfers/sibling_transfers/tests
+++ b/test/tests/mfem/transfers/sibling_transfers/tests
@@ -54,7 +54,6 @@
                   Transfers/active='mfem_to_libmesh_nodal_nodal'"
       capabilities = 'mfem'
       compute_devices = 'cpu'
-      recover = false
       restep = false
       # Allow warnings, needed as we are sampling constant L2 variables on element boundaries,
       # however we know these element boundaries are not shared so this should not cause problems.
@@ -84,7 +83,6 @@
                   MultiApps/mfem_sub/cli_args='Outputs/file_base=OutputData/elem_elem_mfem_sub0'"
       capabilities = 'mfem'
       compute_devices = 'cpu'
-      recover = false
       restep = false
       # Allow warnings, needed as we are sampling constant L2 variables on element boundaries,
       # however we know these element boundaries are not shared so this should not cause problems.
@@ -99,7 +97,6 @@
                   MultiApps/mfem_sub/cli_args='Outputs/file_base=OutputData/nodal_elem_mfem_sub0'"
       capabilities = 'mfem'
       compute_devices = 'cpu'
-      recover = false
       restep = false
       # Allow warnings, needed as we are sampling constant L2 variables on element boundaries,
       # however we know these element boundaries are not shared so this should not cause problems.
@@ -131,7 +128,6 @@
                   MultiApps/mfem_sub/cli_args=VectorPostprocessors/active=nodal_sample"
       capabilities = 'mfem'
       compute_devices = 'cpu'
-      recover = false
       restep = false
       detail = 'and between nodal variables from nodal variables sent from one sub-app to multiple sub-apps run in parallel,'
     []
@@ -145,7 +141,6 @@
       cli_args = "Outputs/file_base=OutputData/nodal_nodal"
       capabilities = 'mfem'
       compute_devices = 'cpu'
-      recover = false
       restep = false
       # Allow warnings, needed as we are sampling constant L2 variables on element boundaries,
       # however we know these element boundaries are not shared so this should not cause problems.
@@ -165,7 +160,6 @@
       capabilities = 'mfem'
       compute_devices = 'cpu'
       max_parallel = 1 # XML schemadiff with multiple ranks
-      recover = false
       restep = false
       # Allow warnings, needed as we are sampling constant L2 variables on element boundaries,
       # however we know these element boundaries are not shared so this should not cause problems.
@@ -179,7 +173,6 @@
       cli_args = "MultiApps/mfem_recv/positions_objects='mfem_recv_locs'"
       capabilities = 'mfem'
       compute_devices = 'cpu'
-      recover = false
       restep = false
       # Allow warnings, needed as we are sampling constant L2 variables on element boundaries,
       # however we know these element boundaries are not shared so this should not cause problems.
@@ -195,7 +188,6 @@
                    MultiApps/mfem_send/cli_args='Mesh/file=../../mesh/square_mixed.e'"
       capabilities = 'mfem'
       compute_devices = 'cpu'
-      recover = false
       restep = false
       # Allow warnings, needed as we are sampling constant L2 variables on element boundaries,
       # however we know these element boundaries are not shared so this should not cause problems.

--- a/test/tests/mfem/variables/tests
+++ b/test/tests/mfem/variables/tests
@@ -10,7 +10,6 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
     restep = false
   []
   [MFEMComplexAuxVariableRecovery]
@@ -56,6 +55,5 @@
     capabilities = 'mfem'
     compute_devices = 'cpu cuda'
     max_parallel = 1 # schemadiff with multiple ranks
-    recover = false
   []
 []

--- a/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/tests
+++ b/test/tests/mfem/vectorpostprocessors/coefficient_value_sampler/tests
@@ -10,7 +10,6 @@
     requirement = 'The system shall evaluate real scalar MFEM function and material coefficients '
                   'at arbitrary points.'
     capabilities = 'mfem'
-    recover = false
   []
 
   [coefficient_boundary_sampling]
@@ -31,6 +30,5 @@
     requirement = 'The system shall reject arbitrary-point sampling of an MFEM coefficient backed '
                   'by values defined only at configured quadrature points.'
     capabilities = 'mfem'
-    recover = false
   []
 []

--- a/test/tests/mfem/vectorpostprocessors/line_value_sampler/tests
+++ b/test/tests/mfem/vectorpostprocessors/line_value_sampler/tests
@@ -8,7 +8,6 @@
     csvdiff = 'line_value_sampler_diffusion_out_line_sample_0001.csv'
     requirement = 'The system shall have the ability to interpolate scalars at points along a line using MFEM.'
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
   []
   [MFEMLineVariableValueSamplerCurlCurl]
@@ -18,7 +17,6 @@
     csvdiff = 'line_value_sampler_curlcurl_out_line_sample_0001.csv'
     requirement = 'The system shall have the ability to interpolate vectors at points along a line using MFEM.'
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
     # The sampled line includes element interfaces in an H(curl) space.
     allow_warnings = true
@@ -31,7 +29,6 @@
     requirement = 'The system shall identify the input block when a line variable sampler is '
                   'configured with fewer than two points.'
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
   []
 []

--- a/test/tests/mfem/vectorpostprocessors/point_value_sampler/tests
+++ b/test/tests/mfem/vectorpostprocessors/point_value_sampler/tests
@@ -8,7 +8,6 @@
     csvdiff = 'point_value_sampler_diffusion_out_point_sample_0001.csv'
     requirement = 'The system shall have the ability to interpolate scalars at arbitrary points using MFEM.'
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
   []
   [MFEMPointVariableValueSamplerCurlCurl]
@@ -18,7 +17,6 @@
     csvdiff = 'point_value_sampler_curlcurl_out_point_sample_0001.csv'
     requirement = 'The system shall have the ability to interpolate vectors at arbitrary points using MFEM.'
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
     # The sampled points include element interfaces in an H(curl) space.
     allow_warnings = true
@@ -29,7 +27,6 @@
     expect_err = 'MFEMVariablePointValueSampler "point_sample" could not find point at'
     requirement = "The system shall issue an error if an attempt is made to sample at a point that is not inside the mesh."
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
   []
   [MFEMValueSamplerBoundaryDiscontinuousWarningRT]
@@ -42,7 +39,6 @@
     issues = '#32988'
     requirement = "The system shall issue a warning if an attempt is made to sample an RT variable near an element boundary."
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
   []
   [MFEMValueSamplerBoundaryDiscontinuousWarningND]
@@ -55,7 +51,6 @@
     issues = '#32988'
     requirement = "The system shall issue a warning if an attempt is made to sample an ND variable near an element boundary."
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
   []
   [MFEMValueSamplerBoundaryDiscontinuousWarningL2]
@@ -65,7 +60,6 @@
     issues = '#32988'
     requirement = "The system shall issue a warning if an attempt is made to sample an L2 variable near an element boundary."
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
   []
   [MFEMComplexVariableValueSamplerPointNotFoundError]
@@ -79,7 +73,6 @@
     issues = '#30076'
     requirement = "The system shall issue an error if a complex variable is sampled at a point that is not inside the mesh."
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
   []
   [MFEMComplexVariableValueSamplerBoundaryDiscontinuousWarning]
@@ -92,7 +85,6 @@
     issues = '#30076 #32988'
     requirement = "The system shall issue a warning if a complex variable is sampled near a boundary where it is discontinuous."
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
   []
   [MFEMVariableValueSamplerBoundaryTolNotOnBoundary]
@@ -100,7 +92,6 @@
     input = point_value_sampler_boundary_tol.i
     requirement = "The system shall not issue an error for a point near but outside a boundary when the tolerance is loose."
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
   []
   [MFEMVariableValueSamplerBoundaryTolOnBoundary]
@@ -110,7 +101,6 @@
     cli_args = 'VectorPostprocessors/point_sample/mesh_boundary_tolerance=1e-10'
     requirement = "The system shall issue an error for a point near but outside a boundary when the tolerance is tight."
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
   []
   [MFEMPointVariableValueSamplerAvgTypeNone]
@@ -122,7 +112,6 @@
                'Outputs/file_base=OutputData/point_value_sampler_avgtype_none'
     requirement = 'The system has the ability to use no average near non-continuous boundaries'
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
     # we will get a warning for being near the boundary
     allow_warnings = 'true'
@@ -136,7 +125,6 @@
                'Outputs/file_base=OutputData/point_value_sampler_avgtype_arithmetic'
     requirement = 'The system has the ability to use arithmetic average near non-continuous boundaries'
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
     # we will get a warning for being near the boundary
     allow_warnings = 'true'
@@ -150,7 +138,6 @@
                'Outputs/file_base=OutputData/point_value_sampler_avgtype_harmonic'
     requirement = 'The system has the ability to use harmonic average near non-continuous boundaries'
     capabilities = 'mfem'
-    recover = false
     compute_devices = 'cpu cuda'
     # we will get a warning for being near the boundary
     allow_warnings = 'true'
@@ -163,6 +150,5 @@
     requirement = 'The system shall sample the prescribed value of an MFEM variable using the '
                   'mesh belonging to its submesh finite element space.'
     capabilities = 'mfem'
-    recover = false
   []
 []


### PR DESCRIPTION
## Reason
#32736 added the ability to recover with mfem.

## Design
Remove `recover = false` from most tests.
At least one more test is affected by #33479.
Cut transition submesh tests can't recover cleanly as is because they change the original/parent mesh so, on recover, we can't recreate the same subdomains again.
Recover from p-refined gridfunctions fails because we have no info on the extra dofs, so there's a size mismatch between the big stored gridfunction and the smaller one we're trying to recover to.
Some other tests diff.

## Impact
Increased test robustness.