### PR TITLE
Fix --restep failures in dynamic mortar contact and penalty friction (#31054)

### DIFF
--- a/modules/combined/test/tests/gap_heat_transfer_jac/tests
+++ b/modules/combined/test/tests/gap_heat_transfer_jac/tests
@@ -3,9 +3,14 @@
     type = Exodiff
     input = two_blocks.i
     exodiff = two_blocks_out.e
-    restep = false # Issue #31054
     issues = '#14626'
     requirement = 'The system shall provide Jacobian entries coupling the primary-side temperature and displacement with the secondary side temperatures for thermal contact such that problems with significant gap heat transfer may have a non-linear solve that converges'
     design = 'GapHeatTransfer.md'
+    # Under --test-restep the quadrature-based PenetrationLocator owned by GapHeatTransfer
+    # (modules/heat_transfer/src/bcs/GapHeatTransfer.C) reseeds its projection-search state from
+    # the discarded solve attempt with no convergence-aware guard, causing the retried nonlinear
+    # solve to diverge (DIVERGED_MAX_IT). This is a framework-level PenetrationLocator issue, not
+    # a modules/contact bug; see Issue #31054.
+    restep = false # Issue #31054
   []
 []

--- a/modules/contact/include/constraints/ComputeDynamicWeightedGapLMMechanicalContact.h
+++ b/modules/contact/include/constraints/ComputeDynamicWeightedGapLMMechanicalContact.h
@@ -156,4 +156,15 @@ protected:
 
   /// The relative velocity
   ADRealVectorValue _relative_velocity;
+
+  /// The timestep index at which the history maps (_dof_to_old_weighted_gap, _dof_to_old_velocity,
+  /// _dof_to_nodal_old_wear_depth) were last advanced. Used to detect a repeated timestep (e.g.
+  /// --test-restep or a rejected step), since timestepSetup() runs once per solve attempt rather
+  /// than once per accepted step.
+  int & _t_step_old;
+
+  /// Set by timestepSetup() to indicate whether the current call is for a repeated timestep, so
+  /// that derived classes advancing their own history in an overriding timestepSetup() can skip
+  /// doing so as well.
+  bool _repeated_timestep;
 };

--- a/modules/contact/include/userobjects/PenaltyFrictionUserObject.h
+++ b/modules/contact/include/userobjects/PenaltyFrictionUserObject.h
@@ -93,4 +93,9 @@ protected:
 
   /// Tolerance to avoid NaN/Inf in automatic differentiation operations.
   const Real _epsilon_tolerance;
+
+  /// The timestep index at which the accumulated slip and tangential traction history were last
+  /// advanced. Used to detect a repeated timestep (e.g. from --test-restep or a rejected step),
+  /// since timestepSetup() runs once per solve attempt rather than once per accepted step.
+  int & _t_step_old_friction;
 };

--- a/modules/contact/src/constraints/ComputeDynamicFrictionalForceLMMechanicalContact.C
+++ b/modules/contact/src/constraints/ComputeDynamicFrictionalForceLMMechanicalContact.C
@@ -161,6 +161,12 @@ ComputeDynamicFrictionalForceLMMechanicalContact::timestepSetup()
 
   ComputeDynamicWeightedGapLMMechanicalContact::timestepSetup();
 
+  // The base class sets _repeated_timestep to indicate whether this call is for a retried
+  // timestep (e.g. --test-restep or a rejected step); if so, the history below has already been
+  // advanced from the accepted state and must not be advanced again.
+  if (_repeated_timestep)
+    return;
+
   _dof_to_old_real_tangential_velocity.clear();
 
   for (auto & map_pr : _dof_to_real_tangential_velocity)

--- a/modules/contact/src/constraints/ComputeDynamicWeightedGapLMMechanicalContact.C
+++ b/modules/contact/src/constraints/ComputeDynamicWeightedGapLMMechanicalContact.C
@@ -106,7 +106,9 @@ ComputeDynamicWeightedGapLMMechanicalContact::ComputeDynamicWeightedGapLMMechani
     _has_wear(isParamValid("wear_depth")),
     _wear_depth(_has_wear ? coupledValueLower("wear_depth") : _zero),
     _newmark_beta(getParam<Real>("newmark_beta")),
-    _newmark_gamma(getParam<Real>("newmark_gamma"))
+    _newmark_gamma(getParam<Real>("newmark_gamma")),
+    _t_step_old(declareRestartableData<int>("t_step_old", 0)),
+    _repeated_timestep(false)
 {
   if (!useDual())
     mooseError("Dynamic mortar contact constraints requires the use of Lagrange multipliers dual "
@@ -226,6 +228,14 @@ ComputeDynamicWeightedGapLMMechanicalContact::timestepSetup()
   // would be wrong. We would need to create a custom dataStore() and dataLoad()
   if (_app.isRecovering())
     mooseError("This object does not support recovering");
+
+  // timestepSetup() runs once per solve attempt, so on a retried timestep (e.g. --test-restep or
+  // a rejected step) the history below has already been advanced from the accepted state;
+  // advancing it again would overwrite that history with the discarded attempt's last values.
+  _repeated_timestep = _t_step == _t_step_old;
+  _t_step_old = _t_step;
+  if (_repeated_timestep)
+    return;
 
   _dof_to_old_weighted_gap.clear();
   _dof_to_old_velocity.clear();

--- a/modules/contact/src/userobjects/PenaltyFrictionUserObject.C
+++ b/modules/contact/src/userobjects/PenaltyFrictionUserObject.C
@@ -82,7 +82,8 @@ PenaltyFrictionUserObject::PenaltyFrictionUserObject(const InputParameters & par
     _penalty_multiplier_friction(getParam<Real>("penalty_multiplier_friction")),
     _adaptivity_friction(
         getParam<MooseEnum>("adaptivity_penalty_friction").getEnum<AdaptivityFrictionalPenalty>()),
-    _epsilon_tolerance(1.0e-40)
+    _epsilon_tolerance(1.0e-40),
+    _t_step_old_friction(declareRestartableData<int>("t_step_old_friction", 0))
 
 {
   if (!_augmented_lagrange_problem == isParamValid("slip_tolerance"))
@@ -127,24 +128,33 @@ PenaltyFrictionUserObject::timestepSetup()
     step_slip = {0.0, 0.0};
   }
 
-  // save off accumulated slip from the last timestep
-  for (auto & map_pr : _dof_to_accumulated_slip)
-  {
-    auto & [accumulated_slip, old_accumulated_slip] = map_pr.second;
-    old_accumulated_slip = accumulated_slip;
-  }
+  // timestepSetup() runs once per solve attempt, so on a retried timestep (e.g. --test-restep or
+  // a rejected step) the accumulated slip and tangential traction history have already been
+  // advanced from the accepted state; advancing them again would overwrite that history with the
+  // discarded attempt's last values.
+  const bool repeated_timestep = _fe_problem.timeStep() == _t_step_old_friction;
+  _t_step_old_friction = _fe_problem.timeStep();
+
+  if (!repeated_timestep)
+    // save off accumulated slip from the last timestep
+    for (auto & map_pr : _dof_to_accumulated_slip)
+    {
+      auto & [accumulated_slip, old_accumulated_slip] = map_pr.second;
+      old_accumulated_slip = accumulated_slip;
+    }
 
   for (auto & dof_lp : _dof_to_local_penalty_friction)
     dof_lp.second = _penalty_friction;
 
-  // save off tangential traction from the last timestep
-  for (auto & map_pr : _dof_to_tangential_traction)
-  {
-    auto & [tangential_traction, old_tangential_traction] = map_pr.second;
-    old_tangential_traction = {MetaPhysicL::raw_value(tangential_traction(0)),
-                               MetaPhysicL::raw_value(tangential_traction(1))};
-    tangential_traction = {0.0, 0.0};
-  }
+  if (!repeated_timestep)
+    // save off tangential traction from the last timestep
+    for (auto & map_pr : _dof_to_tangential_traction)
+    {
+      auto & [tangential_traction, old_tangential_traction] = map_pr.second;
+      old_tangential_traction = {MetaPhysicL::raw_value(tangential_traction(0)),
+                                 MetaPhysicL::raw_value(tangential_traction(1))};
+      tangential_traction = {0.0, 0.0};
+    }
 
   for (auto & [dof_object, delta_tangential_lm] : _dof_to_frictional_lagrange_multipliers)
     delta_tangential_lm.setZero();

--- a/modules/contact/test/tests/3d-mortar-contact/tests
+++ b/modules/contact/test/tests/3d-mortar-contact/tests
@@ -469,7 +469,6 @@
     input = 'frictional-mortar-3d-penalty.i'
     capabilities = 'ad_size>=200'
     exodiff = 'frictional-mortar-3d-penalty_out.e'
-    restep = false # Issue #31054
     requirement = 'The system shall solve a 3D frictional problem with mortar constraint using a '
                   'penalty approach'
     rel_err = 1.0e-5

--- a/modules/contact/test/tests/mortar_aux_kernels/tests
+++ b/modules/contact/test/tests/mortar_aux_kernels/tests
@@ -24,7 +24,6 @@
     max_parallel = 4
     capabilities = 'ad_size>=50 & method!=dbg'
     valgrind = 'none'
-    restep = false # Issue #31054
     requirement = 'The contact module shall be able to compute nodal wear depth values in accordance with Archard '
                   'equation via a mortar auxiliary kernel.'
     # ComputeDynamicWeightedGapLMMechanicalContact does not support recover

--- a/modules/contact/test/tests/mortar_dynamics/tests
+++ b/modules/contact/test/tests/mortar_dynamics/tests
@@ -109,7 +109,6 @@
               'frictional-mortar-3d-dynamics_out_tangent_y_0001.csv'
     requirement = 'The system shall solve a dynamic 3D frictional bouncing block problem with mortar '
                   'constraint using nodal-attached geometry'
-    restep = false # Issue #31054
     rel_err = 1.0e-5
     abs_zero = 1.0e-5
     capabilities = 'ad_size>=150 & method=opt'
@@ -157,7 +156,6 @@
     rel_err = 5.0e-4
     abs_zero = 1.0e-5
     capabilities = 'ad_size>=64'
-    restep = false # Issue #31054
     requirement = 'The system shall solve a dynamic 3D frictional one-element bouncing block problem '
                   'with mortar constraints using nodal geometry and a friction coefficient '
                   'that depends on the normal contact pressure and the relative tangential velocity'

--- a/modules/contact/test/tests/pdass_problems/tests
+++ b/modules/contact/test/tests/pdass_problems/tests
@@ -137,7 +137,6 @@
     input = 'cylinder_friction_penalty_frictional_al_action_amg_bussetta_simple.i'
     rel_err = 1.0e-4
     abs_zero = 1.0e-2
-    restep = false # Issue #31054
     requirement = "The contact module shall be able to approximate frictional contact in a "
                   "two-dimensional cylinder via an augmented Lagrange approach to constraint "
                   "enforcement using the contact action and use the hypre algebraic multigrid "
@@ -147,6 +146,15 @@
                   "penalty values, respectively."
     capabilities = 'method!=dbg'
     recover = false # Only doing one timestep
+    # Under --test-restep, the discarded attempt's SNES/hypre BoomerAMG linear solve leaves the
+    # retried attempt's first Newton correction differing from the non-restepped run by a tiny
+    # relative amount; this floating-point divergence compounds through the augmented Lagrange
+    # (Uzawa) loop and flips isAugmentedLagrangianConverged() one iteration earlier, producing a
+    # converged Lagrange multiplier that fails this test's tight rel_err=1.0e-4 csvdiff check. The
+    # failure reproduces identically whether or not _dof_to_lagrange_multiplier is restored to its
+    # pre-attempt value on the retry, so this is a PETSc/SNES/hypre solver-level effect, not a
+    # modules/contact bookkeeping bug.
+    restep = false # Issue #31054
   []
   [cylinder_friction_penalty_al_separation]
     type = 'CSVDiff'


### PR DESCRIPTION
Fixes 4 of the 6 genuine `--restep` bugs from #31054 in `modules/contact`.

`timestepSetup()` runs once per solve attempt, not once per accepted step, so objects that advance history there (`old <- current`) double-advance it when `--test-restep` retries a converged solve. Guards the history-advance paths in `ComputeDynamicWeightedGapLMMechanicalContact`, `ComputeDynamicFrictionalForceLMMechanicalContact`, and `PenaltyFrictionUserObject`, following the `Predictor::timestepSetup` idiom.

Also re-diagnosed and left in place (with corrected comments) the 2 remaining in-scope markers, `pdass_problems.cylinder_friction_penalty_al_..._bussetta_simple` and `combined:gap_heat_transfer_jac`, which are not fixable locally: one is a PETSc/hypre solver-level floating-point effect, the other a framework-level `PenetrationLocator` issue outside `modules/contact`.

Full `modules/contact` and `modules/combined` test suites pass plain and under `--restep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)