### PR TITLE
Support dataLoad/Store(InfMapType)

### DIFF
--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -26,6 +26,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/enum_elem_quality.h"
 #include "libmesh/enum_elem_type.h"
+#include "libmesh/enum_inf_map_type.h"
 
 #include "LibtorchUtils.h"
 
@@ -135,6 +136,7 @@ inline void dataStore(std::ostream & stream, EnumType & enum_type, void * ctx) \
   dataStore(stream, stored, ctx); \
 }
 
+dataStoreEnum(libMesh::InfMapType, int)
 dataStoreEnum(libMesh::FEFamily, int)
 dataStoreEnum(libMesh::ParallelType, int)
 dataStoreEnum(Moose::CoordinateSystemType, int)
@@ -681,6 +683,7 @@ inline void dataLoad(std::istream & stream, EnumType & enum_type, void * ctx) \
   enum_type = static_cast<EnumType>(loaded); \
 }
 
+dataLoadEnum(libMesh::InfMapType, int)
 dataLoadEnum(libMesh::FEFamily, int)
 dataLoadEnum(libMesh::ParallelType, int)
 dataLoadEnum(Moose::CoordinateSystemType, int)


### PR DESCRIPTION
This became necessary for infinite-element support in #32404, when we added explicit Load/Store support for FEFamily.

I'm not sure how I'm only noticing this now; I swear I build libMesh with infinite-element support on (via --enable-everything) as a matter of habit.

## Reason
Bugfix for builds against libMesh --enable-ifem configurations

## Design
Adds missing specializations

## Impact
No API changes