### PR TITLE
Make FV variables coupleable in FE objects in Kokkos

### DIFF
--- a/framework/src/kokkos/interfaces/KokkosCoupleable.K
+++ b/framework/src/kokkos/interfaces/KokkosCoupleable.K
@@ -26,6 +26,7 @@ Coupleable::kokkosCoupledVectorTagVariable(const std::string & var_name,
   {
     auto var = const_cast<MooseVariableField<Real> *>(
         getVarHelper<MooseVariableField<Real>>(var_name, comp));
+    var->requireQpComputations();
 
     if (tag_name == Moose::OLD_SOLUTION_TAG)
       var->sys().needSolutionState(1);
@@ -64,6 +65,7 @@ Coupleable::kokkosCoupledVectorTagVariables(const std::string & var_name,
     {
       auto var = const_cast<MooseVariableField<Real> *>(
           getVarHelper<MooseVariableField<Real>>(var_name, comp));
+      var->requireQpComputations();
 
       if (tag_name == Moose::OLD_SOLUTION_TAG)
         var->sys().needSolutionState(1);
@@ -103,6 +105,7 @@ Coupleable::kokkosCoupledVectorTagVectorVariable(const std::string & var_name,
   {
     auto var = const_cast<MooseVariableField<RealVectorValue> *>(
         getVarHelper<MooseVariableField<RealVectorValue>>(var_name, comp));
+    var->requireQpComputations();
 
     if (tag_name == Moose::OLD_SOLUTION_TAG)
       var->sys().needSolutionState(1);
@@ -141,6 +144,7 @@ Coupleable::kokkosCoupledVectorTagVectorVariables(const std::string & var_name,
     {
       auto var = const_cast<MooseVariableField<RealVectorValue> *>(
           getVarHelper<MooseVariableField<RealVectorValue>>(var_name, comp));
+      var->requireQpComputations();
 
       if (tag_name == Moose::OLD_SOLUTION_TAG)
         var->sys().needSolutionState(1);

--- a/test/tests/kokkos/fe-fv-interplay/multisystem.i
+++ b/test/tests/kokkos/fe-fv-interplay/multisystem.i
@@ -27,7 +27,7 @@
     variable = u
   []
   [coupled]
-    type = CoupledForce
+    type = KokkosCoupledForce
     variable = u
     v = v
   []


### PR DESCRIPTION
## Reason
FV variables are currently not coupleable in FE objects in Kokkos. Discovered while debugging FE-FV interplay test.

## Design
Make FV variables coupleable in FE objects by requesting QP evaluation when coupled.

## Impact
FV variables are coupleable in FE objects in Kokkos.