### PR TITLE
switch from static_cast<T &> to cast_ref<T &>

### DIFF
--- a/framework/include/auxkernels/AuxKernelBase.h
+++ b/framework/include/auxkernels/AuxKernelBase.h
@@ -104,7 +104,7 @@ protected:
   /// System this kernel is part of
   SystemBase & _sys;
   SystemBase & _nl_sys;
-  AuxiliarySystem & _aux_sys;
+  SystemBase & _aux_sys;
 
   /// Thread ID
   const THREAD_ID _tid;

--- a/framework/include/base/ChainControlDataSystem.h
+++ b/framework/include/base/ChainControlDataSystem.h
@@ -121,7 +121,7 @@ ChainControlDataSystem::getChainControlData(const std::string & data_name)
   else
     _chain_control_data_map[data_name] = std::make_unique<ChainControlData<T>>(_app, data_name);
 
-  return static_cast<ChainControlData<T> &>(*_chain_control_data_map[data_name]);
+  return cast_ref<ChainControlData<T> &>(*_chain_control_data_map[data_name]);
 }
 
 template <typename T>

--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -337,7 +337,7 @@ Factory::clone(const T & object)
     cloned_params.setHitNode(*hit_node, {});
 
   // Fill the new parameters in the warehouse
-  const auto type = static_cast<const MooseBase &>(object).type();
+  const auto type = cast_ref<const MooseBase &>(object).type();
   const auto clone_count = _clone_counter[&object]++;
   const auto name = object.name() + "_clone" + std::to_string(clone_count);
   const auto & params = initialize(type, name, cloned_params, 0);
@@ -359,7 +359,7 @@ Factory::copyConstruct(const T & object)
 {
   static_assert(std::is_base_of_v<MooseObject, T>, "Not a MooseObject");
 
-  const auto type = static_cast<const MooseBase &>(object).type();
+  const auto type = cast_ref<const MooseBase &>(object).type();
   if (object.hasBase())
   {
     const auto & base = object.getBase();

--- a/framework/include/csg/CSGBase.h
+++ b/framework/include/csg/CSGBase.h
@@ -565,7 +565,7 @@ public:
       _universe_list.addUniverse(std::move(unit));
 
     // Register non-owning pointer in the CSGEngUnitList if no name conflicts identified above.
-    _eng_unit_list.addEngUnit(static_cast<CSGEngUnit &>(*raw));
+    _eng_unit_list.addEngUnit(cast_ref<CSGEngUnit &>(*raw));
     return *raw;
   }
 

--- a/framework/include/loops/ComputeFVFluxThread.h
+++ b/framework/include/loops/ComputeFVFluxThread.h
@@ -189,8 +189,8 @@ ThreadedFaceLoop<RangeType>::ThreadedFaceLoop(FEProblemBase & fe_problem,
     _tags(tags),
     _nl_system_num(nl_system_num),
     _on_displaced(on_displaced),
-    _subproblem(_on_displaced ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
-                              : static_cast<SubProblem &>(_fe_problem)),
+    _subproblem(_on_displaced ? cast_ref<SubProblem &>(*_fe_problem.getDisplacedProblem())
+                              : cast_ref<SubProblem &>(_fe_problem)),
     _zeroth_copy(true),
     _incoming_throw_on_error(Moose::_throw_on_error)
 {

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -762,7 +762,7 @@ MaterialPropertyInterface::defaultGenericMaterialProperty(const std::string & na
       const auto nqp = Moose::constMaxQpsPerElem;
       auto & property =
           _default_properties.emplace_back(std::make_unique<prop_type>(default_property_id));
-      auto & T_property = static_cast<prop_type &>(*property);
+      auto & T_property = cast_ref<prop_type &>(*property);
 
       T_property.resize(nqp);
       for (const auto qp : make_range(nqp))
@@ -783,7 +783,7 @@ MaterialPropertyInterface::getBlockMaterialProperty(const MaterialPropertyName &
     mooseError("getBlockMaterialProperty must be called by a block restrictable object");
 
   const auto name = _get_suffix.empty()
-                        ? static_cast<const std::string &>(name_in)
+                        ? cast_ref<const std::string &>(name_in)
                         : MooseUtils::join(std::vector<std::string>({name_in, _get_suffix}), "_");
 
   using pair_type = std::pair<const MaterialProperty<T> *, std::set<SubdomainID>>;
@@ -952,7 +952,7 @@ MaterialPropertyInterface::getGenericMaterialPropertyByName(const MaterialProper
   }
 
   const auto name = _get_suffix.empty()
-                        ? static_cast<const std::string &>(name_in)
+                        ? cast_ref<const std::string &>(name_in)
                         : MooseUtils::join(std::vector<std::string>({name_in, _get_suffix}), "_");
 
   checkExecutionStage();
@@ -1016,7 +1016,7 @@ MaterialPropertyInterface::getKokkosMaterialPropertyByName(const std::string & p
 
   const auto prop_name =
       _get_suffix.empty()
-          ? static_cast<const std::string &>(prop_name_in)
+          ? cast_ref<const std::string &>(prop_name_in)
           : MooseUtils::join(std::vector<std::string>({prop_name_in, _get_suffix}), "_");
 
   checkExecutionStage();
@@ -1054,7 +1054,7 @@ MaterialPropertyInterface::getKokkosBlockMaterialProperty(const MaterialProperty
     mooseError("getKokkosBlockMaterialProperty must be called by a block restrictable object");
 
   const auto name = _get_suffix.empty()
-                        ? static_cast<const std::string &>(name_in)
+                        ? cast_ref<const std::string &>(name_in)
                         : MooseUtils::join(std::vector<std::string>({name_in, _get_suffix}), "_");
 
   using pair_type = std::pair<Moose::Kokkos::MaterialProperty<T, dimension>, std::set<SubdomainID>>;

--- a/framework/include/mfem/solvers/MFEMHypreAME.h
+++ b/framework/include/mfem/solvers/MFEMHypreAME.h
@@ -26,7 +26,7 @@ public:
   /// Sets the mass matrix for the eigensolver
   virtual void SetMassMatrix(mfem::Operator & mass) override
   {
-    _eigensolver->SetMassMatrix(libMesh::cast_ref<mfem::HypreParMatrix &>(mass));
+    _eigensolver->SetMassMatrix(cast_ref<mfem::HypreParMatrix &>(mass));
   }
 
   /// Solves the eigenvalue problem
@@ -53,7 +53,7 @@ protected:
   {
     if (_preconditioner)
       _preconditioner->SetOperator(op);
-    _eigensolver->SetOperator(libMesh::cast_ref<mfem::HypreParMatrix &>(op));
+    _eigensolver->SetOperator(cast_ref<mfem::HypreParMatrix &>(op));
   }
 
   /// Eigensolver to be used for the problem

--- a/framework/include/mfem/solvers/MFEMLORLinearSolverBase.h
+++ b/framework/include/mfem/solvers/MFEMLORLinearSolverBase.h
@@ -119,7 +119,7 @@ LORLinearSolverBase<MFEMSolverType>::UpdateEquationSystemContext()
                                   mfem::HypreBoomerAMG,
                                   mfem::HypreAMS,
                                   mfem::HypreADS>)
-    SetPreconditioner(static_cast<MFEMSolverType &>(GetSolver()));
+    SetPreconditioner(cast_ref<MFEMSolverType &>(GetSolver()));
 }
 
 template <class MFEMSolverType>

--- a/framework/include/outputs/JsonIO.h
+++ b/framework/include/outputs/JsonIO.h
@@ -162,5 +162,5 @@ template <typename T>
 void
 to_json(nlohmann::json & json, const GenericTwoVector<T> & two_vector)
 {
-  to_json(json, static_cast<const Eigen::Matrix<T, 2, 1> &>(two_vector));
+  to_json(json, libMesh::cast_ref<const Eigen::Matrix<T, 2, 1> &>(two_vector));
 }

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -1310,9 +1310,9 @@ SubProblem::getFunctor(const std::string & name,
                                          std::make_unique<Moose::Functor<ADType>>(
                                              std::make_unique<Moose::NullFunctor<ADType>>())));
 
-    return static_cast<Moose::Functor<T> &>(*(requested_functor_is_ad
-                                                  ? std::get<2>(emplace_ret->second)
-                                                  : std::get<1>(emplace_ret->second)));
+    return cast_ref<Moose::Functor<T> &>(*(requested_functor_is_ad
+                                               ? std::get<2>(emplace_ret->second)
+                                               : std::get<1>(emplace_ret->second)));
   }
   else
   {
@@ -1327,9 +1327,9 @@ SubProblem::getFunctor(const std::string & name,
                                          std::make_unique<Moose::Functor<ADType>>(
                                              std::make_unique<Moose::NullFunctor<ADType>>())));
 
-    return static_cast<Moose::Functor<T> &>(*(requested_functor_is_ad
-                                                  ? std::get<2>(emplace_ret->second)
-                                                  : std::get<1>(emplace_ret->second)));
+    return cast_ref<Moose::Functor<T> &>(*(requested_functor_is_ad
+                                               ? std::get<2>(emplace_ret->second)
+                                               : std::get<1>(emplace_ret->second)));
   }
 }
 

--- a/framework/include/reporters/ReporterData.h
+++ b/framework/include/reporters/ReporterData.h
@@ -484,7 +484,7 @@ ReporterData::getReporterValue(const ReporterName & reporter_name,
                "\" is not declared.");
 
   // Force the const version of value, which does not allow for increasing time index
-  return static_cast<const ReporterState<T> &>(
+  return cast_ref<const ReporterState<T> &>(
              getReporterStateHelper<T>(reporter_name, /* declare = */ false))
       .value(time_index);
 }

--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -457,7 +457,7 @@ template <typename T>
 void
 dataStore(std::ostream & stream, GenericTwoVector<T> & v, void * context)
 {
-  dataStore(stream, static_cast<Eigen::Matrix<T, 2, 1> &>(v), context);
+  dataStore(stream, libMesh::cast_ref<Eigen::Matrix<T, 2, 1> &>(v), context);
 }
 
 // Specializations (defined in .C)
@@ -1020,7 +1020,7 @@ template <typename T>
 void
 dataLoad(std::istream & stream, GenericTwoVector<T> & v, void * context)
 {
-  dataLoad(stream, static_cast<Eigen::Matrix<T, 2, 1> &>(v), context);
+  dataLoad(stream, libMesh::cast_ref<Eigen::Matrix<T, 2, 1> &>(v), context);
 }
 
 // Specializations (defined in .C)

--- a/framework/include/restart/Restartable.h
+++ b/framework/include/restart/Restartable.h
@@ -319,7 +319,7 @@ Restartable::declareRestartableDataHelper(const std::string & data_name,
   // at a later date.
   auto data_ptr =
       std::make_unique<RestartableData<T>>(full_name, context, std::forward<Args>(args)...);
-  auto & restartable_data_ref = static_cast<RestartableData<T> &>(
+  auto & restartable_data_ref = cast_ref<RestartableData<T> &>(
       registerRestartableDataOnApp(std::move(data_ptr), _restartable_tid));
 
   return restartable_data_ref;

--- a/framework/include/userobjects/LayeredAverageBase.h
+++ b/framework/include/userobjects/LayeredAverageBase.h
@@ -101,7 +101,7 @@ void
 LayeredAverageBase<BaseType>::threadJoin(const UserObject & y)
 {
   LayeredIntegralBase<BaseType>::threadJoin(y);
-  const auto & lsa = static_cast<const LayeredAverageBase<BaseType> &>(y);
+  const auto & lsa = cast_ref<const LayeredAverageBase<BaseType> &>(y);
   for (const auto i : index_range(_layer_volumes))
     if (lsa.layerHasValue(i))
       _layer_volumes[i] += lsa._layer_volumes[i];

--- a/framework/include/userobjects/NearestPointBase.h
+++ b/framework/include/userobjects/NearestPointBase.h
@@ -219,7 +219,7 @@ template <typename UserObjectType, typename BaseType>
 void
 NearestPointBase<UserObjectType, BaseType>::threadJoin(const UserObject & y)
 {
-  auto & npla = static_cast<const NearestPointBase &>(y);
+  auto & npla = cast_ref<const NearestPointBase &>(y);
 
   for (MooseIndex(_user_objects) i = 0; i < _user_objects.size(); ++i)
     _user_objects[i]->threadJoin(*npla._user_objects[i]);

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -117,8 +117,7 @@ template <typename T>
 void
 setLinearSolverDefaults(FEProblemBase & problem, libMesh::LinearSolver<T> & linear_solver)
 {
-  petscSetKSPDefaults(problem,
-                      libMesh::cast_ref<libMesh::PetscLinearSolver<T> &>(linear_solver).ksp());
+  petscSetKSPDefaults(problem, cast_ref<libMesh::PetscLinearSolver<T> &>(linear_solver).ksp());
 }
 
 /**

--- a/framework/src/actions/AddPeriodicBCAction.C
+++ b/framework/src/actions/AddPeriodicBCAction.C
@@ -40,7 +40,7 @@ AddPeriodicBCAction::validParams()
 }
 
 AddPeriodicBCAction::AddPeriodicBCAction(const InputParameters & params)
-  : Action(params), Moose::PeriodicBCHelper(static_cast<const Action &>(*this))
+  : Action(params), Moose::PeriodicBCHelper(cast_ref<const Action &>(*this))
 {
   checkPeriodicParams();
 }

--- a/framework/src/auxkernels/AuxKernelBase.C
+++ b/framework/src/auxkernels/AuxKernelBase.C
@@ -96,7 +96,7 @@ AuxKernelBase::AuxKernelBase(const InputParameters & parameters)
     _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
     _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
     _nl_sys(*getCheckedPointerParam<SystemBase *>("_nl_sys")),
-    _aux_sys(cast_ref<AuxiliarySystem &>(_sys)),
+    _aux_sys(_sys),
     _tid(parameters.get<THREAD_ID>("_tid")),
     _assembly(_subproblem.assembly(_tid, 0)),
     _mesh(_subproblem.mesh())

--- a/framework/src/auxkernels/AuxKernelBase.C
+++ b/framework/src/auxkernels/AuxKernelBase.C
@@ -96,7 +96,7 @@ AuxKernelBase::AuxKernelBase(const InputParameters & parameters)
     _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
     _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
     _nl_sys(*getCheckedPointerParam<SystemBase *>("_nl_sys")),
-    _aux_sys(static_cast<AuxiliarySystem &>(_sys)),
+    _aux_sys(cast_ref<AuxiliarySystem &>(_sys)),
     _tid(parameters.get<THREAD_ID>("_tid")),
     _assembly(_subproblem.assembly(_tid, 0)),
     _mesh(_subproblem.mesh())

--- a/framework/src/base/LinearSystemContributionObject.C
+++ b/framework/src/base/LinearSystemContributionObject.C
@@ -50,7 +50,7 @@ LinearSystemContributionObject::LinearSystemContributionObject(const InputParame
     TaggingInterface(this),
     _fe_problem(*parameters.get<FEProblemBase *>("_fe_problem_base")),
     _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
-    _linear_system(libMesh::cast_ref<libMesh::LinearImplicitSystem &>(_sys.system())),
+    _linear_system(cast_ref<libMesh::LinearImplicitSystem &>(_sys.system())),
     _tid(parameters.get<THREAD_ID>("_tid")),
     _mesh(_subproblem.mesh())
 {

--- a/framework/src/bcs/ArrayLowerDIntegratedBC.C
+++ b/framework/src/bcs/ArrayLowerDIntegratedBC.C
@@ -172,7 +172,7 @@ ArrayLowerDIntegratedBC::computeLowerDOffDiagJacobian(Moose::ConstraintJacobianT
 
   if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_STANDARD)
   {
-    const auto & jv0 = static_cast<const MooseVariable &>(jvar);
+    const auto & jv0 = cast_ref<const MooseVariable &>(jvar);
     const VariableTestValue & loc_phi =
         (type == Moose::LowerLower || type == Moose::PrimaryLower) ? jv0.phiLower() : jv0.phiFace();
 
@@ -190,7 +190,7 @@ ArrayLowerDIntegratedBC::computeLowerDOffDiagJacobian(Moose::ConstraintJacobianT
   }
   else if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_ARRAY)
   {
-    const auto & jv1 = static_cast<const ArrayMooseVariable &>(jvar);
+    const auto & jv1 = cast_ref<const ArrayMooseVariable &>(jvar);
     const ArrayVariableTestValue & loc_phi =
         (type == Moose::LowerLower || type == Moose::PrimaryLower) ? jv1.phiLower() : jv1.phiFace();
 

--- a/framework/src/bcs/LowerDIntegratedBC.C
+++ b/framework/src/bcs/LowerDIntegratedBC.C
@@ -164,7 +164,7 @@ LowerDIntegratedBC::computeLowerDOffDiagJacobian(Moose::ConstraintJacobianType t
 
   if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_STANDARD)
   {
-    const auto & jv0 = static_cast<const MooseVariable &>(jvar);
+    const auto & jv0 = cast_ref<const MooseVariable &>(jvar);
     const auto & loc_phi =
         (type == Moose::LowerLower || type == Moose::PrimaryLower) ? jv0.phiLower() : jv0.phiFace();
 

--- a/framework/src/constraints/AutomaticMortarGeneration.C
+++ b/framework/src/constraints/AutomaticMortarGeneration.C
@@ -259,9 +259,8 @@ public:
       mooseError("No entries found in the secondary node -> nodal geometry map.");
 
     auto & problem = _app.feProblem();
-    auto & subproblem = _amg._on_displaced
-                            ? static_cast<SubProblem &>(*problem.getDisplacedProblem())
-                            : static_cast<SubProblem &>(problem);
+    auto & subproblem = _amg._on_displaced ? cast_ref<SubProblem &>(*problem.getDisplacedProblem())
+                                           : cast_ref<SubProblem &>(problem);
     auto & nodal_normals_es = subproblem.es();
 
     const std::string nodal_normals_sys_name = "nodal_normals";
@@ -639,7 +638,7 @@ AutomaticMortarGeneration::getNormals(const Elem & secondary_elem,
               : Moose::fe_lagrange_2D_shape(secondary_elem.type(),
                                             secondary_elem.default_order(),
                                             n,
-                                            static_cast<const TypeVector<Real> &>(xi1_pts[qp]));
+                                            cast_ref<const TypeVector<Real> &>(xi1_pts[qp]));
       normals[qp] += phi * nodal_normals[n];
     }
 
@@ -1825,8 +1824,8 @@ AutomaticMortarGeneration::computeMsmStatistics()
     }
 
     _mesh.comm().set_union(primary_elems_to_volume);
-    _mesh.comm().allgather(static_cast<std::vector<Real> &>(secondary));
-    _mesh.comm().allgather(static_cast<std::vector<Real> &>(msm));
+    _mesh.comm().allgather(cast_ref<std::vector<Real> &>(secondary));
+    _mesh.comm().allgather(cast_ref<std::vector<Real> &>(msm));
     primary.reserve(primary_elems_to_volume.size());
     for (const auto [_, volume] : primary_elems_to_volume)
       primary.push_back(volume);
@@ -2624,8 +2623,8 @@ AutomaticMortarGeneration::projectSecondaryNodesSinglePair(
         _failed_secondary_node_projections.insert(secondary_node->id());
         if (_debug)
           _console << "Failed to find primary Elem into which secondary node "
-                   << static_cast<const Point &>(*secondary_node) << ", id '"
-                   << secondary_node->id() << "', projects onto\n"
+                   << cast_ref<const Point &>(*secondary_node) << ", id '" << secondary_node->id()
+                   << "', projects onto\n"
                    << std::endl;
       }
       else if (_debug)
@@ -2879,7 +2878,7 @@ AutomaticMortarGeneration::projectPrimaryNodesSinglePair(
       if (!projection_succeeded && _debug)
       {
         _console << "\nFailed to find point from which primary node "
-                 << static_cast<const Point &>(*primary_node) << " was projected." << std::endl
+                 << cast_ref<const Point &>(*primary_node) << " was projected." << std::endl
                  << std::endl;
       }
     } // loop over side nodes

--- a/framework/src/constraints/MortarConstraint.C
+++ b/framework/src/constraints/MortarConstraint.C
@@ -127,14 +127,14 @@ MortarConstraint::computeJacobian(Moose::MortarType mortar_type)
     std::array<const VectorVariablePhiGradient *, 3> vector_grad_phis;
     if (jvariable.isVector())
     {
-      const auto & temp_var = static_cast<MooseVariableFE<RealVectorValue> &>(jvariable);
+      const auto & temp_var = cast_ref<MooseVariableFE<RealVectorValue> &>(jvariable);
       vector_phis = {{&temp_var.phiFace(), &temp_var.phiFaceNeighbor(), &temp_var.phiLower()}};
       vector_grad_phis = {
           {&temp_var.gradPhiFace(), &temp_var.gradPhiFaceNeighbor(), &temp_var.gradPhiLower()}};
     }
     else
     {
-      const auto & temp_var = static_cast<MooseVariableFE<Real> &>(jvariable);
+      const auto & temp_var = cast_ref<MooseVariableFE<Real> &>(jvariable);
       phis = {{&temp_var.phiFace(), &temp_var.phiFaceNeighbor(), &temp_var.phiLower()}};
       grad_phis = {
           {&temp_var.gradPhiFace(), &temp_var.gradPhiFaceNeighbor(), &temp_var.gradPhiLower()}};

--- a/framework/src/constraints/MortarScalarBase.C
+++ b/framework/src/constraints/MortarScalarBase.C
@@ -155,14 +155,14 @@ MortarScalarBase::computeScalarOffDiagJacobian()
     std::array<const VectorVariablePhiGradient *, 3> vector_grad_phis;
     if (jvariable.isVector())
     {
-      const auto & temp_var = static_cast<MooseVariableFE<RealVectorValue> &>(jvariable);
+      const auto & temp_var = cast_ref<MooseVariableFE<RealVectorValue> &>(jvariable);
       vector_phis = {{&temp_var.phiFace(), &temp_var.phiFaceNeighbor(), &temp_var.phiLower()}};
       vector_grad_phis = {
           {&temp_var.gradPhiFace(), &temp_var.gradPhiFaceNeighbor(), &temp_var.gradPhiLower()}};
     }
     else
     {
-      const auto & temp_var = static_cast<MooseVariableFE<Real> &>(jvariable);
+      const auto & temp_var = cast_ref<MooseVariableFE<Real> &>(jvariable);
       phis = {{&temp_var.phiFace(), &temp_var.phiFaceNeighbor(), &temp_var.phiLower()}};
       grad_phis = {
           {&temp_var.gradPhiFace(), &temp_var.gradPhiFaceNeighbor(), &temp_var.gradPhiLower()}};

--- a/framework/src/csg/CSGBase.C
+++ b/framework/src/csg/CSGBase.C
@@ -1267,11 +1267,11 @@ CSGBase::deleteEngUnit(const CSGEngUnit & unit)
 
   // Delegate to the typed delete method which handles EngUnit index cleanup and type list erasure
   if (const auto * surf_unit = dynamic_cast<const CSGSurfaceEngUnit *>(&unit))
-    deleteSurface(static_cast<const CSGSurface &>(*surf_unit));
+    deleteSurface(cast_ref<const CSGSurface &>(*surf_unit));
   else if (const auto * cell_unit = dynamic_cast<const CSGCellEngUnit *>(&unit))
-    deleteCell(static_cast<const CSGCell &>(*cell_unit));
+    deleteCell(cast_ref<const CSGCell &>(*cell_unit));
   else if (const auto * univ_unit = dynamic_cast<const CSGUniverseEngUnit *>(&unit))
-    deleteUniverse(static_cast<const CSGUniverse &>(*univ_unit));
+    deleteUniverse(cast_ref<const CSGUniverse &>(*univ_unit));
   else
     mooseError(
         "Engineering unit '", unit.getName(), "' has an unrecognized type and cannot be deleted.");
@@ -1337,7 +1337,7 @@ CSGBase::expandEngUnit(const CSGSurfaceEngUnit & unit)
   // unit is const because the eng-unit API exposes only const references; re-fetch a mutable
   // reference to the same object from the owning surface list to perform the expansion, which
   // mutates and consumes the unit (expandUnit() is non-const).
-  auto & mutable_unit = static_cast<CSGSurfaceEngUnit &>(_surface_list.getSurface(unit.getName()));
+  auto & mutable_unit = cast_ref<CSGSurfaceEngUnit &>(_surface_list.getSurface(unit.getName()));
 
   // Derived class creates the CSGSurface object(s) in the unit's base object and sets
   // _expanded_region
@@ -1361,7 +1361,7 @@ CSGBase::expandEngUnit(const CSGSurfaceEngUnit & unit)
   CSGRegion expanded_region = mutable_unit.getExpandedRegion();
 
   // Propagate any stored transformations from the EngUnit to all new expanded surfaces
-  const auto & trans = static_cast<const CSGSurface &>(mutable_unit).getTransformations();
+  const auto & trans = cast_ref<const CSGSurface &>(mutable_unit).getTransformations();
   if (!trans.empty())
     for (const auto & surf_ref : expanded_region.getSurfaces())
     {
@@ -1371,7 +1371,7 @@ CSGBase::expandEngUnit(const CSGSurfaceEngUnit & unit)
     }
 
   // Replace every CSGSurfaceEngUnit reference in regions of CSGCells with the expanded sub-region
-  replaceSurfaceRefsWithRegion(static_cast<const CSGSurface &>(mutable_unit), expanded_region);
+  replaceSurfaceRefsWithRegion(cast_ref<const CSGSurface &>(mutable_unit), expanded_region);
 
   // Remove the EngUnit (destroyed here, no more references to it after
   // replaceSurfaceRefsWithRegion)
@@ -1385,7 +1385,7 @@ CSGBase::expandEngUnit(const CSGCellEngUnit & unit)
   // unit is const because the eng-unit API exposes only const references; re-fetch a mutable
   // reference to the same object from the owning cell list to perform the expansion, which
   // mutates and consumes the unit (expandUnit() is non-const).
-  auto & mutable_unit = static_cast<CSGCellEngUnit &>(_cell_list.getCell(unit.getName()));
+  auto & mutable_unit = cast_ref<CSGCellEngUnit &>(_cell_list.getCell(unit.getName()));
 
   // Derived class populates an internal base object (owned by the unit) with the expanded cell (in
   // root) and any supports
@@ -1400,7 +1400,7 @@ CSGBase::expandEngUnit(const CSGCellEngUnit & unit)
   joinOtherBase(mutable_unit.releaseBase(), false);
 
   // Propagate any stored transformations from the EngUnit to the expanded cell
-  const auto & trans = static_cast<const CSGCell &>(mutable_unit).getTransformations();
+  const auto & trans = cast_ref<const CSGCell &>(mutable_unit).getTransformations();
   if (!trans.empty())
   {
     CSGCell & mutable_cell = _cell_list.getCell(expanded_cell.getName());
@@ -1414,7 +1414,7 @@ CSGBase::expandEngUnit(const CSGCellEngUnit & unit)
     removeCellFromUniverse(getRootUniverse(), expanded_cell);
 
   // Replace all references to the CSGCellEngUnit in universes with the new expanded CSGCell
-  replaceCellRefs(static_cast<const CSGCell &>(mutable_unit), expanded_cell);
+  replaceCellRefs(cast_ref<const CSGCell &>(mutable_unit), expanded_cell);
 
   // Remove the EngUnit (destroyed here, no more references to it after replaceCellRefs)
   deleteEngUnit(unit);
@@ -1429,7 +1429,7 @@ CSGBase::expandEngUnit(const CSGUniverseEngUnit & unit)
   // unit is const because the eng-unit API exposes only const references; re-fetch a mutable
   // reference to the same object from the owning universe list to perform the expansion, which
   // mutates and consumes the unit (expandUnit() is non-const).
-  auto & mutable_unit = static_cast<CSGUniverseEngUnit &>(_universe_list.getUniverse(unit_name));
+  auto & mutable_unit = cast_ref<CSGUniverseEngUnit &>(_universe_list.getUniverse(unit_name));
 
   // Derived class populates the unit's base object; the root of this base is the expanded universe
   // that will be used to replace this universe unit
@@ -1475,7 +1475,7 @@ CSGBase::expandEngUnit(const CSGUniverseEngUnit & unit)
   const CSGUniverse & expanded_univ = getUniverseByName(expanded_name);
 
   // Propagate any stored transformations from the EngUnit to the new expanded universe
-  const auto & trans = static_cast<const CSGUniverse &>(mutable_unit).getTransformations();
+  const auto & trans = cast_ref<const CSGUniverse &>(mutable_unit).getTransformations();
   if (!trans.empty())
   {
     CSGUniverse & mutable_univ = _universe_list.getUniverse(expanded_univ.getName());
@@ -1484,7 +1484,7 @@ CSGBase::expandEngUnit(const CSGUniverseEngUnit & unit)
   }
 
   // Replace references in cell fills, lattice maps and outers, and the root universe
-  replaceUniverseRefs(static_cast<const CSGUniverse &>(mutable_unit), expanded_univ);
+  replaceUniverseRefs(cast_ref<const CSGUniverse &>(mutable_unit), expanded_univ);
 
   // Remove the EngUnit (destroyed here, no more references to it after replaceUniverseRefs)
   deleteEngUnit(unit);

--- a/framework/src/dgkernels/ArrayDGKernel.C
+++ b/framework/src/dgkernels/ArrayDGKernel.C
@@ -252,7 +252,7 @@ ArrayDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
 
   if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_STANDARD)
   {
-    const auto & jv0 = static_cast<const MooseVariable &>(jvar);
+    const auto & jv0 = cast_ref<const MooseVariable &>(jvar);
     const VariableTestValue & loc_phi =
         (type == Moose::ElementElement || type == Moose::NeighborElement) ? jv0.phiFace()
                                                                           : jv0.phiFaceNeighbor();
@@ -277,7 +277,7 @@ ArrayDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
   }
   else if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_ARRAY)
   {
-    const auto & jv1 = static_cast<const ArrayMooseVariable &>(jvar);
+    const auto & jv1 = cast_ref<const ArrayMooseVariable &>(jvar);
     const ArrayVariableTestValue & loc_phi =
         (type == Moose::ElementElement || type == Moose::NeighborElement) ? jv1.phiFace()
                                                                           : jv1.phiFaceNeighbor();

--- a/framework/src/dgkernels/ArrayDGLowerDKernel.C
+++ b/framework/src/dgkernels/ArrayDGLowerDKernel.C
@@ -231,7 +231,7 @@ ArrayDGLowerDKernel::computeOffDiagLowerDJacobian(Moose::ConstraintJacobianType 
 
   if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_STANDARD)
   {
-    const auto & jv0 = static_cast<const MooseVariable &>(jvar);
+    const auto & jv0 = cast_ref<const MooseVariable &>(jvar);
     const VariableTestValue & loc_phi =
         (type == Moose::LowerLower || type == Moose::SecondaryLower || type == Moose::PrimaryLower)
             ? jv0.phiLower()
@@ -251,7 +251,7 @@ ArrayDGLowerDKernel::computeOffDiagLowerDJacobian(Moose::ConstraintJacobianType 
   }
   else if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_ARRAY)
   {
-    const auto & jv1 = static_cast<const ArrayMooseVariable &>(jvar);
+    const auto & jv1 = cast_ref<const ArrayMooseVariable &>(jvar);
     const ArrayVariableTestValue & loc_phi =
         (type == Moose::LowerLower || type == Moose::SecondaryLower || type == Moose::PrimaryLower)
             ? jv1.phiLower()

--- a/framework/src/dgkernels/DGLowerDKernel.C
+++ b/framework/src/dgkernels/DGLowerDKernel.C
@@ -229,7 +229,7 @@ DGLowerDKernel::computeOffDiagLowerDJacobian(Moose::ConstraintJacobianType type,
 
   if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_STANDARD)
   {
-    const auto & jv0 = static_cast<const MooseVariable &>(jvar);
+    const auto & jv0 = cast_ref<const MooseVariable &>(jvar);
     const VariableTestValue & loc_phi =
         (type == Moose::LowerLower || type == Moose::SecondaryLower || type == Moose::PrimaryLower)
             ? jv0.phiLower()

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -56,7 +56,7 @@ EigenExecutionerBase::eigenvalueOld()
 EigenExecutionerBase::EigenExecutionerBase(const InputParameters & parameters)
   : Executioner(parameters),
     _problem(_fe_problem),
-    _eigen_sys(static_cast<MooseEigenSystem &>(_problem.getNonlinearSystemBase(/*nl_sys=*/0))),
+    _eigen_sys(cast_ref<MooseEigenSystem &>(_problem.getNonlinearSystemBase(/*nl_sys=*/0))),
     _feproblem_solve(*this),
     _eigenvalue(addAttributeReporter("eigenvalue", getParam<Real>("k0"))),
     _source_integral(getPostprocessorValue("bx_norm")),

--- a/framework/src/executioners/SolveObject.C
+++ b/framework/src/executioners/SolveObject.C
@@ -26,8 +26,8 @@ SolveObject::SolveObject(Executioner & ex)
     _mesh(_problem.mesh()),
     _displaced_mesh(_displaced_problem ? &_displaced_problem->mesh() : nullptr),
     _solver_sys(_problem.numNonlinearSystems()
-                    ? static_cast<SystemBase &>(_problem.getNonlinearSystemBase(/*nl_sys=*/0))
-                    : static_cast<SystemBase &>(_problem.getLinearSystem(/*l_sys_num=*/0))),
+                    ? cast_ref<SystemBase &>(_problem.getNonlinearSystemBase(/*nl_sys=*/0))
+                    : cast_ref<SystemBase &>(_problem.getLinearSystem(/*l_sys_num=*/0))),
     _aux(_problem.getAuxiliarySystem()),
     _inner_solve(nullptr)
 {

--- a/framework/src/fvkernels/FVFunctorTimeKernel.C
+++ b/framework/src/fvkernels/FVFunctorTimeKernel.C
@@ -30,8 +30,8 @@ FVFunctorTimeKernel::validParams()
 FVFunctorTimeKernel::FVFunctorTimeKernel(const InputParameters & parameters)
   : FVElementalKernel(parameters),
     _functor(isParamValid("functor")
-                 ? static_cast<const Moose::FunctorBase<ADReal> &>(getFunctor<ADReal>("functor"))
-                 : static_cast<Moose::FunctorBase<ADReal> &>(_var))
+                 ? cast_ref<const Moose::FunctorBase<ADReal> &>(getFunctor<ADReal>("functor"))
+                 : cast_ref<Moose::FunctorBase<ADReal> &>(_var))
 {
 }
 

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -277,7 +277,7 @@ PenetrationThread::operator()(const NodeIdRange & range)
           mooseError("No proximate elements found at node ",
                      closest_node->id(),
                      " at ",
-                     static_cast<const Point &>(*closest_node),
+                     cast_ref<const Point &>(*closest_node),
                      " on boundary ",
                      _nearest_node._boundary1,
                      ".  This should never happen.");
@@ -296,7 +296,7 @@ PenetrationThread::operator()(const NodeIdRange & range)
           mooseError("No proximate elements found at node ",
                      closest_node->id(),
                      " at ",
-                     static_cast<const Point &>(*closest_node),
+                     cast_ref<const Point &>(*closest_node),
                      " on boundary ",
                      _nearest_node._boundary1,
                      " share that boundary.  This may happen if the mesh uses the same boundary id "

--- a/framework/src/kernels/EigenKernel.C
+++ b/framework/src/kernels/EigenKernel.C
@@ -165,7 +165,7 @@ EigenKernel::computeOffDiagJacobian(const unsigned int jvar_num)
           for (_qp = 0; _qp < _qrule->n_points(); _qp++)
           {
             RealEigenVector v = _JxW[_qp] * _coord[_qp] * one_over_eigen *
-                                computeQpOffDiagJacobianArray(static_cast<ArrayMooseVariable &>(
+                                computeQpOffDiagJacobianArray(cast_ref<ArrayMooseVariable &>(
                                     const_cast<MooseVariableFieldBase &>(jvar)));
             for (unsigned int k = 0; k < v.size(); ++k)
               _local_ke(_i, _j + k * n) += v(k);

--- a/framework/src/kernels/Kernel.C
+++ b/framework/src/kernels/Kernel.C
@@ -169,10 +169,9 @@ Kernel::computeOffDiagJacobian(const unsigned int jvar_num)
         for (_j = 0; _j < phi_size; _j++)
           for (_qp = 0; _qp < _qrule->n_points(); _qp++)
           {
-            const RealEigenVector v =
-                _JxW[_qp] * _coord[_qp] *
-                computeQpOffDiagJacobianArray(
-                    static_cast<ArrayMooseVariable &>(const_cast<MooseVariableFieldBase &>(jvar)));
+            const RealEigenVector v = _JxW[_qp] * _coord[_qp] *
+                                      computeQpOffDiagJacobianArray(cast_ref<ArrayMooseVariable &>(
+                                          const_cast<MooseVariableFieldBase &>(jvar)));
             for (unsigned int k = 0; k < v.size(); ++k)
               _local_ke(_i, _j + k * n) += v(k);
           }

--- a/framework/src/kernels/KernelScalarBase.C
+++ b/framework/src/kernels/KernelScalarBase.C
@@ -142,7 +142,7 @@ KernelScalarBase::computeScalarOffDiagJacobian(const unsigned int jvar_num)
   if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_STANDARD)
   {
     // Get dofs and order of this variable; at least one will be _var
-    // const auto & jv0 = static_cast<const MooseVariable &>(jvar);
+    // const auto & jv0 = cast_ref<const MooseVariable &>(jvar);
     // const auto & loc_phi = jv0.phi();
     const auto jvar_size = jvar.phiSize();
     _local_ke.resize(_k_order, jvar_size);

--- a/framework/src/loops/NonlinearThread.C
+++ b/framework/src/loops/NonlinearThread.C
@@ -298,31 +298,31 @@ NonlinearThread::computeOnInternalFace(const Elem * neighbor)
 void
 NonlinearThread::compute(KernelBase & kernel)
 {
-  compute(static_cast<ResidualObject &>(kernel));
+  compute(cast_ref<ResidualObject &>(kernel));
 }
 
 void
 NonlinearThread::compute(FVElementalKernel & kernel)
 {
-  compute(static_cast<ResidualObject &>(kernel));
+  compute(cast_ref<ResidualObject &>(kernel));
 }
 
 void
 NonlinearThread::compute(IntegratedBCBase & bc)
 {
-  compute(static_cast<ResidualObject &>(bc));
+  compute(cast_ref<ResidualObject &>(bc));
 }
 
 void
 NonlinearThread::compute(DGKernelBase & dg, const Elem * /*neighbor*/)
 {
-  compute(static_cast<ResidualObject &>(dg));
+  compute(cast_ref<ResidualObject &>(dg));
 }
 
 void
 NonlinearThread::compute(InterfaceKernelBase & ik)
 {
-  compute(static_cast<ResidualObject &>(ik));
+  compute(cast_ref<ResidualObject &>(ik));
 }
 
 void

--- a/framework/src/meshgenerators/CartesianMeshGenerator.C
+++ b/framework/src/meshgenerators/CartesianMeshGenerator.C
@@ -305,15 +305,15 @@ CartesianMeshGenerator::generate()
   switch (_dim)
   {
     case 1:
-      MeshTools::Generation::build_line(static_cast<UnstructuredMesh &>(*mesh), _nx, 0, _nx, EDGE2);
+      MeshTools::Generation::build_line(cast_ref<UnstructuredMesh &>(*mesh), _nx, 0, _nx, EDGE2);
       break;
     case 2:
       MeshTools::Generation::build_square(
-          static_cast<UnstructuredMesh &>(*mesh), _nx, _ny, 0, _nx, 0, _ny, QUAD4);
+          cast_ref<UnstructuredMesh &>(*mesh), _nx, _ny, 0, _nx, 0, _ny, QUAD4);
       break;
     case 3:
       MeshTools::Generation::build_cube(
-          static_cast<UnstructuredMesh &>(*mesh), _nx, _ny, _nz, 0, _nx, 0, _ny, 0, _nz, HEX8);
+          cast_ref<UnstructuredMesh &>(*mesh), _nx, _ny, _nz, 0, _nx, 0, _ny, 0, _nz, HEX8);
       break;
   }
 

--- a/framework/src/meshgenerators/GeneratedMeshGenerator.C
+++ b/framework/src/meshgenerators/GeneratedMeshGenerator.C
@@ -160,15 +160,11 @@ GeneratedMeshGenerator::generate()
     // The build_XYZ mesh generation functions take an
     // UnstructuredMesh& as the first argument, hence the static_cast.
     case 1:
-      MeshTools::Generation::build_line(static_cast<UnstructuredMesh &>(*mesh),
-                                        _nx,
-                                        _xmin,
-                                        _xmax,
-                                        elem_type,
-                                        _gauss_lobatto_grid);
+      MeshTools::Generation::build_line(
+          cast_ref<UnstructuredMesh &>(*mesh), _nx, _xmin, _xmax, elem_type, _gauss_lobatto_grid);
       break;
     case 2:
-      MeshTools::Generation::build_square(static_cast<UnstructuredMesh &>(*mesh),
+      MeshTools::Generation::build_square(cast_ref<UnstructuredMesh &>(*mesh),
                                           _nx,
                                           _ny,
                                           _xmin,
@@ -179,7 +175,7 @@ GeneratedMeshGenerator::generate()
                                           _gauss_lobatto_grid);
       break;
     case 3:
-      MeshTools::Generation::build_cube(static_cast<UnstructuredMesh &>(*mesh),
+      MeshTools::Generation::build_cube(cast_ref<UnstructuredMesh &>(*mesh),
                                         _nx,
                                         _ny,
                                         _nz,

--- a/framework/src/meshmodifiers/ElementSubdomainModifier.C
+++ b/framework/src/meshmodifiers/ElementSubdomainModifier.C
@@ -48,7 +48,7 @@ void
 ElementSubdomainModifier::threadJoin(const UserObject & in_uo)
 {
   // Join the data from uo into _this_ object:
-  const auto & uo = static_cast<const ElementSubdomainModifier &>(in_uo);
+  const auto & uo = cast_ref<const ElementSubdomainModifier &>(in_uo);
 
   _moved_elems.insert(uo._moved_elems.begin(), uo._moved_elems.end());
 }

--- a/framework/src/meshmodifiers/SidesetAroundSubdomainUpdater.C
+++ b/framework/src/meshmodifiers/SidesetAroundSubdomainUpdater.C
@@ -151,7 +151,7 @@ SidesetAroundSubdomainUpdater::initialize()
 void
 SidesetAroundSubdomainUpdater::threadJoin(const UserObject & uo)
 {
-  const auto & sas = static_cast<const SidesetAroundSubdomainUpdater &>(uo);
+  const auto & sas = cast_ref<const SidesetAroundSubdomainUpdater &>(uo);
 
   for (const auto & [pid, list] : sas._add)
     _add[pid].insert(_add[pid].end(), list.begin(), list.end());

--- a/framework/src/mfem/actions/AddMFEMComplexBCComponentAction.C
+++ b/framework/src/mfem/actions/AddMFEMComplexBCComponentAction.C
@@ -38,10 +38,10 @@ AddMFEMComplexBCComponentAction::act()
   MooseUtils::tokenize<std::string>(_pars.blockFullpath(), elements);
 
   if (_problem->feBackend() == Moose::FEBackend::MFEM && _name == "RealComponent")
-    static_cast<MFEMProblem &>(*_problem).addRealComponentToBC(
+    cast_ref<MFEMProblem &>(*_problem).addRealComponentToBC(
         _type, elements[elements.size() - 2], _moose_object_pars);
   else if (_problem->feBackend() == Moose::FEBackend::MFEM && _name == "ImagComponent")
-    static_cast<MFEMProblem &>(*_problem).addImagComponentToBC(
+    cast_ref<MFEMProblem &>(*_problem).addImagComponentToBC(
         _type, elements[elements.size() - 2], _moose_object_pars);
 }
 

--- a/framework/src/mfem/actions/AddMFEMComplexKernelComponentAction.C
+++ b/framework/src/mfem/actions/AddMFEMComplexKernelComponentAction.C
@@ -40,10 +40,10 @@ AddMFEMComplexKernelComponentAction::act()
   MooseUtils::tokenize<std::string>(_pars.blockFullpath(), elements);
 
   if (_problem->feBackend() == Moose::FEBackend::MFEM && _name == "RealComponent")
-    static_cast<MFEMProblem &>(*_problem).addRealComponentToKernel(
+    cast_ref<MFEMProblem &>(*_problem).addRealComponentToKernel(
         _type, elements[elements.size() - 2], _moose_object_pars);
   else if (_problem->feBackend() == Moose::FEBackend::MFEM && _name == "ImagComponent")
-    static_cast<MFEMProblem &>(*_problem).addImagComponentToKernel(
+    cast_ref<MFEMProblem &>(*_problem).addImagComponentToKernel(
         _type, elements[elements.size() - 2], _moose_object_pars);
 }
 

--- a/framework/src/mfem/actions/AddMFEMFESpaceAction.C
+++ b/framework/src/mfem/actions/AddMFEMFESpaceAction.C
@@ -30,7 +30,7 @@ void
 AddMFEMFESpaceAction::act()
 {
   if (_problem->feBackend() == Moose::FEBackend::MFEM)
-    static_cast<MFEMProblem &>(*_problem).addFESpace(_type, _name, _moose_object_pars);
+    cast_ref<MFEMProblem &>(*_problem).addFESpace(_type, _name, _moose_object_pars);
 }
 
 #endif

--- a/framework/src/mfem/actions/AddMFEMFESpaceHierarchyAction.C
+++ b/framework/src/mfem/actions/AddMFEMFESpaceHierarchyAction.C
@@ -30,7 +30,7 @@ void
 AddMFEMFESpaceHierarchyAction::act()
 {
   if (_problem->feBackend() == Moose::FEBackend::MFEM)
-    static_cast<MFEMProblem &>(*_problem).addFESpaceHierarchy(_type, _name, _moose_object_pars);
+    cast_ref<MFEMProblem &>(*_problem).addFESpaceHierarchy(_type, _name, _moose_object_pars);
 }
 
 #endif

--- a/framework/src/mfem/actions/AddMFEMQuadratureFunctionAction.C
+++ b/framework/src/mfem/actions/AddMFEMQuadratureFunctionAction.C
@@ -30,7 +30,7 @@ void
 AddMFEMQuadratureFunctionAction::act()
 {
   if (_problem->feBackend() == Moose::FEBackend::MFEM)
-    static_cast<MFEMProblem &>(*_problem).addQuadratureFunction(_type, _name, _moose_object_pars);
+    cast_ref<MFEMProblem &>(*_problem).addQuadratureFunction(_type, _name, _moose_object_pars);
 }
 
 #endif

--- a/framework/src/mfem/actions/AddMFEMSolverAction.C
+++ b/framework/src/mfem/actions/AddMFEMSolverAction.C
@@ -31,7 +31,7 @@ void
 AddMFEMSolverAction::act()
 {
   if (_problem->feBackend() == Moose::FEBackend::MFEM)
-    static_cast<MFEMProblem &>(*_problem).addMFEMSolver(_type, _name, _moose_object_pars);
+    cast_ref<MFEMProblem &>(*_problem).addMFEMSolver(_type, _name, _moose_object_pars);
 }
 
 #endif

--- a/framework/src/mfem/actions/AddMFEMSubMeshAction.C
+++ b/framework/src/mfem/actions/AddMFEMSubMeshAction.C
@@ -30,7 +30,7 @@ void
 AddMFEMSubMeshAction::act()
 {
   if (_problem->feBackend() == Moose::FEBackend::MFEM)
-    static_cast<MFEMProblem &>(*_problem).addSubMesh(_type, _name, _moose_object_pars);
+    cast_ref<MFEMProblem &>(*_problem).addSubMesh(_type, _name, _moose_object_pars);
 }
 
 #endif

--- a/framework/src/mfem/actions/ResolveMFEMSolversAction.C
+++ b/framework/src/mfem/actions/ResolveMFEMSolversAction.C
@@ -30,7 +30,7 @@ void
 ResolveMFEMSolversAction::act()
 {
   if (_problem->feBackend() == Moose::FEBackend::MFEM)
-    static_cast<MFEMProblem &>(*_problem).resolveMFEMSolvers();
+    cast_ref<MFEMProblem &>(*_problem).resolveMFEMSolvers();
 }
 
 #endif

--- a/framework/src/mfem/actions/SetMFEMMeshFESpaceAction.C
+++ b/framework/src/mfem/actions/SetMFEMMeshFESpaceAction.C
@@ -32,7 +32,7 @@ SetMFEMMeshFESpaceAction::act()
 {
   if (_problem->feBackend() == Moose::FEBackend::MFEM)
   {
-    auto & mfem_problem = static_cast<MFEMProblem &>(*_problem);
+    auto & mfem_problem = cast_ref<MFEMProblem &>(*_problem);
     if (const auto displacement = mfem_problem.getMeshDisplacementGridFunction())
       mfem_problem.mesh().getMFEMParMesh().SetNodalFESpace(displacement.value().get().ParFESpace());
   }

--- a/framework/src/mfem/auxkernels/MFEMComplexAuxKernel.C
+++ b/framework/src/mfem/auxkernels/MFEMComplexAuxKernel.C
@@ -61,7 +61,7 @@ MFEMComplexAuxKernel::complexScale(mfem::ParComplexGridFunction & a,
   // a *= scale
 
   mfem::ParComplexGridFunction b(a.ParFESpace());
-  static_cast<mfem::Vector &>(b) = a;
+  cast_ref<mfem::Vector &>(b) = a;
 
   complexAdd(a, b, scale - 1);
 }

--- a/framework/src/mfem/base/MFEMObject.C
+++ b/framework/src/mfem/base/MFEMObject.C
@@ -32,7 +32,7 @@ MFEMObject::MFEMObject(const InputParameters & parameters)
     VectorPostprocessorInterface(this),
     ReporterInterface(this),
     _mfem_problem(
-        static_cast<MFEMProblem &>(*parameters.getCheckedPointerParam<SubProblem *>("_subproblem")))
+        cast_ref<MFEMProblem &>(*parameters.getCheckedPointerParam<SubProblem *>("_subproblem")))
 {
 }
 

--- a/framework/src/mfem/equation_systems/ComplexEquationSystem.C
+++ b/framework/src/mfem/equation_systems/ComplexEquationSystem.C
@@ -174,7 +174,7 @@ ComplexEquationSystem::ApplyEssentialBCs()
     trial_gf.Update();
 
     // Initial guess for iterative solvers (initial condition or the previous time step solution)
-    static_cast<mfem::Vector &>(trial_gf) = _complex_gfuncs->GetRef(trial_var_name);
+    cast_ref<mfem::Vector &>(trial_gf) = _complex_gfuncs->GetRef(trial_var_name);
 
     _ess_markers.at(i).SetSize(trial_gf.ParFESpace()->GetParMesh()->bdr_attributes.Max(), 0);
     // Set strongly constrained DoFs of trial_gf on essential boundaries and add markers for all

--- a/framework/src/mfem/functions/MFEMCoordinateTransformations.C
+++ b/framework/src/mfem/functions/MFEMCoordinateTransformations.C
@@ -28,8 +28,8 @@ MFEMCoordinateTransformations::validParams()
 
 MFEMCoordinateTransformations::MFEMCoordinateTransformations(const InputParameters & parameters)
   : Function(parameters),
-    _mfem_problem(static_cast<MFEMProblem &>(
-        *parameters.getCheckedPointerParam<SubProblem *>("_subproblem"))),
+    _mfem_problem(
+        cast_ref<MFEMProblem &>(*parameters.getCheckedPointerParam<SubProblem *>("_subproblem"))),
     _coord_type(getParam<MooseEnum>("coord_type")),
     _inv_r_eps(getParam<mfem::real_t>("inv_r_eps"))
 {

--- a/framework/src/mfem/functions/MFEMParsedFunction.C
+++ b/framework/src/mfem/functions/MFEMParsedFunction.C
@@ -27,7 +27,7 @@ MFEMParsedFunction::validParams()
 MFEMParsedFunction::MFEMParsedFunction(const InputParameters & parameters)
   : MooseParsedFunction(parameters),
     FunctionParserUtils(parameters),
-    _mfem_problem(static_cast<MFEMProblem &>(_pfb_feproblem)),
+    _mfem_problem(cast_ref<MFEMProblem &>(_pfb_feproblem)),
     _sym_function(std::make_shared<SymFunction>()),
     _xyzt({"x", "y", "z", "t"})
 {

--- a/framework/src/mfem/mesh/MFEMMesh.C
+++ b/framework/src/mfem/mesh/MFEMMesh.C
@@ -144,7 +144,7 @@ MFEMMesh::buildDummyMooseMesh()
 {
   // The libMesh placeholder is always replicated, independently of the distributed MFEM mesh.
   setParallelType(ParallelType::REPLICATED);
-  auto & dummy = static_cast<UnstructuredMesh &>(getMesh());
+  auto & dummy = cast_ref<UnstructuredMesh &>(getMesh());
   MeshTools::Generation::build_point(dummy);
   if (dimension() >= 2)
     MeshTools::Generation::build_square(dummy, 1, 1, 0., 1., 0., 1., ElemType::QUAD9);

--- a/framework/src/mfem/solvers/MFEMGeometricMultigridSolver.C
+++ b/framework/src/mfem/solvers/MFEMGeometricMultigridSolver.C
@@ -161,7 +161,7 @@ MFEMGeometricMultigridSolver::BuildMultigrid(const mfem::Operator & op)
   mfem::Array<int> & ess_bdr = eq_sys->GetEssentialBoundaryMarkers(_var_name);
 
   auto & finest_fespace =
-      static_cast<mfem::ParFiniteElementSpace &>(_hierarchy->GetFESpaceAtLevel(finest_level));
+      cast_ref<mfem::ParFiniteElementSpace &>(_hierarchy->GetFESpaceAtLevel(finest_level));
   const int finest_size = finest_fespace.GetTrueVSize();
   if (op.Height() != finest_size || op.Width() != finest_size)
     mooseError("GeometricMultigridSolver '",
@@ -185,7 +185,7 @@ MFEMGeometricMultigridSolver::BuildMultigrid(const mfem::Operator & op)
   for (const auto level : make_range(N))
   {
     auto & level_fespace =
-        static_cast<mfem::ParFiniteElementSpace &>(_hierarchy->GetFESpaceAtLevel(level));
+        cast_ref<mfem::ParFiniteElementSpace &>(_hierarchy->GetFESpaceAtLevel(level));
 
     // Compute essential true DoFs for this level.
     mfem::Array<int> level_tdofs;

--- a/framework/src/mfem/solvers/MFEMMatrixFreeAMS.C
+++ b/framework/src/mfem/solvers/MFEMMatrixFreeAMS.C
@@ -97,7 +97,7 @@ Moose::MFEM::LORLinearSolverBase<mfem::MatrixFreeAMS>::UpdateEquationSystemConte
   SetupLOR(_equation_system);
   // update the pointer to the bilinear form representing the curl-curl problem being
   // preconditioned
-  auto & matrix_free_ams = static_cast<Moose::MFEM::MatrixFreeAMS &>(*_solver);
+  auto & matrix_free_ams = cast_ref<Moose::MFEM::MatrixFreeAMS &>(*_solver);
   matrix_free_ams.SetBilinearForm(*_a);
   matrix_free_ams.SetBoundaryMarkers(_ess_bdr_markers);
 }

--- a/framework/src/mfem/solvers/MFEMNewtonNonlinearSolver.C
+++ b/framework/src/mfem/solvers/MFEMNewtonNonlinearSolver.C
@@ -43,6 +43,6 @@ MFEMNewtonNonlinearSolver::ConstructSolver()
 void
 MFEMNewtonNonlinearSolver::SetLinearSolver(mfem::Solver & solver)
 {
-  static_cast<mfem::NewtonSolver &>(GetSolver()).SetSolver(solver);
+  cast_ref<mfem::NewtonSolver &>(GetSolver()).SetSolver(solver);
 }
 #endif

--- a/framework/src/mfem/transfers/MultiAppMFEMCopyTransfer.C
+++ b/framework/src/mfem/transfers/MultiAppMFEMCopyTransfer.C
@@ -30,13 +30,13 @@ MultiAppMFEMCopyTransfer::MultiAppMFEMCopyTransfer(InputParameters const & param
 MFEMProblem &
 MultiAppMFEMCopyTransfer::getActiveFromProblem()
 {
-  return static_cast<MFEMProblem &>(MFEMMultiAppTransfer::getActiveFromProblem());
+  return cast_ref<MFEMProblem &>(MFEMMultiAppTransfer::getActiveFromProblem());
 }
 
 MFEMProblem &
 MultiAppMFEMCopyTransfer::getActiveToProblem()
 {
-  return static_cast<MFEMProblem &>(MFEMMultiAppTransfer::getActiveToProblem());
+  return cast_ref<MFEMProblem &>(MFEMMultiAppTransfer::getActiveToProblem());
 }
 
 void

--- a/framework/src/mfem/transfers/MultiAppMFEMShapeEvaluationTransfer.C
+++ b/framework/src/mfem/transfers/MultiAppMFEMShapeEvaluationTransfer.C
@@ -32,13 +32,13 @@ MultiAppMFEMShapeEvaluationTransfer::MultiAppMFEMShapeEvaluationTransfer(
 MFEMProblem &
 MultiAppMFEMShapeEvaluationTransfer::getActiveFromProblem()
 {
-  return static_cast<MFEMProblem &>(MFEMMultiAppTransfer::getActiveFromProblem());
+  return cast_ref<MFEMProblem &>(MFEMMultiAppTransfer::getActiveFromProblem());
 }
 
 MFEMProblem &
 MultiAppMFEMShapeEvaluationTransfer::getActiveToProblem()
 {
-  return static_cast<MFEMProblem &>(MFEMMultiAppTransfer::getActiveToProblem());
+  return cast_ref<MFEMProblem &>(MFEMMultiAppTransfer::getActiveToProblem());
 }
 
 void

--- a/framework/src/mfem/transfers/MultiAppMFEMTolibMeshShapeEvaluationTransfer.C
+++ b/framework/src/mfem/transfers/MultiAppMFEMTolibMeshShapeEvaluationTransfer.C
@@ -34,7 +34,7 @@ MultiAppMFEMTolibMeshShapeEvaluationTransfer::MultiAppMFEMTolibMeshShapeEvaluati
 MFEMProblem &
 MultiAppMFEMTolibMeshShapeEvaluationTransfer::getActiveFromProblem()
 {
-  return static_cast<MFEMProblem &>(MFEMMultiAppTransfer::getActiveFromProblem());
+  return cast_ref<MFEMProblem &>(MFEMMultiAppTransfer::getActiveFromProblem());
 }
 
 /// Extract locations from libMesh-based MooseVariable at which projection will take place

--- a/framework/src/mfem/transfers/MultiApplibMeshToMFEMShapeEvaluationTransfer.C
+++ b/framework/src/mfem/transfers/MultiApplibMeshToMFEMShapeEvaluationTransfer.C
@@ -35,7 +35,7 @@ MultiApplibMeshToMFEMShapeEvaluationTransfer::MultiApplibMeshToMFEMShapeEvaluati
 MFEMProblem &
 MultiApplibMeshToMFEMShapeEvaluationTransfer::getActiveToProblem()
 {
-  return static_cast<MFEMProblem &>(MFEMMultiAppTransfer::getActiveToProblem());
+  return cast_ref<MFEMProblem &>(MFEMMultiAppTransfer::getActiveToProblem());
 }
 
 void

--- a/framework/src/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMScalarCoefficientPointValueSampler.C
@@ -22,7 +22,7 @@ mfem::ParMesh &
 mainMesh(const InputParameters & parameters)
 {
   auto & problem =
-      static_cast<MFEMProblem &>(*parameters.getCheckedPointerParam<SubProblem *>("_subproblem"));
+      cast_ref<MFEMProblem &>(*parameters.getCheckedPointerParam<SubProblem *>("_subproblem"));
   return problem.mesh().getMFEMParMesh();
 }
 }

--- a/framework/src/mfem/vectorpostprocessors/MFEMVariableSamplerBase.C
+++ b/framework/src/mfem/vectorpostprocessors/MFEMVariableSamplerBase.C
@@ -23,7 +23,7 @@ mfem::ParMesh &
 variableMesh(const InputParameters & parameters)
 {
   auto & problem =
-      static_cast<MFEMProblem &>(*parameters.getCheckedPointerParam<SubProblem *>("_subproblem"));
+      cast_ref<MFEMProblem &>(*parameters.getCheckedPointerParam<SubProblem *>("_subproblem"));
   return const_cast<mfem::ParMesh &>(
       problem.getMFEMVariableMesh(parameters.get<VariableName>("variable")));
 }

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -1563,7 +1563,7 @@ dataStore(std::ostream & stream, SubAppBackups & backups, void * context)
 
   multi_app->backup();
 
-  dataStore(stream, static_cast<std::vector<std::unique_ptr<Backup>> &>(backups), nullptr);
+  dataStore(stream, cast_ref<std::vector<std::unique_ptr<Backup>> &>(backups), nullptr);
 }
 
 void
@@ -1572,7 +1572,7 @@ dataLoad(std::istream & stream, SubAppBackups & backups, void * context)
   MultiApp * multi_app = static_cast<MultiApp *>(context);
   mooseAssert(multi_app, "Not set");
 
-  dataLoad(stream, static_cast<std::vector<std::unique_ptr<Backup>> &>(backups), nullptr);
+  dataLoad(stream, cast_ref<std::vector<std::unique_ptr<Backup>> &>(backups), nullptr);
 
   multi_app->restore();
 }

--- a/framework/src/neml2/userobjects/MOOSEQuantityToNEML2.C
+++ b/framework/src/neml2/userobjects/MOOSEQuantityToNEML2.C
@@ -112,7 +112,7 @@ MOOSEQuantityToNEML2<T, state>::threadJoin(const UserObject & uo)
   if (!_batched)
     return;
   // append vectors
-  const auto & m2n = static_cast<const MOOSEQuantityToNEML2<T, state> &>(uo);
+  const auto & m2n = cast_ref<const MOOSEQuantityToNEML2<T, state> &>(uo);
   _buffer.insert(_buffer.end(), m2n._buffer.begin(), m2n._buffer.end());
 }
 

--- a/framework/src/neml2/userobjects/NEML2Assembly.C
+++ b/framework/src/neml2/userobjects/NEML2Assembly.C
@@ -59,7 +59,7 @@ NEML2Assembly::initialize()
 void
 NEML2Assembly::threadJoin(const UserObject & y)
 {
-  const auto & other = static_cast<const NEML2Assembly &>(y);
+  const auto & other = cast_ref<const NEML2Assembly &>(y);
   mooseAssert(_up_to_date == other._up_to_date,
               "NEML2Assembly becomes out of sync with other thread");
 

--- a/framework/src/neml2/userobjects/NEML2BatchIndexGenerator.C
+++ b/framework/src/neml2/userobjects/NEML2BatchIndexGenerator.C
@@ -76,7 +76,7 @@ NEML2BatchIndexGenerator::threadJoin(const UserObject & uo)
   if (!_outdated)
     return;
 
-  const auto & m2n = static_cast<const NEML2BatchIndexGenerator &>(uo);
+  const auto & m2n = cast_ref<const NEML2BatchIndexGenerator &>(uo);
 
   // append and renumber maps
   for (const auto & [elem_id, batch_index] : m2n._elem_to_batch_index)

--- a/framework/src/neml2/userobjects/NEML2FEInterpolation.C
+++ b/framework/src/neml2/userobjects/NEML2FEInterpolation.C
@@ -216,7 +216,7 @@ NEML2FEInterpolation::syncWithMainThread()
 void
 NEML2FEInterpolation::threadJoin(const UserObject & y)
 {
-  const auto & other = static_cast<const NEML2FEInterpolation &>(y);
+  const auto & other = cast_ref<const NEML2FEInterpolation &>(y);
   mooseAssert(_fem_context_up_to_date == other._fem_context_up_to_date,
               "NEML2FEInterpolation becomes out of sync with other thread");
 

--- a/framework/src/partitioner/LibmeshPartitioner.C
+++ b/framework/src/partitioner/LibmeshPartitioner.C
@@ -175,7 +175,7 @@ LibmeshPartitioner::partition(MeshBase & mesh, const unsigned int n)
   {
     mooseAssert(_partitioner.get(), "Partitioner is a NULL object");
     prepareBlocksForSubdomainPartitioner(
-        mesh, static_cast<libMesh::SubdomainPartitioner &>(*_partitioner.get()));
+        mesh, cast_ref<libMesh::SubdomainPartitioner &>(*_partitioner.get()));
   }
 
   _partitioner->partition(mesh, n);
@@ -188,7 +188,7 @@ LibmeshPartitioner::partition(MeshBase & mesh)
   {
     mooseAssert(_partitioner.get(), "Partitioner is a NULL object");
     prepareBlocksForSubdomainPartitioner(
-        mesh, static_cast<libMesh::SubdomainPartitioner &>(*_partitioner.get()));
+        mesh, cast_ref<libMesh::SubdomainPartitioner &>(*_partitioner.get()));
   }
 
   _partitioner->partition(mesh);

--- a/framework/src/postprocessors/AreaPostprocessor.C
+++ b/framework/src/postprocessors/AreaPostprocessor.C
@@ -29,7 +29,7 @@ AreaPostprocessor::AreaPostprocessor(const InputParameters & parameters)
 void
 AreaPostprocessor::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const AreaPostprocessor &>(y);
+  const auto & pps = cast_ref<const AreaPostprocessor &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/framework/src/postprocessors/AverageElementSize.C
+++ b/framework/src/postprocessors/AverageElementSize.C
@@ -47,7 +47,7 @@ AverageElementSize::getValue() const
 void
 AverageElementSize::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const AverageElementSize &>(y);
+  const auto & pps = cast_ref<const AverageElementSize &>(y);
   _total_size += pps._total_size;
   _elems += pps._elems;
 }

--- a/framework/src/postprocessors/AverageNodalVariableValue.C
+++ b/framework/src/postprocessors/AverageNodalVariableValue.C
@@ -65,7 +65,7 @@ AverageNodalVariableValue::finalize()
 void
 AverageNodalVariableValue::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const AverageNodalVariableValue &>(y);
+  const auto & pps = cast_ref<const AverageNodalVariableValue &>(y);
   _sum += pps._sum;
   _n += pps._n;
 }

--- a/framework/src/postprocessors/AverageVariableChange.C
+++ b/framework/src/postprocessors/AverageVariableChange.C
@@ -59,7 +59,7 @@ void
 AverageVariableChange::threadJoin(const UserObject & y)
 {
   ElementIntegralVariablePostprocessor::threadJoin(y);
-  const auto & pps = static_cast<const AverageVariableChange &>(y);
+  const auto & pps = cast_ref<const AverageVariableChange &>(y);
   _volume += pps._volume;
 }
 

--- a/framework/src/postprocessors/DiscreteVariableResidualNorm.C
+++ b/framework/src/postprocessors/DiscreteVariableResidualNorm.C
@@ -84,7 +84,7 @@ DiscreteVariableResidualNorm::execute()
 void
 DiscreteVariableResidualNorm::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const DiscreteVariableResidualNorm &>(y);
+  const auto & pps = cast_ref<const DiscreteVariableResidualNorm &>(y);
   _local_dof_indices.insert(pps._local_dof_indices.begin(), pps._local_dof_indices.end());
 }
 

--- a/framework/src/postprocessors/ElementAverageFunctorPostprocessor.C
+++ b/framework/src/postprocessors/ElementAverageFunctorPostprocessor.C
@@ -54,6 +54,6 @@ void
 ElementAverageFunctorPostprocessor::threadJoin(const UserObject & y)
 {
   ElementIntegralFunctorPostprocessor::threadJoin(y);
-  const auto & pps = static_cast<const ElementAverageFunctorPostprocessor &>(y);
+  const auto & pps = cast_ref<const ElementAverageFunctorPostprocessor &>(y);
   _volume += pps._volume;
 }

--- a/framework/src/postprocessors/ElementAverageMaterialProperty.C
+++ b/framework/src/postprocessors/ElementAverageMaterialProperty.C
@@ -67,7 +67,7 @@ ElementAverageMaterialPropertyTempl<is_ad>::threadJoin(const UserObject & y)
 {
   ElementIntegralMaterialPropertyTempl<is_ad>::threadJoin(y);
 
-  const auto & pps = static_cast<const ElementAverageMaterialPropertyTempl<is_ad> &>(y);
+  const auto & pps = cast_ref<const ElementAverageMaterialPropertyTempl<is_ad> &>(y);
   _volume += pps._volume;
 }
 

--- a/framework/src/postprocessors/ElementAverageValue.C
+++ b/framework/src/postprocessors/ElementAverageValue.C
@@ -55,6 +55,6 @@ void
 ElementAverageValue::threadJoin(const UserObject & y)
 {
   ElementIntegralVariablePostprocessor::threadJoin(y);
-  const auto & pps = static_cast<const ElementAverageValue &>(y);
+  const auto & pps = cast_ref<const ElementAverageValue &>(y);
   _volume += pps._volume;
 }

--- a/framework/src/postprocessors/ElementExtremeMaterialProperty.C
+++ b/framework/src/postprocessors/ElementExtremeMaterialProperty.C
@@ -116,7 +116,7 @@ template <bool is_ad>
 void
 ElementExtremeMaterialPropertyTempl<is_ad>::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const ElementExtremeMaterialPropertyTempl<is_ad> &>(y);
+  const auto & pps = cast_ref<const ElementExtremeMaterialPropertyTempl<is_ad> &>(y);
 
   switch (_type)
   {

--- a/framework/src/postprocessors/ElementIntegralPostprocessor.C
+++ b/framework/src/postprocessors/ElementIntegralPostprocessor.C
@@ -44,7 +44,7 @@ ElementIntegralPostprocessor::getValue() const
 void
 ElementIntegralPostprocessor::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const ElementIntegralPostprocessor &>(y);
+  const auto & pps = cast_ref<const ElementIntegralPostprocessor &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/framework/src/postprocessors/ElementMaxLevelPostProcessor.C
+++ b/framework/src/postprocessors/ElementMaxLevelPostProcessor.C
@@ -60,7 +60,7 @@ ElementMaxLevelPostProcessor::getValue() const
 void
 ElementMaxLevelPostProcessor::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const ElementMaxLevelPostProcessor &>(y);
+  const auto & pps = cast_ref<const ElementMaxLevelPostProcessor &>(y);
   _max_level = std::max(_max_level, pps._max_level);
 }
 

--- a/framework/src/postprocessors/ElementalVariableValue.C
+++ b/framework/src/postprocessors/ElementalVariableValue.C
@@ -29,7 +29,7 @@ ElementalVariableValue::validParams()
 ElementalVariableValue::ElementalVariableValue(const InputParameters & parameters)
   : GeneralPostprocessor(parameters),
     _mesh(_subproblem.mesh()),
-    _var(libMesh::cast_ref<MooseVariableField<Real> &>(
+    _var(cast_ref<MooseVariableField<Real> &>(
         _subproblem.getActualFieldVariable(_tid, getParam<VariableName>("variable")))),
     _var_sln(_var.sln()),
     _value(0)

--- a/framework/src/postprocessors/ExtremeValueBase.C
+++ b/framework/src/postprocessors/ExtremeValueBase.C
@@ -82,7 +82,7 @@ template <class T>
 void
 ExtremeValueBase<T>::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const ExtremeValueBase<T> &>(y);
+  const auto & pps = cast_ref<const ExtremeValueBase<T> &>(y);
 
   if (((_type == ExtremeType::MAX || _type == ExtremeType::MAX_ABS) &&
        pps._proxy_value > _proxy_value) ||

--- a/framework/src/postprocessors/FunctionElementAverage.C
+++ b/framework/src/postprocessors/FunctionElementAverage.C
@@ -55,6 +55,6 @@ void
 FunctionElementAverage::threadJoin(const UserObject & y)
 {
   FunctionElementIntegral::threadJoin(y);
-  const auto & pps = static_cast<const FunctionElementAverage &>(y);
+  const auto & pps = cast_ref<const FunctionElementAverage &>(y);
   _volume += pps._volume;
 }

--- a/framework/src/postprocessors/FunctionSideAverage.C
+++ b/framework/src/postprocessors/FunctionSideAverage.C
@@ -48,7 +48,7 @@ void
 FunctionSideAverage::threadJoin(const UserObject & y)
 {
   FunctionSideIntegral::threadJoin(y);
-  const auto & pps = static_cast<const FunctionSideAverage &>(y);
+  const auto & pps = cast_ref<const FunctionSideAverage &>(y);
   _volume += pps._volume;
 }
 

--- a/framework/src/postprocessors/FunctionSideIntegral.C
+++ b/framework/src/postprocessors/FunctionSideIntegral.C
@@ -32,7 +32,7 @@ FunctionSideIntegral::FunctionSideIntegral(const InputParameters & parameters)
 void
 FunctionSideIntegral::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const FunctionSideIntegral &>(y);
+  const auto & pps = cast_ref<const FunctionSideIntegral &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/framework/src/postprocessors/InterfaceDiffusiveFluxAverage.C
+++ b/framework/src/postprocessors/InterfaceDiffusiveFluxAverage.C
@@ -63,7 +63,7 @@ void
 InterfaceDiffusiveFluxAverageTempl<is_ad>::threadJoin(const UserObject & y)
 {
   InterfaceDiffusiveFluxIntegralTempl<is_ad>::threadJoin(y);
-  const auto & pps = static_cast<const InterfaceDiffusiveFluxAverageTempl<is_ad> &>(y);
+  const auto & pps = cast_ref<const InterfaceDiffusiveFluxAverageTempl<is_ad> &>(y);
   _volume += pps._volume;
 }
 

--- a/framework/src/postprocessors/InterfaceIntegralPostprocessor.C
+++ b/framework/src/postprocessors/InterfaceIntegralPostprocessor.C
@@ -51,7 +51,7 @@ void
 InterfaceIntegralPostprocessor::threadJoin(const UserObject & y)
 {
   InterfacePostprocessor::threadJoin(y);
-  const auto & pps = static_cast<const InterfaceIntegralPostprocessor &>(y);
+  const auto & pps = cast_ref<const InterfaceIntegralPostprocessor &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/framework/src/postprocessors/InterfacePostprocessor.C
+++ b/framework/src/postprocessors/InterfacePostprocessor.C
@@ -42,7 +42,7 @@ InterfacePostprocessor::execute()
 void
 InterfacePostprocessor::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const InterfacePostprocessor &>(y);
+  const auto & pps = cast_ref<const InterfacePostprocessor &>(y);
   _interface_primary_area += pps._interface_primary_area;
 }
 

--- a/framework/src/postprocessors/InternalSideIntegralPostprocessor.C
+++ b/framework/src/postprocessors/InternalSideIntegralPostprocessor.C
@@ -45,7 +45,7 @@ InternalSideIntegralPostprocessor::getValue() const
 void
 InternalSideIntegralPostprocessor::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const InternalSideIntegralPostprocessor &>(y);
+  const auto & pps = cast_ref<const InternalSideIntegralPostprocessor &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/framework/src/postprocessors/NodalL2Error.C
+++ b/framework/src/postprocessors/NodalL2Error.C
@@ -50,7 +50,7 @@ NodalL2Error::getValue() const
 void
 NodalL2Error::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const NodalL2Error &>(y);
+  const auto & pps = cast_ref<const NodalL2Error &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/framework/src/postprocessors/NodalL2Norm.C
+++ b/framework/src/postprocessors/NodalL2Norm.C
@@ -49,7 +49,7 @@ NodalL2Norm::getValue() const
 void
 NodalL2Norm::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const NodalL2Norm &>(y);
+  const auto & pps = cast_ref<const NodalL2Norm &>(y);
   _sum_of_squares += pps._sum_of_squares;
 }
 

--- a/framework/src/postprocessors/NodalMaxValue.C
+++ b/framework/src/postprocessors/NodalMaxValue.C
@@ -54,6 +54,6 @@ NodalMaxValue::finalize()
 void
 NodalMaxValue::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const NodalMaxValue &>(y);
+  const auto & pps = cast_ref<const NodalMaxValue &>(y);
   _value = std::max(_value, pps._value);
 }

--- a/framework/src/postprocessors/NodalMaxValueId.C
+++ b/framework/src/postprocessors/NodalMaxValueId.C
@@ -69,7 +69,7 @@ NodalMaxValueId::finalize()
 void
 NodalMaxValueId::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const NodalMaxValueId &>(y);
+  const auto & pps = cast_ref<const NodalMaxValueId &>(y);
   if (pps._value > _value)
   {
     _value = pps._value;

--- a/framework/src/postprocessors/NodalSum.C
+++ b/framework/src/postprocessors/NodalSum.C
@@ -57,6 +57,6 @@ NodalSum::finalize()
 void
 NodalSum::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const NodalSum &>(y);
+  const auto & pps = cast_ref<const NodalSum &>(y);
   _sum += pps._sum;
 }

--- a/framework/src/postprocessors/SideAverageFunctorPostprocessor.C
+++ b/framework/src/postprocessors/SideAverageFunctorPostprocessor.C
@@ -57,6 +57,6 @@ SideAverageFunctorPostprocessor::threadJoin(const UserObject & y)
 {
   SideIntegralFunctorPostprocessorTempl<false>::threadJoin(y);
 
-  const auto & pps = static_cast<const SideAverageFunctorPostprocessor &>(y);
+  const auto & pps = cast_ref<const SideAverageFunctorPostprocessor &>(y);
   _area += pps._area;
 }

--- a/framework/src/postprocessors/SideAverageMaterialProperty.C
+++ b/framework/src/postprocessors/SideAverageMaterialProperty.C
@@ -66,7 +66,7 @@ SideAverageMaterialPropertyTempl<is_ad>::threadJoin(const UserObject & y)
 {
   SideIntegralMaterialPropertyTempl<is_ad>::threadJoin(y);
 
-  const auto & pps = static_cast<const SideAverageMaterialPropertyTempl<is_ad> &>(y);
+  const auto & pps = cast_ref<const SideAverageMaterialPropertyTempl<is_ad> &>(y);
   _area += pps._area;
 }
 

--- a/framework/src/postprocessors/SideAverageValue.C
+++ b/framework/src/postprocessors/SideAverageValue.C
@@ -65,7 +65,7 @@ void
 SideAverageValue::threadJoin(const UserObject & y)
 {
   SideIntegralVariablePostprocessor::threadJoin(y);
-  const auto & pps = static_cast<const SideAverageValue &>(y);
+  const auto & pps = cast_ref<const SideAverageValue &>(y);
   _volume += pps._volume;
 }
 

--- a/framework/src/postprocessors/SideDiffusiveFluxAverage.C
+++ b/framework/src/postprocessors/SideDiffusiveFluxAverage.C
@@ -73,7 +73,7 @@ void
 SideDiffusiveFluxAverageTempl<is_ad>::threadJoin(const UserObject & y)
 {
   SideDiffusiveFluxIntegralTempl<is_ad, Real>::threadJoin(y);
-  const auto & pps = static_cast<const SideDiffusiveFluxAverageTempl<is_ad> &>(y);
+  const auto & pps = cast_ref<const SideDiffusiveFluxAverageTempl<is_ad> &>(y);
   _volume += pps._volume;
 }
 

--- a/framework/src/postprocessors/SideIntegralPostprocessor.C
+++ b/framework/src/postprocessors/SideIntegralPostprocessor.C
@@ -53,7 +53,7 @@ SideIntegralPostprocessor::getValue() const
 void
 SideIntegralPostprocessor::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const SideIntegralPostprocessor &>(y);
+  const auto & pps = cast_ref<const SideIntegralPostprocessor &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/framework/src/postprocessors/VolumePostprocessor.C
+++ b/framework/src/postprocessors/VolumePostprocessor.C
@@ -27,7 +27,7 @@ VolumePostprocessor::VolumePostprocessor(const InputParameters & parameters)
 void
 VolumePostprocessor::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const VolumePostprocessor &>(y);
+  const auto & pps = cast_ref<const VolumePostprocessor &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1483,8 +1483,7 @@ FEProblemBase::initialSetup()
               node->n_dofs(nl->number(), bnd_variable.number()))
           {
             std::set<MooseVariableFieldBase *> vars_to_omit = {
-                &static_cast<MooseVariableFieldBase &>(
-                    const_cast<MooseVariableBase &>(bnd_variable))};
+                &cast_ref<MooseVariableFieldBase &>(const_cast<MooseVariableBase &>(bnd_variable))};
 
             boundaryIntegrityCheckError(
                 *bnd_object, bnd_object->checkAllVariables(*node, vars_to_omit), bnd_name);

--- a/framework/src/reporters/ElementExtremeMaterialPropertyReporter.C
+++ b/framework/src/reporters/ElementExtremeMaterialPropertyReporter.C
@@ -159,7 +159,7 @@ template <bool is_ad>
 void
 ElementExtremeMaterialPropertyReporterTempl<is_ad>::threadJoin(const UserObject & uo)
 {
-  const auto & rpt = static_cast<const ElementExtremeMaterialPropertyReporterTempl<is_ad> &>(uo);
+  const auto & rpt = cast_ref<const ElementExtremeMaterialPropertyReporterTempl<is_ad> &>(uo);
   const auto prop_size = _additional_reported_property_values.size();
 
   switch (_type)

--- a/framework/src/reporters/ElementStatistics.C
+++ b/framework/src/reporters/ElementStatistics.C
@@ -60,7 +60,7 @@ ElementStatistics::execute()
 void
 ElementStatistics::threadJoin(const UserObject & uo)
 {
-  const ElementStatistics & ele_uo = static_cast<const ElementStatistics &>(uo);
+  const ElementStatistics & ele_uo = cast_ref<const ElementStatistics &>(uo);
   _max = std::max(_max, ele_uo._max);
   _min = std::min(_min, ele_uo._min);
   _integral += ele_uo._integral;

--- a/framework/src/reporters/MeshInfo.C
+++ b/framework/src/reporters/MeshInfo.C
@@ -389,9 +389,9 @@ MeshInfo::possiblyAddElemInfo()
     // bounding_box
     if (items.bounding_box)
       gather([](const auto & info)
-             { return static_cast<const std::pair<Point, Point> &>(info.bounding_box); },
+             { return cast_ref<const std::pair<Point, Point> &>(info.bounding_box); },
              [](auto & info, const auto & value)
-             { static_cast<std::pair<Point, Point> &>(info.bounding_box) = value; });
+             { cast_ref<std::pair<Point, Point> &>(info.bounding_box) = value; });
 
 #define gather_simple(name)                                                                        \
   if (items.name)                                                                                  \

--- a/framework/src/reporters/NodalStatistics.C
+++ b/framework/src/reporters/NodalStatistics.C
@@ -56,7 +56,7 @@ NodalStatistics::execute()
 void
 NodalStatistics::threadJoin(const UserObject & uo)
 {
-  const NodalStatistics & node_uo = static_cast<const NodalStatistics &>(uo);
+  const NodalStatistics & node_uo = cast_ref<const NodalStatistics &>(uo);
   _max = std::max(_max, node_uo._max);
   _min = std::min(_min, node_uo._min);
   _average += node_uo._average;

--- a/framework/src/restart/DataIO.C
+++ b/framework/src/restart/DataIO.C
@@ -52,7 +52,7 @@ template <>
 void
 dataStore(std::ostream & stream, VariableName & v, void * context)
 {
-  auto & name = static_cast<std::string &>(v);
+  auto & name = cast_ref<std::string &>(v);
   dataStore(stream, name, context);
 }
 
@@ -60,7 +60,7 @@ template <>
 void
 dataStore(std::ostream & stream, UserObjectName & v, void * context)
 {
-  auto & name = static_cast<std::string &>(v);
+  auto & name = cast_ref<std::string &>(v);
   dataStore(stream, name, context);
 }
 
@@ -297,7 +297,7 @@ dataStore(std::ostream & stream, const Point & p, void * context)
 void
 dataStore(std::ostream & stream, libMesh::BoundingBox & bbox, void * context)
 {
-  dataStore(stream, static_cast<std::pair<Point, Point> &>(bbox), context);
+  dataStore(stream, cast_ref<std::pair<Point, Point> &>(bbox), context);
 }
 
 template <>
@@ -420,7 +420,7 @@ template <>
 void
 dataLoad(std::istream & stream, VariableName & v, void * context)
 {
-  auto & name = static_cast<std::string &>(v);
+  auto & name = cast_ref<std::string &>(v);
   dataLoad(stream, name, context);
 }
 
@@ -428,7 +428,7 @@ template <>
 void
 dataLoad(std::istream & stream, UserObjectName & v, void * context)
 {
-  auto & name = static_cast<std::string &>(v);
+  auto & name = cast_ref<std::string &>(v);
   dataLoad(stream, name, context);
 }
 
@@ -664,7 +664,7 @@ dataLoad(std::istream & stream, Point & p, void * context)
 void
 dataLoad(std::istream & stream, libMesh::BoundingBox & bbox, void * context)
 {
-  dataLoad(stream, static_cast<std::pair<Point, Point> &>(bbox), context);
+  dataLoad(stream, cast_ref<std::pair<Point, Point> &>(bbox), context);
 }
 
 template <>

--- a/framework/src/systems/AuxiliarySystem.C
+++ b/framework/src/systems/AuxiliarySystem.C
@@ -41,7 +41,7 @@ using namespace libMesh;
 AuxiliarySystem::AuxiliarySystem(FEProblemBase & subproblem, const std::string & name)
   : SystemBase(subproblem, subproblem, name, Moose::VAR_AUXILIARY),
     PerfGraphInterface(subproblem.getMooseApp().perfGraph(), "AuxiliarySystem"),
-    LinearFVGradientInterface(static_cast<SystemBase &>(*this)),
+    LinearFVGradientInterface(cast_ref<SystemBase &>(*this)),
     _sys(subproblem.es().add_system<System>(name)),
     _current_solution(_sys.current_local_solution.get()),
     _aux_scalar_storage(_app.getExecuteOnEnum()),

--- a/framework/src/systems/LinearSystem.C
+++ b/framework/src/systems/LinearSystem.C
@@ -77,7 +77,7 @@ compute_linear_system(libMesh::EquationSystems & es, const std::string & system_
 LinearSystem::LinearSystem(FEProblemBase & fe_problem, const std::string & name)
   : SolverSystem(fe_problem, fe_problem, name, Moose::VAR_SOLVER),
     PerfGraphInterface(fe_problem.getMooseApp().perfGraph(), "LinearSystem"),
-    LinearFVGradientInterface(static_cast<SystemBase &>(*this)),
+    LinearFVGradientInterface(cast_ref<SystemBase &>(*this)),
     _sys(fe_problem.es().add_system<LinearImplicitSystem>(name)),
     _rhs_time_tag(-1),
     _rhs_time(NULL),
@@ -317,7 +317,7 @@ LinearSystem::solve()
   _n_linear_iters = _linear_implicit_system.n_linear_iterations();
 
   auto & linear_solver =
-      libMesh::cast_ref<PetscLinearSolver<Real> &>(*_linear_implicit_system.get_linear_solver());
+      cast_ref<PetscLinearSolver<Real> &>(*_linear_implicit_system.get_linear_solver());
   _initial_linear_residual = linear_solver.get_initial_residual();
   _final_linear_residual = _linear_implicit_system.final_linear_residual();
   _converged = linear_solver.get_converged_reason() > 0;

--- a/framework/src/systems/NonlinearEigenSystem.C
+++ b/framework/src/systems/NonlinearEigenSystem.C
@@ -89,7 +89,7 @@ assemble_matrix(EquationSystems & es, const std::string & system_name)
     if (p->negativeSignEigenKernel())
       LibmeshPetscCallA(
           p->comm().get(),
-          MatScale(static_cast<PetscMatrix<Number> &>(eigen_system.get_matrix_B()).mat(), -1.0));
+          MatScale(cast_ref<PetscMatrix<Number> &>(eigen_system.get_matrix_B()).mat(), -1.0));
 #endif
     return;
   }
@@ -359,7 +359,7 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
     // Condensed Matrix A
     if (_eigen_sys.has_condensed_matrix_A())
     {
-      Mat mat = static_cast<PetscMatrix<Number> &>(_eigen_sys.get_condensed_matrix_A()).mat();
+      Mat mat = cast_ref<PetscMatrix<Number> &>(_eigen_sys.get_condensed_matrix_A()).mat();
 
       Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, false);
     }
@@ -367,7 +367,7 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
     // Condensed Matrix B
     if (_eigen_sys.has_condensed_matrix_B())
     {
-      Mat mat = static_cast<PetscMatrix<Number> &>(_eigen_sys.get_condensed_matrix_B()).mat();
+      Mat mat = cast_ref<PetscMatrix<Number> &>(_eigen_sys.get_condensed_matrix_B()).mat();
 
       Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, true);
     }
@@ -375,7 +375,7 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
     // Condensed Preconditioning matrix
     if (_eigen_sys.has_condensed_precond_matrix())
     {
-      Mat mat = static_cast<PetscMatrix<Number> &>(_eigen_sys.get_condensed_precond_matrix()).mat();
+      Mat mat = cast_ref<PetscMatrix<Number> &>(_eigen_sys.get_condensed_precond_matrix()).mat();
 
       Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, true);
     }
@@ -385,7 +385,7 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
     // Matrix A
     if (_eigen_sys.has_matrix_A())
     {
-      Mat mat = static_cast<PetscMatrix<Number> &>(_eigen_sys.get_matrix_A()).mat();
+      Mat mat = cast_ref<PetscMatrix<Number> &>(_eigen_sys.get_matrix_A()).mat();
 
       Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, false);
     }
@@ -393,7 +393,7 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
     // Matrix B
     if (_eigen_sys.has_matrix_B())
     {
-      Mat mat = static_cast<PetscMatrix<Number> &>(_eigen_sys.get_matrix_B()).mat();
+      Mat mat = cast_ref<PetscMatrix<Number> &>(_eigen_sys.get_matrix_B()).mat();
 
       Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, true);
     }
@@ -401,7 +401,7 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
     // Preconditioning matrix
     if (_eigen_sys.has_precond_matrix())
     {
-      Mat mat = static_cast<PetscMatrix<Number> &>(_eigen_sys.get_precond_matrix()).mat();
+      Mat mat = cast_ref<PetscMatrix<Number> &>(_eigen_sys.get_precond_matrix()).mat();
 
       Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, true);
     }
@@ -410,7 +410,7 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
   // Shell matrix A
   if (_eigen_sys.has_shell_matrix_A())
   {
-    Mat mat = static_cast<PetscShellMatrix<Number> &>(_eigen_sys.get_shell_matrix_A()).mat();
+    Mat mat = cast_ref<PetscShellMatrix<Number> &>(_eigen_sys.get_shell_matrix_A()).mat();
 
     // Attach callbacks for nonlinear eigenvalue solver
     Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, false);
@@ -422,7 +422,7 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
   // Shell matrix B
   if (_eigen_sys.has_shell_matrix_B())
   {
-    Mat mat = static_cast<PetscShellMatrix<Number> &>(_eigen_sys.get_shell_matrix_B()).mat();
+    Mat mat = cast_ref<PetscShellMatrix<Number> &>(_eigen_sys.get_shell_matrix_B()).mat();
 
     Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, true);
 
@@ -433,7 +433,7 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
   // Shell preconditioning matrix
   if (_eigen_sys.has_shell_precond_matrix())
   {
-    Mat mat = static_cast<PetscShellMatrix<Number> &>(_eigen_sys.get_shell_precond_matrix()).mat();
+    Mat mat = cast_ref<PetscShellMatrix<Number> &>(_eigen_sys.get_shell_precond_matrix()).mat();
 
     Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, true);
   }

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -131,7 +131,7 @@ NonlinearSystem::potentiallySetupFiniteDifferencing()
   }
 
   PetscNonlinearSolver<Real> & solver =
-      static_cast<PetscNonlinearSolver<Real> &>(*_nl_implicit_sys.nonlinear_solver);
+      cast_ref<PetscNonlinearSolver<Real> &>(*_nl_implicit_sys.nonlinear_solver);
   solver.mffd_residual_object = &_fd_residual_functor;
 
   solver.set_snesmf_reuse_base(_fe_problem.useSNESMFReuseBase());
@@ -214,7 +214,7 @@ NonlinearSystem::stopSolve(const ExecFlagType & exec_flag,
                            const std::set<TagID> & vector_tags_to_close)
 {
   PetscNonlinearSolver<Real> & solver =
-      static_cast<PetscNonlinearSolver<Real> &>(*sys().nonlinear_solver);
+      cast_ref<PetscNonlinearSolver<Real> &>(*sys().nonlinear_solver);
 
   if (exec_flag == EXEC_LINEAR || exec_flag == EXEC_POSTCHECK)
   {

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -326,9 +326,8 @@ NonlinearSystemBase::initialSetup()
         auto & mortar_constraints =
             _constraints.getActiveMortarConstraints(primary_secondary_boundary_pair, displaced);
 
-        auto & subproblem = displaced
-                                ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
-                                : static_cast<SubProblem &>(_fe_problem);
+        auto & subproblem = displaced ? cast_ref<SubProblem &>(*_fe_problem.getDisplacedProblem())
+                                      : cast_ref<SubProblem &>(_fe_problem);
 
         auto & mortar_functors =
             displaced ? _displaced_mortar_functors : _undisplaced_mortar_functors;
@@ -1137,8 +1136,8 @@ NonlinearSystemBase::reinitNodeFace(const Node & secondary_node,
                                     const PenetrationInfo & info,
                                     const bool displaced)
 {
-  auto & subproblem = displaced ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
-                                : static_cast<SubProblem &>(_fe_problem);
+  auto & subproblem = displaced ? cast_ref<SubProblem &>(*_fe_problem.getDisplacedProblem())
+                                : cast_ref<SubProblem &>(_fe_problem);
 
   const Elem * primary_elem = info._elem;
   unsigned int primary_side = info._side_num;
@@ -1201,8 +1200,8 @@ NonlinearSystemBase::setConstraintSecondaryValues(NumericVector<Number> & soluti
     mooseAssert(_fe_problem.getDisplacedProblem(),
                 "If we're calling this method with displaced = true, then we better well have a "
                 "displaced problem");
-  auto & subproblem = displaced ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
-                                : static_cast<SubProblem &>(_fe_problem);
+  auto & subproblem = displaced ? cast_ref<SubProblem &>(*_fe_problem.getDisplacedProblem())
+                                : cast_ref<SubProblem &>(_fe_problem);
   const auto & penetration_locators = subproblem.geomSearchData()._penetration_locators;
 
   bool constraints_applied = false;
@@ -1345,8 +1344,8 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
     mooseAssert(_fe_problem.getDisplacedProblem(),
                 "If we're calling this method with displaced = true, then we better well have a "
                 "displaced problem");
-  auto & subproblem = displaced ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
-                                : static_cast<SubProblem &>(_fe_problem);
+  auto & subproblem = displaced ? cast_ref<SubProblem &>(*_fe_problem.getDisplacedProblem())
+                                : cast_ref<SubProblem &>(_fe_problem);
   const auto & penetration_locators = subproblem.geomSearchData()._penetration_locators;
 
   bool constraints_applied;
@@ -1656,8 +1655,8 @@ NonlinearSystemBase::overwriteNodeFace(NumericVector<Number> & soln)
 {
   // Overwrite results from integrator in case we have explicit dynamics contact constraints
   auto & subproblem = _fe_problem.getDisplacedProblem()
-                          ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
-                          : static_cast<SubProblem &>(_fe_problem);
+                          ? cast_ref<SubProblem &>(*_fe_problem.getDisplacedProblem())
+                          : cast_ref<SubProblem &>(_fe_problem);
   const auto & penetration_locators = subproblem.geomSearchData()._penetration_locators;
 
   for (const auto & it : penetration_locators)
@@ -2008,9 +2007,8 @@ NonlinearSystemBase::computeResidualAndJacobianInternal(const std::set<TagID> & 
         LibmeshPetscCall(
             MatSetOption(petsc_matrix->mat(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE));
       if (_fe_problem.ignoreZerosInJacobian())
-        LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
-                                      MAT_IGNORE_ZERO_ENTRIES,
-                                      PETSC_TRUE));
+        LibmeshPetscCall(MatSetOption(
+            cast_ref<PetscMatrix<Number> &>(jacobian).mat(), MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE));
     }
   }
 
@@ -2500,12 +2498,12 @@ NonlinearSystemBase::constraintJacobians(const SparseMatrix<Number> & jacobian_t
   auto & jacobian = getMatrix(systemMatrixTag());
 
   if (!_fe_problem.errorOnJacobianNonzeroReallocation())
-    LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+    LibmeshPetscCall(MatSetOption(cast_ref<PetscMatrix<Number> &>(jacobian).mat(),
                                   MAT_NEW_NONZERO_ALLOCATION_ERR,
                                   PETSC_FALSE));
   if (_fe_problem.ignoreZerosInJacobian())
     LibmeshPetscCall(MatSetOption(
-        static_cast<PetscMatrix<Number> &>(jacobian).mat(), MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE));
+        cast_ref<PetscMatrix<Number> &>(jacobian).mat(), MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE));
 
   std::vector<numeric_index_type> zero_rows;
 
@@ -2513,8 +2511,8 @@ NonlinearSystemBase::constraintJacobians(const SparseMatrix<Number> & jacobian_t
     mooseAssert(_fe_problem.getDisplacedProblem(),
                 "If we're calling this method with displaced = true, then we better well have a "
                 "displaced problem");
-  auto & subproblem = displaced ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
-                                : static_cast<SubProblem &>(_fe_problem);
+  auto & subproblem = displaced ? cast_ref<SubProblem &>(*_fe_problem.getDisplacedProblem())
+                                : cast_ref<SubProblem &>(_fe_problem);
   const auto & penetration_locators = subproblem.geomSearchData()._penetration_locators;
 
   bool constraints_applied;
@@ -2692,7 +2690,7 @@ NonlinearSystemBase::constraintJacobians(const SparseMatrix<Number> & jacobian_t
 
       if (constraints_applied)
       {
-        LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+        LibmeshPetscCall(MatSetOption(cast_ref<PetscMatrix<Number> &>(jacobian).mat(),
                                       MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
                                       PETSC_TRUE));
 
@@ -2711,7 +2709,7 @@ NonlinearSystemBase::constraintJacobians(const SparseMatrix<Number> & jacobian_t
 
     if (constraints_applied)
     {
-      LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+      LibmeshPetscCall(MatSetOption(cast_ref<PetscMatrix<Number> &>(jacobian).mat(),
                                     MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
                                     PETSC_TRUE));
 
@@ -2904,7 +2902,7 @@ NonlinearSystemBase::constraintJacobians(const SparseMatrix<Number> & jacobian_t
 
   if (constraints_applied)
   {
-    LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+    LibmeshPetscCall(MatSetOption(cast_ref<PetscMatrix<Number> &>(jacobian).mat(),
                                   MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
                                   PETSC_TRUE));
 
@@ -3027,9 +3025,8 @@ NonlinearSystemBase::computeJacobianInternal(const std::set<TagID> & tags)
         LibmeshPetscCall(
             MatSetOption(petsc_matrix->mat(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE));
       if (_fe_problem.ignoreZerosInJacobian())
-        LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
-                                      MAT_IGNORE_ZERO_ENTRIES,
-                                      PETSC_TRUE));
+        LibmeshPetscCall(MatSetOption(
+            cast_ref<PetscMatrix<Number> &>(jacobian).mat(), MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE));
     }
   }
 
@@ -3218,7 +3215,7 @@ NonlinearSystemBase::computeJacobianInternal(const std::set<TagID> & tags)
 #if PETSC_RELEASE_GREATER_EQUALS(3, 23, 0)
         if (system_matrix.use_hash_table())
         {
-          hash_copy = libMesh::cast_ref<PetscMatrix<Number> &>(system_matrix).copy_from_hash();
+          hash_copy = cast_ref<PetscMatrix<Number> &>(system_matrix).copy_from_hash();
           view_jac_ptr = hash_copy.get();
         }
         else
@@ -3330,11 +3327,11 @@ NonlinearSystemBase::computeJacobianBlocks(std::vector<JacobianBlock *> & blocks
   {
     SparseMatrix<Number> & jacobian = blocks[i]->_jacobian;
 
-    LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+    LibmeshPetscCall(MatSetOption(cast_ref<PetscMatrix<Number> &>(jacobian).mat(),
                                   MAT_KEEP_NONZERO_PATTERN, // This is changed in 3.1
                                   PETSC_TRUE));
     if (!_fe_problem.errorOnJacobianNonzeroReallocation())
-      LibmeshPetscCall(MatSetOption(static_cast<PetscMatrix<Number> &>(jacobian).mat(),
+      LibmeshPetscCall(MatSetOption(cast_ref<PetscMatrix<Number> &>(jacobian).mat(),
                                     MAT_NEW_NONZERO_ALLOCATION_ERR,
                                     PETSC_TRUE));
 
@@ -4039,9 +4036,8 @@ NonlinearSystemBase::setupScalingData()
                      "the nonlinear system.");
 
         const MooseVariableBase & var =
-            hasVariable(var_name)
-                ? static_cast<MooseVariableBase &>(getVariable(0, var_name))
-                : static_cast<MooseVariableBase &>(getScalarVariable(0, var_name));
+            hasVariable(var_name) ? cast_ref<MooseVariableBase &>(getVariable(0, var_name))
+                                  : cast_ref<MooseVariableBase &>(getScalarVariable(0, var_name));
         auto map_pair = _var_to_group_var.emplace(var.number(), group_index);
         if (!map_pair.second)
           mooseError("Variable ", var_name, " is contained in multiple scaling grouplings");

--- a/framework/src/transfers/MultiAppConservativeTransfer.C
+++ b/framework/src/transfers/MultiAppConservativeTransfer.C
@@ -320,7 +320,7 @@ MultiAppConservativeTransfer::adjustTransferredSolutionNearestPoint(
   auto & to_sys = to_var.sys().system();
   auto var_num = to_sys.variable_number(_to_var_name);
   auto sys_num = to_sys.number();
-  auto & pps = static_cast<const NearestPointIntegralVariablePostprocessor &>(
+  auto & pps = cast_ref<const NearestPointIntegralVariablePostprocessor &>(
       _current_direction == FROM_MULTIAPP ? (to_problem.getUserObjectBase(to_postprocessor))
                                           : (from_problem->getUserObjectBase(from_postprocessor)));
   auto & to_solution = to_var.sys().solution();

--- a/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
@@ -77,7 +77,7 @@ MultiAppVariableValueSampleTransfer::execute()
     case TO_MULTIAPP:
     {
       FEProblemBase & from_problem = getToMultiApp()->problemBase();
-      MooseVariableField<Real> & from_var = static_cast<MooseVariableField<Real> &>(
+      MooseVariableField<Real> & from_var = cast_ref<MooseVariableField<Real> &>(
           from_problem.getActualFieldVariable(0, _from_var_name));
       SystemBase & from_system_base = from_var.sys();
       SubProblem & from_sub_problem = from_system_base.subproblem();

--- a/framework/src/userobjects/ElementIntegralUserObject.C
+++ b/framework/src/userobjects/ElementIntegralUserObject.C
@@ -52,7 +52,7 @@ ElementIntegralUserObject::getValue() const
 void
 ElementIntegralUserObject::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const ElementIntegralUserObject &>(y);
+  const auto & pps = cast_ref<const ElementIntegralUserObject &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/framework/src/userobjects/ElementQualityChecker.C
+++ b/framework/src/userobjects/ElementQualityChecker.C
@@ -145,7 +145,7 @@ ElementQualityChecker::execute()
 void
 ElementQualityChecker::threadJoin(const UserObject & uo)
 {
-  const auto & eqc = static_cast<const ElementQualityChecker &>(uo);
+  const auto & eqc = cast_ref<const ElementQualityChecker &>(uo);
   _elem_ids.insert(eqc._elem_ids.begin(), eqc._elem_ids.end());
   _bypassed_elem_type.insert(eqc._bypassed_elem_type.begin(), eqc._bypassed_elem_type.end());
   _bypassed |= eqc._bypassed;

--- a/framework/src/userobjects/LayeredExtremumMaterialProperty.C
+++ b/framework/src/userobjects/LayeredExtremumMaterialProperty.C
@@ -93,7 +93,7 @@ LayeredExtremumMaterialProperty::finalize()
 void
 LayeredExtremumMaterialProperty::threadJoin(const UserObject & y)
 {
-  const auto & lb = static_cast<const LayeredExtremumMaterialProperty &>(y);
+  const auto & lb = cast_ref<const LayeredExtremumMaterialProperty &>(y);
   for (const auto i : make_range(_num_layers))
     if (lb.layerHasValue(i))
       setLayerValue(i, extreme_value(getLayerValue(i), lb.getLayerValue(i)));

--- a/framework/src/userobjects/NearestNodeNumberUO.C
+++ b/framework/src/userobjects/NearestNodeNumberUO.C
@@ -95,7 +95,7 @@ NearestNodeNumberUO::getClosestNode() const
 void
 NearestNodeNumberUO::threadJoin(const UserObject & y)
 {
-  const auto & nnn = static_cast<const NearestNodeNumberUO &>(y);
+  const auto & nnn = cast_ref<const NearestNodeNumberUO &>(y);
   if (!nnn._closest_node)
     return;
   if (nnn._min_distance < _min_distance ||

--- a/framework/src/userobjects/NodalPatchRecoveryBase.C
+++ b/framework/src/userobjects/NodalPatchRecoveryBase.C
@@ -189,7 +189,7 @@ NodalPatchRecoveryBase::execute()
 void
 NodalPatchRecoveryBase::threadJoin(const UserObject & uo)
 {
-  const auto & npr = static_cast<const NodalPatchRecoveryBase &>(uo);
+  const auto & npr = cast_ref<const NodalPatchRecoveryBase &>(uo);
   _Ae.insert(npr._Ae.begin(), npr._Ae.end());
   _be.insert(npr._be.begin(), npr._be.end());
 }

--- a/framework/src/userobjects/ProjectedStatefulMaterialNodalPatchRecovery.C
+++ b/framework/src/userobjects/ProjectedStatefulMaterialNodalPatchRecovery.C
@@ -172,7 +172,7 @@ void
 ProjectedStatefulMaterialNodalPatchRecoveryTempl<T, is_ad>::threadJoin(const UserObject & uo)
 {
   const auto & npr =
-      static_cast<const ProjectedStatefulMaterialNodalPatchRecoveryTempl<T, is_ad> &>(uo);
+      cast_ref<const ProjectedStatefulMaterialNodalPatchRecoveryTempl<T, is_ad> &>(uo);
   _abs.insert(npr._abs.begin(), npr._abs.end());
 }
 

--- a/framework/src/userobjects/RadialAverage.C
+++ b/framework/src/userobjects/RadialAverage.C
@@ -204,7 +204,7 @@ RadialAverage::finalize()
 void
 RadialAverage::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const RadialAverage &>(y);
+  const auto & uo = cast_ref<const RadialAverage &>(y);
   _qp_data.insert(_qp_data.begin(), uo._qp_data.begin(), uo._qp_data.end());
   _average.insert(uo._average.begin(), uo._average.end());
 }

--- a/framework/src/userobjects/SideIntegralUserObject.C
+++ b/framework/src/userobjects/SideIntegralUserObject.C
@@ -50,7 +50,7 @@ SideIntegralUserObject::getValue() const
 void
 SideIntegralUserObject::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const SideIntegralUserObject &>(y);
+  const auto & pps = cast_ref<const SideIntegralUserObject &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/framework/src/userobjects/VerifyElementUniqueID.C
+++ b/framework/src/userobjects/VerifyElementUniqueID.C
@@ -49,7 +49,7 @@ VerifyElementUniqueID::execute()
 void
 VerifyElementUniqueID::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const VerifyElementUniqueID &>(y);
+  const auto & uo = cast_ref<const VerifyElementUniqueID &>(y);
 
   _all_ids.insert(_all_ids.end(), uo._all_ids.begin(), uo._all_ids.end());
 }

--- a/framework/src/userobjects/VerifyNodalUniqueID.C
+++ b/framework/src/userobjects/VerifyNodalUniqueID.C
@@ -49,7 +49,7 @@ VerifyNodalUniqueID::execute()
 void
 VerifyNodalUniqueID::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const VerifyNodalUniqueID &>(y);
+  const auto & uo = cast_ref<const VerifyNodalUniqueID &>(y);
 
   _all_ids.insert(_all_ids.end(), uo._all_ids.begin(), uo._all_ids.end());
 }

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -67,14 +67,14 @@ using namespace libMesh;
 void
 MooseVecView(NumericVector<Number> & vector)
 {
-  PetscVector<Number> & petsc_vec = static_cast<PetscVector<Number> &>(vector);
+  PetscVector<Number> & petsc_vec = cast_ref<PetscVector<Number> &>(vector);
   LibmeshPetscCallA(vector.comm().get(), VecView(petsc_vec.vec(), 0));
 }
 
 void
 MooseMatView(SparseMatrix<Number> & mat)
 {
-  PetscMatrixBase<Number> & petsc_mat = static_cast<PetscMatrix<Number> &>(mat);
+  PetscMatrixBase<Number> & petsc_mat = cast_ref<PetscMatrix<Number> &>(mat);
   LibmeshPetscCallA(mat.comm().get(), MatView(petsc_mat.mat(), 0));
 }
 
@@ -82,7 +82,7 @@ void
 MooseVecView(const NumericVector<Number> & vector)
 {
   PetscVector<Number> & petsc_vec =
-      static_cast<PetscVector<Number> &>(const_cast<NumericVector<Number> &>(vector));
+      cast_ref<PetscVector<Number> &>(const_cast<NumericVector<Number> &>(vector));
   LibmeshPetscCallA(vector.comm().get(), VecView(petsc_vec.vec(), 0));
 }
 
@@ -90,7 +90,7 @@ void
 MooseMatView(const SparseMatrix<Number> & mat)
 {
   PetscMatrixBase<Number> & petsc_mat =
-      static_cast<PetscMatrix<Number> &>(const_cast<SparseMatrix<Number> &>(mat));
+      cast_ref<PetscMatrix<Number> &>(const_cast<SparseMatrix<Number> &>(mat));
   LibmeshPetscCallA(mat.comm().get(), MatView(petsc_mat.mat(), 0));
 }
 

--- a/framework/src/utils/PetscVectorReader.C
+++ b/framework/src/utils/PetscVectorReader.C
@@ -15,7 +15,7 @@ PetscVectorReader::PetscVectorReader(PetscVector<Number> & vec)
 }
 
 PetscVectorReader::PetscVectorReader(NumericVector<Number> & vec)
-  : _vec(libMesh::cast_ref<PetscVector<Number> &>(vec)), _raw_value(_vec.get_array_read())
+  : _vec(cast_ref<PetscVector<Number> &>(vec)), _raw_value(_vec.get_array_read())
 {
 }
 

--- a/framework/src/variables/MooseVariableDataFV.C
+++ b/framework/src/variables/MooseVariableDataFV.C
@@ -581,10 +581,10 @@ MooseVariableDataFV<OutputType>::computeAD(const unsigned int num_dofs, const un
     assignForAllQps(_ad_dof_values[0], _ad_u, nqp);
 
   if (_need_ad_grad_u)
-    assignForAllQps(static_cast<const MooseVariableFV<OutputType> &>(_var).adGradSln(
-                        _elem, Moose::currentState()),
-                    _ad_grad_u,
-                    nqp);
+    assignForAllQps(
+        cast_ref<const MooseVariableFV<OutputType> &>(_var).adGradSln(_elem, Moose::currentState()),
+        _ad_grad_u,
+        nqp);
 
   if (_need_ad_u_dot)
   {

--- a/framework/src/vectorpostprocessors/ArrayVariableValueVolumeHistogram.C
+++ b/framework/src/vectorpostprocessors/ArrayVariableValueVolumeHistogram.C
@@ -88,7 +88,7 @@ ArrayVariableValueVolumeHistogram::finalize()
 void
 ArrayVariableValueVolumeHistogram::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const ArrayVariableValueVolumeHistogram &>(y);
+  const auto & uo = cast_ref<const ArrayVariableValueVolumeHistogram &>(y);
   mooseAssert(uo._volumes.size() == _volumes.size(),
               "Inconsistent number of array variable components across threads.");
 

--- a/framework/src/vectorpostprocessors/ElementMaterialSampler.C
+++ b/framework/src/vectorpostprocessors/ElementMaterialSampler.C
@@ -197,7 +197,7 @@ ElementMaterialSampler::finalize()
 void
 ElementMaterialSampler::threadJoin(const UserObject & y)
 {
-  const auto & vpp = static_cast<const ElementMaterialSampler &>(y);
+  const auto & vpp = cast_ref<const ElementMaterialSampler &>(y);
   _elem_ids.insert(_elem_ids.end(), vpp._elem_ids.begin(), vpp._elem_ids.end());
   _qp_ids.insert(_qp_ids.end(), vpp._qp_ids.begin(), vpp._qp_ids.end());
   _x_coords.insert(_x_coords.end(), vpp._x_coords.begin(), vpp._x_coords.end());

--- a/framework/src/vectorpostprocessors/ElementValueSampler.C
+++ b/framework/src/vectorpostprocessors/ElementValueSampler.C
@@ -85,7 +85,7 @@ ElementValueSampler::finalize()
 void
 ElementValueSampler::threadJoin(const UserObject & y)
 {
-  const auto & vpp = static_cast<const ElementValueSampler &>(y);
+  const auto & vpp = cast_ref<const ElementValueSampler &>(y);
 
   SamplerBase::threadJoin(vpp);
 }

--- a/framework/src/vectorpostprocessors/ElementVariablesDifferenceMax.C
+++ b/framework/src/vectorpostprocessors/ElementVariablesDifferenceMax.C
@@ -122,7 +122,7 @@ ElementVariablesDifferenceMax::initialize()
 void
 ElementVariablesDifferenceMax::threadJoin(const UserObject & s)
 {
-  const auto & sibling = static_cast<const ElementVariablesDifferenceMax &>(s);
+  const auto & sibling = cast_ref<const ElementVariablesDifferenceMax &>(s);
 
   if (_all[MAXIMUM_DIFFERENCE] < sibling._all[MAXIMUM_DIFFERENCE])
     _all = sibling._all;

--- a/framework/src/vectorpostprocessors/ExtraIDIntegralVectorPostprocessor.C
+++ b/framework/src/vectorpostprocessors/ExtraIDIntegralVectorPostprocessor.C
@@ -165,7 +165,7 @@ ExtraIDIntegralVectorPostprocessor::finalize()
 void
 ExtraIDIntegralVectorPostprocessor::threadJoin(const UserObject & s)
 {
-  const auto & sibling = static_cast<const ExtraIDIntegralVectorPostprocessor &>(s);
+  const auto & sibling = cast_ref<const ExtraIDIntegralVectorPostprocessor &>(s);
 
   for (unsigned int i = 0; i < _integrals.size(); ++i)
     for (size_t j = 0; j < (*_integrals[i]).size(); ++j)

--- a/framework/src/vectorpostprocessors/MeshDivisionFunctorReductionVectorPostprocessor.C
+++ b/framework/src/vectorpostprocessors/MeshDivisionFunctorReductionVectorPostprocessor.C
@@ -135,7 +135,7 @@ MeshDivisionFunctorReductionVectorPostprocessor::finalize()
 void
 MeshDivisionFunctorReductionVectorPostprocessor::threadJoin(const UserObject & s)
 {
-  const auto & sibling = static_cast<const MeshDivisionFunctorReductionVectorPostprocessor &>(s);
+  const auto & sibling = cast_ref<const MeshDivisionFunctorReductionVectorPostprocessor &>(s);
 
   for (const auto i_f : make_range(_nfunctors))
     for (const auto i : index_range(*_functor_reductions[i_f]))

--- a/framework/src/vectorpostprocessors/NodalValueSampler.C
+++ b/framework/src/vectorpostprocessors/NodalValueSampler.C
@@ -114,7 +114,7 @@ NodalValueSampler::finalize()
 void
 NodalValueSampler::threadJoin(const UserObject & y)
 {
-  const auto & vpp = static_cast<const NodalValueSampler &>(y);
+  const auto & vpp = cast_ref<const NodalValueSampler &>(y);
 
   SamplerBase::threadJoin(vpp);
 }

--- a/framework/src/vectorpostprocessors/SideValueSampler.C
+++ b/framework/src/vectorpostprocessors/SideValueSampler.C
@@ -114,7 +114,7 @@ SideValueSampler::finalize()
 void
 SideValueSampler::threadJoin(const UserObject & y)
 {
-  const auto & vpp = static_cast<const SideValueSampler &>(y);
+  const auto & vpp = cast_ref<const SideValueSampler &>(y);
 
   SamplerBase::threadJoin(vpp);
 }

--- a/framework/src/vectorpostprocessors/SidesetInfoVectorPostprocessor.C
+++ b/framework/src/vectorpostprocessors/SidesetInfoVectorPostprocessor.C
@@ -138,7 +138,7 @@ SidesetInfoVectorPostprocessor::finalize()
 void
 SidesetInfoVectorPostprocessor::threadJoin(const UserObject & y)
 {
-  const auto & vpp = static_cast<const SidesetInfoVectorPostprocessor &>(y);
+  const auto & vpp = cast_ref<const SidesetInfoVectorPostprocessor &>(y);
 
   for (auto & e : _boundary_data)
   {

--- a/framework/src/vectorpostprocessors/SpatialAverageBase.C
+++ b/framework/src/vectorpostprocessors/SpatialAverageBase.C
@@ -104,7 +104,7 @@ SpatialAverageBase::finalize()
 void
 SpatialAverageBase::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const SpatialAverageBase &>(y);
+  const auto & uo = cast_ref<const SpatialAverageBase &>(y);
 
   for (MooseIndex(_counts) i = 0; i < _nbins; ++i)
   {

--- a/framework/src/vectorpostprocessors/VariableValueVolumeHistogram.C
+++ b/framework/src/vectorpostprocessors/VariableValueVolumeHistogram.C
@@ -83,7 +83,7 @@ VariableValueVolumeHistogram::finalize()
 void
 VariableValueVolumeHistogram::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const VariableValueVolumeHistogram &>(y);
+  const auto & uo = cast_ref<const VariableValueVolumeHistogram &>(y);
   mooseAssert(uo._volume.size() == _volume.size(),
               "Inconsistent volume vector lengths across threads.");
 

--- a/modules/contact/src/userobjects/NodalArea.C
+++ b/modules/contact/src/userobjects/NodalArea.C
@@ -40,7 +40,7 @@ NodalArea::~NodalArea() {}
 void
 NodalArea::threadJoin(const UserObject & fred)
 {
-  const auto & na = static_cast<const NodalArea &>(fred);
+  const auto & na = cast_ref<const NodalArea &>(fred);
 
   std::map<const Node *, Real>::const_iterator it = na._node_areas.begin();
   const std::map<const Node *, Real>::const_iterator it_end = na._node_areas.end();

--- a/modules/electromagnetics/src/postprocessors/ReflectionCoefficient.C
+++ b/modules/electromagnetics/src/postprocessors/ReflectionCoefficient.C
@@ -67,7 +67,7 @@ ReflectionCoefficient::getValue() const
 void
 ReflectionCoefficient::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const ReflectionCoefficient &>(y);
+  const auto & pps = cast_ref<const ReflectionCoefficient &>(y);
   Real temp_rc = _reflection_coefficient;
   _reflection_coefficient = std::max(temp_rc, pps._reflection_coefficient);
 }

--- a/modules/external_petsc_solver/src/problems/ExternalPETScProblem.C
+++ b/modules/external_petsc_solver/src/problems/ExternalPETScProblem.C
@@ -27,7 +27,7 @@ ExternalPETScProblem::ExternalPETScProblem(const InputParameters & params)
   : ExternalProblem(params),
     _sync_to_var_name(getParam<VariableName>("sync_variable")),
     // Require ExternalPetscSolverApp
-    _external_petsc_app(static_cast<ExternalPetscSolverApp &>(_app)),
+    _external_petsc_app(cast_ref<ExternalPetscSolverApp &>(_app)),
     _ts(_external_petsc_app.getPetscTS()),
     // RestartableData is required for recovering when PETSc solver runs as a master app
     _petsc_sol(declareRestartableData<Vec>("petsc_sol")),

--- a/modules/external_petsc_solver/src/timesteppers/ExternalPetscTimeStepper.C
+++ b/modules/external_petsc_solver/src/timesteppers/ExternalPetscTimeStepper.C
@@ -27,7 +27,7 @@ ExternalPetscTimeStepper::validParams()
 ExternalPetscTimeStepper::ExternalPetscTimeStepper(const InputParameters & parameters)
   : TimeStepper(parameters),
     // ExternalPetscTimeStepper always requires ExternalPETScProblem
-    _external_petsc_problem(static_cast<ExternalPETScProblem &>(_fe_problem))
+    _external_petsc_problem(cast_ref<ExternalPETScProblem &>(_fe_problem))
 {
 }
 

--- a/modules/fluid_properties/unit/src/SodiumSaturationFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/SodiumSaturationFluidPropertiesTest.C
@@ -261,7 +261,7 @@ TEST_F(SodiumSaturationFluidPropertiesTest, volumeEnergyAutomaticDifferentiation
   const Real T = 800.0;
   const Real v = _fp->v_from_p_T(p, T);
   const Real e = _fp->e_from_p_T(p, T);
-  const auto & fp = static_cast<const SinglePhaseFluidProperties &>(*_fp);
+  const auto & fp = cast_ref<const SinglePhaseFluidProperties &>(*_fp);
 
   DNDerivativeType dv;
   DNDerivativeType de;

--- a/modules/functional_expansion_tools/include/userobjects/FXIntegralBaseUserObject.h
+++ b/modules/functional_expansion_tools/include/userobjects/FXIntegralBaseUserObject.h
@@ -236,7 +236,7 @@ void
 FXIntegralBaseUserObject<IntegralBaseVariableUserObject>::threadJoin(const UserObject & s)
 {
   const FXIntegralBaseUserObject<IntegralBaseVariableUserObject> & sibling =
-      static_cast<const FXIntegralBaseUserObject<IntegralBaseVariableUserObject> &>(s);
+      cast_ref<const FXIntegralBaseUserObject<IntegralBaseVariableUserObject> &>(s);
 
   for (std::size_t c = 0; c < _coefficient_partials.size(); ++c)
     _coefficient_partials[c] += sibling._coefficient_partials[c];

--- a/modules/geochemistry/src/userobjects/GeochemistrySpatialReactor.C
+++ b/modules/geochemistry/src/userobjects/GeochemistrySpatialReactor.C
@@ -450,7 +450,7 @@ void
 GeochemistrySpatialReactor::threadJoin(const UserObject & uo)
 {
   _nthreads += 1;
-  const auto & gsr = static_cast<const GeochemistrySpatialReactor &>(uo);
+  const auto & gsr = cast_ref<const GeochemistrySpatialReactor &>(uo);
   for (unsigned i = 0; i < _num_my_nodes; ++i)
   {
     if (!_execute_done[i] && gsr._execute_done[i])

--- a/modules/geochemistry/src/userobjects/NodalVoidVolume.C
+++ b/modules/geochemistry/src/userobjects/NodalVoidVolume.C
@@ -186,7 +186,7 @@ void
 NodalVoidVolume::threadJoin(const UserObject & uo)
 {
   // _nodal_void_volume will have been computed by other threads: add their contributions to ours.
-  const auto & nvv = static_cast<const NodalVoidVolume &>(uo);
+  const auto & nvv = cast_ref<const NodalVoidVolume &>(uo);
   for (auto & our_nvv : _nodal_void_volume)
     our_nvv.second += nvv._nodal_void_volume.at(our_nvv.first);
   // Now _nodal_void_volume is correct for all nodes within this processor's domain (but potentially

--- a/modules/heat_transfer/src/postprocessors/HomogenizedThermalConductivity.C
+++ b/modules/heat_transfer/src/postprocessors/HomogenizedThermalConductivity.C
@@ -95,7 +95,7 @@ HomogenizedThermalConductivity::finalize()
 void
 HomogenizedThermalConductivity::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const HomogenizedThermalConductivity &>(y);
+  const auto & pps = cast_ref<const HomogenizedThermalConductivity &>(y);
 
   _integral_value += pps._integral_value;
   _volume += pps._volume;

--- a/modules/heat_transfer/src/userobjects/GrayLambertSurfaceRadiationBase.C
+++ b/modules/heat_transfer/src/userobjects/GrayLambertSurfaceRadiationBase.C
@@ -252,7 +252,7 @@ GrayLambertSurfaceRadiationBase::finalize()
 void
 GrayLambertSurfaceRadiationBase::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const GrayLambertSurfaceRadiationBase &>(y);
+  const auto & pps = cast_ref<const GrayLambertSurfaceRadiationBase &>(y);
 
   for (unsigned int j = 0; j < _n_sides; ++j)
   {

--- a/modules/heat_transfer/src/userobjects/RayTracingViewFactor.C
+++ b/modules/heat_transfer/src/userobjects/RayTracingViewFactor.C
@@ -33,7 +33,7 @@ RayTracingViewFactor::RayTracingViewFactor(const InputParameters & parameters)
 void
 RayTracingViewFactor::threadJoinViewFactor(const UserObject & y)
 {
-  const auto & vf = static_cast<const RayTracingViewFactor &>(y);
+  const auto & vf = cast_ref<const RayTracingViewFactor &>(y);
   for (unsigned int i = 0; i < _n_sides; ++i)
     for (unsigned int j = 0; j < _n_sides; ++j)
       _view_factors[i][j] += vf._view_factors[i][j];

--- a/modules/heat_transfer/src/userobjects/SelfShadowSideUserObject.C
+++ b/modules/heat_transfer/src/userobjects/SelfShadowSideUserObject.C
@@ -84,7 +84,7 @@ SelfShadowSideUserObject::execute()
 void
 SelfShadowSideUserObject::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const SelfShadowSideUserObject &>(y);
+  const auto & uo = cast_ref<const SelfShadowSideUserObject &>(y);
 
   // merge lists
   _lines.insert(_lines.end(), uo._lines.begin(), uo._lines.end());

--- a/modules/heat_transfer/src/userobjects/UnobstructedPlanarViewFactor.C
+++ b/modules/heat_transfer/src/userobjects/UnobstructedPlanarViewFactor.C
@@ -124,7 +124,7 @@ UnobstructedPlanarViewFactor::initialize()
 void
 UnobstructedPlanarViewFactor::threadJoinViewFactor(const UserObject & y)
 {
-  const auto & vf = static_cast<const UnobstructedPlanarViewFactor &>(y);
+  const auto & vf = cast_ref<const UnobstructedPlanarViewFactor &>(y);
   for (unsigned int i = 0; i < _n_sides; ++i)
     for (unsigned int j = 0; j < _n_sides; ++j)
       _view_factors[i][j] += vf._view_factors[i][j];

--- a/modules/heat_transfer/src/userobjects/ViewFactorBase.C
+++ b/modules/heat_transfer/src/userobjects/ViewFactorBase.C
@@ -134,7 +134,7 @@ ViewFactorBase::finalize()
 void
 ViewFactorBase::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const ViewFactorBase &>(y);
+  const auto & pps = cast_ref<const ViewFactorBase &>(y);
   for (unsigned int i = 0; i < _n_sides; ++i)
     _areas[i] += pps._areas[i];
 

--- a/modules/level_set/src/postprocessors/LevelSetCFLCondition.C
+++ b/modules/level_set/src/postprocessors/LevelSetCFLCondition.C
@@ -50,7 +50,7 @@ LevelSetCFLCondition::finalize()
 void
 LevelSetCFLCondition::threadJoin(const UserObject & user_object)
 {
-  const auto & cfl = static_cast<const LevelSetCFLCondition &>(user_object);
+  const auto & cfl = cast_ref<const LevelSetCFLCondition &>(user_object);
   _cfl_timestep = std::min(_cfl_timestep, cfl._cfl_timestep);
 }
 

--- a/modules/level_set/src/postprocessors/LevelSetVolume.C
+++ b/modules/level_set/src/postprocessors/LevelSetVolume.C
@@ -75,6 +75,6 @@ LevelSetVolume::getValue() const
 void
 LevelSetVolume::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const LevelSetVolume &>(y);
+  const auto & pps = cast_ref<const LevelSetVolume &>(y);
   _volume += pps._volume;
 }

--- a/modules/navier_stokes/src/executioners/LinearAssemblySegregatedSolve.C
+++ b/modules/navier_stokes/src/executioners/LinearAssemblySegregatedSolve.C
@@ -361,10 +361,10 @@ LinearAssemblySegregatedSolve::solveMomentumPredictor()
   std::vector<std::pair<unsigned int, Real>> its_normalized_residuals;
 
   LinearImplicitSystem & momentum_system_0 =
-      libMesh::cast_ref<LinearImplicitSystem &>(_momentum_systems[0]->system());
+      cast_ref<LinearImplicitSystem &>(_momentum_systems[0]->system());
 
   PetscLinearSolver<Real> & momentum_solver =
-      libMesh::cast_ref<PetscLinearSolver<Real> &>(*momentum_system_0.get_linear_solver());
+      cast_ref<PetscLinearSolver<Real> &>(*momentum_system_0.get_linear_solver());
 
   // Solve the momentum equations.
   // TO DO: These equations are VERY similar. If we can store the differences (things coming from
@@ -375,7 +375,7 @@ LinearAssemblySegregatedSolve::solveMomentumPredictor()
 
     // We will need the right hand side and the solution of the next component
     LinearImplicitSystem & momentum_system =
-        libMesh::cast_ref<LinearImplicitSystem &>(_momentum_systems[system_i]->system());
+        cast_ref<LinearImplicitSystem &>(_momentum_systems[system_i]->system());
 
     NumericVector<Number> & solution = *(momentum_system.solution);
     NumericVector<Number> & rhs = *(momentum_system.rhs);
@@ -438,7 +438,7 @@ LinearAssemblySegregatedSolve::solveMomentumPredictor()
   for (const auto system_i : index_range(_momentum_systems))
   {
     LinearImplicitSystem & momentum_system =
-        libMesh::cast_ref<LinearImplicitSystem &>(_momentum_systems[system_i]->system());
+        cast_ref<LinearImplicitSystem &>(_momentum_systems[system_i]->system());
     _momentum_systems[system_i]->setSolution(*(momentum_system.current_local_solution));
     _momentum_systems[system_i]->copyPreviousSolutions(Moose::SolutionIterationType::Nonlinear);
   }
@@ -475,7 +475,7 @@ LinearAssemblySegregatedSolve::solvePressureCorrector()
 
   // We will need some members from the linear system
   LinearImplicitSystem & pressure_system =
-      libMesh::cast_ref<LinearImplicitSystem &>(_pressure_system.system());
+      cast_ref<LinearImplicitSystem &>(_pressure_system.system());
 
   // We will need the solution, the right hand side and the matrix
   NumericVector<Number> & current_local_solution = *(pressure_system.current_local_solution);
@@ -485,7 +485,7 @@ LinearAssemblySegregatedSolve::solvePressureCorrector()
 
   // Fetch the linear solver from the system
   PetscLinearSolver<Real> & pressure_solver =
-      libMesh::cast_ref<PetscLinearSolver<Real> &>(*pressure_system.get_linear_solver());
+      cast_ref<PetscLinearSolver<Real> &>(*pressure_system.get_linear_solver());
 
   _problem.computeLinearSystemSys(pressure_system, mmat, rhs, false);
 
@@ -544,8 +544,7 @@ LinearAssemblySegregatedSolve::solveSolidEnergy()
   _problem.setCurrentLinearSystem(_solid_energy_sys_number);
 
   // We will need some members from the linear system
-  LinearImplicitSystem & system =
-      libMesh::cast_ref<LinearImplicitSystem &>(_solid_energy_system->system());
+  LinearImplicitSystem & system = cast_ref<LinearImplicitSystem &>(_solid_energy_system->system());
 
   // We will need the solution, the right hand side and the matrix
   NumericVector<Number> & current_local_solution = *(system.current_local_solution);
@@ -555,7 +554,7 @@ LinearAssemblySegregatedSolve::solveSolidEnergy()
 
   // Fetch the linear solver from the system
   PetscLinearSolver<Real> & solver =
-      libMesh::cast_ref<PetscLinearSolver<Real> &>(*system.get_linear_solver());
+      cast_ref<PetscLinearSolver<Real> &>(*system.get_linear_solver());
 
   _problem.computeLinearSystemSys(system, mmat, rhs, false);
 
@@ -658,7 +657,7 @@ LinearAssemblySegregatedSolve::solveAdvectedSystem(const unsigned int system_num
   _problem.setCurrentLinearSystem(system_num);
 
   // We will need some members from the implicit linear system
-  LinearImplicitSystem & li_system = libMesh::cast_ref<LinearImplicitSystem &>(system.system());
+  LinearImplicitSystem & li_system = cast_ref<LinearImplicitSystem &>(system.system());
 
   // We will need the solution, the right hand side and the matrix
   NumericVector<Number> & current_local_solution = *(li_system.current_local_solution);
@@ -671,7 +670,7 @@ LinearAssemblySegregatedSolve::solveAdvectedSystem(const unsigned int system_num
 
   // Fetch the linear solver from the system
   PetscLinearSolver<Real> & linear_solver =
-      libMesh::cast_ref<PetscLinearSolver<Real> &>(*li_system.get_linear_solver());
+      cast_ref<PetscLinearSolver<Real> &>(*li_system.get_linear_solver());
 
   _problem.computeLinearSystemSys(li_system, mmat, rhs, true);
 

--- a/modules/navier_stokes/src/executioners/SIMPLESolveNonlinearAssembly.C
+++ b/modules/navier_stokes/src/executioners/SIMPLESolveNonlinearAssembly.C
@@ -182,10 +182,10 @@ SIMPLESolveNonlinearAssembly::solveMomentumPredictor()
 
     // We will need the right hand side and the solution of the next component
     NonlinearImplicitSystem & momentum_system =
-        libMesh::cast_ref<NonlinearImplicitSystem &>(_momentum_systems[system_i]->system());
+        cast_ref<NonlinearImplicitSystem &>(_momentum_systems[system_i]->system());
 
     PetscLinearSolver<Real> & momentum_solver =
-        libMesh::cast_ref<PetscLinearSolver<Real> &>(*momentum_system.get_linear_solver());
+        cast_ref<PetscLinearSolver<Real> &>(*momentum_system.get_linear_solver());
 
     NumericVector<Number> & solution = *(momentum_system.solution);
     NumericVector<Number> & rhs = *(momentum_system.rhs);
@@ -248,7 +248,7 @@ SIMPLESolveNonlinearAssembly::solvePressureCorrector()
 
   // We will need some members from the implicit nonlinear system
   NonlinearImplicitSystem & pressure_system =
-      libMesh::cast_ref<NonlinearImplicitSystem &>(_pressure_system.system());
+      cast_ref<NonlinearImplicitSystem &>(_pressure_system.system());
 
   // We will need the solution, the right hand side and the matrix
   NumericVector<Number> & current_local_solution = *(pressure_system.current_local_solution);
@@ -258,7 +258,7 @@ SIMPLESolveNonlinearAssembly::solvePressureCorrector()
 
   // Fetch the linear solver from the system
   PetscLinearSolver<Real> & pressure_solver =
-      libMesh::cast_ref<PetscLinearSolver<Real> &>(*pressure_system.get_linear_solver());
+      cast_ref<PetscLinearSolver<Real> &>(*pressure_system.get_linear_solver());
 
   // We need a zero vector to be able to emulate the Ax=b system by evaluating the
   // residual and jacobian. Unfortunately, this will leave us with the -b on the right hand side
@@ -313,8 +313,7 @@ SIMPLESolveNonlinearAssembly::solveAdvectedSystem(const unsigned int system_num,
   _problem.setCurrentNonlinearSystem(system_num);
 
   // We will need some members from the implicit nonlinear system
-  NonlinearImplicitSystem & ni_system =
-      libMesh::cast_ref<NonlinearImplicitSystem &>(system.system());
+  NonlinearImplicitSystem & ni_system = cast_ref<NonlinearImplicitSystem &>(system.system());
 
   // We will need the solution, the right hand side and the matrix
   NumericVector<Number> & current_local_solution = *(ni_system.current_local_solution);
@@ -327,7 +326,7 @@ SIMPLESolveNonlinearAssembly::solveAdvectedSystem(const unsigned int system_num,
 
   // Fetch the linear solver from the system
   PetscLinearSolver<Real> & linear_solver =
-      libMesh::cast_ref<PetscLinearSolver<Real> &>(*ni_system.get_linear_solver());
+      cast_ref<PetscLinearSolver<Real> &>(*ni_system.get_linear_solver());
 
   // We need a zero vector to be able to emulate the Ax=b system by evaluating the
   // residual and jacobian. Unfortunately, this will leave us with the -b on the right hand side
@@ -383,7 +382,7 @@ SIMPLESolveNonlinearAssembly::solveSolidEnergySystem()
 
   // We will need some members from the implicit nonlinear system
   NonlinearImplicitSystem & se_system =
-      libMesh::cast_ref<NonlinearImplicitSystem &>(_solid_energy_system->system());
+      cast_ref<NonlinearImplicitSystem &>(_solid_energy_system->system());
 
   // We will need the solution, the right hand side and the matrix
   NumericVector<Number> & current_local_solution = *(se_system.current_local_solution);
@@ -393,7 +392,7 @@ SIMPLESolveNonlinearAssembly::solveSolidEnergySystem()
 
   // Fetch the linear solver from the system
   PetscLinearSolver<Real> & se_solver =
-      libMesh::cast_ref<PetscLinearSolver<Real> &>(*se_system.get_linear_solver());
+      cast_ref<PetscLinearSolver<Real> &>(*se_system.get_linear_solver());
 
   // We need a zero vector to be able to emulate the Ax=b system by evaluating the
   // residual and jacobian. Unfortunately, this will leave us with the -b on the righ hand side

--- a/modules/navier_stokes/src/fvkernels/INSFVMeshAdvection.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVMeshAdvection.C
@@ -36,9 +36,9 @@ INSFVMeshAdvection::INSFVMeshAdvection(const InputParameters & parameters)
     _disp_x(getFunctor<ADReal>("disp_x")),
     _disp_y(getFunctor<ADReal>("disp_y")),
     _disp_z(getFunctor<ADReal>("disp_z")),
-    _adv_quant(isParamValid("advected_quantity") ? static_cast<const Moose::FunctorBase<ADReal> &>(
+    _adv_quant(isParamValid("advected_quantity") ? cast_ref<const Moose::FunctorBase<ADReal> &>(
                                                        getFunctor<ADReal>("advected_quantity"))
-                                                 : static_cast<Moose::FunctorBase<ADReal> &>(_var))
+                                                 : cast_ref<Moose::FunctorBase<ADReal> &>(_var))
 {
 }
 

--- a/modules/navier_stokes/src/postprocessors/CFLTimeStepSize.C
+++ b/modules/navier_stokes/src/postprocessors/CFLTimeStepSize.C
@@ -87,7 +87,7 @@ template <bool is_ad>
 void
 CFLTimeStepSizeTempl<is_ad>::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const CFLTimeStepSizeTempl<is_ad> &>(y);
+  const auto & pps = cast_ref<const CFLTimeStepSizeTempl<is_ad> &>(y);
 
   _dt = std::min(_dt, pps._dt);
 }

--- a/modules/navier_stokes/src/postprocessors/INSExplicitTimestepSelector.C
+++ b/modules/navier_stokes/src/postprocessors/INSExplicitTimestepSelector.C
@@ -108,6 +108,6 @@ INSExplicitTimestepSelector::finalize()
 void
 INSExplicitTimestepSelector::threadJoin(const UserObject & uo)
 {
-  const auto & pps = static_cast<const INSExplicitTimestepSelector &>(uo);
+  const auto & pps = cast_ref<const INSExplicitTimestepSelector &>(uo);
   _value = std::min(_value, pps._value);
 }

--- a/modules/navier_stokes/src/postprocessors/MassFluxWeightedFlowRate.C
+++ b/modules/navier_stokes/src/postprocessors/MassFluxWeightedFlowRate.C
@@ -82,7 +82,7 @@ void
 MassFluxWeightedFlowRate::threadJoin(const UserObject & y)
 {
   VolumetricFlowRate::threadJoin(y);
-  const auto & pps = static_cast<const MassFluxWeightedFlowRate &>(y);
+  const auto & pps = cast_ref<const MassFluxWeightedFlowRate &>(y);
   _mdot += pps._mdot;
 }
 

--- a/modules/navier_stokes/src/postprocessors/PressureDrop.C
+++ b/modules/navier_stokes/src/postprocessors/PressureDrop.C
@@ -307,7 +307,7 @@ PressureDrop::computeQpWeightIntegral() const
 void
 PressureDrop::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const PressureDrop &>(y);
+  const auto & pps = cast_ref<const PressureDrop &>(y);
   _weighted_pressure_upstream += pps._weighted_pressure_upstream;
   _weighted_pressure_downstream += pps._weighted_pressure_downstream;
   _weight_upstream += pps._weight_upstream;

--- a/modules/navier_stokes/src/userobjects/HLLCUserObject.C
+++ b/modules/navier_stokes/src/userobjects/HLLCUserObject.C
@@ -130,7 +130,7 @@ HLLCUserObject::hasData(const Elem * const elem, const unsigned int side) const
 void
 HLLCUserObject::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const HLLCUserObject &>(y);
+  const auto & pps = cast_ref<const HLLCUserObject &>(y);
   for (auto & ws : pps._wave_speed)
   {
     const auto & it = _wave_speed.find(ws.first);

--- a/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
+++ b/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
@@ -180,10 +180,10 @@ INSFVRhieChowInterpolator::INSFVRhieChowInterpolator(const InputParameters & par
       _disps.push_back(std::make_unique<Moose::VectorCompositeFunctor<ADReal>>(
           name() + "_disp_" + std::to_string(tid),
           *_disp_xs[tid],
-          _dim >= 2 ? static_cast<const Moose::FunctorBase<ADReal> &>(*_disp_ys[tid])
-                    : static_cast<const Moose::FunctorBase<ADReal> &>(_zero_functor),
-          _dim >= 3 ? static_cast<const Moose::FunctorBase<ADReal> &>(*_disp_zs[tid])
-                    : static_cast<const Moose::FunctorBase<ADReal> &>(_zero_functor)));
+          _dim >= 2 ? libMesh::cast_ref<const Moose::FunctorBase<ADReal> &>(*_disp_ys[tid])
+                    : libMesh::cast_ref<const Moose::FunctorBase<ADReal> &>(_zero_functor),
+          _dim >= 3 ? libMesh::cast_ref<const Moose::FunctorBase<ADReal> &>(*_disp_zs[tid])
+                    : libMesh::cast_ref<const Moose::FunctorBase<ADReal> &>(_zero_functor)));
   }
 
   if (_velocity_interp_method == Moose::FV::InterpMethod::Average && isParamValid("a_u"))

--- a/modules/optimization/src/executioners/AdjointSolve.C
+++ b/modules/optimization/src/executioners/AdjointSolve.C
@@ -102,7 +102,7 @@ AdjointSolve::solve()
 
   // Convenient references
   // Adjoint matrix, solution, and right-hand-side
-  auto & matrix = static_cast<ImplicitSystem &>(_nl_forward.system()).get_system_matrix();
+  auto & matrix = cast_ref<ImplicitSystem &>(_nl_forward.system()).get_system_matrix();
   auto & solution = _nl_adjoint.solution();
   auto & rhs = _nl_adjoint.getResidualNonTimeVector();
   // Linear solver parameters
@@ -110,7 +110,7 @@ AdjointSolve::solve()
   const auto tol = es.parameters.get<Real>("linear solver tolerance");
   const auto maxits = es.parameters.get<unsigned int>("linear solver maximum iterations");
   // Linear solver for adjoint system
-  auto & solver = *static_cast<ImplicitSystem &>(_nl_adjoint.system()).get_linear_solver();
+  auto & solver = *cast_ref<ImplicitSystem &>(_nl_adjoint.system()).get_linear_solver();
 
   // Assemble adjoint system by evaluating the forward Jacobian, computing the adjoint
   // residual/source, and homogenizing nodal BCs

--- a/modules/optimization/src/executioners/AdjointTransientSolve.C
+++ b/modules/optimization/src/executioners/AdjointTransientSolve.C
@@ -110,7 +110,7 @@ AdjointTransientSolve::evaluateTimeResidual(const NumericVector<Number> & soluti
   // This tag should exist, but the matrix might not necessarily be added
   auto time_matrix_tag = _problem.getMatrixTagID("TIME");
   // Use the adjoint system matrix to hold the time Jacobian
-  auto & time_matrix = static_cast<ImplicitSystem &>(_nl_adjoint.system()).get_system_matrix();
+  auto & time_matrix = cast_ref<ImplicitSystem &>(_nl_adjoint.system()).get_system_matrix();
 
   // Make sure we tell the problem which system we are evaluating
   _problem.setCurrentNonlinearSystem(_forward_sys_num);

--- a/modules/optimization/src/vectorpostprocessors/ElementOptimizationFunctionInnerProduct.C
+++ b/modules/optimization/src/vectorpostprocessors/ElementOptimizationFunctionInnerProduct.C
@@ -47,7 +47,7 @@ ElementOptimizationFunctionInnerProduct::execute()
 void
 ElementOptimizationFunctionInnerProduct::threadJoin(const UserObject & y)
 {
-  const auto & vpp = static_cast<const ElementOptimizationFunctionInnerProduct &>(y);
+  const auto & vpp = cast_ref<const ElementOptimizationFunctionInnerProduct &>(y);
   add(vpp);
 }
 

--- a/modules/optimization/src/vectorpostprocessors/SideOptimizationFunctionInnerProduct.C
+++ b/modules/optimization/src/vectorpostprocessors/SideOptimizationFunctionInnerProduct.C
@@ -47,7 +47,7 @@ SideOptimizationFunctionInnerProduct::execute()
 void
 SideOptimizationFunctionInnerProduct::threadJoin(const UserObject & y)
 {
-  const auto & vpp = static_cast<const SideOptimizationFunctionInnerProduct &>(y);
+  const auto & vpp = cast_ref<const SideOptimizationFunctionInnerProduct &>(y);
   add(vpp);
 }
 

--- a/modules/peridynamics/src/postprocessors/BondStatusConvergedPostprocessorPD.C
+++ b/modules/peridynamics/src/postprocessors/BondStatusConvergedPostprocessorPD.C
@@ -59,6 +59,6 @@ BondStatusConvergedPostprocessorPD::finalize()
 void
 BondStatusConvergedPostprocessorPD::threadJoin(const UserObject & uo)
 {
-  const auto & pps = static_cast<const BondStatusConvergedPostprocessorPD &>(uo);
+  const auto & pps = cast_ref<const BondStatusConvergedPostprocessorPD &>(uo);
   _num_bond_status_updated += pps._num_bond_status_updated;
 }

--- a/modules/peridynamics/src/postprocessors/NodalIntegralPostprocessorBasePD.C
+++ b/modules/peridynamics/src/postprocessors/NodalIntegralPostprocessorBasePD.C
@@ -49,6 +49,6 @@ NodalIntegralPostprocessorBasePD::finalize()
 void
 NodalIntegralPostprocessorBasePD::threadJoin(const UserObject & uo)
 {
-  const auto & pps = static_cast<const NodalIntegralPostprocessorBasePD &>(uo);
+  const auto & pps = cast_ref<const NodalIntegralPostprocessorBasePD &>(uo);
   _integral_value += pps._integral_value;
 }

--- a/modules/peridynamics/src/userobjects/GeneralizedPlaneStrainUserObjectBasePD.C
+++ b/modules/peridynamics/src/userobjects/GeneralizedPlaneStrainUserObjectBasePD.C
@@ -49,7 +49,7 @@ GeneralizedPlaneStrainUserObjectBasePD::initialize()
 void
 GeneralizedPlaneStrainUserObjectBasePD::threadJoin(const UserObject & uo)
 {
-  const auto & gpsuo = static_cast<const GeneralizedPlaneStrainUserObjectBasePD &>(uo);
+  const auto & gpsuo = cast_ref<const GeneralizedPlaneStrainUserObjectBasePD &>(uo);
   _residual += gpsuo._residual;
   _jacobian += gpsuo._jacobian;
 }

--- a/modules/phase_field/include/userobjects/PolycrystalUserObjectBase.h
+++ b/modules/phase_field/include/userobjects/PolycrystalUserObjectBase.h
@@ -71,7 +71,7 @@ public:
    */
   virtual Real getNodalVariableValue(unsigned int op_index, const Node & n) const
   {
-    return getVariableValue(op_index, static_cast<const Point &>(n));
+    return getVariableValue(op_index, cast_ref<const Point &>(n));
   }
 
   /* Returns all available coloring algorithms as an enumeration type for input files.

--- a/modules/phase_field/src/postprocessors/ObtainAvgContactAngle.C
+++ b/modules/phase_field/src/postprocessors/ObtainAvgContactAngle.C
@@ -60,7 +60,7 @@ ObtainAvgContactAngle::getValue() const
 void
 ObtainAvgContactAngle::threadJoin(const UserObject & y)
 {
-  const ObtainAvgContactAngle & pps = static_cast<const ObtainAvgContactAngle &>(y);
+  const ObtainAvgContactAngle & pps = cast_ref<const ObtainAvgContactAngle &>(y);
   _cos_theta_val += pps._cos_theta_val;
   _total_weight += pps._total_weight;
 }

--- a/modules/phase_field/src/postprocessors/WeightedVariableAverage.C
+++ b/modules/phase_field/src/postprocessors/WeightedVariableAverage.C
@@ -65,7 +65,7 @@ WeightedVariableAverage::getValue() const
 void
 WeightedVariableAverage::threadJoin(const UserObject & y)
 {
-  const auto & pp = static_cast<const WeightedVariableAverage &>(y);
+  const auto & pp = cast_ref<const WeightedVariableAverage &>(y);
   _var_integral += pp._var_integral;
   _weight_integral += pp._weight_integral;
 }

--- a/modules/phase_field/src/userobjects/ComputeExternalGrainForceAndTorque.C
+++ b/modules/phase_field/src/userobjects/ComputeExternalGrainForceAndTorque.C
@@ -186,7 +186,7 @@ ComputeExternalGrainForceAndTorque::finalize()
 void
 ComputeExternalGrainForceAndTorque::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const ComputeExternalGrainForceAndTorque &>(y);
+  const auto & pps = cast_ref<const ComputeExternalGrainForceAndTorque &>(y);
   for (unsigned int i = 0; i < _ncomp; ++i)
     _force_torque_store[i] += pps._force_torque_store[i];
   if (_fe_problem.currentlyComputingJacobian())

--- a/modules/phase_field/src/userobjects/ComputeGrainCenterUserObject.C
+++ b/modules/phase_field/src/userobjects/ComputeGrainCenterUserObject.C
@@ -69,7 +69,7 @@ ComputeGrainCenterUserObject::finalize()
 void
 ComputeGrainCenterUserObject::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const ComputeGrainCenterUserObject &>(y);
+  const auto & pps = cast_ref<const ComputeGrainCenterUserObject &>(y);
   for (unsigned int i = 0; i < _ncomp; ++i)
     _grain_data[i] += pps._grain_data[i];
 }

--- a/modules/phase_field/src/userobjects/ComputeGrainForceAndTorque.C
+++ b/modules/phase_field/src/userobjects/ComputeGrainForceAndTorque.C
@@ -183,7 +183,7 @@ ComputeGrainForceAndTorque::finalize()
 void
 ComputeGrainForceAndTorque::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const ComputeGrainForceAndTorque &>(y);
+  const auto & pps = cast_ref<const ComputeGrainForceAndTorque &>(y);
   for (unsigned int i = 0; i < _ncomp; ++i)
     _force_torque_store[i] += pps._force_torque_store[i];
   if (_fe_problem.currentlyComputingJacobian())

--- a/modules/phase_field/src/userobjects/ConservedMaskedNoiseBase.C
+++ b/modules/phase_field/src/userobjects/ConservedMaskedNoiseBase.C
@@ -54,7 +54,7 @@ ConservedMaskedNoiseBase::execute()
 void
 ConservedMaskedNoiseBase::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const ConservedMaskedNoiseBase &>(y);
+  const auto & uo = cast_ref<const ConservedMaskedNoiseBase &>(y);
 
   _random_data.insert(uo._random_data.begin(), uo._random_data.end());
   _integral += uo._integral;

--- a/modules/phase_field/src/userobjects/ConservedNoiseBase.C
+++ b/modules/phase_field/src/userobjects/ConservedNoiseBase.C
@@ -51,7 +51,7 @@ ConservedNoiseBase::execute()
 void
 ConservedNoiseBase::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const ConservedNoiseBase &>(y);
+  const auto & uo = cast_ref<const ConservedNoiseBase &>(y);
 
   _random_data.insert(uo._random_data.begin(), uo._random_data.end());
   _integral += uo._integral;

--- a/modules/phase_field/src/userobjects/DiscreteNucleationInserter.C
+++ b/modules/phase_field/src/userobjects/DiscreteNucleationInserter.C
@@ -115,7 +115,7 @@ void
 DiscreteNucleationInserter::threadJoin(const UserObject & y)
 {
   // combine _local_nucleus_list entries from all threads on the current process
-  const auto & uo = static_cast<const DiscreteNucleationInserter &>(y);
+  const auto & uo = cast_ref<const DiscreteNucleationInserter &>(y);
   _global_nucleus_list.insert(
       _global_nucleus_list.end(), uo._local_nucleus_list.begin(), uo._local_nucleus_list.end());
 

--- a/modules/phase_field/src/userobjects/DiscreteNucleationMap.C
+++ b/modules/phase_field/src/userobjects/DiscreteNucleationMap.C
@@ -124,7 +124,7 @@ DiscreteNucleationMap::threadJoin(const UserObject & y)
   // if the map needs to be updated we merge the maps from all threads
   if (_rebuild_map)
   {
-    const auto & uo = static_cast<const DiscreteNucleationMap &>(y);
+    const auto & uo = cast_ref<const DiscreteNucleationMap &>(y);
     _nucleus_map.insert(uo._nucleus_map.begin(), uo._nucleus_map.end());
   }
 }

--- a/modules/phase_field/src/vectorpostprocessors/GrainTextureVectorPostprocessor.C
+++ b/modules/phase_field/src/vectorpostprocessors/GrainTextureVectorPostprocessor.C
@@ -69,7 +69,7 @@ GrainTextureVectorPostprocessor::execute()
 void
 GrainTextureVectorPostprocessor::threadJoin(const UserObject & y)
 {
-  const auto & vpp = static_cast<const GrainTextureVectorPostprocessor &>(y);
+  const auto & vpp = cast_ref<const GrainTextureVectorPostprocessor &>(y);
   SamplerBase::threadJoin(vpp);
 }
 

--- a/modules/porous_flow/src/userobjects/AdvectiveFluxCalculatorBase.C
+++ b/modules/porous_flow/src/userobjects/AdvectiveFluxCalculatorBase.C
@@ -248,7 +248,7 @@ AdvectiveFluxCalculatorBase::executeOnElement(
 void
 AdvectiveFluxCalculatorBase::threadJoin(const UserObject & uo)
 {
-  const auto & afc = static_cast<const AdvectiveFluxCalculatorBase &>(uo);
+  const auto & afc = cast_ref<const AdvectiveFluxCalculatorBase &>(uo);
   // add the values of _kij computed by different threads
   for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
   {

--- a/modules/porous_flow/src/userobjects/PorousFlowAdvectiveFluxCalculatorBase.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowAdvectiveFluxCalculatorBase.C
@@ -212,7 +212,7 @@ void
 PorousFlowAdvectiveFluxCalculatorBase::threadJoin(const UserObject & uo)
 {
   AdvectiveFluxCalculatorBase::threadJoin(uo);
-  const auto & pfafc = static_cast<const PorousFlowAdvectiveFluxCalculatorBase &>(uo);
+  const auto & pfafc = cast_ref<const PorousFlowAdvectiveFluxCalculatorBase &>(uo);
   // add the values of _dkij_dvar computed by different threads
   const std::size_t num_nodes = _connections.numNodes();
   for (dof_id_type sequential_i = 0; sequential_i < num_nodes; ++sequential_i)

--- a/modules/solid_mechanics/src/postprocessors/CriticalTimeStep.C
+++ b/modules/solid_mechanics/src/postprocessors/CriticalTimeStep.C
@@ -81,6 +81,6 @@ CriticalTimeStep::getValue() const
 void
 CriticalTimeStep::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const CriticalTimeStep &>(y);
+  const auto & pps = cast_ref<const CriticalTimeStep &>(y);
   _critical_time = std::min(pps._critical_time, _critical_time);
 }

--- a/modules/solid_mechanics/src/postprocessors/MaterialTensorAverage.C
+++ b/modules/solid_mechanics/src/postprocessors/MaterialTensorAverage.C
@@ -66,7 +66,7 @@ MaterialTensorAverageTempl<is_ad>::threadJoin(const UserObject & y)
 {
   MaterialTensorIntegralTempl<is_ad>::threadJoin(y);
 
-  const auto & pps = static_cast<const MaterialTensorAverageTempl<is_ad> &>(y);
+  const auto & pps = cast_ref<const MaterialTensorAverageTempl<is_ad> &>(y);
   _volume += pps._volume;
 }
 

--- a/modules/solid_mechanics/src/postprocessors/MaterialTimeStepPostprocessor.C
+++ b/modules/solid_mechanics/src/postprocessors/MaterialTimeStepPostprocessor.C
@@ -139,7 +139,7 @@ MaterialTimeStepPostprocessor::finalize()
 void
 MaterialTimeStepPostprocessor::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const MaterialTimeStepPostprocessor &>(y);
+  const auto & pps = cast_ref<const MaterialTimeStepPostprocessor &>(y);
   if (_use_material_timestep_limit)
     _matl_value = std::min(_matl_value, pps._matl_value);
   if (_use_elements_changed)

--- a/modules/solid_mechanics/src/postprocessors/NormalBoundaryDisplacement.C
+++ b/modules/solid_mechanics/src/postprocessors/NormalBoundaryDisplacement.C
@@ -86,7 +86,7 @@ NormalBoundaryDisplacement::getValue() const
 void
 NormalBoundaryDisplacement::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const NormalBoundaryDisplacement &>(y);
+  const auto & pps = cast_ref<const NormalBoundaryDisplacement &>(y);
 
   switch (_value_type)
   {

--- a/modules/solid_mechanics/src/postprocessors/TorqueReaction.C
+++ b/modules/solid_mechanics/src/postprocessors/TorqueReaction.C
@@ -100,6 +100,6 @@ TorqueReaction::finalize()
 void
 TorqueReaction::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const TorqueReaction &>(y);
+  const auto & pps = cast_ref<const TorqueReaction &>(y);
   _sum += pps._sum;
 }

--- a/modules/solid_mechanics/src/userobjects/GeneralizedPlaneStrainUserObject.C
+++ b/modules/solid_mechanics/src/userobjects/GeneralizedPlaneStrainUserObject.C
@@ -134,7 +134,7 @@ GeneralizedPlaneStrainUserObject::execute()
 void
 GeneralizedPlaneStrainUserObject::threadJoin(const UserObject & uo)
 {
-  const auto & gpsuo = static_cast<const GeneralizedPlaneStrainUserObject &>(uo);
+  const auto & gpsuo = cast_ref<const GeneralizedPlaneStrainUserObject &>(uo);
   for (unsigned int i = 0; i < _residual.size(); ++i)
   {
     _residual[i] += gpsuo._residual[i];

--- a/modules/solid_mechanics/src/userobjects/GlobalStrainUserObject.C
+++ b/modules/solid_mechanics/src/userobjects/GlobalStrainUserObject.C
@@ -81,7 +81,7 @@ GlobalStrainUserObject::execute()
 void
 GlobalStrainUserObject::threadJoin(const UserObject & uo)
 {
-  const auto & pstuo = static_cast<const GlobalStrainUserObject &>(uo);
+  const auto & pstuo = cast_ref<const GlobalStrainUserObject &>(uo);
   _residual += pstuo._residual;
   _jacobian += pstuo._jacobian;
 }

--- a/modules/solid_mechanics/src/vectorpostprocessors/CrackFrontNonlocalMaterialBase.C
+++ b/modules/solid_mechanics/src/vectorpostprocessors/CrackFrontNonlocalMaterialBase.C
@@ -116,7 +116,7 @@ CrackFrontNonlocalMaterialBase::finalize()
 void
 CrackFrontNonlocalMaterialBase::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const CrackFrontNonlocalMaterialBase &>(y);
+  const auto & uo = cast_ref<const CrackFrontNonlocalMaterialBase &>(y);
   for (const auto i : index_range(_avg_crack_tip_scalar))
   {
     _volume[i] += uo._volume[i];

--- a/modules/solid_mechanics/src/vectorpostprocessors/InteractionIntegral.C
+++ b/modules/solid_mechanics/src/vectorpostprocessors/InteractionIntegral.C
@@ -600,7 +600,7 @@ template <bool is_ad>
 void
 InteractionIntegralTempl<is_ad>::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const InteractionIntegralTempl<is_ad> &>(y);
+  const auto & uo = cast_ref<const InteractionIntegralTempl<is_ad> &>(y);
 
   for (auto i = beginIndex(_interaction_integral); i < _interaction_integral.size(); ++i)
     _interaction_integral[i] += uo._interaction_integral[i];

--- a/modules/solid_mechanics/src/vectorpostprocessors/JIntegral.C
+++ b/modules/solid_mechanics/src/vectorpostprocessors/JIntegral.C
@@ -249,7 +249,7 @@ JIntegral::finalize()
 void
 JIntegral::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const JIntegral &>(y);
+  const auto & uo = cast_ref<const JIntegral &>(y);
 
   for (auto i = beginIndex(_j_integral); i < _j_integral.size(); ++i)
     _j_integral[i] += uo._j_integral[i];

--- a/modules/solid_mechanics/test/src/vectorpostprocessors/BlockOrientationVectorPostprocessor.C
+++ b/modules/solid_mechanics/test/src/vectorpostprocessors/BlockOrientationVectorPostprocessor.C
@@ -66,7 +66,7 @@ BlockOrientationVectorPostprocessor::execute()
 void
 BlockOrientationVectorPostprocessor::threadJoin(const UserObject & y)
 {
-  const auto & vpp = static_cast<const BlockOrientationVectorPostprocessor &>(y);
+  const auto & vpp = cast_ref<const BlockOrientationVectorPostprocessor &>(y);
   SamplerBase::threadJoin(vpp);
 }
 

--- a/modules/stochastic_tools/src/reporters/SnapshotContainerBase.C
+++ b/modules/stochastic_tools/src/reporters/SnapshotContainerBase.C
@@ -56,11 +56,11 @@ SnapshotContainerBase::execute()
 void
 dataStore(std::ostream & stream, SnapshotContainerBase::Snapshots & v, void * context)
 {
-  dataStore(stream, static_cast<UniqueStorage<NumericVector<Number>> &>(v), context);
+  dataStore(stream, cast_ref<UniqueStorage<NumericVector<Number>> &>(v), context);
 }
 
 void
 dataLoad(std::istream & stream, SnapshotContainerBase::Snapshots & v, void * context)
 {
-  dataLoad(stream, static_cast<UniqueStorage<NumericVector<Number>> &>(v), context);
+  dataLoad(stream, cast_ref<UniqueStorage<NumericVector<Number>> &>(v), context);
 }

--- a/modules/stochastic_tools/src/vectorpostprocessors/SamplerData.C
+++ b/modules/stochastic_tools/src/vectorpostprocessors/SamplerData.C
@@ -110,7 +110,7 @@ SamplerData::threadJoin(const UserObject & /*uo*/)
   /*
   if (_use_local_samples)
   {
-    const SamplerData & obj = static_cast<const SamplerData &>(uo);
+    const SamplerData & obj = cast_ref<const SamplerData &>(uo);
     for (std::size_t i = 0; i < _sample_vectors.size(); ++i)
       (*_sample_vectors[i]).insert(_sample_vectors[i]->end(), obj._sample_vectors[i]->begin(),
                                    obj._sample_vectors[i]->end());

--- a/modules/subchannel/src/meshgenerators/SCMQuadAssemblyMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMQuadAssemblyMeshGenerator.C
@@ -576,7 +576,7 @@ SCMQuadAssemblyMeshGenerator::generate()
 
   mesh_base->prepare_for_use();
 
-  auto & sch_mesh = static_cast<QuadSubChannelMesh &>(*_mesh);
+  auto & sch_mesh = cast_ref<QuadSubChannelMesh &>(*_mesh);
   transferMetadata(sch_mesh);
   sch_mesh.computeAssemblyHydraulicParameters();
 

--- a/modules/subchannel/src/meshgenerators/SCMQuadDuctMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMQuadDuctMeshGenerator.C
@@ -79,7 +79,7 @@ SCMQuadDuctMeshGenerator::generate()
   mesh_base->prepare_for_use();
 
   // Mirror the Tri variant: provide mapping hooks into the subchannel mesh
-  auto & sch_mesh = static_cast<QuadSubChannelMesh &>(*_mesh);
+  auto & sch_mesh = cast_ref<QuadSubChannelMesh &>(*_mesh);
   sch_mesh.setChannelToDuctMaps(duct_nodes);
 
   return mesh_base;

--- a/modules/subchannel/src/meshgenerators/SCMTriAssemblyMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMTriAssemblyMeshGenerator.C
@@ -892,7 +892,7 @@ SCMTriAssemblyMeshGenerator::generate()
   mesh_base->prepare_for_use();
 
   // move the meta data into TriSubChannelMesh
-  auto & sch_mesh = static_cast<TriSubChannelMesh &>(*_mesh);
+  auto & sch_mesh = cast_ref<TriSubChannelMesh &>(*_mesh);
   sch_mesh._unheated_length_entry = _unheated_length_entry;
   sch_mesh._heated_length = _heated_length;
   sch_mesh._unheated_length_exit = _unheated_length_exit;

--- a/modules/subchannel/src/meshgenerators/SCMTriDuctMeshGenerator.C
+++ b/modules/subchannel/src/meshgenerators/SCMTriDuctMeshGenerator.C
@@ -70,7 +70,7 @@ SCMTriDuctMeshGenerator::generate()
 
   mesh_base->prepare_for_use();
 
-  auto & sch_mesh = static_cast<TriSubChannelMesh &>(*_mesh);
+  auto & sch_mesh = cast_ref<TriSubChannelMesh &>(*_mesh);
   sch_mesh.setChannelToDuctMaps(duct_nodes);
   sch_mesh._duct_mesh_exist = true;
 

--- a/modules/subchannel/src/scmclosures/SCMMixingKimAndChung.C
+++ b/modules/subchannel/src/scmclosures/SCMMixingKimAndChung.C
@@ -37,7 +37,7 @@ SCMMixingKimAndChung::SCMMixingKimAndChung(const InputParameters & parameters)
 {
   if (_is_tri_lattice)
   {
-    const auto & tri_mesh = static_cast<const TriSubChannelMesh &>(_subchannel_mesh);
+    const auto & tri_mesh = cast_ref<const TriSubChannelMesh &>(_subchannel_mesh);
     if (tri_mesh.getWireDiameter() != 0.0 || tri_mesh.getWireLeadLength() != 0.0)
       mooseError("SCMMixingKimAndChung applies only to bare-pin assemblies and cannot be used "
                  "with wire-wrapped triangular bundles.");

--- a/modules/thermal_hydraulics/include/base/Simulation.h
+++ b/modules/thermal_hydraulics/include/base/Simulation.h
@@ -240,11 +240,6 @@ public:
   virtual void setupMesh();
 
   /**
-   * Get the ThermalHydraulicsApp
-   */
-  ThermalHydraulicsApp & getApp() { return _thm_app; }
-
-  /**
    * Check the integrity of the simulation
    */
   virtual void integrityCheck() const;
@@ -391,7 +386,7 @@ protected:
   FEProblemBase & _fe_problem;
 
   /// The application this is associated with
-  ThermalHydraulicsApp & _thm_app;
+  MooseApp & _thm_app;
 
   /// The Factory associated with the MooseApp
   Factory & _thm_factory;

--- a/modules/thermal_hydraulics/src/base/Simulation.C
+++ b/modules/thermal_hydraulics/src/base/Simulation.C
@@ -47,8 +47,7 @@ Simulation::Simulation(FEProblemBase & fe_problem, const InputParameters & pars)
     LoggingInterface(_log),
     _thm_mesh(*static_cast<THMMesh *>(pars.get<MooseMesh *>("mesh"))),
     _fe_problem(fe_problem),
-    _thm_app(
-        cast_ref<ThermalHydraulicsApp &>(*pars.get<MooseApp *>(MooseBase::app_param))),
+    _thm_app(*pars.get<MooseApp *>(MooseBase::app_param)),
     _thm_factory(_thm_app.getFactory()),
     _thm_pars(pars),
     _flow_fe_type(FEType(CONSTANT, MONOMIAL)),
@@ -634,7 +633,7 @@ Simulation::sortAddedComponentVariables() const
 void
 Simulation::addVariables()
 {
-  TransientBase * trex = dynamic_cast<TransientBase *>(getApp().getExecutioner());
+  TransientBase * trex = dynamic_cast<TransientBase *>(_thm_app.getExecutioner());
   if (trex)
   {
     Moose::TimeIntegratorType ti_type = trex->getTimeScheme();

--- a/modules/thermal_hydraulics/src/base/Simulation.C
+++ b/modules/thermal_hydraulics/src/base/Simulation.C
@@ -47,7 +47,8 @@ Simulation::Simulation(FEProblemBase & fe_problem, const InputParameters & pars)
     LoggingInterface(_log),
     _thm_mesh(*static_cast<THMMesh *>(pars.get<MooseMesh *>("mesh"))),
     _fe_problem(fe_problem),
-    _thm_app(static_cast<ThermalHydraulicsApp &>(*pars.get<MooseApp *>(MooseBase::app_param))),
+    _thm_app(
+        cast_ref<ThermalHydraulicsApp &>(*pars.get<MooseApp *>(MooseBase::app_param))),
     _thm_factory(_thm_app.getFactory()),
     _thm_pars(pars),
     _flow_fe_type(FEType(CONSTANT, MONOMIAL)),

--- a/modules/thermal_hydraulics/src/components/Component.C
+++ b/modules/thermal_hydraulics/src/components/Component.C
@@ -42,7 +42,7 @@ Component::Component(const InputParameters & parameters)
     _sim(*getCheckedPointerParam<THMProblem *>("_thm_problem")),
     _factory(_app.getFactory()),
     _zero(_sim._real_zero[0]),
-    _mesh(static_cast<THMMesh &>(_sim.mesh())),
+    _mesh(cast_ref<THMMesh &>(_sim.mesh())),
     _component_setup_status(CREATED)
 {
 }

--- a/modules/thermal_hydraulics/src/postprocessors/ADSpecificImpulse1Phase.C
+++ b/modules/thermal_hydraulics/src/postprocessors/ADSpecificImpulse1Phase.C
@@ -66,7 +66,7 @@ ADSpecificImpulse1Phase::ADSpecificImpulse1Phase(const InputParameters & paramet
 void
 ADSpecificImpulse1Phase::threadJoin(const UserObject & y)
 {
-  const ADSpecificImpulse1Phase & pps = static_cast<const ADSpecificImpulse1Phase &>(y);
+  const ADSpecificImpulse1Phase & pps = cast_ref<const ADSpecificImpulse1Phase &>(y);
   _thrust += pps._thrust;
   _mass_flow_rate += pps._mass_flow_rate;
 }

--- a/modules/thermal_hydraulics/src/postprocessors/EnergyFluxIntegral.C
+++ b/modules/thermal_hydraulics/src/postprocessors/EnergyFluxIntegral.C
@@ -31,7 +31,7 @@ EnergyFluxIntegral::EnergyFluxIntegral(const InputParameters & parameters)
 void
 EnergyFluxIntegral::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const EnergyFluxIntegral &>(y);
+  const auto & pps = cast_ref<const EnergyFluxIntegral &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/modules/thermal_hydraulics/src/postprocessors/MassFluxIntegral.C
+++ b/modules/thermal_hydraulics/src/postprocessors/MassFluxIntegral.C
@@ -28,7 +28,7 @@ MassFluxIntegral::MassFluxIntegral(const InputParameters & parameters)
 void
 MassFluxIntegral::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const MassFluxIntegral &>(y);
+  const auto & pps = cast_ref<const MassFluxIntegral &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/modules/thermal_hydraulics/src/postprocessors/MomentumFluxIntegral.C
+++ b/modules/thermal_hydraulics/src/postprocessors/MomentumFluxIntegral.C
@@ -37,7 +37,7 @@ MomentumFluxIntegral::MomentumFluxIntegral(const InputParameters & parameters)
 void
 MomentumFluxIntegral::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const MomentumFluxIntegral &>(y);
+  const auto & pps = cast_ref<const MomentumFluxIntegral &>(y);
   _integral_value += pps._integral_value;
 }
 

--- a/modules/thermal_hydraulics/src/postprocessors/NodalEnergyFluxPostprocessor.C
+++ b/modules/thermal_hydraulics/src/postprocessors/NodalEnergyFluxPostprocessor.C
@@ -53,6 +53,6 @@ NodalEnergyFluxPostprocessor::finalize()
 void
 NodalEnergyFluxPostprocessor::threadJoin(const UserObject & uo)
 {
-  const auto & niep = static_cast<const NodalEnergyFluxPostprocessor &>(uo);
+  const auto & niep = cast_ref<const NodalEnergyFluxPostprocessor &>(uo);
   _value += niep._value;
 }

--- a/modules/thermal_hydraulics/src/postprocessors/SpecificImpulse1Phase.C
+++ b/modules/thermal_hydraulics/src/postprocessors/SpecificImpulse1Phase.C
@@ -66,7 +66,7 @@ SpecificImpulse1Phase::SpecificImpulse1Phase(const InputParameters & parameters)
 void
 SpecificImpulse1Phase::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const SpecificImpulse1Phase &>(y);
+  const auto & pps = cast_ref<const SpecificImpulse1Phase &>(y);
   _thrust += pps._thrust;
   _mass_flow_rate += pps._mass_flow_rate;
 }

--- a/modules/thermal_hydraulics/src/userobjects/ADGateValve1PhaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/ADGateValve1PhaseUserObject.C
@@ -140,7 +140,7 @@ ADGateValve1PhaseUserObject::execute()
 void
 ADGateValve1PhaseUserObject::threadJoin(const UserObject & uo)
 {
-  const auto & junction_uo = static_cast<const ADGateValve1PhaseUserObject &>(uo);
+  const auto & junction_uo = cast_ref<const ADGateValve1PhaseUserObject &>(uo);
 
   // Store the data computed/retrieved in the other threads
   for (unsigned int i = 0; i < junction_uo._connection_indices.size(); i++)

--- a/modules/thermal_hydraulics/src/userobjects/ADHeatTransferFromHeatStructure3D1PhaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/ADHeatTransferFromHeatStructure3D1PhaseUserObject.C
@@ -82,7 +82,7 @@ ADHeatTransferFromHeatStructure3D1PhaseUserObject::finalize()
 void
 ADHeatTransferFromHeatStructure3D1PhaseUserObject::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const ADHeatTransferFromHeatStructure3D1PhaseUserObject &>(y);
+  const auto & uo = cast_ref<const ADHeatTransferFromHeatStructure3D1PhaseUserObject &>(y);
   for (auto & it : uo._heated_perimeter)
     _heated_perimeter[it.first] = it.second;
   for (auto & it : uo._T_fluid)

--- a/modules/thermal_hydraulics/src/userobjects/ADJunctionOneToOne1PhaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/ADJunctionOneToOne1PhaseUserObject.C
@@ -164,7 +164,7 @@ ADJunctionOneToOne1PhaseUserObject::execute()
 void
 ADJunctionOneToOne1PhaseUserObject::threadJoin(const UserObject & uo)
 {
-  const auto & junction_uo = static_cast<const ADJunctionOneToOne1PhaseUserObject &>(uo);
+  const auto & junction_uo = cast_ref<const ADJunctionOneToOne1PhaseUserObject &>(uo);
 
   // Store the data computed/retrieved in the other threads
   for (unsigned int i = 0; i < junction_uo._connection_indices.size(); i++)

--- a/modules/thermal_hydraulics/src/userobjects/ADJunctionParallelChannels1PhaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/ADJunctionParallelChannels1PhaseUserObject.C
@@ -110,7 +110,7 @@ ADJunctionParallelChannels1PhaseUserObject::threadJoin(const UserObject & uo)
 {
   ADVolumeJunction1PhaseUserObject::threadJoin(uo);
 
-  const auto & jpc_uo = static_cast<const ADJunctionParallelChannels1PhaseUserObject &>(uo);
+  const auto & jpc_uo = cast_ref<const ADJunctionParallelChannels1PhaseUserObject &>(uo);
 
   // Store the data computed/retrieved in the other threads
   for (unsigned int i = 0; i < jpc_uo._connection_indices.size(); i++)

--- a/modules/thermal_hydraulics/src/userobjects/ADShaftConnectedCompressor1PhaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/ADShaftConnectedCompressor1PhaseUserObject.C
@@ -390,7 +390,7 @@ ADShaftConnectedCompressor1PhaseUserObject::threadJoin(const UserObject & uo)
   ADVolumeJunction1PhaseUserObject::threadJoin(uo);
   ADShaftConnectableUserObjectInterface::threadJoin(uo);
 
-  const auto & scpuo = static_cast<const ADShaftConnectedCompressor1PhaseUserObject &>(uo);
+  const auto & scpuo = cast_ref<const ADShaftConnectedCompressor1PhaseUserObject &>(uo);
   _isentropic_torque += scpuo._isentropic_torque;
   _dissipation_torque += scpuo._dissipation_torque;
   _friction_torque += scpuo._friction_torque;

--- a/modules/thermal_hydraulics/src/userobjects/ADShaftConnectedPump1PhaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/ADShaftConnectedPump1PhaseUserObject.C
@@ -238,7 +238,7 @@ ADShaftConnectedPump1PhaseUserObject::threadJoin(const UserObject & uo)
   ADVolumeJunction1PhaseUserObject::threadJoin(uo);
   ADShaftConnectableUserObjectInterface::threadJoin(uo);
 
-  const auto & scpuo = static_cast<const ADShaftConnectedPump1PhaseUserObject &>(uo);
+  const auto & scpuo = cast_ref<const ADShaftConnectedPump1PhaseUserObject &>(uo);
   _hydraulic_torque += scpuo._hydraulic_torque;
   _friction_torque += scpuo._friction_torque;
   _pump_head += scpuo._pump_head;

--- a/modules/thermal_hydraulics/src/userobjects/ADShaftConnectedTurbine1PhaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/ADShaftConnectedTurbine1PhaseUserObject.C
@@ -238,7 +238,7 @@ ADShaftConnectedTurbine1PhaseUserObject::threadJoin(const UserObject & uo)
   ADVolumeJunction1PhaseUserObject::threadJoin(uo);
   ADShaftConnectableUserObjectInterface::threadJoin(uo);
 
-  const auto & scpuo = static_cast<const ADShaftConnectedTurbine1PhaseUserObject &>(uo);
+  const auto & scpuo = cast_ref<const ADShaftConnectedTurbine1PhaseUserObject &>(uo);
   _driving_torque += scpuo._driving_torque;
   _friction_torque += scpuo._friction_torque;
   _flow_coeff += scpuo._flow_coeff;

--- a/modules/thermal_hydraulics/src/userobjects/ADVolumeJunctionBaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/ADVolumeJunctionBaseUserObject.C
@@ -161,7 +161,7 @@ ADVolumeJunctionBaseUserObject::execute()
 void
 ADVolumeJunctionBaseUserObject::threadJoin(const UserObject & uo)
 {
-  const auto & volume_junction_uo = static_cast<const ADVolumeJunctionBaseUserObject &>(uo);
+  const auto & volume_junction_uo = cast_ref<const ADVolumeJunctionBaseUserObject &>(uo);
 
   // Store the data computed/retrieved in the other threads
   for (unsigned int i = 0; i < volume_junction_uo._connection_indices.size(); i++)

--- a/modules/thermal_hydraulics/src/userobjects/FlowChannelHeatStructureCouplerUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/FlowChannelHeatStructureCouplerUserObject.C
@@ -67,7 +67,7 @@ FlowChannelHeatStructureCouplerUserObject::execute()
 void
 FlowChannelHeatStructureCouplerUserObject::threadJoin(const UserObject & uo)
 {
-  const auto & fc_hs_uo = static_cast<const FlowChannelHeatStructureCouplerUserObject &>(uo);
+  const auto & fc_hs_uo = cast_ref<const FlowChannelHeatStructureCouplerUserObject &>(uo);
 
   const auto map_ptrs = getCachedQuantityMaps();
   const auto other_map_ptrs = fc_hs_uo.getCachedQuantityMaps();

--- a/modules/thermal_hydraulics/src/userobjects/FunctionElementLoopIntegralUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/FunctionElementLoopIntegralUserObject.C
@@ -51,7 +51,7 @@ FunctionElementLoopIntegralUserObject::computeElement()
 void
 FunctionElementLoopIntegralUserObject::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const FunctionElementLoopIntegralUserObject &>(y);
+  const auto & uo = cast_ref<const FunctionElementLoopIntegralUserObject &>(y);
   _integral_value += uo._integral_value;
 }
 

--- a/modules/thermal_hydraulics/src/userobjects/HSCoupler2D2DRadiationUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/HSCoupler2D2DRadiationUserObject.C
@@ -117,7 +117,7 @@ HSCoupler2D2DRadiationUserObject::execute()
 void
 HSCoupler2D2DRadiationUserObject::threadJoin(const UserObject & uo)
 {
-  const auto & other_uo = static_cast<const HSCoupler2D2DRadiationUserObject &>(uo);
+  const auto & other_uo = cast_ref<const HSCoupler2D2DRadiationUserObject &>(uo);
   for (auto & it : other_uo._elem_id_to_heat_flux)
     if (_elem_id_to_heat_flux.find(it.first) == _elem_id_to_heat_flux.end())
       _elem_id_to_heat_flux[it.first] = it.second;

--- a/modules/thermal_hydraulics/src/userobjects/HSCoupler2D3DUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/HSCoupler2D3DUserObject.C
@@ -144,7 +144,7 @@ HSCoupler2D3DUserObject::execute()
 void
 HSCoupler2D3DUserObject::threadJoin(const UserObject & uo)
 {
-  const auto & other_uo = static_cast<const HSCoupler2D3DUserObject &>(uo);
+  const auto & other_uo = cast_ref<const HSCoupler2D3DUserObject &>(uo);
   for (auto & it : other_uo._elem_id_to_heat_flux)
     if (_elem_id_to_heat_flux.find(it.first) == _elem_id_to_heat_flux.end())
       _elem_id_to_heat_flux[it.first] = it.second;

--- a/modules/thermal_hydraulics/src/userobjects/HeatFluxFromHeatStructureBaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/HeatFluxFromHeatStructureBaseUserObject.C
@@ -80,7 +80,7 @@ HeatFluxFromHeatStructureBaseUserObject::finalize()
 void
 HeatFluxFromHeatStructureBaseUserObject::threadJoin(const UserObject & y)
 {
-  const auto & uo = static_cast<const HeatFluxFromHeatStructureBaseUserObject &>(y);
+  const auto & uo = cast_ref<const HeatFluxFromHeatStructureBaseUserObject &>(y);
   for (auto & it : uo._heated_perimeter)
     _heated_perimeter[it.first] = it.second;
   for (auto & it : uo._heat_flux)

--- a/modules/thermal_hydraulics/src/userobjects/StoreVariableByElemIDSideUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/StoreVariableByElemIDSideUserObject.C
@@ -52,7 +52,7 @@ StoreVariableByElemIDSideUserObject::execute()
 void
 StoreVariableByElemIDSideUserObject::threadJoin(const UserObject & uo)
 {
-  const auto & other_uo = static_cast<const StoreVariableByElemIDSideUserObject &>(uo);
+  const auto & other_uo = cast_ref<const StoreVariableByElemIDSideUserObject &>(uo);
   const auto other_map = other_uo._elem_id_to_var_values;
   for (auto & it : other_map)
     _elem_id_to_var_values[it.first] = it.second;

--- a/modules/thermal_hydraulics/src/vectorpostprocessors/NumericalFlux3EqnInternalValues.C
+++ b/modules/thermal_hydraulics/src/vectorpostprocessors/NumericalFlux3EqnInternalValues.C
@@ -84,7 +84,7 @@ NumericalFlux3EqnInternalValues::finalize()
 void
 NumericalFlux3EqnInternalValues::threadJoin(const UserObject & y)
 {
-  const auto & vpp = static_cast<const NumericalFlux3EqnInternalValues &>(y);
+  const auto & vpp = cast_ref<const NumericalFlux3EqnInternalValues &>(y);
 
   SamplerBase::threadJoin(vpp);
 }

--- a/modules/xfem/src/userobjects/GeometricCutUserObject.C
+++ b/modules/xfem/src/userobjects/GeometricCutUserObject.C
@@ -129,7 +129,7 @@ GeometricCutUserObject::execute()
 void
 GeometricCutUserObject::threadJoin(const UserObject & y)
 {
-  const auto & gcuo = static_cast<const GeometricCutUserObject &>(y);
+  const auto & gcuo = cast_ref<const GeometricCutUserObject &>(y);
 
   for (const auto & it : gcuo._marked_elems_2d)
   {

--- a/modules/xfem/src/userobjects/MeshCut2DNucleationBase.C
+++ b/modules/xfem/src/userobjects/MeshCut2DNucleationBase.C
@@ -111,7 +111,7 @@ MeshCut2DNucleationBase::execute()
 void
 MeshCut2DNucleationBase::threadJoin(const UserObject & y)
 {
-  const auto & xmuo = static_cast<const MeshCut2DNucleationBase &>(y);
+  const auto & xmuo = cast_ref<const MeshCut2DNucleationBase &>(y);
   for (std::map<unsigned int, std::pair<RealVectorValue, RealVectorValue>>::const_iterator mit =
            xmuo._nucleated_elems.begin();
        mit != xmuo._nucleated_elems.end();

--- a/test/include/postprocessors/SetupInterfaceCount.h
+++ b/test/include/postprocessors/SetupInterfaceCount.h
@@ -142,7 +142,7 @@ void
 SetupInterfaceCount<T>::threadJoinHelper(const UserObject & uo)
 {
   // Accumulate 'execute' count from other threads
-  const SetupInterfaceCount<T> & sic = static_cast<const SetupInterfaceCount<T> &>(uo);
+  const SetupInterfaceCount<T> & sic = cast_ref<const SetupInterfaceCount<T> &>(uo);
   _execute += sic._execute;
   _counts.at("THREADJOIN")++;
 }

--- a/test/src/auxkernels/CheckActiveMatProp.C
+++ b/test/src/auxkernels/CheckActiveMatProp.C
@@ -37,6 +37,6 @@ CheckActiveMatProp::computeValue()
 {
   mooseAssert(dynamic_cast<CheckActiveMatPropProblem *>(&_problem),
               "We don't want undefined behavior");
-  return static_cast<CheckActiveMatPropProblem &>(_problem).getActiveMaterialProperties(_tid).count(
+  return cast_ref<CheckActiveMatPropProblem &>(_problem).getActiveMaterialProperties(_tid).count(
              _prop_id) > 0;
 }

--- a/test/src/kernels/SplineFFn.C
+++ b/test/src/kernels/SplineFFn.C
@@ -21,7 +21,7 @@ SplineFFn::validParams()
 }
 
 SplineFFn::SplineFFn(const InputParameters & parameters)
-  : Kernel(parameters), _fn(static_cast<const SplineFunction &>(getFunction("function")))
+  : Kernel(parameters), _fn(cast_ref<const SplineFunction &>(getFunction("function")))
 {
 }
 

--- a/test/src/meshgenerators/TestDataDrivenGenerator.C
+++ b/test/src/meshgenerators/TestDataDrivenGenerator.C
@@ -94,7 +94,7 @@ TestDataDrivenGenerator::generate()
         getMeshProperty<unsigned int>("ny", getParam<MeshGeneratorName>("ny_generator"));
 
     auto mesh = buildMeshBaseObject();
-    MeshTools::Generation::build_square(static_cast<UnstructuredMesh &>(*mesh), nx, ny);
+    MeshTools::Generation::build_square(cast_ref<UnstructuredMesh &>(*mesh), nx, ny);
     return mesh;
   }
   else if (_subgenerator_no_data_only_mesh && _subgenerator_no_data_only_submesh)

--- a/test/src/postprocessors/InternalSideJump.C
+++ b/test/src/postprocessors/InternalSideJump.C
@@ -69,6 +69,6 @@ InternalSideJump::getValue() const
 void
 InternalSideJump::threadJoin(const UserObject & y)
 {
-  const InternalSideJump & pps = static_cast<const InternalSideJump &>(y);
+  const InternalSideJump & pps = cast_ref<const InternalSideJump &>(y);
   _integral_value += pps._integral_value;
 }

--- a/test/src/postprocessors/NumInternalSides.C
+++ b/test/src/postprocessors/NumInternalSides.C
@@ -52,6 +52,6 @@ NumInternalSides::getValue() const
 void
 NumInternalSides::threadJoin(const UserObject & uo)
 {
-  const NumInternalSides & obj = static_cast<const NumInternalSides &>(uo);
+  const NumInternalSides & obj = cast_ref<const NumInternalSides &>(uo);
   _count += obj.count();
 }

--- a/test/src/postprocessors/SamplerTester.C
+++ b/test/src/postprocessors/SamplerTester.C
@@ -366,7 +366,7 @@ SamplerTester::threadJoin(const UserObject & uo)
 {
   if (_test_type == "thread")
   {
-    const SamplerTester & other = static_cast<const SamplerTester &>(uo);
+    const SamplerTester & other = cast_ref<const SamplerTester &>(uo);
     if (_sampler.getGlobalSamples() != other._sampler.getGlobalSamples())
       mooseError("The sample generation is not working correctly with threads.");
   }

--- a/test/src/postprocessors/SingleInternalFaceValue.C
+++ b/test/src/postprocessors/SingleInternalFaceValue.C
@@ -57,7 +57,7 @@ SingleInternalFaceValue::execute()
 void
 SingleInternalFaceValue::threadJoin(const UserObject & y)
 {
-  const auto & pps = static_cast<const SingleInternalFaceValue &>(y);
+  const auto & pps = cast_ref<const SingleInternalFaceValue &>(y);
   _value += pps.getValue();
 }
 

--- a/test/src/problems/CheckActiveMatPropProblem.C
+++ b/test/src/problems/CheckActiveMatPropProblem.C
@@ -32,19 +32,19 @@ CheckActiveMatPropProblem::getActiveMaterialProperties(const THREAD_ID tid) cons
   // get active properties for materials
   for (auto & mat : _all_materials.getObjects(tid))
   {
-    auto & check_mat = static_cast<ActiveGenericConstantMaterial &>(*mat);
+    auto & check_mat = cast_ref<ActiveGenericConstantMaterial &>(*mat);
     const auto & active_props = check_mat.getActivePropIDs();
     ret.insert(active_props.begin(), active_props.end());
   }
   for (auto & mat : _all_materials[Moose::FACE_MATERIAL_DATA].getObjects(tid))
   {
-    auto & check_mat = static_cast<ActiveGenericConstantMaterial &>(*mat);
+    auto & check_mat = cast_ref<ActiveGenericConstantMaterial &>(*mat);
     const auto & active_props = check_mat.getActivePropIDs();
     ret.insert(active_props.begin(), active_props.end());
   }
   for (auto & mat : _all_materials[Moose::NEIGHBOR_MATERIAL_DATA].getObjects(tid))
   {
-    auto & check_mat = static_cast<ActiveGenericConstantMaterial &>(*mat);
+    auto & check_mat = cast_ref<ActiveGenericConstantMaterial &>(*mat);
     const auto & active_props = check_mat.getActivePropIDs();
     ret.insert(active_props.begin(), active_props.end());
   }

--- a/test/src/userobjects/RandomElementalUserObject.C
+++ b/test/src/userobjects/RandomElementalUserObject.C
@@ -52,7 +52,7 @@ RandomElementalUserObject::finalize()
 void
 RandomElementalUserObject::threadJoin(const UserObject & y)
 {
-  const RandomElementalUserObject & uo = static_cast<const RandomElementalUserObject &>(y);
+  const RandomElementalUserObject & uo = cast_ref<const RandomElementalUserObject &>(y);
 
   _random_data.insert(uo._random_data.begin(), uo._random_data.end());
 }

--- a/test/src/userobjects/TestADScalarKernelUserObject.C
+++ b/test/src/userobjects/TestADScalarKernelUserObject.C
@@ -53,7 +53,7 @@ TestADScalarKernelUserObject::execute()
 void
 TestADScalarKernelUserObject::threadJoin(const UserObject & y)
 {
-  const TestADScalarKernelUserObject & uo = static_cast<const TestADScalarKernelUserObject &>(y);
+  const TestADScalarKernelUserObject & uo = cast_ref<const TestADScalarKernelUserObject &>(y);
   _integral_value += uo._integral_value;
 }
 

--- a/test/src/userobjects/TestXYDelaunayGeneratorArea.C
+++ b/test/src/userobjects/TestXYDelaunayGeneratorArea.C
@@ -63,6 +63,6 @@ TestXYDelaunayGeneratorArea::finalize()
 void
 TestXYDelaunayGeneratorArea::threadJoin(const UserObject & uo)
 {
-  const auto & obj = static_cast<const TestXYDelaunayGeneratorArea &>(uo);
+  const auto & obj = cast_ref<const TestXYDelaunayGeneratorArea &>(uo);
   _failures.insert(_failures.end(), obj._failures.begin(), obj._failures.end());
 }

--- a/test/src/userobjects/TrackDiracFront.C
+++ b/test/src/userobjects/TrackDiracFront.C
@@ -48,7 +48,7 @@ TrackDiracFront::execute()
 void
 TrackDiracFront::threadJoin(const UserObject & y)
 {
-  const TrackDiracFront & tdf = static_cast<const TrackDiracFront &>(y);
+  const TrackDiracFront & tdf = cast_ref<const TrackDiracFront &>(y);
 
   // Merge in the values from "y"
   _dirac_points.insert(_dirac_points.end(), tdf._dirac_points.begin(), tdf._dirac_points.end());

--- a/test/src/vectorpostprocessors/ElementCounterWithID.C
+++ b/test/src/vectorpostprocessors/ElementCounterWithID.C
@@ -65,7 +65,7 @@ ElementCounterWithID::finalize()
 void
 ElementCounterWithID::threadJoin(const UserObject & y)
 {
-  const ElementCounterWithID & uo = static_cast<const ElementCounterWithID &>(y);
+  const ElementCounterWithID & uo = cast_ref<const ElementCounterWithID &>(y);
   for (auto & id : _unique_ids)
     _counters[id] += uo._counters.at(id);
 }

--- a/test/src/vectorpostprocessors/InterfaceElementCounterWithID.C
+++ b/test/src/vectorpostprocessors/InterfaceElementCounterWithID.C
@@ -76,7 +76,7 @@ InterfaceElementCounterWithID::finalize()
 void
 InterfaceElementCounterWithID::threadJoin(const UserObject & y)
 {
-  const InterfaceElementCounterWithID & uo = static_cast<const InterfaceElementCounterWithID &>(y);
+  const InterfaceElementCounterWithID & uo = cast_ref<const InterfaceElementCounterWithID &>(y);
   for (auto & id : _unique_ids)
   {
     _counters[id].first += uo._counters.at(id).first;

--- a/test/src/vectorpostprocessors/InternalSideElementCounterWithID.C
+++ b/test/src/vectorpostprocessors/InternalSideElementCounterWithID.C
@@ -71,7 +71,7 @@ void
 InternalSideElementCounterWithID::threadJoin(const UserObject & y)
 {
   const InternalSideElementCounterWithID & uo =
-      static_cast<const InternalSideElementCounterWithID &>(y);
+      cast_ref<const InternalSideElementCounterWithID &>(y);
   for (auto & id : _unique_ids)
     _counters[id] += uo._counters.at(id);
 }

--- a/test/src/vectorpostprocessors/SideElementCounterWithID.C
+++ b/test/src/vectorpostprocessors/SideElementCounterWithID.C
@@ -63,7 +63,7 @@ SideElementCounterWithID::finalize()
 void
 SideElementCounterWithID::threadJoin(const UserObject & y)
 {
-  const SideElementCounterWithID & uo = static_cast<const SideElementCounterWithID &>(y);
+  const SideElementCounterWithID & uo = cast_ref<const SideElementCounterWithID &>(y);
   for (auto & id : _unique_ids)
     _counters[id] += uo._counters.at(id);
 }

--- a/unit/src/CSGBaseTest.C
+++ b/unit/src/CSGBaseTest.C
@@ -1277,7 +1277,7 @@ TEST(CSGBaseTest, testUseSurfEngUnit)
   ASSERT_EQ("(-polygon_unit)", infixJSONToString(pre_reg.toInfixJSON()));
 
   // surface should be exactly the polygon unit
-  ASSERT_TRUE(static_cast<const CSGSurface &>(poly) == pre_surfs[0]);
+  ASSERT_TRUE(cast_ref<const CSGSurface &>(poly) == pre_surfs[0]);
 
   // expand unit and check surface of cell region again
   csg_obj->expandEngUnit(poly);

--- a/unit/src/CSGEngUnitTest.C
+++ b/unit/src/CSGEngUnitTest.C
@@ -236,7 +236,7 @@ TEST(CSGEngUnitTest, testPolygonUnitClone)
   CSGNPolygonUnit sq("test_square", num_sides, apothem);
   auto clone_ptr = sq.clone();
   const CSGEngUnit & clone_eng = dynamic_cast<const CSGEngUnit &>(*clone_ptr);
-  ASSERT_TRUE(static_cast<const CSGEngUnit &>(sq) == clone_eng);
+  ASSERT_TRUE(cast_ref<const CSGEngUnit &>(sq) == clone_eng);
 }
 
 /// error checks during construction
@@ -275,11 +275,11 @@ TEST(CSGEngUnitTest, testEngUnitEqual)
   // cast all to basic CSGEngUnit type to be able to compare across types (compilation error if
   // object types are different)
   const CSGEngUnit & eng_u1 = u1;
-  ASSERT_TRUE(eng_u1 != static_cast<const CSGEngUnit &>(u2));
-  ASSERT_TRUE(eng_u1 != static_cast<const CSGEngUnit &>(u3));
-  ASSERT_TRUE(eng_u1 != static_cast<const CSGEngUnit &>(u4));
-  ASSERT_TRUE(eng_u1 != static_cast<const CSGEngUnit &>(u5));
-  ASSERT_TRUE(eng_u1 != static_cast<const CSGEngUnit &>(u6));
+  ASSERT_TRUE(eng_u1 != cast_ref<const CSGEngUnit &>(u2));
+  ASSERT_TRUE(eng_u1 != cast_ref<const CSGEngUnit &>(u3));
+  ASSERT_TRUE(eng_u1 != cast_ref<const CSGEngUnit &>(u4));
+  ASSERT_TRUE(eng_u1 != cast_ref<const CSGEngUnit &>(u5));
+  ASSERT_TRUE(eng_u1 != cast_ref<const CSGEngUnit &>(u6));
 }
 
 /// tests that type-name getters resolve to the derived type when an engineering unit is accessed

--- a/unit/src/DataIOTest.C
+++ b/unit/src/DataIOTest.C
@@ -58,13 +58,13 @@ dataLoad(std::istream & stream, std::unique_ptr<DataType> & v, void * context)
 void
 dataStore(std::ostream & stream, DataStorage & v, void * context)
 {
-  dataStore(stream, static_cast<UniqueStorage<DataType> &>(v), context);
+  dataStore(stream, cast_ref<UniqueStorage<DataType> &>(v), context);
 }
 
 void
 dataLoad(std::istream & stream, DataStorage & v, void * context)
 {
-  dataLoad(stream, static_cast<UniqueStorage<DataType> &>(v), context);
+  dataLoad(stream, cast_ref<UniqueStorage<DataType> &>(v), context);
 }
 
 TEST(DataIOTest, signedChar)


### PR DESCRIPTION
## Reason
You actually get a `dynamic_cast<T &>` and trap `std::bad_cast` immediately in dbg/devel modes.

## Design
Replace `static_cast<T &>` with `cast_ref<T &>` throughout.

## Impact
Double-checked casts in dbg/devel modes.
