### PR TITLE
Test cache preparation before printing cached data

### DIFF
--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -116,9 +116,10 @@ outputMeshInformation(FEProblemBase & problem, bool verbose)
           << (forced || pre_split ? ")" : "");
     }
     oss << '\n';
-    oss << std::setw(console_field_width) << "  Mesh Dimension: " << mesh.dimension() << '\n'
-        << std::setw(console_field_width) << "  Spatial Dimension: " << mesh.spatialDimension()
-        << '\n';
+    oss << std::setw(console_field_width) << "  Mesh Dimension: " << mesh.dimension() << '\n';
+    if (mesh.getMesh().preparation().has_cached_elem_data)
+      oss << std::setw(console_field_width) << "  Spatial Dimension: " << mesh.spatialDimension()
+          << '\n';
   }
 
   // Nodes, only associated with the mesh in libMesh


### PR DESCRIPTION
I'd like to enforce via assertion that user code is never relying on outdated caches in a spatial_dimension() call, so when we might have an outdated cache it's necessary to skip that.

Refs #32398; this is to help us add more verification that the optimizations for that aren't getting mesh generators into trouble.