### PR TITLE
Remove using directives from module headers

### DIFF
--- a/modules/contact/include/linesearches/PetscContactLineSearch.h
+++ b/modules/contact/include/linesearches/PetscContactLineSearch.h
@@ -14,13 +14,12 @@
 
 #include "ContactLineSearchBase.h"
 
-using namespace libMesh;
-
 namespace libMesh
 {
 template <typename>
 class PetscNonlinearSolver;
 }
+using libMesh::PetscNonlinearSolver;
 
 /**
  *  Petsc implementation of the contact line search (based on the Petsc LineSearchShell)

--- a/modules/contact/include/linesearches/PetscProjectSolutionOntoBounds.h
+++ b/modules/contact/include/linesearches/PetscProjectSolutionOntoBounds.h
@@ -16,8 +16,6 @@
 
 #include <map>
 
-using namespace libMesh;
-
 class GeometricSearchData;
 class PenetrationLocator;
 class NonlinearSystemBase;
@@ -28,6 +26,7 @@ namespace libMesh
 template <typename>
 class PetscNonlinearSolver;
 }
+using libMesh::PetscNonlinearSolver;
 
 /**
  *  Petsc implementation of the contact line search (based on the Petsc LineSearchShell)

--- a/modules/fluid_properties/include/utils/DimensionlessFlowNumbers.h
+++ b/modules/fluid_properties/include/utils/DimensionlessFlowNumbers.h
@@ -13,8 +13,6 @@
 
 #include "libmesh/libmesh_common.h"
 
-using namespace libMesh;
-
 namespace fp
 {
 

--- a/modules/phase_field/include/utils/ExpressionBuilder.h
+++ b/modules/phase_field/include/utils/ExpressionBuilder.h
@@ -17,8 +17,6 @@
 #include "MooseError.h"
 #include "libmesh/libmesh_common.h"
 
-using namespace libMesh;
-
 /**
  * ExpressionBuilder adds an interface to derived classes that enables
  * convenient construction of FParser expressions through operator overloading.

--- a/modules/stochastic_tools/include/utils/CartesianProduct.h
+++ b/modules/stochastic_tools/include/utils/CartesianProduct.h
@@ -14,8 +14,6 @@
 #include <deque>
 #include "libmesh/libmesh_common.h"
 
-using namespace libMesh;
-
 namespace StochasticTools
 {
 /* Compute the Cartesian Product of the supplied vectors.

--- a/modules/thermal_hydraulics/include/base/WallFrictionModels.h
+++ b/modules/thermal_hydraulics/include/base/WallFrictionModels.h
@@ -12,8 +12,6 @@
 #include "libmesh/libmesh_common.h"
 #include "ADReal.h"
 
-using namespace libMesh;
-
 namespace WallFriction
 {
 

--- a/modules/thermal_hydraulics/include/interfaces/ADShaftConnectableUserObjectInterface.h
+++ b/modules/thermal_hydraulics/include/interfaces/ADShaftConnectableUserObjectInterface.h
@@ -12,7 +12,6 @@
 #include "libmesh/dense_matrix.h"
 #include "InputParameters.h"
 
-using namespace libMesh;
 class UserObject;
 class MooseVariableScalar;
 

--- a/modules/thermal_hydraulics/include/interfaces/ShaftConnectableUserObjectInterface.h
+++ b/modules/thermal_hydraulics/include/interfaces/ShaftConnectableUserObjectInterface.h
@@ -12,7 +12,6 @@
 #include "libmesh/dense_matrix.h"
 #include "InputParameters.h"
 
-using namespace libMesh;
 class UserObject;
 class MooseVariableScalar;
 

--- a/modules/thermal_hydraulics/include/utils/Numerics.h
+++ b/modules/thermal_hydraulics/include/utils/Numerics.h
@@ -17,8 +17,6 @@
 #include "NavierStokesMethods.h"
 #include "HeatTransferUtils.h"
 
-using namespace libMesh;
-
 namespace THM
 {
 

--- a/modules/xfem/include/base/XFEMCrackGrowthIncrement2DCut.h
+++ b/modules/xfem/include/base/XFEMCrackGrowthIncrement2DCut.h
@@ -13,7 +13,9 @@
 #include "libmesh/libmesh.h" // libMesh::invalid_uint
 #include "libmesh/elem.h"
 
-using namespace libMesh;
+using libMesh::Elem;
+using libMesh::Point;
+using libMesh::Real;
 
 struct CutEdgeForCrackGrowthIncr
 {

--- a/modules/xfem/include/base/XFEMCutElem.h
+++ b/modules/xfem/include/base/XFEMCutElem.h
@@ -14,15 +14,6 @@
 #include "MooseTypes.h"
 #include "XFEM.h"
 
-using namespace libMesh;
-
-namespace libMesh
-{
-class MeshBase;
-class Elem;
-class Node;
-class QBase;
-}
 class EFANode;
 class EFAElement;
 

--- a/modules/xfem/include/base/XFEMCutElem2D.h
+++ b/modules/xfem/include/base/XFEMCutElem2D.h
@@ -12,15 +12,6 @@
 #include "XFEMCutElem.h"
 #include "EFAElement2D.h"
 
-using namespace libMesh;
-
-namespace libMesh
-{
-class MeshBase;
-class Elem;
-class Node;
-}
-
 class XFEMCutElem2D : public XFEMCutElem
 {
 public:

--- a/modules/xfem/include/base/XFEMCutElem3D.h
+++ b/modules/xfem/include/base/XFEMCutElem3D.h
@@ -12,15 +12,6 @@
 #include "XFEMCutElem.h"
 #include "EFAElement3D.h"
 
-using namespace libMesh;
-
-namespace libMesh
-{
-class MeshBase;
-class Elem;
-class Node;
-}
-
 class XFEMCutElem3D : public XFEMCutElem
 {
 public:

--- a/modules/xfem/include/base/XFEMFuncs.h
+++ b/modules/xfem/include/base/XFEMFuncs.h
@@ -14,7 +14,9 @@
 #include "libmesh/plane.h"
 #include "EFAPoint.h"
 
-using namespace libMesh;
+using libMesh::Plane;
+using libMesh::Point;
+using libMesh::Real;
 
 namespace Xfem
 {

--- a/modules/xfem/include/userobjects/GeometricCut3DUserObject.h
+++ b/modules/xfem/include/userobjects/GeometricCut3DUserObject.h
@@ -11,8 +11,6 @@
 
 #include "GeometricCutUserObject.h"
 
-using namespace libMesh;
-
 class GeometricCut3DUserObject : public GeometricCutUserObject
 {
 public:

--- a/modules/xfem/include/userobjects/GeometricCutUserObject.h
+++ b/modules/xfem/include/userobjects/GeometricCutUserObject.h
@@ -18,8 +18,6 @@
 #include "libmesh/libmesh.h" // libMesh::invalid_uint
 #include "libmesh/elem.h"
 
-using namespace libMesh;
-
 class XFEM;
 
 namespace Xfem

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -235,8 +235,8 @@ XFEM::updateHeal()
   if (mesh_changed)
   {
     _mesh->update_parallel_id_counts();
-    MeshCommunication().make_elems_parallel_consistent(*_mesh);
-    MeshCommunication().make_nodes_parallel_consistent(*_mesh);
+    libMesh::MeshCommunication().make_elems_parallel_consistent(*_mesh);
+    libMesh::MeshCommunication().make_nodes_parallel_consistent(*_mesh);
     //    _mesh->find_neighbors();
     //    _mesh->contract();
     _mesh->allow_renumbering(false);
@@ -246,8 +246,8 @@ XFEM::updateHeal()
     if (_displaced_mesh)
     {
       _displaced_mesh->update_parallel_id_counts();
-      MeshCommunication().make_elems_parallel_consistent(*_displaced_mesh);
-      MeshCommunication().make_nodes_parallel_consistent(*_displaced_mesh);
+      libMesh::MeshCommunication().make_elems_parallel_consistent(*_displaced_mesh);
+      libMesh::MeshCommunication().make_nodes_parallel_consistent(*_displaced_mesh);
       _displaced_mesh->allow_renumbering(false);
       _displaced_mesh->skip_partitioning(true);
       _displaced_mesh->prepare_for_use();


### PR DESCRIPTION
Refs #33646. Didn't add any using-directives for namespaces or any new header includes, only using-declarations for namespace members and in-place qualifications when using-declarations seemed overkill (granted this is a subjective judgment).