### PR TITLE
Force `TIMESTEP_END` exception to throw error

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -152,6 +152,16 @@ extern const ExecFlagType EXEC_POST_ADAPTIVITY;
 
 namespace Moose
 {
+/**
+ * @return whether \p exec_flag is a solver execution flag, e.g. a flag on which a solver
+ * evaluation such as a residual, Jacobian, or postcheck evaluation is performed
+ *
+ * When a solver execution flag is added to the list of execution flags above, add it to the
+ * implementation of this method as well so that logic keyed on solver evaluations, such as the
+ * MooseException handling in FEProblemBase::checkExceptionAndStopSolve(), picks it up
+ */
+bool isSolverExecFlag(const ExecFlagType & exec_flag);
+
 // MOOSE is not tested with LIBMESH_DIM != 3
 static_assert(LIBMESH_DIM == 3,
               "MOOSE must be built with a libmesh library compiled without --enable-1D-only "

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -64,6 +64,12 @@ const ExecFlagType EXEC_POST_ADAPTIVITY = registerExecFlag("POST_ADAPTIVITY");
 namespace Moose
 {
 
+bool
+isSolverExecFlag(const ExecFlagType & exec_flag)
+{
+  return exec_flag == EXEC_LINEAR || exec_flag == EXEC_NONLINEAR || exec_flag == EXEC_POSTCHECK;
+}
+
 void associateSyntaxInner(Syntax & syntax, ActionFactory & action_factory);
 
 void

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5450,6 +5450,8 @@ FEProblemBase::computeUserObjects(const ExecFlagType & type, const Moose::AuxGro
     computeUserObjectsInternal(type,
                                query.clone().condition<AttribExecutionOrderGroup>(execution_group));
   }
+
+  checkExceptionAndStopSolve();
 }
 
 void

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5451,7 +5451,12 @@ FEProblemBase::computeUserObjects(const ExecFlagType & type, const Moose::AuxGro
                                query.clone().condition<AttribExecutionOrderGroup>(execution_group));
   }
 
-  checkExceptionAndStopSolve();
+  // Exceptions raised on solver execution flags are communicated and handled by the PARALLEL_CATCH
+  // surrounding the assembly loops of the residual, Jacobian and linear systems. On all other
+  // execution flags there is no solve left to fail, so the exception is communicated here in order
+  // to report it at the point of the simulation where it was raised
+  if (!Moose::isSolverExecFlag(_current_execute_on_flag))
+    checkExceptionAndStopSolve();
 }
 
 void
@@ -7159,8 +7164,7 @@ FEProblemBase::checkExceptionAndStopSolve(bool print_message)
   {
     _communicator.broadcast(_exception_message, processor_id);
 
-    if (_current_execute_on_flag == EXEC_LINEAR || _current_execute_on_flag == EXEC_NONLINEAR ||
-        _current_execute_on_flag == EXEC_POSTCHECK)
+    if (Moose::isSolverExecFlag(_current_execute_on_flag))
     {
       // Print the message
       if (_communicator.rank() == 0 && print_message)

--- a/test/include/materials/TimestepSizeExceptionMaterial.h
+++ b/test/include/materials/TimestepSizeExceptionMaterial.h
@@ -1,0 +1,26 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+
+class TimestepSizeExceptionMaterial : public Material
+{
+public:
+  static InputParameters validParams();
+
+  TimestepSizeExceptionMaterial(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties() override;
+
+  MaterialProperty<Real> & _property;
+  const Real _max_dt;
+};

--- a/test/src/materials/TimestepSizeExceptionMaterial.C
+++ b/test/src/materials/TimestepSizeExceptionMaterial.C
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "TimestepSizeExceptionMaterial.h"
+
+registerMooseObject("MooseTestApp", TimestepSizeExceptionMaterial);
+
+InputParameters
+TimestepSizeExceptionMaterial::validParams()
+{
+  InputParameters params = Material::validParams();
+
+  params.addRequiredParam<Real>(
+      "max_dt", "Maximum timestep size before this test material throws a MooseException.");
+
+  params.addClassDescription(
+      "Test material that throws a recoverable MooseException when the timestep is too large.");
+
+  return params;
+}
+
+TimestepSizeExceptionMaterial::TimestepSizeExceptionMaterial(const InputParameters & parameters)
+  : Material(parameters),
+    _property(declareProperty<Real>("exception_test_property")),
+    _max_dt(getParam<Real>("max_dt"))
+{
+}
+
+void
+TimestepSizeExceptionMaterial::computeQpProperties()
+{
+  if (_dt > _max_dt)
+    mooseException("TimestepSizeExceptionMaterial failed on timestep ",
+                   _t_step,
+                   " at time ",
+                   _t,
+                   " with dt ",
+                   _dt);
+
+  _property[_qp] = 1.0;
+}

--- a/test/tests/materials/material/tests
+++ b/test/tests/materials/material/tests
@@ -96,7 +96,7 @@
       type = 'RunException'
       input = 'timestep_end_exception.i'
       expect_err = 'The following parallel-communicated exception was detected during TIMESTEP_END evaluation'
-      detail = 'executed at TIMESTEP_END,'
+      detail = 'executed at the end of a timestep,'
     []
     [serial]
       type = 'Exodiff'

--- a/test/tests/materials/material/tests
+++ b/test/tests/materials/material/tests
@@ -92,7 +92,12 @@
   [exception]
     requirement = "The system shall include that ability to handle C++ exceptions during material "
                   "property calculation routines:"
-
+    [timestep_end_exception]
+      type = 'RunException'
+      input = 'timestep_end_exception.i'
+      expect_err = 'The following parallel-communicated exception was detected during TIMESTEP_END evaluation'
+      detail = 'executed at TIMESTEP_END,'
+    []
     [serial]
       type = 'Exodiff'
       input = 'exception_material.i'
@@ -131,7 +136,6 @@
 
       detail = "from processor 0 during a parallel calculation with 4 processes."
     []
-
   []
 
   [test_constant_on_elem]

--- a/test/tests/materials/material/timestep_end_exception.i
+++ b/test/tests/materials/material/timestep_end_exception.i
@@ -1,0 +1,39 @@
+[Mesh]
+  [mesh]
+    type = GeneratedMeshGenerator
+    dim = 1
+  []
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [time]
+    type = TimeDerivative
+    variable = u
+  []
+[]
+
+[Materials]
+  [exception]
+    type = TimestepSizeExceptionMaterial
+    max_dt = 0.75
+  []
+[]
+
+[Postprocessors]
+  [boundary_property]
+    type = ElementAverageMaterialProperty
+    mat_prop = exception_test_property
+    execute_on = TIMESTEP_END
+  []
+[]
+
+[Executioner]
+  type = Transient
+  end_time = 2
+  dt = 1
+[]


### PR DESCRIPTION
- Adds small new material and input to show that exceptions thrown during `TIMESTEP_END` don't do anything with the exception, resulting in waiting until the next timestep to be thrown and cut the dt.
- Adds `checkExceptionAndStopSolve` to `computeUserObjects` so force checking of the exceptions after user objects are processed.

Closes #33686 