### PR TITLE
Restrict boundary user-object material reinitialization to required dependencies

### DIFF
--- a/framework/include/loops/ComputeUserObjectsThread.h
+++ b/framework/include/loops/ComputeUserObjectsThread.h
@@ -79,6 +79,16 @@ private:
     _query_boundary.queryInto(results, _tid, std::make_tuple(bnd, false), iface);
   }
 
+  struct BoundaryMaterialReinitCache
+  {
+    std::deque<MaterialBase *> face_materials;
+    std::deque<MaterialBase *> boundary_materials;
+  };
+
+  /// Return the exact face and boundary materials required while executing on this boundary.
+  const BoundaryMaterialReinitCache & getBoundaryMaterialReinitCache(
+      BoundaryID bnd_id, SubdomainID subdomain_id, const std::vector<UserObject *> & userobjs);
+
   const TheWarehouse::Query _query;
   TheWarehouse::QueryCache<AttribThread, AttribSubdomains, AttribInterfaces> _query_subdomain;
   TheWarehouse::QueryCache<AttribThread, AttribBoundaries, AttribInterfaces> _query_boundary;
@@ -90,6 +100,10 @@ private:
   std::vector<DomainUserObject *> _all_domain_objs;
 
   AuxiliarySystem & _aux_sys;
+
+  /// Exact material sets required for each boundary/subdomain pair during this loop execution
+  std::map<std::pair<BoundaryID, SubdomainID>, BoundaryMaterialReinitCache>
+      _boundary_material_reinit_cache;
 };
 
 // determine when we need to run user objects based on whether any initial conditions or aux

--- a/framework/include/loops/ComputeUserObjectsThread.h
+++ b/framework/include/loops/ComputeUserObjectsThread.h
@@ -101,7 +101,9 @@ private:
 
   AuxiliarySystem & _aux_sys;
 
-  /// Exact material sets required for each boundary/subdomain pair during this loop execution
+  // Exact material sets required for each boundary/subdomain pair. This cache is valid only for
+  // this ComputeUserObjectsThread mesh traversal; a new ComputeUserObjectsThread, and therefore a
+  // new cache, is created for each computeUserObjectsInternal() execution.
   std::map<std::pair<BoundaryID, SubdomainID>, BoundaryMaterialReinitCache>
       _boundary_material_reinit_cache;
 };

--- a/framework/include/loops/ComputeUserObjectsThread.h
+++ b/framework/include/loops/ComputeUserObjectsThread.h
@@ -86,8 +86,8 @@ private:
   };
 
   /// Return the exact face and boundary materials required while executing on this boundary.
-  const BoundaryMaterialReinitCache & getBoundaryMaterialReinitCache(
-      BoundaryID bnd_id, SubdomainID subdomain_id, const std::vector<UserObject *> & userobjs);
+  const BoundaryMaterialReinitCache & getBoundaryMaterialReinitCache(BoundaryID bnd_id,
+                                                                     SubdomainID subdomain_id);
 
   const TheWarehouse::Query _query;
   TheWarehouse::QueryCache<AttribThread, AttribSubdomains, AttribInterfaces> _query_subdomain;

--- a/framework/include/loops/ThreadedElementLoop.h
+++ b/framework/include/loops/ThreadedElementLoop.h
@@ -11,6 +11,7 @@
 
 #include "ParallelUniqueId.h"
 #include "FEProblemBase.h"
+#include "MaterialBase.h"
 #include "ThreadedElementLoopBase.h"
 #include "ConsoleUtils.h"
 #include "SwapBackSentinel.h"
@@ -58,7 +59,13 @@ public:
 protected:
   void prepareElement(const Elem * elem);
   void clearVarsAndMaterials();
-
+  /// Determine the face and boundary materials required by material property consumers.
+  void getRequiredBoundaryMaterials(
+      const std::vector<const MaterialPropertyInterface *> & material_consumers,
+      BoundaryID bnd_id,
+      SubdomainID subdomain_id,
+      std::deque<MaterialBase *> & required_face_materials,
+      std::deque<MaterialBase *> & required_boundary_materials) const;
   FEProblemBase & _fe_problem;
 
   /**
@@ -196,4 +203,59 @@ ThreadedElementLoop<RangeType>::clearVarsAndMaterials()
 {
   _fe_problem.clearActiveElementalMooseVariables(this->_tid);
   _fe_problem.clearActiveMaterialProperties(this->_tid);
+}
+
+template <typename RangeType>
+void
+ThreadedElementLoop<RangeType>::getRequiredBoundaryMaterials(
+    const std::vector<const MaterialPropertyInterface *> & material_consumers,
+    const BoundaryID bnd_id,
+    const SubdomainID subdomain_id,
+    std::deque<MaterialBase *> & required_face_materials,
+    std::deque<MaterialBase *> & required_boundary_materials) const
+{
+  required_face_materials.clear();
+  required_boundary_materials.clear();
+
+  std::unordered_set<unsigned int> needed_face_props;
+  for (const auto * const consumer : material_consumers)
+  {
+    const auto & dependencies = consumer->getMatPropDependencies();
+    needed_face_props.insert(dependencies.begin(), dependencies.end());
+  }
+
+  const auto & materials = _fe_problem.getRegularMaterialsWarehouse();
+  // Resolve boundary materials first. A boundary material can depend on a property supplied by a
+  // face material, while a property supplied by the boundary-material chain does not also need a
+  // face producer.
+  if (!material_consumers.empty() && materials.hasActiveBoundaryObjects(bnd_id, this->_tid))
+    required_boundary_materials = MaterialBase::buildRequiredMaterials(
+        material_consumers, materials.getActiveBoundaryObjects(bnd_id, this->_tid), true);
+  for (const auto * const material : required_boundary_materials)
+  {
+    const auto & dependencies = material->getMatPropDependencies();
+    needed_face_props.insert(dependencies.begin(), dependencies.end());
+  }
+  // The boundary-material chain has already satisfied these properties. Removing them prevents a
+  // face material that happens to declare the same property from being selected unnecessarily.
+  for (const auto * const material : required_boundary_materials)
+    for (const auto supplied_prop : material->getSuppliedPropIDs())
+      needed_face_props.erase(supplied_prop);
+
+  struct MaterialDependencyConsumer
+  {
+    const std::unordered_set<unsigned int> & dependencies;
+    const std::unordered_set<unsigned int> & getMatPropDependencies() const { return dependencies; }
+  };
+  if (!needed_face_props.empty())
+  {
+    const auto & face_materials = materials[Moose::FACE_MATERIAL_DATA];
+    if (face_materials.hasActiveBlockObjects(subdomain_id, this->_tid))
+    {
+      const MaterialDependencyConsumer face_consumer{needed_face_props};
+      const std::vector<const MaterialDependencyConsumer *> face_consumers{&face_consumer};
+      required_face_materials = MaterialBase::buildRequiredMaterials(
+          face_consumers, face_materials.getActiveBlockObjects(subdomain_id, this->_tid), true);
+    }
+  }
 }

--- a/framework/src/loops/ComputeUserObjectsThread.C
+++ b/framework/src/loops/ComputeUserObjectsThread.C
@@ -170,6 +170,11 @@ ComputeUserObjectsThread::getBoundaryMaterialReinitCache(const BoundaryID bnd_id
   if (!inserted)
     return cache;
 
+  std::vector<UserObject *> userobjs;
+  queryBoundary(Interfaces::SideUserObject, bnd_id, userobjs);
+
+  std::vector<const MaterialPropertyInterface *> material_consumers;
+
   std::vector<const MaterialPropertyInterface *> material_consumers;
   material_consumers.reserve(userobjs.size() + _domain_objs.size());
 
@@ -183,6 +188,13 @@ ComputeUserObjectsThread::getBoundaryMaterialReinitCache(const BoundaryID bnd_id
   add_material_consumers(userobjs);
   add_material_consumers(_domain_objs);
 
+  std::unordered_set<unsigned int> needed_face_props;
+  for (const auto * const consumer : material_consumers)
+  {
+    const auto & dependencies = consumer->getMatPropDependencies();
+    needed_face_props.insert(dependencies.begin(), dependencies.end());
+  }
+
   const auto & materials = _fe_problem.getRegularMaterialsWarehouse();
 
   // Resolve boundary materials first. A boundary material can depend on a property supplied by a
@@ -191,13 +203,6 @@ ComputeUserObjectsThread::getBoundaryMaterialReinitCache(const BoundaryID bnd_id
   if (!material_consumers.empty() && materials.hasActiveBoundaryObjects(bnd_id, _tid))
     cache.boundary_materials = MaterialBase::buildRequiredMaterials(
         material_consumers, materials.getActiveBoundaryObjects(bnd_id, _tid), true);
-
-  std::unordered_set<unsigned int> needed_face_props;
-  for (const auto * const consumer : material_consumers)
-  {
-    const auto & dependencies = consumer->getMatPropDependencies();
-    needed_face_props.insert(dependencies.begin(), dependencies.end());
-  }
 
   for (const auto * const material : cache.boundary_materials)
   {
@@ -250,12 +255,13 @@ ComputeUserObjectsThread::onBoundary(const Elem * elem,
   if (lower_d_elem)
     _fe_problem.reinitLowerDElem(lower_d_elem, _tid);
 
-  const auto & required_mats =
-      getBoundaryMaterialReinitCache(bnd_id, elem->subdomain_id(), userobjs);
+  const auto & required_mats = getBoundaryMaterialReinitCache(bnd_id, elem->subdomain_id());
 
   // Set up Sentinel class so that, even if reinitMaterialsFace() throws, we
   // still remember to swap back during stack unwinding.
   SwapBackSentinel sentinel(_fe_problem, &FEProblem::swapBackMaterialsFace, _tid);
+
+  // Preserve the stateful material-data swapping used by the previous unrestricted reinit calls.
   _fe_problem.reinitMaterialsFaceOnBoundary(
       bnd_id, elem->subdomain_id(), _tid, true, &required_mats.face_materials);
   _fe_problem.reinitMaterialsBoundary(bnd_id, _tid, true, &required_mats.boundary_materials);

--- a/framework/src/loops/ComputeUserObjectsThread.C
+++ b/framework/src/loops/ComputeUserObjectsThread.C
@@ -158,6 +158,81 @@ ComputeUserObjectsThread::onElement(const Elem * elem)
   }
 }
 
+const ComputeUserObjectsThread::BoundaryMaterialReinitCache &
+ComputeUserObjectsThread::getBoundaryMaterialReinitCache(const BoundaryID bnd_id,
+                                                         const SubdomainID subdomain_id,
+                                                         const std::vector<UserObject *> & userobjs)
+{
+  const auto cache_key = std::make_pair(bnd_id, subdomain_id);
+  auto [cache_it, inserted] = _boundary_material_reinit_cache.try_emplace(cache_key);
+  auto & cache = cache_it->second;
+
+  if (!inserted)
+    return cache;
+
+  std::vector<const MaterialPropertyInterface *> material_consumers;
+  material_consumers.reserve(userobjs.size() + _domain_objs.size());
+
+  const auto add_material_consumers = [&material_consumers](const auto & objects)
+  {
+    for (const auto * const object : objects)
+      if (const auto * const consumer = dynamic_cast<const MaterialPropertyInterface *>(object))
+        material_consumers.push_back(consumer);
+  };
+
+  add_material_consumers(userobjs);
+  add_material_consumers(_domain_objs);
+
+  const auto & materials = _fe_problem.getRegularMaterialsWarehouse();
+
+  // Resolve boundary materials first. A boundary material can depend on a property supplied by a
+  // face material, while a property supplied by the boundary-material chain does not also need a
+  // face producer.
+  if (!material_consumers.empty() && materials.hasActiveBoundaryObjects(bnd_id, _tid))
+    cache.boundary_materials = MaterialBase::buildRequiredMaterials(
+        material_consumers, materials.getActiveBoundaryObjects(bnd_id, _tid), true);
+
+  std::unordered_set<unsigned int> needed_face_props;
+  for (const auto * const consumer : material_consumers)
+  {
+    const auto & dependencies = consumer->getMatPropDependencies();
+    needed_face_props.insert(dependencies.begin(), dependencies.end());
+  }
+
+  for (const auto * const material : cache.boundary_materials)
+  {
+    const auto & dependencies = material->getMatPropDependencies();
+    needed_face_props.insert(dependencies.begin(), dependencies.end());
+  }
+
+  // The boundary-material chain has already satisfied these properties. Removing them prevents a
+  // face material that happens to declare the same property from being selected unnecessarily.
+  for (const auto * const material : cache.boundary_materials)
+    for (const auto supplied_prop : material->getSuppliedPropIDs())
+      needed_face_props.erase(supplied_prop);
+
+  struct MaterialDependencyConsumer
+  {
+    const std::unordered_set<unsigned int> & dependencies;
+
+    const std::unordered_set<unsigned int> & getMatPropDependencies() const { return dependencies; }
+  };
+
+  if (!needed_face_props.empty())
+  {
+    const auto & face_materials = materials[Moose::FACE_MATERIAL_DATA];
+    if (face_materials.hasActiveBlockObjects(subdomain_id, _tid))
+    {
+      const MaterialDependencyConsumer face_consumer{needed_face_props};
+      const std::vector<const MaterialDependencyConsumer *> face_consumers{&face_consumer};
+      cache.face_materials = MaterialBase::buildRequiredMaterials(
+          face_consumers, face_materials.getActiveBlockObjects(subdomain_id, _tid), true);
+    }
+  }
+
+  return cache;
+}
+
 void
 ComputeUserObjectsThread::onBoundary(const Elem * elem,
                                      unsigned int side,
@@ -175,11 +250,15 @@ ComputeUserObjectsThread::onBoundary(const Elem * elem,
   if (lower_d_elem)
     _fe_problem.reinitLowerDElem(lower_d_elem, _tid);
 
+  const auto & required_mats =
+      getBoundaryMaterialReinitCache(bnd_id, elem->subdomain_id(), userobjs);
+
   // Set up Sentinel class so that, even if reinitMaterialsFace() throws, we
   // still remember to swap back during stack unwinding.
   SwapBackSentinel sentinel(_fe_problem, &FEProblem::swapBackMaterialsFace, _tid);
-  _fe_problem.reinitMaterialsFaceOnBoundary(bnd_id, elem->subdomain_id(), _tid);
-  _fe_problem.reinitMaterialsBoundary(bnd_id, _tid);
+  _fe_problem.reinitMaterialsFaceOnBoundary(
+      bnd_id, elem->subdomain_id(), _tid, true, &required_mats.face_materials);
+  _fe_problem.reinitMaterialsBoundary(bnd_id, _tid, true, &required_mats.boundary_materials);
 
   for (const auto & uo : userobjs)
     uo->execute();

--- a/framework/src/loops/ComputeUserObjectsThread.C
+++ b/framework/src/loops/ComputeUserObjectsThread.C
@@ -169,6 +169,8 @@ ComputeUserObjectsThread::getBoundaryMaterialReinitCache(const BoundaryID bnd_id
   if (!inserted)
     return cache;
 
+  // SideUserObjects are boundary-restricted, not block-restricted. The current subdomain is
+  // accounted for below when selecting the active face materials.
   std::vector<UserObject *> userobjs;
   queryBoundary(Interfaces::SideUserObject, bnd_id, userobjs);
 
@@ -184,54 +186,8 @@ ComputeUserObjectsThread::getBoundaryMaterialReinitCache(const BoundaryID bnd_id
 
   add_material_consumers(userobjs);
   add_material_consumers(_domain_objs);
-
-  std::unordered_set<unsigned int> needed_face_props;
-  for (const auto * const consumer : material_consumers)
-  {
-    const auto & dependencies = consumer->getMatPropDependencies();
-    needed_face_props.insert(dependencies.begin(), dependencies.end());
-  }
-
-  const auto & materials = _fe_problem.getRegularMaterialsWarehouse();
-
-  // Resolve boundary materials first. A boundary material can depend on a property supplied by a
-  // face material, while a property supplied by the boundary-material chain does not also need a
-  // face producer.
-  if (!material_consumers.empty() && materials.hasActiveBoundaryObjects(bnd_id, _tid))
-    cache.boundary_materials = MaterialBase::buildRequiredMaterials(
-        material_consumers, materials.getActiveBoundaryObjects(bnd_id, _tid), true);
-
-  for (const auto * const material : cache.boundary_materials)
-  {
-    const auto & dependencies = material->getMatPropDependencies();
-    needed_face_props.insert(dependencies.begin(), dependencies.end());
-  }
-
-  // The boundary-material chain has already satisfied these properties. Removing them prevents a
-  // face material that happens to declare the same property from being selected unnecessarily.
-  for (const auto * const material : cache.boundary_materials)
-    for (const auto supplied_prop : material->getSuppliedPropIDs())
-      needed_face_props.erase(supplied_prop);
-
-  struct MaterialDependencyConsumer
-  {
-    const std::unordered_set<unsigned int> & dependencies;
-
-    const std::unordered_set<unsigned int> & getMatPropDependencies() const { return dependencies; }
-  };
-
-  if (!needed_face_props.empty())
-  {
-    const auto & face_materials = materials[Moose::FACE_MATERIAL_DATA];
-    if (face_materials.hasActiveBlockObjects(subdomain_id, _tid))
-    {
-      const MaterialDependencyConsumer face_consumer{needed_face_props};
-      const std::vector<const MaterialDependencyConsumer *> face_consumers{&face_consumer};
-      cache.face_materials = MaterialBase::buildRequiredMaterials(
-          face_consumers, face_materials.getActiveBlockObjects(subdomain_id, _tid), true);
-    }
-  }
-
+  getRequiredBoundaryMaterials(
+      material_consumers, bnd_id, subdomain_id, cache.face_materials, cache.boundary_materials);
   return cache;
 }
 
@@ -258,7 +214,8 @@ ComputeUserObjectsThread::onBoundary(const Elem * elem,
   // still remember to swap back during stack unwinding.
   SwapBackSentinel sentinel(_fe_problem, &FEProblem::swapBackMaterialsFace, _tid);
 
-  // Preserve the stateful material-data swapping used by the previous unrestricted reinit calls.
+  // TODO: Explore whether stateful material property data needs to be swapped in user object
+  // loops by changing swap_stateful=false in the following calls.
   _fe_problem.reinitMaterialsFaceOnBoundary(
       bnd_id, elem->subdomain_id(), _tid, true, &required_mats.face_materials);
   _fe_problem.reinitMaterialsBoundary(bnd_id, _tid, true, &required_mats.boundary_materials);

--- a/framework/src/loops/ComputeUserObjectsThread.C
+++ b/framework/src/loops/ComputeUserObjectsThread.C
@@ -160,8 +160,7 @@ ComputeUserObjectsThread::onElement(const Elem * elem)
 
 const ComputeUserObjectsThread::BoundaryMaterialReinitCache &
 ComputeUserObjectsThread::getBoundaryMaterialReinitCache(const BoundaryID bnd_id,
-                                                         const SubdomainID subdomain_id,
-                                                         const std::vector<UserObject *> & userobjs)
+                                                         const SubdomainID subdomain_id)
 {
   const auto cache_key = std::make_pair(bnd_id, subdomain_id);
   auto [cache_it, inserted] = _boundary_material_reinit_cache.try_emplace(cache_key);
@@ -172,8 +171,6 @@ ComputeUserObjectsThread::getBoundaryMaterialReinitCache(const BoundaryID bnd_id
 
   std::vector<UserObject *> userobjs;
   queryBoundary(Interfaces::SideUserObject, bnd_id, userobjs);
-
-  std::vector<const MaterialPropertyInterface *> material_consumers;
 
   std::vector<const MaterialPropertyInterface *> material_consumers;
   material_consumers.reserve(userobjs.size() + _domain_objs.size());

--- a/test/include/materials/BoundaryMaterialReinitTest.h
+++ b/test/include/materials/BoundaryMaterialReinitTest.h
@@ -1,0 +1,37 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#pragma once
+
+#include "Material.h"
+
+/**
+ * Test material for checking selective material reinitialization on boundaries.
+ */
+class BoundaryMaterialReinitTest : public Material
+{
+public:
+  static InputParameters validParams();
+
+  BoundaryMaterialReinitTest(const InputParameters & parameters);
+
+protected:
+  void computeQpProperties() override;
+
+  /// Property supplied by this material
+  MaterialProperty<Real> & _property;
+
+  /// Constant contribution to the supplied property
+  const Real _value;
+
+  /// Optional material property dependency
+  const MaterialProperty<Real> * const _coupled_property;
+
+  /// Whether computing the automatically-created face material is an error for this test
+  const bool _error_on_face;
+};

--- a/test/src/materials/BoundaryMaterialReinitTest.C
+++ b/test/src/materials/BoundaryMaterialReinitTest.C
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://mooseframework.inl.gov
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+
+#include "BoundaryMaterialReinitTest.h"
+
+registerMooseObject("MooseTestApp", BoundaryMaterialReinitTest);
+
+InputParameters
+BoundaryMaterialReinitTest::validParams()
+{
+  auto params = Material::validParams();
+  params.addRequiredParam<MaterialPropertyName>("property",
+                                                "The property supplied by this material.");
+  params.addParam<Real>("value", 0.0, "A constant contribution to the supplied property.");
+  params.addParam<MaterialPropertyName>(
+      "coupled_property", "An optional material property to add to the supplied property.");
+  params.addParam<bool>(
+      "error_on_face", false, "Whether to error if the face copy of this material is computed.");
+  return params;
+}
+
+BoundaryMaterialReinitTest::BoundaryMaterialReinitTest(const InputParameters & parameters)
+  : Material(parameters),
+    _property(declareProperty<Real>("property")),
+    _value(getParam<Real>("value")),
+    _coupled_property(isParamValid("coupled_property")
+                          ? &getMaterialProperty<Real>("coupled_property")
+                          : nullptr),
+    _error_on_face(getParam<bool>("error_on_face"))
+{
+}
+
+void
+BoundaryMaterialReinitTest::computeQpProperties()
+{
+  if (_error_on_face && materialDataType() == Moose::FACE_MATERIAL_DATA)
+    mooseError("The face copy of ", name(), " should not have been computed.");
+
+  _property[_qp] = _value;
+  if (_coupled_property)
+    _property[_qp] += (*_coupled_property)[_qp];
+}

--- a/test/tests/materials/selective_boundary_reinit/boundary_face_dependency.i
+++ b/test/tests/materials/selective_boundary_reinit/boundary_face_dependency.i
@@ -1,0 +1,43 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Materials]
+  [face_source]
+    type = BoundaryMaterialReinitTest
+    property = face_property
+    value = 2
+  []
+  [boundary]
+    type = BoundaryMaterialReinitTest
+    boundary = left
+    property = boundary_property
+    value = 3
+    coupled_property = face_property
+  []
+[]
+
+[Postprocessors]
+  [boundary_average]
+    type = SideAverageMaterialProperty
+    boundary = left
+    property = boundary_property
+    execute_on = INITIAL
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  csv = true
+  execute_on = INITIAL
+[]

--- a/test/tests/materials/selective_boundary_reinit/direct_face_dependency.i
+++ b/test/tests/materials/selective_boundary_reinit/direct_face_dependency.i
@@ -1,0 +1,36 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Materials]
+  [face_source]
+    type = BoundaryMaterialReinitTest
+    property = face_property
+    value = 2
+  []
+[]
+
+[Postprocessors]
+  [face_average]
+    type = SideAverageMaterialProperty
+    boundary = left
+    property = face_property
+    execute_on = INITIAL
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  csv = true
+  execute_on = INITIAL
+[]

--- a/test/tests/materials/selective_boundary_reinit/gold/boundary_face_dependency_out.csv
+++ b/test/tests/materials/selective_boundary_reinit/gold/boundary_face_dependency_out.csv
@@ -1,0 +1,2 @@
+time,boundary_average
+0,5

--- a/test/tests/materials/selective_boundary_reinit/gold/direct_face_dependency_out.csv
+++ b/test/tests/materials/selective_boundary_reinit/gold/direct_face_dependency_out.csv
@@ -1,0 +1,2 @@
+time,face_average
+0,2

--- a/test/tests/materials/selective_boundary_reinit/tests
+++ b/test/tests/materials/selective_boundary_reinit/tests
@@ -3,6 +3,7 @@
     type = 'RunApp'
     input = 'unrelated_face_material.i'
     issues = '#31418'
+    design = 'syntax/Materials/index.md'
     requirement = 'The system shall not evaluate an unrelated face material while executing user objects on a boundary.'
   []
   [direct_face_dependency]
@@ -10,6 +11,7 @@
     input = 'direct_face_dependency.i'
     csvdiff = 'direct_face_dependency_out.csv'
     issues = '#31418'
+    design = 'syntax/Materials/index.md'
     requirement = 'The system shall evaluate a face material directly required by a side user object.'
   []
   [boundary_face_dependency]
@@ -17,6 +19,7 @@
     input = 'boundary_face_dependency.i'
     csvdiff = 'boundary_face_dependency_out.csv'
     issues = '#31418'
+    design = 'syntax/Materials/index.md'
     requirement = 'The system shall evaluate face materials required by boundary-material dependencies of user objects.'
   []
 []

--- a/test/tests/materials/selective_boundary_reinit/tests
+++ b/test/tests/materials/selective_boundary_reinit/tests
@@ -5,13 +5,6 @@
     issues = '#31418'
     requirement = 'The system shall not evaluate an unrelated face material while executing user objects on a boundary.'
   []
-  [unrelated_face_material_threaded]
-    type = 'RunApp'
-    input = 'unrelated_face_material.i'
-    min_threads = 2
-    issues = '#31418'
-    requirement = 'The system shall selectively reinitialize boundary materials during threaded user object execution.'
-  []
   [direct_face_dependency]
     type = 'CSVDiff'
     input = 'direct_face_dependency.i'

--- a/test/tests/materials/selective_boundary_reinit/tests
+++ b/test/tests/materials/selective_boundary_reinit/tests
@@ -1,0 +1,29 @@
+[Tests]
+  [unrelated_face_material]
+    type = 'RunApp'
+    input = 'unrelated_face_material.i'
+    issues = '#31418'
+    requirement = 'The system shall not evaluate an unrelated face material while executing user objects on a boundary.'
+  []
+  [unrelated_face_material_threaded]
+    type = 'RunApp'
+    input = 'unrelated_face_material.i'
+    min_threads = 2
+    issues = '#31418'
+    requirement = 'The system shall selectively reinitialize boundary materials during threaded user object execution.'
+  []
+  [direct_face_dependency]
+    type = 'CSVDiff'
+    input = 'direct_face_dependency.i'
+    csvdiff = 'direct_face_dependency_out.csv'
+    issues = '#31418'
+    requirement = 'The system shall evaluate a face material directly required by a side user object.'
+  []
+  [boundary_face_dependency]
+    type = 'CSVDiff'
+    input = 'boundary_face_dependency.i'
+    csvdiff = 'boundary_face_dependency_out.csv'
+    issues = '#31418'
+    requirement = 'The system shall evaluate face materials required by boundary-material dependencies of user objects.'
+  []
+[]

--- a/test/tests/materials/selective_boundary_reinit/unrelated_face_material.i
+++ b/test/tests/materials/selective_boundary_reinit/unrelated_face_material.i
@@ -1,0 +1,44 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 8
+  ny = 8
+[]
+
+[AuxVariables]
+  [u]
+  []
+[]
+
+[Materials]
+  [volume]
+    type = BoundaryMaterialReinitTest
+    property = volume_property
+    value = 2
+    error_on_face = true
+  []
+[]
+
+[Postprocessors]
+  [volume_average]
+    type = ElementAverageMaterialProperty
+    mat_prop = volume_property
+    execute_on = TIMESTEP_END
+  []
+  [side_average]
+    type = SideAverageValue
+    variable = u
+    boundary = left
+    execute_on = TIMESTEP_END
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 2
+  dt = 1
+[]


### PR DESCRIPTION
This is key for some large thermomechanic simulations with expensive nonlinear stress update material properties that 1) don't need to be regenerated, and 2) sometimes give garbage answers for some reason during `TIMESTEP_END`. Ref #31418

Code and summary generated with ChatGPT FTW...amazing...

## Summary

Restrict boundary user-object material reinitialization to the boundary and face material dependency chains actually required by the user objects executing on the current boundary.

Previously, `ComputeUserObjectsThread::onBoundary()` reinitialized all active face and boundary materials. Because the active material set is prepared from the union of dependencies required by several user-object types, this could cause unrelated autogenerated face materials to execute during boundary user-object evaluation.

The new implementation:

* Collects material-property consumers from the side and domain user objects executing in the boundary context.
* Determines the required boundary materials using the existing `MaterialBase::buildRequiredMaterials()` dependency traversal.
* Propagates dependencies of those required boundary materials when determining the required face materials, preserving chains such as:
  `SideUserObject -> BoundaryMaterial -> FaceMaterial`.
* Passes explicit material lists to `reinitMaterialsFaceOnBoundary()` and `reinitMaterialsBoundary()` instead of reinitializing all active materials.
* Caches the selected material lists by `(BoundaryID, SubdomainID)` within each `ComputeUserObjectsThread` execution.

The cache avoids repeating the same dependency analysis for every face on a sideset. It is intentionally scoped to the lifetime of `ComputeUserObjectsThread`, which is constructed for each user-object execution. This provides automatic invalidation between executions/timesteps and avoids the need for a user-facing cache-recompute option. Each split thread builds its own cache so cached `MaterialBase *` pointers remain thread-local.

## Tests

Regression coverage verifies that:

* A material required only by an element postprocessor does not have its autogenerated face copy evaluated by an unrelated side postprocessor.
* A face material directly required by a side user object is still evaluated.
* Transitive `SideUserObject -> BoundaryMaterial -> FaceMaterial` dependencies are preserved.

This reduces unnecessary material evaluation and prevents expensive or nonlinear face-material copies from being executed solely because an unrelated material property is active elsewhere in the user-object traversal.
