### PR TITLE
Error instead of segfault when MultiAppCopyTransfer procs mismatch

### DIFF
--- a/framework/src/transfers/MultiAppDofCopyTransfer.C
+++ b/framework/src/transfers/MultiAppDofCopyTransfer.C
@@ -81,6 +81,16 @@ MultiAppDofCopyTransfer::initialSetup()
   if (from_problem->mesh().getParallelType() != to_problem->mesh().getParallelType())
     mooseError("The parallel types (distributed or replicated) of the meshes are not the same.");
 
+  // MultiAppDofCopyTransfer-derived transfers copy degree of freedom values directly between
+  // the origin and target solution vectors, so both problems must share the same parallel
+  // decomposition. A common way to violate this is restricting a sub-app's processor count,
+  // e.g. through the MultiApp 'max_procs_per_app' parameter (see idaholab/moose#11045).
+  if (from_problem->comm().size() != to_problem->comm().size())
+    mooseError("The number of processors used by the origin and target problems must be the "
+               "same to use MultiAppDofCopyTransfer-derived transfers. Check that the MultiApp "
+               "'max_procs_per_app' parameter is not restricting sub-apps to a different number "
+               "of processors than the parent app.");
+
   // Convert block names to block IDs, fill with all blocks if unspecified
   if (_has_block_restrictions)
   {

--- a/test/tests/transfers/multiapp_copy_transfer/errors/tests
+++ b/test/tests/transfers/multiapp_copy_transfer/errors/tests
@@ -18,4 +18,15 @@
 
     requirement = 'The system shall report an error when the MultiAppCopyTransfer object is used on meshes with different variable types.'
   [../]
+  [./different_num_procs]
+    type = RunException
+    input = parent.i
+    cli_args = 'MultiApps/sub/max_procs_per_app=1'
+    min_parallel = 2
+    max_parallel = 2
+    issues = '#11045'
+    expect_err = 'The number of processors used by the origin and target problems must be the same'
+
+    requirement = 'The system shall report an error, instead of segfaulting, when a MultiAppCopyTransfer object is used with a sub-app restricted to a different number of processors than its parent app.'
+  [../]
 []


### PR DESCRIPTION
## Summary

Running a MultiApp simulation where a sub-app's processor count is restricted via `MultiApps/<name>/max_procs_per_app` **and** a `MultiAppCopyTransfer` is used between the parent and sub-app causes a segfault instead of a clean error:

No index 67 in ghosted vector.
Vector contains [0,67)
And empty ghost array.

## Root Cause

`MultiAppCopyTransfer` (via its base class `MultiAppDofCopyTransfer`) copies degree-of-freedom values **directly** between the origin and target solution vectors, indexing one problem's DOF numbering into the other's parallel vector. This is only valid when both problems share an **identical parallel decomposition** — same mesh partitioning, and critically, the same number of processors.

`initialSetup()` already checked for:
- matching mesh parallel type (replicated vs. distributed)
- matching global node/element counts

...but never checked that both problems actually run on the **same number of MPI ranks**. `max_procs_per_app` (or any other mechanism that splits the communicator unevenly) silently breaks that invariant: the sub-app's solution vector is partitioned across fewer ranks than the parent's, so a direct DOF-index lookup (`from_solution(from_dof)`) can land on an index that's neither owned nor ghosted on the current rank — hence the segfault instead of a helpful error.

This matches what a maintainer noted back in 2018: `MultiAppCopyTransfer` isn't designed to be extended to handle mismatched decompositions (that would require re-implementing it as a location-based transfer), but it should at least fail with a clear error rather than crashing.

## Fix

Added a check in `MultiAppDofCopyTransfer::initialSetup()` that compares the origin and target problems' communicator sizes and raises a `mooseError` if they differ, pointing the user at `max_procs_per_app` as the likely cause:

```cpp
// MultiAppDofCopyTransfer-derived transfers copy degree of freedom values directly between
// the origin and target solution vectors, so both problems must share the same parallel
// decomposition. A common way to violate this is restricting a sub-app's processor count,
// e.g. through the MultiApp 'max_procs_per_app' parameter (see idaholab/moose#11045).
if (from_problem->comm().size() != to_problem->comm().size())
  mooseError("The number of processors used by the origin and target problems must be the "
             "same to use MultiAppDofCopyTransfer-derived transfers. Check that the MultiApp "
             "'max_procs_per_app' parameter is not restricting sub-apps to a different number "
             "of processors than the parent app.");

This is a detection fix, not a feature fix — restricted-proc sub-apps still can't use MultiAppCopyTransfer, but they now get a clear, actionable error instead of a crash.

Testing

Added errors.different_num_procs to test/tests/transfers/multiapp_copy_transfer/errors/tests, running the existing 2-app test with max_procs_per_app=1 under 2 MPI ranks and asserting the new error message fires. Full multiapp_copy_transfer suite (31 tests) passes with no regressions.
