### PR TITLE
Disable coredumps by default in tests

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -17,6 +17,7 @@ import json
 import os
 import platform
 import re
+import resource
 import shutil
 import socket
 import subprocess
@@ -434,6 +435,10 @@ class TestHarness:
 
         # Parse arguments
         self.options: argparse.Namespace = self.parseCLArgs(argv)
+
+        # Disable system coredumps
+        if not self.options.no_disable_coredumps:
+            resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
 
         # Determine the executable if we have an application
         try:
@@ -1773,6 +1778,11 @@ class TestHarness:
 
         envgroup = parser.add_argument_group(
             "Environment Options", "Control the runtime environment"
+        )
+        envgroup.add_argument(
+            "--no-disable-coredumps",
+            action="store_true",
+            help="Do not disable system core dumps when running tests",
         )
         envgroup.add_argument(
             "--no-hwloc-topology",

--- a/python/TestHarness/runners/SubprocessRunner.py
+++ b/python/TestHarness/runners/SubprocessRunner.py
@@ -100,12 +100,11 @@ class SubprocessRunner(Runner):
             "shell": use_shell,
             "cwd": tester.getTestDir(),
         }
-        # On Windows, there is an issue with path translation when the command is passed in
-        # as a list.
+        # So that we can os.killpg to kill the entire process group
         if platform.system() == "Windows":
             process_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
         else:
-            process_kwargs["preexec_fn"] = os.setsid
+            process_kwargs["process_group"] = 0
 
         # Augment the environment if needed
         process_env = tester.augmentEnvironment(self.options)


### PR DESCRIPTION
## Reason

When running many tests at a time, especially those that call MPI_Abort, we can sometimes end up with a lot of processing time going to core dumps. By default, this should be disabled because as far as I know folks don't look for those dumps.

## Design

Disable system core dumps by default, and add a `--no-disable-coredumps` option to disable this disabling.

## Impact

Could lead to less resource usage by the test harness. 