### PR TITLE
Complete removal of using-directives for namespace libMesh

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -71,15 +71,6 @@ class Assembly;
 }
 #endif
 
-// Assembly.h does not import Moose.h nor libMeshReducedNamespace.h
-using libMesh::FEBase;
-using libMesh::FEFamily;
-using libMesh::FEType;
-using libMesh::FEVectorBase;
-using libMesh::LAGRANGE_VEC;
-using libMesh::Order;
-using libMesh::QuadratureType;
-
 /// Computes a conversion multiplier for use when computing integraals for the
 /// current coordinate system type.  This allows us to handle cases where we use RZ,
 /// spherical, or other non-cartesian coordinate systems. The factor returned

--- a/framework/include/base/libMeshReducedNamespace.h
+++ b/framework/include/base/libMeshReducedNamespace.h
@@ -81,6 +81,7 @@ class Tri7;
 class RemoteElem;
 }
 
+using libMesh::C0POLYGON;
 using libMesh::Edge;
 using libMesh::Edge2;
 using libMesh::EDGE2;
@@ -138,7 +139,6 @@ using libMesh::Tri6;
 using libMesh::TRI6;
 using libMesh::Tri7;
 using libMesh::TRI7;
-using libMesh::C0POLYGON;
 
 // Continuity types
 using libMesh::C_ONE;
@@ -249,18 +249,18 @@ using libMesh::TypeVector;
 using libMesh::VectorValue;
 
 // Common FE families
+using libMesh::HERMITE;
 using libMesh::HIERARCHIC;
 using libMesh::L2_HIERARCHIC;
 using libMesh::L2_LAGRANGE;
+using libMesh::L2_RAVIART_THOMAS;
 using libMesh::LAGRANGE;
 using libMesh::LAGRANGE_VEC;
 using libMesh::MONOMIAL;
 using libMesh::MONOMIAL_VEC;
-using libMesh::SCALAR;
 using libMesh::NEDELEC_ONE;
 using libMesh::RAVIART_THOMAS;
-using libMesh::L2_RAVIART_THOMAS;
-using libMesh::HERMITE;
+using libMesh::SCALAR;
 
 // Counting from 0 to 20
 using libMesh::CONSTANT;

--- a/framework/include/base/libMeshReducedNamespace.h
+++ b/framework/include/base/libMeshReducedNamespace.h
@@ -65,6 +65,7 @@ class Pyramid;
 class Pyramid5;
 class Pyramid13;
 class Pyramid14;
+class Pyramid18;
 class Quad;
 class Quad4;
 class Quad8;
@@ -110,6 +111,8 @@ using libMesh::Pyramid13;
 using libMesh::PYRAMID13;
 using libMesh::Pyramid14;
 using libMesh::PYRAMID14;
+using libMesh::Pyramid18;
+using libMesh::PYRAMID18;
 using libMesh::Pyramid5;
 using libMesh::PYRAMID5;
 using libMesh::Quad;
@@ -135,6 +138,7 @@ using libMesh::Tri6;
 using libMesh::TRI6;
 using libMesh::Tri7;
 using libMesh::TRI7;
+using libMesh::C0POLYGON;
 
 // Continuity types
 using libMesh::C_ONE;
@@ -251,7 +255,12 @@ using libMesh::L2_LAGRANGE;
 using libMesh::LAGRANGE;
 using libMesh::LAGRANGE_VEC;
 using libMesh::MONOMIAL;
+using libMesh::MONOMIAL_VEC;
 using libMesh::SCALAR;
+using libMesh::NEDELEC_ONE;
+using libMesh::RAVIART_THOMAS;
+using libMesh::L2_RAVIART_THOMAS;
+using libMesh::HERMITE;
 
 // Counting from 0 to 20
 using libMesh::CONSTANT;

--- a/framework/include/constraints/AutomaticMortarGeneration.h
+++ b/framework/include/constraints/AutomaticMortarGeneration.h
@@ -31,23 +31,10 @@
 #include <unordered_map>
 
 // Forward declarations
-namespace libMesh
-{
-class MeshBase;
-class System;
-}
 class GetPot;
 
 // Using statements
-using libMesh::boundary_id_type;
 using libMesh::CompareDofObjectsByID;
-using libMesh::dof_id_type;
-using libMesh::Elem;
-using libMesh::MeshBase;
-using libMesh::Node;
-using libMesh::Point;
-using libMesh::Real;
-using libMesh::subdomain_id_type;
 
 typedef boundary_id_type BoundaryID;
 typedef subdomain_id_type SubdomainID;

--- a/framework/include/constraints/MortarSegmentHelper.h
+++ b/framework/include/constraints/MortarSegmentHelper.h
@@ -19,9 +19,6 @@
 #include <string>
 #include <vector>
 
-using libMesh::Point;
-using libMesh::Real;
-
 #ifdef MOOSE_UNIT_TEST
 class MortarSegmentHelperTest;
 #endif

--- a/framework/include/constraints/MortarSegmentInfo.h
+++ b/framework/include/constraints/MortarSegmentInfo.h
@@ -23,10 +23,6 @@ class Elem;
 // C++ includes
 #include <utility>
 
-// Using statements
-using libMesh::Elem;
-using libMesh::Real;
-
 enum class MortarSegmentTriangulationMode : unsigned char
 {
   Delaunay,

--- a/framework/include/constraints/NanoflannMeshAdaptor.h
+++ b/framework/include/constraints/NanoflannMeshAdaptor.h
@@ -23,15 +23,6 @@
 SORRY THIS APPLICATION REQUIRES NANOFLANN
 #endif
 
-// Using statements. These are used so that the code below does not
-// need to be littered with libMesh:: disambiguations.
-using libMesh::Point;
-using libMesh::MeshBase;
-using libMesh::Real;
-using libMesh::subdomain_id_type;
-using libMesh::dof_id_type;
-using libMesh::Elem;
-
 /**
  * This allows us to adapt the MeshBase class for use with nanoflann.
  *

--- a/framework/include/relationshipmanagers/AugmentSparsityOnInterface.h
+++ b/framework/include/relationshipmanagers/AugmentSparsityOnInterface.h
@@ -16,12 +16,8 @@
 // libMesh includes
 #include "libmesh/mesh_base.h"
 
-using libMesh::boundary_id_type;
 using libMesh::CouplingMatrix;
-using libMesh::Elem;
 using libMesh::GhostingFunctor;
-using libMesh::MeshBase;
-using libMesh::processor_id_type;
 
 class AugmentSparsityOnInterface : public RelationshipManager
 {

--- a/framework/include/relationshipmanagers/GhostBoundary.h
+++ b/framework/include/relationshipmanagers/GhostBoundary.h
@@ -16,12 +16,8 @@
 // libMesh includes
 #include "libmesh/mesh_base.h"
 
-using libMesh::boundary_id_type;
 using libMesh::CouplingMatrix;
-using libMesh::Elem;
 using libMesh::GhostingFunctor;
-using libMesh::MeshBase;
-using libMesh::processor_id_type;
 
 /**
  * GhostBoundary is used to ghost elements on a boundary. It is

--- a/framework/include/utils/MooseLagrangeHelpers.h
+++ b/framework/include/utils/MooseLagrangeHelpers.h
@@ -14,8 +14,6 @@
 
 namespace Moose
 {
-using libMesh::Order;
-
 // Copy in libmesh's lagrange helper functions, but we template it
 template <typename T>
 T

--- a/framework/include/utils/PetscVectorReader.h
+++ b/framework/include/utils/PetscVectorReader.h
@@ -14,11 +14,6 @@
 #include "libmesh/libmesh_common.h"
 #include "MooseError.h"
 
-using libMesh::Number;
-using libMesh::numeric_index_type;
-using libMesh::NumericVector;
-using libMesh::PetscVector;
-
 /**
  * A class which helps with repeated reading from a petsc vector.
  * Its main purpose is to avoid unnecessary calls to the get_array() function

--- a/framework/include/utils/SymmetricRankFourTensor.h
+++ b/framework/include/utils/SymmetricRankFourTensor.h
@@ -31,7 +31,6 @@
 
 #include <array>
 
-using libMesh::Real;
 using libMesh::tuple_of;
 namespace libMesh
 {

--- a/framework/include/utils/TrilinearInterpolation.h
+++ b/framework/include/utils/TrilinearInterpolation.h
@@ -12,8 +12,6 @@
 #include <vector>
 #include "Moose.h"
 
-using libMesh::Real;
-
 /**
  * This class interpolates a function of three values (f(x,y,z)).  It takes 4
  * vectors for x, y, z, and function values, f(x,y,z).  The vector of function

--- a/framework/include/utils/VectorCompositeFunctor.h
+++ b/framework/include/utils/VectorCompositeFunctor.h
@@ -12,8 +12,6 @@
 #include "MooseFunctor.h"
 #include "libmesh/vector_value.h"
 
-using libMesh::VectorValue;
-
 namespace Moose
 {
 /**

--- a/framework/include/variables/MooseVariableData.h
+++ b/framework/include/variables/MooseVariableData.h
@@ -36,7 +36,6 @@ class DenseVector;
 using libMesh::DenseVector;
 using libMesh::DofMap;
 using libMesh::QBase;
-using libMesh::VectorValue;
 
 class TimeIntegrator;
 class Assembly;

--- a/framework/src/actions/AdaptivityAction.C
+++ b/framework/src/actions/AdaptivityAction.C
@@ -25,8 +25,6 @@
 #include "libmesh/system_norm.h"
 #include "libmesh/enum_norm_type.h"
 
-using namespace libMesh;
-
 registerMooseAction("MooseApp", AdaptivityAction, "setup_adaptivity");
 registerMooseAction("MooseApp", AdaptivityAction, "add_geometric_rm");
 registerMooseAction("MooseApp", AdaptivityAction, "add_algebraic_rm");
@@ -181,9 +179,9 @@ AdaptivityAction::act()
         weights[system.getVariable(0, name).number()] = value;
       }
 
-      std::vector<FEMNormType> norms(system.nVariables(), H1_SEMINORM);
+      std::vector<libMesh::FEMNormType> norms(system.nVariables(), libMesh::H1_SEMINORM);
 
-      SystemNorm sys_norm(norms, weights);
+      libMesh::SystemNorm sys_norm(norms, weights);
 
       adapt.setErrorNorm(sys_norm);
     }

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -20,8 +20,6 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/fe_interface.h"
 
-using namespace libMesh;
-
 registerMooseAction("MooseApp", AddVariableAction, "add_variable");
 
 InputParameters
@@ -190,7 +188,7 @@ AddVariableAction::createInitialConditionAction(const std::vector<Real> & value)
   associateWithParameter("initial_condition", action_params);
 
   const auto fe_field_type = FEInterface::field_type(_fe_type);
-  const bool is_vector = fe_field_type == TYPE_VECTOR;
+  const bool is_vector = fe_field_type == libMesh::TYPE_VECTOR;
   const auto is_array = _components > 1 || _moose_object_pars.get<bool>("array");
 
   if (_scalar_var)
@@ -265,7 +263,7 @@ AddVariableAction::variableType(const FEType & fe_type, const bool is_fv, const 
 
   if (is_array)
   {
-    if (fe_field_type == TYPE_VECTOR)
+    if (fe_field_type == libMesh::TYPE_VECTOR)
       ::mooseError("Vector finite element families do not currently have ArrayVariable support");
     else
       return "ArrayMooseVariable";
@@ -274,7 +272,7 @@ AddVariableAction::variableType(const FEType & fe_type, const bool is_fv, const 
     return "MooseVariableConstMonomial";
   else if (fe_type.family == SCALAR)
     return "MooseVariableScalar";
-  else if (fe_field_type == TYPE_VECTOR)
+  else if (fe_field_type == libMesh::TYPE_VECTOR)
     return "VectorMooseVariable";
   else
     return "MooseVariable";

--- a/framework/src/actions/MeshOnlyAction.C
+++ b/framework/src/actions/MeshOnlyAction.C
@@ -21,8 +21,6 @@
 #include "libmesh/exodusII_io_helper.h"
 #include "libmesh/checkpoint_io.h"
 
-using namespace libMesh;
-
 registerMooseAction("MooseApp", MeshOnlyAction, "mesh_only");
 
 InputParameters
@@ -212,7 +210,7 @@ MeshOnlyAction::act()
   {
     TIME_SECTION("act", 1, "Writing Checkpoint");
 
-    CheckpointIO io(mesh_ptr->getMesh(), false);
+    libMesh::CheckpointIO io(mesh_ptr->getMesh(), false);
     io.write(mesh_file);
 
     // Write mesh metadata

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -26,8 +26,6 @@
 #include "libmesh/error_vector.h"
 #include "libmesh/distributed_mesh.h"
 
-using namespace libMesh;
-
 #ifdef LIBMESH_ENABLE_AMR
 
 Adaptivity::Adaptivity(FEProblemBase & fe_problem)
@@ -66,8 +64,8 @@ Adaptivity::init(const unsigned int steps,
   // does not exist at that point.
   _displaced_problem = _fe_problem.getDisplacedProblem();
 
-  _mesh_refinement = std::make_unique<MeshRefinement>(_mesh);
-  _error = std::make_unique<ErrorVector>();
+  _mesh_refinement = std::make_unique<libMesh::MeshRefinement>(_mesh);
+  _error = std::make_unique<libMesh::ErrorVector>();
 
   EquationSystems & es = _fe_problem.es();
   es.parameters.set<bool>("adaptivity") = true;
@@ -89,7 +87,7 @@ Adaptivity::init(const unsigned int steps,
                  "zeroth solver system solution is analyzed for determining whether to toggle "
                  "h-refinement flags to p-refinement flags");
 
-    _sibling_coupling = std::make_unique<SiblingCoupling>();
+    _sibling_coupling = std::make_unique<libMesh::SiblingCoupling>();
     _fe_problem.getSolverSystem(0).system().get_dof_map().add_algebraic_ghosting_functor(
         *_sibling_coupling);
   }
@@ -103,7 +101,8 @@ Adaptivity::init(const unsigned int steps,
     displaced_es.parameters.set<bool>("adaptivity") = true;
 
     if (!_displaced_mesh_refinement)
-      _displaced_mesh_refinement = std::make_unique<MeshRefinement>(_displaced_problem->mesh());
+      _displaced_mesh_refinement =
+          std::make_unique<libMesh::MeshRefinement>(_displaced_problem->mesh());
 
     // The periodic boundaries pointer allows the MeshRefinement
     // object to determine elements which are "topological" neighbors,
@@ -124,18 +123,18 @@ void
 Adaptivity::setErrorEstimator(const MooseEnum & error_estimator_name)
 {
   if (error_estimator_name == "KellyErrorEstimator")
-    _error_estimator = std::make_unique<KellyErrorEstimator>();
+    _error_estimator = std::make_unique<libMesh::KellyErrorEstimator>();
   else if (error_estimator_name == "LaplacianErrorEstimator")
-    _error_estimator = std::make_unique<LaplacianErrorEstimator>();
+    _error_estimator = std::make_unique<libMesh::LaplacianErrorEstimator>();
   else if (error_estimator_name == "PatchRecoveryErrorEstimator")
-    _error_estimator = std::make_unique<PatchRecoveryErrorEstimator>();
+    _error_estimator = std::make_unique<libMesh::PatchRecoveryErrorEstimator>();
   else
     mooseError(std::string("Unknown error_estimator selection: ") +
                std::string(error_estimator_name));
 }
 
 void
-Adaptivity::setErrorNorm(SystemNorm & sys_norm)
+Adaptivity::setErrorNorm(libMesh::SystemNorm & sys_norm)
 {
   mooseAssert(_error_estimator, "error_estimator not initialized. Did you call init_adaptivity()?");
   _error_estimator->error_norm = sys_norm;
@@ -232,7 +231,7 @@ Adaptivity::adaptMesh(std::string marker_name /*=std::string()*/)
   // local smoothness and prior h & p error estimates
   if (_adaptivity_type == AdaptivityType::HP)
   {
-    _hp_coarsen_test = std::make_unique<HPCoarsenTest>();
+    _hp_coarsen_test = std::make_unique<libMesh::HPCoarsenTest>();
     _hp_coarsen_test->select_refinement(_fe_problem.getSolverSystem(/*nl_sys=*/0).system());
   }
 
@@ -304,7 +303,7 @@ Adaptivity::uniformRefine(MooseMesh * mesh, unsigned int level /*=libMesh::inval
 
   // NOTE: we are using a separate object here, since adaptivity may not be on, but we need to be
   // able to do refinements
-  MeshRefinement mesh_refinement(*mesh);
+  libMesh::MeshRefinement mesh_refinement(*mesh);
   if (level == libMesh::invalid_uint)
     level = mesh->uniformRefineLevel();
 
@@ -331,9 +330,10 @@ Adaptivity::uniformRefineWithProjection()
 
   // NOTE: we are using a separate object here, since adaptivity may not be on, but we need to be
   // able to do refinements
-  MeshRefinement mesh_refinement(_mesh);
+  libMesh::MeshRefinement mesh_refinement(_mesh);
   unsigned int level = _mesh.uniformRefineLevel();
-  MeshRefinement displaced_mesh_refinement(_displaced_problem ? _displaced_problem->mesh() : _mesh);
+  libMesh::MeshRefinement displaced_mesh_refinement(_displaced_problem ? _displaced_problem->mesh()
+                                                                       : _mesh);
 
   // we have to go step by step so EquationSystems::reinit() won't freak out
   for (unsigned int i = 0; i < level; i++)
@@ -386,12 +386,12 @@ Adaptivity::setInitialMarkerVariableName(std::string marker_field)
   _initial_marker_variable_name = marker_field;
 }
 
-ErrorVector &
+libMesh::ErrorVector &
 Adaptivity::getErrorVector(const std::string & indicator_field)
 {
   // Insert or retrieve error vector
   auto insert_pair = moose_try_emplace(
-      _indicator_field_to_error_vector, indicator_field, std::make_unique<ErrorVector>());
+      _indicator_field_to_error_vector, indicator_field, std::make_unique<libMesh::ErrorVector>());
   return *insert_pair.first->second;
 }
 
@@ -403,7 +403,7 @@ Adaptivity::updateErrorVectors()
   // Resize all of the ErrorVectors in case the mesh has changed
   for (const auto & it : _indicator_field_to_error_vector)
   {
-    ErrorVector & vec = *(it.second);
+    libMesh::ErrorVector & vec = *(it.second);
     vec.assign(_mesh.getMesh().max_elem_id(), 0);
   }
 

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -36,8 +36,6 @@
 
 #include <algorithm>
 
-using namespace libMesh;
-
 template <typename P, typename C>
 void
 coordTransformFactor(const SubProblem & s,
@@ -636,7 +634,7 @@ Assembly::createQRules(QuadratureType type,
     q.vol->allow_rules_with_negative_weights = allow_negative_qweights;
     q.face = QBase::build(type, dim - 1, face_order);
     q.face->allow_rules_with_negative_weights = allow_negative_qweights;
-    q.fv_face = QBase::build(QMONOMIAL, dim - 1, CONSTANT);
+    q.fv_face = QBase::build(libMesh::QMONOMIAL, dim - 1, CONSTANT);
     q.fv_face->allow_rules_with_negative_weights = allow_negative_qweights;
     q.neighbor = std::make_unique<ArbitraryQuadrature>(dim - 1, face_order);
     q.neighbor->allow_rules_with_negative_weights = allow_negative_qweights;
@@ -1429,7 +1427,7 @@ Assembly::computeFaceMap(const Elem & elem, const unsigned int side, const std::
           _ad_d2xyzdxi2_map[p].zero();
 
       const auto n_mapping_shape_functions =
-          FE<2, LAGRANGE>::n_dofs(&side_elem, side_elem.default_order());
+          libMesh::FE<2, LAGRANGE>::n_dofs(&side_elem, side_elem.default_order());
 
       for (unsigned int i = 0; i < n_mapping_shape_functions; i++)
       {
@@ -1497,7 +1495,7 @@ Assembly::computeFaceMap(const Elem & elem, const unsigned int side, const std::
         }
 
       const unsigned int n_mapping_shape_functions =
-          FE<3, LAGRANGE>::n_dofs(&side_elem, side_elem.default_order());
+          libMesh::FE<3, LAGRANGE>::n_dofs(&side_elem, side_elem.default_order());
 
       for (unsigned int i = 0; i < n_mapping_shape_functions; i++)
       {
@@ -2490,7 +2488,7 @@ Assembly::init(const CouplingMatrix * cm)
     for (unsigned int k = 0; k < ivar->count(); ++k)
     {
       unsigned int iv = i + k;
-      for (const auto & j : ConstCouplingRow(iv, *_cm))
+      for (const auto & j : libMesh::ConstCouplingRow(iv, *_cm))
       {
         if (_sys.isScalarVariable(j))
         {
@@ -2534,7 +2532,7 @@ Assembly::init(const CouplingMatrix * cm)
     if (i >= _component_block_diagonal.size())
       _component_block_diagonal.resize(i + 1, true);
 
-    for (const auto & j : ConstCouplingRow(i, *_cm))
+    for (const auto & j : libMesh::ConstCouplingRow(i, *_cm))
       if (_sys.isScalarVariable(j))
       {
         auto & jvar = _sys.getScalarVariable(_tid, j);
@@ -2661,7 +2659,7 @@ Assembly::initNonlocalCoupling()
     for (unsigned int k = 0; k < ivar->count(); ++k)
     {
       unsigned int iv = i + k;
-      for (const auto & j : ConstCouplingRow(iv, _nonlocal_cm))
+      for (const auto & j : libMesh::ConstCouplingRow(iv, _nonlocal_cm))
         if (!_sys.isScalarVariable(j))
         {
           auto & jvar = _sys.getVariable(_tid, j);
@@ -3570,7 +3568,7 @@ Assembly::addJacobianBlock(SparseMatrix<Number> & jacobian,
 
   for (unsigned int i = 0; i < ivar.count(); ++i)
   {
-    for (const auto & jt : ConstCouplingRow(iv + i, *_cm))
+    for (const auto & jt : libMesh::ConstCouplingRow(iv + i, *_cm))
     {
       if (jt < jv || jt >= jv + jvar.count())
         continue;
@@ -3623,7 +3621,7 @@ Assembly::cacheJacobianBlock(const DenseMatrix<Number> & jac_block,
 
   for (unsigned int i = 0; i < ivar.count(); ++i)
   {
-    for (const auto & jt : ConstCouplingRow(iv + i, *_cm))
+    for (const auto & jt : libMesh::ConstCouplingRow(iv + i, *_cm))
     {
       if (jt < jv || jt >= jv + jvar.count())
         continue;
@@ -3681,7 +3679,7 @@ Assembly::cacheJacobianBlockNonzero(const DenseMatrix<Number> & jac_block,
   for (unsigned int i = 0; i < ivar.count(); ++i)
   {
     unsigned int iv = ivar.number();
-    for (const auto & jt : ConstCouplingRow(iv + i, *_cm))
+    for (const auto & jt : libMesh::ConstCouplingRow(iv + i, *_cm))
     {
       unsigned int jv = jvar.number();
       if (jt < jv || jt >= jv + jvar.count())

--- a/framework/src/base/MeshGeneratorSystem.C
+++ b/framework/src/base/MeshGeneratorSystem.C
@@ -15,8 +15,6 @@
 
 #include "libmesh/mesh_tools.h"
 
-using namespace libMesh;
-
 const std::string MeshGeneratorSystem::data_driven_generator_param = "data_driven_generator";
 const std::string MeshGeneratorSystem::allow_data_driven_param =
     "allow_data_driven_mesh_generation";
@@ -114,11 +112,11 @@ MeshGeneratorSystem::getMeshGeneratorParamDependencies(const InputParameters & p
 
   for (const auto & [name, param] : params)
     if (const auto dependency =
-            dynamic_cast<const Parameters::Parameter<MeshGeneratorName> *>(param.get()))
+            dynamic_cast<const libMesh::Parameters::Parameter<MeshGeneratorName> *>(param.get()))
       add_dependency(name, dependency->get());
-    else if (const auto dependencies =
-                 dynamic_cast<const Parameters::Parameter<std::vector<MeshGeneratorName>> *>(
-                     param.get()))
+    else if (const auto dependencies = dynamic_cast<
+                 const libMesh::Parameters::Parameter<std::vector<MeshGeneratorName>> *>(
+                 param.get()))
     {
       if (allow_empty && dependencies->get().empty())
         add_dependency(name, std::string());

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -91,8 +91,6 @@
 #include <thread>
 #include <filesystem>
 
-using namespace libMesh;
-
 namespace
 {
 /**
@@ -189,7 +187,7 @@ packMeshBackup(const MooseApp & app, Backup & backup)
 
   const auto mesh_path = temporaryBackupMeshPath(app, "backup", true);
   {
-    CheckpointIO io(app.feProblem().mesh().getMesh(), false);
+    libMesh::CheckpointIO io(app.feProblem().mesh().getMesh(), false);
     io.write(mesh_path.string());
   }
 
@@ -233,7 +231,7 @@ restoreMeshBackup(const MooseApp & app, Backup & backup, MooseMesh & mesh)
   mesh_base.clear();
 
   {
-    CheckpointIO io(mesh_base, false);
+    libMesh::CheckpointIO io(mesh_base, false);
     io.read(mesh_path.string());
   }
 
@@ -2592,7 +2590,7 @@ MooseApp::dynamicAppRegistration(const std::string & app_name,
                                  bool lib_load_deps)
 {
 #ifdef LIBMESH_HAVE_DLOPEN
-  Parameters params;
+  libMesh::Parameters params;
   params.set<std::string>("app_name") = app_name;
   params.set<RegistrationType>("reg_type") = APPLICATION;
   params.set<std::string>("registration_method") = app_name + "__registerApps";
@@ -2651,7 +2649,7 @@ MooseApp::dynamicAllRegistration(const std::string & app_name,
                                  const std::string & library_name)
 {
 #ifdef LIBMESH_HAVE_DLOPEN
-  Parameters params;
+  libMesh::Parameters params;
   params.set<std::string>("app_name") = app_name;
   params.set<RegistrationType>("reg_type") = REGALL;
   params.set<std::string>("registration_method") = app_name + "__registerAll";
@@ -2672,7 +2670,7 @@ MooseApp::dynamicAllRegistration(const std::string & app_name,
 }
 
 void
-MooseApp::dynamicRegistration(const Parameters & params)
+MooseApp::dynamicRegistration(const libMesh::Parameters & params)
 {
   const auto paths = getLibrarySearchPaths(params.get<std::string>("library_path"));
   const auto library_name = params.get<std::string>("library_name");
@@ -2686,7 +2684,7 @@ MooseApp::dynamicRegistration(const Parameters & params)
 
 void
 MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
-                                     const Parameters & params,
+                                     const libMesh::Parameters & params,
                                      const bool load_dependencies)
 {
   std::string line;

--- a/framework/src/base/MooseError.C
+++ b/framework/src/base/MooseError.C
@@ -14,8 +14,6 @@
 
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 namespace moose
 {
 
@@ -86,7 +84,7 @@ mooseErrorRaw(std::string msg,
     // anything thrown) and mooseError because we didn't understand
     // it, we just want to continue up the stack.
     if (this_thread_aborting)
-      libmesh_abort();
+      libMesh::libmesh_abort();
 
     this_thread_aborting = true;
 
@@ -113,7 +111,7 @@ mooseErrorRaw(std::string msg,
     if (show_trace && libMesh::global_n_processors() == 1)
     {
       std::ostringstream oss;
-      print_trace(oss);
+      libMesh::print_trace(oss);
       auto trace = oss.str();
       if (!prefix.empty()) // multiapp prefix
         MooseUtils::indentMessage(prefix, trace);
@@ -129,7 +127,7 @@ mooseErrorRaw(std::string msg,
     if (libMesh::global_n_processors() > 1)
       libMesh::write_traceout();
 
-    libmesh_abort();
+    libMesh::libmesh_abort();
   }
 }
 

--- a/framework/src/constraints/AutomaticMortarGeneration.C
+++ b/framework/src/constraints/AutomaticMortarGeneration.C
@@ -53,7 +53,6 @@
 #include <cmath>
 #include <limits>
 
-using namespace libMesh;
 using MetaPhysicL::DualNumber;
 
 // Make newer nanoflann API spelling compatible with older nanoflann
@@ -1783,9 +1782,9 @@ std::vector<AutomaticMortarGeneration::MsmSubdomainStats>
 AutomaticMortarGeneration::computeMsmStatistics()
 {
   std::vector<MsmSubdomainStats> result;
-  StatisticsVector<Real> primary;
-  StatisticsVector<Real> secondary;
-  StatisticsVector<Real> msm;
+  libMesh::StatisticsVector<Real> primary;
+  libMesh::StatisticsVector<Real> secondary;
+  libMesh::StatisticsVector<Real> msm;
   std::unordered_map<dof_id_type, Real> primary_elems_to_volume;
 
   for (const auto & [primary_subd_id, secondary_subd_id] : _primary_secondary_subdomain_id_pairs)
@@ -2137,7 +2136,7 @@ AutomaticMortarGeneration::computeNodalGeometry()
               "AutomaticMortarGeneration::computeNodalGeometry() is only valid for "
               "mortar constraints on 2D or 3D meshes.");
   // A nodal lower-dimensional nodal quadrature rule to be used on faces.
-  QNodal qface(dim - 1);
+  libMesh::QNodal qface(dim - 1);
 
   // A map from the node id to the attached elemental normals/weights evaluated at the node. Th
   // length of the vector will correspond to the number of elements attached to the node. If it is a

--- a/framework/src/constraints/MortarSegmentHelper.C
+++ b/framework/src/constraints/MortarSegmentHelper.C
@@ -37,8 +37,6 @@
 #include <unordered_map>
 #include <utility>
 
-using namespace libMesh;
-
 namespace
 {
 
@@ -77,7 +75,7 @@ validateProjectedQuadrilateral(const std::vector<Point> & polygon, const char * 
 
   // Normalization makes the libMesh map checks relative to the local projected size. The value
   // matches other mortar projection and clipping decisions.
-  const Real scaled_jacobian = element.quality(SCALED_JACOBIAN);
+  const Real scaled_jacobian = element.quality(libMesh::SCALED_JACOBIAN);
   if (!element.has_invertible_map(mortar_reference_mapping_tolerance) ||
       !std::isfinite(scaled_jacobian) || scaled_jacobian <= mortar_reference_mapping_tolerance)
     mooseException("The projected ",

--- a/framework/src/executioners/EigenProblemSolve.C
+++ b/framework/src/executioners/EigenProblemSolve.C
@@ -18,9 +18,6 @@
 
 #include "libmesh/petsc_solver_exception.h"
 
-// Needed for LIBMESH_CHECK_ERR
-using libMesh::PetscSolverException;
-
 InputParameters
 EigenProblemSolve::validParams()
 {

--- a/framework/src/geometries/Ball.C
+++ b/framework/src/geometries/Ball.C
@@ -12,9 +12,6 @@
 
 #include <cmath>
 
-using libMesh::Point;
-using libMesh::Real;
-
 bool
 Ball::intersect(const LineSegment & line_segment) const
 {

--- a/framework/src/geometries/LineSegment.C
+++ b/framework/src/geometries/LineSegment.C
@@ -15,10 +15,6 @@
 #include "libmesh/plane.h"
 #include "libmesh/vector_value.h"
 
-using libMesh::Point;
-using libMesh::Real;
-using libMesh::RealVectorValue;
-
 LineSegment::LineSegment(const Point & p0, const Point & p1) : _p0(p0), _p1(p1) {}
 
 bool

--- a/framework/src/geometries/Triangle.C
+++ b/framework/src/geometries/Triangle.C
@@ -13,9 +13,6 @@
 
 #include <cmath>
 
-using libMesh::Point;
-using libMesh::Real;
-
 Triangle::Triangle(const Point & p0, const Point & p1, const Point & p2) : _p0(p0), _p1(p1), _p2(p2)
 {
 }

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -21,8 +21,6 @@
 
 #include <algorithm>
 
-using namespace libMesh;
-
 // Anonymous namespace for helper functions that ought to be moved
 // into libMesh
 namespace

--- a/framework/src/ics/InitialConditionTempl.C
+++ b/framework/src/ics/InitialConditionTempl.C
@@ -16,8 +16,6 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/quadrature.h"
 
-using namespace libMesh;
-
 template <typename T>
 InitialConditionTempl<T>::InitialConditionTempl(const InputParameters & parameters)
   : InitialConditionBase(parameters),

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -19,7 +19,6 @@
 #include "libmesh/nemesis_io.h"
 #include "libmesh/parallel_mesh.h"
 
-using libMesh::ExodusII_IO;
 using libMesh::Nemesis_IO;
 
 registerMooseObject("MooseApp", FileMesh);

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -64,8 +64,6 @@
 #include "libmesh/enum_to_string.h"
 #include "libmesh/elem_side_builder.h"
 
-using namespace libMesh;
-
 // Make newer nanoflann API compatible with older nanoflann versions
 #if NANOFLANN_VERSION < 0x150
 namespace nanoflann
@@ -2987,7 +2985,7 @@ MooseMesh::init()
 std::vector<std::filesystem::path>
 MooseMesh::writeRecoveryFiles(const std::filesystem::path & file_base)
 {
-  CheckpointIO io(getMesh(), false);
+  libMesh::CheckpointIO io(getMesh(), false);
   io.write(file_base);
   return {};
 }

--- a/framework/src/outputs/AdvancedOutput.C
+++ b/framework/src/outputs/AdvancedOutput.C
@@ -26,8 +26,6 @@
 
 #include "libmesh/fe_interface.h"
 
-using namespace libMesh;
-
 // A function, only available in this file, for adding the AdvancedOutput parameters. This is
 // used to eliminate code duplication between the difference specializations of the validParams
 // function.
@@ -458,7 +456,7 @@ AdvancedOutput::initAvailableLists()
         if (type.order == CONSTANT && !_problem_ptr->havePRefinement() &&
             type.family != MONOMIAL_VEC)
           _execute_data["elemental"].available.insert(vname);
-        else if (FEInterface::field_type(type) == TYPE_VECTOR)
+        else if (FEInterface::field_type(type) == libMesh::TYPE_VECTOR)
         {
           const auto geom_type = ((type.family == MONOMIAL_VEC) && (type.order == CONSTANT) &&
                                   !_problem_ptr->havePRefinement())
@@ -546,7 +544,7 @@ AdvancedOutput::initShowHideLists(const std::vector<VariableName> & show,
 
         if (type.order == CONSTANT)
           _execute_data["elemental"].show.insert(vname);
-        else if (FEInterface::field_type(type) == TYPE_VECTOR)
+        else if (FEInterface::field_type(type) == libMesh::TYPE_VECTOR)
         {
           const auto geom_type =
               ((type.family == MONOMIAL_VEC) && (type.order == CONSTANT)) ? "elemental" : "nodal";
@@ -600,7 +598,7 @@ AdvancedOutput::initShowHideLists(const std::vector<VariableName> & show,
 
         if (type.order == CONSTANT)
           _execute_data["elemental"].hide.insert(vname);
-        else if (FEInterface::field_type(type) == TYPE_VECTOR)
+        else if (FEInterface::field_type(type) == libMesh::TYPE_VECTOR)
         {
           switch (_es_ptr->get_mesh().spatial_dimension())
           {

--- a/framework/src/outputs/BlockRestrictionDebugOutput.C
+++ b/framework/src/outputs/BlockRestrictionDebugOutput.C
@@ -32,8 +32,6 @@
 #include <functional>
 #include <map>
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", BlockRestrictionDebugOutput);
 
 namespace
@@ -313,7 +311,7 @@ BlockRestrictionDebugOutput::printBlockRestrictionMap() const
       const auto & sys = auxSystem.system();
       for (unsigned int vg = 0; vg < sys.n_variable_groups(); vg++)
       {
-        const VariableGroup & vg_description(sys.variable_group(vg));
+        const libMesh::VariableGroup & vg_description(sys.variable_group(vg));
         for (unsigned int vn = 0; vn < vg_description.n_variables(); vn++)
         {
           if (vg_description.active_on_subdomain(subdomain_id))
@@ -474,7 +472,7 @@ BlockRestrictionDebugOutput::printBlockRestrictionGroups() const
   const auto & aux_system = _problem_ptr->getAuxiliarySystem().system();
   for (const auto vg : make_range(aux_system.n_variable_groups()))
   {
-    const VariableGroup & vg_description(aux_system.variable_group(vg));
+    const libMesh::VariableGroup & vg_description(aux_system.variable_group(vg));
     std::set<SubdomainID> blocks;
     for (const auto subdomain_id : mesh_subdomains)
       if (vg_description.active_on_subdomain(subdomain_id))

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -26,8 +26,6 @@
 #include "libmesh/enum_xdr_mode.h"
 #include "libmesh/utility.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", Checkpoint);
 
 InputParameters
@@ -216,8 +214,8 @@ Checkpoint::updateCheckpointFiles(CheckpointFileNames file_struct)
     // Delete checkpoint files
     // This file may not exist so don't worry about checking for success
     if (processor_id() == 0)
-      CheckpointIO::cleanup(delete_files.checkpoint,
-                            _problem_ptr->mesh().isDistributedMesh() ? comm().size() : 1);
+      libMesh::CheckpointIO::cleanup(delete_files.checkpoint,
+                                     _problem_ptr->mesh().isDistributedMesh() ? comm().size() : 1);
   }
 }
 

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -32,8 +32,6 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/simple_range.h"
 
-using namespace libMesh;
-
 namespace ConsoleUtils
 {
 
@@ -222,7 +220,7 @@ outputSystemInformationHelper(std::stringstream & oss, System & system)
     oss << std::setw(console_field_width) << "  Variables: ";
     for (unsigned int vg = 0; vg < system.n_variable_groups(); vg++)
     {
-      const VariableGroup & vg_description(system.variable_group(vg));
+      const libMesh::VariableGroup & vg_description(system.variable_group(vg));
 
       if (vg_description.n_variables() > 1)
         oss << "{ ";

--- a/framework/src/outputs/DOFMapOutput.C
+++ b/framework/src/outputs/DOFMapOutput.C
@@ -23,8 +23,6 @@
 #include <cxxabi.h>
 #include <fstream>
 
-using namespace libMesh;
-
 registerMooseObjectAliased("MooseApp", DOFMapOutput, "DOFMap");
 
 InputParameters
@@ -140,7 +138,7 @@ DOFMapOutput::output()
   oss << ", \"vars\": [";
   for (unsigned int vg = 0; vg < dof_map.n_variable_groups(); ++vg)
   {
-    const VariableGroup & vg_description(dof_map.variable_group(vg));
+    const libMesh::VariableGroup & vg_description(dof_map.variable_group(vg));
     for (unsigned int vn = 0; vn < vg_description.n_variables(); ++vn)
     {
       unsigned int var = vg_description.number(vn);

--- a/framework/src/outputs/GMVOutput.C
+++ b/framework/src/outputs/GMVOutput.C
@@ -13,8 +13,6 @@
 #include "libmesh/equation_systems.h"
 #include "libmesh/gmv_io.h"
 
-using namespace libMesh;
-
 registerMooseObjectAliased("MooseApp", GMVOutput, "GMV");
 
 InputParameters
@@ -46,7 +44,7 @@ GMVOutput::GMVOutput(const InputParameters & parameters)
 void
 GMVOutput::output()
 {
-  GMVIO out(_es_ptr->get_mesh());
+  libMesh::GMVIO out(_es_ptr->get_mesh());
   out.write_equation_systems(filename(), *_es_ptr);
   _file_num++;
 }

--- a/framework/src/outputs/Nemesis.C
+++ b/framework/src/outputs/Nemesis.C
@@ -19,8 +19,6 @@
 #include "libmesh/dof_map.h"
 #include "libmesh/nemesis_io.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", Nemesis);
 
 InputParameters
@@ -78,7 +76,7 @@ Nemesis::outputSetup()
   }
 
   // Create the new NemesisIO object
-  _nemesis_io_ptr = std::make_unique<Nemesis_IO>(_problem_ptr->mesh().getMesh());
+  _nemesis_io_ptr = std::make_unique<libMesh::Nemesis_IO>(_problem_ptr->mesh().getMesh());
   _nemesis_initialized = false;
 
   if (_write_hdf5)

--- a/framework/src/outputs/SampledOutput.C
+++ b/framework/src/outputs/SampledOutput.C
@@ -19,8 +19,6 @@
 #include "libmesh/mesh_function.h"
 #include "libmesh/explicit_system.h"
 
-using namespace libMesh;
-
 InputParameters
 SampledOutput::validParams()
 {
@@ -146,7 +144,7 @@ SampledOutput::initSample()
   // Perform the mesh refinement
   if (_refinements > 0)
   {
-    MeshRefinement mesh_refinement(_mesh_ptr->getMesh());
+    libMesh::MeshRefinement mesh_refinement(_mesh_ptr->getMesh());
 
     // We want original and refined partitioning to match so we can
     // query from one to the other safely on distributed meshes.
@@ -340,7 +338,7 @@ SampledOutput::updateSample()
         // it for re-initialization
         // TODO: inherit from MeshChangedInterface and rebuild mesh functions on meshChanged()
         if (!_mesh_functions[sys_num][var_num] || _sampling_mesh_changed)
-          _mesh_functions[sys_num][var_num] = std::make_unique<MeshFunction>(
+          _mesh_functions[sys_num][var_num] = std::make_unique<libMesh::MeshFunction>(
               source_es,
               _serialize ? *_serialized_solution : *source_sys.solution,
               source_sys.get_dof_map(),

--- a/framework/src/outputs/XDA.C
+++ b/framework/src/outputs/XDA.C
@@ -16,8 +16,6 @@
 // libMesh includes
 #include "libmesh/enum_xdr_mode.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", XDA);
 registerMooseObjectAliased("MooseApp", XDA, "XDR");
 
@@ -58,7 +56,7 @@ XDA::output()
   mesh_name.insert(mesh_name.size() - 4, "_mesh");
 
   // Set the binary flag
-  XdrMODE mode = _binary ? ENCODE : WRITE;
+  libMesh::XdrMODE mode = _binary ? libMesh::ENCODE : libMesh::WRITE;
 
   // Write the files
   _mesh_ptr->getMesh().write(mesh_name);

--- a/framework/src/partitioner/PetscExternalPartitioner.C
+++ b/framework/src/partitioner/PetscExternalPartitioner.C
@@ -18,8 +18,6 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/petsc_solver_exception.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", PetscExternalPartitioner);
 
 #include <memory>
@@ -77,7 +75,7 @@ PetscExternalPartitioner::preLinearPartition(MeshBase & mesh)
   // Temporarily cache the old partition method
   auto old_partitioner = std::move(mesh.partitioner());
   // Create a linear partitioner
-  mesh.partitioner() = std::make_unique<LinearPartitioner>();
+  mesh.partitioner() = std::make_unique<libMesh::LinearPartitioner>();
   // Partition mesh
   mesh.partition(n_processors());
   // Restore the old partition

--- a/framework/src/preconditioners/FieldSplitPreconditioner.C
+++ b/framework/src/preconditioners/FieldSplitPreconditioner.C
@@ -25,8 +25,6 @@
 #include "libmesh/petsc_nonlinear_solver.h"
 #include "libmesh/coupling_matrix.h"
 
-using namespace libMesh;
-
 template <typename Base>
 InputParameters
 FieldSplitPreconditionerTempl<Base>::validParams()
@@ -140,7 +138,8 @@ FieldSplitPreconditioner::setupDM()
   // call would be in DMInitializePackage()
   LibmeshPetscCall(DMMooseRegisterAll());
   // Create and set up the DM that will consume the split options and deal with block matrices.
-  auto * const petsc_solver = cast_ptr<PetscNonlinearSolver<Number> *>(_nl.nonlinearSolver());
+  auto * const petsc_solver =
+      cast_ptr<libMesh::PetscNonlinearSolver<Number> *>(_nl.nonlinearSolver());
   SNES snes = petsc_solver->snes(prefix().c_str());
   // if there exists a DMMoose object, not to recreate a new one
   LibmeshPetscCall(SNESGetDM(snes, &dm));
@@ -155,7 +154,7 @@ FieldSplitPreconditioner::setupDM()
   LibmeshPetscCall(DMDestroy(&dm));
 }
 
-const DofMapBase &
+const libMesh::DofMapBase &
 FieldSplitPreconditioner::dofMap() const
 {
   return _nl.dofMap();

--- a/framework/src/preconditioners/StaticCondensationFieldSplitPreconditioner.C
+++ b/framework/src/preconditioners/StaticCondensationFieldSplitPreconditioner.C
@@ -19,8 +19,6 @@
 #include "libmesh/static_condensation_dof_map.h"
 #include "libmesh/petsc_linear_solver.h"
 
-using namespace libMesh;
-
 registerMooseObjectAliased("MooseApp", StaticCondensationFieldSplitPreconditioner, "SCFSP");
 
 InputParameters
@@ -65,7 +63,8 @@ StaticCondensationFieldSplitPreconditioner::setupDM()
   // call would be in DMInitializePackage()
   LibmeshPetscCall(DMMooseRegisterAll());
   // Create and set up the DM that will consume the split options and deal with block matrices.
-  auto & petsc_solver = cast_ref<PetscLinearSolver<Number> &>(scSysMat().reduced_system_solver());
+  auto & petsc_solver =
+      cast_ref<libMesh::PetscLinearSolver<Number> &>(scSysMat().reduced_system_solver());
   auto ksp = petsc_solver.ksp();
   // if there exists a DMMoose object, then we do not need to recreate one
   LibmeshPetscCall(KSPGetDM(ksp, &dm));
@@ -89,6 +88,7 @@ StaticCondensationFieldSplitPreconditioner::setupDM()
 KSP
 StaticCondensationFieldSplitPreconditioner::getKSP()
 {
-  auto & petsc_solver = cast_ref<PetscLinearSolver<Number> &>(scSysMat().reduced_system_solver());
+  auto & petsc_solver =
+      cast_ref<libMesh::PetscLinearSolver<Number> &>(scSysMat().reduced_system_solver());
   return petsc_solver.ksp();
 }

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -26,8 +26,6 @@
 #include "libmesh/transient_system.h"
 #include "libmesh/explicit_system.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", DisplacedProblem);
 
 InputParameters
@@ -1125,7 +1123,7 @@ DisplacedProblem::meshChanged(const bool contract_mesh, const bool clean_refinem
   {
     // Finally clean refinement flags so that if someone tries to project vectors again without
     // an intervening mesh refinement to clean flags they won't run into trouble
-    MeshRefinement refinement(_mesh.getMesh());
+    libMesh::MeshRefinement refinement(_mesh.getMesh());
     refinement.clean_refinement_flags();
   }
 

--- a/framework/src/problems/EigenProblem.C
+++ b/framework/src/problems/EigenProblem.C
@@ -26,9 +26,6 @@
 #include "libmesh/eigen_solver.h"
 #include "libmesh/enum_eigen_solver_type.h"
 
-// Needed for LIBMESH_CHECK_ERR
-using libMesh::PetscSolverException;
-
 registerMooseObject("MooseApp", EigenProblem);
 
 InputParameters

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -144,8 +144,6 @@
 // C++
 #include <cstring> // for "Jacobian" exception test
 
-using namespace libMesh;
-
 // Anonymous namespace for helper function
 namespace
 {
@@ -2344,7 +2342,7 @@ FEProblemBase::reinitDirac(const Elem * elem, const THREAD_ID tid)
       for (unsigned int tid = 0; tid < libMesh::n_threads(); ++tid)
       {
         // the highest available order in libMesh is 43
-        _scalar_zero[tid].resize(FORTYTHIRD, 0);
+        _scalar_zero[tid].resize(libMesh::FORTYTHIRD, 0);
         _zero[tid].resize(max_qpts, 0);
         _grad_zero[tid].resize(max_qpts, RealGradient(0.));
         _second_zero[tid].resize(max_qpts, RealTensor(0.));
@@ -2986,7 +2984,7 @@ FEProblemBase::duplicateVariableCheck(const std::string & var_name,
 
     if (curr_sys_ptr->hasVariable(var_name))
     {
-      const Variable & var =
+      const libMesh::Variable & var =
           curr_sys_ptr->system().variable(curr_sys_ptr->system().variable_number(var_name));
 
       // variable type
@@ -3428,7 +3426,7 @@ FEProblemBase::addAuxVariable(const std::string & var_name,
     var_type = "MooseVariableConstMonomial";
   else if (type.family == SCALAR)
     var_type = "MooseVariableScalar";
-  else if (FEInterface::field_type(type) == TYPE_VECTOR)
+  else if (FEInterface::field_type(type) == libMesh::TYPE_VECTOR)
     var_type = "VectorMooseVariable";
   else
     var_type = "MooseVariable";
@@ -6683,7 +6681,7 @@ FEProblemBase::updateMaxQps()
   for (unsigned int tid = 0; tid < libMesh::n_threads(); ++tid)
   {
     // the highest available order in libMesh is 43
-    _scalar_zero[tid].resize(FORTYTHIRD, 0);
+    _scalar_zero[tid].resize(libMesh::FORTYTHIRD, 0);
     _zero[tid].resize(max_qpts, 0);
     _ad_zero[tid].resize(max_qpts, 0);
     _grad_zero[tid].resize(max_qpts, RealGradient(0.));
@@ -8865,7 +8863,7 @@ FEProblemBase::meshChanged(const bool intermediate_change,
   {
     // Finally clear refinement flags so that if someone tries to project vectors again without
     // an intervening mesh refinement to clear flags they won't run into trouble
-    MeshRefinement refinement(_mesh.getMesh());
+    libMesh::MeshRefinement refinement(_mesh.getMesh());
     refinement.clean_refinement_flags();
   }
 

--- a/framework/src/problems/SubProblem.C
+++ b/framework/src/problems/SubProblem.C
@@ -30,8 +30,6 @@
 
 #include <regex>
 
-using namespace libMesh;
-
 InputParameters
 SubProblem::validParams()
 {
@@ -1015,20 +1013,20 @@ SubProblem::reinitMortarElem(const Elem * elem, const THREAD_ID tid)
 }
 
 void
-SubProblem::cloneAlgebraicGhostingFunctor(GhostingFunctor & algebraic_gf, bool to_mesh)
+SubProblem::cloneAlgebraicGhostingFunctor(libMesh::GhostingFunctor & algebraic_gf, bool to_mesh)
 {
   EquationSystems & eq = es();
   const auto n_sys = eq.n_systems();
 
   auto pr = _root_alg_gf_to_sys_clones.emplace(
-      &algebraic_gf, std::vector<std::shared_ptr<GhostingFunctor>>(n_sys - 1));
+      &algebraic_gf, std::vector<std::shared_ptr<libMesh::GhostingFunctor>>(n_sys - 1));
   mooseAssert(pr.second, "We are adding a duplicate algebraic ghosting functor");
   auto & clones_vec = pr.first->second;
 
   for (MooseIndex(n_sys) i = 1; i < n_sys; ++i)
   {
     DofMap & dof_map = eq.get_system(i).get_dof_map();
-    std::shared_ptr<GhostingFunctor> clone_alg_gf = algebraic_gf.clone();
+    std::shared_ptr<libMesh::GhostingFunctor> clone_alg_gf = algebraic_gf.clone();
     std::dynamic_pointer_cast<RelationshipManager>(clone_alg_gf)
         ->init(mesh(), *algebraic_gf.get_mesh(), &dof_map);
     dof_map.add_algebraic_ghosting_functor(clone_alg_gf, to_mesh);
@@ -1037,7 +1035,7 @@ SubProblem::cloneAlgebraicGhostingFunctor(GhostingFunctor & algebraic_gf, bool t
 }
 
 void
-SubProblem::addAlgebraicGhostingFunctor(GhostingFunctor & algebraic_gf, bool to_mesh)
+SubProblem::addAlgebraicGhostingFunctor(libMesh::GhostingFunctor & algebraic_gf, bool to_mesh)
 {
   EquationSystems & eq = es();
   const auto n_sys = eq.n_systems();
@@ -1049,19 +1047,19 @@ SubProblem::addAlgebraicGhostingFunctor(GhostingFunctor & algebraic_gf, bool to_
 }
 
 void
-SubProblem::cloneCouplingGhostingFunctor(GhostingFunctor & coupling_gf, bool to_mesh)
+SubProblem::cloneCouplingGhostingFunctor(libMesh::GhostingFunctor & coupling_gf, bool to_mesh)
 {
   const std::size_t num_nl_sys = numNonlinearSystems();
 
   auto pr = _root_coupling_gf_to_sys_clones.emplace(
-      &coupling_gf, std::vector<std::shared_ptr<GhostingFunctor>>(num_nl_sys - 1));
+      &coupling_gf, std::vector<std::shared_ptr<libMesh::GhostingFunctor>>(num_nl_sys - 1));
   mooseAssert(pr.second, "We are adding a duplicate coupling functor");
   auto & clones_vec = pr.first->second;
 
   for (const auto i : make_range(std::size_t(1), num_nl_sys))
   {
     DofMap & dof_map = systemBaseNonlinear(i).system().get_dof_map();
-    std::shared_ptr<GhostingFunctor> clone_coupling_gf = coupling_gf.clone();
+    std::shared_ptr<libMesh::GhostingFunctor> clone_coupling_gf = coupling_gf.clone();
     std::dynamic_pointer_cast<RelationshipManager>(clone_coupling_gf)
         ->init(mesh(), *coupling_gf.get_mesh(), &dof_map);
     dof_map.add_coupling_functor(clone_coupling_gf, to_mesh);
@@ -1070,7 +1068,7 @@ SubProblem::cloneCouplingGhostingFunctor(GhostingFunctor & coupling_gf, bool to_
 }
 
 void
-SubProblem::addCouplingGhostingFunctor(GhostingFunctor & coupling_gf, bool to_mesh)
+SubProblem::addCouplingGhostingFunctor(libMesh::GhostingFunctor & coupling_gf, bool to_mesh)
 {
   const auto num_nl_sys = numNonlinearSystems();
   if (!num_nl_sys)
@@ -1081,7 +1079,7 @@ SubProblem::addCouplingGhostingFunctor(GhostingFunctor & coupling_gf, bool to_me
 }
 
 void
-SubProblem::removeAlgebraicGhostingFunctor(GhostingFunctor & algebraic_gf)
+SubProblem::removeAlgebraicGhostingFunctor(libMesh::GhostingFunctor & algebraic_gf)
 {
   EquationSystems & eq = es();
   const auto n_sys = eq.n_systems();
@@ -1124,7 +1122,7 @@ SubProblem::removeAlgebraicGhostingFunctor(GhostingFunctor & algebraic_gf)
 }
 
 void
-SubProblem::removeCouplingGhostingFunctor(GhostingFunctor & coupling_gf)
+SubProblem::removeCouplingGhostingFunctor(libMesh::GhostingFunctor & coupling_gf)
 {
   EquationSystems & eq = es();
   const auto num_nl_sys = numNonlinearSystems();

--- a/framework/src/relationshipmanagers/ElementPointNeighborLayers.C
+++ b/framework/src/relationshipmanagers/ElementPointNeighborLayers.C
@@ -14,8 +14,6 @@
 
 #include "libmesh/point_neighbor_coupling.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", ElementPointNeighborLayers);
 
 InputParameters
@@ -43,7 +41,7 @@ ElementPointNeighborLayers::ElementPointNeighborLayers(const ElementPointNeighbo
 {
 }
 
-std::unique_ptr<GhostingFunctor>
+std::unique_ptr<libMesh::GhostingFunctor>
 ElementPointNeighborLayers::clone() const
 {
   return _app.getFactory().copyConstruct(*this);
@@ -73,7 +71,7 @@ ElementPointNeighborLayers::operator>=(const RelationshipManager & rhs) const
 void
 ElementPointNeighborLayers::internalInitWithMesh(const MeshBase &)
 {
-  auto functor = std::make_unique<PointNeighborCoupling>();
+  auto functor = std::make_unique<libMesh::PointNeighborCoupling>();
   functor->set_n_levels(_layers);
 
   _functor = std::move(functor);

--- a/framework/src/relationshipmanagers/ElementSideNeighborLayers.C
+++ b/framework/src/relationshipmanagers/ElementSideNeighborLayers.C
@@ -19,8 +19,6 @@
 #include "libmesh/point_neighbor_coupling.h"
 #include "libmesh/dof_map.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", ElementSideNeighborLayers);
 
 InputParameters
@@ -56,7 +54,7 @@ ElementSideNeighborLayers::ElementSideNeighborLayers(const ElementSideNeighborLa
 {
 }
 
-std::unique_ptr<GhostingFunctor>
+std::unique_ptr<libMesh::GhostingFunctor>
 ElementSideNeighborLayers::clone() const
 {
   return _app.getFactory().copyConstruct(*this);
@@ -111,13 +109,13 @@ ElementSideNeighborLayers::internalInitWithMesh(const MeshBase &)
 {
   if (_use_point_neighbors)
   {
-    auto functor = std::make_unique<PointNeighborCoupling>();
+    auto functor = std::make_unique<libMesh::PointNeighborCoupling>();
     initFunctor(*functor);
     _functor = std::move(functor);
   }
   else
   {
-    auto functor = std::make_unique<DefaultCoupling>();
+    auto functor = std::make_unique<libMesh::DefaultCoupling>();
     initFunctor(*functor);
     _functor = std::move(functor);
   }
@@ -129,8 +127,10 @@ ElementSideNeighborLayers::dofmap_reinit()
   if (_dof_map)
   {
     if (_use_point_neighbors)
-      cast_ptr<PointNeighborCoupling *>(_functor.get())->set_dof_coupling(_dof_map->_dof_coupling);
+      cast_ptr<libMesh::PointNeighborCoupling *>(_functor.get())
+          ->set_dof_coupling(_dof_map->_dof_coupling);
     else
-      cast_ptr<DefaultCoupling *>(_functor.get())->set_dof_coupling(_dof_map->_dof_coupling);
+      cast_ptr<libMesh::DefaultCoupling *>(_functor.get())
+          ->set_dof_coupling(_dof_map->_dof_coupling);
   }
 }

--- a/framework/src/relationshipmanagers/GhostAllPointNeighbors.C
+++ b/framework/src/relationshipmanagers/GhostAllPointNeighbors.C
@@ -22,8 +22,6 @@
 
 registerMooseObject("MooseApp", GhostAllPointNeighbors);
 
-using namespace libMesh;
-
 InputParameters
 GhostAllPointNeighbors::validParams()
 {
@@ -96,7 +94,7 @@ GhostAllPointNeighbors::operator>=(const RelationshipManager & other) const
          dynamic_cast<const GhostHigherDLowerDPointNeighbors *>(&other);
 }
 
-std::unique_ptr<GhostingFunctor>
+std::unique_ptr<libMesh::GhostingFunctor>
 GhostAllPointNeighbors::clone() const
 {
   return _app.getFactory().copyConstruct(*this);

--- a/framework/src/relationshipmanagers/GhostEverything.C
+++ b/framework/src/relationshipmanagers/GhostEverything.C
@@ -20,8 +20,6 @@
 
 registerMooseObject("MooseApp", GhostEverything);
 
-using namespace libMesh;
-
 InputParameters
 GhostEverything::validParams()
 {
@@ -62,7 +60,7 @@ GhostEverything::operator>=(const RelationshipManager & other) const
   return baseGreaterEqual(other);
 }
 
-std::unique_ptr<GhostingFunctor>
+std::unique_ptr<libMesh::GhostingFunctor>
 GhostEverything::clone() const
 {
   return _app.getFactory().copyConstruct(*this);

--- a/framework/src/relationshipmanagers/GhostHigherDLowerDPointNeighbors.C
+++ b/framework/src/relationshipmanagers/GhostHigherDLowerDPointNeighbors.C
@@ -21,8 +21,6 @@
 
 registerMooseObject("MooseApp", GhostHigherDLowerDPointNeighbors);
 
-using namespace libMesh;
-
 InputParameters
 GhostHigherDLowerDPointNeighbors::validParams()
 {
@@ -102,7 +100,7 @@ GhostHigherDLowerDPointNeighbors::operator>=(const RelationshipManager & other) 
          dynamic_cast<const GhostLowerDElems *>(&other);
 }
 
-std::unique_ptr<GhostingFunctor>
+std::unique_ptr<libMesh::GhostingFunctor>
 GhostHigherDLowerDPointNeighbors::clone() const
 {
   return _app.getFactory().copyConstruct(*this);

--- a/framework/src/relationshipmanagers/GhostLowerDElems.C
+++ b/framework/src/relationshipmanagers/GhostLowerDElems.C
@@ -20,8 +20,6 @@
 
 registerMooseObject("MooseApp", GhostLowerDElems);
 
-using namespace libMesh;
-
 InputParameters
 GhostLowerDElems::validParams()
 {
@@ -77,7 +75,7 @@ GhostLowerDElems::operator>=(const RelationshipManager & other) const
   return dynamic_cast<const GhostLowerDElems *>(&other);
 }
 
-std::unique_ptr<GhostingFunctor>
+std::unique_ptr<libMesh::GhostingFunctor>
 GhostLowerDElems::clone() const
 {
   return _app.getFactory().copyConstruct(*this);

--- a/framework/src/relationshipmanagers/GhostPrimaryFace.C
+++ b/framework/src/relationshipmanagers/GhostPrimaryFace.C
@@ -16,8 +16,6 @@
 
 registerMooseObject("MooseApp", GhostPrimaryFace);
 
-using namespace libMesh;
-
 InputParameters
 GhostPrimaryFace::validParams()
 {
@@ -160,7 +158,7 @@ GhostPrimaryFace::operator>=(const RelationshipManager & other) const
          _secondary_boundary_name == primary_face->_secondary_boundary_name;
 }
 
-std::unique_ptr<GhostingFunctor>
+std::unique_ptr<libMesh::GhostingFunctor>
 GhostPrimaryFace::clone() const
 {
   return _app.getFactory().copyConstruct(*this);

--- a/framework/src/relationshipmanagers/ProxyRelationshipManager.C
+++ b/framework/src/relationshipmanagers/ProxyRelationshipManager.C
@@ -14,8 +14,6 @@
 #include "libmesh/elem.h"
 #include "libmesh/dof_map.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", ProxyRelationshipManager);
 
 InputParameters
@@ -114,7 +112,7 @@ ProxyRelationshipManager::operator>=(const RelationshipManager & /*rhs*/) const
   return false;
 }
 
-std::unique_ptr<GhostingFunctor>
+std::unique_ptr<libMesh::GhostingFunctor>
 ProxyRelationshipManager::clone() const
 {
   return _app.getFactory().copyConstruct(*this);

--- a/framework/src/relationshipmanagers/RelationshipManager.C
+++ b/framework/src/relationshipmanagers/RelationshipManager.C
@@ -10,8 +10,6 @@
 #include "RelationshipManager.h"
 #include "MooseApp.h"
 
-using namespace libMesh;
-
 InputParameters
 RelationshipManager::validParams()
 {
@@ -156,7 +154,7 @@ RelationshipManager::oneLayerGhosting(Moose::RelationshipManagerType rm_type)
 void
 RelationshipManager::init(MooseMesh & moose_mesh,
                           const MeshBase & mesh,
-                          const DofMap * const dof_map)
+                          const libMesh::DofMap * const dof_map)
 {
   mooseAssert(_dof_map ? dof_map == _dof_map : true,
               "Trying to initialize with a different dof map");

--- a/framework/src/restart/DataIO.C
+++ b/framework/src/restart/DataIO.C
@@ -25,8 +25,6 @@
 
 #include "mtwist.h"
 
-using namespace libMesh;
-
 template <>
 void
 dataStore<mt_state>(std::ostream & stream, mt_state & foo, void * ctx)
@@ -374,7 +372,7 @@ dataStore(std::ostream & stream,
   // Store the solver package so that we know what vector type to construct
   libMesh::SolverPackage solver_package;
   if (dynamic_cast<libMesh::PetscVector<Number> *>(v.get()))
-    solver_package = PETSC_SOLVERS;
+    solver_package = libMesh::PETSC_SOLVERS;
   else
     mooseError("Can only store unique_ptrs of PetscVectors");
   int solver_package_int = solver_package;

--- a/framework/src/systems/AuxiliarySystem.C
+++ b/framework/src/systems/AuxiliarySystem.C
@@ -34,8 +34,6 @@
 // C++
 #include <cstring> // for "Jacobian" exception test
 
-using namespace libMesh;
-
 // AuxiliarySystem ////////
 
 AuxiliarySystem::AuxiliarySystem(FEProblemBase & subproblem, const std::string & name)
@@ -269,7 +267,7 @@ AuxiliarySystem::addVariable(const std::string & var_type,
 
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
-    if (FEInterface::field_type(fe_type) == TYPE_VECTOR)
+    if (FEInterface::field_type(fe_type) == libMesh::TYPE_VECTOR)
     {
       auto * var = _vars[tid].getActualFieldVariable<RealVectorValue>(name);
       if (var)
@@ -872,7 +870,7 @@ AuxiliarySystem::computeElementalArrayVars(ExecFlagType type)
 }
 
 void
-AuxiliarySystem::augmentSparsity(SparsityPattern::Graph & /*sparsity*/,
+AuxiliarySystem::augmentSparsity(libMesh::SparsityPattern::Graph & /*sparsity*/,
                                  std::vector<dof_id_type> & /*n_nz*/,
                                  std::vector<dof_id_type> &
                                  /*n_oz*/)

--- a/framework/src/systems/LinearSystem.C
+++ b/framework/src/systems/LinearSystem.C
@@ -58,8 +58,6 @@
 
 #include <ios>
 
-using namespace libMesh;
-
 namespace Moose
 {
 void
@@ -317,7 +315,7 @@ LinearSystem::solve()
   _n_linear_iters = _linear_implicit_system.n_linear_iterations();
 
   auto & linear_solver =
-      cast_ref<PetscLinearSolver<Real> &>(*_linear_implicit_system.get_linear_solver());
+      cast_ref<libMesh::PetscLinearSolver<Real> &>(*_linear_implicit_system.get_linear_solver());
   _initial_linear_residual = linear_solver.get_initial_residual();
   _final_linear_residual = _linear_implicit_system.final_linear_residual();
   _converged = linear_solver.get_converged_reason() > 0;

--- a/framework/src/systems/NonlinearEigenSystem.C
+++ b/framework/src/systems/NonlinearEigenSystem.C
@@ -33,8 +33,6 @@
 #include "libmesh/petsc_solver_exception.h"
 #include "libmesh/slepc_eigen_solver.h"
 
-using namespace libMesh;
-
 #ifdef LIBMESH_HAVE_SLEPC
 
 namespace Moose
@@ -44,7 +42,7 @@ void
 assemble_matrix(EquationSystems & es, const std::string & system_name)
 {
   EigenProblem * p = es.parameters.get<EigenProblem *>("_eigen_problem");
-  CondensedEigenSystem & eigen_system = es.get_system<CondensedEigenSystem>(system_name);
+  auto & eigen_system = es.get_system<libMesh::CondensedEigenSystem>(system_name);
   NonlinearEigenSystem & eigen_nl =
       p->getNonlinearEigenSystem(/*nl_sys_num=*/eigen_system.number());
 
@@ -107,8 +105,8 @@ assemble_matrix(EquationSystems & es, const std::string & system_name)
 
 NonlinearEigenSystem::NonlinearEigenSystem(EigenProblem & eigen_problem, const std::string & name)
   : NonlinearSystemBase(
-        eigen_problem, eigen_problem.es().add_system<CondensedEigenSystem>(name), name),
-    _eigen_sys(eigen_problem.es().get_system<CondensedEigenSystem>(name)),
+        eigen_problem, eigen_problem.es().add_system<libMesh::CondensedEigenSystem>(name), name),
+    _eigen_sys(eigen_problem.es().get_system<libMesh::CondensedEigenSystem>(name)),
     _eigen_problem(eigen_problem),
     _solver_configuration(nullptr),
     _n_eigen_pairs_required(eigen_problem.getNEigenPairsRequired()),
@@ -118,8 +116,8 @@ NonlinearEigenSystem::NonlinearEigenSystem(EigenProblem & eigen_problem, const s
     _preconditioner(nullptr),
     _num_constrained_dofs(0)
 {
-  SlepcEigenSolver<Number> * solver =
-      cast_ptr<SlepcEigenSolver<Number> *>(_eigen_sys.eigen_solver.get());
+  libMesh::SlepcEigenSolver<Number> * solver =
+      cast_ptr<libMesh::SlepcEigenSolver<Number> *>(_eigen_sys.eigen_solver.get());
 
   if (!solver)
     mooseError("A slepc eigen solver is required");
@@ -410,7 +408,7 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
   // Shell matrix A
   if (_eigen_sys.has_shell_matrix_A())
   {
-    Mat mat = cast_ref<PetscShellMatrix<Number> &>(_eigen_sys.get_shell_matrix_A()).mat();
+    Mat mat = cast_ref<libMesh::PetscShellMatrix<Number> &>(_eigen_sys.get_shell_matrix_A()).mat();
 
     // Attach callbacks for nonlinear eigenvalue solver
     Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, false);
@@ -422,7 +420,7 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
   // Shell matrix B
   if (_eigen_sys.has_shell_matrix_B())
   {
-    Mat mat = cast_ref<PetscShellMatrix<Number> &>(_eigen_sys.get_shell_matrix_B()).mat();
+    Mat mat = cast_ref<libMesh::PetscShellMatrix<Number> &>(_eigen_sys.get_shell_matrix_B()).mat();
 
     Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, true);
 
@@ -433,7 +431,8 @@ NonlinearEigenSystem::attachSLEPcCallbacks()
   // Shell preconditioning matrix
   if (_eigen_sys.has_shell_precond_matrix())
   {
-    Mat mat = cast_ref<PetscShellMatrix<Number> &>(_eigen_sys.get_shell_precond_matrix()).mat();
+    Mat mat =
+        cast_ref<libMesh::PetscShellMatrix<Number> &>(_eigen_sys.get_shell_precond_matrix()).mat();
 
     Moose::SlepcSupport::attachCallbacksToMat(_eigen_problem, mat, true);
   }
@@ -482,7 +481,7 @@ NonlinearEigenSystem::residualVectorBX()
   return _work_rhs_vector_BX;
 }
 
-NonlinearSolver<Number> *
+libMesh::NonlinearSolver<Number> *
 NonlinearEigenSystem::nonlinearSolver()
 {
   mooseError("did not implement yet \n");
@@ -507,8 +506,8 @@ NonlinearEigenSystem::getSNES()
 EPS
 NonlinearEigenSystem::getEPS()
 {
-  SlepcEigenSolver<Number> * solver =
-      cast_ptr<SlepcEigenSolver<Number> *>(&(*_eigen_sys.eigen_solver));
+  libMesh::SlepcEigenSolver<Number> * solver =
+      cast_ptr<libMesh::SlepcEigenSolver<Number> *>(&(*_eigen_sys.eigen_solver));
 
   if (!solver)
     mooseError("Unable to retrieve eigen solver");

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -29,8 +29,6 @@
 #include "libmesh/default_coupling.h"
 #include "libmesh/petsc_solver_exception.h"
 
-using namespace libMesh;
-
 namespace Moose
 {
 void
@@ -109,8 +107,8 @@ NonlinearSystem::NonlinearSystem(FEProblemBase & fe_problem, const std::string &
   nonlinearSolver()->transpose_nullspace = Moose::compute_transpose_nullspace;
   nonlinearSolver()->nearnullspace = Moose::compute_nearnullspace;
 
-  PetscNonlinearSolver<Real> * petsc_solver =
-      cast_ptr<PetscNonlinearSolver<Real> *>(_nl_implicit_sys.nonlinear_solver.get());
+  libMesh::PetscNonlinearSolver<Real> * petsc_solver =
+      cast_ptr<libMesh::PetscNonlinearSolver<Real> *>(_nl_implicit_sys.nonlinear_solver.get());
   if (petsc_solver)
   {
     petsc_solver->set_residual_zero_out(false);
@@ -130,8 +128,8 @@ NonlinearSystem::potentiallySetupFiniteDifferencing()
     setupFiniteDifferencedPreconditioner();
   }
 
-  PetscNonlinearSolver<Real> & solver =
-      cast_ref<PetscNonlinearSolver<Real> &>(*_nl_implicit_sys.nonlinear_solver);
+  libMesh::PetscNonlinearSolver<Real> & solver =
+      cast_ref<libMesh::PetscNonlinearSolver<Real> &>(*_nl_implicit_sys.nonlinear_solver);
   solver.mffd_residual_object = &_fd_residual_functor;
 
   solver.set_snesmf_reuse_base(_fe_problem.useSNESMFReuseBase());
@@ -213,8 +211,8 @@ void
 NonlinearSystem::stopSolve(const ExecFlagType & exec_flag,
                            const std::set<TagID> & vector_tags_to_close)
 {
-  PetscNonlinearSolver<Real> & solver =
-      cast_ref<PetscNonlinearSolver<Real> &>(*sys().nonlinear_solver);
+  libMesh::PetscNonlinearSolver<Real> & solver =
+      cast_ref<libMesh::PetscNonlinearSolver<Real> &>(*sys().nonlinear_solver);
 
   if (exec_flag == EXEC_LINEAR || exec_flag == EXEC_POSTCHECK)
   {
@@ -260,8 +258,8 @@ NonlinearSystem::setupStandardFiniteDifferencedPreconditioner()
   // Make sure that libMesh isn't going to override our preconditioner
   _nl_implicit_sys.nonlinear_solver->jacobian = nullptr;
 
-  PetscNonlinearSolver<Number> * petsc_nonlinear_solver =
-      cast_ptr<PetscNonlinearSolver<Number> *>(_nl_implicit_sys.nonlinear_solver.get());
+  libMesh::PetscNonlinearSolver<Number> * petsc_nonlinear_solver =
+      cast_ptr<libMesh::PetscNonlinearSolver<Number> *>(_nl_implicit_sys.nonlinear_solver.get());
 
   PetscMatrix<Number> * petsc_mat =
       cast_ptr<PetscMatrix<Number> *>(&_nl_implicit_sys.get_system_matrix());
@@ -279,8 +277,8 @@ NonlinearSystem::setupColoringFiniteDifferencedPreconditioner()
   // Make sure that libMesh isn't going to override our preconditioner
   _nl_implicit_sys.nonlinear_solver->jacobian = nullptr;
 
-  PetscNonlinearSolver<Number> & petsc_nonlinear_solver =
-      dynamic_cast<PetscNonlinearSolver<Number> &>(*_nl_implicit_sys.nonlinear_solver);
+  libMesh::PetscNonlinearSolver<Number> & petsc_nonlinear_solver =
+      dynamic_cast<libMesh::PetscNonlinearSolver<Number> &>(*_nl_implicit_sys.nonlinear_solver);
 
   // Pointer to underlying PetscMatrix type
   PetscMatrix<Number> * petsc_mat =
@@ -371,8 +369,8 @@ NonlinearSystem::computeScalingResidual()
 SNES
 NonlinearSystem::getSNES()
 {
-  PetscNonlinearSolver<Number> * petsc_solver =
-      dynamic_cast<PetscNonlinearSolver<Number> *>(nonlinearSolver());
+  libMesh::PetscNonlinearSolver<Number> * petsc_solver =
+      dynamic_cast<libMesh::PetscNonlinearSolver<Number> *>(nonlinearSolver());
 
   if (petsc_solver)
   {

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -113,8 +113,6 @@ EXTERN_C_BEGIN
 extern PetscErrorCode DMCreate_Moose(DM);
 EXTERN_C_END
 
-using namespace libMesh;
-
 namespace
 {
 template <typename T>
@@ -351,7 +349,7 @@ NonlinearSystemBase::initialSetup()
     if (_off_diagonals_in_auto_scaling)
       _scaling_matrix = std::make_unique<OffDiagonalScalingMatrix<Number>>(_communicator);
     else
-      _scaling_matrix = std::make_unique<DiagonalMatrix<Number>>(_communicator);
+      _scaling_matrix = std::make_unique<libMesh::DiagonalMatrix<Number>>(_communicator);
   }
 
   if (_preconditioner)
@@ -1019,7 +1017,7 @@ NonlinearSystemBase::getResidualTimeVector()
     _Re_time_tag = _fe_problem.addVectorTag("TIME");
 
     // Most applications don't need the expense of ghosting
-    ParallelType ptype = _need_residual_ghosted ? GHOSTED : PARALLEL;
+    libMesh::ParallelType ptype = _need_residual_ghosted ? GHOSTED : PARALLEL;
     _Re_time = &addVector(_Re_time_tag, false, ptype);
   }
   else if (_need_residual_ghosted && _Re_time->type() == PARALLEL)
@@ -1042,7 +1040,7 @@ NonlinearSystemBase::getResidualNonTimeVector()
     _Re_non_time_tag = _fe_problem.addVectorTag("NONTIME");
 
     // Most applications don't need the expense of ghosting
-    ParallelType ptype = _need_residual_ghosted ? GHOSTED : PARALLEL;
+    libMesh::ParallelType ptype = _need_residual_ghosted ? GHOSTED : PARALLEL;
     _Re_non_time = &addVector(_Re_non_time_tag, false, ptype);
   }
   else if (_need_residual_ghosted && _Re_non_time->type() == PARALLEL)

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -33,8 +33,6 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/static_condensation.h"
 
-using namespace libMesh;
-
 /// Free function used for a libMesh callback
 void
 extraSendList(std::vector<dof_id_type> & send_list, void * context)
@@ -45,7 +43,7 @@ extraSendList(std::vector<dof_id_type> & send_list, void * context)
 
 /// Free function used for a libMesh callback
 void
-extraSparsity(SparsityPattern::Graph & sparsity,
+extraSparsity(libMesh::SparsityPattern::Graph & sparsity,
               std::vector<dof_id_type> & n_nz,
               std::vector<dof_id_type> & n_oz,
               void * context)
@@ -359,7 +357,7 @@ SystemBase::reinitElem(const Elem * const elem, THREAD_ID tid)
     for (auto & [tag, matrix] : _active_tagged_matrices)
     {
       libmesh_ignore(tag);
-      cast_ptr<StaticCondensation *>(matrix)->set_current_elem(*elem);
+      cast_ptr<libMesh::StaticCondensation *>(matrix)->set_current_elem(*elem);
     }
 }
 
@@ -487,7 +485,7 @@ SystemBase::augmentSendList(std::vector<dof_id_type> & send_list)
         // Have to get each variable's dofs
         for (unsigned int v = 0; v < n_vars; v++)
         {
-          const Variable & var = sys.variable(v);
+          const libMesh::Variable & var = sys.variable(v);
           unsigned int var_num = var.number();
           unsigned int n_comp = var.n_components();
 
@@ -604,7 +602,9 @@ SystemBase::removeMatrix(TagID tag_id)
 }
 
 NumericVector<Number> &
-SystemBase::addVector(const std::string & vector_name, const bool project, const ParallelType type)
+SystemBase::addVector(const std::string & vector_name,
+                      const bool project,
+                      const libMesh::ParallelType type)
 {
   if (hasVector(vector_name))
     return getVector(vector_name);
@@ -614,7 +614,7 @@ SystemBase::addVector(const std::string & vector_name, const bool project, const
 }
 
 NumericVector<Number> &
-SystemBase::addVector(TagID tag, const bool project, const ParallelType type)
+SystemBase::addVector(TagID tag, const bool project, const libMesh::ParallelType type)
 {
   if (!_subproblem.vectorTagExists(tag))
     mooseError("Cannot add tagged vector with TagID ",
@@ -627,7 +627,7 @@ SystemBase::addVector(TagID tag, const bool project, const ParallelType type)
   {
     auto & vec = getVector(tag);
 
-    if (type != ParallelType::AUTOMATIC && vec.type() != type)
+    if (type != AUTOMATIC && vec.type() != type)
       mooseError("Cannot add tagged vector '",
                  _subproblem.vectorTagName(tag),
                  "', in system '",
@@ -741,7 +741,7 @@ SystemBase::addVariable(const std::string & var_type,
 
   if (var_type == "ArrayMooseVariable")
   {
-    if (fe_field_type == TYPE_VECTOR)
+    if (fe_field_type == libMesh::TYPE_VECTOR)
       mooseError("Vector family type cannot be used in an array variable");
 
     std::vector<std::string> array_var_component_names;
@@ -1556,7 +1556,7 @@ SystemBase::applyScalingFactors(const std::vector<Real> & inverse_scaling_factor
 void
 SystemBase::addScalingVector()
 {
-  addVector("scaling_factors", /*project=*/false, libMesh::ParallelType::GHOSTED);
+  addVector("scaling_factors", /*project=*/false, GHOSTED);
   _subproblem.hasScalingVector(number());
 }
 

--- a/framework/src/timeintegrators/ExplicitTimeIntegrator.C
+++ b/framework/src/timeintegrators/ExplicitTimeIntegrator.C
@@ -22,8 +22,6 @@
 // libMesh includes
 #include "libmesh/enum_convergence_flags.h"
 
-using namespace libMesh;
-
 InputParameters
 ExplicitTimeIntegrator::validParams()
 {
@@ -182,7 +180,7 @@ ExplicitTimeIntegrator::setupSolver()
   }
 
   if (_solve_type == CONSISTENT || _solve_type == LUMP_PRECONDITIONED)
-    _linear_solver = LinearSolver<Number>::build(comm());
+    _linear_solver = libMesh::LinearSolver<Number>::build(comm());
 
   if (_solve_type == LUMP_PRECONDITIONED)
   {
@@ -272,27 +270,27 @@ ExplicitTimeIntegrator::checkLinearConvergence()
 
   switch (reason)
   {
-    case CONVERGED_RTOL_NORMAL:
-    case CONVERGED_ATOL_NORMAL:
-    case CONVERGED_RTOL:
-    case CONVERGED_ATOL:
-    case CONVERGED_ITS:
-    case CONVERGED_CG_NEG_CURVE:
-    case CONVERGED_CG_CONSTRAINED:
-    case CONVERGED_STEP_LENGTH:
-    case CONVERGED_HAPPY_BREAKDOWN:
+    case libMesh::CONVERGED_RTOL_NORMAL:
+    case libMesh::CONVERGED_ATOL_NORMAL:
+    case libMesh::CONVERGED_RTOL:
+    case libMesh::CONVERGED_ATOL:
+    case libMesh::CONVERGED_ITS:
+    case libMesh::CONVERGED_CG_NEG_CURVE:
+    case libMesh::CONVERGED_CG_CONSTRAINED:
+    case libMesh::CONVERGED_STEP_LENGTH:
+    case libMesh::CONVERGED_HAPPY_BREAKDOWN:
       return true;
-    case DIVERGED_NULL:
-    case DIVERGED_ITS:
-    case DIVERGED_DTOL:
-    case DIVERGED_BREAKDOWN:
-    case DIVERGED_BREAKDOWN_BICG:
-    case DIVERGED_NONSYMMETRIC:
-    case DIVERGED_INDEFINITE_PC:
-    case DIVERGED_NAN:
-    case DIVERGED_INDEFINITE_MAT:
-    case CONVERGED_ITERATING:
-    case DIVERGED_PCSETUP_FAILED:
+    case libMesh::DIVERGED_NULL:
+    case libMesh::DIVERGED_ITS:
+    case libMesh::DIVERGED_DTOL:
+    case libMesh::DIVERGED_BREAKDOWN:
+    case libMesh::DIVERGED_BREAKDOWN_BICG:
+    case libMesh::DIVERGED_NONSYMMETRIC:
+    case libMesh::DIVERGED_INDEFINITE_PC:
+    case libMesh::DIVERGED_NAN:
+    case libMesh::DIVERGED_INDEFINITE_MAT:
+    case libMesh::CONVERGED_ITERATING:
+    case libMesh::DIVERGED_PCSETUP_FAILED:
       return false;
     default:
       mooseError("Unknown convergence reason in ExplicitTimeIntegrator.");

--- a/framework/src/transfers/MultiAppGeneralFieldTransfer.C
+++ b/framework/src/transfers/MultiAppGeneralFieldTransfer.C
@@ -29,8 +29,6 @@
 #include "timpi/communicator.h"
 #include "timpi/parallel_sync.h"
 
-using namespace libMesh;
-
 namespace GeneralFieldTransfer
 {
 Number OutOfMeshValue = std::numeric_limits<Real>::infinity();
@@ -1476,7 +1474,8 @@ MultiAppGeneralFieldTransfer::setSolutionVectorValues(
     {
       // We may need to use existing data values in places where the
       // from app domain doesn't overlap
-      MeshFunction to_func(es, *to_sys->current_local_solution, to_sys->get_dof_map(), var_num);
+      libMesh::MeshFunction to_func(
+          es, *to_sys->current_local_solution, to_sys->get_dof_map(), var_num);
       to_func.init();
 
       GeneralFieldTransfer::CachedData<Number> f(

--- a/framework/src/transfers/MultiAppGeometricInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppGeometricInterpolationTransfer.C
@@ -23,8 +23,6 @@
 #include "libmesh/system.h"
 #include "libmesh/radial_basis_interpolation.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", MultiAppGeometricInterpolationTransfer);
 registerMooseObjectRenamed("MooseApp",
                            MultiAppInterpolationTransfer,
@@ -125,7 +123,7 @@ MultiAppGeometricInterpolationTransfer::fillSourceInterpolationPoints(
     FEProblemBase & from_problem,
     const MooseVariableFieldBase & from_var,
     const MultiAppCoordTransform & from_app_transform,
-    std::unique_ptr<InverseDistanceInterpolation<LIBMESH_DIM>> & idi)
+    std::unique_ptr<libMesh::InverseDistanceInterpolation<LIBMESH_DIM>> & idi)
 {
   auto & from_moose_mesh = from_problem.mesh(_displaced_source_mesh);
   const auto & from_mesh = from_moose_mesh.getMesh();
@@ -265,7 +263,7 @@ MultiAppGeometricInterpolationTransfer::interpolateTargetPoints(
     MooseVariableFieldBase & to_var,
     NumericVector<Real> & to_solution,
     const MultiAppCoordTransform & to_app_transform,
-    const std::unique_ptr<InverseDistanceInterpolation<LIBMESH_DIM>> & idi)
+    const std::unique_ptr<libMesh::InverseDistanceInterpolation<LIBMESH_DIM>> & idi)
 {
   // Moose system
   SystemBase & to_system_base = to_var.sys();
@@ -404,15 +402,16 @@ MultiAppGeometricInterpolationTransfer::execute()
 
   const FEProblemBase & fe_problem =
       hasFromMultiApp() ? getFromMultiApp()->problemBase() : getToMultiApp()->problemBase();
-  std::unique_ptr<InverseDistanceInterpolation<LIBMESH_DIM>> idi;
+  std::unique_ptr<libMesh::InverseDistanceInterpolation<LIBMESH_DIM>> idi;
   switch (_interp_type)
   {
     case 0:
-      idi = std::make_unique<InverseDistanceInterpolation<LIBMESH_DIM>>(
+      idi = std::make_unique<libMesh::InverseDistanceInterpolation<LIBMESH_DIM>>(
           fe_problem.comm(), _num_points, _power);
       break;
     case 1:
-      idi = std::make_unique<RadialBasisInterpolation<LIBMESH_DIM>>(fe_problem.comm(), _radius);
+      idi = std::make_unique<libMesh::RadialBasisInterpolation<LIBMESH_DIM>>(fe_problem.comm(),
+                                                                             _radius);
       break;
     default:
       mooseError("Unknown interpolation type!");

--- a/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
@@ -21,8 +21,6 @@
 #include "libmesh/system.h"
 #include "libmesh/radial_basis_interpolation.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseApp", MultiAppPostprocessorInterpolationTransfer);
 
 InputParameters
@@ -92,16 +90,17 @@ MultiAppPostprocessorInterpolationTransfer::execute()
     case FROM_MULTIAPP:
     {
       errorIfObjectExecutesOnTransferInSourceApp(_postprocessor);
-      std::unique_ptr<InverseDistanceInterpolation<LIBMESH_DIM>> idi;
+      std::unique_ptr<libMesh::InverseDistanceInterpolation<LIBMESH_DIM>> idi;
 
       switch (_interp_type)
       {
         case 0:
-          idi = std::make_unique<InverseDistanceInterpolation<LIBMESH_DIM>>(
+          idi = std::make_unique<libMesh::InverseDistanceInterpolation<LIBMESH_DIM>>(
               _communicator, _num_points, _power);
           break;
         case 1:
-          idi = std::make_unique<RadialBasisInterpolation<LIBMESH_DIM>>(_communicator, _radius);
+          idi = std::make_unique<libMesh::RadialBasisInterpolation<LIBMESH_DIM>>(_communicator,
+                                                                                 _radius);
           break;
         default:
           mooseError("Unknown interpolation type!");

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -30,8 +30,6 @@
 // TIMPI includes
 #include "timpi/parallel_sync.h"
 
-using namespace libMesh;
-
 void
 assemble_l2(EquationSystems & es, const std::string & system_name)
 {
@@ -318,7 +316,7 @@ MultiAppProjectionTransfer::execute()
   }
 
   // Setup the local mesh functions.
-  std::vector<MeshFunction> local_meshfuns;
+  std::vector<libMesh::MeshFunction> local_meshfuns;
   for (unsigned int i_from = 0; i_from < _from_problems.size(); i_from++)
   {
     FEProblemBase & from_problem = *_from_problems[i_from];

--- a/framework/src/transfers/MultiAppShapeEvaluationTransfer.C
+++ b/framework/src/transfers/MultiAppShapeEvaluationTransfer.C
@@ -27,8 +27,6 @@
 #include "timpi/communicator.h"
 #include "timpi/parallel_sync.h"
 
-using namespace libMesh;
-
 registerMooseObjectDeprecated("MooseApp", MultiAppShapeEvaluationTransfer, "12/31/2024 24:00");
 registerMooseObjectRenamed("MooseApp",
                            MultiAppMeshFunctionTransfer,
@@ -238,7 +236,7 @@ MultiAppShapeEvaluationTransfer::transferVariable(unsigned int i)
   }
 
   // Setup the local mesh functions.
-  std::vector<MeshFunction> local_meshfuns;
+  std::vector<libMesh::MeshFunction> local_meshfuns;
   local_meshfuns.reserve(_from_problems.size());
   for (unsigned int i_from = 0; i_from < _from_problems.size(); ++i_from)
   {

--- a/framework/src/utils/ArbitraryQuadrature.C
+++ b/framework/src/utils/ArbitraryQuadrature.C
@@ -12,11 +12,9 @@
 // libMesh includes
 #include "libmesh/enum_quadrature_type.h"
 
-using namespace libMesh;
-
 ArbitraryQuadrature::ArbitraryQuadrature(const unsigned int d, const Order o) : QBase(d, o) {}
 
-std::unique_ptr<QBase>
+std::unique_ptr<libMesh::QBase>
 ArbitraryQuadrature::clone() const
 {
   return std::make_unique<ArbitraryQuadrature>(*this);

--- a/framework/src/utils/MooseMeshElementConversionUtils.C
+++ b/framework/src/utils/MooseMeshElementConversionUtils.C
@@ -25,8 +25,6 @@
 #include "libmesh/cell_pyramid5.h"
 #include "libmesh/cell_c0polyhedron.h"
 
-using namespace libMesh;
-
 namespace MooseMeshElementConversionUtils
 {
 void
@@ -238,10 +236,10 @@ polyhedronElemSplitter(MeshBase & mesh,
     exist_extra_ids[j] = elem->get_extra_integer(j);
 
   // Split the polygon using its tetrahedralization
-  const auto poly = dynamic_cast<C0Polyhedron *>(elem);
+  const auto poly = dynamic_cast<libMesh::C0Polyhedron *>(elem);
   Node * v_avg_node = nullptr;
   // Currently the only extra node ever use to tetrahedralize
-  if (dynamic_cast<C0Polyhedron *>(elem))
+  if (dynamic_cast<libMesh::C0Polyhedron *>(elem))
     v_avg_node =
         mesh.add_point(elem->vertex_average(), mesh.max_node_id() + elem_id, elem->processor_id());
 

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -32,8 +32,6 @@
 #include "libmesh/preconditioner.h"
 #include "libmesh/elem_side_builder.h"
 
-using namespace libMesh;
-
 template <typename I1, typename I2>
 void
 checkSize(const std::string & split_name, const I1 split_size, const I2 size_expected_by_parent)
@@ -53,7 +51,7 @@ checkSize(const std::string & split_name, const I1 split_size, const I2 size_exp
 struct DM_Moose
 {
   NonlinearSystemBase * _nl; // nonlinear system context
-  const DofMapBase * _dof_map;
+  const libMesh::DofMapBase * _dof_map;
   const System * _system;
   DM_Moose * _parent = nullptr;
   std::set<std::string> * _vars; // variables
@@ -236,7 +234,7 @@ DMMooseSetNonlinearSystem(DM dm, NonlinearSystemBase & nl)
 }
 
 PetscErrorCode
-DMMooseSetDofMap(DM dm, const DofMapBase & dof_map)
+DMMooseSetDofMap(DM dm, const libMesh::DofMapBase & dof_map)
 {
   PetscFunctionBegin;
   LibmeshPetscCallQ(DMMooseValidityCheck(dm));
@@ -2060,7 +2058,7 @@ DMDestroy_Moose(DM dm)
 PetscErrorCode
 DMCreateMoose(MPI_Comm comm,
               NonlinearSystemBase & nl,
-              const DofMapBase & dof_map,
+              const libMesh::DofMapBase & dof_map,
               const System & system,
               const std::string & dm_name,
               DM * dm)

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -62,8 +62,6 @@
 #include <optional>
 #include <string>
 
-using namespace libMesh;
-
 void
 MooseVecView(NumericVector<Number> & vector)
 {
@@ -74,7 +72,7 @@ MooseVecView(NumericVector<Number> & vector)
 void
 MooseMatView(SparseMatrix<Number> & mat)
 {
-  PetscMatrixBase<Number> & petsc_mat = cast_ref<PetscMatrix<Number> &>(mat);
+  libMesh::PetscMatrixBase<Number> & petsc_mat = cast_ref<PetscMatrix<Number> &>(mat);
   LibmeshPetscCallA(mat.comm().get(), MatView(petsc_mat.mat(), 0));
 }
 
@@ -89,7 +87,7 @@ MooseVecView(const NumericVector<Number> & vector)
 void
 MooseMatView(const SparseMatrix<Number> & mat)
 {
-  PetscMatrixBase<Number> & petsc_mat =
+  libMesh::PetscMatrixBase<Number> & petsc_mat =
       cast_ref<PetscMatrix<Number> &>(const_cast<SparseMatrix<Number> &>(mat));
   LibmeshPetscCallA(mat.comm().get(), MatView(petsc_mat.mat(), 0));
 }
@@ -222,7 +220,8 @@ applyMatrixTypeOptions(FEProblemBase & problem,
       continue;
 
     for (auto & [_, mat] : as_range(lm_sys.matrices_begin(), lm_sys.matrices_end()))
-      if (auto * const petsc_mat = dynamic_cast<PetscMatrixBase<Number> *>(mat.get()); petsc_mat)
+      if (auto * const petsc_mat = dynamic_cast<libMesh::PetscMatrixBase<Number> *>(mat.get());
+          petsc_mat)
       {
         LibmeshPetscCallA(
             problem.comm().get(),
@@ -628,7 +627,8 @@ petscSetDefaults(FEProblemBase & problem)
     NonlinearSystemBase & nl = problem.getNonlinearSystemBase(nl_index);
 
     // dig out PETSc solver
-    auto * const petsc_solver = cast_ptr<PetscNonlinearSolver<Number> *>(nl.nonlinearSolver());
+    auto * const petsc_solver =
+        cast_ptr<libMesh::PetscNonlinearSolver<Number> *>(nl.nonlinearSolver());
 
     // Ensure we properly prefix SNES which in turn prefixes its KSP
     const char * snes_prefix = nullptr;
@@ -656,7 +656,7 @@ petscSetDefaults(FEProblemBase & problem)
     LinearSystem & lin_sys = problem.getLinearSystem(sys_index);
     auto & lm_lin_sys = lin_sys.linearImplicitSystem();
     auto * const petsc_solver =
-        dynamic_cast<PetscLinearSolver<Number> *>(lm_lin_sys.get_linear_solver());
+        dynamic_cast<libMesh::PetscLinearSolver<Number> *>(lm_lin_sys.get_linear_solver());
     // Ensure we properly prefix KSP
     if (lm_lin_sys.prefix_with_name())
       petsc_solver->init(lm_lin_sys.prefix().c_str());
@@ -749,8 +749,9 @@ setLineSearchFromParams(FEProblemBase & fe_problem, const InputParameters & para
           if (!nl_system)
             mooseError("You've requested a line search but you must be solving an EigenProblem. "
                        "These two things are not consistent.");
-          PetscNonlinearSolver<Real> * petsc_nonlinear_solver =
-              dynamic_cast<PetscNonlinearSolver<Real> *>(nl_system->nonlinear_solver.get());
+          libMesh::PetscNonlinearSolver<Real> * petsc_nonlinear_solver =
+              dynamic_cast<libMesh::PetscNonlinearSolver<Real> *>(
+                  nl_system->nonlinear_solver.get());
           if (!petsc_nonlinear_solver)
             mooseError("Currently the MOOSE line searches all use Petsc, so you "
                        "must use Petsc as your non-linear solver.");

--- a/framework/src/utils/RayTracing.C
+++ b/framework/src/utils/RayTracing.C
@@ -17,8 +17,6 @@
 #include "libmesh/mesh.h"
 #include "libmesh/elem.h"
 
-using namespace libMesh;
-
 namespace Moose
 {
 
@@ -58,7 +56,7 @@ sideIntersectedByLine(const Elem * elem,
     if (dim == 3)
     {
       // Make a plane out of the first three nodes on the side
-      Plane plane(side_elem->point(0), side_elem->point(1), side_elem->point(2));
+      libMesh::Plane plane(side_elem->point(0), side_elem->point(1), side_elem->point(2));
 
       // See if they intersect
       intersect = line_segment.intersect(plane, intersection_point);

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -24,8 +24,6 @@
 #include "petscsnes.h"
 #include "slepceps.h"
 
-using namespace libMesh;
-
 namespace Moose
 {
 namespace SlepcSupport
@@ -613,7 +611,7 @@ mooseEPSFormMatrices(EigenProblem & eigen_problem, EPS eps, Vec x, void * ctx)
 namespace
 {
 void
-updateCurrentLocalSolution(CondensedEigenSystem & sys, Vec x)
+updateCurrentLocalSolution(libMesh::CondensedEigenSystem & sys, Vec x)
 {
   auto & dof_map = sys.get_dof_map();
 
@@ -641,7 +639,7 @@ updateCurrentLocalSolution(CondensedEigenSystem & sys, Vec x)
 }
 
 std::unique_ptr<NumericVector<Number>>
-createWrappedResidual(CondensedEigenSystem & sys, Vec r)
+createWrappedResidual(libMesh::CondensedEigenSystem & sys, Vec r)
 {
   auto & dof_map = sys.get_dof_map();
 

--- a/framework/src/variables/MooseVariableFE.C
+++ b/framework/src/variables/MooseVariableFE.C
@@ -18,8 +18,6 @@
 
 #include "libmesh/quadrature_monomial.h"
 
-using namespace libMesh;
-
 template <>
 InputParameters
 MooseVariableFE<Real>::validParams()
@@ -1045,7 +1043,7 @@ template <typename OutputType>
 typename MooseVariableFE<OutputType>::ValueType
 MooseVariableFE<OutputType>::evaluate(const ElemArg & elem_arg, const StateArg & state) const
 {
-  const QMonomial qrule(elem_arg.elem->dim(), CONSTANT);
+  const libMesh::QMonomial qrule(elem_arg.elem->dim(), CONSTANT);
   // We can use whatever we want for the point argument since it won't be used
   const ElemQpArg elem_qp_arg{elem_arg.elem, /*qp=*/0, &qrule, Point(0, 0, 0)};
   evaluateOnElement(elem_qp_arg, state, /*cache_eligible=*/false);
@@ -1058,7 +1056,7 @@ MooseVariableFE<OutputType>::faceEvaluate(const FaceArg & face_arg,
                                           const StateArg & state,
                                           const std::vector<ValueType> & cache_data) const
 {
-  const QMonomial qrule(face_arg.fi->elem().dim() - 1, CONSTANT);
+  const libMesh::QMonomial qrule(face_arg.fi->elem().dim() - 1, CONSTANT);
   auto side_evaluate =
       [this, &qrule, &state, &cache_data](const Elem * const elem, const unsigned int side)
   {
@@ -1138,7 +1136,7 @@ typename MooseVariableFE<OutputType>::GradientType
 MooseVariableFE<OutputType>::evaluateGradient(const ElemArg & elem_arg,
                                               const StateArg & state) const
 {
-  const QMonomial qrule(elem_arg.elem->dim(), CONSTANT);
+  const libMesh::QMonomial qrule(elem_arg.elem->dim(), CONSTANT);
   // We can use whatever we want for the point argument since it won't be used
   const ElemQpArg elem_qp_arg{elem_arg.elem, /*qp=*/0, &qrule, Point(0, 0, 0)};
   evaluateOnElement(elem_qp_arg, state, /*cache_eligible=*/false);
@@ -1172,7 +1170,7 @@ MooseVariableFE<OutputType>::evaluateDot(const ElemArg & elem_arg, const StateAr
   mooseAssert(_time_integrator->dt(),
               "A time derivative is being requested but the time integrator wants to perform a 0s "
               "time step");
-  const QMonomial qrule(elem_arg.elem->dim(), CONSTANT);
+  const libMesh::QMonomial qrule(elem_arg.elem->dim(), CONSTANT);
   // We can use whatever we want for the point argument since it won't be used
   const ElemQpArg elem_qp_arg{elem_arg.elem, /*qp=*/0, &qrule, Point(0, 0, 0)};
   evaluateOnElement(elem_qp_arg, state, /*cache_eligible=*/false);
@@ -1189,7 +1187,7 @@ MooseVariableFE<OutputType>::evaluateGradDot(const ElemArg & elem_arg, const Sta
   mooseAssert(_time_integrator->dt(),
               "A time derivative is being requested but the time integrator wants to perform a 0s "
               "time step");
-  const QMonomial qrule(elem_arg.elem->dim(), CONSTANT);
+  const libMesh::QMonomial qrule(elem_arg.elem->dim(), CONSTANT);
   // We can use whatever we want for the point argument since it won't be used
   const ElemQpArg elem_qp_arg{elem_arg.elem, /*qp=*/0, &qrule, Point(0, 0, 0)};
   evaluateOnElement(elem_qp_arg, state, /*cache_eligible=*/false);

--- a/modules/chemical_reactions/src/kernels/CoupledConvectionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledConvectionReactionSub.C
@@ -9,8 +9,6 @@
 
 #include "CoupledConvectionReactionSub.h"
 
-using libMesh::RealGradient;
-
 registerMooseObject("ChemicalReactionsApp", CoupledConvectionReactionSub);
 
 InputParameters

--- a/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
+++ b/modules/chemical_reactions/src/kernels/CoupledDiffusionReactionSub.C
@@ -9,8 +9,6 @@
 
 #include "CoupledDiffusionReactionSub.h"
 
-using libMesh::RealGradient;
-
 registerMooseObject("ChemicalReactionsApp", CoupledDiffusionReactionSub);
 
 InputParameters

--- a/modules/doc/content/newsletter/2024/2024_11.md
+++ b/modules/doc/content/newsletter/2024/2024_11.md
@@ -38,7 +38,7 @@ This list will be adjusted, mostly further reduced, over time.
 
 In order to continue to use `libMesh` namespace objects, we recommend:
 
-- prefacing objects with the namespace name, for example `libMesh::ValueValue` for a `VectorValue`
+- prefixing objects with the namespace name, for example `libMesh::VectorValue` for a `VectorValue`
 - in source files, you may add `using namespace libMesh;` in order not to require such prefixes. This is standard practice.
 - in header files, doing so is not generally recommended, and the use of prefixes should be preferred
 

--- a/modules/doc/content/newsletter/2026/2026_09.md
+++ b/modules/doc/content/newsletter/2026/2026_09.md
@@ -7,6 +7,15 @@ for a complete description of all MOOSE changes.
 
 ## MOOSE Improvements
 
+### Complete removal of using-directives for namespace libMesh
+
+Using-directives for namespace libMesh, i.e., `using namespace libMesh;`, have been entirely
+removed. Prefer using qualified names, e.g., `libMesh::VectorValue` for `VectorValue`. If you feel
+that practice becomes prohibitively verbose, cumbersome or hampers readability, leverage
+using-declarations for libMesh namespace members, e.g. `using libMesh::VectorValue;`. Unity builds
+will leak using-declarations across translation units, so be mindful. This is also the reason
+using-directives have been removed: they leak the entire namespace across translation units.
+
 ## MOOSE Bug Fixes
 
 ## MOOSE Modules Changes

--- a/modules/doc/content/newsletter/2026/2026_09.md
+++ b/modules/doc/content/newsletter/2026/2026_09.md
@@ -13,7 +13,7 @@ Using-directives for namespace libMesh, i.e., `using namespace libMesh;`, have b
 removed. Prefer using qualified names, e.g., `libMesh::VectorValue` for `VectorValue`. If you feel
 that practice becomes prohibitively verbose, cumbersome or hampers readability, leverage
 using-declarations for libMesh namespace members, e.g. `using libMesh::VectorValue;`. Unity builds
-will leak using-declarations across translation units, so be mindful. This is also the reason
+will leak using-declarations across translation units within a folder, so be mindful. This is also the reason
 using-directives have been removed: they leak the entire namespace across translation units.
 
 ## MOOSE Bug Fixes

--- a/modules/navier_stokes/src/executioners/LinearAssemblySegregatedSolve.C
+++ b/modules/navier_stokes/src/executioners/LinearAssemblySegregatedSolve.C
@@ -13,8 +13,6 @@
 #include "LinearSystem.h"
 #include "Executioner.h"
 
-using namespace libMesh;
-
 InputParameters
 LinearAssemblySegregatedSolve::validParams()
 {
@@ -363,8 +361,8 @@ LinearAssemblySegregatedSolve::solveMomentumPredictor()
   LinearImplicitSystem & momentum_system_0 =
       cast_ref<LinearImplicitSystem &>(_momentum_systems[0]->system());
 
-  PetscLinearSolver<Real> & momentum_solver =
-      cast_ref<PetscLinearSolver<Real> &>(*momentum_system_0.get_linear_solver());
+  libMesh::PetscLinearSolver<Real> & momentum_solver =
+      cast_ref<libMesh::PetscLinearSolver<Real> &>(*momentum_system_0.get_linear_solver());
 
   // Solve the momentum equations.
   // TO DO: These equations are VERY similar. If we can store the differences (things coming from
@@ -484,8 +482,8 @@ LinearAssemblySegregatedSolve::solvePressureCorrector()
   NumericVector<Number> & rhs = *(pressure_system.rhs);
 
   // Fetch the linear solver from the system
-  PetscLinearSolver<Real> & pressure_solver =
-      cast_ref<PetscLinearSolver<Real> &>(*pressure_system.get_linear_solver());
+  libMesh::PetscLinearSolver<Real> & pressure_solver =
+      cast_ref<libMesh::PetscLinearSolver<Real> &>(*pressure_system.get_linear_solver());
 
   _problem.computeLinearSystemSys(pressure_system, mmat, rhs, false);
 
@@ -553,8 +551,8 @@ LinearAssemblySegregatedSolve::solveSolidEnergy()
   NumericVector<Number> & rhs = *(system.rhs);
 
   // Fetch the linear solver from the system
-  PetscLinearSolver<Real> & solver =
-      cast_ref<PetscLinearSolver<Real> &>(*system.get_linear_solver());
+  libMesh::PetscLinearSolver<Real> & solver =
+      cast_ref<libMesh::PetscLinearSolver<Real> &>(*system.get_linear_solver());
 
   _problem.computeLinearSystemSys(system, mmat, rhs, false);
 
@@ -648,7 +646,7 @@ std::pair<unsigned int, Real>
 LinearAssemblySegregatedSolve::solveAdvectedSystem(const unsigned int system_num,
                                                    LinearSystem & system,
                                                    const Real relaxation_factor,
-                                                   SolverConfiguration & solver_config,
+                                                   libMesh::SolverConfiguration & solver_config,
                                                    const Real absolute_tol,
                                                    const bool reuse_pc,
                                                    const Real field_relaxation,
@@ -669,8 +667,8 @@ LinearAssemblySegregatedSolve::solveAdvectedSystem(const unsigned int system_num
   auto diff_diagonal = solution.zero_clone();
 
   // Fetch the linear solver from the system
-  PetscLinearSolver<Real> & linear_solver =
-      cast_ref<PetscLinearSolver<Real> &>(*li_system.get_linear_solver());
+  libMesh::PetscLinearSolver<Real> & linear_solver =
+      cast_ref<libMesh::PetscLinearSolver<Real> &>(*li_system.get_linear_solver());
 
   _problem.computeLinearSystemSys(li_system, mmat, rhs, true);
 

--- a/modules/navier_stokes/src/executioners/SIMPLESolveNonlinearAssembly.C
+++ b/modules/navier_stokes/src/executioners/SIMPLESolveNonlinearAssembly.C
@@ -14,8 +14,6 @@
 
 #include "libmesh/nonlinear_implicit_system.h"
 
-using namespace libMesh;
-
 InputParameters
 SIMPLESolveNonlinearAssembly::validParams()
 {
@@ -64,7 +62,7 @@ SIMPLESolveNonlinearAssembly::SIMPLESolveNonlinearAssembly(Executioner & ex)
     _momentum_system_numbers.push_back(_problem.nlSysNum(_momentum_system_names[system_i]));
     _momentum_systems.push_back(
         &_problem.getNonlinearSystemBase(_momentum_system_numbers[system_i]));
-    _momentum_systems[system_i]->addVector(_pressure_tag_id, false, ParallelType::PARALLEL);
+    _momentum_systems[system_i]->addVector(_pressure_tag_id, false, PARALLEL);
 
     // We disable this considering that this object passes petsc options a little differently
     _momentum_systems[system_i]->system().prefix_with_name(false);
@@ -184,8 +182,8 @@ SIMPLESolveNonlinearAssembly::solveMomentumPredictor()
     NonlinearImplicitSystem & momentum_system =
         cast_ref<NonlinearImplicitSystem &>(_momentum_systems[system_i]->system());
 
-    PetscLinearSolver<Real> & momentum_solver =
-        cast_ref<PetscLinearSolver<Real> &>(*momentum_system.get_linear_solver());
+    libMesh::PetscLinearSolver<Real> & momentum_solver =
+        cast_ref<libMesh::PetscLinearSolver<Real> &>(*momentum_system.get_linear_solver());
 
     NumericVector<Number> & solution = *(momentum_system.solution);
     NumericVector<Number> & rhs = *(momentum_system.rhs);
@@ -257,8 +255,8 @@ SIMPLESolveNonlinearAssembly::solvePressureCorrector()
   NumericVector<Number> & rhs = *(pressure_system.rhs);
 
   // Fetch the linear solver from the system
-  PetscLinearSolver<Real> & pressure_solver =
-      cast_ref<PetscLinearSolver<Real> &>(*pressure_system.get_linear_solver());
+  libMesh::PetscLinearSolver<Real> & pressure_solver =
+      cast_ref<libMesh::PetscLinearSolver<Real> &>(*pressure_system.get_linear_solver());
 
   // We need a zero vector to be able to emulate the Ax=b system by evaluating the
   // residual and jacobian. Unfortunately, this will leave us with the -b on the right hand side
@@ -325,8 +323,8 @@ SIMPLESolveNonlinearAssembly::solveAdvectedSystem(const unsigned int system_num,
   auto diff_diagonal = solution.zero_clone();
 
   // Fetch the linear solver from the system
-  PetscLinearSolver<Real> & linear_solver =
-      cast_ref<PetscLinearSolver<Real> &>(*ni_system.get_linear_solver());
+  libMesh::PetscLinearSolver<Real> & linear_solver =
+      cast_ref<libMesh::PetscLinearSolver<Real> &>(*ni_system.get_linear_solver());
 
   // We need a zero vector to be able to emulate the Ax=b system by evaluating the
   // residual and jacobian. Unfortunately, this will leave us with the -b on the right hand side
@@ -391,8 +389,8 @@ SIMPLESolveNonlinearAssembly::solveSolidEnergySystem()
   NumericVector<Number> & rhs = *(se_system.rhs);
 
   // Fetch the linear solver from the system
-  PetscLinearSolver<Real> & se_solver =
-      cast_ref<PetscLinearSolver<Real> &>(*se_system.get_linear_solver());
+  libMesh::PetscLinearSolver<Real> & se_solver =
+      cast_ref<libMesh::PetscLinearSolver<Real> &>(*se_system.get_linear_solver());
 
   // We need a zero vector to be able to emulate the Ax=b system by evaluating the
   // residual and jacobian. Unfortunately, this will leave us with the -b on the righ hand side

--- a/modules/navier_stokes/src/problems/NavierStokesProblem.C
+++ b/modules/navier_stokes/src/problems/NavierStokesProblem.C
@@ -13,8 +13,6 @@
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/static_condensation.h"
 
-using namespace libMesh;
-
 registerMooseObject("NavierStokesApp", NavierStokesProblem);
 
 InputParameters
@@ -116,7 +114,7 @@ NavierStokesProblem::initialSetup()
       if (_have_L_matrix)
         mooseError("Static condensation and LSC preconditioning not supported together");
       if (_have_mass_matrix)
-        cast_ref<StaticCondensation &>(solver_sys->getMatrix(massMatrixTagID()))
+        cast_ref<libMesh::StaticCondensation &>(solver_sys->getMatrix(massMatrixTagID()))
             .uncondensed_dofs_only();
     }
 }
@@ -202,11 +200,11 @@ NavierStokesProblem::setupLSCMatrices(PC schur_pc)
   {
     auto & sparse_mass_mat = _current_nl_sys->getMatrix(massMatrixTagID());
     if (_current_nl_sys->system().has_static_condensation())
-      global_Q = cast_ref<const PetscMatrixBase<Number> &>(
-                     cast_ref<StaticCondensation &>(sparse_mass_mat).get_condensed_mat())
+      global_Q = cast_ref<const libMesh::PetscMatrixBase<Number> &>(
+                     cast_ref<libMesh::StaticCondensation &>(sparse_mass_mat).get_condensed_mat())
                      .mat();
     else
-      global_Q = cast_ref<PetscMatrixBase<Number> &>(sparse_mass_mat).mat();
+      global_Q = cast_ref<libMesh::PetscMatrixBase<Number> &>(sparse_mass_mat).mat();
   }
 
   // The Poisson operator matrix corresponding to the velocity degrees of freedom. This is only used
@@ -214,7 +212,8 @@ NavierStokesProblem::setupLSCMatrices(PC schur_pc)
   Mat global_L = nullptr;
   if (_have_L_matrix)
     global_L =
-        cast_ref<PetscMatrixBase<Number> &>(_current_nl_sys->getMatrix(LMatrixTagID())).mat();
+        cast_ref<libMesh::PetscMatrixBase<Number> &>(_current_nl_sys->getMatrix(LMatrixTagID()))
+            .mat();
 
   //
   // Process down from our system matrices to the sub-matrix containing the velocity-pressure dofs

--- a/modules/navier_stokes/src/utils/FaceCenteredMapFunctor.C
+++ b/modules/navier_stokes/src/utils/FaceCenteredMapFunctor.C
@@ -17,15 +17,13 @@
 #include "libmesh/elem.h"
 #include "libmesh/point.h"
 
-using namespace libMesh;
-
 namespace Moose
 {
 template <typename T, typename T2, typename std::enable_if<ScalarTraits<T>::value, int>::type = 0>
-inline TypeVector<typename CompareTypes<T, T2>::supertype>
+inline TypeVector<typename libMesh::CompareTypes<T, T2>::supertype>
 outer_product(const T & a, const TypeVector<T2> & b)
 {
-  TypeVector<typename CompareTypes<T, T2>::supertype> ret;
+  TypeVector<typename libMesh::CompareTypes<T, T2>::supertype> ret;
   for (const auto i : make_range(Moose::dim))
     ret(i) = a * b(i);
 
@@ -33,7 +31,7 @@ outer_product(const T & a, const TypeVector<T2> & b)
 }
 
 template <typename T, typename T2>
-inline TypeTensor<typename CompareTypes<T, T2>::supertype>
+inline TypeTensor<typename libMesh::CompareTypes<T, T2>::supertype>
 outer_product(const TypeVector<T> & a, const TypeVector<T2> & b)
 {
   return libMesh::outer_product(a, b);

--- a/modules/optimization/include/utils/ParameterMesh.h
+++ b/modules/optimization/include/utils/ParameterMesh.h
@@ -30,8 +30,6 @@ class System;
 class DofMap;
 }
 
-using libMesh::RealGradient;
-
 /**
  * Utility class to use an Exodus mesh to define controllable parameters for optimization problems
  * This class will:

--- a/modules/optimization/src/executioners/AdjointSolve.C
+++ b/modules/optimization/src/executioners/AdjointSolve.C
@@ -21,8 +21,6 @@
 #include "libmesh/petsc_vector.h"
 #include "petscmat.h"
 
-using namespace libMesh;
-
 InputParameters
 AdjointSolve::validParams()
 {
@@ -186,7 +184,7 @@ AdjointSolve::applyNodalBCs(SparseMatrix<Number> & matrix,
     if (petsc_matrix && petsc_solution && petsc_rhs)
       LibmeshPetscCall(MatZeroRowsColumns(petsc_matrix->mat(),
                                           cast_int<PetscInt>(nbc_dofs.size()),
-                                          numeric_petsc_cast(nbc_dofs.data()),
+                                          libMesh::numeric_petsc_cast(nbc_dofs.data()),
                                           1.0,
                                           petsc_solution->vec(),
                                           petsc_rhs->vec()));
@@ -203,7 +201,7 @@ AdjointSolve::checkIntegrity()
   for (const auto & adj_var : adj_vars)
     // If the user supplies any scaling factors for individual variables the
     // adjoint system won't be consistent.
-    if (!absolute_fuzzy_equals(adj_var->scalingFactor(), 1.0))
+    if (!libMesh::absolute_fuzzy_equals(adj_var->scalingFactor(), 1.0))
       mooseError(
           "User cannot supply scaling factors for adjoint variables.   Adjoint system is scaled "
           "automatically by the forward system.");

--- a/modules/optimization/src/utils/ParameterMesh.C
+++ b/modules/optimization/src/utils/ParameterMesh.C
@@ -35,8 +35,6 @@
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/fe_base.h"
 
-using namespace libMesh;
-
 ParameterMesh::ParameterMesh(const FEType & param_type,
                              const std::string & exodus_mesh,
                              const bool find_closest,
@@ -55,7 +53,7 @@ ParameterMesh::ParameterMesh(const FEType & param_type,
   _exodusII_io->read(exodus_mesh);
   _mesh.read(exodus_mesh);
   // Create system to store parameter values
-  _eq = std::make_unique<EquationSystems>(_mesh);
+  _eq = std::make_unique<libMesh::EquationSystems>(_mesh);
   _sys = &_eq->add_system<ExplicitSystem>("_parameter_mesh_sys");
   _sys->add_variable("_parameter_mesh_var", param_type);
 
@@ -102,7 +100,7 @@ ParameterMesh::ParameterMesh(const FEType & param_type,
     _node_kdtree = std::make_unique<KDTree>(_mesh_nodes, 10);
   // Update cached values for gradient computations
   const_cast<unsigned short int &>(_param_var_id) = var_id;
-  const_cast<const DofMap *&>(_dof_map) = &_sys->get_dof_map();
+  const_cast<const libMesh::DofMap *&>(_dof_map) = &_sys->get_dof_map();
   const_cast<FEType &>(_fe_type) = _dof_map->variable_type(_param_var_id);
 }
 
@@ -125,7 +123,7 @@ ParameterMesh::getIndexAndWeight(const Point & pt,
   // Map the physical co-ordinates to the reference co-ordinates
   Point coor = FEMap::inverse_map(elem->dim(), elem, test_point);
   // get the shape function value via the FEInterface
-  FEComputeData fe_data(*_eq, coor);
+  libMesh::FEComputeData fe_data(*_eq, coor);
   FEInterface::compute_data(elem->dim(), _fe_type, elem, fe_data);
   // Set weights to the value of the shape functions
   weights = fe_data.shape;
@@ -153,7 +151,7 @@ ParameterMesh::getIndexAndWeight(const Point & pt,
   // Map the physical co-ordinates to the reference co-ordinates
   Point coor = FEMap::inverse_map(elem->dim(), elem, test_point);
   // get the shape function value via the FEInterface
-  FEComputeData fe_data(*_eq, coor);
+  libMesh::FEComputeData fe_data(*_eq, coor);
   fe_data.enable_derivative();
   FEInterface::compute_data(elem->dim(), _fe_type, elem, fe_data);
   // Set weights to the value of the shape functions
@@ -271,7 +269,7 @@ ParameterMesh::closestPoint(const Elem & elem, const Point & p) const
       Point a = *(elem.node_ptr(0));
       Point b = *(elem.node_ptr(1));
       Point c = *(elem.node_ptr(2));
-      Plane pl(a, b, c);
+      libMesh::Plane pl(a, b, c);
       Point trial = pl.closest_point(p);
       if (elem.contains_point(trial))
         return trial;
@@ -285,8 +283,8 @@ ParameterMesh::closestPoint(const Elem & elem, const Point & p) const
       Point b = *(elem.node_ptr(1));
       Point c = *(elem.node_ptr(2));
       Point d = *(elem.node_ptr(3));
-      Plane pl1(a, b, c);
-      Plane pl2(b, c, d);
+      libMesh::Plane pl1(a, b, c);
+      libMesh::Plane pl2(b, c, d);
       Point trial1 = pl1.closest_point(p);
       Point trial2 = pl2.closest_point(p);
       if (!trial1.absolute_fuzzy_equals(trial2, TOLERANCE * TOLERANCE))

--- a/modules/optimization/src/utils/ReadExodusMeshVars.C
+++ b/modules/optimization/src/utils/ReadExodusMeshVars.C
@@ -17,8 +17,6 @@
 #include "libmesh/numeric_vector.h"
 #include <memory>
 
-using namespace libMesh;
-
 ReadExodusMeshVars::ReadExodusMeshVars(const FEType & param_type,
                                        const std::string & exodus_mesh,
                                        const std::string var_name)
@@ -30,7 +28,7 @@ ReadExodusMeshVars::ReadExodusMeshVars(const FEType & param_type,
   _exodusII_io->read(exodus_mesh);
   _mesh.read(exodus_mesh);
   // Create system to store parameter values
-  _eq = std::make_unique<EquationSystems>(_mesh);
+  _eq = std::make_unique<libMesh::EquationSystems>(_mesh);
   _sys = &_eq->add_system<ExplicitSystem>("_reading_exodus_mesh_var");
 
   // Make Exodus vars for equation system

--- a/modules/ray_tracing/src/raytracing/TraceRay.C
+++ b/modules/ray_tracing/src/raytracing/TraceRay.C
@@ -41,7 +41,6 @@
 #include "libmesh/enum_to_string.h"
 #include "libmesh/mesh.h"
 
-using namespace libMesh;
 using namespace TraceRayTools;
 
 TraceRay::TraceRay(RayTracingStudy & study, const THREAD_ID tid)
@@ -61,7 +60,7 @@ void
 TraceRay::preExecute()
 {
   _current_subdomain_id = Elem::invalid_subdomain_id;
-  _current_elem_type = INVALID_ELEM;
+  _current_elem_type = libMesh::INVALID_ELEM;
 
   // Zero out all results
   for (auto & val : _results)

--- a/modules/ray_tracing/src/raytracing/TraceRayTools.C
+++ b/modules/ray_tracing/src/raytracing/TraceRayTools.C
@@ -34,8 +34,6 @@
 #include "libmesh/remote_elem.h"
 #include "libmesh/tensor_value.h"
 
-using namespace libMesh;
-
 namespace TraceRayTools
 {
 
@@ -729,7 +727,7 @@ withinEdgeOnSide(const Elem * const elem,
 }
 
 template <typename T>
-typename std::enable_if<std::is_base_of<Cell, T>::value, bool>::type
+typename std::enable_if<std::is_base_of<libMesh::Cell, T>::value, bool>::type
 withinEdgeOnSideTempl(const Elem * const elem,
                       const Point & point,
                       const unsigned short side,

--- a/modules/ray_tracing/src/userobjects/RayTracingStudy.C
+++ b/modules/ray_tracing/src/userobjects/RayTracingStudy.C
@@ -27,8 +27,6 @@
 #include "libmesh/periodic_boundary.h"
 #include "libmesh/periodic_boundaries.h"
 
-using namespace libMesh;
-
 InputParameters
 RayTracingStudy::validParams()
 {
@@ -195,7 +193,7 @@ RayTracingStudy::RayTracingStudy(const InputParameters & parameters)
 
     // Setup the face FEs for normal computation on the fly
     _threaded_fe_face[tid] = FEBase::build(_mesh.dimension(), FEType(CONSTANT, MONOMIAL));
-    _threaded_q_face[tid] = QBase::build(QGAUSS, _mesh.dimension() - 1, CONSTANT);
+    _threaded_q_face[tid] = QBase::build(libMesh::QGAUSS, _mesh.dimension() - 1, CONSTANT);
     _threaded_fe_face[tid]->attach_quadrature_rule(_threaded_q_face[tid].get());
     _threaded_fe_face[tid]->get_normals();
   }
@@ -264,8 +262,8 @@ RayTracingStudy::initialSetup()
                  "\nIn this case, the study must use the execute_on = PRE_KERNELS");
 
   // Build 1D quadrature rule for along a segment
-  _segment_qrule =
-      QBase::build(QGAUSS, 1, _fe_problem.getSystemBase(_sys.number()).getMinQuadratureOrder());
+  _segment_qrule = QBase::build(
+      libMesh::QGAUSS, 1, _fe_problem.getSystemBase(_sys.number()).getMinQuadratureOrder());
 }
 
 void

--- a/modules/rdg/include/userobjects/SlopeLimitingBase.h
+++ b/modules/rdg/include/userobjects/SlopeLimitingBase.h
@@ -11,8 +11,6 @@
 
 #include "ElementLoopUserObject.h"
 
-using libMesh::RealGradient;
-
 /**
  * Base class for slope limiting to limit
  * the slopes of cell average variables

--- a/modules/rdg/include/userobjects/SlopeReconstructionBase.h
+++ b/modules/rdg/include/userobjects/SlopeReconstructionBase.h
@@ -12,8 +12,6 @@
 #include "BCUserObject.h"
 #include "ElementLoopUserObject.h"
 
-using libMesh::RealGradient;
-
 /**
  * Base class for piecewise linear slope reconstruction
  * to get the slopes of element average variables

--- a/modules/reactor/src/meshgenerators/RevolveGenerator.C
+++ b/modules/reactor/src/meshgenerators/RevolveGenerator.C
@@ -31,8 +31,6 @@
 #include "libmesh/point.h"
 #include "libmesh/mesh_tools.h"
 
-using namespace libMesh;
-
 // C++ includes
 #include <cmath>
 

--- a/modules/shifted_boundary_method/unit/src/ActiveElementFractionTest.C
+++ b/modules/shifted_boundary_method/unit/src/ActiveElementFractionTest.C
@@ -15,8 +15,6 @@
 #include "libmesh/face_quad4.h"
 #include "libmesh/enum_order.h"
 
-using namespace libMesh;
-
 // activeElementFraction integrates a predicate over the element with quadrature and returns the
 // active fraction of the total measure. On the unit square, a symmetric Gauss rule splits an
 // x < 0.5 half-space predicate exactly in two, and the all/none predicates give the exact
@@ -24,7 +22,7 @@ using namespace libMesh;
 TEST(ActiveElementFractionTest, UnitSquare)
 {
   Parallel::Communicator comm(MPI_COMM_SELF);
-  auto mesh = std::make_unique<SerialMesh>(comm);
+  auto mesh = std::make_unique<libMesh::SerialMesh>(comm);
 
   Node * n0 = mesh->add_point(Point(0.0, 0.0, 0.0), 0);
   Node * n1 = mesh->add_point(Point(1.0, 0.0, 0.0), 1);

--- a/modules/shifted_boundary_method/unit/src/WaterTightTest.C
+++ b/modules/shifted_boundary_method/unit/src/WaterTightTest.C
@@ -18,8 +18,6 @@
 #include <array>
 #include <utility>
 
-using namespace libMesh;
-
 namespace
 {
 // Add the points to the mesh (node id == index) and return the created nodes.
@@ -51,7 +49,7 @@ edgeLoopIsWatertight(const Parallel::Communicator & comm,
                      const std::vector<Point> & points,
                      const std::vector<std::pair<unsigned int, unsigned int>> & edges)
 {
-  SerialMesh mesh(comm);
+  libMesh::SerialMesh mesh(comm);
   const auto nodes = addNodes(mesh, points);
   for (const auto & [id0, id1] : edges)
   {
@@ -69,7 +67,7 @@ triSurfaceIsWatertight(const Parallel::Communicator & comm,
                        const std::vector<Point> & points,
                        const std::vector<std::array<unsigned int, 3>> & faces)
 {
-  SerialMesh mesh(comm);
+  libMesh::SerialMesh mesh(comm);
   const auto nodes = addNodes(mesh, points);
   for (const auto & f : faces)
   {

--- a/modules/solid_mechanics/include/utils/ElasticityTensorTools.h
+++ b/modules/solid_mechanics/include/utils/ElasticityTensorTools.h
@@ -11,14 +11,6 @@
 
 #include "RankFourTensorForward.h"
 
-namespace libMesh
-{
-template <typename>
-class VectorValue;
-typedef VectorValue<Real> RealGradient;
-}
-using libMesh::RealGradient;
-
 namespace ElasticityTensorTools
 {
 

--- a/modules/solid_mechanics/src/constraints/NodalFrictionalConstraint.C
+++ b/modules/solid_mechanics/src/constraints/NodalFrictionalConstraint.C
@@ -17,8 +17,6 @@
 // C++ includes
 #include <limits.h>
 
-using namespace libMesh;
-
 registerMooseObject("SolidMechanicsApp", NodalFrictionalConstraint);
 
 InputParameters

--- a/modules/solid_mechanics/src/constraints/NodalStickConstraint.C
+++ b/modules/solid_mechanics/src/constraints/NodalStickConstraint.C
@@ -17,8 +17,6 @@
 // C++ includes
 #include <limits.h>
 
-using namespace libMesh;
-
 registerMooseObject("SolidMechanicsApp", NodalStickConstraint);
 
 InputParameters

--- a/modules/stochastic_tools/src/utils/POD.C
+++ b/modules/stochastic_tools/src/utils/POD.C
@@ -11,8 +11,6 @@
 #include "MooseError.h"
 #include "POD.h"
 
-using namespace libMesh;
-
 namespace StochasticTools
 {
 
@@ -80,9 +78,10 @@ POD::computePOD(const VariableName & vname,
   // global indices
   dof_id_type local_beg = 0;
   dof_id_type local_end = 0;
-  LibmeshPetscCallA(
-      _communicator.get(),
-      MatGetOwnershipRange(mat, numeric_petsc_cast(&local_beg), numeric_petsc_cast(&local_end)));
+  LibmeshPetscCallA(_communicator.get(),
+                    MatGetOwnershipRange(mat,
+                                         libMesh::numeric_petsc_cast(&local_beg),
+                                         libMesh::numeric_petsc_cast(&local_end)));
 
   unsigned int counter = 0;
   if (local_rows)
@@ -158,7 +157,7 @@ POD::computePOD(const VariableName & vname,
   // Find the local size needed for u
   dof_id_type local_snapsize = 0;
   LibmeshPetscCallA(_communicator.get(),
-                    MatGetLocalSize(mat, NULL, numeric_petsc_cast(&local_snapsize)));
+                    MatGetLocalSize(mat, NULL, libMesh::numeric_petsc_cast(&local_snapsize)));
 
   PetscVector<Real> u(_communicator);
   u.init(snapshot_size, local_snapsize, false, PARALLEL);

--- a/modules/stochastic_tools/unit/src/TestBootstrapCalculators.C
+++ b/modules/stochastic_tools/unit/src/TestBootstrapCalculators.C
@@ -17,7 +17,6 @@
 #include "libmesh/communicator.h"
 #include "libmesh/parallel_object.h"
 
-using namespace libMesh;
 using namespace StochasticTools;
 
 /**
@@ -92,7 +91,7 @@ TEST(BootstrapCalculators, Percentile)
 
   // Parallel object to give to calculators
   Parallel::Communicator comm;
-  ParallelObject po(comm);
+  libMesh::ParallelObject po(comm);
 
   // Construct mean and standard-deviation calculators
   MultiMooseEnum calc("mean stddev", "mean stddev", true);
@@ -136,7 +135,7 @@ TEST(BootstrapCalculators, BiasCorrectedAccelerated)
 
   // Parallel object to give to calculators
   Parallel::Communicator comm;
-  ParallelObject po(comm);
+  libMesh::ParallelObject po(comm);
 
   // Construct mean and standard-deviation calculators
   MultiMooseEnum calc("mean stddev", "mean stddev", true);
@@ -182,7 +181,7 @@ TEST(BootstrapCalculators, Percentile_Vec)
 
   // Parallel object to give to calculators
   Parallel::Communicator comm;
-  ParallelObject po(comm);
+  libMesh::ParallelObject po(comm);
 
   // Construct mean and standard-deviation calculators
   MultiMooseEnum calc("mean stddev", "mean stddev", true);
@@ -233,7 +232,7 @@ TEST(BootstrapCalculators, BiasCorrectedAccelerated_Vec)
 
   // Parallel object to give to calculators
   Parallel::Communicator comm;
-  ParallelObject po(comm);
+  libMesh::ParallelObject po(comm);
 
   // Construct mean and standard-deviation calculators
   MultiMooseEnum calc("mean stddev", "mean stddev", true);

--- a/modules/stochastic_tools/unit/src/TestStochasticToolsCalculators.C
+++ b/modules/stochastic_tools/unit/src/TestStochasticToolsCalculators.C
@@ -13,7 +13,6 @@
 #include "libmesh/communicator.h"
 #include "libmesh/parallel_object.h"
 
-using namespace libMesh;
 using namespace StochasticTools;
 
 template <typename InType, typename OutType>
@@ -21,7 +20,7 @@ std::pair<std::vector<OutType>, std::vector<OutType>>
 calculate(const InType & x, const std::vector<std::string> & compute)
 {
   Parallel::Communicator comm;
-  ParallelObject po(comm);
+  libMesh::ParallelObject po(comm);
   std::vector<std::unique_ptr<StochasticTools::Calculator<InType, OutType>>> calcs;
   for (const auto & stat : compute)
     calcs.push_back(StochasticTools::makeCalculator<InType, OutType>(stat, po));

--- a/modules/stochastic_tools/unit/src/TestStochasticToolsSobolCalculators.C
+++ b/modules/stochastic_tools/unit/src/TestStochasticToolsSobolCalculators.C
@@ -16,7 +16,6 @@
 #include "libmesh/communicator.h"
 #include "libmesh/parallel_object.h"
 
-using namespace libMesh;
 using namespace StochasticTools;
 
 Real
@@ -108,7 +107,7 @@ TEST(StochasticTools, Sobol_Saltelli2002)
 
     // Compute SOBOL indices
     Parallel::Communicator comm;
-    ParallelObject po(comm);
+    libMesh::ParallelObject po(comm);
     SobolCalculator<std::vector<Real>, Real> calc(po, "SOBOL", true);
     std::vector<Real> sobol = calc.compute(data, false);
 
@@ -150,7 +149,7 @@ TEST(StochasticTools, Sobol_Saltelli2002)
   {
     // Construct Sobol calculator
     Parallel::Communicator comm;
-    ParallelObject po(comm);
+    libMesh::ParallelObject po(comm);
     SobolCalculator<std::vector<Real>, Real> calc(po, "SOBOL", true);
 
     // Construct bootstrap calculator
@@ -286,7 +285,7 @@ TEST(StochasticTools, Sobol_Analytical)
 
   // Compute SOBOL indices
   Parallel::Communicator comm;
-  ParallelObject po(comm);
+  libMesh::ParallelObject po(comm);
 
   {
     // Compute SOBOL vectors of g_function

--- a/modules/thermal_hydraulics/include/relationshipmanagers/AugmentSparsityBetweenElements.h
+++ b/modules/thermal_hydraulics/include/relationshipmanagers/AugmentSparsityBetweenElements.h
@@ -11,8 +11,6 @@
 
 #include "RelationshipManager.h"
 
-using libMesh::processor_id_type;
-
 /**
  * Relationship manager to add ghosting between elements
  *

--- a/modules/thermal_hydraulics/src/base/Simulation.C
+++ b/modules/thermal_hydraulics/src/base/Simulation.C
@@ -31,8 +31,6 @@
 
 #include "libmesh/string_to_enum.h"
 
-using namespace libMesh;
-
 std::map<VariableName, int> Simulation::_component_variable_order_map;
 
 void
@@ -127,7 +125,7 @@ Simulation::setupQuadrature()
       order = fe_type.default_quadrature_order();
   }
 
-  _fe_problem.createQRules(QGAUSS, order, order, order);
+  _fe_problem.createQRules(libMesh::QGAUSS, order, order, order);
 }
 
 void

--- a/modules/thermal_hydraulics/src/base/THMMesh.C
+++ b/modules/thermal_hydraulics/src/base/THMMesh.C
@@ -15,8 +15,6 @@
 #include "libmesh/face_quad4.h"
 #include "libmesh/face_quad9.h"
 
-using namespace libMesh;
-
 registerMooseObject("ThermalHydraulicsApp", THMMesh);
 
 const BoundaryName THMMesh::INVALID_BOUNDARY_ID = "invalid_boundary_id";
@@ -117,7 +115,7 @@ THMMesh::addNodeElement(dof_id_type node)
 {
   dof_id_type elem_id = getNextElementId();
 
-  Elem * elem = new NodeElem;
+  Elem * elem = new libMesh::NodeElem;
   elem->set_id(elem_id);
   _mesh->add_elem(elem);
   elem->set_node(0, _mesh->node_ptr(node));

--- a/modules/thermal_hydraulics/src/relationshipmanagers/AugmentSparsityBetweenElements.C
+++ b/modules/thermal_hydraulics/src/relationshipmanagers/AugmentSparsityBetweenElements.C
@@ -12,8 +12,6 @@
 
 registerMooseObject("ThermalHydraulicsApp", AugmentSparsityBetweenElements);
 
-using namespace libMesh;
-
 InputParameters
 AugmentSparsityBetweenElements::validParams()
 {
@@ -35,7 +33,7 @@ AugmentSparsityBetweenElements::AugmentSparsityBetweenElements(
 {
 }
 
-std::unique_ptr<GhostingFunctor>
+std::unique_ptr<libMesh::GhostingFunctor>
 AugmentSparsityBetweenElements::clone() const
 {
   return _app.getFactory().clone(*this);
@@ -71,7 +69,7 @@ AugmentSparsityBetweenElements::operator()(const MeshBase::const_element_iterato
                                            processor_id_type p,
                                            map_type & coupled_elements)
 {
-  const CouplingMatrix * const null_mat = libmesh_nullptr;
+  const libMesh::CouplingMatrix * const null_mat = libmesh_nullptr;
   for (const auto & elem : as_range(range_begin, range_end))
   {
     auto it = _elem_map.find(elem->id());

--- a/test/src/postprocessors/TestVectorType.C
+++ b/test/src/postprocessors/TestVectorType.C
@@ -13,8 +13,6 @@
 
 #include "libmesh/numeric_vector.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseTestApp", TestVectorType);
 
 InputParameters
@@ -41,7 +39,7 @@ TestVectorType::TestVectorType(const InputParameters & parameters)
                   ? (SystemBase &)_fe_problem.getNonlinearSystemBase(/*nl_sys_num=*/0)
                   : (SystemBase &)_fe_problem.getAuxiliarySystem()),
     _test_vec_name(getParam<std::string>("vector")),
-    _par_type(getParam<MooseEnum>("vector_type").getEnum<ParallelType>())
+    _par_type(getParam<MooseEnum>("vector_type").getEnum<libMesh::ParallelType>())
 {
 }
 

--- a/test/src/userobjects/RestartableTypes.C
+++ b/test/src/userobjects/RestartableTypes.C
@@ -9,8 +9,6 @@
 
 #include "RestartableTypes.h"
 
-using namespace libMesh;
-
 registerMooseObject("MooseTestApp", RestartableTypes);
 
 InputParameters
@@ -35,7 +33,7 @@ RestartableTypes::RestartableTypes(const InputParameters & params)
     _map_data(declareRestartableData<std::map<unsigned int, Real>>("map_data")),
     _dense_vector_data(declareRestartableData<DenseVector<Real>>("dense_vector_data")),
     _dense_matrix_data(declareRestartableData<DenseMatrix<Real>>("dense_matrix_data")),
-    _raw_parameters(declareRestartableData<Parameters>("raw_parameters"))
+    _raw_parameters(declareRestartableData<libMesh::Parameters>("raw_parameters"))
 {
   _vector_data.resize(4, 1);
   _vector_vector_data.resize(4);

--- a/unit/src/ColumnMajorMatrixTest.C
+++ b/unit/src/ColumnMajorMatrixTest.C
@@ -12,8 +12,6 @@
 // Moose includes
 #include "ColumnMajorMatrix.h"
 
-using libMesh::VectorValue;
-
 TEST_F(ColumnMajorMatrixTest, addMatrixScalar)
 {
   ColumnMajorMatrix as(3, 3);

--- a/unit/src/DenseMatrixADRealTest.C
+++ b/unit/src/DenseMatrixADRealTest.C
@@ -14,26 +14,24 @@
 
 #include "gtest/gtest.h"
 
-using namespace libMesh;
-
 TEST(DenseMatrixADReal, TryOperations)
 {
-  DenseMatrix<ADReal> a(3, 3);
-  DenseMatrix<ADReal> b(3, 3);
+  libMesh::DenseMatrix<ADReal> a(3, 3);
+  libMesh::DenseMatrix<ADReal> b(3, 3);
   a.left_multiply(b);
   a.left_multiply_transpose(b);
   a.right_multiply(b);
   a.right_multiply_transpose(b);
 
-  DenseVector<ADReal> vec(3);
-  DenseVector<ADReal> dest(3);
+  libMesh::DenseVector<ADReal> vec(3);
+  libMesh::DenseVector<ADReal> dest(3);
 
   a.vector_mult(dest, vec);
   a.vector_mult_transpose(dest, vec);
   a.vector_mult_add(dest, 1, vec);
   a.outer_product(vec, dest);
 
-  DenseMatrix<ADReal> sub(2, 2);
+  libMesh::DenseMatrix<ADReal> sub(2, 2);
   a.get_principal_submatrix(2, 2, sub);
 
   vec(0) = 1;
@@ -45,18 +43,18 @@ TEST(DenseMatrixADReal, TryOperations)
   a(2, 2) = 1;
 
   a.lu_solve(vec, dest);
-  EXPECT_NEAR(dest(0).value(), vec(0).value(), TOLERANCE);
-  EXPECT_NEAR(dest(1).value(), vec(1).value(), TOLERANCE);
-  EXPECT_NEAR(dest(2).value(), vec(2).value(), TOLERANCE);
+  EXPECT_NEAR(dest(0).value(), vec(0).value(), libMesh::TOLERANCE);
+  EXPECT_NEAR(dest(1).value(), vec(1).value(), libMesh::TOLERANCE);
+  EXPECT_NEAR(dest(2).value(), vec(2).value(), libMesh::TOLERANCE);
 
-  EXPECT_NEAR(1, a.det().value(), TOLERANCE);
+  EXPECT_NEAR(1, a.det().value(), libMesh::TOLERANCE);
 
   b(0, 0) = 1;
   b(1, 1) = 1;
   b(2, 2) = 1;
 
   b.cholesky_solve(vec, dest);
-  EXPECT_NEAR(dest(0).value(), vec(0).value(), TOLERANCE);
-  EXPECT_NEAR(dest(1).value(), vec(1).value(), TOLERANCE);
-  EXPECT_NEAR(dest(2).value(), vec(2).value(), TOLERANCE);
+  EXPECT_NEAR(dest(0).value(), vec(0).value(), libMesh::TOLERANCE);
+  EXPECT_NEAR(dest(1).value(), vec(1).value(), libMesh::TOLERANCE);
+  EXPECT_NEAR(dest(2).value(), vec(2).value(), libMesh::TOLERANCE);
 }

--- a/unit/src/GhostPrimaryFaceTest.C
+++ b/unit/src/GhostPrimaryFaceTest.C
@@ -32,8 +32,6 @@
 #include <array>
 #include <memory>
 
-using namespace libMesh;
-
 namespace
 {
 constexpr BoundaryID primary_boundary_id = 10;
@@ -131,10 +129,10 @@ buildNodeFaceInterfaceMesh(MeshBase & mesh)
   boundary_info.add_side(remote_primary, 0, primary_boundary_id);
 }
 
-GhostingFunctor::map_type
+libMesh::GhostingFunctor::map_type
 coupledElementsForProcessor(RelationshipManager & rm, MeshBase & mesh)
 {
-  GhostingFunctor::map_type coupled_elements;
+  libMesh::GhostingFunctor::map_type coupled_elements;
   rm(mesh.active_pid_elements_begin(local_processor_id),
      mesh.active_pid_elements_end(local_processor_id),
      local_processor_id,

--- a/unit/src/LineSegmentTest.C
+++ b/unit/src/LineSegmentTest.C
@@ -11,8 +11,6 @@
 
 #include "libmesh/plane.h"
 
-using namespace libMesh;
-
 TEST_F(LineSegmentTest, closestPointTest)
 {
   // positive x end cases
@@ -312,13 +310,13 @@ TEST_F(LineSegmentTest, containsPointTest)
 TEST_F(LineSegmentTest, planeIntersectTest)
 {
   Point result;
-  Plane xy;
+  libMesh::Plane xy;
   xy.xy_plane(1);
-  Plane xz;
+  libMesh::Plane xz;
   xz.xz_plane(1);
-  Plane yz;
+  libMesh::Plane yz;
   yz.yz_plane(1);
-  Plane diag(Point(0, 0, 0), Point(1, 1, 1), Point(-1, 1, 0));
+  libMesh::Plane diag(Point(0, 0, 0), Point(1, 1, 1), Point(-1, 1, 0));
 
   // Test all the 3D LineSegments against all 4 planes
   EXPECT_FALSE(_pos3x.intersect(xy, result));

--- a/unit/src/MooseArrayTest.C
+++ b/unit/src/MooseArrayTest.C
@@ -11,8 +11,6 @@
 
 #include "MooseArray.h"
 
-using libMesh::Real;
-
 TEST(MooseArray, defaultConstructor)
 {
   MooseArray<int> ma;

--- a/unit/src/RankThreeTensorTest.C
+++ b/unit/src/RankThreeTensorTest.C
@@ -20,9 +20,6 @@
 
 #include "metaphysicl/raw_type.h"
 
-using libMesh::Real;
-using libMesh::VectorValue;
-
 TEST(RankThreeTensor, constructors)
 {
   // Default


### PR DESCRIPTION
## Reason
using-directives leak the entire namespace across translation units in unity builds.

## Design
Removed all using-directives for namespace libMesh, either a) qualifying names in src files as needed or b) added a few extra names to `libMeshReducedNamespace.h` to avoid awkward expressions such as `(type.family == LAGRANGE_VEC) || (type.family == libMesh::MONOMIAL_VEC)`. Also removed unnecessary using-declarations for namespace libMesh members, which don't require any workaround, these were straight removals. Added a note to the 2026/09 newsletter to reflect these changes.

## Impact
Amortizing technical debt.