### PR TITLE
Restore compatibility with older VTK versions

### DIFF
--- a/framework/include/utils/ImageSampler.h
+++ b/framework/include/utils/ImageSampler.h
@@ -58,12 +58,21 @@ Define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS=1 if built with vendored nlohm
 #include "vtkTIFFReader.h"
 #include "vtkImageData.h"
 #include "vtkStringArray.h"
-#include "vtkImageBinaryThreshold.h"
 #include "vtkImageNormalize.h"
 #include "vtkImageCast.h"
 #include "vtkImageShiftScale.h"
 #include "vtkImageMagnitude.h"
 #include "vtkImageFlip.h"
+
+// Compatibility with both older and new VTK
+#if LIBMESH_DETECTED_VTK_VERSION_MAJOR < 9 ||                                                      \
+    (LIBMESH_DETECTED_VTK_VERSION_MAJOR == 9 && LIBMESH_DETECTED_VTK_VERSION_MINOR < 7)
+#include "vtkImageThreshold.h"
+#define mooseVtkImageBinaryThreshold vtkImageThreshold
+#else
+#include "vtkImageBinaryThreshold.h"
+#define mooseVtkImageBinaryThreshold vtkImageBinaryThreshold
+#endif
 
 // If VTK is built without an external nlohmann, then it assumes it
 // will never be compiled against another nlohmann, and it defines an
@@ -140,7 +149,7 @@ private:
   vtkSmartPointer<vtkImageReader2> _image;
 
   /// Pointer to thresholding filter
-  vtkSmartPointer<vtkImageBinaryThreshold> _image_threshold;
+  vtkSmartPointer<mooseVtkImageBinaryThreshold> _image_threshold;
 
   /// Pointer to the shift and scaling filter
   vtkSmartPointer<vtkImageShiftScale> _shift_scale_filter;

--- a/framework/include/utils/MeshBaseImageSampler.h
+++ b/framework/include/utils/MeshBaseImageSampler.h
@@ -58,12 +58,21 @@ Define MOOSE_VTK_UNDEF_NLOHMANNJSON_HEADER_GUARDS=1 if built with vendored nlohm
 #include "vtkTIFFReader.h"
 #include "vtkImageData.h"
 #include "vtkStringArray.h"
-#include "vtkImageBinaryThreshold.h"
 #include "vtkImageNormalize.h"
 #include "vtkImageCast.h"
 #include "vtkImageShiftScale.h"
 #include "vtkImageMagnitude.h"
 #include "vtkImageFlip.h"
+
+// Compatibility with both older and new VTK
+#if LIBMESH_DETECTED_VTK_VERSION_MAJOR < 9 ||                                                      \
+    (LIBMESH_DETECTED_VTK_VERSION_MAJOR == 9 && LIBMESH_DETECTED_VTK_VERSION_MINOR < 7)
+#include "vtkImageThreshold.h"
+#define mooseVtkImageBinaryThreshold vtkImageThreshold
+#else
+#include "vtkImageBinaryThreshold.h"
+#define mooseVtkImageBinaryThreshold vtkImageBinaryThreshold
+#endif
 
 // If VTK is built without an external nlohmann, then it assumes it
 // will never be compiled against another nlohmann, and it defines an
@@ -145,7 +154,7 @@ private:
   vtkSmartPointer<vtkImageReader2> _image;
 
   /// Pointer to thresholding filter
-  vtkSmartPointer<vtkImageBinaryThreshold> _image_threshold;
+  vtkSmartPointer<mooseVtkImageBinaryThreshold> _image_threshold;
 
   /// Pointer to the shift and scaling filter
   vtkSmartPointer<vtkImageShiftScale> _shift_scale_filter;

--- a/framework/src/utils/ImageSampler.C
+++ b/framework/src/utils/ImageSampler.C
@@ -311,13 +311,18 @@ ImageSampler::vtkThreshold()
                "be set");
 
   // Create the thresholding object
-  _image_threshold = vtkSmartPointer<vtkImageBinaryThreshold>::New();
+  _image_threshold = vtkSmartPointer<mooseVtkImageBinaryThreshold>::New();
 
   // Set the data source
   _image_threshold->SetInputConnection(_algorithm);
 
   // Setup the thresholding options
+#if LIBMESH_DETECTED_VTK_VERSION_MAJOR < 9 ||                                                      \
+    (LIBMESH_DETECTED_VTK_VERSION_MAJOR == 9 && LIBMESH_DETECTED_VTK_VERSION_MINOR < 7)
+  _image_threshold->ThresholdByUpper(_is_pars.get<Real>("threshold"));
+#else
   _image_threshold->SetLowerThreshold(_is_pars.get<Real>("threshold"));
+#endif
   _image_threshold->ReplaceInOn();
   _image_threshold->SetInValue(_is_pars.get<Real>("upper_value"));
   _image_threshold->ReplaceOutOn();

--- a/framework/src/utils/MeshBaseImageSampler.C
+++ b/framework/src/utils/MeshBaseImageSampler.C
@@ -307,13 +307,18 @@ MeshBaseImageSampler::vtkThreshold()
                "be set");
 
   // Create the thresholding object
-  _image_threshold = vtkSmartPointer<vtkImageBinaryThreshold>::New();
+  _image_threshold = vtkSmartPointer<mooseVtkImageBinaryThreshold>::New();
 
   // Set the data source
   _image_threshold->SetInputConnection(_algorithm);
 
   // Setup the thresholding options
+#if LIBMESH_DETECTED_VTK_VERSION_MAJOR < 9 ||                                                      \
+    (LIBMESH_DETECTED_VTK_VERSION_MAJOR == 9 && LIBMESH_DETECTED_VTK_VERSION_MINOR < 7)
+  _image_threshold->ThresholdByUpper(_is_pars.get<Real>("threshold"));
+#else
   _image_threshold->SetLowerThreshold(_is_pars.get<Real>("threshold"));
+#endif
   _image_threshold->ReplaceInOn();
   _image_threshold->SetInValue(_is_pars.get<Real>("upper_value"));
   _image_threshold->ReplaceOutOn();


### PR DESCRIPTION
Refs #33466, where this regressed.

## Reason
We now avoid using APIs that are deprecated in VTK 9.7, which is good, except that the new APIs are non-existent in VTK pre-9.7

## Design
Use version detection to select the proper VTK APIs at runtime.

## Impact
No user-facing changes.

MOOSE compiles on my system again.