### PR TITLE
Use proper preparation logic in getBoundaryIDs

### DIFF
--- a/framework/include/utils/MooseMeshUtils.h
+++ b/framework/include/utils/MooseMeshUtils.h
@@ -69,9 +69,13 @@ changeSubdomainId(MeshBase & mesh, const subdomain_id_type old_id, const subdoma
  *
  * The ordering of the returned boundary ID vector matches the vector of the boundary
  * names in \p boundary_name.
+ *
  * When a boundary name is not available in the mesh, if \p generate_unknown is true
  * a non-existant boundary ID will be returned, otherwise a BoundaryInfo::invalid_id
  * will be returned.
+ *
+ * If generate_unknown is true and !mesh.preparation().has_boundary_id_sets, this
+ * must be called across all ranks for synchronization.
  */
 std::vector<BoundaryID> getBoundaryIDs(const libMesh::MeshBase & mesh,
                                        const std::vector<BoundaryName> & boundary_name,
@@ -83,9 +87,13 @@ std::vector<BoundaryID> getBoundaryIDs(const libMesh::MeshBase & mesh,
  *
  * The ordering of the returned boundary ID vector matches the vector of the boundary
  * names in \p boundary_name.
+ *
  * When a boundary name is not available in the mesh, if \p generate_unknown is true
  * a non-existant boundary ID will be returned, otherwise a BoundaryInfo::invalid_id
  * will be returned.
+ *
+ * If generate_unknown is true and !mesh.preparation().has_boundary_id_sets, this
+ * must be called across all ranks for synchronization.
  */
 std::vector<BoundaryID> getBoundaryIDs(const libMesh::MeshBase & mesh,
                                        const std::vector<BoundaryName> & boundary_name,
@@ -97,9 +105,13 @@ std::vector<BoundaryID> getBoundaryIDs(const libMesh::MeshBase & mesh,
  * Because libMesh allows the same boundary to have multiple different boundary names,
  * the size of the returned boundary ID set may be smaller than the size of the boundary
  * name vector.
+ *
  * When a boundary name is not available in the mesh, if \p generate_unknown is true
  * a non-existant boundary ID will be returned, otherwise a BoundaryInfo::invalid_id
  * will be returned.
+ *
+ * If generate_unknown is true and !mesh.preparation().has_boundary_id_sets, this
+ * must be called across all ranks for synchronization.
  */
 std::set<BoundaryID> getBoundaryIDSet(const libMesh::MeshBase & mesh,
                                       const std::vector<BoundaryName> & boundary_name,

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -120,35 +120,33 @@ getBoundaryIDs(const MeshBase & mesh,
                bool generate_unknown,
                const std::set<BoundaryID> & mesh_boundary_ids)
 {
-  libmesh_parallel_only(mesh.comm());
-
   const BoundaryInfo & boundary_info = mesh.get_boundary_info();
   const std::map<BoundaryID, std::string> & sideset_map = boundary_info.get_sideset_name_map();
   const std::map<BoundaryID, std::string> & nodeset_map = boundary_info.get_nodeset_name_map();
 
-  BoundaryID current_max_boundary_id = 0;
   /* It is required to generate a new ID for a given name. It is used often in mesh modifiers such
    * as SideSetsBetweenSubdomains. Then we need to check the current boundary ids since they are
    * changing during "mesh modify()", and figure out the right max boundary ID. Most of mesh
    * modifiers are running in serial, and we won't involve a global communication.
    */
+  BoundaryID max_boundary_id = 0;
   if (generate_unknown)
   {
     bool has_boundary_id_sets = mesh.preparation().has_boundary_id_sets;
-    mesh.comm().min(has_boundary_id_sets);
+
+    // Ideally, this requirement should be able to be enforced earlier when we
+    // get the name maps. However, that preparedness check on sideset and
+    // nodeset maps doesn't exist yet.
+    if (!has_boundary_id_sets)
+      libmesh_parallel_only(mesh.comm());
 
     const auto & bids = has_boundary_id_sets ? boundary_info.get_global_boundary_ids()
                                              : boundary_info.get_boundary_ids();
-    current_max_boundary_id = bids.empty() ? 0 : *(bids.rbegin());
-
+    if (bids.size())
+      max_boundary_id = *(bids.rbegin());
     if (!has_boundary_id_sets)
-      mesh.comm().max(current_max_boundary_id);
+      mesh.comm().max(max_boundary_id);
   }
-
-  BoundaryID max_boundary_id = mesh_boundary_ids.empty() ? 0 : *(mesh_boundary_ids.rbegin());
-
-  max_boundary_id =
-      max_boundary_id > current_max_boundary_id ? max_boundary_id : current_max_boundary_id;
 
   std::vector<BoundaryID> ids(boundary_name.size());
   for (const auto i : index_range(boundary_name))


### PR DESCRIPTION
## Reason

#33466 modified the logic in `MooseMeshUtils::getBoundaryIDs()` requiring it to always be called in parallel. Unfortunately, there are already use cases where it's not called in parallel. The parallel requirement should only be in a specific case (for now).

This fixes the failure in https://civet.inl.gov/job/4093470/, where `WallDistanceMixingLengthAux` is calling this method not in parallel.

## Design

Only require parallel execution with `generate_unknown=true` and when mesh preparedness doesn't have synced IDs. This logic is poor for the moment because ideally we want to use the same kind of logic for getting the maps. However, that doesn't exist yet.

## Impact

Will revert `MooseMeshUtils::getBoundaryIDs()` to the previous behavior, while also making way for more preparedness checks in the future.