### PR TITLE
Append output object name to common file_base only to avoid collision…

### DIFF
--- a/framework/doc/content/syntax/Outputs/index.md
+++ b/framework/doc/content/syntax/Outputs/index.md
@@ -53,6 +53,57 @@ For example, if the input file (input.i) contained the following `[Outputs]` blo
 
 Note, the use of "file_base" anywhere in the `[Outputs]` block disables all default naming behavior.
 
+### file_base resolution order
+
+Each output object resolves its `file_base` from one of three sources, in order of priority:
+
+1. **Its own `file_base`.** An output sub-block that sets `file_base` within its own block always
+   uses that value, regardless of anything set at the top level of `[Outputs]`.
+2. **The common `file_base`.** An output that does *not* set its own `file_base` inherits, verbatim,
+   the `file_base` set at the top level of the `[Outputs]` block, if one is set. Short-cut syntax
+   outputs (e.g. `exodus = true`) always fall into this case -- they have no block of their own to
+   set a `file_base` in, so they either use the common `file_base` verbatim or, if none is set, the
+   default described below. The object name is never appended to a short-cut syntax output's
+   filename.
+3. **The default naming scheme.** If neither the object's own block nor the top level of
+   `[Outputs]` sets `file_base`, the naming scheme described above applies: an "_out" suffix for
+   short-cut syntax, or the sub-block's own name as the suffix.
+
+A collision arises when two or more outputs that each fall into case 2 above -- i.e. that inherit
+the *same* common `file_base` rather than setting their own -- would resolve to the same
+(extension-inclusive) filename. This can only happen among outputs sharing a common `file_base`:
+an output that sets its own `file_base` (case 1) or that falls back to the default naming scheme
+because no `file_base` is set anywhere (case 3) already has the object name (or another
+disambiguating suffix) baked into its filename, so it cannot collide with another output this way.
+
+MOOSE does not silently rename an output to resolve such a collision
+(see [#4215](https://github.com/idaholab/moose/issues/4215)). Instead, MOOSE errors and requires the
+user to explicitly resolve the collision by one of:
+
+- Setting `append_object_name = true` on the colliding sub-block(s), which appends the sub-block's
+  own name to the common `file_base`, producing `<file_base>_<subblock_name>.<ext>`; or
+- Giving the colliding sub-block(s) their own distinct `file_base`, per case 1 above.
+
+An output that shares the common `file_base` but does not actually collide with anything (for
+example, a lone `CSV` output alongside two colliding `Exodus` outputs) keeps the common `file_base`
+verbatim and is unaffected.
+
+!listing id=output-common-file-base caption=Example of resolving common "file_base" collisions.
+[Outputs]
+  file_base = input
+  exodus = true  # short-cut syntax always keeps the common file_base: creates input.e
+  [exodus_a]
+    type = Exodus
+    append_object_name = true # would otherwise collide with 'exodus': creates input_exodus_a.e
+  []
+  [csv]
+    type = CSV    # no collision, so the common file_base is kept verbatim: creates input.csv
+  []
+[]
+
+Omitting `append_object_name = true` on `exodus_a` above would cause MOOSE to error, since it
+would then silently collide with `exodus`.
+
 ## Available Output Types
 
 [output-types] provides a list of the most common output types, including the short-cut syntax

--- a/framework/doc/content/syntax/Outputs/index.md
+++ b/framework/doc/content/syntax/Outputs/index.md
@@ -53,11 +53,12 @@ For example, if the input file (input.i) contained the following `[Outputs]` blo
 
 Note, the use of "file_base" anywhere in the `[Outputs]` block disables all default naming behavior.
 
-### file_base resolution order
+### Rules for the output file name
 
-Each output object resolves its `file_base` from one of three sources, in order of priority:
+For output objects that write an output file, each resolves its output file name from one of
+three sources, in order of priority:
 
-1. **Its own `file_base`.** An output sub-block that sets `file_base` within its own block always
+1. **Its own `file_base` parameter.** An output sub-block that sets `file_base` within its own block always
    uses that value, regardless of anything set at the top level of `[Outputs]`.
 2. **The common `file_base`.** An output that does *not* set its own `file_base` inherits, verbatim,
    the `file_base` set at the top level of the `[Outputs]` block, if one is set. Short-cut syntax

--- a/framework/include/outputs/OutputWarehouse.h
+++ b/framework/include/outputs/OutputWarehouse.h
@@ -116,6 +116,11 @@ public:
   const InputParameters * getCommonParameters() const;
 
   /**
+   * Whether the common [Outputs] block set file_base from input parsing
+   */
+  bool commonFileBaseSet() const;
+
+  /**
    * Return the sync times for all objects
    */
   std::set<Real> & getSyncTimes();

--- a/framework/src/outputs/FileOutput.C
+++ b/framework/src/outputs/FileOutput.C
@@ -32,6 +32,10 @@ FileOutput::validParams()
       "with Outputs/file_base when available. Otherwise, MOOSE uses input file name and this "
       "object name for a master input or uses master file_base, the subapp name and this object "
       "name for a subapp input to set it.");
+  // Captured by FEProblemBase::addOutput(), before the common [Outputs] block's file_base (if
+  // any) is copied down onto this object's own parameters, since that copy makes 'file_base'
+  // appear valid and user-set here even when this object's own block never set it (see #4215).
+  params.addPrivateParam<bool>("_file_base_set_by_own_block", false);
   params.addParam<std::string>("file_base_suffix", "Suffix to add to the file base");
   params.addParam<bool>(
       "append_object_name",
@@ -122,7 +126,10 @@ FileOutput::filename()
 void
 FileOutput::setFileBase(const std::string & file_base)
 {
-  if (!isParamValid("file_base"))
+  // Only refuse to override this object's file base if its own block explicitly set 'file_base';
+  // 'isParamValid' alone is not enough, since a 'file_base' inherited from a common [Outputs]
+  // block also reads as valid here even though this object's own block never set it (see #4215).
+  if (!getParam<bool>("_file_base_set_by_own_block"))
     setFileBaseInternal(file_base);
 }
 

--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -157,7 +157,11 @@ OutputWarehouse::addOutputFilename(const OutputName & obj_name, const OutFileBas
   _file_base_map[obj_name].insert(filename);
   for (const auto & it : _file_base_map)
     if (it.first != obj_name && it.second.find(filename) != it.second.end())
-      mooseError("An output file with the name, ", filename, ", already exists.");
+      mooseError("An output file with the name, ",
+                 filename,
+                 ", already exists. If both outputs fall back to a common 'file_base' set in the "
+                 "[Outputs] block, give one of them its own distinct 'file_base' or set "
+                 "'append_object_name = true' on it to avoid this collision.");
 }
 
 void
@@ -302,6 +306,12 @@ OutputWarehouse::getCommonParameters() const
   return _common_params_ptr;
 }
 
+bool
+OutputWarehouse::commonFileBaseSet() const
+{
+  return _common_params_ptr && _common_params_ptr->isParamValid("file_base");
+}
+
 std::set<Real> &
 OutputWarehouse::getSyncTimes()
 {
@@ -409,6 +419,24 @@ OutputWarehouse::reset()
 void
 OutputWarehouse::resetFileBase()
 {
+  // Tentatively resolve every FileOutput that will fall back to the app's
+  // file_base -- shortcut-syntax outputs built by CommonOutputAction and
+  // sub-block outputs alike, as long as neither sets its own 'file_base' --
+  // and tally the results by the resulting (extension-inclusive) filename.
+  // Two fallback outputs whose tentative filenames match this way would
+  // otherwise collide (see #4215); shortcut outputs are included here so a
+  // sub-block output colliding with a shortcut output is detected too, even
+  // though only sub-block outputs act on the collision below (shortcut
+  // outputs always keep the common file_base verbatim).
+  std::map<std::string, unsigned int> fallback_filename_counts;
+  for (const auto & obj : _all_objects)
+    if (FileOutput * file_output = dynamic_cast<FileOutput *>(obj))
+      if (!obj->getParam<bool>("_file_base_set_by_own_block"))
+      {
+        file_output->setFileBase(_app.getOutputFileBase());
+        fallback_filename_counts[file_output->filename()]++;
+      }
+
   // Set the file base from the application to FileOutputs and add associated filenames
   for (const auto & obj : _all_objects)
     if (FileOutput * file_output = dynamic_cast<FileOutput *>(obj))
@@ -416,15 +444,54 @@ OutputWarehouse::resetFileBase()
       std::string file_base;
       if (obj->parameters().get<bool>("_built_by_moose"))
       {
+        // Shortcut-syntax outputs always keep the common/default file_base
+        // verbatim; the object name is never appended to them.
         if (obj->isParamValid("file_base"))
           file_base = obj->getParam<std::string>("file_base");
         else
           file_base = _app.getOutputFileBase();
       }
-      else if (obj->getParam<bool>("append_object_name"))
-        file_base = _app.getOutputFileBase(true) + "_" + obj->name();
       else
-        file_base = _app.getOutputFileBase();
+      {
+        // A sub-block output that doesn't set its own 'file_base' and whose
+        // tentatively-resolved filename collides with another output's --
+        // another sub-block, or a shortcut-syntax output -- must be
+        // disambiguated. MOOSE will not silently choose a name for the user
+        // in that case: require the user to explicitly opt in to appending
+        // the object name (or to explicitly opt out and accept the
+        // collision) rather than doing it for them. With no common
+        // 'file_base' set at all, the object name is always appended,
+        // matching the ordinary default naming scheme -- there is no
+        // collision to speak of in that case.
+        const bool collides = commonFileBaseSet() &&
+                              !obj->getParam<bool>("_file_base_set_by_own_block") &&
+                              fallback_filename_counts[file_output->filename()] > 1;
+
+        if (collides && !obj->parameters().isParamSetByUser("append_object_name"))
+          mooseError(
+              "The output object '",
+              obj->name(),
+              "' would write to the file '",
+              file_output->filename(),
+              "', which is also used by another output object, because both fall back to the "
+              "common 'file_base' set in the [Outputs] block. MOOSE will not silently rename an "
+              "output to resolve this collision. Set 'append_object_name = true' on '",
+              obj->name(),
+              "' (or on the other colliding output(s)) to have the object name appended and "
+              "disambiguate the filenames, or give '",
+              obj->name(),
+              "' its own distinct 'file_base'.");
+
+        const bool append_by_default = !commonFileBaseSet();
+        const bool append = obj->parameters().isParamSetByUser("append_object_name")
+                                ? obj->getParam<bool>("append_object_name")
+                                : append_by_default;
+
+        if (append)
+          file_base = _app.getOutputFileBase(true) + "_" + obj->name();
+        else
+          file_base = _app.getOutputFileBase();
+      }
 
       file_output->setFileBase(file_base);
       addOutputFilename(obj->name(), file_output->filename());

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -9688,6 +9688,13 @@ FEProblemBase::addOutput(const std::string & object_type,
       parameters.get<bool>("output_screen"))
     parameters.set<ExecFlagEnum>("execute_input_on") = EXEC_INITIAL;
 
+  // Record whether this object's own block set 'file_base' itself before a common 'file_base'
+  // from the [Outputs] block, if any, is copied down onto it below -- that copy makes
+  // 'file_base' look valid and user-set on this object even when only the common block set it
+  // (see #4215), so this must be captured first.
+  if (parameters.isParamDefined("_file_base_set_by_own_block"))
+    parameters.set<bool>("_file_base_set_by_own_block") = parameters.isParamSetByUser("file_base");
+
   // Apply only user-set parameters from the common [Outputs] block so that
   // each output type's own defaults are not overridden by common defaults.
   const InputParameters * common = output_warehouse.getCommonParameters();

--- a/test/tests/outputs/common_file_base_names/common_file_base_names.i
+++ b/test/tests/outputs/common_file_base_names/common_file_base_names.i
@@ -1,0 +1,57 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Postprocessors]
+  [avg_u]
+    type = AverageNodalVariableValue
+    variable = u
+  []
+[]
+
+[Outputs]
+  file_base = common_file_base_names
+  [exodus_a]
+    type = Exodus
+  []
+  [exodus_b]
+    type = Exodus
+  []
+  [csv_a]
+    type = CSV
+  []
+[]

--- a/test/tests/outputs/common_file_base_names/tests
+++ b/test/tests/outputs/common_file_base_names/tests
@@ -1,0 +1,30 @@
+[Tests]
+  issues = '#4215'
+  design = 'syntax/Outputs/index.md'
+
+  [collision_error]
+    type = RunException
+    input = common_file_base_names.i
+    expect_err = "MOOSE will not silently rename an output to resolve this collision"
+    recover = false
+
+    requirement = "The system shall error, rather than silently choose a filename, when two or "
+                  "more outputs that do not set their own 'file_base' would write to the same "
+                  "file under a common 'file_base' set in the [Outputs] block, unless the user "
+                  "has explicitly set 'append_object_name' on the colliding outputs."
+  []
+
+  [collision_resolved]
+    type = CheckFiles
+    input = common_file_base_names.i
+    cli_args = 'Outputs/exodus_a/append_object_name=true Outputs/exodus_b/append_object_name=true'
+    check_files = 'common_file_base_names_exodus_a.e common_file_base_names_exodus_b.e '
+                  'common_file_base_names.csv'
+    recover = false
+
+    requirement = "The system shall append the object name to a common 'file_base' for outputs "
+                  "that would otherwise collide when the user explicitly opts in with "
+                  "'append_object_name = true', while leaving the file base of a non-colliding "
+                  "output that shares the same common 'file_base' unchanged."
+  []
+[]

--- a/test/tests/outputs/common_file_base_names/tests
+++ b/test/tests/outputs/common_file_base_names/tests
@@ -8,10 +8,11 @@
     expect_err = "MOOSE will not silently rename an output to resolve this collision"
     recover = false
 
-    requirement = "The system shall error, rather than silently choose a filename, when two or "
-                  "more outputs that do not set their own 'file_base' would write to the same "
-                  "file under a common 'file_base' set in the [Outputs] block, unless the user "
-                  "has explicitly set 'append_object_name' on the colliding outputs."
+    requirement = "The system shall error, rather than silently choose a file name, when two or "
+                  "more outputs that do not set their own file name would write to the same "
+                  "file under a common file name set in the [Outputs] block, unless the user "
+                  "has requested the object name be appended to the file name on the colliding "
+                  "outputs."
   []
 
   [collision_resolved]
@@ -22,9 +23,9 @@
                   'common_file_base_names.csv'
     recover = false
 
-    requirement = "The system shall append the object name to a common 'file_base' for outputs "
-                  "that would otherwise collide when the user explicitly opts in with "
-                  "'append_object_name = true', while leaving the file base of a non-colliding "
-                  "output that shares the same common 'file_base' unchanged."
+    requirement = "The system shall append the object name to a common file name for outputs "
+                  "that would otherwise collide when the user requests it, while leaving the "
+                  "file name of a non-colliding output that shares the same common file name "
+                  "unchanged."
   []
 []


### PR DESCRIPTION
Fix #4215: smarter common file_base in [Outputs]
And somewhat #18332 

Problem

A common file_base in [Outputs] is inherited verbatim by sub-blocks that don't set their own — even when that causes two outputs to collide on the same filename.
```
[Outputs]
  file_base = my_out
  [a]
    type = Exodus
  []
  [b]
    type = Exodus
  []
[]
```

Both a and b resolve to my_out.e:

An output file with the name, my_out.e, already exists.
