### PR TITLE
Half outputs/format.hit_search test time

### DIFF
--- a/test/tests/outputs/format/test_hit_output.py
+++ b/test/tests/outputs/format/test_hit_output.py
@@ -148,6 +148,8 @@ class TestInputFileFormatSearch(TestHITBase):
         self.assertIn("initial_steps", params)
         self.assertEqual(len(params.keys()), 1)
 
+
+class TestLowerCaseOptionDocs(TestHITBase):
     def testLowerCaseOptionDocs(self):
         """
         Make sure lower-case enum option documentation is dumped.

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -227,4 +227,15 @@
     design = 'JsonInputFileFormatter.md MooseApp.md'
     requirement = 'The system shall be able to dump a subset of input file (HIT) syntax.'
   []
+
+  [hit_search_lowercase_option_docs]
+    type = 'PythonUnitTest'
+    input = 'test_hit_output.py'
+    test_case = 'TestLowerCaseOptionDocs'
+    max_buffer_size = -1
+    min_slots = 2 # memory heavy
+    issues = '#7855 #7661 #2881 #10839 #12455'
+    design = 'JsonInputFileFormatter.md MooseApp.md'
+    requirement = 'The system shall dump lower-case enum option documentation in a subset of input file (HIT) syntax.'
+  []
 []


### PR DESCRIPTION
https://civet.inl.gov/job/4147735/ on #32394 shows the test timing out. The overall test time can be cut roughly in half by creating a new class for explicitly testing dumping of lower-case enum options. In this way `TestInputFileFormatSearch` has a single method to test and `TestLowerCaseOptionDocs` has a single method to test