### PR TITLE
Fix flaky MFEM transfer tests

### DIFF
--- a/test/tests/mfem/transfers/mfem_parent_mfem_sub/tests
+++ b/test/tests/mfem/transfers/mfem_parent_mfem_sub/tests
@@ -23,6 +23,7 @@
         capabilities = 'mfem'
         recover = false
         detail = 'checking the sub-application and parent application outputs against each other.'
+        min_slots = 4 # occasionally uses lots of memory
       []
     []
     [ComplexFromSubToParent]
@@ -122,6 +123,7 @@
         capabilities = 'mfem'
         recover = false
         detail = 'checking the sub-application and parent application outputs against each other.'
+        min_slots = 4 # occasionally uses lots of memory
       []
     []
     [ToSubFromParent]
@@ -145,6 +147,7 @@
         capabilities = 'mfem'
         recover = false
         detail = 'checking the sub-application and parent application outputs against each other.'
+        min_slots = 4 # occasionally uses lots of memory
       []
     []
     [ComplexFromSubToParent]

--- a/test/tests/mfem/transfers/mfem_sub_mfem_sub/tests
+++ b/test/tests/mfem/transfers/mfem_sub_mfem_sub/tests
@@ -22,6 +22,7 @@
         capabilities = 'mfem'
         recover = false
         detail = 'checking the sub-application and parent application outputs against each other.'
+        min_slots = 4 # occasionally uses lots of memory
       []
     []
     [error]


### PR DESCRIPTION
refs #32580

Increase slots to allow more memory usage for flaky tests.
See e.g. [this run](https://civet.inl.gov/job/4148479/) and [this discussion](https://github.com/idaholab/moose/pull/32580#issuecomment-5607334254).

## Reason

Tests are inconsistently failing in CI due to using too much memory.
