### PR TITLE
complete_preparation() after transformMesh()

### DIFF
--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -686,12 +686,17 @@ MultiApp::preTransfer(Real /*dt*/, Real target_time)
         for (const auto i : make_range(_my_num_apps))
         {
           auto app_ptr = _apps[i];
+          auto & mesh = app_ptr->getExecutioner()->feProblem().mesh();
           if (usingPositions())
             app_ptr->getExecutioner()->feProblem().coordTransform().transformMesh(
-                app_ptr->getExecutioner()->feProblem().mesh(), _positions[_first_local_app + i]);
+                mesh, _positions[_first_local_app + i]);
           else
-            app_ptr->getExecutioner()->feProblem().coordTransform().transformMesh(
-                app_ptr->getExecutioner()->feProblem().mesh(), Point(0, 0, 0));
+            app_ptr->getExecutioner()->feProblem().coordTransform().transformMesh(mesh,
+                                                                                  Point(0, 0, 0));
+
+          // Transforming marks mesh->spatial_dimension() as invalid,
+          // so we reprepare before trying to print that later.
+          mesh.getMesh().complete_preparation();
         }
 
       // If the time step covers multiple reset times, set them all as having 'happened'
@@ -1286,12 +1291,16 @@ MultiApp::createApp(unsigned int i, Real start_time)
   // Transform the app mesh if requested
   if (_run_in_position)
   {
+    auto & mesh = app->getExecutioner()->feProblem().mesh();
     if (usingPositions())
       app->getExecutioner()->feProblem().coordTransform().transformMesh(
-          app->getExecutioner()->feProblem().mesh(), _positions[_first_local_app + i]);
+          mesh, _positions[_first_local_app + i]);
     else
-      app->getExecutioner()->feProblem().coordTransform().transformMesh(
-          app->getExecutioner()->feProblem().mesh(), Point(0, 0, 0));
+      app->getExecutioner()->feProblem().coordTransform().transformMesh(mesh, Point(0, 0, 0));
+
+    // Transforming marks mesh->spatial_dimension() as invalid, so we
+    // reprepare before trying to print that later.
+    mesh.getMesh().complete_preparation();
   }
 }
 


### PR DESCRIPTION
The input mesh here is already prepared, but the output mesh will have a cache invalidated by the transform.

Refs #32398 - this is the fix for the issue that I was trying to work around with #33613

## Reason
MOOSE `transformMesh()` invalidates the `spatial_dimension()` cache.  I'd like to start asserting in libMesh that that cache doesn't get used when it's not definitely valid, and my assertions fail when a MultiApp prints a transformed mesh spatial_dimension() to console.

## Design
If a MultiApp setup transforms a mesh, it should re-complete mesh preparation afterward.

## Impact
No user-facing impacts.  The libMesh PR this will enable might catch other issues in downstream apps.