### PR TITLE
Increase slots for memory heavy test

### DIFF
--- a/test/tests/reporters/mesh_info/tests
+++ b/test/tests/reporters/mesh_info/tests
@@ -139,6 +139,7 @@
                   Reporters/mesh_info/subdomain_items="min_volume max_volume"
                   Outputs/file_base=subdomain_items_out'
       skip_keys = 'part number_of_parts'
+      min_slots = 2 # memory heavy
 
       detail = "includes selected extra information about subdomains"
     []


### PR DESCRIPTION
## Reason

This test often hits memory limits on the distributed mesh recover test.

## Design

Increase slots for test.

## Impact

Test allocates more resources but won't cause memory errors.