### PR TITLE
Remove using namespace libMesh directives

### DIFF
--- a/framework/src/actions/AddNodalNormalsAction.C
+++ b/framework/src/actions/AddNodalNormalsAction.C
@@ -14,8 +14,6 @@
 #include "libmesh/fe.h"
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 registerMooseAction("MooseApp", AddNodalNormalsAction, "add_aux_variable");
 registerMooseAction("MooseApp", AddNodalNormalsAction, "add_postprocessor");
 registerMooseAction("MooseApp", AddNodalNormalsAction, "add_user_object");

--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -19,8 +19,6 @@
 #include "MooseUtils.h"
 #include "BlockRestrictionDebugOutput.h"
 
-using namespace libMesh;
-
 registerMooseAction("MooseApp", SetupDebugAction, "add_output");
 
 InputParameters

--- a/framework/src/constraints/MortarSegmentInfo.C
+++ b/framework/src/constraints/MortarSegmentInfo.C
@@ -12,8 +12,6 @@
 
 #include "libmesh/elem.h"
 
-using namespace libMesh;
-
 // Initialize constant static members.
 const Real MortarSegmentInfo::invalid_xi = 99;
 

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -19,8 +19,6 @@
 #include "libmesh/enum_point_locator_type.h"
 #include "libmesh/point.h"
 
-using namespace libMesh;
-
 DiracKernelInfo::DiracKernelInfo()
   : _point_locator(), _point_equal_distance_sq(libMesh::TOLERANCE * libMesh::TOLERANCE)
 {

--- a/framework/src/functions/MooseParsedFunctionWrapper.C
+++ b/framework/src/functions/MooseParsedFunctionWrapper.C
@@ -13,8 +13,6 @@
 #include "Function.h"
 #include "MooseUtils.h"
 
-using namespace libMesh;
-
 MooseParsedFunctionWrapper::MooseParsedFunctionWrapper(FEProblemBase & feproblem,
                                                        const std::string & function_str,
                                                        const std::vector<std::string> & vars,

--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -26,8 +26,6 @@
 // C++
 #include <cstring> // for "Jacobian" exception test
 
-using namespace libMesh;
-
 namespace Moose
 {
 

--- a/framework/src/geomsearch/PenetrationInfo.C
+++ b/framework/src/geomsearch/PenetrationInfo.C
@@ -20,8 +20,6 @@
 
 #include "libmesh/elem.h"
 
-using namespace libMesh;
-
 PenetrationInfo::PenetrationInfo(const Elem * elem,
                                  const Elem * side,
                                  unsigned int side_num,

--- a/framework/src/geomsearch/PenetrationLocator.C
+++ b/framework/src/geomsearch/PenetrationLocator.C
@@ -19,8 +19,6 @@
 #include "SubProblem.h"
 #include "MooseApp.h"
 
-using namespace libMesh;
-
 PenetrationLocator::PenetrationLocator(SubProblem & subproblem,
                                        GeometricSearchData & /*geom_search_data*/,
                                        MooseMesh & mesh,

--- a/framework/src/hdgkernels/AdvectionHDGAssemblyHelper.C
+++ b/framework/src/hdgkernels/AdvectionHDGAssemblyHelper.C
@@ -12,8 +12,6 @@
 #include "MooseObject.h"
 #include "TransientInterface.h"
 
-using namespace libMesh;
-
 InputParameters
 AdvectionHDGAssemblyHelper::validParams()
 {

--- a/framework/src/hdgkernels/DiffusionIPHDGAssemblyHelper.C
+++ b/framework/src/hdgkernels/DiffusionIPHDGAssemblyHelper.C
@@ -19,8 +19,6 @@
 #include "MooseVariableFE.h"
 #include "TransientInterface.h"
 
-using namespace libMesh;
-
 InputParameters
 DiffusionIPHDGAssemblyHelper::validParams()
 {

--- a/framework/src/hdgkernels/DiffusionLHDGAssemblyHelper.C
+++ b/framework/src/hdgkernels/DiffusionLHDGAssemblyHelper.C
@@ -16,8 +16,6 @@
 #include "NonlinearThread.h"
 #include "TransientInterface.h"
 
-using namespace libMesh;
-
 InputParameters
 DiffusionLHDGAssemblyHelper::validParams()
 {

--- a/framework/src/hdgkernels/DiffusionLHDGKernel.C
+++ b/framework/src/hdgkernels/DiffusionLHDGKernel.C
@@ -17,8 +17,6 @@
 #include "MaterialPropertyInterface.h"
 #include "NonlinearThread.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", DiffusionLHDGKernel);
 
 InputParameters

--- a/framework/src/hdgkernels/ElementAndTraceScalarHDGAssemblyHelper.C
+++ b/framework/src/hdgkernels/ElementAndTraceScalarHDGAssemblyHelper.C
@@ -17,8 +17,6 @@
 #include "TaggingInterface.h"
 #include "TransientInterface.h"
 
-using namespace libMesh;
-
 InputParameters
 ElementAndTraceScalarHDGAssemblyHelper::validParams()
 {

--- a/framework/src/kernels/ConservativeAdvection.C
+++ b/framework/src/kernels/ConservativeAdvection.C
@@ -10,8 +10,6 @@
 #include "ConservativeAdvection.h"
 #include "SystemBase.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", ConservativeAdvection);
 registerMooseObject("MooseApp", ADConservativeAdvection);
 

--- a/framework/src/loops/ComputeJacobianForScalingThread.C
+++ b/framework/src/loops/ComputeJacobianForScalingThread.C
@@ -16,8 +16,6 @@
 // C++
 #include <cstring> // for "Jacobian" exception test
 
-using namespace libMesh;
-
 ComputeJacobianForScalingThread::ComputeJacobianForScalingThread(FEProblemBase & fe_problem,
                                                                  const std::set<TagID> & tags)
   : ComputeFullJacobianThread(fe_problem, tags)

--- a/framework/src/meshgenerators/BSplineCurveGenerator.C
+++ b/framework/src/meshgenerators/BSplineCurveGenerator.C
@@ -18,8 +18,6 @@
 #include "libmesh/edge_edge3.h"
 #include "libmesh/edge_edge4.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", BSplineCurveGenerator);
 
 InputParameters

--- a/framework/src/multiapps/QuadraturePointMultiApp.C
+++ b/framework/src/multiapps/QuadraturePointMultiApp.C
@@ -18,8 +18,6 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", QuadraturePointMultiApp);
 // TODO: Deprecate and use Positions system
 

--- a/framework/src/neml2/userobjects/NEML2Assembly.C
+++ b/framework/src/neml2/userobjects/NEML2Assembly.C
@@ -15,8 +15,6 @@
 // MOOSE includes
 #include "NEML2Assembly.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", NEML2Assembly);
 
 InputParameters

--- a/framework/src/neml2/userobjects/NEML2FEInterpolation.C
+++ b/framework/src/neml2/userobjects/NEML2FEInterpolation.C
@@ -22,8 +22,6 @@
 // MOOSE includes
 #include "NEML2FEInterpolation.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", NEML2FEInterpolation);
 
 InputParameters

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -24,8 +24,6 @@
 // libMesh includes
 #include "libmesh/enum_norm_type.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", Console);
 
 InputParameters

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -21,8 +21,6 @@
 #include "libmesh/exodusII_io.h"
 #include "libmesh/libmesh_config.h" // LIBMESH_HAVE_HDF5
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", Exodus);
 
 InputParameters

--- a/framework/src/positions/QuadraturePointsPositions.C
+++ b/framework/src/positions/QuadraturePointsPositions.C
@@ -11,8 +11,6 @@
 #include "libmesh/quadrature_gauss.h"
 #include "SetupQuadratureAction.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", QuadraturePointsPositions);
 
 InputParameters

--- a/framework/src/preconditioners/PhysicsBasedPreconditioner.C
+++ b/framework/src/preconditioners/PhysicsBasedPreconditioner.C
@@ -28,8 +28,6 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/coupling_matrix.h"
 
-using namespace libMesh;
-
 registerMooseObjectAliased("MooseApp", PhysicsBasedPreconditioner, "PBP");
 
 InputParameters

--- a/framework/src/preconditioners/VariableCondensationPreconditioner.C
+++ b/framework/src/preconditioners/VariableCondensationPreconditioner.C
@@ -35,8 +35,6 @@
 
 #include <petscmat.h>
 
-using namespace libMesh;
-
 registerMooseObjectAliased("MooseApp", VariableCondensationPreconditioner, "VCP");
 
 InputParameters

--- a/framework/src/predictors/Predictor.C
+++ b/framework/src/predictors/Predictor.C
@@ -15,8 +15,6 @@
 
 #include "libmesh/numeric_vector.h"
 
-using namespace libMesh;
-
 InputParameters
 Predictor::validParams()
 {

--- a/framework/src/problems/DumpObjectsProblem.C
+++ b/framework/src/problems/DumpObjectsProblem.C
@@ -21,8 +21,6 @@
 
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", DumpObjectsProblem);
 
 InputParameters

--- a/framework/src/problems/ReferenceResidualProblem.C
+++ b/framework/src/problems/ReferenceResidualProblem.C
@@ -10,8 +10,6 @@
 #include "ReferenceResidualProblem.h"
 #include "ReferenceResidualConvergence.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", ReferenceResidualProblem);
 
 InputParameters

--- a/framework/src/relationshipmanagers/AugmentSparsityOnInterface.C
+++ b/framework/src/relationshipmanagers/AugmentSparsityOnInterface.C
@@ -20,8 +20,6 @@
 
 registerMooseObject("MooseApp", AugmentSparsityOnInterface);
 
-using namespace libMesh;
-
 InputParameters
 AugmentSparsityOnInterface::validParams()
 {

--- a/framework/src/relationshipmanagers/GhostBoundary.C
+++ b/framework/src/relationshipmanagers/GhostBoundary.C
@@ -20,8 +20,6 @@
 
 registerMooseObject("MooseApp", GhostBoundary);
 
-using namespace libMesh;
-
 InputParameters
 GhostBoundary::validParams()
 {

--- a/framework/src/systems/LinearFVGradientInterface.C
+++ b/framework/src/systems/LinearFVGradientInterface.C
@@ -22,8 +22,6 @@
 
 #include "libmesh/numeric_vector.h"
 
-using namespace libMesh;
-
 const FVGradientMethod &
 LinearFVGradientInterface::resolveFVGradientMethod(const GradientMethodName & method_name)
 {

--- a/framework/src/systems/SolverSystem.C
+++ b/framework/src/systems/SolverSystem.C
@@ -13,8 +13,6 @@
 #include "TimeIntegrator.h"
 #include "MooseUtils.h"
 
-using namespace libMesh;
-
 SolverSystem::SolverSystem(SubProblem & subproblem,
                            FEProblemBase & fe_problem,
                            const std::string & name,

--- a/framework/src/timeintegrators/AStableDirk4.C
+++ b/framework/src/timeintegrators/AStableDirk4.C
@@ -14,8 +14,6 @@
 #include "PetscSupport.h"
 #include "LStableDirk4.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", AStableDirk4);
 
 InputParameters

--- a/framework/src/timeintegrators/ActuallyExplicitEuler.C
+++ b/framework/src/timeintegrators/ActuallyExplicitEuler.C
@@ -15,8 +15,6 @@
 // libMesh includes
 #include "libmesh/nonlinear_solver.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", ActuallyExplicitEuler);
 
 InputParameters

--- a/framework/src/timeintegrators/CentralDifference.C
+++ b/framework/src/timeintegrators/CentralDifference.C
@@ -15,8 +15,6 @@
 // libMesh includes
 #include "libmesh/nonlinear_solver.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", CentralDifference);
 
 InputParameters

--- a/framework/src/timeintegrators/ExplicitRK2.C
+++ b/framework/src/timeintegrators/ExplicitRK2.C
@@ -12,8 +12,6 @@
 #include "FEProblem.h"
 #include "PetscSupport.h"
 
-using namespace libMesh;
-
 InputParameters
 ExplicitRK2::validParams()
 {

--- a/framework/src/timeintegrators/ExplicitSSPRungeKutta.C
+++ b/framework/src/timeintegrators/ExplicitSSPRungeKutta.C
@@ -15,8 +15,6 @@
 // libMesh includes
 #include "libmesh/nonlinear_solver.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", ExplicitSSPRungeKutta);
 
 InputParameters

--- a/framework/src/timeintegrators/LStableDirk2.C
+++ b/framework/src/timeintegrators/LStableDirk2.C
@@ -12,8 +12,6 @@
 #include "FEProblem.h"
 #include "PetscSupport.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", LStableDirk2);
 
 InputParameters

--- a/framework/src/timeintegrators/LStableDirk3.C
+++ b/framework/src/timeintegrators/LStableDirk3.C
@@ -11,8 +11,6 @@
 #include "NonlinearSystem.h"
 #include "FEProblem.h"
 #include "PetscSupport.h"
-using namespace libMesh;
-
 registerMooseObject("MooseApp", LStableDirk3);
 
 InputParameters

--- a/framework/src/timeintegrators/LStableDirk4.C
+++ b/framework/src/timeintegrators/LStableDirk4.C
@@ -12,8 +12,6 @@
 #include "FEProblem.h"
 #include "PetscSupport.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", LStableDirk4);
 
 InputParameters

--- a/framework/src/timeintegrators/TimeIntegrator.C
+++ b/framework/src/timeintegrators/TimeIntegrator.C
@@ -15,8 +15,6 @@
 #include "libmesh/nonlinear_solver.h"
 #include "libmesh/dof_map.h"
 
-using namespace libMesh;
-
 InputParameters
 TimeIntegrator::validParams()
 {

--- a/framework/src/timesteppers/AB2PredictorCorrector.C
+++ b/framework/src/timesteppers/AB2PredictorCorrector.C
@@ -25,8 +25,6 @@
 #include <iostream>
 #include <fstream>
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", AB2PredictorCorrector);
 
 InputParameters

--- a/framework/src/timesteppers/ExodusTimeSequenceStepper.C
+++ b/framework/src/timesteppers/ExodusTimeSequenceStepper.C
@@ -12,8 +12,6 @@
 #include "libmesh/serial_mesh.h"
 #include "libmesh/exodusII_io.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", ExodusTimeSequenceStepper);
 
 InputParameters

--- a/framework/src/transfers/MultiAppDofCopyTransfer.C
+++ b/framework/src/transfers/MultiAppDofCopyTransfer.C
@@ -16,8 +16,6 @@
 #include "libmesh/id_types.h"
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 InputParameters
 MultiAppDofCopyTransfer::validParams()
 {

--- a/framework/src/transfers/MultiAppGeneralFieldFunctorTransfer.C
+++ b/framework/src/transfers/MultiAppGeneralFieldFunctorTransfer.C
@@ -19,8 +19,6 @@
 #include "MooseAppCoordTransform.h"
 #include "MooseFunctorArguments.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", MultiAppGeneralFieldFunctorTransfer);
 
 InputParameters

--- a/framework/src/transfers/MultiAppGeneralFieldKDTreeTransferBase.C
+++ b/framework/src/transfers/MultiAppGeneralFieldKDTreeTransferBase.C
@@ -20,8 +20,6 @@
 
 #include "libmesh/system.h"
 
-using namespace libMesh;
-
 InputParameters
 MultiAppGeneralFieldKDTreeTransferBase::validParams()
 {

--- a/framework/src/transfers/MultiAppGeneralFieldNearestLocationTransfer.C
+++ b/framework/src/transfers/MultiAppGeneralFieldNearestLocationTransfer.C
@@ -20,8 +20,6 @@
 
 #include "libmesh/system.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", MultiAppGeneralFieldNearestLocationTransfer);
 registerMooseObjectRenamed("MooseApp",
                            MultiAppGeneralFieldNearestNodeTransfer,

--- a/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
@@ -24,8 +24,6 @@
 
 #include "timpi/parallel_sync.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", MultiAppVariableValueSamplePostprocessorTransfer);
 
 InputParameters

--- a/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
@@ -21,8 +21,6 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/system.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", MultiAppVariableValueSampleTransfer);
 
 InputParameters

--- a/framework/src/transfers/Transfer.C
+++ b/framework/src/transfers/Transfer.C
@@ -19,8 +19,6 @@
 // libMesh
 #include "libmesh/system.h"
 
-using namespace libMesh;
-
 const Number Transfer::OutOfMeshValue = -999999;
 
 InputParameters

--- a/framework/src/utils/BSpline.C
+++ b/framework/src/utils/BSpline.C
@@ -13,8 +13,6 @@
 #include "SplineUtils.h"
 #include "Conversion.h"
 
-using namespace libMesh;
-
 namespace Moose
 {
 BSpline::BSpline(const unsigned int degree,

--- a/framework/src/utils/BoundaryLayerUtils.C
+++ b/framework/src/utils/BoundaryLayerUtils.C
@@ -23,8 +23,6 @@
 #include "libmesh/poly2tri_triangulator.h"
 #include "libmesh/unstructured_mesh.h"
 
-using namespace libMesh;
-
 namespace BoundaryLayerUtils
 {
 

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -19,8 +19,6 @@
 // system includes
 #include <iomanip>
 
-using namespace libMesh;
-
 namespace Moose
 {
 std::map<std::string, CoordinateSystemType> coordinate_system_type_to_enum;

--- a/framework/src/utils/ElementsIntersectedByPlane.C
+++ b/framework/src/utils/ElementsIntersectedByPlane.C
@@ -17,8 +17,6 @@
 
 #include <algorithm>
 
-using namespace libMesh;
-
 namespace Moose
 {
 

--- a/framework/src/utils/FillBetweenPointVectorsTools.C
+++ b/framework/src/utils/FillBetweenPointVectorsTools.C
@@ -24,8 +24,6 @@
 #include "libmesh/face_tri3.h"
 #include "libmesh/face_quad4.h"
 
-using namespace libMesh;
-
 namespace FillBetweenPointVectorsTools
 {
 void

--- a/framework/src/utils/ImageSampler.C
+++ b/framework/src/utils/ImageSampler.C
@@ -14,8 +14,6 @@
 
 #include "libmesh/mesh_tools.h"
 
-using namespace libMesh;
-
 InputParameters
 ImageSampler::validParams()
 {

--- a/framework/src/utils/LinearFVGradientReader.C
+++ b/framework/src/utils/LinearFVGradientReader.C
@@ -19,8 +19,6 @@
 
 #include "libmesh/numeric_vector.h"
 
-using namespace libMesh;
-
 LinearFVGradientReader::LinearFVGradientReader(const SystemBase & sys,
                                                const GradientContainer & components,
                                                const FVGradientMethod & method,

--- a/framework/src/utils/MeshCoarseningUtils.C
+++ b/framework/src/utils/MeshCoarseningUtils.C
@@ -14,8 +14,6 @@
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/remote_elem.h"
 
-using namespace libMesh;
-
 namespace MeshCoarseningUtils
 {
 bool

--- a/framework/src/utils/MeshTriangulationUtils.C
+++ b/framework/src/utils/MeshTriangulationUtils.C
@@ -22,8 +22,6 @@
 #include "libmesh/poly2tri_triangulator.h"
 #include "libmesh/unstructured_mesh.h"
 
-using namespace libMesh;
-
 namespace MeshTriangulationUtils
 {
 

--- a/framework/src/utils/MooseAppCoordTransform.C
+++ b/framework/src/utils/MooseAppCoordTransform.C
@@ -14,8 +14,6 @@
 #include "MooseMesh.h"
 #include "libmesh/mesh_modification.h"
 
-using namespace libMesh;
-
 MooseAppCoordTransform::Direction
 MooseAppCoordTransform::processZAxis(const Direction z_axis)
 {

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -29,8 +29,6 @@
 
 #include "timpi/parallel_sync.h"
 
-using namespace libMesh;
-
 namespace MooseMeshUtils
 {
 

--- a/framework/src/utils/MooseMeshXYCuttingUtils.C
+++ b/framework/src/utils/MooseMeshXYCuttingUtils.C
@@ -18,8 +18,6 @@
 #include "libmesh/parallel_algebra.h"
 #include "libmesh/face_tri3.h"
 
-using namespace libMesh;
-
 namespace MooseMeshXYCuttingUtils
 {
 

--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -23,8 +23,6 @@
 #include "libmesh/fe_type.h"
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 // Users should never actually create this object
 registerMooseObject("MooseApp", MooseVariableBase);
 

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -22,8 +22,6 @@
 #include "libmesh/type_n_tensor.h"
 #include "libmesh/fe_interface.h"
 
-using namespace libMesh;
-
 template <typename OutputType>
 MooseVariableData<OutputType>::MooseVariableData(const MooseVariableFE<OutputType> & var,
                                                  SystemBase & sys,

--- a/framework/src/variables/MooseVariableDependencyInterface.C
+++ b/framework/src/variables/MooseVariableDependencyInterface.C
@@ -17,8 +17,6 @@
 #include "libmesh/dof_object.h"
 #include "libmesh/dof_map.h"
 
-using namespace libMesh;
-
 MooseVariableDependencyInterface::MooseVariableDependencyInterface(const MooseObject *) {}
 
 #ifdef MOOSE_KOKKOS_ENABLED

--- a/modules/heat_transfer/src/userobjects/ViewFactorRayStudy.C
+++ b/modules/heat_transfer/src/userobjects/ViewFactorRayStudy.C
@@ -24,8 +24,6 @@
 #include "ReflectRayBC.h"
 #include "RayTracingPackingUtils.h"
 
-using namespace libMesh;
-
 registerMooseObject("HeatTransferApp", ViewFactorRayStudy);
 
 InputParameters

--- a/modules/navier_stokes/src/actions/CNSAction.C
+++ b/modules/navier_stokes/src/actions/CNSAction.C
@@ -21,8 +21,6 @@
 #include "libmesh/vector_value.h"
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 registerMooseAction("NavierStokesApp", CNSAction, "add_navier_stokes_variables");
 registerMooseAction("NavierStokesApp", CNSAction, "add_navier_stokes_kernels");
 registerMooseAction("NavierStokesApp", CNSAction, "add_navier_stokes_bcs");

--- a/modules/navier_stokes/src/actions/INSAction.C
+++ b/modules/navier_stokes/src/actions/INSAction.C
@@ -23,8 +23,6 @@
 #include "libmesh/vector_value.h"
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 registerMooseAction("NavierStokesApp", INSAction, "append_mesh_generator");
 registerMooseAction("NavierStokesApp", INSAction, "add_navier_stokes_variables");
 registerMooseAction("NavierStokesApp", INSAction, "add_navier_stokes_ics");

--- a/modules/navier_stokes/src/correctors/NSPressurePin.C
+++ b/modules/navier_stokes/src/correctors/NSPressurePin.C
@@ -17,8 +17,6 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/mesh_tools.h"
 
-using namespace libMesh;
-
 registerMooseObject("NavierStokesApp", NSPressurePin);
 registerMooseObjectRenamed("NavierStokesApp", NSFVPressurePin, "01/19/2025 00:00", NSPressurePin);
 

--- a/modules/navier_stokes/src/executioners/PIMPLE.C
+++ b/modules/navier_stokes/src/executioners/PIMPLE.C
@@ -13,8 +13,6 @@
 #include "AuxiliarySystem.h"
 #include "LinearSystem.h"
 
-using namespace libMesh;
-
 registerMooseObject("NavierStokesApp", PIMPLE);
 
 InputParameters

--- a/modules/navier_stokes/src/executioners/PIMPLESolve.C
+++ b/modules/navier_stokes/src/executioners/PIMPLESolve.C
@@ -12,8 +12,6 @@
 #include "SegregatedSolverUtils.h"
 #include "LinearSystem.h"
 
-using namespace libMesh;
-
 InputParameters
 PIMPLESolve::validParams()
 {

--- a/modules/navier_stokes/src/executioners/SIMPLE.C
+++ b/modules/navier_stokes/src/executioners/SIMPLE.C
@@ -11,8 +11,6 @@
 #include "SIMPLE.h"
 #include "FEProblem.h"
 
-using namespace libMesh;
-
 registerMooseObject("NavierStokesApp", SIMPLE);
 
 InputParameters

--- a/modules/navier_stokes/src/executioners/SIMPLESolve.C
+++ b/modules/navier_stokes/src/executioners/SIMPLESolve.C
@@ -12,8 +12,6 @@
 #include "SegregatedSolverUtils.h"
 #include "LinearSystem.h"
 
-using namespace libMesh;
-
 InputParameters
 SIMPLESolve::validParams()
 {

--- a/modules/navier_stokes/src/hdgkernels/MassContinuityAssemblyHelper.C
+++ b/modules/navier_stokes/src/hdgkernels/MassContinuityAssemblyHelper.C
@@ -16,8 +16,6 @@
 #include "SystemBase.h"
 #include "TransientInterface.h"
 
-using namespace libMesh;
-
 InputParameters
 MassContinuityAssemblyHelper::validParams()
 {

--- a/modules/navier_stokes/src/hdgkernels/NavierStokesLHDGAssemblyHelper.C
+++ b/modules/navier_stokes/src/hdgkernels/NavierStokesLHDGAssemblyHelper.C
@@ -16,8 +16,6 @@
 #include "NS.h"
 #include "TransientInterface.h"
 
-using namespace libMesh;
-
 InputParameters
 NavierStokesLHDGAssemblyHelper::validParams()
 {

--- a/modules/navier_stokes/src/hdgkernels/NavierStokesStressIPHDGAssemblyHelper.C
+++ b/modules/navier_stokes/src/hdgkernels/NavierStokesStressIPHDGAssemblyHelper.C
@@ -18,8 +18,6 @@
 #include "Assembly.h"
 #include "MooseMesh.h"
 
-using namespace libMesh;
-
 InputParameters
 NavierStokesStressIPHDGAssemblyHelper::validParams()
 {

--- a/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
+++ b/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
@@ -37,8 +37,6 @@
 #include "metaphysicl/parallel_semidynamicsparsenumberarray.h"
 #include "timpi/parallel_sync.h"
 
-using namespace libMesh;
-
 registerMooseObject("NavierStokesApp", INSFVRhieChowInterpolator);
 
 InputParameters

--- a/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolatorSegregated.C
+++ b/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolatorSegregated.C
@@ -27,8 +27,6 @@
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/petsc_vector.h"
 
-using namespace libMesh;
-
 registerMooseObject("NavierStokesApp", INSFVRhieChowInterpolatorSegregated);
 
 InputParameters

--- a/modules/navier_stokes/src/userobjects/PINSFVRhieChowInterpolatorSegregated.C
+++ b/modules/navier_stokes/src/userobjects/PINSFVRhieChowInterpolatorSegregated.C
@@ -10,8 +10,6 @@
 #include "PINSFVRhieChowInterpolatorSegregated.h"
 #include "NS.h"
 
-using namespace libMesh;
-
 registerMooseObject("NavierStokesApp", PINSFVRhieChowInterpolatorSegregated);
 
 InputParameters

--- a/modules/navier_stokes/src/userobjects/RhieChowFaceFluxProvider.C
+++ b/modules/navier_stokes/src/userobjects/RhieChowFaceFluxProvider.C
@@ -9,8 +9,6 @@
 
 #include "RhieChowFaceFluxProvider.h"
 
-using namespace libMesh;
-
 InputParameters
 RhieChowFaceFluxProvider::validParams()
 {

--- a/modules/navier_stokes/src/userobjects/RhieChowInterpolatorBase.C
+++ b/modules/navier_stokes/src/userobjects/RhieChowInterpolatorBase.C
@@ -22,8 +22,6 @@
 #include "VectorCompositeFunctor.h"
 #include "FVElementalKernel.h"
 
-using namespace libMesh;
-
 InputParameters
 RhieChowInterpolatorBase::validParams()
 {

--- a/modules/navier_stokes/src/userobjects/RhieChowMassFlux.C
+++ b/modules/navier_stokes/src/userobjects/RhieChowMassFlux.C
@@ -27,8 +27,6 @@
 #include "libmesh/elem_range.h"
 #include "libmesh/petsc_matrix.h"
 
-using namespace libMesh;
-
 registerMooseObject("NavierStokesApp", RhieChowMassFlux);
 
 InputParameters

--- a/modules/navier_stokes/unit/src/TestFaceCenteredMapFunctor.C
+++ b/modules/navier_stokes/unit/src/TestFaceCenteredMapFunctor.C
@@ -15,7 +15,6 @@
 #include "libmesh/quadrature_gauss.h"
 #include "MooseMain.h"
 
-using namespace libMesh;
 using namespace Moose;
 using namespace FV;
 

--- a/modules/optimization/src/executioners/AdjointTransientSolve.C
+++ b/modules/optimization/src/executioners/AdjointTransientSolve.C
@@ -16,8 +16,6 @@
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/numeric_vector.h"
 
-using namespace libMesh;
-
 InputParameters
 AdjointTransientSolve::validParams()
 {

--- a/modules/optimization/src/optimizationreporters/ParameterMeshOptimization.C
+++ b/modules/optimization/src/optimizationreporters/ParameterMeshOptimization.C
@@ -16,8 +16,6 @@
 
 #include "ReadExodusMeshVars.h"
 
-using namespace libMesh;
-
 registerMooseObject("OptimizationApp", ParameterMeshOptimization);
 
 InputParameters

--- a/modules/phase_field/src/actions/CHPFCRFFSplitVariablesAction.C
+++ b/modules/phase_field/src/actions/CHPFCRFFSplitVariablesAction.C
@@ -15,8 +15,6 @@
 
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 registerMooseAction("PhaseFieldApp", CHPFCRFFSplitVariablesAction, "add_variable");
 
 InputParameters

--- a/modules/phase_field/src/actions/ConservedAction.C
+++ b/modules/phase_field/src/actions/ConservedAction.C
@@ -18,8 +18,6 @@
 
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 registerMooseAction("PhaseFieldApp", ConservedAction, "add_variable");
 
 registerMooseAction("PhaseFieldApp", ConservedAction, "add_kernel");

--- a/modules/phase_field/src/actions/GrainGrowthAction.C
+++ b/modules/phase_field/src/actions/GrainGrowthAction.C
@@ -20,8 +20,6 @@
 
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 registerMooseAction("PhaseFieldApp", GrainGrowthAction, "add_aux_variable");
 registerMooseAction("PhaseFieldApp", GrainGrowthAction, "add_aux_kernel");
 registerMooseAction("PhaseFieldApp", GrainGrowthAction, "add_variable");

--- a/modules/phase_field/src/actions/NonconservedAction.C
+++ b/modules/phase_field/src/actions/NonconservedAction.C
@@ -18,8 +18,6 @@
 
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 registerMooseAction("PhaseFieldApp", NonconservedAction, "add_variable");
 
 registerMooseAction("PhaseFieldApp", NonconservedAction, "add_kernel");

--- a/modules/phase_field/src/utils/PolycrystalICTools.C
+++ b/modules/phase_field/src/utils/PolycrystalICTools.C
@@ -18,8 +18,6 @@
 #include "libmesh/periodic_boundaries.h"
 #include "libmesh/point_locator_base.h"
 
-using namespace libMesh;
-
 namespace GraphColoring
 {
 const unsigned int INVALID_COLOR = std::numeric_limits<unsigned int>::max();

--- a/modules/ray_tracing/src/outputs/RayTracingMeshOutput.C
+++ b/modules/ray_tracing/src/outputs/RayTracingMeshOutput.C
@@ -24,8 +24,6 @@
 #include "libmesh/parallel_sync.h"
 #include "libmesh/remote_elem.h"
 
-using namespace libMesh;
-
 InputParameters
 RayTracingMeshOutput::validParams()
 {

--- a/modules/ray_tracing/src/raytracing/ClaimRays.C
+++ b/modules/ray_tracing/src/raytracing/ClaimRays.C
@@ -19,8 +19,6 @@
 #include "libmesh/enum_point_locator_type.h"
 #include "libmesh/mesh_tools.h"
 
-using namespace libMesh;
-
 ClaimRays::ClaimRays(RayTracingStudy & study,
                      const std::vector<std::shared_ptr<Ray>> & rays,
                      std::vector<std::shared_ptr<Ray>> & local_rays,

--- a/modules/ray_tracing/src/raytracing/Ray.C
+++ b/modules/ray_tracing/src/raytracing/Ray.C
@@ -17,8 +17,6 @@
 // MOOSE includes
 #include "DataIO.h"
 
-using namespace libMesh;
-
 Ray::Ray(RayTracingStudy * study,
          const RayID id,
          const std::size_t data_size,

--- a/modules/ray_tracing/src/utils/BoundingBoxIntersectionHelper.C
+++ b/modules/ray_tracing/src/utils/BoundingBoxIntersectionHelper.C
@@ -17,8 +17,6 @@
 #include "TraceRayTools.h"
 #include "DebugRay.h"
 
-using namespace libMesh;
-
 BoundingBoxIntersectionHelper::BoundingBoxIntersectionHelper(const BoundingBox & bbox,
                                                              const unsigned int dim)
   : _comm(), _mesh(std::make_unique<Mesh>(_comm, dim))

--- a/modules/ray_tracing/src/utils/ElemIndexHelper.C
+++ b/modules/ray_tracing/src/utils/ElemIndexHelper.C
@@ -9,8 +9,6 @@
 
 #include "ElemIndexHelper.h"
 
-using namespace libMesh;
-
 ElemIndexHelper::ElemIndexHelper(MeshBase & mesh, const std::string & extra_elem_integer_name)
   : _mesh(mesh), _extra_integer(invalid_uint), _initialized(false)
 {

--- a/modules/rdg/src/materials/AEFVMaterial.C
+++ b/modules/rdg/src/materials/AEFVMaterial.C
@@ -12,8 +12,6 @@
 
 #include "libmesh/quadrature.h"
 
-using namespace libMesh;
-
 registerMooseObject("RdgApp", AEFVMaterial);
 
 InputParameters

--- a/modules/reactor/src/meshgenerators/CoarseMeshExtraElementIDGenerator.C
+++ b/modules/reactor/src/meshgenerators/CoarseMeshExtraElementIDGenerator.C
@@ -14,8 +14,6 @@
 #include "libmesh/elem.h"
 #include "libmesh/mesh_serializer.h"
 
-using namespace libMesh;
-
 registerMooseObject("ReactorApp", CoarseMeshExtraElementIDGenerator);
 
 InputParameters

--- a/modules/reactor/src/meshgenerators/PolygonConcentricCircleMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PolygonConcentricCircleMeshGenerator.C
@@ -9,8 +9,6 @@
 
 #include "PolygonConcentricCircleMeshGenerator.h"
 
-using namespace libMesh;
-
 registerMooseObject("ReactorApp", PolygonConcentricCircleMeshGenerator);
 
 InputParameters

--- a/modules/reactor/src/meshgenerators/PolygonMeshGeneratorBase.C
+++ b/modules/reactor/src/meshgenerators/PolygonMeshGeneratorBase.C
@@ -14,8 +14,6 @@
 #include <cmath>
 #include <iomanip>
 
-using namespace libMesh;
-
 InputParameters
 PolygonMeshGeneratorBase::validParams()
 {

--- a/modules/reactor/src/utils/ReportingIDGeneratorUtils.C
+++ b/modules/reactor/src/utils/ReportingIDGeneratorUtils.C
@@ -9,8 +9,6 @@
 
 #include "ReportingIDGeneratorUtils.h"
 
-using namespace libMesh;
-
 std::vector<dof_id_type>
 ReportingIDGeneratorUtils::getCellwiseIntegerIDs(
     const std::vector<std::unique_ptr<ReplicatedMesh>> & meshes,

--- a/modules/shifted_boundary_method/unit/src/OrientedBoundingBoxTest.C
+++ b/modules/shifted_boundary_method/unit/src/OrientedBoundingBoxTest.C
@@ -19,8 +19,6 @@
 #include <cstdio>
 #include <vector>
 
-using namespace libMesh;
-
 namespace
 {
 /// True if `target` matches some point in `pts` within `tol`.

--- a/modules/shifted_boundary_method/unit/src/SBMSurfaceDistanceTest.C
+++ b/modules/shifted_boundary_method/unit/src/SBMSurfaceDistanceTest.C
@@ -15,8 +15,6 @@
 #include "libmesh/face_tri3.h"
 #include "libmesh/edge_edge2.h"
 
-using namespace libMesh;
-
 // The surface-element geometry (normals, intersect, bounding ball, projected
 // bounding-box diagonal, unsupported-geometry dispatchers) is covered by the
 // framework SurfaceElementTest. These tests cover only the SBM-owned

--- a/modules/solid_mechanics/src/actions/LineElementAction.C
+++ b/modules/solid_mechanics/src/actions/LineElementAction.C
@@ -20,8 +20,6 @@
 #include "libmesh/string_to_enum.h"
 #include <algorithm>
 
-using namespace libMesh;
-
 registerMooseAction("SolidMechanicsApp", LineElementAction, "create_problem");
 registerMooseAction("SolidMechanicsApp", LineElementAction, "add_variable");
 registerMooseAction("SolidMechanicsApp", LineElementAction, "add_aux_variable");

--- a/modules/solid_mechanics/src/scalarkernels/GlobalStrain.C
+++ b/modules/solid_mechanics/src/scalarkernels/GlobalStrain.C
@@ -17,8 +17,6 @@
 #include "RankTwoTensor.h"
 #include "RankFourTensor.h"
 
-using namespace libMesh;
-
 registerMooseObject("SolidMechanicsApp", GlobalStrain);
 
 InputParameters

--- a/modules/solid_mechanics/src/userobjects/CavityPressureUserObject.C
+++ b/modules/solid_mechanics/src/userobjects/CavityPressureUserObject.C
@@ -9,8 +9,6 @@
 
 #include "CavityPressureUserObject.h"
 
-using namespace libMesh;
-
 registerMooseObject("SolidMechanicsApp", CavityPressureUserObject);
 
 InputParameters

--- a/modules/solid_mechanics/src/utils/RotationTensor.C
+++ b/modules/solid_mechanics/src/utils/RotationTensor.C
@@ -10,8 +10,6 @@
 #include "RotationTensor.h"
 #include "libmesh/libmesh.h"
 
-using namespace libMesh;
-
 RotationTensor::RotationTensor(Axis axis, Real angle) { update(axis, angle); }
 
 RotationTensor::RotationTensor(const RealVectorValue & euler_angles) { update(euler_angles); }

--- a/modules/solid_mechanics/test/plugins/mutex_test.C
+++ b/modules/solid_mechanics/test/plugins/mutex_test.C
@@ -15,8 +15,6 @@
 #include "SMAAspUserUtilities.h"
 #include "MooseError.h"
 
-using namespace libMesh;
-
 Real mutex_test_global_thread_counter;
 
 extern "C" void

--- a/modules/solid_mechanics/test/plugins/sma_memory.C
+++ b/modules/solid_mechanics/test/plugins/sma_memory.C
@@ -15,8 +15,6 @@
 #include "SMAAspUserUtilities.h"
 #include "MooseError.h"
 
-using namespace libMesh;
-
 extern "C" void
 uexternaldb_(
     int * LOP, int * /* LRESTART */, Real /* TIME */[], Real * /* DTIME */, int * KSTEP, int * KINC)

--- a/modules/thermal_hydraulics/src/base/FlowModel.C
+++ b/modules/thermal_hydraulics/src/base/FlowModel.C
@@ -13,8 +13,6 @@
 #include "ConstantFunction.h"
 #include "THMNames.h"
 
-using namespace libMesh;
-
 InputParameters
 FlowModel::validParams()
 {

--- a/modules/thermal_hydraulics/src/base/HeatConductionModel.C
+++ b/modules/thermal_hydraulics/src/base/HeatConductionModel.C
@@ -15,8 +15,6 @@
 #include "HeatStructureInterface.h"
 #include "HeatStructureCylindricalBase.h"
 
-using namespace libMesh;
-
 InputParameters
 HeatConductionModel::validParams()
 {

--- a/modules/xfem/src/base/XFEMFuncs.C
+++ b/modules/xfem/src/base/XFEMFuncs.C
@@ -12,8 +12,6 @@
 #include "MooseError.h"
 #include "Conversion.h"
 
-using namespace libMesh;
-
 namespace Xfem
 {
 

--- a/test/src/auxkernels/CoupledGradAux.C
+++ b/test/src/auxkernels/CoupledGradAux.C
@@ -9,8 +9,6 @@
 
 #include "CoupledGradAux.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseTestApp", CoupledGradAux);
 
 InputParameters

--- a/test/src/kernels/ExceptionKernel.C
+++ b/test/src/kernels/ExceptionKernel.C
@@ -14,8 +14,6 @@
 
 #include "libmesh/threads.h"
 
-using namespace libMesh;
-
 /**
  * Class static initialization:
  * These members are used to create easily accessed shared memory among threads

--- a/test/src/materials/ErrorMaterial.C
+++ b/test/src/materials/ErrorMaterial.C
@@ -10,8 +10,6 @@
 #include "ErrorMaterial.h"
 #include "NonlinearSystemBase.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseTestApp", ErrorMaterial);
 
 InputParameters

--- a/test/src/materials/ExceptionMaterial.C
+++ b/test/src/materials/ExceptionMaterial.C
@@ -10,8 +10,6 @@
 #include "ExceptionMaterial.h"
 #include "NonlinearSystemBase.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseTestApp", ExceptionMaterial);
 
 InputParameters

--- a/test/src/materials/QuadratureMaterial.C
+++ b/test/src/materials/QuadratureMaterial.C
@@ -9,8 +9,6 @@
 
 #include "QuadratureMaterial.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseTestApp", QuadratureMaterial);
 
 InputParameters

--- a/test/src/problems/FixedPointProblem.C
+++ b/test/src/problems/FixedPointProblem.C
@@ -11,8 +11,6 @@
 
 #include "NonlinearSystemBase.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseTestApp", FixedPointProblem);
 
 InputParameters

--- a/test/src/userobjects/AllSystemsEvaluable.C
+++ b/test/src/userobjects/AllSystemsEvaluable.C
@@ -18,8 +18,6 @@
 #include "libmesh/dof_map.h"
 #include "libmesh/numeric_vector.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseTestApp", AllSystemsEvaluable);
 
 InputParameters

--- a/test/src/userobjects/RandomHitSolutionModifier.C
+++ b/test/src/userobjects/RandomHitSolutionModifier.C
@@ -14,8 +14,6 @@
 #include "NonlinearSystemBase.h"
 #include "RandomHitUserObject.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseTestApp", RandomHitSolutionModifier);
 
 InputParameters

--- a/test/src/userobjects/TestSaveInMesh.C
+++ b/test/src/userobjects/TestSaveInMesh.C
@@ -15,8 +15,6 @@
 #include "libmesh/checkpoint_io.h"
 #include "libmesh/nemesis_io.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseTestApp", TestSaveInMesh);
 
 InputParameters

--- a/test/src/userobjects/TestWeightedGapUserObject.C
+++ b/test/src/userobjects/TestWeightedGapUserObject.C
@@ -15,8 +15,6 @@
 #include "libmesh/quadrature.h"
 #include "timpi/parallel_sync.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseTestApp", TestWeightedGapUserObject);
 
 InputParameters

--- a/unit/src/LimitersTest.C
+++ b/unit/src/LimitersTest.C
@@ -21,7 +21,6 @@
 #include "libmesh/tensor_value.h"
 #include "MooseMain.h"
 
-using namespace libMesh;
 using namespace Moose::FV;
 
 TEST(LimitersTest, limitVector)

--- a/unit/src/MooseFunctorTest.C
+++ b/unit/src/MooseFunctorTest.C
@@ -24,7 +24,6 @@
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/type_tensor.h"
 
-using namespace libMesh;
 using namespace Moose;
 using namespace FV;
 

--- a/unit/src/MortarProjectionTest.C
+++ b/unit/src/MortarProjectionTest.C
@@ -19,8 +19,6 @@
 #include <array>
 #include <vector>
 
-using namespace libMesh;
-
 namespace
 {
 Point

--- a/unit/src/MortarSegmentHelperTest.C
+++ b/unit/src/MortarSegmentHelperTest.C
@@ -22,8 +22,6 @@
 #include <string>
 #include <vector>
 
-using namespace libMesh;
-
 class MortarSegmentHelperTest : public ::testing::Test
 {
 protected:

--- a/unit/src/ParsedFunctionTest.C
+++ b/unit/src/ParsedFunctionTest.C
@@ -14,8 +14,6 @@
 #include "libmesh/fe_map.h"
 #include "libmesh/quadrature_gauss.h"
 
-using namespace libMesh;
-
 ParsedFunction<Real> *
 ParsedFunctionTest::fptr(MooseParsedFunction & f)
 {

--- a/unit/src/PointInPolygonTest.C
+++ b/unit/src/PointInPolygonTest.C
@@ -18,8 +18,6 @@
 
 #include <limits>
 
-using namespace libMesh;
-
 namespace
 {
 /// Build closed-loop EDGE2 boundary elements from an ordered list of polygon vertices, keeping the

--- a/unit/src/SurfaceElementSetTest.C
+++ b/unit/src/SurfaceElementSetTest.C
@@ -17,8 +17,6 @@
 
 #include "gtest/gtest.h"
 
-using namespace libMesh;
-
 namespace
 {
 

--- a/unit/src/SurfaceElementTest.C
+++ b/unit/src/SurfaceElementTest.C
@@ -17,8 +17,6 @@
 #include "LineSegment.h"
 #include "Ball.h"
 
-using namespace libMesh;
-
 namespace
 {
 // Owns an Edge2 and its two nodes; a SurfaceEdge2 wrapping owner.edge is valid only while the


### PR DESCRIPTION
## Reason
Old habits do die hard. Another step in the right direction, we'll get there one day. Refs #28499 and #28842.

## Design
Remove ~60% of `using namespace libMesh` directives.

## Impact
Avoid polluting global namespace scope unnecessarily.
